### PR TITLE
sui-types: convert ValidDuring TransactionExpiration from proto

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -16,6 +16,7 @@ use sui_rpc::proto::sui::rpc::v2::ObjectReference;
 use sui_rpc::proto::sui::rpc::v2::ProgrammableTransaction;
 use sui_rpc::proto::sui::rpc::v2::SimulateTransactionRequest;
 use sui_rpc::proto::sui::rpc::v2::Transaction;
+use sui_rpc::proto::sui::rpc::v2::TransactionExpiration as ProtoTransactionExpiration;
 use sui_rpc::proto::sui::rpc::v2::TransactionKind;
 use sui_rpc::proto::sui::rpc::v2::TransferObjects;
 use sui_rpc::proto::sui::rpc::v2::UserSignature;
@@ -810,4 +811,136 @@ async fn test_gas_selection_with_address_balance() {
         resolved.transaction().transaction().expiration().kind(),
         TransactionExpirationKind::ValidDuring
     );
+}
+
+#[sim_test]
+async fn simulate_transaction_with_valid_during_expiration() {
+    let _guard = sui_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
+        cfg.create_root_accumulator_object_for_testing();
+        cfg.enable_address_balance_gas_payments_for_testing();
+        cfg
+    });
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+
+    let mut client = sui_rpc::Client::new(test_cluster.rpc_url()).unwrap();
+    let chain_id = test_cluster.get_chain_identifier();
+    let receiver = test_cluster.get_address_1();
+
+    // Fund the receiver's address balance with enough SUI to cover the gas budget.
+    let txn = sui_test_transaction_builder::make_transfer_sui_address_balance_transaction(
+        &test_cluster.wallet,
+        Some(receiver),
+        100_000_000_000,
+    )
+    .await;
+    super::super::execute_transaction(&mut client, &txn).await;
+
+    let current_epoch = test_cluster
+        .fullnode_handle
+        .sui_node
+        .with(|node| node.state().epoch_store_for_testing().epoch());
+
+    let supplied_nonce: u32 = 0xdead_beef;
+    let supplied_chain_str = sui_sdk_types::Digest::new(*chain_id.as_bytes()).to_string();
+
+    let mut transaction = Transaction::default();
+    {
+        let ptb = transaction.kind_mut().programmable_transaction_mut();
+        ptb.set_inputs(vec![Input::default().with_object_id("0x6")]);
+        ptb.set_commands(vec![Command::from(
+            MoveCall::default()
+                .with_package("0x2")
+                .with_module("clock")
+                .with_function("timestamp_ms")
+                .with_arguments(vec![Argument::new_input(0)]),
+        )])
+    }
+    transaction.set_sender(receiver.to_string());
+    transaction.set_expiration(
+        ProtoTransactionExpiration::default()
+            .with_kind(TransactionExpirationKind::ValidDuring)
+            .with_epoch(current_epoch.saturating_add(1))
+            .with_min_epoch(current_epoch)
+            .with_chain(supplied_chain_str.clone())
+            .with_nonce(supplied_nonce),
+    );
+
+    let resolved = client
+        .execution_client()
+        .simulate_transaction(
+            SimulateTransactionRequest::new(transaction).with_do_gas_selection(true),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    // The transaction must simulate successfully and have used the address balance for gas.
+    assert!(resolved.transaction().effects().status().success());
+    assert!(
+        resolved
+            .transaction()
+            .transaction()
+            .gas_payment()
+            .objects()
+            .is_empty()
+    );
+
+    // The supplied `ValidDuring` expiration must round-trip through the conversion unchanged.
+    let resolved_expiration = resolved.transaction().transaction().expiration();
+    assert_eq!(
+        resolved_expiration.kind(),
+        TransactionExpirationKind::ValidDuring
+    );
+    assert_eq!(resolved_expiration.epoch, Some(current_epoch + 1));
+    assert_eq!(resolved_expiration.min_epoch, Some(current_epoch));
+    assert!(resolved_expiration.min_timestamp.is_none());
+    assert!(resolved_expiration.max_timestamp.is_none());
+    assert_eq!(
+        resolved_expiration.chain.as_deref(),
+        Some(supplied_chain_str.as_str())
+    );
+    assert_eq!(resolved_expiration.nonce, Some(supplied_nonce));
+
+    // The BCS-encoded `TransactionData` must also carry the supplied `ValidDuring` expiration.
+    let (transaction_data, _, _) = proto_to_response(resolved);
+    assert!(matches!(
+        transaction_data.expiration(),
+        sui_types::transaction::TransactionExpiration::ValidDuring {
+            min_epoch: Some(min),
+            max_epoch: Some(max),
+            min_timestamp: None,
+            max_timestamp: None,
+            chain,
+            nonce,
+        } if *min == current_epoch
+            && *max == current_epoch + 1
+            && *chain == chain_id
+            && *nonce == supplied_nonce
+    ));
+}
+
+#[test]
+fn valid_during_transaction_expiration_round_trips_through_proto() {
+    use sui_types::transaction::TransactionExpiration;
+
+    let chain = sui_types::digests::ChainIdentifier::from(
+        sui_types::digests::CheckpointDigest::new([7u8; 32]),
+    );
+    let original = TransactionExpiration::ValidDuring {
+        min_epoch: Some(42),
+        max_epoch: Some(43),
+        min_timestamp: Some(1_700_000_000_123),
+        max_timestamp: Some(1_700_000_999_456),
+        chain,
+        nonce: 0xc0ffee,
+    };
+
+    let proto = ProtoTransactionExpiration::from(original);
+    let round_tripped = TransactionExpiration::try_from(&proto).unwrap();
+
+    assert_eq!(round_tripped, original);
 }

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -11,6 +11,21 @@ fn ms_to_timestamp(ms: u64) -> prost_types::Timestamp {
         nanos: ((ms % 1000) * 1_000_000) as _,
     }
 }
