### PR TITLE
[move][move-decompiler] Add block comments when emitting blocks.

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/ast.rs
+++ b/external-crates/move/crates/move-decompiler/src/ast.rs
@@ -63,6 +63,11 @@ pub struct Function {
     /// Return types. Empty for `(): ()`, single element for one return, multiple for a tuple.
     pub returns: Vec<Type>,
     pub code: Exp,
+    /// Basic-block ids that the structurer received as input but never emitted into the
+    /// structured output. Non-empty means the renderer prepends a
+    /// `// Did not structure and emit blocks N, K, ...` notice so the reader knows part of
+    /// the bytecode is missing from this function's source view.
+    pub unstructured_blocks: Vec<u64>,
 }
 
 #[derive(Debug, Clone)]

--- a/external-crates/move/crates/move-decompiler/src/ast.rs
+++ b/external-crates/move/crates/move-decompiler/src/ast.rs
@@ -273,6 +273,11 @@ pub enum Exp {
     // ideally not needed, but useful to avoid failing on an entire module
     // just because we can't handle one thing
     Unstructured(Vec<UnstructuredNode>),
+    /// A `D::Structured::Block(code)` after lowering. The `u64` matches the label carried by
+    /// any `Unstructured(Goto)` that targets this block, so a surviving goto can be traced
+    /// to its destination by scanning for the matching `Block` in the rendered output. The
+    /// body is the lowered block contents (typically a `Seq`).
+    Block(u64, Box<Exp>),
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -314,6 +319,7 @@ impl Exp {
                 }
                 UnstructuredNode::Goto(_) => false,
             }),
+            Exp::Block(_, body) => body.contains_break(),
         }
     }
 
@@ -353,6 +359,7 @@ impl Exp {
                 }
                 UnstructuredNode::Goto(_) => false,
             }),
+            Exp::Block(_, body) => body.contains_continue(),
         }
     }
 
@@ -453,6 +460,7 @@ impl Exp {
                 }
             }
             Exp::Value(_) | Exp::Constant(_) | Exp::Break(_) | Exp::Continue(_) => {}
+            Exp::Block(_, body) => body.collect_referenced_names(out),
         }
     }
 }
@@ -589,6 +597,7 @@ impl std::fmt::Display for Exp {
                     | Exp::UnpackVariant(_, _, _, _)
                     | Exp::VecUnpack(_, _)
                     | Exp::Unstructured(_)
+                    | Exp::Block(_, _)
             )
         }
 
@@ -801,6 +810,10 @@ impl std::fmt::Display for Exp {
                     indent(f, level)?;
                     writeln!(f, "}}")
                 }
+                // Block is a marker; recur into the body. The pretty printer emits the
+                // `/* block N */` comment; the Debug `Display` path is for tests and stays
+                // transparent.
+                Exp::Block(_, body) => fmt_exp(f, body, level),
             }
         }
 

