### PR TITLE
[graphql-alt] Allowlist client SDK version metric label

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -41,6 +41,9 @@ pub struct RpcConfig {
 
     /// Configuration for streaming subscriptions.
     pub subscription: SubscriptionConfig,
+
+    /// Configuration for the request-logging extension.
+    pub logging: LoggingConfig,
 }
 
 #[DefaultConfig]
@@ -53,6 +56,7 @@ pub struct RpcLayer {
     pub watermark: WatermarkLayer,
     pub zklogin: ZkLoginLayer,
     pub subscription: SubscriptionLayer,
+    pub logging: LoggingLayer,
 }
 
 #[derive(Clone)]
@@ -276,6 +280,39 @@ impl SubscriptionLayer {
     }
 }
 
+#[derive(Clone, Default, Debug)]
+pub struct LoggingConfig {
+    /// Per-SDK list of versions emitted verbatim as the `client_sdk_version` Prometheus label.
+    /// Versions outside this list map to `"other"`. Add an entry only when explicitly tracking
+    /// adoption or retention of a specific SDK version.
+    pub sdk_version_allowlist: BTreeMap<String, BTreeSet<String>>,
+}
+
+#[DefaultConfig]
+#[derive(Default, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct LoggingLayer {
+    pub sdk_version_allowlist: Option<BTreeMap<String, BTreeSet<String>>>,
+}
+
+impl LoggingLayer {
+    pub(crate) fn finish(self, base: LoggingConfig) -> LoggingConfig {
+        LoggingConfig {
+            sdk_version_allowlist: self
+                .sdk_version_allowlist
+                .unwrap_or(base.sdk_version_allowlist),
+        }
+    }
+}
+
+impl From<LoggingConfig> for LoggingLayer {
+    fn from(value: LoggingConfig) -> Self {
+        Self {
+            sdk_version_allowlist: Some(value.sdk_version_allowlist),
+        }
+    }
+}
+
 impl RpcLayer {
     pub fn example() -> Self {
         Self {
@@ -285,6 +322,7 @@ impl RpcLayer {
             watermark: WatermarkConfig::default().into(),
             zklogin: ZkLoginConfig::default().into(),
             subscription: SubscriptionConfig::default().into(),
+            logging: LoggingConfig::default().into(),
         }
     }
 
@@ -296,6 +334,7 @@ impl RpcLayer {
             watermark: self.watermark.finish(WatermarkConfig::default()),
             zklogin: self.zklogin.finish(ZkLoginConfig::default()),
             subscription: self.subscription.finish(SubscriptionConfig::default()),
+            logging: self.logging.finish(LoggingConfig::default()),
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
@@ -39,6 +39,7 @@ use tracing::log::log_enabled;
 use tracing::warn;
 use uuid::Uuid;
 
+use crate::config::LoggingConfig;
 use crate::error::code;
 use crate::error::error_codes;
 use crate::error::fill_error_code;
@@ -54,20 +55,13 @@ pub const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-req
 const CLIENT_SDK_TYPE_HEADER: HeaderName = HeaderName::from_static("client-sdk-type");
 
 /// Header identifying the SDK version that issued the request. The value is matched against
-/// `SDK_VERSION_ALLOWLIST` before being used as the `client_sdk_version` Prometheus label or
-/// recorded in request log lines; versions outside the allowlist appear as
-/// `CLIENT_LABEL_OTHER`.
+/// `LoggingConfig::sdk_version_allowlist` before being used as the `client_sdk_version`
+/// Prometheus label or recorded in request log lines; versions outside the allowlist appear
+/// as `CLIENT_LABEL_OTHER`.
 const CLIENT_SDK_VERSION_HEADER: HeaderName = HeaderName::from_static("client-sdk-version");
 
 /// SDKs we accept verbatim as the `client_sdk_type` Prometheus label.
 const SDK_TYPE_WHITELIST: &[&str] = &["rust", "typescript", "python"];
-
-/// Per-SDK list of versions we emit verbatim as the `client_sdk_version` Prometheus label.
-/// Versions outside this list map to `CLIENT_LABEL_OTHER`, which keeps label cardinality
-/// bounded by the size of this list rather than by the space of possible header values.
-/// Add an entry only when we explicitly want to track adoption or retention of a specific
-/// SDK version.
-const SDK_VERSION_ALLOWLIST: &[(&str, &[&str])] = &[];
 
 /// Sentinel label value substituted when a client SDK header is present but does not match an
 /// allowed value. Distinct from the empty string we use when the header is absent, so dashboards
@@ -131,7 +125,7 @@ impl Session {
 }
 
 impl ClientInfo {
-    pub(crate) fn from_headers(headers: &HeaderMap) -> Self {
+    pub(crate) fn from_headers(headers: &HeaderMap, config: &LoggingConfig) -> Self {
         let sdk_type = headers
             .get(&CLIENT_SDK_TYPE_HEADER)
             .and_then(|v| v.to_str().ok())
@@ -139,7 +133,7 @@ impl ClientInfo {
         let sdk_version = headers
             .get(&CLIENT_SDK_VERSION_HEADER)
             .and_then(|v| v.to_str().ok())
-            .map(|v| sanitize_sdk_version(sdk_type.as_deref().unwrap_or(""), v));
+            .map(|v| sanitize_sdk_version(sdk_type.as_deref().unwrap_or(""), v, config));
         Self {
             sdk_type,
             sdk_version,
@@ -354,13 +348,15 @@ fn sanitize_sdk_type(value: &str) -> String {
 }
 
 /// Sanitize a `client-sdk-version` header value before it is used as a Prometheus label.
-/// Returns the value verbatim if `(sdk_type, value)` is listed in `SDK_VERSION_ALLOWLIST`,
-/// otherwise `CLIENT_LABEL_OTHER`. Bounding label cardinality this way is what protects the
-/// metric against an adversarially-chosen version string.
-fn sanitize_sdk_version(sdk_type: &str, value: &str) -> String {
-    if SDK_VERSION_ALLOWLIST
-        .iter()
-        .any(|&(t, vs)| t == sdk_type && vs.contains(&value))
+/// Returns the value verbatim if `(sdk_type, value)` is listed in
+/// `LoggingConfig::sdk_version_allowlist`, otherwise `CLIENT_LABEL_OTHER`. Bounding label
+/// cardinality this way is what protects the metric against an adversarially-chosen version
+/// string.
+fn sanitize_sdk_version(sdk_type: &str, value: &str, config: &LoggingConfig) -> String {
+    if config
+        .sdk_version_allowlist
+        .get(sdk_type)
+        .is_some_and(|vs| vs.contains(value))
     {
         value.to_string()
     } else {
@@ -370,6 +366,9 @@ fn sanitize_sdk_version(sdk_type: &str, value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
+
     use async_graphql::EmptyMutation;
     use async_graphql::EmptySubscription;
     use async_graphql::Object;
@@ -390,7 +389,7 @@ mod tests {
 
     #[test]
     fn client_info_missing_headers_yield_none() {
-        let info = ClientInfo::from_headers(&HeaderMap::new());
+        let info = ClientInfo::from_headers(&HeaderMap::new(), &LoggingConfig::default());
 
         assert!(info.sdk_type.is_none());
         assert!(info.sdk_version.is_none());
@@ -405,7 +404,7 @@ mod tests {
             HeaderValue::from_static("1.69.0"),
         );
 
-        let info = ClientInfo::from_headers(&headers);
+        let info = ClientInfo::from_headers(&headers, &LoggingConfig::default());
 
         assert_eq!(info.sdk_type.as_deref(), Some("rust"));
         assert_eq!(info.sdk_version.as_deref(), Some(CLIENT_LABEL_OTHER));
@@ -417,10 +416,43 @@ mod tests {
         headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("haskell"));
         headers.insert(CLIENT_SDK_VERSION_HEADER, HeaderValue::from_static("0.1.0"));
 
-        let info = ClientInfo::from_headers(&headers);
+        let info = ClientInfo::from_headers(&headers, &LoggingConfig::default());
 
         assert_eq!(info.sdk_type.as_deref(), Some(CLIENT_LABEL_OTHER));
         assert_eq!(info.sdk_version.as_deref(), Some(CLIENT_LABEL_OTHER));
+    }
+
+    #[test]
+    fn client_info_version_header_missing_yields_none() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
+
+        let info = ClientInfo::from_headers(&headers, &LoggingConfig::default());
+
+        assert_eq!(info.sdk_type.as_deref(), Some("rust"));
+        assert!(info.sdk_version.is_none());
+    }
+
+    #[test]
+    fn client_info_allowlisted_version_kept_verbatim() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
+        headers.insert(
+            CLIENT_SDK_VERSION_HEADER,
+            HeaderValue::from_static("1.69.0"),
+        );
+
+        let config = LoggingConfig {
+            sdk_version_allowlist: BTreeMap::from([(
+                "rust".to_string(),
+                BTreeSet::from(["1.69.0".to_string()]),
+            )]),
+        };
+
+        let info = ClientInfo::from_headers(&headers, &config);
+
+        assert_eq!(info.sdk_type.as_deref(), Some("rust"));
+        assert_eq!(info.sdk_version.as_deref(), Some("1.69.0"));
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
@@ -53,17 +53,21 @@ pub const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-req
 /// bucketed into `CLIENT_LABEL_OTHER`.
 const CLIENT_SDK_TYPE_HEADER: HeaderName = HeaderName::from_static("client-sdk-type");
 
-/// Header identifying the SDK version that issued the request. The value flows into the
-/// `client_sdk_version` Prometheus label, sanitized by `sanitize_sdk_version`. Values longer
-/// than `MAX_SDK_VERSION_LEN` or containing characters outside `[A-Za-z0-9._-]` are bucketed
-/// into `CLIENT_LABEL_OTHER`.
+/// Header identifying the SDK version that issued the request. The value is matched against
+/// `SDK_VERSION_ALLOWLIST` before being used as the `client_sdk_version` Prometheus label or
+/// recorded in request log lines; versions outside the allowlist appear as
+/// `CLIENT_LABEL_OTHER`.
 const CLIENT_SDK_VERSION_HEADER: HeaderName = HeaderName::from_static("client-sdk-version");
 
 /// SDKs we accept verbatim as the `client_sdk_type` Prometheus label.
 const SDK_TYPE_WHITELIST: &[&str] = &["rust", "typescript", "python"];
 
-/// Maximum length of a `client-sdk-version` value we accept verbatim.
-const MAX_SDK_VERSION_LEN: usize = 32;
+/// Per-SDK list of versions we emit verbatim as the `client_sdk_version` Prometheus label.
+/// Versions outside this list map to `CLIENT_LABEL_OTHER`, which keeps label cardinality
+/// bounded by the size of this list rather than by the space of possible header values.
+/// Add an entry only when we explicitly want to track adoption or retention of a specific
+/// SDK version.
+const SDK_VERSION_ALLOWLIST: &[(&str, &[&str])] = &[];
 
 /// Sentinel label value substituted when a client SDK header is present but does not match an
 /// allowed value. Distinct from the empty string we use when the header is absent, so dashboards
@@ -128,15 +132,17 @@ impl Session {
 
 impl ClientInfo {
     pub(crate) fn from_headers(headers: &HeaderMap) -> Self {
+        let sdk_type = headers
+            .get(&CLIENT_SDK_TYPE_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(sanitize_sdk_type);
+        let sdk_version = headers
+            .get(&CLIENT_SDK_VERSION_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| sanitize_sdk_version(sdk_type.as_deref().unwrap_or(""), v));
         Self {
-            sdk_type: headers
-                .get(&CLIENT_SDK_TYPE_HEADER)
-                .and_then(|v| v.to_str().ok())
-                .map(sanitize_sdk_type),
-            sdk_version: headers
-                .get(&CLIENT_SDK_VERSION_HEADER)
-                .and_then(|v| v.to_str().ok())
-                .map(sanitize_sdk_version),
+            sdk_type,
+            sdk_version,
         }
     }
 }
@@ -347,18 +353,15 @@ fn sanitize_sdk_type(value: &str) -> String {
     }
 }
 
-/// Sanitize a `client-sdk-version` header value before it is used as a Prometheus label. Values
-/// longer than `MAX_SDK_VERSION_LEN` or containing characters outside `[A-Za-z0-9._-]` are
-/// bucketed to `CLIENT_LABEL_OTHER`. Build metadata (`+...`) is rejected on purpose, because
-/// per-build suffixes are exactly the cardinality vector we are trying to avoid.
-fn sanitize_sdk_version(value: &str) -> String {
-    let valid = !value.is_empty()
-        && value.len() <= MAX_SDK_VERSION_LEN
-        && value
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'));
-
-    if valid {
+/// Sanitize a `client-sdk-version` header value before it is used as a Prometheus label.
+/// Returns the value verbatim if `(sdk_type, value)` is listed in `SDK_VERSION_ALLOWLIST`,
+/// otherwise `CLIENT_LABEL_OTHER`. Bounding label cardinality this way is what protects the
+/// metric against an adversarially-chosen version string.
+fn sanitize_sdk_version(sdk_type: &str, value: &str) -> String {
+    if SDK_VERSION_ALLOWLIST
+        .iter()
+        .any(|&(t, vs)| t == sdk_type && vs.contains(&value))
+    {
         value.to_string()
     } else {
         CLIENT_LABEL_OTHER.to_string()
@@ -386,7 +389,15 @@ mod tests {
     }
 
     #[test]
-    fn client_info_extracts_sdk_headers() {
+    fn client_info_missing_headers_yield_none() {
+        let info = ClientInfo::from_headers(&HeaderMap::new());
+
+        assert!(info.sdk_type.is_none());
+        assert!(info.sdk_version.is_none());
+    }
+
+    #[test]
+    fn client_info_non_allowlisted_version_bucketed_other() {
         let mut headers = HeaderMap::new();
         headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
         headers.insert(
@@ -397,15 +408,7 @@ mod tests {
         let info = ClientInfo::from_headers(&headers);
 
         assert_eq!(info.sdk_type.as_deref(), Some("rust"));
-        assert_eq!(info.sdk_version.as_deref(), Some("1.69.0"));
-    }
-
-    #[test]
-    fn client_info_missing_headers_yield_none() {
-        let info = ClientInfo::from_headers(&HeaderMap::new());
-
-        assert!(info.sdk_type.is_none());
-        assert!(info.sdk_version.is_none());
+        assert_eq!(info.sdk_version.as_deref(), Some(CLIENT_LABEL_OTHER));
     }
 
     #[test]
@@ -417,36 +420,6 @@ mod tests {
         let info = ClientInfo::from_headers(&headers);
 
         assert_eq!(info.sdk_type.as_deref(), Some(CLIENT_LABEL_OTHER));
-        assert_eq!(info.sdk_version.as_deref(), Some("0.1.0"));
-    }
-
-    #[test]
-    fn client_info_oversized_version_bucketed_other() {
-        let mut headers = HeaderMap::new();
-        let too_long = "1.".to_string() + &"0".repeat(MAX_SDK_VERSION_LEN);
-        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
-        headers.insert(
-            CLIENT_SDK_VERSION_HEADER,
-            HeaderValue::from_str(&too_long).unwrap(),
-        );
-
-        let info = ClientInfo::from_headers(&headers);
-
-        assert_eq!(info.sdk_type.as_deref(), Some("rust"));
-        assert_eq!(info.sdk_version.as_deref(), Some(CLIENT_LABEL_OTHER));
-    }
-
-    #[test]
-    fn client_info_version_with_build_metadata_bucketed_other() {
-        let mut headers = HeaderMap::new();
-        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
-        headers.insert(
-            CLIENT_SDK_VERSION_HEADER,
-            HeaderValue::from_static("1.0.0+abc123"),
-        );
-
-        let info = ClientInfo::from_headers(&headers);
-
         assert_eq!(info.sdk_version.as_deref(), Some(CLIENT_LABEL_OTHER));
     }
 

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -29,6 +29,7 @@ use axum::routing::MethodRouter;
 use axum::routing::get;
 use axum::routing::post;
 use axum_extra::TypedHeader;
+use config::LoggingConfig;
 use config::RpcConfig;
 use extensions::query_limits::QueryLimitsChecker;
 use extensions::query_limits::rich;
@@ -407,6 +408,7 @@ pub async fn start_rpc(
         .route(HEALTH_PATH, get(health::check))
         .layer(watermark_task.watermarks())
         .layer(config.health)
+        .layer(config.logging)
         .layer(DbProbe(database_url))
         .extension(Timeout::new(config.limits.timeouts()))
         .extension(QueryLimitsChecker::new(
@@ -472,6 +474,7 @@ async fn graphql(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Extension(schema): Extension<Schema<Query, Mutation, Subscription>>,
     Extension(watermark): Extension<WatermarksLock>,
+    Extension(logging): Extension<LoggingConfig>,
     TypedHeader(content_length): TypedHeader<ContentLength>,
     show_usage: Option<TypedHeader<ShowUsage>>,
     headers: axum::http::HeaderMap,
@@ -480,7 +483,7 @@ async fn graphql(
     let mut request = request
         .into_inner()
         .data(content_length)
-        .data(Session::new(addr).with_client_info(ClientInfo::from_headers(&headers)))
+        .data(Session::new(addr).with_client_info(ClientInfo::from_headers(&headers, &logging)))
         .data(watermark.read().await.clone())
         .data(rich::Meter::default());
 


### PR DESCRIPTION
## Description 

- Replace the charset and length sanitization on the `client_sdk_version` Prometheus label with a per-SDK allowlist (`SDK_VERSION_ALLOWLIST`). Versions outside the allowlist appear as `other`, keeping label cardinality bounded by the size of the list rather than by the space of header values an attacker can construct.
 - The allowlist starts empty; adding a version is a one-line change in `logging.rs`. We only add an entry when we explicitly want to track adoption or retention of that version.
## Why

Follow-up to #26437. even with a 32-character cap and a `[A-Za-z0-9._-]` charset, the version label has roughly `65^32` possible values, which is a valid Prometheus cardinality DoS vector (precedent: SUIPR-379, a paid bug bounty on gRPC metrics in January). The allowlist closes that gap.

## Test plan 

How did you test the new or updated feature?
- e2e test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
