### PR TITLE
[sui-fork] reuse `latest` marker for object state (deleted, wrapped) 

### DIFF
--- a/crates/sui-fork/design/owned_objects_design.md
+++ b/crates/sui-fork/design/owned_objects_design.md
@@ -12,7 +12,8 @@ existing object-version cache.
 
 ## Goals
 
-- Keep `objects/<object_id>/latest` as the highest cached object version.
+- Keep live `objects/<object_id>/latest` files numeric-only while encoding local
+  removed current state as version-first metadata.
 - Prevent locally deleted objects from being resurrected by remote fallback.
 - Track live `Owner::AddressOwner` objects created or changed by local
   execution.
@@ -33,24 +34,12 @@ objects/
     <version>
 ```
 
-`latest` remains a cache marker for the highest object version written to disk.
-It is not deleted when local execution deletes an object, because exact-version
-reads must still be able to load historical versions.
-
-Local execution can now add:
-
-```text
-objects/
-  <object_id>/
-    removed
-```
-
-The `removed` file is an explicit local tombstone. It is a human-readable text
-file containing the removal kind plus object reference, such as
-`deleted <version> <digest>` or `wrapped <version> <digest>`. When present,
-current-object reads return `None` and do not fall back to the remote GraphQL
-endpoint. Exact-version reads ignore this marker and can still load
-`objects/<object_id>/<version>`.
+`latest` is a human-readable current-state marker. Live objects keep the
+existing numeric-only format, `<version>`. Local execution encodes removals in
+the same file as `<version>,deleted` or `<version>,wrapped`. When `latest`
+contains deleted or wrapped state, current-object reads return `None` and do
+not fall back to the remote GraphQL endpoint. Exact-version reads ignore this
+state and can still load `objects/<object_id>/<version>`.
 
 The owned-object index is stored separately:
 
@@ -78,18 +67,20 @@ object-owned, and package objects are excluded.
 ## Write Path
 
 Remote object cache writes only call `write_object`. They write version files
-and update `latest`; they do not clear removal markers or update the owned
-index.
+and update numeric live `latest` metadata; they preserve existing deleted or
+wrapped `latest` state and do not update the owned index.
 
 Local execution flows through `DataStore::update_objects`:
 
 1. For each deleted object ID:
-   - write `objects/<object_id>/removed` with kind `deleted`
+   - write `objects/<object_id>/latest` as `<version>,deleted`
    - remove the object ID from `indices/owned_objects`
+   - reject direct deletion if the current local latest state is `wrapped`; the
+     effects path must report `unwrapped_then_deleted` for an unwrap-and-delete
+     transaction
 2. For each written object:
    - write `objects/<object_id>/<version>`
-   - update `objects/<object_id>/latest`
-   - clear `objects/<object_id>/removed` only if it is kind `wrapped`
+   - update `objects/<object_id>/latest` to numeric-only live state unless the object is deleted
    - upsert the owned index entry if the object is `Owner::AddressOwner`
    - remove any existing owned index entry otherwise
 3. Rewrite `indices/owned_objects` via temp-file then rename.
@@ -100,8 +91,8 @@ writes the sorted vector back.
 
 ## Read Path
 
-`DataStore::get_object` checks the local removal marker before reading from disk
-or falling back to GraphQL. This keeps post-fork removals authoritative.
+`DataStore::get_object` checks object `latest` state before reading from disk or
+falling back to GraphQL. This keeps post-fork removals authoritative.
 
 `DataStore::get_object_at_version` remains exact-version only. It can return
 historical cached object versions even if the current object is marked removed.
@@ -124,7 +115,7 @@ Unsupported index methods return empty iterators or `None`.
 
 - The current-object read path cannot resurrect locally deleted objects from the
   remote endpoint.
-- The owned-object index is durable and sorted, but it is not a complete live
+- The owned-object index is sorted, but it is not a complete live
   object database.
 - Owned-object reads and local object/index updates are coordinated by an
   in-process snapshot guard shared by cloned `DataStore` handles. This does not
@@ -133,14 +124,14 @@ Unsupported index methods return empty iterators or `None`.
 - The index only covers locally materialized post-fork writes.
 - Aggregate balance APIs are out of scope for this first version.
 - Crash recovery is limited to atomic replacement of the index file. A future
-  version can rebuild the index by scanning object files and removal markers if
-  stronger recovery is needed.
+  version can rebuild the index by scanning object files and object `latest`
+  metadata if stronger recovery is needed.
 
 ## Test Coverage
 
 The design should be validated with tests for:
 
-- removal markers blocking latest/current reads while preserving exact-version
+- object `latest` removal state blocking current reads while preserving exact-version
   reads
 - owned index upsert, removal, persistence, and sort order
 - address writes appearing in `owned_objects`

--- a/crates/sui-fork/design/seeding_design.md
+++ b/crates/sui-fork/design/seeding_design.md
@@ -39,8 +39,8 @@ the checkpoint must be within the last 1h.
 When restarting a fork with the same `--data-dir` and `--checkpoint`, the existing
 seeding information that is stored on disk will be reused. If `--address` or `--object` is
 provided, the tool will error with a message indicating that a seed manifest already exists.
-The durable owned-object index and local deleted markers remain authoritative over the manifest
-after the fork has executed local transactions.
+The owned-object index and local object `latest` state remain authoritative over the
+manifest after the fork has executed local transactions.
 
 ## Generated files
 
@@ -174,9 +174,9 @@ async fn resolve_seeds(
 
 ## Composition with owned_objects_design.md
 
-The seed manifest is the immutable pre-fork baseline. The durable
-`indices/owned_objects` file and object tombstones are the current local state
-once the fork has started executing.
+The seed manifest is the immutable pre-fork baseline. The
+`indices/owned_objects` file and object `latest` metadata are the current local
+state once the fork has started executing.
 
 **Index rebuild on startup** (two sources):
 1. If `indices/owned_objects` exists, use it as-is and do not rewrite it from the manifest.
@@ -191,12 +191,12 @@ once the fork has started executing.
   read masks fetch BCS lazily
 
 **When a seeded object is deleted/mutated post-fork**:
-- `update_objects()` removes the old index entry, adds the new address-owned entry,
-  or removes the entry for wrapped/shared/immutable/object-owned transitions
-- local deleted markers prevent current-object reads from falling back to the remote endpoint
+- `update_objects()` removes the old index entry, adds the new address-owned entry, or removes the
+  entry for wrapped/shared/immutable/object-owned transitions
+- local object `latest` removal state prevents current-object reads from falling back to the remote endpoint
 
 **Key invariant**: Seed manifest is immutable after creation. Post-fork state is tracked entirely
-through the durable owned-object index, object BCS files, and deleted markers.
+through the owned-object index, object BCS files, and object `latest` state.
 
 ## Edge cases
 

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -11,7 +11,7 @@
 //! Under either root:
 //!     - objects/
 //!         - {object_id}/
-//!            - latest                  (text: <version>[,deleted|,wrapped])
+//!            - latest                  (text: version[,deleted|,wrapped])
 //!            - {version}                (BCS-encoded Object)
 //!     - indices/
 //!         - owned_objects              (BCS-encoded `Vec<OwnedObjectEntry>`)

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -39,6 +39,7 @@ use std::path::PathBuf;
 use anyhow::Context as _;
 use anyhow::Error;
 use anyhow::bail;
+use anyhow::ensure;
 
 use move_core_types::language_storage::StructTag;
 use sui_types::base_types::ObjectID;
@@ -919,30 +920,29 @@ fn parse_object_latest_metadata(
     content: &str,
     path: &Path,
 ) -> anyhow::Result<ObjectLatestMetadata> {
-    let content = content.trim();
-    let mut parts = content.split(',');
-    let version = parts.next().unwrap_or_default();
-    anyhow::ensure!(
-        !version.is_empty(),
-        "Missing object latest version in: {}",
-        path.display()
-    );
+    parse_object_latest_inner(content).with_context(|| {
+        format!(
+            "parsing object latest metadata from {content:?}, file: {}",
+            path.display()
+        )
+    })
+}
 
-    let state = match parts.next() {
-        None => ObjectLatestState::Live,
-        Some(state) => ObjectLatestState::from_suffix(state)
-            .with_context(|| format!("Failed to parse object latest file: {}", path.display()))?,
+// Inner function to parse checkpoint `latest` files, which are expected to be numeric-only without
+// state suffixes.
+fn parse_object_latest_inner(content: &str) -> anyhow::Result<ObjectLatestMetadata> {
+    let (version, state) = if let Some((version, suffix)) = content.trim().split_once(',') {
+        ensure!(!suffix.is_empty(), "state is empty");
+
+        let state = ObjectLatestState::from_suffix(suffix).context("cannot parse state")?;
+
+        (version, state)
+    } else {
+        (content.trim(), ObjectLatestState::Live)
     };
 
-    anyhow::ensure!(
-        parts.next().is_none(),
-        "Unexpected extra object latest data in: {}",
-        path.display()
-    );
-
-    let version = version
-        .parse::<u64>()
-        .with_context(|| format!("Failed to parse object latest version: {}", path.display()))?;
+    ensure!(!version.is_empty(), "version is empty");
+    let version: u64 = version.parse().context("version should be a u64")?;
 
     Ok(ObjectLatestMetadata { version, state })
 }

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -11,8 +11,7 @@
 //! Under either root:
 //!     - objects/
 //!         - {object_id}/
-//!            - latest                  (text: latest persisted version number)
-//!            - removed                 (text marker: removed kind + object ref)
+//!            - latest                  (text: <version>[,deleted|,wrapped])
 //!            - {version}                (BCS-encoded Object)
 //!     - indices/
 //!         - owned_objects              (BCS-encoded `Vec<OwnedObjectEntry>`)
@@ -33,24 +32,20 @@
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::io::ErrorKind;
 use std::io::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
 use anyhow::Error;
-use anyhow::anyhow;
 use anyhow::bail;
 
 use move_core_types::language_storage::StructTag;
 use sui_types::base_types::ObjectID;
-use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
 use sui_types::digests::CheckpointContentsDigest;
 use sui_types::digests::CheckpointDigest;
-use sui_types::digests::ObjectDigest;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEvents;
@@ -79,8 +74,6 @@ const INDICES_DIR: &str = "indices";
 const CHECKPOINTS_DIR: &str = "checkpoints";
 /// Per-chain transaction storage directory.
 const TRANSACTIONS_DIR: &str = "transactions";
-/// Filename marking the current local removal state for an object.
-const REMOVED_FILE: &str = "removed";
 /// BCS-encoded owned-object index filename.
 const OWNED_OBJECTS_INDEX_FILE: &str = "owned_objects";
 /// Filename for the BCS-encoded transaction data within a transaction directory.
@@ -102,26 +95,64 @@ const LATEST_FILE: &str = "latest";
 /// JSON file containing immutable fork metadata and optional pre-fork seed metadata.
 const SEED_MANIFEST_FILE: &str = "seed_manifest.json";
 
-/// Current-state removal kind for an object affected by local execution.
+/// Current state encoded in an object `latest` file.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RemovedObjectKind {
+pub(crate) enum ObjectLatestState {
+    /// The current object is live; the latest file is numeric-only.
+    Live,
+    /// The current object was deleted locally and must not fall back to remote state.
     Deleted,
+    /// The current object was wrapped locally and can become live again through an unwrap write.
     Wrapped,
 }
 
-impl RemovedObjectKind {
-    fn marker_text(self) -> &'static str {
-        match self {
-            Self::Deleted => "deleted",
-            Self::Wrapped => "wrapped",
-        }
-    }
-
-    fn from_marker_text(value: &str) -> anyhow::Result<Self> {
+impl ObjectLatestState {
+    /// Parse the optional state suffix after `<version>,`.
+    fn from_suffix(value: &str) -> anyhow::Result<Self> {
         match value {
             "deleted" => Ok(Self::Deleted),
             "wrapped" => Ok(Self::Wrapped),
-            _ => bail!("Unknown object removal marker kind: {value}"),
+            "" => bail!("Missing object latest state"),
+            _ => bail!("Unknown object latest state: {value}"),
+        }
+    }
+
+    /// Return the serialized state suffix; live latest files intentionally have no suffix.
+    fn suffix(self) -> Option<&'static str> {
+        match self {
+            Self::Live => None,
+            Self::Deleted => Some("deleted"),
+            Self::Wrapped => Some("wrapped"),
+        }
+    }
+
+    /// Return whether this state blocks current-object reads and remote fallback.
+    pub(crate) fn is_removed(self) -> bool {
+        matches!(self, Self::Deleted | Self::Wrapped)
+    }
+}
+
+/// Parsed metadata from an object `latest` file.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ObjectLatestMetadata {
+    version: u64,
+    state: ObjectLatestState,
+}
+
+impl ObjectLatestMetadata {
+    /// Construct numeric-only latest metadata for a live object version.
+    fn live(version: u64) -> Self {
+        Self {
+            version,
+            state: ObjectLatestState::Live,
+        }
+    }
+
+    /// Render the exact payload stored in `objects/<id>/latest`.
+    fn format(self) -> String {
+        match self.state.suffix() {
+            Some(state) => format!("{},{}", self.version, state),
+            None => self.version.to_string(),
         }
     }
 }
@@ -381,18 +412,18 @@ impl FilesystemStore {
 
     /// Get the latest object version available on disk for the given object ID.
     pub(crate) fn get_latest_object(&self, object_id: &ObjectID) -> anyhow::Result<Option<Object>> {
-        if self.is_object_currently_removed(object_id)? {
-            return Ok(None);
-        }
-
         let object_dir = self.objects_dir().join(object_id.to_string());
 
         if !object_dir.exists() {
             return Ok(None);
         }
 
-        let latest_version = self.read_latest_file(&object_dir)?;
-        let version_file = object_dir.join(latest_version.to_string());
+        let latest = self.read_object_latest_metadata(&object_dir)?;
+        if latest.state.is_removed() {
+            return Ok(None);
+        }
+
+        let version_file = object_dir.join(latest.version.to_string());
         self.read_bcs_file(&version_file).map(Some)
     }
 
@@ -413,171 +444,162 @@ impl FilesystemStore {
         self.read_bcs_file(&version_file).map(Some)
     }
 
-    /// Write the given object to disk under the objects directory, using the object ID and version
-    /// as the path. It will also update the latest file to point to this version.
+    /// Write an object fetched from remote/cache paths. Existing deleted or wrapped current-state
+    /// metadata is preserved so remote reads cannot resurrect local removals.
     pub(crate) fn write_object(&self, object: &Object) -> anyhow::Result<()> {
         let object_dir = self.objects_dir().join(object.id().to_string());
         let version = object.version().value();
         let version_file = object_dir.join(version.to_string());
         self.write_bcs_file(&version_file, object)?;
 
-        let latest_version = if object_dir.join(LATEST_FILE).exists() {
-            std::cmp::max(self.read_latest_file(&object_dir)?, version)
-        } else {
-            version
+        let Some(latest) = self.read_object_latest_metadata_if_exists(&object_dir)? else {
+            return self
+                .write_object_latest_metadata(&object_dir, ObjectLatestMetadata::live(version));
         };
-        let latest_file = object_dir.join(LATEST_FILE);
-        fs::write(latest_file, latest_version.to_string())
-            .with_context(|| format!("Failed to write latest file for object {}", object.id()))
-    }
-
-    /// Mark an object as deleted by local execution. Historical version files remain on disk and
-    /// can still be read by exact version, but current reads must not resurrect the object.
-    pub(crate) fn mark_object_deleted(&self, object_ref: &ObjectRef) -> anyhow::Result<()> {
-        self.write_object_removed_marker(RemovedObjectKind::Deleted, object_ref)
-    }
-
-    /// Mark an object as wrapped by local execution. Historical version files remain on disk and
-    /// can still be read by exact version; a later live write can clear this marker.
-    pub(crate) fn mark_object_wrapped(&self, object_ref: &ObjectRef) -> anyhow::Result<()> {
-        if self.is_object_deleted(&object_ref.0)? {
+        if latest.state.is_removed() {
             return Ok(());
         }
-        self.write_object_removed_marker(RemovedObjectKind::Wrapped, object_ref)
+
+        self.write_object_latest_metadata(
+            &object_dir,
+            ObjectLatestMetadata::live(std::cmp::max(latest.version, version)),
+        )
     }
 
-    /// Clear the local deletion marker. Normal live writes do not call this because post-fork
-    /// deletions are terminal; it is available for tests and explicit cache repair.
-    pub(crate) fn clear_object_deleted(&self, object_id: &ObjectID) -> anyhow::Result<()> {
-        self.clear_object_removed_marker_kind(object_id, RemovedObjectKind::Deleted)
-    }
+    /// Write an object produced by local execution. Wrapped state is cleared by a live write, while
+    /// deleted state remains terminal.
+    pub(crate) fn write_live_object(&self, object: &Object) -> anyhow::Result<()> {
+        let object_dir = self.objects_dir().join(object.id().to_string());
+        let version = object.version().value();
+        let version_file = object_dir.join(version.to_string());
+        self.write_bcs_file(&version_file, object)?;
 
-    /// Clear the local wrapped marker for an object that has become live again.
-    pub(crate) fn clear_object_wrapped(&self, object_id: &ObjectID) -> anyhow::Result<()> {
-        self.clear_object_removed_marker_kind(object_id, RemovedObjectKind::Wrapped)
-    }
-
-    /// Return whether local execution has deleted the object.
-    pub(crate) fn is_object_deleted(&self, object_id: &ObjectID) -> anyhow::Result<bool> {
-        Ok(self.object_removed_kind(object_id)? == Some(RemovedObjectKind::Deleted))
-    }
-
-    /// Return whether local execution has wrapped the object.
-    pub(crate) fn is_object_wrapped(&self, object_id: &ObjectID) -> anyhow::Result<bool> {
-        Ok(self.object_removed_kind(object_id)? == Some(RemovedObjectKind::Wrapped))
-    }
-
-    /// Return whether local execution has made the object inaccessible by direct current ID
-    /// lookup.
-    pub(crate) fn is_object_currently_removed(&self, object_id: &ObjectID) -> anyhow::Result<bool> {
-        Ok(self.object_removed_kind(object_id)?.is_some())
-    }
-
-    /// Write the current removal marker file for the given object reference.
-    fn write_object_removed_marker(
-        &self,
-        kind: RemovedObjectKind,
-        object_ref: &ObjectRef,
-    ) -> anyhow::Result<()> {
-        let object_id = object_ref.0;
-        let object_dir = self.objects_dir().join(object_id.to_string());
-        fs::create_dir_all(&object_dir)
-            .with_context(|| format!("Failed to create directory: {}", object_dir.display()))?;
-        let contents = format!(
-            "{} {} {}\n",
-            kind.marker_text(),
-            object_ref.1.value(),
-            object_ref.2
-        );
-        fs::write(object_dir.join(REMOVED_FILE), contents)
-            .with_context(|| format!("Failed to mark object {} removed", object_id))
-    }
-
-    /// Clear the current removal marker if it matches `kind`.
-    fn clear_object_removed_marker_kind(
-        &self,
-        object_id: &ObjectID,
-        kind: RemovedObjectKind,
-    ) -> anyhow::Result<()> {
         if self
-            .read_object_removed_marker_kind(object_id)?
-            .is_some_and(|removed_kind| removed_kind == kind)
+            .read_object_latest_metadata_if_exists(&object_dir)?
+            .is_some_and(|latest| latest.state == ObjectLatestState::Deleted)
         {
-            self.clear_object_removed_marker(object_id)?;
+            return Ok(());
         }
-        Ok(())
+
+        self.write_object_latest_metadata(&object_dir, ObjectLatestMetadata::live(version))
     }
 
-    /// Return the current removal kind.
-    fn object_removed_kind(
+    /// Mark an object as deleted in `latest`. This rejects direct deletes over wrapped state
+    /// because wrapped objects must first be unwrapped.
+    pub(crate) fn mark_object_as_deleted(
         &self,
-        object_id: &ObjectID,
-    ) -> anyhow::Result<Option<RemovedObjectKind>> {
-        self.read_object_removed_marker_kind(object_id)
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> anyhow::Result<()> {
+        self.mark_object_removed(object_id, version, ObjectLatestState::Deleted)
     }
 
-    /// Read the canonical `removed` marker.
-    fn read_object_removed_marker_kind(
+    /// Mark an object as wrapped in `latest`. Deleted state stays terminal and is not replaced.
+    pub(crate) fn mark_object_as_wrapped(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> anyhow::Result<()> {
+        self.mark_object_removed(object_id, version, ObjectLatestState::Wrapped)
+    }
+
+    /// Shared writer for direct deleted and wrapped latest-state transitions.
+    fn mark_object_removed(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+        state: ObjectLatestState,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(state.is_removed(), "object latest removal state expected");
+        let object_dir = self.objects_dir().join(object_id.to_string());
+
+        if let Some(latest) = self.read_object_latest_metadata_if_exists(&object_dir)? {
+            match (latest.state, state) {
+                (ObjectLatestState::Deleted, ObjectLatestState::Wrapped) => return Ok(()),
+                (ObjectLatestState::Wrapped, ObjectLatestState::Deleted) => {
+                    bail!("cannot delete wrapped object {object_id} without unwrapping it first");
+                }
+                _ => {}
+            }
+        }
+
+        self.write_object_latest_metadata(
+            &object_dir,
+            ObjectLatestMetadata {
+                version: version.value(),
+                state,
+            },
+        )
+    }
+
+    /// Mark an object as deleted after it was unwrapped and deleted in one transaction. This
+    /// explicit path is the only removal write that may move wrapped latest state to deleted.
+    pub(crate) fn mark_object_as_unwrapped_then_deleted(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> anyhow::Result<()> {
+        let object_dir = self.objects_dir().join(object_id.to_string());
+
+        self.write_object_latest_metadata(
+            &object_dir,
+            ObjectLatestMetadata {
+                version: version.value(),
+                state: ObjectLatestState::Deleted,
+            },
+        )
+    }
+
+    /// Return the current object latest state, if the object has local latest metadata.
+    pub(crate) fn object_latest_state(
         &self,
         object_id: &ObjectID,
-    ) -> anyhow::Result<Option<RemovedObjectKind>> {
-        let path = self
-            .objects_dir()
-            .join(object_id.to_string())
-            .join(REMOVED_FILE);
-        if !path.exists() {
+    ) -> anyhow::Result<Option<ObjectLatestState>> {
+        let object_dir = self.objects_dir().join(object_id.to_string());
+        self.read_object_latest_metadata_if_exists(&object_dir)
+            .map(|latest| latest.map(|latest| latest.state))
+    }
+
+    /// Read object latest metadata when present, returning `None` for objects without local state.
+    fn read_object_latest_metadata_if_exists(
+        &self,
+        object_dir: &Path,
+    ) -> anyhow::Result<Option<ObjectLatestMetadata>> {
+        let latest_path = object_dir.join(LATEST_FILE);
+        if !latest_path.exists() {
             return Ok(None);
         }
-
-        let content = fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read object removed marker: {}", path.display()))?;
-        let mut parts = content.split_whitespace();
-        let kind = parts
-            .next()
-            .ok_or_else(|| anyhow!("Missing object removal kind in: {}", path.display()))
-            .and_then(RemovedObjectKind::from_marker_text)?;
-        let _version = parts
-            .next()
-            .ok_or_else(|| anyhow!("Missing object removal version in: {}", path.display()))?
-            .parse::<u64>()
-            .with_context(|| {
-                format!(
-                    "Failed to parse object removal version in: {}",
-                    path.display()
-                )
-            })?;
-        let _digest = parts
-            .next()
-            .ok_or_else(|| anyhow!("Missing object removal digest in: {}", path.display()))?
-            .parse::<ObjectDigest>()
-            .with_context(|| {
-                format!(
-                    "Failed to parse object removal digest in: {}",
-                    path.display()
-                )
-            })?;
-        anyhow::ensure!(
-            parts.next().is_none(),
-            "Unexpected extra object removal marker data in: {}",
-            path.display()
-        );
-
-        Ok(Some(kind))
+        self.read_object_latest_metadata(object_dir).map(Some)
     }
 
-    /// Clear the removal marker for the given object ID. If the file does not exist, this is a
-    /// no-op.
-    fn clear_object_removed_marker(&self, object_id: &ObjectID) -> anyhow::Result<()> {
-        let path = self
-            .objects_dir()
-            .join(object_id.to_string())
-            .join(REMOVED_FILE);
-        match fs::remove_file(&path) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(err)
-                .with_context(|| format!("Failed to clear object marker: {}", path.display())),
+    /// Read and parse the required object latest file for a known local object directory.
+    fn read_object_latest_metadata(
+        &self,
+        object_dir: &Path,
+    ) -> anyhow::Result<ObjectLatestMetadata> {
+        let latest_path = object_dir.join(LATEST_FILE);
+        if !latest_path.exists() {
+            bail!(
+                "Latest file not found in directory: {}",
+                object_dir.display()
+            );
         }
+        let content = fs::read_to_string(&latest_path)
+            .with_context(|| format!("Failed to read latest file: {}", latest_path.display()))?;
+        parse_object_latest_metadata(&content, &latest_path)
+    }
+
+    /// Persist object latest metadata using the version-first text format.
+    fn write_object_latest_metadata(
+        &self,
+        object_dir: &Path,
+        latest: ObjectLatestMetadata,
+    ) -> anyhow::Result<()> {
+        fs::create_dir_all(object_dir)
+            .with_context(|| format!("Failed to create directory: {}", object_dir.display()))?;
+        let latest_file = object_dir.join(LATEST_FILE);
+        fs::write(&latest_file, latest.format())
+            .with_context(|| format!("Failed to write latest file: {}", latest_file.display()))
     }
 
     /// Read the owned-object index. Missing index files represent an empty index.
@@ -637,7 +659,7 @@ impl FilesystemStore {
             .with_context(|| format!("Failed to replace owned-object index: {}", path.display()))
     }
 
-    /// Return whether the durable owned-object index has already been initialized.
+    /// Return whether the owned-object index has already been initialized.
     pub(crate) fn owned_object_index_exists(&self) -> bool {
         self.owned_objects_index_path().exists()
     }
@@ -697,7 +719,7 @@ impl FilesystemStore {
             checkpoint_dir.display()
         );
 
-        self.read_latest_file(&checkpoint_dir)
+        self.read_numeric_latest_file(&checkpoint_dir)
     }
 
     /// Get the highest checkpoint sequence number available on disk, returning `None` when
@@ -710,7 +732,7 @@ impl FilesystemStore {
             return Ok(None);
         }
 
-        self.read_latest_file(&checkpoint_dir).map(Some)
+        self.read_numeric_latest_file(&checkpoint_dir).map(Some)
     }
 
     /// Path to the per-sequence directory holding `summary`.
@@ -826,7 +848,7 @@ impl FilesystemStore {
         if !checkpoints_dir.join(LATEST_FILE).exists() {
             return Ok(None);
         }
-        let sequence = self.read_latest_file(&checkpoints_dir)?;
+        let sequence = self.read_numeric_latest_file(&checkpoints_dir)?;
         self.get_checkpoint_by_sequence_number(sequence)
     }
 
@@ -842,7 +864,7 @@ impl FilesystemStore {
             .with_context(|| format!("Failed to create directory: {}", dir.display()))?;
         let path = dir.join(LATEST_FILE);
         let current = if path.exists() {
-            Some(self.read_latest_file(&dir)?)
+            Some(self.read_numeric_latest_file(&dir)?)
         } else {
             None
         };
@@ -876,9 +898,8 @@ impl FilesystemStore {
         Ok(())
     }
 
-    /// Read the latest file that contains a number representing the latest checkpoint sequence or
-    /// object version.
-    fn read_latest_file(&self, dir: &Path) -> Result<u64, Error> {
+    /// Read a numeric-only latest file, used for checkpoint metadata.
+    fn read_numeric_latest_file(&self, dir: &Path) -> Result<u64, Error> {
         let latest_path = dir.join(LATEST_FILE);
         if !latest_path.exists() {
             bail!("Latest file not found in directory: {}", dir.display());
@@ -890,6 +911,40 @@ impl FilesystemStore {
             .parse::<u64>()
             .with_context(|| format!("Failed to parse latest file: {}", latest_path.display()))
     }
+}
+
+/// Parse `objects/<id>/latest`, keeping live files numeric-only while accepting deleted/wrapped
+/// state suffixes for current-state removals.
+fn parse_object_latest_metadata(
+    content: &str,
+    path: &Path,
+) -> anyhow::Result<ObjectLatestMetadata> {
+    let content = content.trim();
+    let mut parts = content.split(',');
+    let version = parts.next().unwrap_or_default();
+    anyhow::ensure!(
+        !version.is_empty(),
+        "Missing object latest version in: {}",
+        path.display()
+    );
+
+    let state = match parts.next() {
+        None => ObjectLatestState::Live,
+        Some(state) => ObjectLatestState::from_suffix(state)
+            .with_context(|| format!("Failed to parse object latest file: {}", path.display()))?,
+    };
+
+    anyhow::ensure!(
+        parts.next().is_none(),
+        "Unexpected extra object latest data in: {}",
+        path.display()
+    );
+
+    let version = version
+        .parse::<u64>()
+        .with_context(|| format!("Failed to parse object latest version: {}", path.display()))?;
+
+    Ok(ObjectLatestMetadata { version, state })
 }
 
 fn remove_owned_entry(entries: &mut Vec<OwnedObjectEntry>, object_id: ObjectID) {

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -160,7 +160,7 @@ pub(crate) fn ensure_seed_manifest_matches(
     Ok(())
 }
 
-/// Initialize the durable owned-object index from the seed manifest when it is safe to do so.
+/// Initialize the owned-object index from the seed manifest when it is safe to do so.
 pub(crate) fn initialize_owned_index_from_seed(
     data_store: &DataStore,
     manifest: &SeedManifest,

--- a/crates/sui-fork/src/store.rs
+++ b/crates/sui-fork/src/store.rs
@@ -69,8 +69,8 @@ use crate::TransactionInfo;
 use crate::TransactionRead;
 use crate::VersionQuery;
 use crate::filesystem::FilesystemStore;
+use crate::filesystem::ObjectLatestState;
 use crate::filesystem::OwnedObjectEntry;
-use crate::filesystem::RemovedObjectKind;
 
 /// A data store for Sui data, combining a shared local filesystem cache with a remote GraphQL
 /// endpoint for historical reads. Pre-fork data is fetched on demand and cached locally; post-fork
@@ -94,10 +94,22 @@ struct DataStoreInner {
     local_snapshot_lock: RwLock<()>,
 }
 
-/// Object reference paired with the current-state removal kind that produced it.
+/// Source of an object removal emitted by transaction effects.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RemovedObjectKind {
+    /// The object moved directly from live to deleted.
+    Deleted,
+    /// The object moved directly from live to wrapped.
+    Wrapped,
+    /// The object was unwrapped and deleted in the same transaction.
+    UnwrappedThenDeleted,
+}
+
+/// Object version paired with the current-state removal kind that produced it.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct RemovedObject {
-    object_ref: ObjectRef,
+    object_id: ObjectID,
+    version: SequenceNumber,
     kind: RemovedObjectKind,
 }
 
@@ -327,7 +339,12 @@ impl DataStore {
     /// Local-first lookup for the latest known version of an object. Falls back to a remote
     /// `AtCheckpoint(forked_at_checkpoint)` query and caches the result on disk.
     fn get_latest_object(&self, object_id: &ObjectID) -> anyhow::Result<Option<Object>> {
-        if self.inner.local.is_object_currently_removed(object_id)? {
+        if self
+            .inner
+            .local
+            .object_latest_state(object_id)?
+            .is_some_and(ObjectLatestState::is_removed)
+        {
             return Ok(None);
         }
 
@@ -501,7 +518,7 @@ impl DataStore {
         None
     }
 
-    /// Persist local object writes and current-state tombstones, then update the address-owned
+    /// Persist local object writes and current-state removals, then update the address-owned
     /// index from the same diff.
     fn apply_object_updates(
         &mut self,
@@ -513,7 +530,7 @@ impl DataStore {
             .expect("failed to lock local snapshot for object update");
         let removed_object_ids: Vec<_> = removed_objects
             .iter()
-            .map(|removed| removed.object_ref.0)
+            .map(|removed| removed.object_id)
             .collect();
 
         for removed in &removed_objects {
@@ -521,35 +538,36 @@ impl DataStore {
                 RemovedObjectKind::Deleted => self
                     .inner
                     .local
-                    .mark_object_deleted(&removed.object_ref)
-                    .expect("failed to mark object deleted on disk"),
+                    .mark_object_as_deleted(removed.object_id, removed.version)
+                    .expect("failed to write deleted object latest state on disk"),
                 RemovedObjectKind::Wrapped => self
                     .inner
                     .local
-                    .mark_object_wrapped(&removed.object_ref)
-                    .expect("failed to mark object wrapped on disk"),
+                    .mark_object_as_wrapped(removed.object_id, removed.version)
+                    .expect("failed to write wrapped object latest state on disk"),
+                RemovedObjectKind::UnwrappedThenDeleted => self
+                    .inner
+                    .local
+                    .mark_object_as_unwrapped_then_deleted(removed.object_id, removed.version)
+                    .expect("failed to write unwrapped-then-deleted object latest state on disk"),
             }
         }
 
         for object in written_objects.values() {
             self.inner
                 .local
-                .write_object(object)
+                .write_live_object(object)
                 .expect("failed to write object to disk");
-            self.inner
-                .local
-                .clear_object_wrapped(&object.id())
-                .expect("failed to clear object wrapped marker");
         }
 
         let indexable_written_objects: Vec<_> = written_objects
             .values()
             .filter(|object| {
-                !self
-                    .inner
+                self.inner
                     .local
-                    .is_object_deleted(&object.id())
-                    .expect("failed to read object removal marker")
+                    .object_latest_state(&object.id())
+                    .expect("failed to read object latest state")
+                    != Some(ObjectLatestState::Deleted)
             })
             .collect();
 
@@ -670,23 +688,34 @@ fn struct_tag_filter_matches(filter: &StructTag, candidate: &StructTag) -> bool 
             || filter.type_params.as_slice() == candidate.type_params.as_slice())
 }
 
-/// Extract removal kinds before passing removals through `update_objects`, whose trait signature
-/// does not distinguish deleted, wrapped, or unwrapped-then-deleted objects.
+/// Preserve effect removal categories before passing removals through `update_objects`, whose trait
+/// signature does not distinguish deleted, wrapped, or unwrapped-then-deleted objects.
 fn removed_objects_from_effects(effects: &TransactionEffects) -> Vec<RemovedObject> {
     effects
         .deleted()
         .into_iter()
-        .chain(effects.unwrapped_then_deleted())
         .map(|object_ref| RemovedObject {
-            object_ref,
+            object_id: object_ref.0,
+            version: object_ref.1,
             kind: RemovedObjectKind::Deleted,
         })
+        .chain(
+            effects
+                .unwrapped_then_deleted()
+                .into_iter()
+                .map(|object_ref| RemovedObject {
+                    object_id: object_ref.0,
+                    version: object_ref.1,
+                    kind: RemovedObjectKind::UnwrappedThenDeleted,
+                }),
+        )
         .chain(
             effects
                 .wrapped()
                 .into_iter()
                 .map(|object_ref| RemovedObject {
-                    object_ref,
+                    object_id: object_ref.0,
+                    version: object_ref.1,
                     kind: RemovedObjectKind::Wrapped,
                 }),
         )
@@ -998,8 +1027,9 @@ impl SimulatorStore for DataStore {
     ) {
         let removed_objects = deleted_objects
             .into_iter()
-            .map(|object_ref| RemovedObject {
-                object_ref,
+            .map(|(object_id, version, _digest)| RemovedObject {
+                object_id,
+                version,
                 kind: RemovedObjectKind::Deleted,
             })
             .collect();

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -8,6 +8,7 @@
 
 use std::ffi::OsString;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 
 use sui_types::base_types::ObjectID;
@@ -127,6 +128,55 @@ fn object_dir(store: &FilesystemStore, object_id: &ObjectID) -> std::path::PathB
     store.objects_dir().join(object_id.to_string())
 }
 
+fn object_latest_path(store: &FilesystemStore, object_id: &ObjectID) -> std::path::PathBuf {
+    object_dir(store, object_id).join(LATEST_FILE)
+}
+
+fn assert_no_old_removal_marker_files(dir: &Path) {
+    assert!(!dir.join("removed").exists());
+    assert!(!dir.join("deleted").exists());
+    assert!(!dir.join("wrapped").exists());
+}
+
+#[test]
+fn test_parse_object_latest_metadata_accepts_version_first_formats() {
+    let path = Path::new("latest");
+
+    assert_eq!(
+        parse_object_latest_metadata("5", path).unwrap(),
+        ObjectLatestMetadata {
+            version: 5,
+            state: ObjectLatestState::Live,
+        },
+    );
+    assert_eq!(
+        parse_object_latest_metadata("5,deleted", path).unwrap(),
+        ObjectLatestMetadata {
+            version: 5,
+            state: ObjectLatestState::Deleted,
+        },
+    );
+    assert_eq!(
+        parse_object_latest_metadata("5,wrapped\n", path).unwrap(),
+        ObjectLatestMetadata {
+            version: 5,
+            state: ObjectLatestState::Wrapped,
+        },
+    );
+}
+
+#[test]
+fn test_parse_object_latest_metadata_rejects_invalid_formats() {
+    let path = Path::new("latest");
+
+    for content in ["", ",deleted", "5,missing", "5,", "5,deleted,extra"] {
+        assert!(
+            parse_object_latest_metadata(content, path).is_err(),
+            "{content:?} should be rejected",
+        );
+    }
+}
+
 #[test]
 fn test_write_and_read_latest_object() {
     let (_dir, store) = test_store();
@@ -134,6 +184,10 @@ fn test_write_and_read_latest_object() {
     let obj = make_object(id, 5);
 
     store.write_object(&obj).unwrap();
+    assert_eq!(
+        fs::read_to_string(object_latest_path(&store, &id)).unwrap(),
+        "5"
+    );
     let loaded = store.get_latest_object(&id).unwrap();
     assert_eq!(loaded.clone().unwrap(), obj);
     assert_eq!(loaded.unwrap().version(), SequenceNumber::from_u64(5));
@@ -187,99 +241,162 @@ fn test_latest_tracks_highest_written_version() {
 }
 
 #[test]
-fn test_deleted_marker_blocks_latest_but_preserves_exact_versions() {
+fn test_deleted_latest_blocks_latest_but_preserves_exact_versions() {
     let (_dir, store) = test_store();
     let id = ObjectID::random();
     let obj = make_object(id, 5);
 
     store.write_object(&obj).unwrap();
-    let object_ref = obj.compute_object_reference();
-    store.mark_object_deleted(&object_ref).unwrap();
+    store.mark_object_as_deleted(id, obj.version()).unwrap();
 
-    assert!(store.is_object_deleted(&id).unwrap());
+    assert_eq!(
+        store.object_latest_state(&id).unwrap(),
+        Some(ObjectLatestState::Deleted)
+    );
     assert!(store.get_latest_object(&id).unwrap().is_none());
     let dir = object_dir(&store, &id);
     assert_eq!(
-        fs::read_to_string(dir.join(REMOVED_FILE)).unwrap(),
-        format!("deleted {} {}\n", object_ref.1.value(), object_ref.2),
+        fs::read_to_string(dir.join(LATEST_FILE)).unwrap(),
+        "5,deleted"
     );
-    assert!(!dir.join("deleted").exists());
-    assert!(!dir.join("wrapped").exists());
+    assert_no_old_removal_marker_files(&dir);
 
     let exact = store.get_object_at_version(&id, 5).unwrap();
     assert_eq!(exact.unwrap(), obj);
 
-    store.clear_object_deleted(&id).unwrap();
-    let latest = store.get_latest_object(&id).unwrap();
-    assert_eq!(latest.unwrap(), obj);
+    let written_again = make_object(id, 7);
+    store.write_live_object(&written_again).unwrap();
+    assert_eq!(
+        fs::read_to_string(dir.join(LATEST_FILE)).unwrap(),
+        "5,deleted"
+    );
+    assert!(store.get_latest_object(&id).unwrap().is_none());
+    assert_eq!(
+        store.get_object_at_version(&id, 7).unwrap().unwrap(),
+        written_again
+    );
 }
 
 #[test]
-fn test_wrapped_marker_blocks_latest_preserves_exact_and_clears_on_write() {
+fn test_wrapped_latest_blocks_latest_preserves_exact_and_clears_on_live_write() {
     let (_dir, store) = test_store();
     let id = ObjectID::random();
     let owner = SuiAddress::random_for_testing_only();
     let obj = make_object_with_owner(id, 5, Owner::AddressOwner(owner));
 
     store.write_object(&obj).unwrap();
-    let object_ref = obj.compute_object_reference();
-    store.mark_object_wrapped(&object_ref).unwrap();
+    store.mark_object_as_wrapped(id, obj.version()).unwrap();
 
-    assert!(store.is_object_wrapped(&id).unwrap());
+    assert_eq!(
+        store.object_latest_state(&id).unwrap(),
+        Some(ObjectLatestState::Wrapped)
+    );
     assert!(store.get_latest_object(&id).unwrap().is_none());
     let dir = object_dir(&store, &id);
     assert_eq!(
-        fs::read_to_string(dir.join(REMOVED_FILE)).unwrap(),
-        format!("wrapped {} {}\n", object_ref.1.value(), object_ref.2),
+        fs::read_to_string(dir.join(LATEST_FILE)).unwrap(),
+        "5,wrapped"
     );
-    assert!(!dir.join("deleted").exists());
-    assert!(!dir.join("wrapped").exists());
+    assert_no_old_removal_marker_files(&dir);
 
     let exact = store.get_object_at_version(&id, 5).unwrap();
     assert_eq!(exact.unwrap(), obj);
 
     let unwrapped = make_object_with_owner(id, 7, Owner::AddressOwner(owner));
-    store.write_object(&unwrapped).unwrap();
-    store.clear_object_wrapped(&id).unwrap();
+    store.write_live_object(&unwrapped).unwrap();
 
-    assert!(!store.is_object_wrapped(&id).unwrap());
+    assert_eq!(
+        store.object_latest_state(&id).unwrap(),
+        Some(ObjectLatestState::Live)
+    );
+    assert_eq!(fs::read_to_string(dir.join(LATEST_FILE)).unwrap(), "7");
     let latest = store.get_latest_object(&id).unwrap();
     assert_eq!(latest.unwrap(), unwrapped);
 }
 
 #[test]
-fn test_clear_wrapped_preserves_deleted_marker() {
+fn test_remote_object_write_preserves_removed_latest_state() {
     let (_dir, store) = test_store();
-    let id = ObjectID::random();
-    let obj = make_object(id, 5);
 
-    store.write_object(&obj).unwrap();
-    store
-        .mark_object_deleted(&obj.compute_object_reference())
-        .unwrap();
-    store.clear_object_wrapped(&id).unwrap();
+    for (state, version, cached_version, expected_latest) in [
+        (ObjectLatestState::Wrapped, 5, 7, "5,wrapped"),
+        (ObjectLatestState::Deleted, 3, 8, "3,deleted"),
+    ] {
+        let id = ObjectID::random();
+        let object = make_object(id, version);
+        let cached_later = make_object(id, cached_version);
 
-    assert!(store.is_object_deleted(&id).unwrap());
-    assert!(!store.is_object_wrapped(&id).unwrap());
-    assert!(store.get_latest_object(&id).unwrap().is_none());
+        store.write_object(&object).unwrap();
+        match state {
+            ObjectLatestState::Deleted => {
+                store.mark_object_as_deleted(id, object.version()).unwrap()
+            }
+            ObjectLatestState::Wrapped => {
+                store.mark_object_as_wrapped(id, object.version()).unwrap()
+            }
+            ObjectLatestState::Live => unreachable!("test only covers removed latest states"),
+        }
+        store.write_object(&cached_later).unwrap();
+
+        let dir = object_dir(&store, &id);
+        assert_eq!(
+            fs::read_to_string(dir.join(LATEST_FILE)).unwrap(),
+            expected_latest
+        );
+        assert!(store.get_latest_object(&id).unwrap().is_none());
+        assert_eq!(
+            store
+                .get_object_at_version(&id, cached_version)
+                .unwrap()
+                .unwrap(),
+            cached_later
+        );
+    }
 }
 
 #[test]
-fn test_deleted_marker_overwrites_wrapped_marker() {
+fn test_direct_deleted_latest_does_not_overwrite_wrapped_latest() {
     let (_dir, store) = test_store();
     let id = ObjectID::random();
     let obj = make_object(id, 5);
-    let object_ref = obj.compute_object_reference();
 
     store.write_object(&obj).unwrap();
-    store.mark_object_wrapped(&object_ref).unwrap();
-    store.mark_object_deleted(&object_ref).unwrap();
+    store.mark_object_as_wrapped(id, obj.version()).unwrap();
+    let err = store.mark_object_as_deleted(id, obj.version()).unwrap_err();
 
-    assert!(store.is_object_deleted(&id).unwrap());
-    assert!(!store.is_object_wrapped(&id).unwrap());
+    assert!(
+        err.to_string().contains("cannot delete wrapped object"),
+        "{err:?}",
+    );
     assert_eq!(
-        fs::read_to_string(object_dir(&store, &id).join(REMOVED_FILE)).unwrap(),
-        format!("deleted {} {}\n", object_ref.1.value(), object_ref.2),
+        store.object_latest_state(&id).unwrap(),
+        Some(ObjectLatestState::Wrapped)
+    );
+    assert_eq!(
+        fs::read_to_string(object_latest_path(&store, &id)).unwrap(),
+        "5,wrapped",
+    );
+}
+
+#[test]
+fn test_unwrapped_then_deleted_latest_overwrites_wrapped_latest() {
+    let (_dir, store) = test_store();
+    let id = ObjectID::random();
+    let obj = make_object(id, 5);
+
+    store.write_object(&obj).unwrap();
+    store.mark_object_as_wrapped(id, obj.version()).unwrap();
+    store
+        .mark_object_as_unwrapped_then_deleted(id, SequenceNumber::from_u64(7))
+        .unwrap();
+
+    assert_eq!(
+        store.object_latest_state(&id).unwrap(),
+        Some(ObjectLatestState::Deleted)
+    );
+    assert_eq!(
+        fs::read_to_string(object_latest_path(&store, &id)).unwrap(),
+        "7,deleted",
     );
 }
 
@@ -379,6 +496,16 @@ fn test_get_highest_checkpoint_errors_when_latest_file_missing() {
     fs::create_dir_all(store.checkpoints_dir()).unwrap();
     let err = store.get_highest_checkpoint_sequence_number().unwrap_err();
     assert!(err.to_string().contains("Latest file not found"));
+}
+
+#[test]
+fn test_checkpoint_latest_rejects_object_latest_state_suffix() {
+    let (_dir, store) = test_store();
+    fs::create_dir_all(store.checkpoints_dir()).unwrap();
+    fs::write(store.checkpoints_dir().join(LATEST_FILE), "5,deleted").unwrap();
+
+    let err = store.get_highest_checkpoint_sequence_number().unwrap_err();
+    assert!(err.to_string().contains("Failed to parse latest file"));
 }
 
 #[test]

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -407,11 +407,8 @@ fn test_local_wrap_removes_current_object_but_preserves_historical_lookup() {
     store.apply_object_updates(
         BTreeMap::new(),
         vec![RemovedObject {
-            object_ref: (
-                object_id,
-                SequenceNumber::from_u64(2),
-                ObjectDigest::OBJECT_DIGEST_WRAPPED,
-            ),
+            object_id,
+            version: SequenceNumber::from_u64(2),
             kind: RemovedObjectKind::Wrapped,
         }],
     );
@@ -441,7 +438,7 @@ fn test_local_wrap_removes_current_object_but_preserves_historical_lookup() {
 }
 
 #[test]
-fn test_unwrapped_write_clears_wrapped_marker_and_reindexes_owner() {
+fn test_unwrapped_write_clears_wrapped_latest_and_reindexes_owner() {
     let (_temp, mut store) = test_data_store();
     let owner = SuiAddress::random_for_testing_only();
     let recipient = SuiAddress::random_for_testing_only();
@@ -452,11 +449,8 @@ fn test_unwrapped_write_clears_wrapped_marker_and_reindexes_owner() {
     store.apply_object_updates(
         BTreeMap::new(),
         vec![RemovedObject {
-            object_ref: (
-                object_id,
-                SequenceNumber::from_u64(2),
-                ObjectDigest::OBJECT_DIGEST_WRAPPED,
-            ),
+            object_id,
+            version: SequenceNumber::from_u64(2),
             kind: RemovedObjectKind::Wrapped,
         }],
     );
@@ -464,7 +458,10 @@ fn test_unwrapped_write_clears_wrapped_marker_and_reindexes_owner() {
     let unwrapped = make_gas_object(object_id, 3, Owner::AddressOwner(recipient));
     store.apply_object_updates(BTreeMap::from([(object_id, unwrapped.clone())]), vec![]);
 
-    assert!(!store.local().is_object_wrapped(&object_id).unwrap());
+    assert_eq!(
+        store.local().object_latest_state(&object_id).unwrap(),
+        Some(ObjectLatestState::Live),
+    );
     assert_eq!(
         DataStore::get_object(&store, &object_id)
             .expect("current object read should not error")
@@ -478,7 +475,7 @@ fn test_unwrapped_write_clears_wrapped_marker_and_reindexes_owner() {
 }
 
 #[test]
-fn test_terminal_deleted_marker_prevents_reindexing_written_object() {
+fn test_terminal_deleted_latest_prevents_reindexing_written_object() {
     let (_temp, mut store) = test_data_store();
     let owner = SuiAddress::random_for_testing_only();
     let object_id = ObjectID::random();
@@ -489,11 +486,8 @@ fn test_terminal_deleted_marker_prevents_reindexing_written_object() {
     store.apply_object_updates(
         BTreeMap::from([(object_id, written_again)]),
         vec![RemovedObject {
-            object_ref: (
-                object_id,
-                SequenceNumber::from_u64(2),
-                ObjectDigest::OBJECT_DIGEST_DELETED,
-            ),
+            object_id,
+            version: SequenceNumber::from_u64(2),
             kind: RemovedObjectKind::Deleted,
         }],
     );
@@ -507,13 +501,25 @@ fn test_terminal_deleted_marker_prevents_reindexing_written_object() {
 }
 
 #[test]
-fn test_removed_objects_from_effects_marks_unwrapped_then_deleted_as_deleted() {
+fn test_removed_objects_from_effects_preserves_removal_kind() {
     let owner = SuiAddress::random_for_testing_only();
-    let object_id = ObjectID::random();
-    let object_ref = (
-        object_id,
+    let deleted_id = ObjectID::random();
+    let deleted_ref = (
+        deleted_id,
         SequenceNumber::from_u64(2),
         ObjectDigest::OBJECT_DIGEST_DELETED,
+    );
+    let unwrapped_then_deleted_id = ObjectID::random();
+    let unwrapped_then_deleted_ref = (
+        unwrapped_then_deleted_id,
+        SequenceNumber::from_u64(3),
+        ObjectDigest::OBJECT_DIGEST_DELETED,
+    );
+    let wrapped_id = ObjectID::random();
+    let wrapped_ref = (
+        wrapped_id,
+        SequenceNumber::from_u64(4),
+        ObjectDigest::OBJECT_DIGEST_WRAPPED,
     );
     let gas_ref = (
         ObjectID::random(),
@@ -530,9 +536,9 @@ fn test_removed_objects_from_effects_marks_unwrapped_then_deleted_as_deleted() {
         vec![],
         vec![],
         vec![],
-        vec![],
-        vec![object_ref],
-        vec![],
+        vec![deleted_ref],
+        vec![unwrapped_then_deleted_ref],
+        vec![wrapped_ref],
         (gas_ref, Owner::AddressOwner(owner)),
         None,
         vec![],
@@ -540,10 +546,23 @@ fn test_removed_objects_from_effects_marks_unwrapped_then_deleted_as_deleted() {
 
     assert_eq!(
         removed_objects_from_effects(&effects),
-        vec![RemovedObject {
-            object_ref,
-            kind: RemovedObjectKind::Deleted,
-        }],
+        vec![
+            RemovedObject {
+                object_id: deleted_id,
+                version: deleted_ref.1,
+                kind: RemovedObjectKind::Deleted,
+            },
+            RemovedObject {
+                object_id: unwrapped_then_deleted_id,
+                version: unwrapped_then_deleted_ref.1,
+                kind: RemovedObjectKind::UnwrappedThenDeleted,
+            },
+            RemovedObject {
+                object_id: wrapped_id,
+                version: wrapped_ref.1,
+                kind: RemovedObjectKind::Wrapped,
+            },
+        ],
     );
 }
 


### PR DESCRIPTION
## Description 

This PR removes the `deleted|wrapped` markers for objects and moves them into the `latest` file, which now contains `version, deleted|wrapped`. The reason for this is to have fewer disk calls than previously.

## Test plan 

Update tests and added new tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