--- a/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
+++ b/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
@@ -199,20 +199,54 @@ fn function(context: &Context, fun: &Function) -> Doc {
     let header = fun_header_doc(fun);
     let code = &fun.code;
 
+    // Notice for input blocks the structurer received but never emitted. Prepending it
+    // inside the function braces puts the warning right above the recovered source so a
+    // reader of the decompiled file can't miss it.
+    let unstructured_notice: Option<Doc> = if fun.unstructured_blocks.is_empty() {
+        None
+    } else {
+        let ids = fun
+            .unstructured_blocks
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(D::text(format!(
+            "// Did not structure and emit blocks {ids}"
+        )))
+    };
+
     // Three cases for the body to avoid double-bracing:
     // - empty Seq (e.g., from a refined-away trailing `return`) -> just `{}`
     // - non-empty Seq, or a `Block` wrapping one -> already renders as `{ ... }` via the
     //   Block-aware `exp` path
     // - any other Exp -> wrap in our own braces
     let inner = peek_block(code);
-    match inner {
-        Exp::Seq(seq) if seq.is_empty() => header.concat_space(Doc::text("{}")),
-        Exp::Seq(_) => header.concat_space(exp(context, code)),
-        _ => header
+    match (inner, unstructured_notice) {
+        // No notice: keep the existing fast paths so the rendering is bit-identical to
+        // before for cleanly-structured functions.
+        (Exp::Seq(seq), None) if seq.is_empty() => header.concat_space(Doc::text("{}")),
+        (Exp::Seq(_), None) => header.concat_space(exp(context, code)),
+        (_, None) => header
             .concat_space(Doc::text("{"))
             .concat(Doc::nest(Doc::line().concat(exp(context, code)), 4))
             .concat(Doc::line())
             .concat(Doc::text("}")),
+        // Notice present: we always wrap in our own braces so the notice can sit at the
+        // top of the body.
+        (Exp::Seq(seq), Some(notice)) if seq.is_empty() => header
+            .concat_space(Doc::text("{"))
+            .concat(Doc::nest(Doc::line().concat(notice), 4))
+            .concat(Doc::line())
+            .concat(Doc::text("}")),
+        (_, Some(notice)) => {
+            let body = notice.concat(Doc::line()).concat(exp(context, code));
+            header
+                .concat_space(Doc::text("{"))
+                .concat(Doc::nest(Doc::line().concat(body), 4))
+                .concat(Doc::line())
+                .concat(Doc::text("}"))
+        }
     }
 }
 
@@ -242,6 +276,7 @@ fn fun_header_doc(fun: &Function) -> Doc {
         parameters,
         returns,
         code: _,
+        unstructured_blocks: _,
     } = fun;
 
     let mut prefix_parts: Vec<Doc> = Vec::new();

--- a/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
+++ b/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
@@ -201,9 +201,11 @@ fn function(context: &Context, fun: &Function) -> Doc {
 
     // Three cases for the body to avoid double-bracing:
     // - empty Seq (e.g., from a refined-away trailing `return`) -> just `{}`
-    // - non-empty Seq -> already renders as `{ ... }`, use it as-is
+    // - non-empty Seq, or a `Block` wrapping one -> already renders as `{ ... }` via the
+    //   Block-aware `exp` path
     // - any other Exp -> wrap in our own braces
-    match code {
+    let inner = peek_block(code);
+    match inner {
         Exp::Seq(seq) if seq.is_empty() => header.concat_space(Doc::text("{}")),
         Exp::Seq(_) => header.concat_space(exp(context, code)),
         _ => header
@@ -211,6 +213,15 @@ fn function(context: &Context, fun: &Function) -> Doc {
             .concat(Doc::nest(Doc::line().concat(exp(context, code)), 4))
             .concat(Doc::line())
             .concat(Doc::text("}")),
+    }
+}
+
+/// Look through any number of `Exp::Block` wrappers — used by the function-body dispatcher
+/// to decide which braces strategy applies based on the underlying shape.
+fn peek_block(exp: &Exp) -> &Exp {
+    match exp {
+        Exp::Block(_, body) => peek_block(body),
+        _ => exp,
     }
 }
 
@@ -549,15 +560,36 @@ fn exp(context: &Context, exp: &Exp) -> Doc {
         D::braces(D::line().concat(body.indent(4)).concat(D::line()))
     }
 
-    // Render a list of statements separated by lines.
+    // Render a list of statements separated by lines. `Block(N, body)` items get a leading
+    // `/* block N */` comment; if `body` is a `Seq`, its items are inlined as siblings (no
+    // nested braces), so the comment marks the start of the block and the statements continue
+    // until the next block marker or the end of the enclosing sequence.
     fn stmts<'a, I>(context: &Context, it: I) -> Doc
     where
         I: IntoIterator<Item = &'a Exp>,
     {
-        D::intersperse(
-            it.into_iter().map(|e| recur(context, e)),
-            D::text(";").concat(D::line()),
-        )
+        let mut docs: Vec<Doc> = Vec::new();
+        for e in it {
+            push_stmt(context, e, &mut docs);
+        }
+        D::intersperse(docs, D::text(";").concat(D::line()))
+    }
+
+    fn push_stmt(context: &Context, e: &Exp, out: &mut Vec<Doc>) {
+        match e {
+            Exp::Block(id, body) => {
+                out.push(D::text(format!("/* block {id} */")));
+                match &**body {
+                    Exp::Seq(vs) => {
+                        for v in vs {
+                            push_stmt(context, v, out);
+                        }
+                    }
+                    inner => push_stmt(context, inner, out),
+                }
+            }
+            _ => out.push(recur(context, e)),
+        }
     }
 
     // Expression-ish printers --------------------------------------------
@@ -731,30 +763,48 @@ fn exp(context: &Context, exp: &Exp) -> Doc {
             Exp::Unstructured(nodes) => {
                 D::text("unstructured").concat_space(unstructured_block(context, nodes))
             }
+            // Expression-position Block: emit an inline `/* block N */` comment and recur
+            // into the body. Statement-position rendering goes through `stmts` / `push_stmt`,
+            // which keeps the comment on its own line above the inlined body items.
+            Exp::Block(id, body) => {
+                D::text(format!("/* block {id} */")).concat_space(recur(context, body))
+            }
         }
     }
 
     fn e_block(context: &Context, e: &Exp) -> Doc {
-        // If it's already a block/seq, print its statements;
-        // otherwise, treat the single expression as a statement.
-        match e {
+        // Peel `Block` wrappers, collecting `/* block N */` comments to lead the brace-block,
+        // then delegate the inner shape (Seq → stmts; single Exp → statement).
+        let mut headers: Vec<Doc> = Vec::new();
+        let mut inner = e;
+        while let Exp::Block(id, body) = inner {
+            headers.push(D::text(format!("/* block {id} */")));
+            inner = body;
+        }
+        match inner {
             Exp::Seq(vs) => {
                 let final_semi = matches!(
                     vs.last(),
                     Some(Exp::LetBind(_, _) | Exp::Assign(_, _) | Exp::Declare(_))
                 );
-                let mut stmts = stmts(context, vs);
-                if final_semi {
-                    stmts = stmts.concat(D::text(";"));
+                let mut docs = headers;
+                for v in vs {
+                    push_stmt(context, v, &mut docs);
                 }
-                braces_block(stmts)
+                let mut body = D::intersperse(docs, D::text(";").concat(D::line()));
+                if final_semi {
+                    body = body.concat(D::text(";"));
+                }
+                braces_block(body)
             }
             other => {
                 let final_semi = matches!(
                     other,
                     Exp::LetBind(_, _) | Exp::Assign(_, _) | Exp::Declare(_)
                 );
-                let mut body = recur(context, other);
+                let mut docs = headers;
+                docs.push(recur(context, other));
+                let mut body = D::intersperse(docs, D::text(";").concat(D::line()));
                 if final_semi {
                     body = body.concat(D::text(";"));
                 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/collect_uses.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/collect_uses.rs
@@ -238,6 +238,7 @@ fn rewrite_self_types(exp: &mut Exp, current_mid: ModuleId<Symbol>) {
                 rewrite_self_types(a, current_mid);
             }
         }
+        Exp::Block(_, body) => rewrite_self_types(body, current_mid),
         Exp::Break(_)
         | Exp::Continue(_)
         | Exp::Declare(_)
@@ -448,6 +449,7 @@ fn collect_local_names_exp(exp: &Exp, out: &mut BTreeSet<Symbol>) {
                 }
             }
         }
+        Exp::Block(_, body) => collect_local_names_exp(body, out),
     }
 }
 
@@ -540,6 +542,7 @@ fn count_type_refs_exp(exp: &Exp, out: &mut BTreeMap<(ModuleId<Symbol>, Symbol),
                 count_type_refs_exp(a, out);
             }
         }
+        Exp::Block(_, body) => count_type_refs_exp(body, out),
         Exp::Break(_)
         | Exp::Continue(_)
         | Exp::Declare(_)
@@ -647,6 +650,7 @@ fn count_module_refs_exp(
                 count_module_refs_exp(a, type_uses, out);
             }
         }
+        Exp::Block(_, body) => count_module_refs_exp(body, type_uses, out),
         Exp::Break(_)
         | Exp::Continue(_)
         | Exp::Declare(_)
@@ -725,6 +729,7 @@ fn rewrite(
                 rewrite(a, uses, type_uses);
             }
         }
