### PR TITLE
[sui-fork] simplify seeding and owned object index data

### DIFF
--- a/crates/sui-fork/README.md
+++ b/crates/sui-fork/README.md
@@ -106,7 +106,7 @@ sui-fork status
 ```
 
 > [!TIP]
-> If your test depends on address-owned objects at startup, add repeatable
+> If your test depends on address-owned objects in the fork, add repeatable
 > `--address 0x...` or `--object 0x...` flags to `sui-fork start`.
 
 ## Impersonating Senders
@@ -155,7 +155,7 @@ sui-fork start --checkpoint 12345678 --address 0x... --object 0x...
   address at the fork checkpoint. Address seeding requires a checkpoint in the
   GraphQL object enumeration range, which is usually a range within the last hour.
 - `--object` is repeatable and fetches that object at the fork checkpoint. If
-  the object is address-owned, it is added to the initial owned-object index.
+  the object is address-owned, it is recorded in the seed manifest.
 - Fork metadata is written once to `seed_manifest.json` under the fork
   directory. The manifest is immutable and records the source network, original
   fork checkpoint, and any optional seed object references. When no seed inputs
@@ -166,7 +166,9 @@ manifest already exists and any seed flags are provided, startup fails instead
 of overwriting or reinterpreting the local state. Resume uses the original fork
 checkpoint from `seed_manifest.json`, starts from the highest locally persisted
 checkpoint, and keeps the durable owned-object index and deleted-object markers
-authoritative over the manifest seed entries.
+authoritative over the manifest seed entries. If the owned-object index has not
+been initialized yet, the first owned-object read or local execution update
+builds it from the manifest by fetching the exact seeded object versions.
 
 ## Limitations
 - Sequential execution: Transactions are executed one at a time, no parallelism.
@@ -174,8 +176,8 @@ authoritative over the manifest seed entries.
 - Staking and related operations are not supported.
 - Single validator, single authority network.
 - Object fetching overhead: First access to objects requires network download.
-- Forking from a checkpoint older than 1 hour requires explicit object seeding (you need to know which owned objects you want to have pulled at startup)
-- Owned-object enumeration only covers locally materialized post-fork state; it is not a full inventory of every object an address owned at the fork checkpoint.
+- Forking from a checkpoint older than 1 hour requires explicit object seeding (you need to know which owned objects should be recorded in the seed manifest).
+- Owned-object enumeration covers seeded objects plus locally materialized post-fork state; it is not a full inventory of every object an address owned at the fork checkpoint unless those objects were seeded.
 - Objects deleted or wrapped after the fork point are no longer available through direct current-ID lookup, but exact historical versions remain readable when available.
 - If it forks at checkpoint X, you cannot depend on objects created after checkpoint X from the actual real network. You'll need to restart the network at that checkpoint or a later one.
 - Not recommended for parallel test execution since all transactions are executed sequentially on a single validator.

--- a/crates/sui-fork/README.md
+++ b/crates/sui-fork/README.md
@@ -151,14 +151,14 @@ sui-fork start --checkpoint 12345678 --address 0x... --object 0x...
 - On Unix, the default `{base_path}` is `$XDG_DATA_HOME/sui_fork_data` when
   `XDG_DATA_HOME` is set, otherwise `$HOME/.sui_fork_data`.
 - On Windows, the default `{base_path}` is `%APPDATA%/sui_fork_data`.
-- `--address` is repeatable and seeds metadata for every object owned by that
+- `--address` is repeatable and seeds object references for every object owned by that
   address at the fork checkpoint. Address seeding requires a checkpoint in the
   GraphQL object enumeration range, which is usually a range within the last hour.
 - `--object` is repeatable and fetches that object at the fork checkpoint. If
   the object is address-owned, it is added to the initial owned-object index.
 - Fork metadata is written once to `seed_manifest.json` under the fork
   directory. The manifest is immutable and records the source network, original
-  fork checkpoint, and any optional seed object metadata. When no seed inputs
+  fork checkpoint, and any optional seed object references. When no seed inputs
   are provided, it is still written with an empty seed entry list.
 
 When restarting with the same fork data directory, omit seed flags. If a seed

--- a/crates/sui-fork/README.md
+++ b/crates/sui-fork/README.md
@@ -154,8 +154,9 @@ sui-fork start --checkpoint 12345678 --address 0x... --object 0x...
 - `--address` is repeatable and seeds object references for every object owned by that
   address at the fork checkpoint. Address seeding requires a checkpoint in the
   GraphQL object enumeration range, which is usually a range within the last hour.
-- `--object` is repeatable and fetches that object at the fork checkpoint. If
-  the object is address-owned, it is recorded in the seed manifest.
+- `--object` is repeatable and resolves lightweight metadata for that object at
+  the fork checkpoint. If the object is address-owned, it is recorded in the seed
+  manifest.
 - Fork metadata is written once to `seed_manifest.json` under the fork
   directory. The manifest is immutable and records the source network, original
   fork checkpoint, and any optional seed object references. When no seed inputs

--- a/crates/sui-fork/design/owned_objects_design.md
+++ b/crates/sui-fork/design/owned_objects_design.md
@@ -54,10 +54,7 @@ indices/
 ```rust
 struct OwnedObjectEntry {
     owner: SuiAddress,
-    object_id: ObjectID,
-    version: SequenceNumber,
-    object_type: StructTag,
-    balance: Option<u64>,
+    object_ref: ObjectRef,
 }
 ```
 
@@ -98,15 +95,16 @@ falling back to GraphQL. This keeps post-fork removals authoritative.
 historical cached object versions even if the current object is marked removed.
 
 `SimulatorStore::owned_objects(owner)` reads `indices/owned_objects`, filters by
-owner, validates each entry against the current object state, then returns the
-matching objects.
+owner, loads each candidate object through the normal object read path,
+validates the loaded object against the indexed object ref and owner, then
+returns the matching objects.
 
 `RpcStateReader::indexes()` returns the `DataStore` itself as a minimal
 `RpcIndexes` implementation. `owned_objects_iter` supports:
 
 - owner filtering
 - optional type filtering, with empty type parameters matching all type params
-  for the same address/module/name
+  for the same address/module/name, after object BCS is loaded
 - cursor lower-bound filtering by `object_id`
 
 Unsupported index methods return empty iterators or `None`.

--- a/crates/sui-fork/design/owned_objects_design.md
+++ b/crates/sui-fork/design/owned_objects_design.md
@@ -7,8 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 
 This document describes the first-version owned-object index design for
 `sui-fork`. The design is intentionally small: it supports owned object
-enumeration for locally materialized post-fork state while preserving the
-existing object-version cache.
+enumeration for seeded fork-point objects and locally materialized post-fork
+state while preserving the existing object-version cache.
 
 ## Goals
 
@@ -20,8 +20,10 @@ existing object-version cache.
 - Support `SimulatorStore::owned_objects(owner)` and the v2 RPC
   `list_owned_objects` path through `RpcIndexes::owned_objects_iter`.
 
-This does not build a full pre-fork address inventory. Objects only enter the
-owned-object index when local execution writes them through `update_objects`.
+This does not build a full pre-fork address inventory by default. Seeded
+objects enter the owned-object index when it is lazily initialized from
+`seed_manifest.json`; post-fork objects enter when local execution writes them
+through `update_objects`.
 
 ## Filesystem State
 
@@ -55,11 +57,14 @@ indices/
 struct OwnedObjectEntry {
     owner: SuiAddress,
     object_ref: ObjectRef,
+    object_type: StructTag,
+    balance: Option<u64>,
 }
 ```
 
-Objets with `AddressOwner` and `ConsensusAddressOwner` types are kept in the index. Shared, immutable,
-object-owned, and package objects are excluded.
+Objects with `AddressOwner` and `ConsensusAddressOwner` types are kept in the
+index. Shared, immutable, object-owned, and package objects are excluded. Coin
+objects store their balance in the index; non-coin objects use `None`.
 
 ## Write Path
 
@@ -68,6 +73,9 @@ and update numeric live `latest` metadata; they preserve existing deleted or
 wrapped `latest` state and do not update the owned index.
 
 Local execution flows through `DataStore::update_objects`:
+
+Before applying the local diff, initialize `indices/owned_objects` from
+`seed_manifest.json` if the index is missing.
 
 1. For each deleted object ID:
    - write `objects/<object_id>/latest` as `<version>,deleted`
@@ -95,16 +103,15 @@ falling back to GraphQL. This keeps post-fork removals authoritative.
 historical cached object versions even if the current object is marked removed.
 
 `SimulatorStore::owned_objects(owner)` reads `indices/owned_objects`, filters by
-owner, loads each candidate object through the normal object read path,
-validates the loaded object against the indexed object ref and owner, then
-returns the matching objects.
+owner, then loads each candidate object through the normal object read path and
+returns the matching objects at the indexed versions.
 
 `RpcStateReader::indexes()` returns the `DataStore` itself as a minimal
 `RpcIndexes` implementation. `owned_objects_iter` supports:
 
 - owner filtering
 - optional type filtering, with empty type parameters matching all type params
-  for the same address/module/name, after object BCS is loaded
+  for the same address/module/name, using the indexed object type
 - cursor lower-bound filtering by `object_id`
 
 Unsupported index methods return empty iterators or `None`.
@@ -113,13 +120,13 @@ Unsupported index methods return empty iterators or `None`.
 
 - The current-object read path cannot resurrect locally deleted objects from the
   remote endpoint.
-- The owned-object index is sorted, but it is not a complete live
-  object database.
+- The owned-object index is durable and sorted, but it is not a complete live
+  object database; it covers seeded objects plus local post-fork writes.
 - Owned-object reads and local object/index updates are coordinated by an
   in-process snapshot guard shared by cloned `DataStore` handles. This does not
   provide cross-process locking for multiple processes using the same data
   directory.
-- The index only covers locally materialized post-fork writes.
+- The index does not enumerate unseeded pre-fork objects.
 - Aggregate balance APIs are out of scope for this first version.
 - Crash recovery is limited to atomic replacement of the index file. A future
   version can rebuild the index by scanning object files and object `latest`

--- a/crates/sui-fork/design/poc.md
+++ b/crates/sui-fork/design/poc.md
@@ -85,7 +85,7 @@ At startup, the user has the choice to seed addresses or objects, recording enou
 
 
 If the user provides both `--address` and `--object`, the tool combines the object refs resolved from both sources and persists them to `seed_manifest.json`.
