### PR TITLE
[json-rpc] Refactor dev-inspect and dry-run to use the same backend `simulate`  call 

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -87,6 +87,7 @@ use sui_types::messages_consensus::AuthorityCapabilitiesV2;
 use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::storage::ChildObjectResolver;
 use sui_types::storage::InputKey;
+use sui_types::storage::OverlayBackingPackageStore;
 use sui_types::storage::TrackingBackingStore;
 use sui_types::traffic_control::{
     PolicyConfig, RemoteFirewallConfig, TrafficControlReconfigParams,
@@ -113,7 +114,7 @@ use crate::jsonrpc_index::{
     CoinInfo, IndexStoreCacheUpdates, IndexStoreCacheUpdatesWithLocks, ObjectIndexChanges,
 };
 use mysten_common::{debug_fatal, debug_fatal_no_invariant};
-use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
+use shared_crypto::intent::{Intent, IntentScope};
 use sui_config::genesis::Genesis;
 use sui_config::node::{DBCheckpointConfig, ExpensiveSafetyCheckConfig};
 use sui_framework::{BuiltInFramework, SystemPackage};
@@ -130,7 +131,7 @@ use sui_types::authenticator_state::get_authenticator_state;
 use sui_types::balance::Balance;
 use sui_types::coin_reservation;
 use sui_types::committee::{EpochId, ProtocolVersion};
-use sui_types::crypto::{AuthoritySignInfo, Signer, default_hash};
+use sui_types::crypto::{AuthoritySignInfo, Signer};
 use sui_types::deny_list_v1::check_coin_deny_list_v1;
 use sui_types::digests::ChainIdentifier;
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName};
@@ -143,9 +144,7 @@ use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;
 use sui_types::gas::{GasCostSummary, SuiGasStatus};