+        Exp::Block(_, body) => rewrite(body, uses, type_uses),
         Exp::Break(_)
         | Exp::Continue(_)
         | Exp::Declare(_)

--- a/external-crates/move/crates/move-decompiler/src/refinement/fuse_let.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/fuse_let.rs
@@ -3,7 +3,10 @@
 
 use std::collections::BTreeSet;
 
-use crate::{ast::Exp, refinement::Refine};
+use crate::{
+    ast::Exp,
+    refinement::{Refine, utils::peek},
+};
 
 pub fn refine(exp: &mut Exp) -> bool {
     FuseLet.refine(exp)
@@ -73,12 +76,9 @@ fn fuse_seq(items: &mut Vec<Exp>) -> bool {
         }
 
         // Apply fusions in reverse so positional indices remain valid as we mutate in place.
+        // The `Assign` may sit inside a `Block` wrapper; preserve the wrapper.
         for &j in fusion_positions.iter().rev() {
-            let item = std::mem::replace(&mut items[j], Exp::Seq(vec![]));
-            let Exp::Assign(targets, rhs) = item else {
-                unreachable!("fusion_positions only records Assign indices");
-            };
-            items[j] = Exp::LetBind(targets, rhs);
+            rewrite_assign_to_letbind(&mut items[j]);
         }
 
         // Drop the fused names from the Declare; remove the Declare if nothing remains.
@@ -112,7 +112,8 @@ fn classify_item(
     fusion_positions: &mut Vec<usize>,
     j: usize,
 ) {
-    if let Exp::Assign(targets, rhs) = item {
+    // Peek through `Block` wrappers — the `Assign` we're hunting may sit inside one.
+    if let Exp::Assign(targets, rhs) = peek(item) {
         let rhs_refs = rhs.referenced_names();
         let all_targets_pending = targets.iter().all(|t| pending.contains(t));
         let rhs_safe = !rhs_refs.iter().any(|n| pending.contains(n));
@@ -138,5 +139,20 @@ fn classify_item(
     // Any other item: collect every name it touches and block them.
     for n in &item.referenced_names() {
         pending.remove(n);
+    }
+}
+
+/// Rewrite an `Assign` to a `LetBind` in place, preserving any surrounding `Block` wrapper
+/// (so the block ID stays attached for goto cross-referencing).
+fn rewrite_assign_to_letbind(item: &mut Exp) {
+    match item {
+        Exp::Assign(_, _) => {
+            let Exp::Assign(targets, rhs) = std::mem::replace(item, Exp::Seq(vec![])) else {
+                unreachable!()
+            };
+            *item = Exp::LetBind(targets, rhs);
+        }
+        Exp::Block(_, body) => rewrite_assign_to_letbind(body),
+        _ => unreachable!("fusion_positions only records Assign indices (possibly Block-wrapped)"),
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/hoist_arm_assignments.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/hoist_arm_assignments.rs
@@ -72,17 +72,19 @@ fn arms_mut(exp: &mut Exp) -> Vec<&mut Exp> {
     }
 }
 
-/// `Assign([X], _)` directly, or the trailing entry of a `Seq` that is — returns `X`.
+/// `Assign([X], _)` directly, or the trailing entry of a `Seq` that is — returns `X`. Peeks
+/// through any `Block` wrappers that lowering left around the arm body and its tail.
 fn trailing_assign_target(exp: &Exp) -> Option<&str> {
     match exp {
         Exp::Assign(names, _) if names.len() == 1 => Some(&names[0]),
         Exp::Seq(items) => items.last().and_then(trailing_assign_target),
+        Exp::Block(_, body) => trailing_assign_target(body),
         _ => None,
     }
 }
 
-/// Replace the trailing `Assign([_], rhs)` (possibly nested in a `Seq`) with just `rhs`, in
-/// place, so the arm now evaluates to what the assignment's RHS was.
+/// Replace the trailing `Assign([_], rhs)` (possibly nested in a `Seq` or `Block`) with just
+/// `rhs`, in place, so the arm now evaluates to what the assignment's RHS was.
 fn strip_trailing_assign(exp: &mut Exp) {
     match exp {
         Exp::Assign(_, _) => exp.map_mut(|e| match e {
@@ -94,6 +96,7 @@ fn strip_trailing_assign(exp: &mut Exp) {
                 strip_trailing_assign(last);
             }
         }
+        Exp::Block(_, body) => strip_trailing_assign(body),
         _ => {}
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/introduce_while.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/introduce_while.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     ast::Exp,
-    refinement::{Refine, utils::negate},
+    refinement::{
+        Refine,
+        utils::{negate, peek, peek_mut, unwrap_block},
+    },
 };
 
 pub fn refine(exp: &mut Exp) -> bool {
@@ -23,7 +26,7 @@ impl Refine for IntroduceWhile0 {
             return false;
         };
 
-        let Exp::IfElse(_, conseq, alt) = &**body else {
+        let Exp::IfElse(_, conseq, alt) = peek(body) else {
             return false;
         };
         let Some(alt) = &**alt else {
@@ -32,7 +35,7 @@ impl Refine for IntroduceWhile0 {
         // Only fire when the Break(label) matches this loop's label (so the break really exits
         // *this* Loop and not a labeled outer one).
         let target = *loop_label;
-        if !is_break_to(conseq, target) && !is_break_to(alt, target) {
+        if !is_break_to(peek(conseq), target) && !is_break_to(peek(alt), target) {
             return false;
         }
 
@@ -40,11 +43,11 @@ impl Refine for IntroduceWhile0 {
             let Exp::Loop(loop_label, body) = e else {
                 unreachable!()
             };
-            let Exp::IfElse(mut test, conseq, alt) = *body else {
+            let Exp::IfElse(mut test, conseq, alt) = unwrap_block(*body) else {
                 unreachable!()
             };
             let alt = alt.unwrap();
-            if is_break_to(&conseq, loop_label) {
+            if is_break_to(peek(&conseq), loop_label) {
                 negate(&mut test);
                 Exp::While(loop_label, test, Box::new(alt))
             } else {
@@ -71,18 +74,18 @@ impl Refine for IntroduceWhile1 {
         };
         let loop_label = *loop_label;
 
-        match &mut **loop_body {
+        match peek_mut(loop_body) {
             Exp::Seq(seq) if !seq.is_empty() => {
-                let Exp::IfElse(_, conseq, alt) = &seq[0] else {
+                let Exp::IfElse(_, conseq, alt) = peek(&seq[0]) else {
                     return false;
                 };
-                if !is_break_to(conseq, loop_label) {
+                if !is_break_to(peek(conseq), loop_label) {
                     return false;
                 }
                 let None = alt.as_ref() else {
                     return false;
                 };
-                let Exp::IfElse(mut test, _, _) = seq.remove(0) else {
+                let Exp::IfElse(mut test, _, _) = unwrap_block(seq.remove(0)) else {
                     return false;
                 };
                 negate(&mut test);

--- a/external-crates/move/crates/move-decompiler/src/refinement/loop_to_seq.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/loop_to_seq.rs
@@ -1,7 +1,13 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ast::Exp, refinement::Refine};
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{peek, peek_mut},
+    },
+};
 
 pub fn refine(exp: &mut Exp) -> bool {
     LoopToSeq.refine(exp)
@@ -18,13 +24,14 @@ impl Refine for LoopToSeq {
             return false;
         };
         let loop_label = *loop_label;
-        let Exp::Seq(seq) = &mut **body else {
+        // Peek through any outer `Block` to reach the body's Seq.
+        let Exp::Seq(seq) = peek_mut(body) else {
             return false;
         };
 
         // Only fire when the trailing break exits *this* loop (label matches). If it has
         // another loop's label, we can't drop it — it'd change meaning.
-        if matches!(seq.last(), Some(Exp::Break(l)) if *l == loop_label) {
+        if matches!(seq.last().map(peek), Some(Exp::Break(l)) if *l == loop_label) {
             // If there is a continue, we cannot drop the break.
             if seq
                 .iter()

--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -116,6 +116,7 @@ trait Refine {
             E::VecUnpack(_, e) => self.refine(e),
             E::Unpack(_, _, e) => self.refine(e),
             E::UnpackVariant(_, _, _, e) => self.refine(e),
+            E::Block(_, body) => self.refine(body),
             E::Unstructured(nodes) => {
                 use crate::ast::UnstructuredNode;
                 let mut changed = false;

--- a/external-crates/move/crates/move-decompiler/src/refinement/reconstruct_match.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/reconstruct_match.rs
@@ -1,7 +1,13 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ast::Exp, refinement::Refine};
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{peek, peek_mut},
+    },
+};
 
 use move_symbol_pool::Symbol;
 
@@ -67,12 +73,13 @@ impl Refine for ReconstructMatch {
 // Helpers
 
 /// True iff `body` starts (directly, or as the first item of a `Seq`) with an `UnpackVariant`
-/// whose variant tag is `arm_variant`.
+/// whose variant tag is `arm_variant`. Looks through `Block` wrappers at both the body and
+/// the first-Seq-element positions, since translation wraps every lowered block.
 fn has_leading_unpack(body: &Exp, arm_variant: Symbol) -> bool {
-    match body {
+    match peek(body) {
         Exp::UnpackVariant(_, (_, v), _, _) => *v == arm_variant,
         Exp::Seq(items) => matches!(
-            items.first(),
+            items.first().map(peek),
             Some(Exp::UnpackVariant(_, (_, v), _, _)) if *v == arm_variant
         ),
         _ => false,
@@ -81,19 +88,25 @@ fn has_leading_unpack(body: &Exp, arm_variant: Symbol) -> bool {
 
 /// If `body` starts with an `UnpackVariant` of `arm_variant`, remove it and return its field
 /// bindings. The body either becomes the empty `Seq` (when the unpack *was* the whole body)
-/// or loses just its leading statement (when the unpack sat at the head of a `Seq`).
+/// or loses just its leading statement (when the unpack sat at the head of a `Seq`). Peeks
+/// through `Block` wrappers around both the body and the first Seq item.
 fn take_leading_unpack(body: &mut Exp, arm_variant: Symbol) -> Option<Vec<(Symbol, String)>> {
-    match body {
+    let inner = peek_mut(body);
+    match inner {
         Exp::UnpackVariant(_, (_, v), _, _) if *v == arm_variant => {
-            let Exp::UnpackVariant(_, _, fields, _) = std::mem::replace(body, Exp::Seq(vec![]))
+            let Exp::UnpackVariant(_, _, fields, _) = std::mem::replace(inner, Exp::Seq(vec![]))
             else {
                 unreachable!()
             };
             Some(fields)
         }
-        Exp::Seq(items) if matches!(items.first(), Some(Exp::UnpackVariant(_, (_, v), _, _)) if *v == arm_variant) =>
+        Exp::Seq(items) if matches!(items.first().map(peek), Some(Exp::UnpackVariant(_, (_, v), _, _)) if *v == arm_variant) =>
         {
-            let Exp::UnpackVariant(_, _, fields, _) = items.remove(0) else {
+            // The unpack itself may be wrapped in `Block` (every lowered basic block is).
+            // Strip the wrapper before destructuring.
+            let raw = items.remove(0);
+            let Exp::UnpackVariant(_, _, fields, _) = crate::refinement::utils::unwrap_block(raw)
+            else {
                 unreachable!()
             };
             Some(fields)

--- a/external-crates/move/crates/move-decompiler/src/refinement/remove_trailing_continue.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/remove_trailing_continue.rs
@@ -1,7 +1,13 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ast::Exp, refinement::Refine};
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{peek, peek_mut},
+    },
+};
 
 pub fn refine(exp: &mut Exp) -> bool {
     let r1 = LoopRemoveTrailingContinue.refine(exp);
@@ -21,10 +27,10 @@ impl Refine for LoopRemoveTrailingContinue {
         };
         let loop_label = *loop_label;
 
-        match &mut **body {
+        match peek_mut(body) {
             Exp::Seq(seq) if !seq.is_empty() => {
                 // Only drop a trailing continue if it targets this loop (label matches).
-                if matches!(seq.last(), Some(Exp::Continue(l)) if *l == loop_label) {
+                if matches!(seq.last().map(peek), Some(Exp::Continue(l)) if *l == loop_label) {
                     seq.pop();
                     true
                 } else {
@@ -32,7 +38,7 @@ impl Refine for LoopRemoveTrailingContinue {
                 }
             }
             Exp::Continue(l) if *l == loop_label => {
-                **body = Exp::Seq(vec![]);
+                *peek_mut(body) = Exp::Seq(vec![]);
                 true
             }
             _ => false,
@@ -52,9 +58,9 @@ impl Refine for WhileRemoveTrailingContinue {
         };
         let loop_label = *loop_label;
 
-        match &mut **body {
+        match peek_mut(body) {
             Exp::Seq(seq) if !seq.is_empty() => {
-                if matches!(seq.last(), Some(Exp::Continue(l)) if *l == loop_label) {
+                if matches!(seq.last().map(peek), Some(Exp::Continue(l)) if *l == loop_label) {
                     seq.pop();
                     true
                 } else {
@@ -62,7 +68,7 @@ impl Refine for WhileRemoveTrailingContinue {
                 }
             }
             Exp::Continue(l) if *l == loop_label => {
-                **body = Exp::Seq(vec![]);
+                *peek_mut(body) = Exp::Seq(vec![]);
                 true
             }
             _ => false,

--- a/external-crates/move/crates/move-decompiler/src/refinement/remove_trailing_return.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/remove_trailing_return.rs
@@ -30,6 +30,9 @@ fn elide_tail(exp: &mut Exp) -> bool {
             }
             changed
         }
+        // Transparently descend through Block — the block ID rides along but doesn't gate
+        // tail-return elision.
+        Exp::Block(_, body) => elide_tail(body),
         _ => false,
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/strip_loop_labels.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/strip_loop_labels.rs
@@ -82,6 +82,7 @@ fn used_inside_nested_loop(exp: &Exp, target: Label) -> bool {
             | Exp::Unpack(_, _, e)
             | Exp::UnpackVariant(_, _, _, e)
             | Exp::VecUnpack(_, e) => go(e, target, in_nested),
+            Exp::Block(_, body) => go(body, target, in_nested),
             Exp::Break(None)
             | Exp::Declare(_)
             | Exp::Continue(None)

--- a/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
@@ -6,6 +6,34 @@
 use crate::ast::Exp;
 use move_stackless_bytecode_2::ast::PrimitiveOp;
 
+/// Look through any `Exp::Block` wrappers to reach the inner expression. Used by refinements
+/// whose pattern matching cares about the underlying form, not block delimiters. `Block`
+/// carries a block ID for goto cross-referencing; refinements that aren't tracking block
+/// boundaries (most of them) want the inner shape.
+pub(super) fn peek(exp: &Exp) -> &Exp {
+    match exp {
+        Exp::Block(_, body) => peek(body),
+        _ => exp,
+    }
+}
+
+pub(super) fn peek_mut(exp: &mut Exp) -> &mut Exp {
+    match exp {
+        Exp::Block(_, body) => peek_mut(body),
+        _ => exp,
+    }
+}
+
+/// Owned counterpart to `peek`: consume any outer `Block` wrappers and return the inner
+/// expression. Used when a refinement needs to destructure (move out of) the value, dropping
+/// the block ID (typically because the surrounding control flow is being rewritten).
+pub(super) fn unwrap_block(exp: Exp) -> Exp {
+    match exp {
+        Exp::Block(_, body) => unwrap_block(*body),
+        e => e,
+    }
+}
+
 /// Negate a boolean expression. Strips a single outer `!` if present, otherwise wraps in `!`.
 //
 // TODO: simplify double negation, De Morgan, etc.

--- a/external-crates/move/crates/move-decompiler/src/structuring/graph.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/graph.rs
@@ -27,6 +27,12 @@ pub struct Graph {
     /// enclosing-loop successor that `structure_loop` will append after the `Loop` form;
     /// `structure_code_node`'s `next` fusion consults it for the same reason.
     pub loop_exits: HashMap<NodeIndex, HashSet<NodeIndex>>,
+    /// Per-node emission flag. Set when a structurer constructs a `Block`, `IfElse`,
+    /// `Switch`, or `JumpIf` carrying that node's code. After `structure()` returns,
+    /// any input node whose slot is still `false` was never emitted into the structured
+    /// output — the rendered function carries a `// Did not structure and emit blocks …`
+    /// note listing them.
+    pub emitted: Vec<bool>,
 }
 
 impl Graph {
@@ -67,6 +73,7 @@ impl Graph {
             print_heading("loop heads");
             println!("{loop_heads:#?}");
         }
+        let node_count = cfg.node_count();
         let mut graph = Self {
             cfg,
             dom_tree,
@@ -75,6 +82,7 @@ impl Graph {
             post_dominators,
             return_,
             loop_exits: HashMap::new(),
+            emitted: vec![false; node_count],
         };
         // Populate `loop_exits` from the loops' bodies after the graph is otherwise built so
         // `find_loop_nodes` has the dom-tree and back-edges available.
@@ -90,6 +98,28 @@ impl Graph {
         }
         graph.loop_exits = loop_exits;
         graph
+    }
+
+    /// Mark `code` (a basic-block id) as emitted into the structured output. Called at every
+    /// site that constructs a `Block`, `IfElse`, `Switch`, or `JumpIf` carrying a `Code`.
+    pub fn mark_emitted(&mut self, code: u64) {
+        let idx = code as usize;
+        if idx < self.emitted.len() {
+            self.emitted[idx] = true;
+        }
+    }
+
+    /// Input nodes (out of `all_nodes`) whose basic-block ids never got `mark_emitted`
+    /// during structuring. Sorted ascending; intended to drive the rendered
+    /// `// Did not structure and emit blocks …` notice.
+    pub fn unemitted_from(&self, all_nodes: &[NodeIndex]) -> Vec<u64> {
+        let mut out: Vec<u64> = all_nodes
+            .iter()
+            .filter(|n| !self.emitted.get(n.index()).copied().unwrap_or(false))
+            .map(|n| n.index() as u64)
+            .collect();
+        out.sort_unstable();
+        out
     }
 
     pub fn update_latch_nodes(&mut self, node: NodeIndex, latch: NodeIndex) {

--- a/external-crates/move/crates/move-decompiler/src/structuring/hoist_declarations.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/hoist_declarations.rs
@@ -189,6 +189,14 @@ fn summarize_exp(e: &Exp) -> Summary {
                 subs: vec![],
             }
         }
+        Exp::Block(_, body) => {
+            let s = summarize_exp(body);
+            let entries = s.entries.clone();
+            Summary {
+                entries,
+                subs: vec![s],
+            }
+        }
     }
 }
 
@@ -359,6 +367,10 @@ fn exp(e: Exp, summary: Summary, already_bound: &HashSet<String>) -> Exp {
         Exp::VecUnpack(names, value) => {
             let value_sum = expect_one(subs);
             Exp::VecUnpack(names, Box::new(exp(*value, value_sum, already_bound)))
+        }
+        Exp::Block(id, body) => {
+            let body_sum = expect_one(subs);
+            Exp::Block(id, Box::new(exp(*body, body_sum, already_bound)))
         }
         e @ (Exp::Value(_)
         | Exp::Constant(_)

--- a/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
@@ -31,13 +31,16 @@ pub(crate) fn structure(
     config: &config::Config,
     mut input: BTreeMap<D::Label, D::Input>,
     entry_node: D::Label,
-) -> D::Structured {
+) -> (D::Structured, Vec<u64>) {
     // Native functions have empty basic blocks - return early to avoid panicking in Graph::new
     if input.is_empty() {
-        return D::Structured::Seq(vec![]);
+        return (D::Structured::Seq(vec![]), vec![]);
     }
 
     let mut graph = Graph::new(config, &input, entry_node);
+    // Capture node ids up front — `structure_nodes` drains `input` as it processes each
+    // node, so by the time we report `unemitted` the map is empty.
+    let all_nodes: Vec<NodeIndex> = input.keys().copied().collect();
 
     let mut structured_blocks: BTreeMap<D::Label, D::Structured> = BTreeMap::new();
 
@@ -61,7 +64,8 @@ pub(crate) fn structure(
 
     let mut result = structured_blocks.remove(&entry_node).unwrap();
     flatten_sequence(&mut result);
-    result
+    let unemitted = graph.unemitted_from(&all_nodes);
+    (result, unemitted)
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -471,6 +475,7 @@ fn structure_acyclic_region(
                 graph.update_latch_branch_nodes(start, absorbed);
             }
 
+            graph.mark_emitted(code);
             D::Structured::IfElse(code, Box::new(conseq_arm), Box::new(Some(alt_arm)))
         }
         D::Input::Variants(_lbl, code, enum_, items) => {
@@ -510,6 +515,7 @@ fn structure_acyclic_region(
                     (v, body)
                 })
                 .collect();
+            graph.mark_emitted(code);
             // Maybe we could reconstruct matches from the arms? It would require a lot more —
             // and more painful — analysis.
             D::Structured::Switch(code, enum_, arms)
@@ -625,7 +631,7 @@ fn hoist_order(graph: &Graph, _start: NodeIndex, orphans: &[NodeIndex]) -> Vec<N
 
 fn structure_latch_node(
     config: &config::Config,
-    graph: &Graph,
+    graph: &mut Graph,
     node_ndx: NodeIndex,
     node: D::Input,
 ) -> D::Structured {
@@ -635,12 +641,16 @@ fn structure_latch_node(
     assert!(graph.back_edges.contains_key(&node_ndx));
     match node {
         D::Input::Condition(_, code, conseq, alt) => {
+            graph.mark_emitted(code);
             D::Structured::JumpIf(GotoSource::LatchTest, code, conseq, alt)
         }
-        D::Input::Code(_, code, next) => D::Structured::Seq(vec![
-            D::Structured::Block(code),
-            D::Structured::Jump(GotoSource::LatchCode, next.unwrap()),
-        ]),
+        D::Input::Code(_, code, next) => {
+            graph.mark_emitted(code);
+            D::Structured::Seq(vec![
+                D::Structured::Block(code),
+                D::Structured::Jump(GotoSource::LatchCode, next.unwrap()),
+            ])
+        }
         D::Input::Variants(_, _, _, _) => unreachable!(),
     }
 }
@@ -656,10 +666,13 @@ fn structure_code_node(
         println!("structuring code node: {node:#?}");
     }
     match node {
-        D::Input::Code(_, code, Some(next)) if next == node_ndx => D::Structured::Seq(vec![
-            D::Structured::Block(code),
-            D::Structured::Jump(GotoSource::SelfLoop, next),
-        ]),
+        D::Input::Code(_, code, Some(next)) if next == node_ndx => {
+            graph.mark_emitted(code);
+            D::Structured::Seq(vec![
+                D::Structured::Block(code),
+                D::Structured::Jump(GotoSource::SelfLoop, next),
+            ])
+        }
         D::Input::Code(_, code, next) => {
             // Fuse `next` only if it's our exclusive dom-tree child — i.e. it's in
             // `ichildren` and singly entered (no other path from outside its own subtree
@@ -675,6 +688,7 @@ fn structure_code_node(
                 graph.dom_tree.get(node_ndx).immediate_children().collect();
             let enclosing_loop_exits: Option<HashSet<NodeIndex>> =
                 graph.loop_exits.get(&node_ndx).cloned();
+            graph.mark_emitted(code);
             let mut seq = vec![D::Structured::Block(code)];
             if let Some(next) = next {
                 let fuse = ichildren.contains(&next)

--- a/external-crates/move/crates/move-decompiler/src/testing.rs
+++ b/external-crates/move/crates/move-decompiler/src/testing.rs
@@ -130,6 +130,6 @@ pub fn structuring_unit_test(file_path: &std::path::Path) -> String {
         return "Expected an entry point `0`, but none was found".to_owned();
     }
     let config = crate::config::Config::default();
-    let structured = crate::structuring::structure(&config, input, 0.into());
+    let (structured, _unemitted) = crate::structuring::structure(&config, input, 0.into());
     structured.to_test_string()
 }

--- a/external-crates/move/crates/move-decompiler/src/translate.rs
+++ b/external-crates/move/crates/move-decompiler/src/translate.rs
@@ -257,6 +257,12 @@ fn function<S: SourceKind>(
         println!("{}", structured.to_test_string());
     }
     let mut code = generate_output(terms, structured);
+    // Block markers exist only to give surviving `Unstructured(Goto)`s something to point
+    // at. Keep `Block(N, _)` iff some surviving goto targets `N`; strip the rest. Functions
+    // with no surviving gotos shed every marker, restoring pre-Block adjacency for the
+    // refinement pipeline.
+    let targets = collect_goto_targets(&code);
+    strip_untargeted_blocks(&mut code, &targets);
     crate::structuring::hoist_declarations::hoist_declarations(&mut code, param_names);
     crate::refinement::refine(&mut code);
     if config.debug_print.decompiled_code {
@@ -399,11 +405,162 @@ fn extract_input(block: &SB::BasicBlock, next_block_label: Option<SB::Label>) ->
     }
 }
 
+/// Collect every label that a surviving `Unstructured(Goto(_))` targets. Block markers
+/// whose ID is in this set are kept (for cross-referencing); the rest are stripped.
+fn collect_goto_targets(exp: &Exp) -> HashSet<u64> {
+    let mut out = HashSet::new();
+    collect_goto_targets_into(exp, &mut out);
+    out
+}
+
+fn collect_goto_targets_into(exp: &Exp, out: &mut HashSet<u64>) {
+    use crate::ast::UnstructuredNode;
+    match exp {
+        Exp::Unstructured(nodes) => {
+            for n in nodes {
+                match n {
+                    UnstructuredNode::Goto(label) => {
+                        out.insert(*label);
+                    }
+                    UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                        collect_goto_targets_into(body, out);
+                    }
+                }
+            }
+        }
+        Exp::Block(_, body)
+        | Exp::Loop(_, body)
+        | Exp::Assign(_, body)
+        | Exp::LetBind(_, body)
+        | Exp::Abort(body)
+        | Exp::Borrow(_, body)
+        | Exp::Unpack(_, _, body)
+        | Exp::UnpackVariant(_, _, _, body)
+        | Exp::VecUnpack(_, body) => collect_goto_targets_into(body, out),
+        Exp::While(_, c, b) => {
+            collect_goto_targets_into(c, out);
+            collect_goto_targets_into(b, out);
+        }
+        Exp::IfElse(c, t, alt) => {
+            collect_goto_targets_into(c, out);
+            collect_goto_targets_into(t, out);
+            if let Some(a) = alt.as_ref().as_ref() {
+                collect_goto_targets_into(a, out);
+            }
+        }
+        Exp::Switch(c, _, arms) => {
+            collect_goto_targets_into(c, out);
+            for (_, e) in arms {
+                collect_goto_targets_into(e, out);
+            }
+        }
+        Exp::Match(c, _, arms) => {
+            collect_goto_targets_into(c, out);
+            for (_, _, e) in arms {
+                collect_goto_targets_into(e, out);
+            }
+        }
+        Exp::Seq(es) | Exp::Return(es) | Exp::Call(_, es) => {
+            for e in es {
+                collect_goto_targets_into(e, out);
+            }
+        }
+        Exp::Primitive { args, .. } | Exp::Data { args, .. } => {
+            for a in args {
+                collect_goto_targets_into(a, out);
+            }
+        }
+        Exp::Break(_)
+        | Exp::Continue(_)
+        | Exp::Declare(_)
+        | Exp::Value(_)
+        | Exp::Variable(_)
+        | Exp::Constant(_) => {}
+    }
+}
+
+/// Recursively strip every `Exp::Block(id, body)` whose `id` is not in `targets`, leaving
+/// targeted blocks intact. A block keeps its wrapper iff some surviving goto names its ID;
+/// untargeted wrappers would only fragment the AST for refinements without aiding the
+/// reader.
+fn strip_untargeted_blocks(exp: &mut Exp, targets: &HashSet<u64>) {
+    // First collapse this node if it's an un-targeted Block. The loop chases nested
+    // un-targeted wrappers in a single pass.
+    while let Exp::Block(id, body) = exp
+        && !targets.contains(id)
+    {
+        let inner = std::mem::replace(body.as_mut(), Exp::Seq(vec![]));
+        *exp = inner;
+    }
+    // Then recur into children, including the inside of any kept `Block`.
+    match exp {
+        Exp::Block(_, body)
+        | Exp::Loop(_, body)
+        | Exp::Assign(_, body)
+        | Exp::LetBind(_, body)
+        | Exp::Abort(body)
+        | Exp::Borrow(_, body)
+        | Exp::Unpack(_, _, body)
+        | Exp::UnpackVariant(_, _, _, body)
+        | Exp::VecUnpack(_, body) => strip_untargeted_blocks(body, targets),
+        Exp::While(_, c, b) => {
+            strip_untargeted_blocks(c, targets);
+            strip_untargeted_blocks(b, targets);
+        }
+        Exp::IfElse(c, t, alt) => {
+            strip_untargeted_blocks(c, targets);
+            strip_untargeted_blocks(t, targets);
+            if let Some(a) = alt.as_mut().as_mut() {
+                strip_untargeted_blocks(a, targets);
+            }
+        }
+        Exp::Switch(c, _, arms) => {
+            strip_untargeted_blocks(c, targets);
+            for (_, e) in arms {
+                strip_untargeted_blocks(e, targets);
+            }
+        }
+        Exp::Match(c, _, arms) => {
+            strip_untargeted_blocks(c, targets);
+            for (_, _, e) in arms {
+                strip_untargeted_blocks(e, targets);
+            }
+        }
+        Exp::Seq(es) | Exp::Return(es) | Exp::Call(_, es) => {
+            for e in es {
+                strip_untargeted_blocks(e, targets);
+            }
+        }
+        Exp::Primitive { args, .. } | Exp::Data { args, .. } => {
+            for a in args {
+                strip_untargeted_blocks(a, targets);
+            }
+        }
+        Exp::Unstructured(nodes) => {
+            use crate::ast::UnstructuredNode;
+            for n in nodes {
+                if let UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) = n {
+                    strip_untargeted_blocks(body, targets);
+                }
+            }
+        }
+        Exp::Break(_)
+        | Exp::Continue(_)
+        | Exp::Declare(_)
+        | Exp::Value(_)
+        | Exp::Variable(_)
+        | Exp::Constant(_) => {}
+    }
+}
+
 fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Structured) -> Exp {
     match structured {
         D::Structured::Break(label) => Out::Exp::Break(Some(label.index() as u64)),
         D::Structured::Continue(label) => Out::Exp::Continue(Some(label.index() as u64)),
-        D::Structured::Block(lbl) => terms.remove(&(lbl as u32).into()).unwrap(),
+        D::Structured::Block(lbl) => {
+            let term = terms.remove(&(lbl as u32).into()).unwrap();
+            Out::Exp::Block(lbl, Box::new(term))
+        }
         D::Structured::Loop(label, body) => Out::Exp::Loop(
             Some(label.index() as u64),
             Box::new(generate_output(terms, *body)),
@@ -437,7 +594,7 @@ fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Struc
                 Box::new(generate_output(terms.clone(), *conseq)),
                 Box::new(alt_exp),
             ));
-            Out::Exp::Seq(exps)
+            Out::Exp::Block(lbl, Box::new(Out::Exp::Seq(exps)))
         }
         D::Structured::Switch(lbl, enum_, cases) => {
             let term = terms.remove(&(lbl as u32).into()).unwrap();
@@ -455,7 +612,7 @@ fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Struc
                 Out::TypeRef::Qualified(Out::ModuleRef::Qualified(enum_.0), enum_.1),
                 cases,
             ));
-            Out::Exp::Seq(exps)
+            Out::Exp::Block(lbl, Box::new(Out::Exp::Seq(exps)))
         }
         D::Structured::Jump(src, target) => {
             let label = target.index() as u64;
@@ -489,7 +646,7 @@ fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Struc
                     Out::UnstructuredNode::Goto(else_label),
                 ]))),
             ));
-            Out::Exp::Seq(seq)
+            Out::Exp::Block(code, Box::new(Out::Exp::Seq(seq)))
         }
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/translate.rs
+++ b/external-crates/move/crates/move-decompiler/src/translate.rs
@@ -251,7 +251,7 @@ fn function<S: SourceKind>(
         print_heading("input");
         println!("{input:?}");
     }
-    let structured = crate::structuring::structure(config, input, entry);
+    let (structured, unstructured_blocks) = crate::structuring::structure(config, input, entry);
     if config.debug_print.structured {
         print_heading("structured");
         println!("{}", structured.to_test_string());
@@ -277,6 +277,7 @@ fn function<S: SourceKind>(
         parameters,
         returns,
         code,
+        unstructured_blocks,
     }
 }
 


### PR DESCRIPTION
## Description 

This changes output to include block IDs when we have to emit `goto`, so that we can see where the `goto` targets.

## Test plan 

Snapshots updated.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