-The seed manifest is reused on restart and is the source for lazy owned-object index initialization.
+The seed manifest is reused on restart if needed, and is the source for lazy owned-object index initialization.
 
 ```json
 {
@@ -94,7 +94,6 @@ The seed manifest is reused on restart and is the source for lazy owned-object i
     "entries": [
         {
             "object_ref": ["0xabcdef1234567890abcdef1234567890abcdef12", 42, "..."],
-            "owner": "0x1234567890abcdef1234567890abcdef12345678"
         }
     ]
 }

--- a/crates/sui-fork/design/poc.md
+++ b/crates/sui-fork/design/poc.md
@@ -78,37 +78,24 @@ As data is persisted to disk, the user needs to provide a directory where the ne
 
 ### **Startup object seeding**
 
-At startup, the user has the choice to seed addresses or objects, to make the forked network “aware” of them.
+At startup, the user has the choice to seed addresses or objects, recording enough metadata for the forked network to initialize its owned-object index when needed.
 
-`--address` adds an address for seeding (works in the consistent range), loads that address's objects and adds them to the seed.
-`--object` add the object by ID directly to the seed.
+`--address` adds an address for seeding (works in the consistent range), resolves that address's owned object refs, and records them in the seed manifest.
+`--object` adds an object by ID to the seed manifest if it is address-owned at the fork checkpoint.
 
 
-Note that seeding can also be done from a file:
-
-```json
-{
-    "network": "testnet",
-    "checkpoint": 12345678,
-    "addresses": [
-        "0x1234567890abcdef1234567890abcdef12345678",
-        "0xabcdef1234567890abcdef1234567890abcdef12"
-    ],
-    "objects": [
-        "0xabcdef1234567890abcdef1234567890abcdef12"
-    ]
-}
-```
-
-If the user provides both `--address` and `--object`, the tool will combine the objects resolved from both sources and use that as the initial seed for the forked network.
-The initial seed will be dumped to a file `generated_{network}_{checkpoint}.json` for future reference. This file can be used to restart the same forked network with the same seed, which is useful for debugging or CI purposes.
+If the user provides both `--address` and `--object`, the tool combines the object refs resolved from both sources and persists them to `seed_manifest.json`.
+The seed manifest is reused on restart and is the source for lazy owned-object index initialization.
 
 ```json
 {
     "network": "testnet",
     "checkpoint": 12345678,
-    "objects": [
-        "0xabcdef1234567890abcdef1234567890abcdef12"
+    "entries": [
+        {
+            "object_ref": ["0xabcdef1234567890abcdef1234567890abcdef12", 42, "..."],
+            "owner": "0x1234567890abcdef1234567890abcdef12345678"
+        }
     ]
 }
 ```

--- a/crates/sui-fork/design/seeding_design.md
+++ b/crates/sui-fork/design/seeding_design.md
@@ -12,11 +12,9 @@ when it is first needed.
 Seeding resolves object refs (id, version, digest) plus owner at startup,
 establishing the minimal manifest needed to build a complete ownership index later.
 
-Object contents are NOT fetched during seeding for address-based seeds. Content
-fetching is deferred until lazy owned-object index initialization. For explicit
-`--object` IDs, we reuse the existing `multiGetObjects`
-infrastructure which does fetch BCS — a useful side-effect since these objects
-will likely be accessed during execution anyway.
+Object contents are NOT fetched during seeding. Content fetching is deferred
+until an actual object read or lazy owned-object index initialization needs the
+full object BCS.
 
 ### Checkpoint age constraint
 
@@ -32,11 +30,10 @@ Two new flags on the `start` command:
 --object <ID>        Seed a specific object ID if it is address-owned (repeatable)
 ```
 
-Both can be combined. Addresses are resolved into seed entries with owner plus
-object ref; explicit object IDs are fetched via the existing `multiGetObjects`
-path and reduced to the same minimal seed entry shape. Results are merged and
-deduped by object ID. It is important to note if addresses is passed, the
-checkpoint must be within the last 1h.
+Both can be combined. Addresses and explicit object IDs are resolved into seed
+entries with owner plus object ref. Results are merged and deduped by object ID.
+It is important to note if addresses is passed, the checkpoint must be within
+the last 1h.
 
 When restarting a fork with the same `--data-dir` and `--checkpoint`, the existing
 seeding information that is stored on disk will be reused. If `--address` or `--object` is
@@ -114,13 +111,27 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
   variants are handled by the query fallback and skipped; they are not
   controlled by the seeded address for the initial index.
 
-### Individual objects (reuse existing)
+### Individual objects query
 
-For explicit `--object` IDs, reuse the existing `object_query::query()`
-infrastructure (`multiGetObjects` with `ObjectFragment` that fetches `objectBcs`).
-BCS gets cached to disk. After fetching, extract the owner and object ref from
-the deserialized `Object`; persist only those fields in the `SeedEntry`.
-Object type and balance are not part of the seed manifest.
+For explicit `--object` IDs, use a metadata-only `multiGetObjects` query. The
+provided object ID is used as the object ref ID; the query does not request
+`Object.address` or `objectBcs`.
+
+```graphql
+query($keys: [ObjectKey!]!) {
+  multiGetObjects(keys: $keys) {
+    version
+    digest
+    owner {
+      ... on AddressOwner { address { address } }
+      ... on ConsensusAddressOwner { address { address } }
+    }
+  }
+}
+```
+
+The query returns the same minimal seed entry shape as address seeding. Object
+type, balance, and full BCS are not part of the seed manifest.
 
 ## Implementation Details
 
@@ -159,7 +170,7 @@ async fn resolve_seeds(
 
 1. For each address → paginate `address_objects_query`, collect entries
 2. Collect explicit object IDs not already resolved by address seeding (dedup)
-3. For remaining object IDs → `object_query::query()` (existing), extract refs and owner
+3. For remaining object IDs → metadata-only object seed query, collect entries
 4. Merge, dedup by `object_id`
 5. Return `SeedManifest`
 

--- a/crates/sui-fork/design/seeding_design.md
+++ b/crates/sui-fork/design/seeding_design.md
@@ -3,17 +3,18 @@
 ## Problem
 
 The forking tool can execute transactions against forked state but cannot answer
-"what objects does address X own?" without explicit rpc querying at startup / before first transaction.
+"what objects does address X own?" unless the fork has durable ownership metadata.
 For example, if a user would like to execute a transaction, the forked network does not have
 yet the ownership information - which gas coins it owns. To enable this, seeding
-allows the tool to resolve ownership information at startup and build an initial ownership index.
+records object ownership metadata at startup so the owned-object index can be initialized
+when it is first needed.
 
 Seeding resolves object refs (id, version, digest) plus owner at startup,
-establishing the data needed to build an ownership index.
+establishing the minimal manifest needed to build a complete ownership index later.
 
 Object contents are NOT fetched during seeding for address-based seeds. Content
-fetching is deferred to the existing `get_object_from_remote()` path used by
-execution. For explicit `--object` IDs, we reuse the existing `multiGetObjects`
+fetching is deferred until lazy owned-object index initialization. For explicit
+`--object` IDs, we reuse the existing `multiGetObjects`
 infrastructure which does fetch BCS — a useful side-effect since these objects
 will likely be accessed during execution anyway.
 
@@ -28,19 +29,20 @@ Two new flags on the `start` command:
 
 ```
 --address <ADDR>     Seed all owned objects for this address (repeatable)
---object <ID>        Seed a specific object by ID (repeatable)
+--object <ID>        Seed a specific object ID if it is address-owned (repeatable)
 ```
 
-Both can be combined. Addresses are resolved into object refs; explicit
-object IDs are fetched via the existing `multiGetObjects` path. Results are
-merged and deduped by object ID. It is important to note if addresses is passed,
-the checkpoint must be within the last 1h.
+Both can be combined. Addresses are resolved into seed entries with owner plus
+object ref; explicit object IDs are fetched via the existing `multiGetObjects`
+path and reduced to the same minimal seed entry shape. Results are merged and
+deduped by object ID. It is important to note if addresses is passed, the
+checkpoint must be within the last 1h.
 
 When restarting a fork with the same `--data-dir` and `--checkpoint`, the existing
 seeding information that is stored on disk will be reused. If `--address` or `--object` is
 provided, the tool will error with a message indicating that a seed manifest already exists.
 The owned-object index and local object `latest` state remain authoritative over the
-manifest after the fork has executed local transactions.
+manifest after the fork has initialized the index or executed local transactions.
 
 ## Generated files
 
@@ -118,6 +120,7 @@ For explicit `--object` IDs, reuse the existing `object_query::query()`
 infrastructure (`multiGetObjects` with `ObjectFragment` that fetches `objectBcs`).
 BCS gets cached to disk. After fetching, extract the owner and object ref from
 the deserialized `Object`; persist only those fields in the `SeedEntry`.
+Object type and balance are not part of the seed manifest.
 
 ## Implementation Details
 
@@ -166,17 +169,16 @@ The seed manifest is the immutable pre-fork baseline. The
 `indices/owned_objects` file and object `latest` metadata are the current local
 state once the fork has started executing.
 
-**Index rebuild on startup** (two sources):
+**Index initialization**:
 1. If `indices/owned_objects` exists, use it as-is and do not rewrite it from the manifest.
 2. If the index is missing and the fork has not advanced past the fork checkpoint, initialize it
-   from `seed_manifest.json`.
+   from `seed_manifest.json` before the first owned-object read or local execution update.
 3. If the index is missing but local checkpoints are newer than the fork checkpoint, fail closed
    instead of rebuilding stale seed state over local mutations.
 
-**When a seeded object is first accessed** (e.g., as tx input):
-- `get_object_from_remote()` fetches full BCS, writes to disk
-- the owned index entry identifies candidate objects, while object-loading reads fetch BCS lazily
-  before type, balance, or object contents are returned
+During initialization, each seed entry is fetched at the exact seeded version and fork checkpoint,
+validated against the manifest owner/ref, written to the local object cache, and converted into a
+complete owned-object index entry with object type and optional coin balance.
 
 **When a seeded object is deleted/mutated post-fork**:
 - `update_objects()` removes the old index entry, adds the new address-owned entry, or removes the
@@ -199,12 +201,12 @@ through the owned-object index, object BCS files, and object `latest` state.
 
 | File | Action |
 |------|--------|
-| `src/seed.rs` | New — types, seed policy, manifest/index initialization |
+| `src/seed.rs` | New — types, seed policy, manifest resolution |
 | `src/gql/queries.rs` | Modify — new `address_owned_objects_query` module |
-| `src/cli.rs` | Modify — three new CLI args on Start |
+| `src/cli.rs` | Modify — seed CLI args on Start |
 | `src/startup.rs` | Modify — wire seeding into initialize() |
 | `src/filesystem.rs` | Modify — seed manifest read/write |
-| `src/store.rs` | Modify — expose `gql()` and `local()` accessors |
+| `src/store.rs` | Modify — lazy owned-object index initialization |
 | `src/lib.rs` | Modify — add `mod seed` |
 
 ## Implementation order
@@ -214,5 +216,5 @@ through the owned-object index, object BCS files, and object `latest` state.
 3. Filesystem manifest read/write
 4. Resolution logic (`resolve_seeds()`)
 5. CLI args + plumbing through `cmd_start` → `initialize`
-6. Store accessors
+6. Lazy index initialization in `DataStore`
 7. Tests

--- a/crates/sui-fork/design/seeding_design.md
+++ b/crates/sui-fork/design/seeding_design.md
@@ -6,11 +6,11 @@ The forking tool can execute transactions against forked state but cannot answer
 "what objects does address X own?" unless the fork has durable ownership metadata.
 For example, if a user would like to execute a transaction, the forked network does not have
 yet the ownership information - which gas coins it owns. To enable this, seeding
-records object ownership metadata at startup so the owned-object index can be initialized
-when it is first needed.
+records object reference metadata at startup so the owned-object index can be
+initialized when it is first needed.
 
-Seeding resolves object refs (id, version, digest) plus owner at startup,
-establishing the minimal manifest needed to build a complete ownership index later.
+Seeding resolves object refs (id, version, digest) at startup, establishing
+the minimal manifest needed to build a complete ownership index later.
 
 Object contents are NOT fetched during seeding. Content fetching is deferred
 until an actual object read or lazy owned-object index initialization needs the
@@ -31,7 +31,7 @@ Two new flags on the `start` command:
 ```
 
 Both can be combined. Addresses and explicit object IDs are resolved into seed
-entries with owner plus object ref. Results are merged and deduped by object ID.
+entries with object refs. Results are merged and deduped by object ID.
 It is important to note if addresses is passed, the checkpoint must be within
 the last 1h.
 
@@ -53,8 +53,7 @@ One file is written to `{data_dir}/{network}/forked_at_{checkpoint}/`:
     "checkpoint": 12345678,
     "entries": [
         {
-            "object_ref": ["0x...", 42, "..."],
-            "owner": "0x..."
+            "object_ref": ["0x...", 42, "..."]
         }
     ]
 }
@@ -92,10 +91,6 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
             address
             version
             digest
-            owner {
-              ... on AddressOwner { address { address } }
-              ... on ConsensusAddressOwner { address { address } }
-            }
           }
           pageInfo { hasNextPage endCursor }
         }
@@ -107,9 +102,8 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
 
 - Page size: 50
 - Paginate with cursor loop (same pattern as `events_query`)
-- Only collect `AddressOwner` and `ConsensusAddressOwner` entries. Other owner
-  variants are handled by the query fallback and skipped; they are not
-  controlled by the seeded address for the initial index.
+- Collect every returned node as an object ref. `Address.objects` is the source
+  of truth for address-owned membership and the manifest does not persist owner.
 
 ### Individual objects query
 
@@ -130,8 +124,9 @@ query($keys: [ObjectKey!]!) {
 }
 ```
 
-The query returns the same minimal seed entry shape as address seeding. Object
-type, balance, and full BCS are not part of the seed manifest.
+The query returns object refs for seed entries after confirming address
+ownership. Object type, balance, owner, and full BCS are not part of the seed
+manifest.
 
 ## Implementation Details
 
@@ -141,7 +136,6 @@ type, balance, and full BCS are not part of the seed manifest.
 #[derive(Serialize, Deserialize)]
 struct SeedEntry {
     object_ref: ObjectRef,
-    owner: SuiAddress,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -188,8 +182,8 @@ state once the fork has started executing.
    instead of rebuilding stale seed state over local mutations.
 
 During initialization, each seed entry is fetched at the exact seeded version and fork checkpoint,
-validated against the manifest owner/ref, written to the local object cache, and converted into a
-complete owned-object index entry with object type and optional coin balance.
+validated against the manifest ref, written to the local object cache, and converted into a
+complete owned-object index entry with owner, object type, and optional coin balance.
 
 **When a seeded object is deleted/mutated post-fork**:
 - `update_objects()` removes the old index entry, adds the new address-owned entry, or removes the

--- a/crates/sui-fork/design/seeding_design.md
+++ b/crates/sui-fork/design/seeding_design.md
@@ -8,8 +8,8 @@ For example, if a user would like to execute a transaction, the forked network d
 yet the ownership information - which gas coins it owns. To enable this, seeding
 allows the tool to resolve ownership information at startup and build an initial ownership index.
 
-Seeding resolves object refs (id, version, digest) + lightweight metadata (owner, type)
-at startup, establishing the data needed to build an ownership index.
+Seeding resolves object refs (id, version, digest) plus owner at startup,
+establishing the data needed to build an ownership index.
 
 Object contents are NOT fetched during seeding for address-based seeds. Content
 fetching is deferred to the existing `get_object_from_remote()` path used by
@@ -46,7 +46,7 @@ manifest after the fork has executed local transactions.
 
 One file is written to `{data_dir}/{network}/forked_at_{checkpoint}/`:
 
-### `seed_manifest.json` — internal, full metadata for index rebuilding
+### `seed_manifest.json` — internal refs for index rebuilding
 
 ```json
 {
@@ -54,12 +54,8 @@ One file is written to `{data_dir}/{network}/forked_at_{checkpoint}/`:
     "checkpoint": 12345678,
     "entries": [
         {
-            "object_id": "0x...",
-            "version": 42,
-            "digest": "...",
-            "owner": "0x...",
-            "object_type": "0x2::coin::Coin<0x2::sui::SUI>",
-            "balance": 1000000
+            "object_ref": ["0x...", 42, "..."],
+            "owner": "0x..."
         }
     ]
 }
@@ -101,10 +97,6 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
               ... on AddressOwner { address { address } }
               ... on ConsensusAddressOwner { address { address } }
             }
-            contents {
-              type { repr }
-              json
-            }
           }
           pageInfo { hasNextPage endCursor }
         }
@@ -124,8 +116,8 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
 
 For explicit `--object` IDs, reuse the existing `object_query::query()`
 infrastructure (`multiGetObjects` with `ObjectFragment` that fetches `objectBcs`).
-BCS gets cached to disk. After fetching, extract metadata (owner, type, version,
-digest) from the deserialized `Object` for the `SeedEntry`.
+BCS gets cached to disk. After fetching, extract the owner and object ref from
+the deserialized `Object`; persist only those fields in the `SeedEntry`.
 
 ## Implementation Details
 
@@ -134,12 +126,8 @@ digest) from the deserialized `Object` for the `SeedEntry`.
 ```rust
 #[derive(Serialize, Deserialize)]
 struct SeedEntry {
-    object_id: ObjectID,
-    version: SequenceNumber,
-    digest: ObjectDigest,
+    object_ref: ObjectRef,
     owner: SuiAddress,
-    object_type: StructTag,
-    balance: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -168,7 +156,7 @@ async fn resolve_seeds(
 
 1. For each address → paginate `address_objects_query`, collect entries
 2. Collect explicit object IDs not already resolved by address seeding (dedup)
-3. For remaining object IDs → `object_query::query()` (existing), extract metadata
+3. For remaining object IDs → `object_query::query()` (existing), extract refs and owner
 4. Merge, dedup by `object_id`
 5. Return `SeedManifest`
 
@@ -187,8 +175,8 @@ state once the fork has started executing.
 
 **When a seeded object is first accessed** (e.g., as tx input):
 - `get_object_from_remote()` fetches full BCS, writes to disk
-- the owned index entry can already satisfy default owned-object listing, while object-loading
-  read masks fetch BCS lazily
+- the owned index entry identifies candidate objects, while object-loading reads fetch BCS lazily
+  before type, balance, or object contents are returned
 
 **When a seeded object is deleted/mutated post-fork**:
 - `update_objects()` removes the old index entry, adds the new address-owned entry, or removes the

--- a/crates/sui-fork/src/cli.rs
+++ b/crates/sui-fork/src/cli.rs
@@ -56,7 +56,7 @@ enum Command {
         #[arg(long)]
         data_dir: Option<PathBuf>,
 
-        /// Address whose owned objects should seed the initial owned-object index
+        /// Address whose owned objects should be recorded in the seed manifest
         #[arg(long = "address")]
         addresses: Vec<SuiAddress>,
 

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -41,7 +41,6 @@ use anyhow::Error;
 use anyhow::bail;
 use anyhow::ensure;
 
-use move_core_types::language_storage::StructTag;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
@@ -162,10 +161,7 @@ impl ObjectLatestMetadata {
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub(crate) struct OwnedObjectEntry {
     pub(crate) owner: SuiAddress,
-    pub(crate) object_id: ObjectID,
-    pub(crate) version: SequenceNumber,
-    pub(crate) object_type: StructTag,
-    pub(crate) balance: Option<u64>,
+    pub(crate) object_ref: ObjectRef,
 }
 
 impl OwnedObjectEntry {
@@ -176,10 +172,7 @@ impl OwnedObjectEntry {
         };
         Some(Self {
             owner,
-            object_id: object.id(),
-            version: object.version(),
-            object_type: object.struct_tag()?,
-            balance: object.as_coin_maybe().map(|coin| coin.value()),
+            object_ref: object.compute_object_reference(),
         })
     }
 }
@@ -948,13 +941,13 @@ fn parse_object_latest_inner(content: &str) -> anyhow::Result<ObjectLatestMetada
 }
 
 fn remove_owned_entry(entries: &mut Vec<OwnedObjectEntry>, object_id: ObjectID) {
-    if let Ok(index) = entries.binary_search_by_key(&object_id, |entry| entry.object_id) {
+    if let Ok(index) = entries.binary_search_by_key(&object_id, |entry| entry.object_ref.0) {
         entries.remove(index);
     }
 }
 
 fn upsert_owned_entry(entries: &mut Vec<OwnedObjectEntry>, entry: OwnedObjectEntry) {
-    match entries.binary_search_by_key(&entry.object_id, |existing| existing.object_id) {
+    match entries.binary_search_by_key(&entry.object_ref.0, |existing| existing.object_ref.0) {
         Ok(index) => entries[index] = entry,
         Err(index) => entries.insert(index, entry),
     }

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -41,6 +41,7 @@ use anyhow::Error;
 use anyhow::bail;
 use anyhow::ensure;
 
+use move_core_types::language_storage::StructTag;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
@@ -162,17 +163,22 @@ impl ObjectLatestMetadata {
 pub(crate) struct OwnedObjectEntry {
     pub(crate) owner: SuiAddress,
     pub(crate) object_ref: ObjectRef,
+    pub(crate) object_type: StructTag,
+    pub(crate) balance: Option<u64>,
 }
 
 impl OwnedObjectEntry {
-    fn from_object(object: &Object) -> Option<Self> {
+    pub(crate) fn from_object(object: &Object) -> Option<Self> {
         let owner = match &object.owner {
             Owner::AddressOwner(owner) | Owner::ConsensusAddressOwner { owner, .. } => *owner,
             _ => return None,
         };
+        let object_type = object.struct_tag()?;
         Some(Self {
             owner,
             object_ref: object.compute_object_reference(),
+            object_type,
+            balance: object.as_coin_maybe().map(|coin| coin.value()),
         })
     }
 }

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -43,6 +43,7 @@ use anyhow::ensure;
 
 use move_core_types::language_storage::StructTag;
 use sui_types::base_types::ObjectID;
+use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
 use sui_types::digests::CheckpointContentsDigest;

--- a/crates/sui-fork/src/gql/client.rs
+++ b/crates/sui-fork/src/gql/client.rs
@@ -9,6 +9,7 @@ use cynic::Operation;
 use reqwest::header::USER_AGENT;
 
 use sui_protocol_config::Chain;
+use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
 use sui_types::effects::TransactionEvents;
 use sui_types::messages_checkpoint::CheckpointContents;
@@ -24,6 +25,7 @@ use crate::ObjectRead;
 use crate::TransactionInfo;
 use crate::TransactionRead;
 use crate::gql::AddressOwnedObject;
+use crate::gql::ObjectSeedMetadata;
 use crate::gql::queries;
 
 macro_rules! block_on {
@@ -137,6 +139,15 @@ impl GraphQLClient {
         checkpoint: CheckpointSequenceNumber,
     ) -> Result<Vec<AddressOwnedObject>, Error> {
         queries::address_owned_objects_query::query(address, checkpoint, self).await
+    }
+
+    /// Fetch lightweight metadata for explicit object seeds at a checkpoint.
+    pub(crate) async fn get_object_seed_metadata_at_checkpoint(
+        &self,
+        object_ids: &[ObjectID],
+        checkpoint: CheckpointSequenceNumber,
+    ) -> Result<Vec<ObjectSeedMetadata>, Error> {
+        queries::object_seed_query::query(object_ids, checkpoint, self).await
     }
 
     /// Get the latest checkpoint sequence number from GraphQL RPC.

--- a/crates/sui-fork/src/gql/mod.rs
+++ b/crates/sui-fork/src/gql/mod.rs
@@ -6,3 +6,4 @@ mod queries;
 
 pub use client::GraphQLClient;
 pub(crate) use queries::address_owned_objects_query::AddressOwnedObject;
+pub(crate) use queries::object_seed_query::ObjectSeedMetadata;

--- a/crates/sui-fork/src/gql/queries.rs
+++ b/crates/sui-fork/src/gql/queries.rs
@@ -678,6 +678,402 @@ pub(crate) mod address_owned_objects_query {
     }
 }
 
+pub(crate) mod object_seed_query {
+    use sui_types::base_types::ObjectID;
+    use sui_types::base_types::SequenceNumber;
+    use sui_types::base_types::SuiAddress as SuiAddressType;
+    use sui_types::digests::ObjectDigest;
+    use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+    use super::address_owned_objects_query::AddressOwnedObject;
+    use super::*;
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) enum ObjectSeedMetadata {
+        Missing,
+        NonAddressOwned,
+        AddressOwned(AddressOwnedObject),
+    }
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    #[cynic(graphql_type = "SuiAddress")]
+    pub(crate) struct SuiAddress(pub String);
+
+    #[derive(cynic::InputObject, Debug)]
+    #[cynic(graphql_type = "ObjectKey")]
+    pub(crate) struct ObjectKey {
+        pub address: SuiAddress,
+        pub version: Option<u64>,
+        pub root_version: Option<u64>,
+        pub at_checkpoint: Option<u64>,
+    }
+
+    #[derive(cynic::QueryVariables)]
+    pub(crate) struct ObjectSeedArgs {
+        pub keys: Vec<ObjectKey>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        variables = "ObjectSeedArgs",
+        graphql_type = "Query",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct Query {
+        #[arguments(keys: $keys)]
+        multi_get_objects: Vec<Option<ObjectSeedObject>>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Object", schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct ObjectSeedObject {
+        version: Option<u64>,
+        digest: Option<String>,
+        owner: Option<Owner>,
+    }
+
+    #[derive(cynic::InlineFragments)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) enum Owner {
+        AddressOwner(AddressOwner),
+        ConsensusAddressOwner(ConsensusAddressOwner),
+        #[cynic(fallback)]
+        Other,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct AddressOwner {
+        address: Option<OwnerAddress>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct ConsensusAddressOwner {
+        address: Option<OwnerAddress>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        graphql_type = "Address",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct OwnerAddress {
+        address: SuiAddress,
+    }
+
+    const MAX_KEYS_SIZE: usize = 30;
+
+    pub(crate) async fn query(
+        object_ids: &[ObjectID],
+        checkpoint: CheckpointSequenceNumber,
+        client: &GraphQLClient,
+    ) -> Result<Vec<ObjectSeedMetadata>, Error> {
+        let mut results = Vec::with_capacity(object_ids.len());
+
+        for object_ids in object_ids.chunks(MAX_KEYS_SIZE) {
+            let keys = object_ids
+                .iter()
+                .map(|object_id| ObjectKey {
+                    address: SuiAddress(object_id.to_string()),
+                    version: None,
+                    root_version: None,
+                    at_checkpoint: Some(checkpoint),
+                })
+                .collect();
+            let operation = Query::build(ObjectSeedArgs { keys });
+            let response = client.run_query(&operation).await.with_context(|| {
+                format!("failed to query object seeds at checkpoint {checkpoint}")
+            })?;
+            let data = response.data.with_context(|| {
+                format!(
+                    "missing data in object seed query response at checkpoint {checkpoint}: {:?}",
+                    response.errors,
+                )
+            })?;
+
+            if data.multi_get_objects.len() != object_ids.len() {
+                return Err(anyhow!(
+                    "object seed query returned {} results for {} object IDs",
+                    data.multi_get_objects.len(),
+                    object_ids.len(),
+                ));
+            }
+
+            for (object_id, object) in object_ids.iter().copied().zip_eq(data.multi_get_objects) {
+                results.push(decode_object_seed(object_id, object)?);
+            }
+        }
+
+        Ok(results)
+    }
+
+    fn decode_object_seed(
+        object_id: ObjectID,
+        object: Option<ObjectSeedObject>,
+    ) -> Result<ObjectSeedMetadata, Error> {
+        let Some(object) = object else {
+            return Ok(ObjectSeedMetadata::Missing);
+        };
+        let owner = match object.owner {
+            Some(Owner::AddressOwner(owner)) => parse_owner_address(owner.address, &object_id)?,
+            Some(Owner::ConsensusAddressOwner(owner)) => {
+                parse_owner_address(owner.address, &object_id)?
+            }
+            _ => return Ok(ObjectSeedMetadata::NonAddressOwned),
+        };
+        let digest = object
+            .digest
+            .with_context(|| format!("seed object {object_id} is missing digest"))?
+            .parse::<ObjectDigest>()
+            .with_context(|| format!("invalid seed object digest for {object_id}"))?;
+        let version = object
+            .version
+            .with_context(|| format!("seed object {object_id} is missing version"))?;
+
+        Ok(ObjectSeedMetadata::AddressOwned(AddressOwnedObject {
+            object_ref: (object_id, SequenceNumber::from_u64(version), digest),
+            owner,
+        }))
+    }
+
+    fn parse_owner_address(
+        address: Option<OwnerAddress>,
+        object_id: &ObjectID,
+    ) -> Result<SuiAddressType, Error> {
+        address
+            .with_context(|| format!("seed object {object_id} is missing owner address"))?
+            .address
+            .0
+            .parse::<SuiAddressType>()
+            .with_context(|| format!("invalid seed owner for object {object_id}"))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use sui_types::base_types::ObjectID;
+        use sui_types::object::Object;
+        use sui_types::object::Owner as SuiOwner;
+        use wiremock::Mock;
+        use wiremock::MockServer;
+        use wiremock::ResponseTemplate;
+        use wiremock::matchers::body_partial_json;
+        use wiremock::matchers::method;
+        use wiremock::matchers::path;
+
+        use super::*;
+        use crate::Node;
+
+        fn object_seed_response(nodes: Vec<serde_json::Value>) -> serde_json::Value {
+            serde_json::json!({
+                "data": {
+                    "multiGetObjects": nodes,
+                }
+            })
+        }
+
+        fn address_owned_object_node(object: &Object, owner: SuiAddressType) -> serde_json::Value {
+            serde_json::json!({
+                "version": object.version().value(),
+                "digest": object.digest().to_string(),
+                "owner": {
+                    "__typename": "AddressOwner",
+                    "address": { "address": owner.to_string() },
+                }
+            })
+        }
+
+        fn consensus_owned_object_node(
+            object: &Object,
+            owner: SuiAddressType,
+        ) -> serde_json::Value {
+            serde_json::json!({
+                "version": object.version().value(),
+                "digest": object.digest().to_string(),
+                "owner": {
+                    "__typename": "ConsensusAddressOwner",
+                    "address": { "address": owner.to_string() },
+                }
+            })
+        }
+
+        fn assert_object_seed_query_shape(query: &str) {
+            assert!(query.contains("multiGetObjects"));
+            assert!(query.contains("version"));
+            assert!(query.contains("digest"));
+            assert!(query.contains("... on AddressOwner"));
+            assert!(query.contains("... on ConsensusAddressOwner"));
+            assert!(!query.contains("objectBcs"));
+
+            let object_selection_before_owner = query
+                .split("multiGetObjects")
+                .nth(1)
+                .expect("query should include multiGetObjects")
+                .split("owner")
+                .next()
+                .expect("query should include owner");
+            assert!(
+                !object_selection_before_owner
+                    .lines()
+                    .any(|line| line.trim() == "address"),
+                "object seed query should not request Object.address",
+            );
+        }
+
+        #[tokio::test]
+        async fn query_returns_address_owned_metadata_without_object_bcs() {
+            let server = MockServer::start().await;
+            let owner = SuiAddressType::random_for_testing_only();
+            let first = Object::with_id_owner_version_for_testing(
+                ObjectID::random(),
+                SequenceNumber::from_u64(7),
+                SuiOwner::AddressOwner(owner),
+            );
+            let second = Object::with_id_owner_version_for_testing(
+                ObjectID::random(),
+                SequenceNumber::from_u64(8),
+                SuiOwner::ConsensusAddressOwner {
+                    start_version: SequenceNumber::from_u64(8),
+                    owner,
+                },
+            );
+            let missing = ObjectID::random();
+
+            Mock::given(method("POST"))
+                .and(path("/"))
+                .and(body_partial_json(serde_json::json!({
+                    "variables": {
+                        "keys": [
+                            {
+                                "address": first.id().to_string(),
+                                "atCheckpoint": 10,
+                            },
+                            {
+                                "address": missing.to_string(),
+                                "atCheckpoint": 10,
+                            },
+                            {
+                                "address": second.id().to_string(),
+                                "atCheckpoint": 10,
+                            },
+                        ],
+                    }
+                })))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(object_seed_response(vec![
+                        address_owned_object_node(&first, owner),
+                        serde_json::Value::Null,
+                        consensus_owned_object_node(&second, owner),
+                    ])),
+                )
+                .mount(&server)
+                .await;
+
+            let gql = GraphQLClient::new(Node::Custom(server.uri()), "test")
+                .expect("graphql client should build");
+            let entries = query(&[first.id(), missing, second.id()], 10, &gql)
+                .await
+                .expect("object seeds should resolve");
+
+            assert_eq!(entries.len(), 3);
+            assert_eq!(
+                entries[0],
+                ObjectSeedMetadata::AddressOwned(AddressOwnedObject {
+                    object_ref: first.compute_object_reference(),
+                    owner,
+                })
+            );
+            assert_eq!(entries[1], ObjectSeedMetadata::Missing);
+            assert_eq!(
+                entries[2],
+                ObjectSeedMetadata::AddressOwned(AddressOwnedObject {
+                    object_ref: second.compute_object_reference(),
+                    owner,
+                })
+            );
+
+            let requests = server
+                .received_requests()
+                .await
+                .expect("wiremock should record requests");
+            let request_body: serde_json::Value = requests[0]
+                .body_json()
+                .expect("request body should be json");
+            let query = request_body
+                .get("query")
+                .and_then(serde_json::Value::as_str)
+                .expect("query string should be present");
+            assert_object_seed_query_shape(query);
+        }
+
+        #[tokio::test]
+        async fn query_errors_on_malformed_object_seed_metadata() {
+            let owner = SuiAddressType::random_for_testing_only();
+            let object = Object::with_id_owner_version_for_testing(
+                ObjectID::random(),
+                SequenceNumber::from_u64(7),
+                SuiOwner::AddressOwner(owner),
+            );
+
+            for (node, expected_error) in [
+                (
+                    serde_json::json!({
+                        "version": object.version().value(),
+                        "digest": null,
+                        "owner": {
+                            "__typename": "AddressOwner",
+                            "address": { "address": owner.to_string() },
+                        }
+                    }),
+                    "missing digest",
+                ),
+                (
+                    serde_json::json!({
+                        "version": null,
+                        "digest": object.digest().to_string(),
+                        "owner": {
+                            "__typename": "AddressOwner",
+                            "address": { "address": owner.to_string() },
+                        }
+                    }),
+                    "missing version",
+                ),
+                (
+                    serde_json::json!({
+                        "version": object.version().value(),
+                        "digest": object.digest().to_string(),
+                        "owner": {
+                            "__typename": "AddressOwner",
+                            "address": null,
+                        }
+                    }),
+                    "missing owner address",
+                ),
+            ] {
+                let server = MockServer::start().await;
+                Mock::given(method("POST"))
+                    .and(path("/"))
+                    .respond_with(
+                        ResponseTemplate::new(200).set_body_json(object_seed_response(vec![node])),
+                    )
+                    .mount(&server)
+                    .await;
+
+                let gql = GraphQLClient::new(Node::Custom(server.uri()), "test")
+                    .expect("graphql client should build");
+                let err = query(&[object.id()], 10, &gql)
+                    .await
+                    .expect_err("malformed object seed metadata should fail");
+
+                assert!(
+                    err.to_string().contains(expected_error),
+                    "expected error containing {expected_error:?}, got {err:?}",
+                );
+            }
+        }
+    }
+}
+
 pub(crate) mod events_query {
     use super::*;
     use sui_types::effects::TransactionEvents;

--- a/crates/sui-fork/src/gql/queries.rs
+++ b/crates/sui-fork/src/gql/queries.rs
@@ -245,7 +245,6 @@ pub(crate) mod address_owned_objects_query {
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub(crate) struct AddressOwnedObject {
         pub(crate) object_ref: ObjectRef,
-        pub(crate) owner: SuiAddressType,
     }
 
     #[derive(cynic::QueryVariables)]
@@ -321,37 +320,6 @@ pub(crate) mod address_owned_objects_query {
         address: SuiAddress,
         version: Option<u64>,
         digest: Option<String>,
-        owner: Option<Owner>,
-    }
-
-    #[derive(cynic::InlineFragments)]
-    #[cynic(schema_module = "crate::gql::queries::schema")]
-    pub(crate) enum Owner {
-        AddressOwner(AddressOwner),
-        ConsensusAddressOwner(ConsensusAddressOwner),
-        #[cynic(fallback)]
-        Other,
-    }
-
-    #[derive(cynic::QueryFragment)]
-    #[cynic(schema_module = "crate::gql::queries::schema")]
-    pub(crate) struct AddressOwner {
-        address: Option<OwnerAddress>,
-    }
-
-    #[derive(cynic::QueryFragment)]
-    #[cynic(schema_module = "crate::gql::queries::schema")]
-    pub(crate) struct ConsensusAddressOwner {
-        address: Option<OwnerAddress>,
-    }
-
-    #[derive(cynic::QueryFragment)]
-    #[cynic(
-        graphql_type = "Address",
-        schema_module = "crate::gql::queries::schema"
-    )]
-    pub(crate) struct OwnerAddress {
-        address: SuiAddress,
     }
 
     #[derive(cynic::Scalar, Debug, Clone)]
@@ -398,9 +366,7 @@ pub(crate) mod address_owned_objects_query {
             };
 
             for node in objects.nodes {
-                if let Some(entry) = decode_move_object(node)? {
-                    entries.push(entry);
-                }
+                entries.push(decode_move_object(node)?);
             }
 
             if !objects.page_info.has_next_page {
@@ -412,16 +378,7 @@ pub(crate) mod address_owned_objects_query {
         Ok(entries)
     }
 
-    fn decode_move_object(node: MoveObject) -> Result<Option<AddressOwnedObject>, Error> {
-        let owner = match node.owner {
-            Some(Owner::AddressOwner(owner)) => {
-                parse_owner_address(owner.address, &node.address.0)?
-            }
-            Some(Owner::ConsensusAddressOwner(owner)) => {
-                parse_owner_address(owner.address, &node.address.0)?
-            }
-            _ => return Ok(None),
-        };
+    fn decode_move_object(node: MoveObject) -> Result<AddressOwnedObject, Error> {
         let object_id = node
             .address
             .0
@@ -436,22 +393,9 @@ pub(crate) mod address_owned_objects_query {
             .version
             .ok_or_else(|| anyhow!("seed object {object_id} is missing version"))?;
 
-        Ok(Some(AddressOwnedObject {
+        Ok(AddressOwnedObject {
             object_ref: (object_id, SequenceNumber::from_u64(version), digest),
-            owner,
-        }))
-    }
-
-    fn parse_owner_address(
-        address: Option<OwnerAddress>,
-        object_id: &str,
-    ) -> Result<SuiAddressType, Error> {
-        address
-            .context("address seed entry is missing owner address")?
-            .address
-            .0
-            .parse::<SuiAddressType>()
-            .with_context(|| format!("invalid seed owner for object {object_id}"))
+        })
     }
 
     #[cfg(test)]
@@ -519,43 +463,16 @@ pub(crate) mod address_owned_objects_query {
             })
         }
 
-        fn address_owned_node(object: &Object, owner: SuiAddressType) -> serde_json::Value {
+        fn address_object_node(object: &Object) -> serde_json::Value {
             serde_json::json!({
                 "address": object.id().to_string(),
                 "version": object.version().value(),
                 "digest": object.digest().to_string(),
-                "owner": {
-                    "__typename": "AddressOwner",
-                    "address": { "address": owner.to_string() },
-                }
-            })
-        }
-
-        fn consensus_owned_node(object: &Object, owner: SuiAddressType) -> serde_json::Value {
-            serde_json::json!({
-                "address": object.id().to_string(),
-                "version": object.version().value(),
-                "digest": object.digest().to_string(),
-                "owner": {
-                    "__typename": "ConsensusAddressOwner",
-                    "address": { "address": owner.to_string() },
-                }
-            })
-        }
-
-        fn immutable_node(object: &Object) -> serde_json::Value {
-            serde_json::json!({
-                "address": object.id().to_string(),
-                "version": object.version().value(),
-                "digest": object.digest().to_string(),
-                "owner": {
-                    "__typename": "Immutable",
-                }
             })
         }
 
         #[tokio::test]
-        async fn query_paginates_and_includes_consensus_address_owned_objects() {
+        async fn query_paginates_address_owned_object_refs_without_owner() {
             let server = MockServer::start().await;
             let owner = SuiAddressType::random_for_testing_only();
             let first = Object::with_id_owner_version_for_testing(
@@ -571,12 +488,6 @@ pub(crate) mod address_owned_objects_query {
                     owner,
                 },
             );
-            let immutable = Object::with_id_owner_version_for_testing(
-                ObjectID::random(),
-                SequenceNumber::from_u64(9),
-                SuiOwner::Immutable,
-            );
-
             Mock::given(method("POST"))
                 .and(path("/"))
                 .and(body_partial_json(serde_json::json!({
@@ -584,7 +495,7 @@ pub(crate) mod address_owned_objects_query {
                 })))
                 .respond_with(
                     ResponseTemplate::new(200).set_body_json(address_objects_response(
-                        vec![address_owned_node(&first, owner)],
+                        vec![address_object_node(&first)],
                         true,
                         Some("cursor-1"),
                     )),
@@ -598,10 +509,7 @@ pub(crate) mod address_owned_objects_query {
                 })))
                 .respond_with(
                     ResponseTemplate::new(200).set_body_json(address_objects_response(
-                        vec![
-                            consensus_owned_node(&second, owner),
-                            immutable_node(&immutable),
-                        ],
+                        vec![address_object_node(&second)],
                         false,
                         None,
                     )),
@@ -617,9 +525,7 @@ pub(crate) mod address_owned_objects_query {
 
             assert_eq!(entries.len(), 2);
             assert_eq!(entries[0].object_ref, first.compute_object_reference());
-            assert_eq!(entries[0].owner, owner);
             assert_eq!(entries[1].object_ref, second.compute_object_reference());
-            assert_eq!(entries[1].owner, owner);
 
             let requests = server
                 .received_requests()
@@ -633,8 +539,9 @@ pub(crate) mod address_owned_objects_query {
                 .and_then(serde_json::Value::as_str)
                 .expect("query string should be present");
             assert!(query.contains("address(address: $address)"));
-            assert!(query.contains("... on AddressOwner"));
-            assert!(query.contains("... on ConsensusAddressOwner"));
+            assert!(query.contains("version"));
+            assert!(query.contains("digest"));
+            assert!(!query.contains("owner"));
             assert!(!query.contains("contents"));
             assert!(!query.contains("balance"));
         }
@@ -815,7 +722,7 @@ pub(crate) mod object_seed_query {
         let Some(object) = object else {
             return Ok(ObjectSeedMetadata::Missing);
         };
-        let owner = match object.owner {
+        match object.owner {
             Some(Owner::AddressOwner(owner)) => parse_owner_address(owner.address, &object_id)?,
             Some(Owner::ConsensusAddressOwner(owner)) => {
                 parse_owner_address(owner.address, &object_id)?
@@ -833,7 +740,6 @@ pub(crate) mod object_seed_query {
 
         Ok(ObjectSeedMetadata::AddressOwned(AddressOwnedObject {
             object_ref: (object_id, SequenceNumber::from_u64(version), digest),
-            owner,
         }))
     }
 
@@ -980,7 +886,6 @@ pub(crate) mod object_seed_query {
                 entries[0],
                 ObjectSeedMetadata::AddressOwned(AddressOwnedObject {
                     object_ref: first.compute_object_reference(),
-                    owner,
                 })
             );
             assert_eq!(entries[1], ObjectSeedMetadata::Missing);
@@ -988,7 +893,6 @@ pub(crate) mod object_seed_query {
                 entries[2],
                 ObjectSeedMetadata::AddressOwned(AddressOwnedObject {
                     object_ref: second.compute_object_reference(),
-                    owner,
                 })
             );
 

--- a/crates/sui-fork/src/gql/queries.rs
+++ b/crates/sui-fork/src/gql/queries.rs
@@ -229,9 +229,8 @@ pub(crate) mod address_owned_objects_query {
     use anyhow::Error;
     use anyhow::anyhow;
     use cynic::QueryBuilder as _;
-    use move_core_types::language_storage::StructTag;
-    use sui_types::SUI_FRAMEWORK_ADDRESS;
     use sui_types::base_types::ObjectID;
+    use sui_types::base_types::ObjectRef;
     use sui_types::base_types::SequenceNumber;
     use sui_types::base_types::SuiAddress as SuiAddressType;
     use sui_types::digests::ObjectDigest;
@@ -245,12 +244,8 @@ pub(crate) mod address_owned_objects_query {
     /// Lightweight metadata for an address-owned object at a checkpoint.
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub(crate) struct AddressOwnedObject {
-        pub(crate) object_id: ObjectID,
-        pub(crate) version: SequenceNumber,
-        pub(crate) digest: ObjectDigest,
+        pub(crate) object_ref: ObjectRef,
         pub(crate) owner: SuiAddressType,
-        pub(crate) object_type: StructTag,
-        pub(crate) balance: Option<u64>,
     }
 
     #[derive(cynic::QueryVariables)]
@@ -327,7 +322,6 @@ pub(crate) mod address_owned_objects_query {
         version: Option<u64>,
         digest: Option<String>,
         owner: Option<Owner>,
-        contents: Option<MoveValue>,
     }
 
     #[derive(cynic::InlineFragments)]
@@ -359,24 +353,6 @@ pub(crate) mod address_owned_objects_query {
     pub(crate) struct OwnerAddress {
         address: SuiAddress,
     }
-
-    #[derive(cynic::QueryFragment)]
-    #[cynic(schema_module = "crate::gql::queries::schema")]
-    pub(crate) struct MoveValue {
-        #[cynic(rename = "type")]
-        object_type: Option<MoveType>,
-        json: Option<Json>,
-    }
-
-    #[derive(cynic::QueryFragment)]
-    #[cynic(schema_module = "crate::gql::queries::schema")]
-    pub(crate) struct MoveType {
-        repr: String,
-    }
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    #[cynic(graphql_type = "JSON")]
-    pub(crate) struct Json(pub serde_json::Value);
 
     #[derive(cynic::Scalar, Debug, Clone)]
     #[cynic(graphql_type = "SuiAddress")]
@@ -436,23 +412,6 @@ pub(crate) mod address_owned_objects_query {
         Ok(entries)
     }
 
-    fn coin_balance_from_json(
-        object_type: &StructTag,
-        json: Option<&serde_json::Value>,
-    ) -> Option<u64> {
-        if object_type.address != SUI_FRAMEWORK_ADDRESS
-            || object_type.module.as_ident_str().as_str() != "coin"
-            || object_type.name.as_ident_str().as_str() != "Coin"
-        {
-            return None;
-        }
-
-        let balance = json?.get("balance")?;
-        balance
-            .as_u64()
-            .or_else(|| balance.as_str().and_then(|value| value.parse().ok()))
-    }
-
     fn decode_move_object(node: MoveObject) -> Result<Option<AddressOwnedObject>, Error> {
         let owner = match node.owner {
             Some(Owner::AddressOwner(owner)) => {
@@ -463,15 +422,6 @@ pub(crate) mod address_owned_objects_query {
             }
             _ => return Ok(None),
         };
-        let contents = node
-            .contents
-            .ok_or_else(|| anyhow!("seed object {} is missing contents", node.address.0))?;
-        let object_type = contents
-            .object_type
-            .ok_or_else(|| anyhow!("seed object {} is missing type", node.address.0))?
-            .repr
-            .parse::<StructTag>()
-            .with_context(|| format!("invalid seed object type for {}", node.address.0))?;
         let object_id = node
             .address
             .0
@@ -485,16 +435,10 @@ pub(crate) mod address_owned_objects_query {
         let version = node
             .version
             .ok_or_else(|| anyhow!("seed object {object_id} is missing version"))?;
-        let balance =
-            coin_balance_from_json(&object_type, contents.json.as_ref().map(|json| &json.0));
 
         Ok(Some(AddressOwnedObject {
-            object_id,
-            version: SequenceNumber::from_u64(version),
-            digest,
+            object_ref: (object_id, SequenceNumber::from_u64(version), digest),
             owner,
-            object_type,
-            balance,
         }))
     }
 
@@ -513,7 +457,6 @@ pub(crate) mod address_owned_objects_query {
     #[cfg(test)]
     mod tests {
         use sui_types::base_types::ObjectID;
-        use sui_types::gas_coin::GasCoin;
         use sui_types::object::Object;
         use sui_types::object::Owner as SuiOwner;
         use wiremock::Mock;
@@ -584,10 +527,6 @@ pub(crate) mod address_owned_objects_query {
                 "owner": {
                     "__typename": "AddressOwner",
                     "address": { "address": owner.to_string() },
-                },
-                "contents": {
-                    "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
-                    "json": { "balance": "123" },
                 }
             })
         }
@@ -600,10 +539,6 @@ pub(crate) mod address_owned_objects_query {
                 "owner": {
                     "__typename": "ConsensusAddressOwner",
                     "address": { "address": owner.to_string() },
-                },
-                "contents": {
-                    "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
-                    "json": { "balance": "456" },
                 }
             })
         }
@@ -615,23 +550,8 @@ pub(crate) mod address_owned_objects_query {
                 "digest": object.digest().to_string(),
                 "owner": {
                     "__typename": "Immutable",
-                },
-                "contents": {
-                    "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
-                    "json": { "balance": "789" },
                 }
             })
-        }
-
-        #[test]
-        fn coin_balance_from_json_reads_string_balance() {
-            let ty = GasCoin::type_();
-            let json = serde_json::json!({
-                "id": "0x1",
-                "balance": "42",
-            });
-
-            assert_eq!(coin_balance_from_json(&ty, Some(&json)), Some(42));
         }
 
         #[tokio::test]
@@ -696,12 +616,10 @@ pub(crate) mod address_owned_objects_query {
                 .expect("address seed should resolve");
 
             assert_eq!(entries.len(), 2);
-            assert_eq!(entries[0].object_id, first.id());
-            assert_eq!(entries[0].version, first.version());
-            assert_eq!(entries[0].balance, Some(123));
-            assert_eq!(entries[1].object_id, second.id());
-            assert_eq!(entries[1].version, second.version());
-            assert_eq!(entries[1].balance, Some(456));
+            assert_eq!(entries[0].object_ref, first.compute_object_reference());
+            assert_eq!(entries[0].owner, owner);
+            assert_eq!(entries[1].object_ref, second.compute_object_reference());
+            assert_eq!(entries[1].owner, owner);
 
             let requests = server
                 .received_requests()
@@ -717,6 +635,8 @@ pub(crate) mod address_owned_objects_query {
             assert!(query.contains("address(address: $address)"));
             assert!(query.contains("... on AddressOwner"));
             assert!(query.contains("... on ConsensusAddressOwner"));
+            assert!(!query.contains("contents"));
+            assert!(!query.contains("balance"));
         }
 
         #[tokio::test]

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -4,8 +4,8 @@
 //! Fork manifest and seed resolution for the initial owned-object index.
 //!
 //! The manifest is written for every initialized fork directory. Address seeds resolve
-//! lightweight object metadata at the fork checkpoint, while explicit object seeds also cache
-//! the full object BCS through the existing object query path.
+//! object references at the fork checkpoint, while explicit object seeds also cache the full
+//! object BCS through the existing object query path.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -17,11 +17,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use tracing::warn;
 
-use move_core_types::language_storage::StructTag;
 use sui_types::base_types::ObjectID;
+use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
-use sui_types::digests::ObjectDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::object::Owner;
@@ -43,15 +42,11 @@ pub struct SeedInput {
     pub object_ids: Vec<ObjectID>,
 }
 
-/// Object metadata used to seed the initial owned-object index.
+/// Object reference and owner used to seed the initial owned-object index.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SeedEntry {
-    pub(crate) object_id: ObjectID,
-    pub(crate) version: SequenceNumber,
-    pub(crate) digest: ObjectDigest,
+    pub(crate) object_ref: ObjectRef,
     pub(crate) owner: SuiAddress,
-    pub(crate) object_type: StructTag,
-    pub(crate) balance: Option<u64>,
 }
 
 /// Durable manifest for fork metadata and optional pre-fork seed metadata.
@@ -80,12 +75,8 @@ impl SeedEntry {
         };
 
         Some(Self {
-            object_id: object.id(),
-            version: object.version(),
-            digest: object.digest(),
+            object_ref: object.compute_object_reference(),
             owner,
-            object_type: object.struct_tag()?,
-            balance: object.as_coin_maybe().map(|coin| coin.value()),
         })
     }
 }
@@ -100,12 +91,8 @@ impl SeedInput {
 impl From<AddressOwnedObject> for SeedEntry {
     fn from(object: AddressOwnedObject) -> Self {
         Self {
-            object_id: object.object_id,
-            version: object.version,
-            digest: object.digest,
+            object_ref: object.object_ref,
             owner: object.owner,
-            object_type: object.object_type,
-            balance: object.balance,
         }
     }
 }
@@ -114,10 +101,7 @@ impl From<&SeedEntry> for OwnedObjectEntry {
     fn from(entry: &SeedEntry) -> Self {
         Self {
             owner: entry.owner,
-            object_id: entry.object_id,
-            version: entry.version,
-            object_type: entry.object_type.clone(),
-            balance: entry.balance,
+            object_ref: entry.object_ref,
         }
     }
 }
@@ -313,7 +297,7 @@ async fn resolve_seeds(
             warn!(%address, checkpoint, "address seed resolved no owned objects");
         }
         for entry in address_entries {
-            entries.insert(entry.object_id, entry);
+            entries.insert(entry.object_ref.0, entry);
         }
     }
 
@@ -322,7 +306,7 @@ async fn resolve_seeds(
         .filter(|object_id| !entries.contains_key(object_id))
         .collect();
     for entry in resolve_object_seeds(data_store, checkpoint, &remaining_object_ids)? {
-        entries.insert(entry.object_id, entry);
+        entries.insert(entry.object_ref.0, entry);
     }
 
     Ok(SeedManifest {
@@ -471,7 +455,10 @@ mod tests {
         .expect("seed manifest should resolve");
 
         assert_eq!(manifest.entries.len(), 1);
-        assert_eq!(manifest.entries[0].object_id, object.id());
+        assert_eq!(
+            manifest.entries[0].object_ref,
+            object.compute_object_reference()
+        );
         assert_eq!(
             store
                 .local()

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Fork manifest and seed resolution for the initial owned-object index.
+//! Fork manifest and seed resolution for lazy owned-object index initialization.
 //!
 //! The manifest is written for every initialized fork directory. Address seeds resolve
 //! object references at the fork checkpoint, while explicit object seeds also cache the full
@@ -29,20 +29,19 @@ use crate::DataStore;
 use crate::ObjectKey;
 use crate::ObjectRead as _;
 use crate::VersionQuery;
-use crate::filesystem::OwnedObjectEntry;
 use crate::gql::AddressOwnedObject;
 use crate::gql::GraphQLClient;
 
 /// CLI seed input before it has been resolved against the upstream chain.
 #[derive(Clone, Debug, Default)]
 pub struct SeedInput {
-    /// Addresses whose owned objects should seed the initial owned-object index.
+    /// Addresses whose owned objects should be recorded in the seed manifest.
     pub addresses: Vec<SuiAddress>,
     /// Object IDs to fetch and seed when they are owned by an address.
     pub object_ids: Vec<ObjectID>,
 }
 
-/// Object reference and owner used to seed the initial owned-object index.
+/// Object reference and owner used to seed lazy owned-object index initialization.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SeedEntry {
     pub(crate) object_ref: ObjectRef,
@@ -97,15 +96,6 @@ impl From<AddressOwnedObject> for SeedEntry {
     }
 }
 
-impl From<&SeedEntry> for OwnedObjectEntry {
-    fn from(entry: &SeedEntry) -> Self {
-        Self {
-            owner: entry.owner,
-            object_ref: entry.object_ref,
-        }
-    }
-}
-
 /// Reject seed inputs that would overwrite or reinterpret an existing manifest.
 pub(crate) fn ensure_seed_policy(data_store: &DataStore, input: &SeedInput) -> Result<(), Error> {
     if data_store.local().seed_manifest_exists() && !input.is_empty() {
@@ -142,31 +132,6 @@ pub(crate) fn ensure_seed_manifest_matches(
     }
 
     Ok(())
-}
-
-/// Initialize the owned-object index from the seed manifest when it is safe to do so.
-pub(crate) fn initialize_owned_index_from_seed(
-    data_store: &DataStore,
-    manifest: &SeedManifest,
-) -> Result<(), Error> {
-    if data_store.local().owned_object_index_exists() {
-        return Ok(());
-    }
-
-    if let Some(checkpoint) = data_store.get_highest_verified_checkpoint()?
-        && checkpoint.data().sequence_number > data_store.forked_at_checkpoint()
-    {
-        bail!(
-            "seed manifest exists but the owned-object index is missing while local checkpoints have advanced past the fork checkpoint; refusing to rebuild stale seed state",
-        );
-    }
-
-    let entries: Vec<_> = manifest
-        .entries
-        .iter()
-        .map(OwnedObjectEntry::from)
-        .collect();
-    data_store.local().write_owned_object_entries(&entries)
 }
 
 /// Load or create the seed manifest for the current fork directory.
@@ -271,7 +236,7 @@ fn resolve_object_seeds(
             warn!(
                 %object_id,
                 checkpoint,
-                "object seed is not owned by an address and will not be added to the owned-object index",
+                "object seed is not owned by an address and will not be added to the seed manifest",
             );
         }
     }

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -4,8 +4,8 @@
 //! Fork manifest and seed resolution for lazy owned-object index initialization.
 //!
 //! The manifest is written for every initialized fork directory. Address and explicit object
-//! seeds resolve lightweight owner/object-ref metadata at the fork checkpoint. Full object BCS is
-//! fetched later when an object read or lazy owned-object index initialization needs it.
+//! seeds resolve lightweight object-ref metadata at the fork checkpoint. Full object BCS is fetched
+//! later when an object read or lazy owned-object index initialization needs it.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -36,11 +36,10 @@ pub struct SeedInput {
     pub object_ids: Vec<ObjectID>,
 }
 
-/// Object reference and owner used to seed lazy owned-object index initialization.
+/// Object reference used to seed lazy owned-object index initialization.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SeedEntry {
     pub(crate) object_ref: ObjectRef,
-    pub(crate) owner: SuiAddress,
 }
 
 /// Durable manifest for fork metadata and optional pre-fork seed metadata.
@@ -72,7 +71,6 @@ impl From<AddressOwnedObject> for SeedEntry {
     fn from(object: AddressOwnedObject) -> Self {
         Self {
             object_ref: object.object_ref,
-            owner: object.owner,
         }
     }
 }
@@ -443,7 +441,6 @@ mod tests {
             manifest.entries[0].object_ref,
             object.compute_object_reference()
         );
-        assert_eq!(manifest.entries[0].owner, owner);
         assert!(
             store
                 .local()
@@ -518,7 +515,6 @@ mod tests {
             manifest.entries[0].object_ref,
             object.compute_object_reference()
         );
-        assert_eq!(manifest.entries[0].owner, owner);
         assert!(
             store
                 .local()

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -3,9 +3,9 @@
 
 //! Fork manifest and seed resolution for lazy owned-object index initialization.
 //!
-//! The manifest is written for every initialized fork directory. Address seeds resolve
-//! object references at the fork checkpoint, while explicit object seeds also cache the full
-//! object BCS through the existing object query path.
+//! The manifest is written for every initialized fork directory. Address and explicit object
+//! seeds resolve lightweight owner/object-ref metadata at the fork checkpoint. Full object BCS is
+//! fetched later when an object read or lazy owned-object index initialization needs it.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -19,18 +19,13 @@ use tracing::warn;
 
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
-use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use sui_types::object::Object;
-use sui_types::object::Owner;
 
 use crate::DataStore;
-use crate::ObjectKey;
-use crate::ObjectRead as _;
-use crate::VersionQuery;
 use crate::gql::AddressOwnedObject;
 use crate::gql::GraphQLClient;
+use crate::gql::ObjectSeedMetadata;
 
 /// CLI seed input before it has been resolved against the upstream chain.
 #[derive(Clone, Debug, Default)]
@@ -63,20 +58,6 @@ impl SeedManifest {
             checkpoint,
             entries: Vec::new(),
         }
-    }
-}
-
-impl SeedEntry {
-    fn from_object(object: &Object) -> Option<Self> {
-        let owner = match &object.owner {
-            Owner::AddressOwner(owner) | Owner::ConsensusAddressOwner { owner, .. } => *owner,
-            _ => return None,
-        };
-
-        Some(Self {
-            object_ref: object.compute_object_reference(),
-            owner,
-        })
     }
 }
 
@@ -205,8 +186,8 @@ async fn resolve_address_seed(
         .collect())
 }
 
-fn resolve_object_seeds(
-    data_store: &DataStore,
+async fn resolve_object_seeds(
+    gql: &GraphQLClient,
     checkpoint: CheckpointSequenceNumber,
     object_ids: &[ObjectID],
 ) -> Result<Vec<SeedEntry>, Error> {
@@ -214,30 +195,24 @@ fn resolve_object_seeds(
         return Ok(Vec::new());
     }
 
-    let keys: Vec<_> = object_ids
-        .iter()
-        .map(|object_id| ObjectKey {
-            object_id: *object_id,
-            version_query: VersionQuery::AtCheckpoint(checkpoint),
-        })
-        .collect();
-    let objects = data_store.gql().get_objects(&keys)?;
+    let objects = gql
+        .get_object_seed_metadata_at_checkpoint(object_ids, checkpoint)
+        .await?;
     let mut entries = Vec::new();
 
     for (object_id, object) in object_ids.iter().zip_eq(objects) {
-        let Some((object, _)) = object else {
-            warn!(%object_id, checkpoint, "object seed not found at fork checkpoint");
-            continue;
-        };
-        data_store.local().write_object(&object)?;
-        if let Some(entry) = SeedEntry::from_object(&object) {
-            entries.push(entry);
-        } else {
-            warn!(
-                %object_id,
-                checkpoint,
-                "object seed is not owned by an address and will not be added to the seed manifest",
-            );
+        match object {
+            ObjectSeedMetadata::Missing => {
+                warn!(%object_id, checkpoint, "object seed not found at fork checkpoint");
+            }
+            ObjectSeedMetadata::NonAddressOwned => {
+                warn!(
+                    %object_id,
+                    checkpoint,
+                    "object seed is not owned by an address and will not be added to the seed manifest",
+                );
+            }
+            ObjectSeedMetadata::AddressOwned(object) => entries.push(SeedEntry::from(object)),
         }
     }
 
@@ -270,7 +245,7 @@ async fn resolve_seeds(
         .into_iter()
         .filter(|object_id| !entries.contains_key(object_id))
         .collect();
-    for entry in resolve_object_seeds(data_store, checkpoint, &remaining_object_ids)? {
+    for entry in resolve_object_seeds(data_store.gql(), checkpoint, &remaining_object_ids).await? {
         entries.insert(entry.object_ref.0, entry);
     }
 
@@ -283,30 +258,59 @@ async fn resolve_seeds(
 
 #[cfg(test)]
 mod tests {
-    use fastcrypto::encoding::Base64 as FastCryptoBase64;
-    use fastcrypto::encoding::Encoding as _;
     use serde_json::json;
+    use sui_types::base_types::SequenceNumber;
+    use sui_types::object::Object;
+    use sui_types::object::Owner;
     use wiremock::Mock;
     use wiremock::MockServer;
     use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_partial_json;
     use wiremock::matchers::method;
     use wiremock::matchers::path;
 
     use super::*;
 
-    fn object_response_body(object: &Object) -> serde_json::Value {
+    fn object_seed_response_body(
+        object: &Object,
+        owner: SuiAddress,
+        owner_type: &str,
+    ) -> serde_json::Value {
         json!({
             "data": {
                 "multiGetObjects": [{
-                    "address": object.id().to_string(),
                     "version": object.version().value(),
-                    "objectBcs": FastCryptoBase64::from_bytes(
-                        &bcs::to_bytes(object).expect("object should serialize"),
-                    )
-                    .encoded(),
+                    "digest": object.digest().to_string(),
+                    "owner": {
+                        "__typename": owner_type,
+                        "address": { "address": owner.to_string() },
+                    },
                 }]
             }
         })
+    }
+
+    fn assert_object_seed_query_shape(query: &str) {
+        assert!(query.contains("multiGetObjects"));
+        assert!(query.contains("version"));
+        assert!(query.contains("digest"));
+        assert!(query.contains("... on AddressOwner"));
+        assert!(query.contains("... on ConsensusAddressOwner"));
+        assert!(!query.contains("objectBcs"));
+
+        let object_selection_before_owner = query
+            .split("multiGetObjects")
+            .nth(1)
+            .expect("query should include multiGetObjects")
+            .split("owner")
+            .next()
+            .expect("query should include owner");
+        assert!(
+            !object_selection_before_owner
+                .lines()
+                .any(|line| line.trim() == "address"),
+            "object seed query should not request Object.address",
+        );
     }
 
     fn available_range_response(
@@ -382,16 +386,17 @@ mod tests {
         .await
         .expect_err("seed resolution should fail");
 
+        let err = format!("{err:?}");
         assert!(
-            err.to_string().contains("Failed to read response")
-                || err.to_string().contains("Object bcs is None")
-                || err.to_string().contains("Missing data")
+            err.contains("failed to query object seeds")
+                || err.contains("Failed to read response")
+                || err.contains("Missing data")
         );
         assert!(!store.local().seed_manifest_exists());
     }
 
     #[tokio::test]
-    async fn prepare_seed_manifest_fetches_explicit_object_and_caches_bcs() {
+    async fn prepare_seed_manifest_fetches_explicit_object_metadata_without_caching_bcs() {
         let server = MockServer::start().await;
         let owner = SuiAddress::random_for_testing_only();
         let object = Object::with_id_owner_version_for_testing(
@@ -401,7 +406,21 @@ mod tests {
         );
         Mock::given(method("POST"))
             .and(path("/"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(object_response_body(&object)))
+            .and(body_partial_json(json!({
+                "variables": {
+                    "keys": [{
+                        "address": object.id().to_string(),
+                        "atCheckpoint": 11,
+                    }]
+                }
+            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(object_seed_response_body(
+                    &object,
+                    owner,
+                    "AddressOwner",
+                )),
+            )
             .mount(&server)
             .await;
 
@@ -424,14 +443,28 @@ mod tests {
             manifest.entries[0].object_ref,
             object.compute_object_reference()
         );
-        assert_eq!(
+        assert_eq!(manifest.entries[0].owner, owner);
+        assert!(
             store
                 .local()
                 .get_object_at_version(&object.id(), object.version().value())
                 .expect("local object lookup should not fail")
-                .unwrap(),
-            object,
+                .is_none(),
+            "explicit object seeding should not cache BCS",
         );
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("wiremock should record requests");
+        let request_body: serde_json::Value = requests[0]
+            .body_json()
+            .expect("request body should be json");
+        let query = request_body
+            .get("query")
+            .and_then(serde_json::Value::as_str)
+            .expect("query string should be present");
+        assert_object_seed_query_shape(query);
     }
 
     #[tokio::test]
@@ -448,7 +481,21 @@ mod tests {
         );
         Mock::given(method("POST"))
             .and(path("/"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(object_response_body(&object)))
+            .and(body_partial_json(json!({
+                "variables": {
+                    "keys": [{
+                        "address": object.id().to_string(),
+                        "atCheckpoint": 11,
+                    }]
+                }
+            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(object_seed_response_body(
+                    &object,
+                    owner,
+                    "ConsensusAddressOwner",
+                )),
+            )
             .mount(&server)
             .await;
 
@@ -467,15 +514,18 @@ mod tests {
         .expect("seed manifest should resolve");
 
         assert_eq!(manifest.entries.len(), 1);
-        assert_eq!(manifest.entries[0].object_id, object.id());
-        assert_eq!(manifest.entries[0].owner, owner);
         assert_eq!(
+            manifest.entries[0].object_ref,
+            object.compute_object_reference()
+        );
+        assert_eq!(manifest.entries[0].owner, owner);
+        assert!(
             store
                 .local()
                 .get_object_at_version(&object.id(), object.version().value())
                 .expect("local object lookup should not fail")
-                .unwrap(),
-            object,
+                .is_none(),
+            "explicit object seeding should not cache BCS",
         );
     }
 

--- a/crates/sui-fork/src/startup.rs
+++ b/crates/sui-fork/src/startup.rs
@@ -115,9 +115,7 @@ pub async fn initialize(
     // 2. Download and persist the startup checkpoint (summary + contents),
     //    then read the summary back through the cache-aware getter.
     data_store.download_and_persist_startup_checkpoint()?;
-    let manifest =
-        crate::seed::prepare_seed_manifest(&data_store, node.network_name(), &seed_input).await?;
-    crate::seed::initialize_owned_index_from_seed(&data_store, &manifest)?;
+    crate::seed::prepare_seed_manifest(&data_store, node.network_name(), &seed_input).await?;
     let checkpoint = data_store
         .get_highest_verified_checkpoint()?
         .ok_or_else(|| anyhow!("checkpoint {} not found", forked_at_checkpoint))?;

--- a/crates/sui-fork/src/store.rs
+++ b/crates/sui-fork/src/store.rs
@@ -582,7 +582,7 @@ impl DataStore {
                         seed_entry.object_ref.0,
                     )
                 })?;
-                if entry.owner != seed_entry.owner || entry.object_ref != seed_entry.object_ref {
+                if entry.object_ref != seed_entry.object_ref {
                     bail!(
                         "seeded object {} metadata does not match fetched object at fork checkpoint {}",
                         seed_entry.object_ref.0,

--- a/crates/sui-fork/src/store.rs
+++ b/crates/sui-fork/src/store.rs
@@ -610,67 +610,82 @@ impl DataStore {
         object_type: Option<StructTag>,
         cursor: Option<OwnedObjectInfo>,
     ) -> StorageResult<Vec<OwnedObjectInfo>> {
-        let _local_snapshot_guard = self.read_local_snapshot()?;
-        self.get_owned_objects_unlocked(owner, object_type, cursor)
+        self.get_owned_object_infos(owner, object_type, cursor)
     }
 
-    /// Get owned objects while the caller holds a local snapshot guard.
-    fn get_owned_objects_unlocked(
+    /// Read the owned-object index, load object BCS, validate object refs, and return owned-object
+    /// RPC metadata.
+    fn get_owned_object_infos(
         &self,
         owner: SuiAddress,
         object_type: Option<StructTag>,
         cursor: Option<OwnedObjectInfo>,
     ) -> StorageResult<Vec<OwnedObjectInfo>> {
-        let entries = self
-            .inner
-            .local
-            .get_owned_object_entries()
-            .map_err(|e| StorageError::custom(e.to_string()))?;
+        let entries = {
+            let _local_snapshot_guard = self.read_local_snapshot()?;
+            self.inner
+                .local
+                .get_owned_object_entries()
+                .map_err(|e| StorageError::custom(e.to_string()))?
+        };
         let cursor_object_id = cursor.map(|cursor| cursor.object_id);
 
-        Ok(entries
+        entries
             .into_iter()
             .filter(|entry| entry.owner == owner)
-            .filter(|entry| {
-                object_type
-                    .as_ref()
-                    .is_none_or(|ty| struct_tag_filter_matches(ty, &entry.object_type))
-            })
             // `RpcIndexes` cursors are lower bounds. The v2 RPC layer stores
             // the first not-yet-returned item in the page token and expects
             // the next iterator to include it.
-            .filter(|entry| cursor_object_id.is_none_or(|id| entry.object_id >= id))
-            .filter_map(|entry| self.valid_owned_object_info(entry))
-            .collect())
+            .filter(|entry| cursor_object_id.is_none_or(|id| entry.object_ref.0 >= id))
+            .try_fold(Vec::new(), |mut infos, entry| {
+                if let Some(info) = self.valid_owned_object_info(entry, object_type.as_ref())? {
+                    infos.push(info);
+                }
+                Ok(infos)
+            })
     }
 
     /// Validate that the given `OwnedObjectEntry` corresponds to a locally cached object still
     /// controlled by the indexed address. This guards against stale index
     /// entries that point to objects that have been deleted or wrapped by later transactions.
-    fn valid_owned_object_info(&self, entry: OwnedObjectEntry) -> Option<OwnedObjectInfo> {
-        if let Some(object) = self.local().get_latest_object(&entry.object_id).ok()? {
-            if object.version() != entry.version {
-                return None;
+    fn valid_owned_object_info(
+        &self,
+        entry: OwnedObjectEntry,
+        object_type_filter: Option<&StructTag>,
+    ) -> StorageResult<Option<OwnedObjectInfo>> {
+        let object = self
+            .get_object(&entry.object_ref.0)
+            .map_err(|e| StorageError::custom(e.to_string()))?;
+        let Some(object) = object else {
+            return Ok(None);
+        };
+
+        let owner_matches = match &object.owner {
+            sui_types::object::Owner::AddressOwner(owner)
+            | sui_types::object::Owner::ConsensusAddressOwner { owner, .. } => {
+                *owner == entry.owner
             }
-            match &object.owner {
-                sui_types::object::Owner::AddressOwner(owner)
-                | sui_types::object::Owner::ConsensusAddressOwner { owner, .. }
-                    if *owner == entry.owner => {}
-                _ => return None,
-            }
-            let object_type = object.struct_tag()?;
-            if object_type != entry.object_type {
-                return None;
-            }
+            _ => false,
+        };
+        if !owner_matches || object.compute_object_reference() != entry.object_ref {
+            return Ok(None);
         }
 
-        Some(OwnedObjectInfo {
+        let Some(object_type) = object.struct_tag() else {
+            return Ok(None);
+        };
+        if object_type_filter.is_some_and(|filter| !struct_tag_filter_matches(filter, &object_type))
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(OwnedObjectInfo {
             owner: entry.owner,
-            object_type: entry.object_type,
-            balance: entry.balance,
-            object_id: entry.object_id,
-            version: entry.version,
-        })
+            object_type,
+            balance: object.as_coin_maybe().map(|coin| coin.value()),
+            object_id: entry.object_ref.0,
+            version: entry.object_ref.1,
+        }))
     }
 }
 
@@ -889,24 +904,17 @@ impl SimulatorStore for DataStore {
     }
 
     fn owned_objects(&self, owner: SuiAddress) -> Box<dyn Iterator<Item = Object> + '_> {
-        let objects = match self
-            .read_local_snapshot()
-            .and_then(|_local_snapshot_guard| {
-                self.get_owned_objects_unlocked(owner, None, None)
-                    .map(|infos| {
-                        infos
-                            .into_iter()
-                            .filter_map(|info| {
-                                self.inner
-                                    .local
-                                    .get_latest_object(&info.object_id)
-                                    .ok()
-                                    .flatten()
-                                    .filter(|object| object.version() == info.version)
-                            })
-                            .collect()
-                    })
-            }) {
+        let objects = match self.get_owned_object_infos(owner, None, None).map(|infos| {
+            infos
+                .into_iter()
+                .filter_map(|info| {
+                    self.get_object(&info.object_id)
+                        .ok()
+                        .flatten()
+                        .filter(|object| object.version() == info.version)
+                })
+                .collect()
+        }) {
             Ok(objects) => objects,
             Err(err) => {
                 tracing::error!(%owner, "failed to read owned-object index: {err:?}");

--- a/crates/sui-fork/src/store.rs
+++ b/crates/sui-fork/src/store.rs
@@ -7,7 +7,10 @@ use std::sync::RwLock;
 use std::sync::RwLockReadGuard;
 use std::sync::RwLockWriteGuard;
 
+use anyhow::Context as _;
 use anyhow::anyhow;
+use anyhow::bail;
+use itertools::Itertools as _;
 use tracing::info;
 
 use move_core_types::annotated_value::MoveTypeLayout;
@@ -518,16 +521,96 @@ impl DataStore {
         None
     }
 
+    fn ensure_owned_object_index_initialized(&self) -> anyhow::Result<()> {
+        if self.inner.local.owned_object_index_exists() {
+            return Ok(());
+        }
+
+        let _local_snapshot_guard = self.write_local_snapshot()?;
+        if self.inner.local.owned_object_index_exists() {
+            return Ok(());
+        }
+
+        if let Some(checkpoint) = self.inner.local.get_highest_verified_checkpoint()?
+            && checkpoint.data().sequence_number > self.forked_at_checkpoint()
+        {
+            bail!(
+                "owned-object index is missing while local checkpoints have advanced past the fork checkpoint; refusing to rebuild stale seed state",
+            );
+        }
+
+        let mut entries = BTreeMap::new();
+        if self.inner.local.seed_manifest_exists() {
+            let manifest = self.inner.local.read_seed_manifest()?;
+            if manifest.checkpoint != self.forked_at_checkpoint() {
+                bail!(
+                    "Seed manifest checkpoint {} does not match requested checkpoint {}. Use a different --data-dir.",
+                    manifest.checkpoint,
+                    self.forked_at_checkpoint(),
+                );
+            }
+
+            let keys: Vec<_> = manifest
+                .entries
+                .iter()
+                .map(|entry| ObjectKey {
+                    object_id: entry.object_ref.0,
+                    version_query: VersionQuery::VersionAtCheckpoint {
+                        version: entry.object_ref.1.value(),
+                        checkpoint: self.forked_at_checkpoint(),
+                    },
+                })
+                .collect();
+            let objects = self
+                .inner
+                .gql
+                .get_objects(&keys)
+                .context("failed to fetch seeded objects for owned-object index")?;
+
+            for (seed_entry, object) in manifest.entries.iter().zip_eq(objects) {
+                let Some((object, _)) = object else {
+                    bail!(
+                        "seeded object {} version {} was not found at fork checkpoint {}",
+                        seed_entry.object_ref.0,
+                        seed_entry.object_ref.1.value(),
+                        self.forked_at_checkpoint(),
+                    );
+                };
+                let entry = OwnedObjectEntry::from_object(&object).with_context(|| {
+                    format!(
+                        "seeded object {} is not an address-owned Move object",
+                        seed_entry.object_ref.0,
+                    )
+                })?;
+                if entry.owner != seed_entry.owner || entry.object_ref != seed_entry.object_ref {
+                    bail!(
+                        "seeded object {} metadata does not match fetched object at fork checkpoint {}",
+                        seed_entry.object_ref.0,
+                        self.forked_at_checkpoint(),
+                    );
+                }
+
+                self.inner.local.write_object(&object)?;
+                entries.insert(entry.object_ref.0, entry);
+            }
+        }
+
+        let entries: Vec<_> = entries.into_values().collect();
+        self.inner.local.write_owned_object_entries(&entries)
+    }
+
     /// Persist local object writes and current-state removals, then update the address-owned
     /// index from the same diff.
     fn apply_object_updates(
         &mut self,
         written_objects: BTreeMap<ObjectID, Object>,
         removed_objects: Vec<RemovedObject>,
-    ) {
+    ) -> anyhow::Result<()> {
+        self.ensure_owned_object_index_initialized()
+            .context("failed to initialize owned-object index")?;
         let _local_snapshot_guard = self
             .write_local_snapshot()
-            .expect("failed to lock local snapshot for object update");
+            .context("failed to lock local snapshot for object update")?;
         let removed_object_ids: Vec<_> = removed_objects
             .iter()
             .map(|removed| removed.object_id)
@@ -539,17 +622,32 @@ impl DataStore {
                     .inner
                     .local
                     .mark_object_as_deleted(removed.object_id, removed.version)
-                    .expect("failed to write deleted object latest state on disk"),
+                    .with_context(|| {
+                        format!(
+                            "failed to mark object {} deleted on disk",
+                            removed.object_id
+                        )
+                    })?,
                 RemovedObjectKind::Wrapped => self
                     .inner
                     .local
                     .mark_object_as_wrapped(removed.object_id, removed.version)
-                    .expect("failed to write wrapped object latest state on disk"),
+                    .with_context(|| {
+                        format!(
+                            "failed to mark object {} wrapped on disk",
+                            removed.object_id
+                        )
+                    })?,
                 RemovedObjectKind::UnwrappedThenDeleted => self
                     .inner
                     .local
                     .mark_object_as_unwrapped_then_deleted(removed.object_id, removed.version)
-                    .expect("failed to write unwrapped-then-deleted object latest state on disk"),
+                    .with_context(|| {
+                        format!(
+                            "failed to mark object {} unwrapped-then-deleted on disk",
+                            removed.object_id
+                        )
+                    })?,
             }
         }
 
@@ -557,24 +655,26 @@ impl DataStore {
             self.inner
                 .local
                 .write_live_object(object)
-                .expect("failed to write object to disk");
+                .with_context(|| format!("failed to write object {} to disk", object.id()))?;
         }
 
-        let indexable_written_objects: Vec<_> = written_objects
-            .values()
-            .filter(|object| {
-                self.inner
-                    .local
-                    .object_latest_state(&object.id())
-                    .expect("failed to read object latest state")
-                    != Some(ObjectLatestState::Deleted)
-            })
-            .collect();
+        let mut indexable_written_objects = Vec::new();
+        for object in written_objects.values() {
+            if self
+                .inner
+                .local
+                .object_latest_state(&object.id())
+                .with_context(|| format!("failed to read object {} latest state", object.id()))?
+                != Some(ObjectLatestState::Deleted)
+            {
+                indexable_written_objects.push(object);
+            }
+        }
 
         self.inner
             .local
             .apply_owned_object_index_updates(&removed_object_ids, indexable_written_objects)
-            .expect("failed to update owned-object index");
+            .context("failed to update owned-object index")
     }
 
     /// Construct a `DataStore` for tests, backed by an explicit local root and a fake (unused)
@@ -613,14 +713,15 @@ impl DataStore {
         self.get_owned_object_infos(owner, object_type, cursor)
     }
 
-    /// Read the owned-object index, load object BCS, validate object refs, and return owned-object
-    /// RPC metadata.
+    /// Initialize the owned-object index when needed, then read complete indexed RPC metadata.
     fn get_owned_object_infos(
         &self,
         owner: SuiAddress,
         object_type: Option<StructTag>,
         cursor: Option<OwnedObjectInfo>,
     ) -> StorageResult<Vec<OwnedObjectInfo>> {
+        self.ensure_owned_object_index_initialized()
+            .map_err(|e| StorageError::custom(e.to_string()))?;
         let entries = {
             let _local_snapshot_guard = self.read_local_snapshot()?;
             self.inner
@@ -630,62 +731,26 @@ impl DataStore {
         };
         let cursor_object_id = cursor.map(|cursor| cursor.object_id);
 
-        entries
+        Ok(entries
             .into_iter()
             .filter(|entry| entry.owner == owner)
             // `RpcIndexes` cursors are lower bounds. The v2 RPC layer stores
             // the first not-yet-returned item in the page token and expects
             // the next iterator to include it.
             .filter(|entry| cursor_object_id.is_none_or(|id| entry.object_ref.0 >= id))
-            .try_fold(Vec::new(), |mut infos, entry| {
-                if let Some(info) = self.valid_owned_object_info(entry, object_type.as_ref())? {
-                    infos.push(info);
-                }
-                Ok(infos)
+            .filter(|entry| {
+                object_type
+                    .as_ref()
+                    .is_none_or(|filter| struct_tag_filter_matches(filter, &entry.object_type))
             })
-    }
-
-    /// Validate that the given `OwnedObjectEntry` corresponds to a locally cached object still
-    /// controlled by the indexed address. This guards against stale index
-    /// entries that point to objects that have been deleted or wrapped by later transactions.
-    fn valid_owned_object_info(
-        &self,
-        entry: OwnedObjectEntry,
-        object_type_filter: Option<&StructTag>,
-    ) -> StorageResult<Option<OwnedObjectInfo>> {
-        let object = self
-            .get_object(&entry.object_ref.0)
-            .map_err(|e| StorageError::custom(e.to_string()))?;
-        let Some(object) = object else {
-            return Ok(None);
-        };
-
-        let owner_matches = match &object.owner {
-            sui_types::object::Owner::AddressOwner(owner)
-            | sui_types::object::Owner::ConsensusAddressOwner { owner, .. } => {
-                *owner == entry.owner
-            }
-            _ => false,
-        };
-        if !owner_matches || object.compute_object_reference() != entry.object_ref {
-            return Ok(None);
-        }
-
-        let Some(object_type) = object.struct_tag() else {
-            return Ok(None);
-        };
-        if object_type_filter.is_some_and(|filter| !struct_tag_filter_matches(filter, &object_type))
-        {
-            return Ok(None);
-        }
-
-        Ok(Some(OwnedObjectInfo {
-            owner: entry.owner,
-            object_type,
-            balance: object.as_coin_maybe().map(|coin| coin.value()),
-            object_id: entry.object_ref.0,
-            version: entry.object_ref.1,
-        }))
+            .map(|entry| OwnedObjectInfo {
+                owner: entry.owner,
+                object_type: entry.object_type,
+                balance: entry.balance,
+                object_id: entry.object_ref.0,
+                version: entry.object_ref.1,
+            })
+            .collect())
     }
 }
 
@@ -1002,30 +1067,56 @@ impl SimulatorStore for DataStore {
         self.insert_transaction(transaction);
         self.insert_transaction_effects(effects);
         self.insert_events(&tx_digest, events);
-        self.apply_object_updates(written_objects, removed_objects);
+        if let Err(err) = self.apply_object_updates(written_objects, removed_objects) {
+            tracing::error!(
+                tx_digest = %tx_digest,
+                "failed to persist transaction object updates: {err:?}",
+            );
+        }
     }
 
     fn insert_transaction(&mut self, transaction: VerifiedTransaction) {
         let digest = *transaction.digest();
-        self.inner
+        if let Err(err) = self
+            .inner
             .local
             .write_transaction(&digest, &transaction)
-            .expect("failed to persist transaction to disk");
+            .with_context(|| format!("failed to persist transaction {digest} to disk"))
+        {
+            tracing::error!(
+                tx_digest = %digest,
+                "failed to persist transaction: {err:?}",
+            );
+        }
     }
 
     fn insert_transaction_effects(&mut self, effects: TransactionEffects) {
         let digest = *effects.transaction_digest();
-        self.inner
+        if let Err(err) = self
+            .inner
             .local
             .write_transaction_effects(&digest, &effects)
-            .expect("failed to persist transaction effects to disk");
+            .with_context(|| format!("failed to persist transaction {digest} effects to disk"))
+        {
+            tracing::error!(
+                tx_digest = %digest,
+                "failed to persist transaction effects: {err:?}",
+            );
+        }
     }
 
     fn insert_events(&mut self, tx_digest: &TransactionDigest, events: TransactionEvents) {
-        self.inner
+        if let Err(err) = self
+            .inner
             .local
             .write_transaction_events(tx_digest, &events)
-            .expect("failed to persist transaction events to disk");
+            .with_context(|| format!("failed to persist transaction {tx_digest} events to disk"))
+        {
+            tracing::error!(
+                tx_digest = %tx_digest,
+                "failed to persist transaction events: {err:?}",
+            );
+        }
     }
 
     fn update_objects(
@@ -1041,7 +1132,9 @@ impl SimulatorStore for DataStore {
                 kind: RemovedObjectKind::Deleted,
             })
             .collect();
-        self.apply_object_updates(written_objects, removed_objects);
+        if let Err(err) = self.apply_object_updates(written_objects, removed_objects) {
+            tracing::error!("failed to persist object updates: {err:?}");
+        }
     }
 
     fn backing_store(&self) -> &dyn BackingStore {

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -424,6 +424,12 @@ fn test_owned_object_index_upserts_removes_and_stays_sorted() {
     assert!(
         entries
             .iter()
+            .all(|entry| entry.object_type == sui_types::gas_coin::GasCoin::type_())
+    );
+    assert!(entries.iter().all(|entry| entry.balance == Some(1_000_000)));
+    assert!(
+        entries
+            .iter()
             .any(|entry| entry.object_ref == first.compute_object_reference())
     );
     assert!(
@@ -447,6 +453,11 @@ fn test_owned_object_index_upserts_removes_and_stays_sorted() {
         first_entry.object_ref,
         transferred.compute_object_reference()
     );
+    assert_eq!(
+        first_entry.object_type,
+        sui_types::gas_coin::GasCoin::type_()
+    );
+    assert_eq!(first_entry.balance, Some(1_000_000));
 
     store
         .apply_owned_object_index_updates(&[second_id], std::iter::empty::<&Object>())

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -477,7 +477,6 @@ fn test_seed_manifest_round_trips_and_is_immutable() {
         checkpoint: 42,
         entries: vec![SeedEntry {
             object_ref: object.compute_object_reference(),
-            owner,
         }],
     };
 

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -418,10 +418,19 @@ fn test_owned_object_index_upserts_removes_and_stays_sorted() {
     assert!(
         entries
             .windows(2)
-            .all(|window| window[0].object_id < window[1].object_id)
+            .all(|window| window[0].object_ref.0 < window[1].object_ref.0)
     );
     assert!(entries.iter().all(|entry| entry.owner == owner));
-    assert!(entries.iter().all(|entry| entry.balance == Some(1_000_000)));
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.object_ref == first.compute_object_reference())
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.object_ref == second.compute_object_reference())
+    );
 
     let transferred = make_object_with_owner(first_id, 2, Owner::AddressOwner(next_owner));
     store
@@ -431,17 +440,20 @@ fn test_owned_object_index_upserts_removes_and_stays_sorted() {
         .get_owned_object_entries()
         .unwrap()
         .into_iter()
-        .find(|entry| entry.object_id == first_id)
+        .find(|entry| entry.object_ref.0 == first_id)
         .unwrap();
     assert_eq!(first_entry.owner, next_owner);
-    assert_eq!(first_entry.version, SequenceNumber::from_u64(2));
+    assert_eq!(
+        first_entry.object_ref,
+        transferred.compute_object_reference()
+    );
 
     store
         .apply_owned_object_index_updates(&[second_id], std::iter::empty::<&Object>())
         .unwrap();
     let entries = store.get_owned_object_entries().unwrap();
     assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].object_id, first_id);
+    assert_eq!(entries[0].object_ref.0, first_id);
 }
 
 #[test]
@@ -453,12 +465,8 @@ fn test_seed_manifest_round_trips_and_is_immutable() {
         network: "testnet".to_owned(),
         checkpoint: 42,
         entries: vec![SeedEntry {
-            object_id: object.id(),
-            version: object.version(),
-            digest: object.digest(),
+            object_ref: object.compute_object_reference(),
             owner,
-            object_type: object.struct_tag().unwrap(),
-            balance: object.as_coin_maybe().map(|coin| coin.value()),
         }],
     };
 

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -9,7 +9,15 @@
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
+use fastcrypto::encoding::Base64 as FastCryptoBase64;
+use fastcrypto::encoding::Encoding as _;
 use rand::rngs::OsRng;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::body_partial_json;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
 
 use simulacrum::Simulacrum;
 use simulacrum::store::SimulatorStore;
@@ -34,6 +42,9 @@ use sui_types::transaction::GasData;
 use sui_types::transaction::Transaction;
 use sui_types::transaction::TransactionData;
 use sui_types::transaction::TransactionKind;
+
+use crate::seed::SeedEntry;
+use crate::seed::SeedManifest;
 
 use super::*;
 
@@ -104,6 +115,42 @@ fn make_gas_object(id: ObjectID, version: u64, owner: Owner) -> Object {
         storage_rebate: 0,
     }
     .into()
+}
+
+fn object_at_checkpoint_response(object: &Object) -> serde_json::Value {
+    serde_json::json!({
+        "data": {
+            "checkpoint": {
+                "query": {
+                    "object": {
+                        "address": object.id().to_string(),
+                        "version": object.version().value(),
+                        "objectBcs": FastCryptoBase64::from_bytes(
+                            &bcs::to_bytes(object).expect("object should serialize"),
+                        )
+                        .encoded(),
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn mock_seed_object(server: &MockServer, checkpoint: u64, object: &Object) {
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_partial_json(serde_json::json!({
+            "variables": {
+                "sequenceNumber": checkpoint,
+                "address": object.id().to_string(),
+                "version": object.version().value(),
+            }
+        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(object_at_checkpoint_response(object)),
+        )
+        .mount(server)
+        .await;
 }
 
 #[test]
@@ -305,19 +352,19 @@ fn test_owned_objects_removes_non_address_owned_transitions() {
 }
 
 #[test]
-fn test_seeded_owned_object_info_is_derived_from_bcs_until_deleted() {
+fn test_owned_object_info_uses_index_metadata_until_deleted() {
     let (_temp, mut store) = test_data_store();
     let owner = SuiAddress::random_for_testing_only();
     let object_id = ObjectID::random();
     let object = make_gas_object(object_id, 7, Owner::AddressOwner(owner));
-
-    store.local().write_object(&object).unwrap();
 
     store
         .local()
         .write_owned_object_entries(&[OwnedObjectEntry {
             owner,
             object_ref: object.compute_object_reference(),
+            object_type: GasCoin::type_(),
+            balance: Some(1_000_000),
         }])
         .unwrap();
 
@@ -345,6 +392,153 @@ fn test_seeded_owned_object_info_is_derived_from_bcs_until_deleted() {
             .expect("owned-object iterator should build")
             .count(),
         0,
+    );
+}
+
+#[tokio::test]
+async fn test_owned_object_query_lazily_initializes_complete_index_from_seed_manifest() {
+    let temp = tempfile::tempdir().expect("failed to create tempdir");
+    let checkpoint = 42;
+    let owner = SuiAddress::random_for_testing_only();
+    let object_id = ObjectID::random();
+    let object = make_gas_object(object_id, 7, Owner::AddressOwner(owner));
+
+    let server = MockServer::start().await;
+    mock_seed_object(&server, checkpoint, &object).await;
+
+    let store =
+        DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), checkpoint);
+    store
+        .local()
+        .write_seed_manifest(&SeedManifest {
+            network: "custom".to_owned(),
+            checkpoint,
+            entries: vec![SeedEntry {
+                object_ref: object.compute_object_reference(),
+                owner,
+            }],
+        })
+        .expect("seed manifest should write");
+
+    assert!(!store.local().owned_object_index_exists());
+
+    let infos: Vec<_> = RpcIndexes::owned_objects_iter(&store, owner, Some(GasCoin::type_()), None)
+        .expect("owned-object iterator should initialize from seed")
+        .map(|result| result.expect("owned-object entry should decode"))
+        .collect();
+
+    assert_eq!(infos.len(), 1);
+    assert_eq!(infos[0].object_id, object_id);
+    assert_eq!(infos[0].version, SequenceNumber::from_u64(7));
+    assert_eq!(infos[0].object_type, GasCoin::type_());
+    assert_eq!(infos[0].balance, Some(1_000_000));
+
+    let entries = store
+        .local()
+        .get_owned_object_entries()
+        .expect("owned-object index should read");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].object_type, GasCoin::type_());
+    assert_eq!(entries[0].balance, Some(1_000_000));
+    assert_eq!(
+        store
+            .local()
+            .get_object_at_version(&object_id, 7)
+            .expect("seeded object should be cached"),
+        Some(object),
+    );
+}
+
+#[tokio::test]
+async fn test_local_execution_before_owned_query_preserves_other_seeded_entries() {
+    let temp = tempfile::tempdir().expect("failed to create tempdir");
+    let checkpoint = 42;
+    let owner = SuiAddress::random_for_testing_only();
+    let recipient = SuiAddress::random_for_testing_only();
+    let first_id = ObjectID::random();
+    let second_id = ObjectID::random();
+    let first = make_gas_object(first_id, 1, Owner::AddressOwner(owner));
+    let second = make_gas_object(second_id, 1, Owner::AddressOwner(owner));
+    let transferred = make_gas_object(first_id, 2, Owner::AddressOwner(recipient));
+
+    let server = MockServer::start().await;
+    mock_seed_object(&server, checkpoint, &first).await;
+    mock_seed_object(&server, checkpoint, &second).await;
+
+    let mut store =
+        DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), checkpoint);
+    store
+        .local()
+        .write_seed_manifest(&SeedManifest {
+            network: "custom".to_owned(),
+            checkpoint,
+            entries: vec![
+                SeedEntry {
+                    object_ref: first.compute_object_reference(),
+                    owner,
+                },
+                SeedEntry {
+                    object_ref: second.compute_object_reference(),
+                    owner,
+                },
+            ],
+        })
+        .expect("seed manifest should write");
+
+    store.update_objects(BTreeMap::from([(first_id, transferred)]), vec![]);
+
+    let owner_infos: Vec<_> =
+        RpcIndexes::owned_objects_iter(&store, owner, Some(GasCoin::type_()), None)
+            .expect("owned-object iterator should build")
+            .map(|result| result.expect("owned-object entry should decode"))
+            .collect();
+    assert_eq!(owner_infos.len(), 1);
+    assert_eq!(owner_infos[0].object_id, second_id);
+    assert_eq!(owner_infos[0].version, SequenceNumber::from_u64(1));
+
+    let recipient_infos: Vec<_> =
+        RpcIndexes::owned_objects_iter(&store, recipient, Some(GasCoin::type_()), None)
+            .expect("owned-object iterator should build")
+            .map(|result| result.expect("owned-object entry should decode"))
+            .collect();
+    assert_eq!(recipient_infos.len(), 1);
+    assert_eq!(recipient_infos[0].object_id, first_id);
+    assert_eq!(recipient_infos[0].version, SequenceNumber::from_u64(2));
+}
+
+#[test]
+fn test_missing_owned_index_after_local_checkpoint_advancement_fails_closed() {
+    let (_temp, store) = test_data_store();
+    let owner = SuiAddress::random_for_testing_only();
+    let object = make_gas_object(ObjectID::random(), 1, Owner::AddressOwner(owner));
+    let data =
+        sui_types::test_checkpoint_data_builder::TestCheckpointBuilder::new(1).build_checkpoint();
+    let checkpoint =
+        sui_types::messages_checkpoint::VerifiedCheckpoint::new_unchecked(data.summary);
+
+    store
+        .local()
+        .write_seed_manifest(&SeedManifest {
+            network: "custom".to_owned(),
+            checkpoint: 0,
+            entries: vec![SeedEntry {
+                object_ref: object.compute_object_reference(),
+                owner,
+            }],
+        })
+        .expect("seed manifest should write");
+    store
+        .local()
+        .write_checkpoint_summary(&checkpoint)
+        .expect("advanced checkpoint should write");
+
+    let err = match RpcIndexes::owned_objects_iter(&store, owner, Some(GasCoin::type_()), None) {
+        Ok(_) => panic!("owned-object iterator should fail closed"),
+        Err(err) => err,
+    };
+    assert!(
+        err.to_string()
+            .contains("owned-object index is missing while local checkpoints have advanced")
     );
 }
 
@@ -397,7 +591,7 @@ fn test_local_wrap_removes_current_object_but_preserves_historical_lookup() {
     let object = make_gas_object(object_id, 1, Owner::AddressOwner(owner));
 
     store.update_objects(BTreeMap::from([(object_id, object.clone())]), vec![]);
-    store.apply_object_updates(
+    let result = store.apply_object_updates(
         BTreeMap::new(),
         vec![RemovedObject {
             object_id,
@@ -405,6 +599,7 @@ fn test_local_wrap_removes_current_object_but_preserves_historical_lookup() {
             kind: RemovedObjectKind::Wrapped,
         }],
     );
+    assert!(result.is_ok(), "object updates should apply: {result:?}");
 
     assert_eq!(SimulatorStore::owned_objects(&store, owner).count(), 0);
     assert!(
@@ -439,7 +634,7 @@ fn test_unwrapped_write_clears_wrapped_latest_and_reindexes_owner() {
     let object = make_gas_object(object_id, 1, Owner::AddressOwner(owner));
 
     store.update_objects(BTreeMap::from([(object_id, object)]), vec![]);
-    store.apply_object_updates(
+    let result = store.apply_object_updates(
         BTreeMap::new(),
         vec![RemovedObject {
             object_id,
@@ -447,9 +642,12 @@ fn test_unwrapped_write_clears_wrapped_latest_and_reindexes_owner() {
             kind: RemovedObjectKind::Wrapped,
         }],
     );
+    assert!(result.is_ok(), "object updates should apply: {result:?}");
 
     let unwrapped = make_gas_object(object_id, 3, Owner::AddressOwner(recipient));
-    store.apply_object_updates(BTreeMap::from([(object_id, unwrapped.clone())]), vec![]);
+    let result =
+        store.apply_object_updates(BTreeMap::from([(object_id, unwrapped.clone())]), vec![]);
+    assert!(result.is_ok(), "object updates should apply: {result:?}");
 
     assert_eq!(
         store.local().object_latest_state(&object_id).unwrap(),
@@ -476,7 +674,7 @@ fn test_terminal_deleted_latest_prevents_reindexing_written_object() {
     let written_again = make_gas_object(object_id, 3, Owner::AddressOwner(owner));
 
     store.update_objects(BTreeMap::from([(object_id, object)]), vec![]);
-    store.apply_object_updates(
+    let result = store.apply_object_updates(
         BTreeMap::from([(object_id, written_again)]),
         vec![RemovedObject {
             object_id,
@@ -484,6 +682,7 @@ fn test_terminal_deleted_latest_prevents_reindexing_written_object() {
             kind: RemovedObjectKind::Deleted,
         }],
     );
+    assert!(result.is_ok(), "object updates should apply: {result:?}");
 
     assert_eq!(SimulatorStore::owned_objects(&store, owner).count(), 0);
     assert!(

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -305,19 +305,19 @@ fn test_owned_objects_removes_non_address_owned_transitions() {
 }
 
 #[test]
-fn test_seeded_owned_object_metadata_lists_without_bcs_until_deleted() {
+fn test_seeded_owned_object_info_is_derived_from_bcs_until_deleted() {
     let (_temp, mut store) = test_data_store();
     let owner = SuiAddress::random_for_testing_only();
     let object_id = ObjectID::random();
+    let object = make_gas_object(object_id, 7, Owner::AddressOwner(owner));
+
+    store.local().write_object(&object).unwrap();
 
     store
         .local()
         .write_owned_object_entries(&[OwnedObjectEntry {
             owner,
-            object_id,
-            version: SequenceNumber::from_u64(7),
-            object_type: GasCoin::type_(),
-            balance: Some(123),
+            object_ref: object.compute_object_reference(),
         }])
         .unwrap();
 
@@ -328,15 +328,8 @@ fn test_seeded_owned_object_metadata_lists_without_bcs_until_deleted() {
     assert_eq!(infos.len(), 1);
     assert_eq!(infos[0].object_id, object_id);
     assert_eq!(infos[0].version, SequenceNumber::from_u64(7));
-    assert_eq!(infos[0].balance, Some(123));
-    assert!(
-        store
-            .local()
-            .get_latest_object(&object_id)
-            .expect("local lookup should not fail")
-            .is_none(),
-        "seed metadata should not require local BCS",
-    );
+    assert_eq!(infos[0].object_type, GasCoin::type_());
+    assert_eq!(infos[0].balance, Some(1_000_000));
 
     store.update_objects(
         BTreeMap::new(),

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -415,7 +415,6 @@ async fn test_owned_object_query_lazily_initializes_complete_index_from_seed_man
             checkpoint,
             entries: vec![SeedEntry {
                 object_ref: object.compute_object_reference(),
-                owner,
             }],
         })
         .expect("seed manifest should write");
@@ -475,11 +474,9 @@ async fn test_local_execution_before_owned_query_preserves_other_seeded_entries(
             entries: vec![
                 SeedEntry {
                     object_ref: first.compute_object_reference(),
-                    owner,
                 },
                 SeedEntry {
                     object_ref: second.compute_object_reference(),
-                    owner,
                 },
             ],
         })
@@ -523,7 +520,6 @@ fn test_missing_owned_index_after_local_checkpoint_advancement_fails_closed() {
             checkpoint: 0,
             entries: vec![SeedEntry {
                 object_ref: object.compute_object_reference(),
-                owner,
             }],
         })
         .expect("seed manifest should write");


### PR DESCRIPTION
## Description 

This PR simplifies the seeding of owned objects to only keep object ref + owner instead of downloading object data at startup. Any owned object query will require to fetch the BCS to extract the needed data, the first time. This keeps lazy loading of objects uniform across normal transaction execution and owned objects query.
For subsequent requests, the owned-object index data keeps data for object type and balance, which make default owned object queries easy (grpc default read mask for owned object queries includes object type), avoiding deserializing object bcs.

The seed data will be used when the owned object index needs to be initialized.

## Test plan 

Existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