-use sui_types::inner_temporary_store::{
-    InnerTemporaryStore, ObjectMap, TemporaryModuleResolver, TxCoins, WrittenObjects,
-};
+use sui_types::inner_temporary_store::{InnerTemporaryStore, ObjectMap, TxCoins, WrittenObjects};
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointCommitment, CheckpointContents, CheckpointContentsDigest,
@@ -2214,7 +2213,6 @@ impl AuthorityState {
     pub async fn dry_exec_transaction(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
     ) -> SuiResult<(
         DryRunTransactionBlockResponse,
         BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
@@ -2236,22 +2234,7 @@ impl AuthorityState {
             .into());
         }
 
-        self.dry_exec_transaction_impl(&epoch_store, transaction, transaction_digest)
-    }
-
-    #[allow(clippy::type_complexity)]
-    pub fn dry_exec_transaction_for_benchmark(
-        &self,
-        transaction: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> SuiResult<(
-        DryRunTransactionBlockResponse,
-        BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
-        TransactionEffects,
-        Option<ObjectID>,
-    )> {
-        let epoch_store = self.load_epoch_store_one_call_per_task();
-        self.dry_exec_transaction_impl(&epoch_store, transaction, transaction_digest)
+        self.dry_exec_transaction_impl(&epoch_store, transaction)
     }
 
     #[allow(clippy::type_complexity)]
@@ -2259,174 +2242,63 @@ impl AuthorityState {
         &self,
         epoch_store: &AuthorityPerEpochStore,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
     ) -> SuiResult<(
         DryRunTransactionBlockResponse,
         BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
         TransactionEffects,
         Option<ObjectID>,
     )> {
-        // Cheap validity checks for a transaction, including input size limits.
-        transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
-
-        let input_object_kinds = transaction.input_objects()?;
-        let receiving_object_refs = transaction.receiving_objects();
-
-        sui_transaction_checks::deny::check_transaction_for_signing(
-            &transaction,
-            &[],
-            &input_object_kinds,
-            &receiving_object_refs,
-            &self.config.transaction_deny_config,
-            self.get_backing_package_store().as_ref(),
+        // Route through `simulate_transaction` -- `dry-exec` matches
+        // `simulate_transaction(_, TransactionChecks::Enabled, _)`
+        let sim = self.simulate_transaction(
+            transaction.clone(),
+            TransactionChecks::Enabled,
+            /* allow_mock_gas_coin */ true,
         )?;
 
-        let (input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(
-            // We don't want to cache this transaction since it's a dry run.
-            None,
-            &input_object_kinds,
-            &receiving_object_refs,
-            epoch_store.epoch(),
-        )?;
+        self.build_dry_run_response(epoch_store, transaction, sim)
+    }
 
-        // make a gas object if one was not provided
-        let mut gas_data = transaction.gas_data().clone();
-        let is_gasless =
-            epoch_store.protocol_config().enable_gasless() && transaction.is_gasless_transaction();
-        let ((gas_status, checked_input_objects), mock_gas) = if is_gasless {
-            // Gasless transactions don't use gas coins — skip mock gas object injection.
-            (
-                sui_transaction_checks::check_transaction_input(
-                    epoch_store.protocol_config(),
-                    epoch_store.reference_gas_price(),
-                    &transaction,
-                    input_objects,
-                    &receiving_objects,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?,
-                None,
-            )
-        } else if transaction.gas().is_empty() {
-            let sender = transaction.sender();
-            // use a 1B sui coin
-            const MIST_TO_SUI: u64 = 1_000_000_000;
-            const DRY_RUN_SUI: u64 = 1_000_000_000;
-            let max_coin_value = MIST_TO_SUI * DRY_RUN_SUI;
-            let gas_object_id = ObjectID::random();
-            let gas_object = Object::new_move(
-                MoveObject::new_gas_coin(OBJECT_START_VERSION, gas_object_id, max_coin_value),
-                Owner::AddressOwner(sender),
-                TransactionDigest::genesis_marker(),
-            );
-            let gas_object_ref = gas_object.compute_object_reference();
-            gas_data.payment = vec![gas_object_ref];
-            (
-                sui_transaction_checks::check_transaction_input_with_given_gas(
-                    epoch_store.protocol_config(),
-                    epoch_store.reference_gas_price(),
-                    &transaction,
-                    input_objects,
-                    receiving_objects,
-                    gas_object,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?,
-                Some(gas_object_id),
-            )
-        } else {
-            (
-                sui_transaction_checks::check_transaction_input(
-                    epoch_store.protocol_config(),
-                    epoch_store.reference_gas_price(),
-                    &transaction,
-                    input_objects,
-                    &receiving_objects,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?,
-                None,
-            )
-        };
-
-        let protocol_config = epoch_store.protocol_config();
-        let (mut kind, signer, _) = transaction.execution_parts();
-
-        let silent = true;
-        let executor = sui_execution::executor(protocol_config, silent)
-            .expect("Creating an executor should not fail here");
-
-        let expensive_checks = false;
-        let early_execution_error = get_early_execution_error(
-            &transaction_digest,
-            &checked_input_objects,
-            self.config.certificate_deny_config.certificate_deny_set(),
-            // TODO(address-balances): This does not currently support balance withdraws properly.
-            // For address balance withdraws, this cannot detect insufficient balance. We need to
-            // first check if the balance is sufficient, similar to how we schedule withdraws.
-            // For object balance withdraws, we need to handle the case where object balance is
-            // insufficient in the post-execution.
-            &FundsWithdrawStatus::MaybeSufficient,
-        );
-        let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
-        };
-
-        // Skip on early error: the tx will fail anyway.
-        let rewritten_inputs = if execution_params.is_ok() {
-            rewrite_transaction_for_coin_reservations(
-                self.chain_identifier,
-                &*self.coin_reservation_resolver,
-                transaction.sender(),
-                &mut kind,
-                // dry run reads the latest accumulator
-                None,
-            )?
-        } else {
-            None
-        };
-
-        let (inner_temp_store, _, effects, _timings, execution_error) = self
-            .execute_transaction_to_effects(
-                executor.as_ref(),
-                self.get_backing_store().as_ref(),
-                protocol_config,
-                expensive_checks,
-                execution_params,
-                &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-                epoch_store
-                    .epoch_start_config()
-                    .epoch_data()
-                    .epoch_start_timestamp(),
-                checked_input_objects,
-                gas_data,
-                gas_status,
-                kind,
-                rewritten_inputs,
-                signer,
-                transaction_digest,
-            );
+    /// Adapt a `SimulateTransactionResult` into the
+    /// `(DryRunTransactionBlockResponse, written_objects_with_kind, effects, mock_gas_id)`
+    /// tuple that the JSON-RPC dry-run layer consumes. Shared between
+    /// `dry_exec_transaction_impl` and `dry_exec_transaction_for_benchmark`'s
+    /// callers; pulls together:
+    ///   - layout resolution over the simulate-produced `ObjectSet`,
+    ///   - `(ObjectRef, Object, WriteKind)` derivation by walking
+    ///     `effects.created / unwrapped / mutated` against that `ObjectSet`,
+    ///   - `execution_error_source` from `sim.execution_result`,
+    ///   - the `SuiTransactionBlockData` / `SuiTransactionBlockEffects` /
+    ///     `SuiTransactionBlockEvents` conversions.
+    #[allow(clippy::type_complexity)]
+    fn build_dry_run_response(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        transaction: TransactionData,
+        sim: SimulateTransactionResult,
+    ) -> SuiResult<(
+        DryRunTransactionBlockResponse,
+        BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
+        TransactionEffects,
+        Option<ObjectID>,
+    )> {
+        let SimulateTransactionResult {
+            effects,
+            events,
+            objects,
+            execution_result,
+            mock_gas_id,
+            suggested_gas_price,
+            ..
+        } = sim;
 
         let tx_digest = *effects.transaction_digest();
 
-        let module_cache =
-            TemporaryModuleResolver::new(&inner_temp_store, epoch_store.module_cache().clone());
-
-        let mut layout_resolver = epoch_store.executor().type_layout_resolver(
-            epoch_store.protocol_config(),
-            Box::new(PackageStoreWithFallback::new(
-                &inner_temp_store,
-                self.get_backing_package_store(),
-            )),
-        );
-        // Returning empty vector here because we recalculate changes in the rpc layer.
-        let object_changes = Vec::new();
-
-        // Returning empty vector here because we recalculate changes in the rpc layer.
-        let balance_changes = Vec::new();
-
-        let written_with_kind = effects
+        // Walk effects' created / unwrapped / mutated lists against the
+        // simulate-produced ObjectSet (which carries both input and written
+        // objects). Refs missing from `objects` are dropped silently — that
+        // would indicate a simulate-vs-effects inconsistency.
+        let written_with_kind: BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> = effects
             .created()
             .into_iter()
             .map(|(oref, _)| (oref, WriteKind::Create))
@@ -2442,48 +2314,53 @@ impl AuthorityState {
                     .into_iter()
                     .map(|(oref, _)| (oref, WriteKind::Mutate)),
             )
-            .map(|(oref, kind)| {
-                let obj = inner_temp_store.written.get(&oref.0).unwrap();
-                // TODO: Avoid clones.
-                (oref.0, (oref, obj.clone(), kind))
+            .filter_map(|(oref, kind)| {
+                objects
+                    .get(&ObjectKey(oref.0, oref.1))
+                    .map(|obj| (oref.0, (oref, obj.clone(), kind)))
             })
             .collect();
 
-        let execution_error_source = execution_error
+        // Resolve event/object layouts against the simulate-produced ObjectSet
+        // (newly-published packages from the simulation appear there), with the
+        // node's backing package store as fallback for already-on-chain packages.
+        let mut layout_resolver = epoch_store.executor().type_layout_resolver(
+            epoch_store.protocol_config(),
+            Box::new(OverlayBackingPackageStore::new(
+                &objects,
+                self.get_backing_package_store(),
+            )),
+        );
+
+        let execution_error_source = execution_result
             .as_ref()
             .err()
             .and_then(|e| e.source_ref().as_ref().map(|e| e.to_string()));
 
-        Ok((
-            DryRunTransactionBlockResponse {
-                suggested_gas_price: self
-                    .congestion_tracker
-                    .get_suggested_gas_prices(&transaction),
-                input: SuiTransactionBlockData::try_from_with_module_cache(
-                    transaction,
-                    &module_cache,
-                )
-                .map_err(|e| SuiErrorKind::TransactionSerializationError {
-                    error: format!(
-                        "Failed to convert transaction to SuiTransactionBlockData: {}",
-                        e
-                    ),
-                })?, // TODO: replace the underlying try_from to SuiError. This one goes deep
-                effects: effects.clone().try_into()?,
-                events: SuiTransactionBlockEvents::try_from(
-                    inner_temp_store.events.clone(),
-                    tx_digest,
-                    None,
-                    layout_resolver.as_mut(),
-                )?,
-                object_changes,
-                balance_changes,
-                execution_error_source,
-            },
-            written_with_kind,
-            effects,
-            mock_gas,
-        ))
+        let response = DryRunTransactionBlockResponse {
+            suggested_gas_price,
+            input: SuiTransactionBlockData::try_from_with_module_cache(
+                transaction,
+                &epoch_store.module_cache().clone(),
+            )
+            .map_err(|e| SuiErrorKind::TransactionSerializationError {
+                error: format!("Failed to convert transaction to SuiTransactionBlockData: {e}"),
+            })?,
+            effects: effects.clone().try_into()?,
+            events: SuiTransactionBlockEvents::try_from(
+                events.unwrap_or_default(),
+                tx_digest,
+                None,
+                layout_resolver.as_mut(),
+            )?,
+            // The RPC layer recalculates object_changes / balance_changes from
+            // the written_objects map and effects.
+            object_changes: Vec::new(),
+            balance_changes: Vec::new(),
+            execution_error_source,
+        };
+
+        Ok((response, written_with_kind, effects, mock_gas_id))
     }
 
     pub fn simulate_transaction(
@@ -2757,7 +2634,6 @@ impl AuthorityState {
     }
 
     /// The object ID for gas can be any object ID, even for an uncreated object
-    #[allow(clippy::collapsible_else_if)]
     #[instrument(skip_all)]
     pub async fn dev_inspect_transaction_block(
         &self,
@@ -2771,41 +2647,19 @@ impl AuthorityState {
         skip_checks: Option<bool>,
     ) -> SuiResult<DevInspectResults> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
-
-        if !self.is_fullnode(&epoch_store) {
-            return Err(SuiErrorKind::UnsupportedFeatureError {
-                error: "dev-inspect is only supported on fullnodes".to_string(),
-            }
-            .into());
-        }
-
-        if transaction_kind.is_system_tx() {
-            return Err(SuiErrorKind::UnsupportedFeatureError {
-                error: "system transactions are not supported".to_string(),
-            }
-            .into());
-        }
+        let protocol_config = epoch_store.protocol_config();
+        let reference_gas_price = epoch_store.reference_gas_price();
 
         let skip_checks = skip_checks.unwrap_or(true);
-        if skip_checks && self.config.dev_inspect_disabled {
-            return Err(SuiErrorKind::UnsupportedFeatureError {
-                error: "dev-inspect with skip_checks is not allowed on this node".to_string(),
-            }
-            .into());
-        }
-
         let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
-        let reference_gas_price = epoch_store.reference_gas_price();
-        let protocol_config = epoch_store.protocol_config();
-        let max_tx_gas = protocol_config.max_tx_gas();
 
+        // Synthesize the full TransactionData the caller would have signed.
         let price = gas_price.unwrap_or(reference_gas_price);
-        let budget = gas_budget.unwrap_or(max_tx_gas);
+        let budget = gas_budget.unwrap_or(protocol_config.max_tx_gas());
         let owner = gas_sponsor.unwrap_or(sender);
-        // Payment might be empty here, but it's fine we'll have to deal with it later after reading all the input objects.
         let payment = gas_objects.unwrap_or_default();
-        let mut transaction = TransactionData::V1(TransactionDataV1 {
-            kind: transaction_kind.clone(),
+        let transaction = TransactionData::V1(TransactionDataV1 {
+            kind: transaction_kind,
             sender,
             gas_data: GasData {
                 payment,
@@ -2816,6 +2670,8 @@ impl AuthorityState {
             expiration: TransactionExpiration::None,
         });
 
+        // Capture raw bytes before simulate (which may mutate gas_data for mock
+        // gas injection).
         let raw_txn_data = if show_raw_txn_data_and_effects {
             bcs::to_bytes(&transaction).map_err(|_| {
                 SuiErrorKind::TransactionSerializationError {
@@ -2826,159 +2682,42 @@ impl AuthorityState {
             vec![]
         };
 
-        transaction.validity_check_no_gas_check(protocol_config)?;
-
-        let input_object_kinds = transaction.input_objects()?;
-        let receiving_object_refs = transaction.receiving_objects();
-
-        sui_transaction_checks::deny::check_transaction_for_signing(
-            &transaction,
-            &[],
-            &input_object_kinds,
-            &receiving_object_refs,
-            &self.config.transaction_deny_config,
-            self.get_backing_package_store().as_ref(),
-        )?;
-
-        let (mut input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(
-            // We don't want to cache this transaction since it's a dev inspect.
-            None,
-            &input_object_kinds,
-            &receiving_object_refs,
-            epoch_store.epoch(),
-        )?;
-
-        let (gas_status, checked_input_objects) = if skip_checks {
-            // If we are skipping checks, then we call the check_dev_inspect_input function which will perform
-            // only lightweight checks on the transaction input. And if the gas field is empty, that means we will
-            // use the dummy gas object so we need to add it to the input objects vector.
-            if transaction.gas().is_empty() {
-                // Create and use a dummy gas object if there is no gas object provided.
-                let dummy_gas_object = Object::new_gas_with_balance_and_owner_for_testing(
-                    DEV_INSPECT_GAS_COIN_VALUE,
-                    transaction.gas_owner(),
-                );
-                let gas_object_ref = dummy_gas_object.compute_object_reference();
-                transaction.gas_data_mut().payment = vec![gas_object_ref];
-                input_objects.push(ObjectReadResult::new(
-                    InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref),
-                    dummy_gas_object.into(),
-                ));
-            }
-            sui_transaction_checks::check_dev_inspect_input(
-                protocol_config,
-                &transaction,
-                input_objects,
-                receiving_objects,
-                reference_gas_price,
-            )?
+        // Route through `simulate_transaction`:
+        //   skip_checks = true  → TransactionChecks::Disabled
+        //   skip_checks = false → TransactionChecks::Enabled
+        let checks = if skip_checks {
+            TransactionChecks::Disabled
         } else {
-            // If we are not skipping checks, then we call the check_transaction_input function and its dummy gas
-            // variant which will perform full fledged checks just like a real transaction execution.
-            if transaction.gas().is_empty() {
-                // Create and use a dummy gas object if there is no gas object provided.
-                let dummy_gas_object = Object::new_gas_with_balance_and_owner_for_testing(
-                    DEV_INSPECT_GAS_COIN_VALUE,
-                    transaction.gas_owner(),
-                );
-                let gas_object_ref = dummy_gas_object.compute_object_reference();
-                transaction.gas_data_mut().payment = vec![gas_object_ref];
-                sui_transaction_checks::check_transaction_input_with_given_gas(
-                    epoch_store.protocol_config(),
-                    epoch_store.reference_gas_price(),
-                    &transaction,
-                    input_objects,
-                    receiving_objects,
-                    dummy_gas_object,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?
-            } else {
-                sui_transaction_checks::check_transaction_input(
-                    epoch_store.protocol_config(),
-                    epoch_store.reference_gas_price(),
-                    &transaction,
-                    input_objects,
-                    &receiving_objects,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?
-            }
+            TransactionChecks::Enabled
         };
-
-        let executor = sui_execution::executor(protocol_config, /* silent */ true)
-            .expect("Creating an executor should not fail here");
-        let gas_data = transaction.gas_data().clone();
-        let intent_msg = IntentMessage::new(
-            Intent {
-                version: IntentVersion::V0,
-                scope: IntentScope::TransactionData,
-                app_id: AppId::Sui,
-            },
-            transaction,
-        );
-        let transaction_digest = TransactionDigest::new(default_hash(&intent_msg.value));
-        let early_execution_error = get_early_execution_error(
-            &transaction_digest,
-            &checked_input_objects,
-            self.config.certificate_deny_config.certificate_deny_set(),
-            // TODO(address-balances): Mimic withdraw scheduling and pass the result.
-            &FundsWithdrawStatus::MaybeSufficient,
-        );
-        let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
-        };
-
-        let mut transaction_kind = transaction_kind;
-        let rewritten_inputs = rewrite_transaction_for_coin_reservations(
-            self.chain_identifier,
-            &*self.coin_reservation_resolver,
-            sender,
-            &mut transaction_kind,
-            None,
-        )?;
-        let (inner_temp_store, _, effects, execution_result) = executor.dev_inspect_transaction(
-            self.get_backing_store().as_ref(),
-            protocol_config,
-            self.metrics.execution_metrics.clone(),
-            /* expensive checks */ false,
-            execution_params,
-            &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-            epoch_store
-                .epoch_start_config()
-                .epoch_data()
-                .epoch_start_timestamp(),
-            checked_input_objects,
-            gas_data,
-            gas_status,
-            transaction_kind,
-            rewritten_inputs,
-            sender,
-            transaction_digest,
-            skip_checks,
-        );
+        let sim =
+            self.simulate_transaction(transaction, checks, /* allow_mock_gas_coin */ true)?;
 
         let raw_effects = if show_raw_txn_data_and_effects {
-            bcs::to_bytes(&effects).map_err(|_| SuiErrorKind::TransactionSerializationError {
-                error: "Failed to serialize transaction effects during dev inspect".to_string(),
+            bcs::to_bytes(&sim.effects).map_err(|_| {
+                SuiErrorKind::TransactionSerializationError {
+                    error: "Failed to serialize transaction effects during dev inspect".to_string(),
+                }
             })?
         } else {
             vec![]
         };
 
+        // Resolve event/object layouts against the simulate-produced ObjectSet
+        // (newly-published packages from the simulation appear there), with the
+        // node's backing package store as fallback for already-on-chain packages.
         let mut layout_resolver = epoch_store.executor().type_layout_resolver(
             epoch_store.protocol_config(),
-            Box::new(PackageStoreWithFallback::new(
-                &inner_temp_store,
+            Box::new(OverlayBackingPackageStore::new(
+                &sim.objects,
                 self.get_backing_package_store(),
             )),
         );
 
         DevInspectResults::new(
-            effects,
-            inner_temp_store.events.clone(),
-            execution_result,
+            sim.effects,
+            sim.events.unwrap_or_default(),
+            sim.execution_result,
             raw_txn_data,
             raw_effects,
             layout_resolver.as_mut(),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -256,13 +256,8 @@ async fn test_dry_run_transaction_block() {
         .unwrap()
         .version();
 
-    let transaction_digest = *transaction.digest();
-
     let (response, _, _, _) = fullnode
-        .dry_exec_transaction(
-            transaction.data().intent_message().value.clone(),
-            transaction_digest,
-        )
+        .dry_exec_transaction(transaction.data().intent_message().value.clone())
         .await
         .unwrap();
     assert_eq!(*response.effects.status(), SuiExecutionStatus::Success);
@@ -286,10 +281,7 @@ async fn test_dry_run_transaction_block() {
         txn_data.gas_budget(),
         txn_data.gas_price(),
     );
-    let (response, _, _, _) = fullnode
-        .dry_exec_transaction(txn_data, transaction_digest)
-        .await
-        .unwrap();
+    let (response, _, _, _) = fullnode.dry_exec_transaction(txn_data).await.unwrap();
     let gas_usage_no_gas = response.effects.gas_cost_summary();
     assert_eq!(*response.effects.status(), SuiExecutionStatus::Success);
     assert_eq!(gas_usage, gas_usage_no_gas);
@@ -318,10 +310,7 @@ async fn test_dry_run_no_gas_big_transfer() {
     let signed = to_sender_signed_transaction(data, &sender_key);
 
     let (dry_run_res, _, _, _) = fullnode
-        .dry_exec_transaction(
-            signed.data().intent_message().value.clone(),
-            *signed.digest(),
-        )
+        .dry_exec_transaction(signed.data().intent_message().value.clone())
         .await
         .unwrap();
     assert_eq!(*dry_run_res.effects.status(), SuiExecutionStatus::Success);
@@ -994,12 +983,8 @@ async fn test_dev_inspect_on_validator() {
 async fn test_dry_run_on_validator() {
     let (validator, _fullnode, transaction, _gas_object_id, _shared_object_id) =
         construct_shared_object_transaction_with_sequence_number(None).await;
-    let transaction_digest = *transaction.digest();
     let response = validator
-        .dry_exec_transaction(
-            transaction.data().intent_message().value.clone(),
-            transaction_digest,
-        )
+        .dry_exec_transaction(transaction.data().intent_message().value.clone())
         .await;
     assert!(response.is_err());
 }
@@ -1114,13 +1099,11 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
         rgp,
     );
-    let transaction = to_sender_signed_transaction(data.clone(), &sender_key);
-    let digest = *transaction.digest();
     let DryRunTransactionBlockResponse {
         effects,
         execution_error_source,
         ..
-    } = fullnode.dry_exec_transaction(data, digest).await.unwrap().0;
+    } = fullnode.dry_exec_transaction(data).await.unwrap().0;
 
     assert_eq!(effects.deleted().len(), 0);
     assert!(execution_error_source.is_some());
@@ -1137,7 +1120,7 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
 // tests using a gas coin with version MAX - 1
 #[tokio::test]
 async fn test_dry_run_dev_inspect_max_gas_version() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let (sender, _sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectID::random();
     let (validator, fullnode) = init_state_validator_with_fullnode().await;
     let (validator, object_basics) = publish_object_basics(validator).await;
@@ -1180,10 +1163,8 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
         rgp,
     );
-    let transaction = to_sender_signed_transaction(data.clone(), &sender_key);
-    let digest = *transaction.digest();
     let DryRunTransactionBlockResponse { effects, .. } =
-        fullnode.dry_exec_transaction(data, digest).await.unwrap().0;
+        fullnode.dry_exec_transaction(data).await.unwrap().0;
     assert_eq!(effects.status(), &SuiExecutionStatus::Success);
 }
 
@@ -3901,7 +3882,7 @@ async fn test_iter_live_object_set() {
 
 #[tokio::test]
 async fn test_clever_abort_error() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let (sender, _sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectID::random();
     let (validator, fullnode) = init_state_validator_with_fullnode().await;
     let (validator, aborts) = publish_aborts(validator).await;
@@ -3936,17 +3917,11 @@ async fn test_clever_abort_error() {
         rgp,
     );
 
-    let transaction = to_sender_signed_transaction(txn_data.clone(), &sender_key);
-    let digest = *transaction.digest();
     let DryRunTransactionBlockResponse {
         effects,
         execution_error_source,
         ..
-    } = fullnode
-        .dry_exec_transaction(txn_data, digest)
-        .await
-        .unwrap()
-        .0;
+    } = fullnode.dry_exec_transaction(txn_data).await.unwrap().0;
 
     assert!(matches!(
         effects.status(),
@@ -3983,17 +3958,11 @@ async fn test_clever_abort_error() {
         rgp,
     );
 
-    let transaction = to_sender_signed_transaction(txn_data.clone(), &sender_key);
-    let digest = *transaction.digest();
     let DryRunTransactionBlockResponse {
         effects,
         execution_error_source,
         ..
-    } = fullnode
-        .dry_exec_transaction(txn_data, digest)
-        .await
-        .unwrap()
-        .0;
+    } = fullnode.dry_exec_transaction(txn_data).await.unwrap().0;
 
     assert!(matches!(
         effects.status(),
@@ -4032,17 +4001,11 @@ async fn test_clever_abort_error() {
         rgp,
     );
 
-    let transaction = to_sender_signed_transaction(txn_data.clone(), &sender_key);
-    let digest = *transaction.digest();
     let DryRunTransactionBlockResponse {
         effects,
         execution_error_source,
         ..
-    } = fullnode
-        .dry_exec_transaction(txn_data, digest)
-        .await
-        .unwrap()
-        .0;
+    } = fullnode.dry_exec_transaction(txn_data).await.unwrap().0;
 
     assert!(matches!(
         effects.status(),
@@ -4080,17 +4043,11 @@ async fn test_clever_abort_error() {
         rgp,
     );
 
-    let transaction = to_sender_signed_transaction(txn_data.clone(), &sender_key);
-    let digest = *transaction.digest();
     let DryRunTransactionBlockResponse {
         effects,
         execution_error_source,
         ..
-    } = fullnode
-        .dry_exec_transaction(txn_data, digest)
-        .await
-        .unwrap()
-        .0;
+    } = fullnode.dry_exec_transaction(txn_data).await.unwrap().0;
 
     assert!(matches!(
         effects.status(),
@@ -5376,10 +5333,7 @@ async fn test_for_inc_201_dry_run() {
         _,
         _,
     ) = fullnode
-        .dry_exec_transaction(
-            signed.data().intent_message().value.clone(),
-            *signed.digest(),
-        )
+        .dry_exec_transaction(signed.data().intent_message().value.clone())
         .await
         .unwrap();
     assert_eq!(effects.status(), &SuiExecutionStatus::Success);
@@ -5431,10 +5385,7 @@ async fn test_function_not_found() {
         _,
         _,
     ) = fullnode
-        .dry_exec_transaction(
-            signed.data().intent_message().value.clone(),
-            *signed.digest(),
-        )
+        .dry_exec_transaction(signed.data().intent_message().value.clone())
         .await
         .unwrap();
     assert_eq!(
@@ -5488,10 +5439,7 @@ async fn test_arity_mismatch() {
         _,
         _,
     ) = authority
-        .dry_exec_transaction(
-            signed.data().intent_message().value.clone(),
-            *signed.digest(),
-        )
+        .dry_exec_transaction(signed.data().intent_message().value.clone())
         .await
         .unwrap();
     assert_eq!(

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -205,12 +205,7 @@ async fn run_all_entry_points(env: &TestEnv, data: TransactionData) -> Vec<Entry
     results.push((NodeEntryPoint::Validator, mapped));
 
     // Path 2: Fullnode dry_exec_transaction
-    let tx_digest = TransactionDigest::new(Default::default());
-    let mapped = match env
-        .fullnode
-        .dry_exec_transaction(data.clone(), tx_digest)
-        .await
-    {
+    let mapped = match env.fullnode.dry_exec_transaction(data.clone()).await {
         Ok((_, _, effects, _)) => Ok(effects.gas_cost_summary().clone()),
         Err(e) => Err(e),
     };

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -8,8 +8,7 @@ use sui_test_transaction_builder::{FundSource, TestTransactionBuilder};
 use sui_types::{
     base_types::{FullObjectRef, ObjectID, SequenceNumber, SuiAddress},
     coin_reservation::ParsedObjectRefWithdrawal,
-    crypto::default_hash,
-    digests::{CheckpointDigest, TransactionDigest},
+    digests::CheckpointDigest,
     effects::TransactionEffectsAPI,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
@@ -1413,14 +1412,13 @@ async fn test_fake_coin_reservation_dry_run_does_not_panic() {
         },
         expiration: TransactionExpiration::None,
     });
-    let digest = TransactionDigest::new(default_hash(&tx_data));
 
     let state = test_env
         .cluster
         .fullnode_handle
         .sui_node
         .with(|node| node.state().clone());
-    let join = tokio::task::spawn(async move { state.dry_exec_transaction(tx_data, digest).await });
+    let join = tokio::task::spawn(async move { state.dry_exec_transaction(tx_data).await });
 
     match join.await {
         Ok(Ok(_)) => panic!("dry-run with fake coin reservation should have errored"),
@@ -1522,14 +1520,13 @@ async fn test_fake_coin_reservation_dry_run_safe_when_flag_disabled() {
         },
         expiration: TransactionExpiration::None,
     });
-    let digest = TransactionDigest::new(default_hash(&tx_data));
 
     let state = test_env
         .cluster
         .fullnode_handle
         .sui_node
         .with(|node| node.state().clone());
-    let join = tokio::task::spawn(async move { state.dry_exec_transaction(tx_data, digest).await });
+    let join = tokio::task::spawn(async move { state.dry_exec_transaction(tx_data).await });
 
     match join.await {
         Ok(Ok(_)) => panic!("dry-run with fake coin reservation should have errored"),

--- a/crates/sui-e2e-tests/tests/gasless_tests.rs
+++ b/crates/sui-e2e-tests/tests/gasless_tests.rs
@@ -139,14 +139,11 @@ async fn test_gasless_dryrun() {
         0,
         0,
     );
-    let tx_digest = sui_types::digests::TransactionDigest::genesis_marker();
     let result = test_env
         .cluster
         .fullnode_handle
         .sui_node
-        .with_async(
-            |node| async move { node.state().dry_exec_transaction(tx_data, tx_digest).await },
-        )
+        .with_async(|node| async move { node.state().dry_exec_transaction(tx_data).await })
         .await;
     assert!(
         result.is_ok(),

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -109,7 +109,6 @@ pub trait StateRead: Send + Sync {
     async fn dry_exec_transaction(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
     ) -> StateReadResult<(
         DryRunTransactionBlockResponse,
         BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
@@ -371,16 +370,13 @@ impl StateRead for AuthorityState {
     async fn dry_exec_transaction(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
     ) -> StateReadResult<(
         DryRunTransactionBlockResponse,
         BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
         TransactionEffects,
         Option<ObjectID>,
     )> {
-        Ok(self
-            .dry_exec_transaction(transaction, transaction_digest)
-            .await?)
+        Ok(self.dry_exec_transaction(transaction).await?)
     }
 
     async fn dev_inspect_transaction_block(

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -16,7 +16,6 @@ use crate::{
     ObjectProviderCache, SuiRpcModule, get_balance_changes_from_effect, get_object_changes,
     with_tracing,
 };
-use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use sui_core::authority::AuthorityState;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactionOrchestrator;
@@ -27,7 +26,6 @@ use sui_json_rpc_types::{
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::SuiAddress;
-use sui_types::crypto::default_hash;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::signature::GenericSignature;
@@ -269,32 +267,20 @@ impl TransactionExecutionApi {
     pub fn prepare_dry_run_transaction_block(
         &self,
         tx_bytes: Base64,
-    ) -> Result<(TransactionData, TransactionDigest, Vec<InputObjectKind>), SuiRpcInputError> {
+    ) -> Result<(TransactionData, Vec<InputObjectKind>), SuiRpcInputError> {
         let tx_data: TransactionData = self.convert_bytes(tx_bytes)?;
         let input_objs = tx_data.input_objects()?;
-        let intent_msg = IntentMessage::new(
-            Intent {
-                version: IntentVersion::V0,
-                scope: IntentScope::TransactionData,
-                app_id: AppId::Sui,
-            },
-            tx_data,
-        );
-        let txn_digest = TransactionDigest::new(default_hash(&intent_msg.value));
-        Ok((intent_msg.value, txn_digest, input_objs))
+        Ok((tx_data, input_objs))
     }
 
     async fn dry_run_transaction_block(
         &self,
         tx_bytes: Base64,
     ) -> Result<DryRunTransactionBlockResponse, Error> {
-        let (txn_data, txn_digest, input_objs) =
-            self.prepare_dry_run_transaction_block(tx_bytes)?;
+        let (txn_data, input_objs) = self.prepare_dry_run_transaction_block(tx_bytes)?;
         let sender = txn_data.sender();
-        let (resp, written_objects, transaction_effects, mock_gas) = self
-            .state
-            .dry_exec_transaction(txn_data.clone(), txn_digest)
-            .await?;
+        let (resp, written_objects, transaction_effects, mock_gas) =
+            self.state.dry_exec_transaction(txn_data.clone()).await?;
         let object_cache = ObjectProviderCache::new_with_cache(self.state.clone(), written_objects);
         let balance_changes = get_balance_changes_from_effect(
             &object_cache,

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -21,7 +21,7 @@ use sui_types::digests::ChainIdentifier;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::gas_coin::GAS;
 use sui_types::transaction::DEFAULT_VALIDATOR_GAS_PRICE;
-use sui_types::transaction::{Argument, Command, Transaction};
+use sui_types::transaction::{Argument, Command, Transaction, TransactionKey};
 use sui_types::{Identifier, SUI_FRAMEWORK_PACKAGE_ID};
 use tracing::{info, warn};
 
@@ -243,9 +243,8 @@ impl BenchmarkContext {
     ) {
         let assigned_versions = assigned_versions.into_map();
         if print_sample_tx {
-            // We must use the first transaction in case there are shared objects and the transactions
-            // must be executed in order.
-            self.execute_sample_transaction(&transactions[0]).await;
+            self.execute_sample_transaction(&transactions, &assigned_versions)
+                .await;
         }
 
         let tx_count = transactions.len();
@@ -309,8 +308,10 @@ impl BenchmarkContext {
         assigned_versions: AssignedTxAndVersions,
         print_sample_tx: bool,
     ) {
+        let assigned_versions = assigned_versions.into_map();
         if print_sample_tx {
-            self.execute_sample_transaction(&transactions[0]).await;
+            self.execute_sample_transaction(&transactions, &assigned_versions)
+                .await;
         }
 
         let tx_count = transactions.len();
@@ -355,16 +356,31 @@ impl BenchmarkContext {
     }
 
     /// Print out a sample transaction and its effects so that we can get a rough idea
-    /// what we are measuring.
-    async fn execute_sample_transaction(&self, sample_transaction: &Transaction) {
+    /// what we are measuring. Effects are produced against a throwaway in-memory
+    /// snapshot of validator state so the real benchmark loop can still execute
+    /// the same transaction afterwards.
+    async fn execute_sample_transaction(
+        &self,
+        transactions: &[Transaction],
+        assigned_versions: &HashMap<TransactionKey, AssignedVersions>,
+    ) {
+        // We must use the first transaction in case there are shared objects
+        // and the transactions must be executed in order.
+        let sample = &transactions[0];
+        let versions = assigned_versions
+            .get(&sample.key())
+            .cloned()
+            .unwrap_or_default();
+
         info!(
             "Sample transaction digest={:?}: {:?}",
-            sample_transaction.digest(),
-            sample_transaction.data()
+            sample.digest(),
+            sample.data()
         );
+        let sandbox = self.validator.create_in_memory_store();
         let effects = self
-            .validator()
-            .execute_dry_run(sample_transaction.clone())
+            .validator
+            .execute_transaction_in_memory(sandbox, sample.clone(), &versions)
             .await;
         info!("Sample effects: {:?}\n\n", effects);
         assert!(effects.status().is_ok());
@@ -376,7 +392,9 @@ impl BenchmarkContext {
         assigned_versions: AssignedTxAndVersions,
         checkpoint_size: usize,
     ) {
-        self.execute_sample_transaction(&transactions[0]).await;
+        let assigned_versions = assigned_versions.into_map();
+        self.execute_sample_transaction(&transactions, &assigned_versions)
+            .await;
 
         info!("Executing all transactions to generate effects");
         let tx_count = transactions.len();
@@ -450,10 +468,9 @@ impl BenchmarkContext {
         &self,
         store: InMemoryObjectStore,
         transactions: Vec<Transaction>,
-        assigned_versions: AssignedTxAndVersions,
+        assigned_versions: HashMap<TransactionKey, AssignedVersions>,
     ) -> Vec<TransactionEffects> {
         let is_consensus_tx = transactions.iter().any(|tx| tx.is_consensus_tx());
-        let assigned_versions = assigned_versions.into_map();
         if is_consensus_tx {
             // With shared objects, we must execute each transaction in order.
             let mut effects = Vec::new();

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -123,19 +123,6 @@ impl SingleValidator {
         effects
     }
 
-    pub async fn execute_dry_run(&self, transaction: Transaction) -> TransactionEffects {
-        let effects = self
-            .get_validator()
-            .dry_exec_transaction_for_benchmark(
-                transaction.data().intent_message().value.clone(),
-                *transaction.digest(),
-            )
-            .unwrap()
-            .2;
-        assert!(effects.status().is_ok());
-        effects
-    }
-
     /// Creates a VerifiedExecutableTransaction from a Transaction using MFP style certification.
     fn create_executable(&self, transaction: Transaction) -> VerifiedExecutableTransaction {
         VerifiedExecutableTransaction::new_from_consensus(

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -128,7 +128,6 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
     async fn dry_run_transaction_block(
         &self,
         transaction_block: TransactionData,
-        transaction_digest: TransactionDigest,
     ) -> SuiResult<DryRunTransactionBlockResponse>;
 
     async fn dev_inspect_transaction_block(
@@ -212,10 +211,9 @@ impl TransactionalAdapter for ValidatorWithFullnode {
     async fn dry_run_transaction_block(
         &self,
         transaction_block: TransactionData,
-        transaction_digest: TransactionDigest,
     ) -> SuiResult<DryRunTransactionBlockResponse> {
         self.fullnode
-            .dry_exec_transaction(transaction_block, transaction_digest)
+            .dry_exec_transaction(transaction_block)
             .await
             .map(|result| result.0)
     }
@@ -499,7 +497,6 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
     async fn dry_run_transaction_block(
         &self,
         _transaction_block: TransactionData,
-        _transaction_digest: TransactionDigest,
     ) -> SuiResult<DryRunTransactionBlockResponse> {
         unimplemented!("dry_run_transaction_block not supported in simulator mode")
     }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -2184,11 +2184,7 @@ impl SuiTestAdapter {
     }
 
     async fn dry_run(&mut self, transaction: TransactionData) -> anyhow::Result<TxnSummary> {
-        let digest = transaction.digest();
-        let results = self
-            .executor
-            .dry_run_transaction_block(transaction, digest)
-            .await?;
+        let results = self.executor.dry_run_transaction_block(transaction).await?;
         let DryRunTransactionBlockResponse {
             effects, events, ..
         } = results;

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -12,7 +12,6 @@ use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
 use sui_move_build::BuildConfig;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::crypto::get_authority_key_pair;
-use sui_types::digests::TransactionDigest;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::SuiError;
 use sui_types::execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus};
@@ -167,9 +166,8 @@ impl Executor {
     }
 
     pub fn dry_run_transaction(&self, tx_data: TransactionData) -> Result<(), SuiError> {
-        let digest = TransactionDigest::random();
         self.rt
-            .block_on(self.state.dry_exec_transaction(tx_data, digest))
+            .block_on(self.state.dry_exec_transaction(tx_data))
             .map(|_| ())
     }
 


### PR DESCRIPTION
## Description 

This removes a bunch of duplicate logic and code, makes sure that there is one source of truth for dry-run/dev-inspect semantics, and cleans up the internal API a bit.

## Test plan 

Existing tests

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