+
+fn timestamp_to_ms(timestamp: &prost_types::Timestamp) -> Result<u64, &'static str> {
+    let seconds: u64 = timestamp
+        .seconds
+        .try_into()
+        .map_err(|_| "invalid timestamp: negative seconds")?;
+    let nanos: u64 = timestamp
+        .nanos
+        .try_into()
+        .map_err(|_| "invalid timestamp: negative nanos")?;
+    seconds
+        .checked_mul(1000)
+        .and_then(|ms| ms.checked_add(nanos / 1_000_000))
+        .ok_or("invalid timestamp: out of range")
+}
 use crate::message_envelope::Message as _;
 use fastcrypto::traits::ToFromBytes;
 use sui_rpc::field::FieldMaskTree;
@@ -2289,6 +2304,39 @@ impl TryFrom<&TransactionExpiration> for crate::transaction::TransactionExpirati
         Ok(match value.kind() {
             TransactionExpirationKind::None => Self::None,
             TransactionExpirationKind::Epoch => Self::Epoch(value.epoch()),
+            TransactionExpirationKind::ValidDuring => {
+                let chain_str = value
+                    .chain
+                    .as_deref()
+                    .ok_or("ValidDuring expiration is missing chain")?;
+                let chain_digest: sui_sdk_types::Digest = chain_str
+                    .parse()
+                    .map_err(|_| "ValidDuring expiration has invalid chain digest")?;
+                let chain = crate::digests::ChainIdentifier::from(
+                    crate::digests::CheckpointDigest::new(chain_digest.into_inner()),
+                );
+                let nonce = value
+                    .nonce
+                    .ok_or("ValidDuring expiration is missing nonce")?;
+                let min_timestamp = value
+                    .min_timestamp
+                    .as_ref()
+                    .map(timestamp_to_ms)
+                    .transpose()?;
+                let max_timestamp = value
+                    .max_timestamp
+                    .as_ref()
+                    .map(timestamp_to_ms)
+                    .transpose()?;
+                Self::ValidDuring {
+                    min_epoch: value.min_epoch,
+                    max_epoch: value.epoch,
+                    min_timestamp,
+                    max_timestamp,
+                    chain,
+                    nonce,
+                }
+            }
             TransactionExpirationKind::Unknown | _ => {
                 return Err("unknown TransactionExpirationKind");
             }


### PR DESCRIPTION
Previously, `TryFrom<&proto::TransactionExpiration>` rejected the `ValidDuring` variant with an "unknown TransactionExpirationKind" error, so callers that supplied a `ValidDuring` expiration to gRPC endpoints like `SimulateTransaction` were unable to use it even though the forward conversion already encoded the variant.

With this commit, the `TryFrom` decodes `ValidDuring` by parsing the `chain` field back into a `ChainIdentifier`, decoding the optional timestamps via a new `timestamp_to_ms` helper, and requiring both `chain` and `nonce` to be present. Also add e2e tests next to the simulate/resolve tests: a round-trip test over the conversion and a sim_test that supplies an explicit `ValidDuring` expiration to `SimulateTransaction` and verifies the resolved transaction preserves `epoch`, `min_epoch`, `chain`, and `nonce` both in the proto response and after BCS deserialization to `TransactionData`.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
