### PR TITLE
[move][move-decompiler] Refine `if` and rewrite into `assert` when possible.

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/ast.rs
+++ b/external-crates/move/crates/move-decompiler/src/ast.rs
@@ -161,6 +161,16 @@ impl Type {
 pub enum ModuleRef {
     Qualified(ModuleId<Symbol>),
     Aliased(Symbol),
+    /// No module prefix — for macros and other unqualified builtins. The `Symbol` in the
+    /// containing `Call` is rendered alone, e.g. `assert!`. `Display` emits an empty string;
+    /// the Call printers detect this variant and skip the `::` separator.
+    Builtin,
+}
+
+impl ModuleRef {
+    pub fn is_builtin(&self) -> bool {
+        matches!(self, ModuleRef::Builtin)
+    }
 }
 
 impl std::fmt::Display for ModuleRef {
@@ -168,6 +178,7 @@ impl std::fmt::Display for ModuleRef {
         match self {
             ModuleRef::Qualified(mid) => write!(f, "{mid}"),
             ModuleRef::Aliased(name) => write!(f, "{name}"),
+            ModuleRef::Builtin => Ok(()),
         }
     }
 }
@@ -696,8 +707,15 @@ impl std::fmt::Display for Exp {
                 }
                 Exp::Call((module_name, fun_name), exps) => {
                     indent(f, level)?;
-                    write!(f, "{module_name}::{fun_name}(")?;
-                    for exp in exps {
+                    if module_name.is_builtin() {
+                        write!(f, "{fun_name}(")?;
+                    } else {
+                        write!(f, "{module_name}::{fun_name}(")?;
+                    }
+                    for (i, exp) in exps.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
                         fmt_exp(f, exp, level)?;
                     }
                     writeln!(f, ")")

--- a/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
+++ b/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
@@ -619,7 +619,12 @@ fn exp(context: &Context, exp: &Exp) -> Doc {
                 D::text("let").concat_space(lhs_doc)
             }
             Exp::Call((m, f), args) => {
-                D::text(format!("{m}::{f}")).concat(exp_list(context, args).parens())
+                let head = if m.is_builtin() {
+                    D::text(format!("{f}"))
+                } else {
+                    D::text(format!("{m}::{f}"))
+                };
+                head.concat(exp_list(context, args).parens())
             }
             Exp::Abort(e) => D::text("abort").concat_space(recur(context, e)),
             Exp::Borrow(mutable, e) => {

--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -10,8 +10,10 @@ mod hoist_arm_assignments;
 mod introduce_while;
 mod loop_to_seq;
 mod reconstruct_match;
+mod recover_asserts;
 mod remove_trailing_continue;
 mod remove_trailing_return;
+mod simplify_if;
 mod strip_loop_labels;
 mod utils;
 
@@ -26,8 +28,13 @@ const REFINEMENTS: &[Refinement] = &[
     introduce_while::refine,
     loop_to_seq::refine,
     reconstruct_match::refine,
+    // Strip spurious trailing `continue`/`return` markers first — they're structurer
+    // artifacts that would otherwise make `simplify_if`'s `always_terminates` predicate
+    // fire on arms whose true Move-level shape doesn't actually terminate.
     remove_trailing_continue::refine,
     remove_trailing_return::refine,
+    simplify_if::refine,
+    recover_asserts::refine,
     strip_loop_labels::refine,
 ];
 

--- a/external-crates/move/crates/move-decompiler/src/refinement/recover_asserts.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/recover_asserts.rs
@@ -1,0 +1,70 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    ast::{Exp, ModuleRef},
+    refinement::{Refine, utils::negate},
+};
+use move_symbol_pool::Symbol;
+
+// Recognize the `assert!` idiom in structured output. Two empty-arm shapes:
+//
+//   - `if (cond) { } else { abort code }`        →  `assert!(cond, code)`
+//   - `if (cond) { abort code }` (no/empty else) →  `assert!(!cond, code)`
+//
+// The non-empty-arm variants (`if (cond) { rest } else { abort code }` and its mirror)
+// are not handled here — `simplify_if` hoists `rest` out first, leaving an empty-arm
+// shape that this pass then collapses. Keeping the assert recovery scoped to the
+// empty-arm forms means it's a pure pattern-match: no AST shape manipulation, just a
+// node-for-node rewrite.
+
+pub fn refine(exp: &mut Exp) -> bool {
+    RecoverAsserts.refine(exp)
+}
+
+struct RecoverAsserts;
+
+impl Refine for RecoverAsserts {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Exp::IfElse(cond, then_b, else_b) = exp else {
+            return false;
+        };
+
+        // `if (cond) { } else { abort code }` — the natural shape from a `!cond` test that
+        // branches to abort on failure. Pull `cond` and `code` verbatim.
+        if is_empty(then_b)
+            && let Some(else_inner) = else_b.as_ref().as_ref()
+            && let Exp::Abort(code) = else_inner
+        {
+            *exp = assert_call(cond.as_ref().clone(), (**code).clone());
+            return true;
+        }
+
+        // `if (cond) { abort code }` (or empty-else equivalent) — the negation of the above.
+        // Wrap `cond` in `!` (or strip an existing `!`) so the recovered assertion reads in
+        // the same direction.
+        let else_is_empty_or_missing = else_b.as_ref().as_ref().is_none_or(is_empty);
+        if else_is_empty_or_missing && let Exp::Abort(code) = then_b.as_ref() {
+            let mut negated = cond.as_ref().clone();
+            negate(&mut negated);
+            *exp = assert_call(negated, (**code).clone());
+            return true;
+        }
+
+        false
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Helpers
+
+fn assert_call(cond: Exp, code: Exp) -> Exp {
+    Exp::Call(
+        (ModuleRef::Builtin, Symbol::from("assert!")),
+        vec![cond, code],
+    )
+}
+
+fn is_empty(exp: &Exp) -> bool {
+    matches!(exp, Exp::Seq(items) if items.is_empty())
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/simplify_if.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/simplify_if.rs
@@ -1,0 +1,135 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    ast::Exp,
+    refinement::{Refine, utils::negate},
+};
+
+// Three local cleanups on `IfElse`:
+//
+// 1. If the then-arm `always_terminates` (abort/return/break/continue, or a Seq/IfElse
+//    that recursively does), the else-arm is unreachable as fall-through from inside the
+//    if — it only runs when the test was false. Hoist it out as a sibling after the if:
+//      `if (t) { terminator } else alt` → `if (t) { terminator }; alt`.
+//
+// 2. Symmetric: if the else-arm always_terminates and the then-arm is non-empty, negate
+//    the test, swap the arms, and hoist the (now-conseq's old-then) body out:
+//      `if (t) { rest } else { terminator }` → `if (!t) { terminator }; rest`.
+//    The negation keeps the rewrite in the early-exit idiom (`if (!t) abort; rest`)
+//    rather than the equivalent `if (t) { rest }; (else-terminator-unreachable)` shape.
+//
+// 3. An empty else carries no information — drop it: `if (t) c else {}` → `if (t) c`.
+//
+// Precedence between rules 1 and 2 when both could fire (both arms always_terminate):
+// prefer the rule that keeps an `Abort` in the conditional. When `else` is an `Abort` and
+// `then` isn't, rule 2 wins — `recover_asserts` can then fold the result into
+// `assert!(cond, code)`. Otherwise rule 1 wins (which also keeps abort-in-then where the
+// then-arm is the abort). For both-non-abort terminators we just go with rule 1.
+//
+// Run before `recover_asserts` so the rewritten empty-arm shape with a single Abort
+// terminator can fold to `assert!(cond, code)`.
+
+pub fn refine(exp: &mut Exp) -> bool {
+    SimplifyIf.refine(exp)
+}
+
+struct SimplifyIf;
+
+impl Refine for SimplifyIf {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Exp::IfElse(cond, then_b, else_b) = exp else {
+            return false;
+        };
+
+        // Abort-preference for the rules-1-and-2 tiebreak: when else is a singleton Abort
+        // and then isn't, prefer rule 2 so the abort stays in the conditional.
+        let abort_in_else = else_b.as_ref().as_ref().is_some_and(is_singleton_abort);
+        let abort_in_then = is_singleton_abort(then_b);
+        let prefer_rule_2 = abort_in_else && !abort_in_then;
+
+        // Rule 1 (skipped when abort-preference says rule 2 wins).
+        if !prefer_rule_2
+            && always_terminates(then_b)
+            && let Some(alt) = else_b.as_ref().as_ref()
+            && !is_empty(alt)
+        {
+            let if_only = Exp::IfElse(
+                Box::new(cond.as_ref().clone()),
+                Box::new(then_b.as_ref().clone()),
+                Box::new(None),
+            );
+            *exp = with_rest(if_only, alt.clone());
+            return true;
+        }
+
+        // Rule 2.
+        if let Some(alt) = else_b.as_ref().as_ref()
+            && always_terminates(alt)
+            && !is_empty(then_b)
+        {
+            let mut neg = cond.as_ref().clone();
+            negate(&mut neg);
+            let if_only = Exp::IfElse(Box::new(neg), Box::new(alt.clone()), Box::new(None));
+            *exp = with_rest(if_only, then_b.as_ref().clone());
+            return true;
+        }
+
+        // Rule 3.
+        if let Some(alt) = else_b.as_ref().as_ref()
+            && is_empty(alt)
+        {
+            **else_b = None;
+            return true;
+        }
+
+        false
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Helpers
+
+/// An expression `always_terminates` if every CFG path through it leaves the surrounding
+/// statement context — `abort`/`return`/`break`/`continue`, a `Seq` whose last item does,
+/// or an `IfElse` where both arms do.
+fn always_terminates(exp: &Exp) -> bool {
+    match exp {
+        Exp::Abort(_) | Exp::Return(_) | Exp::Break(_) | Exp::Continue(_) => true,
+        Exp::Seq(items) => items.last().is_some_and(always_terminates),
+        Exp::IfElse(_, t, alt) => {
+            always_terminates(t.as_ref()) && alt.as_ref().as_ref().is_some_and(always_terminates)
+        }
+        _ => false,
+    }
+}
+
+/// `Abort(_)` directly, or wrapped in a singleton `Seq`. Used by the abort-preference
+/// tiebreak between rules 1 and 2.
+fn is_singleton_abort(exp: &Exp) -> bool {
+    match exp {
+        Exp::Abort(_) => true,
+        Exp::Seq(items) if items.len() == 1 => is_singleton_abort(&items[0]),
+        _ => false,
+    }
+}
+
+/// Build `Seq[if_exp, ...rest]`, flattening if `rest` is already a `Seq` so we don't nest
+/// pointlessly. An empty `rest` collapses to just `if_exp` — but the rules above only call
+/// here with `!is_empty(rest)`, so this branch exists for safety.
+fn with_rest(if_exp: Exp, rest: Exp) -> Exp {
+    if is_empty(&rest) {
+        return if_exp;
+    }
+    let mut items = Vec::with_capacity(2);
+    items.push(if_exp);
+    match rest {
+        Exp::Seq(rs) => items.extend(rs),
+        other => items.push(other),
+    }
+    Exp::Seq(items)
+}
+
+fn is_empty(exp: &Exp) -> bool {
+    matches!(exp, Exp::Seq(items) if items.is_empty())
+}

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/cetus_clmm_worker.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/cetus_clmm_worker.mv.snap
@@ -250,40 +250,33 @@ public entry fun add_collateral_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
     let l44 = vault::before_add_collateral(l21, l20, l19, l18, l17, l16, l15, cetus_clmm_worker::health(freeze(l41), freeze(l42), l43), l49, cetus_clmm_worker::is_reserve_consistent(), l13, l14);
     let l46 = vault::extract_add_collateral_context_coin_send(&mut l44, l14);
     let l48 = vault::get_add_collateral_context_debt(&l44);
-    if (table::contains(&l0.shares, l5)) {
-        let l53 = *(table::borrow(&l0.shares, l5));
-        let l22 = l53;
-        let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l22);
-        let l47 = cetus_clmm_worker::work_inner(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
-        if (coin::value(&l47) == 0u64) {
-            coin::destroy_zero(l47)
-        } else {
-            pay::keep(l47, freeze(l14))
-        };
-        let l28 = l13;
-        let l27 = l12;
-        let l26 = l11;
-        let l25 = l4;
-        let l24 = l1;
-        let l50 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l24), freeze(l25), l26, l27, l28);
-        let l36 = &l0.position_operator_cap;
-        let l35 = l1;
-        let l34 = l44;
-        let l33 = l8;
-        let l31 = l5;
-        let l30 = l4;
-        let l29 = l0;
-        vault::after_add_collateral(l36, l35, l34, l33, cetus_clmm_worker::health(freeze(l29), freeze(l30), l31), l50, cetus_clmm_worker::is_reserve_consistent());
-        let l52 = *(table::borrow(&l0.shares, l5));
-        let l37 = l52;
-        if (cetus_clmm_worker::share_to_balance(freeze(l0), l37) > l45) {
-            
-        } else {
-            abort C36
-        }
+    assert!(table::contains(&l0.shares, l5), C35);
+    let l53 = *(table::borrow(&l0.shares, l5));
+    let l22 = l53;
+    let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l22);
+    let l47 = cetus_clmm_worker::work_inner(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
+    if (coin::value(&l47) == 0u64) {
+        coin::destroy_zero(l47)
     } else {
-        abort C35
-    }
+        pay::keep(l47, freeze(l14))
+    };
+    let l28 = l13;
+    let l27 = l12;
+    let l26 = l11;
+    let l25 = l4;
+    let l24 = l1;
+    let l50 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l24), freeze(l25), l26, l27, l28);
+    let l36 = &l0.position_operator_cap;
+    let l35 = l1;
+    let l34 = l44;
+    let l33 = l8;
+    let l31 = l5;
+    let l30 = l4;
+    let l29 = l0;
+    vault::after_add_collateral(l36, l35, l34, l33, cetus_clmm_worker::health(freeze(l29), freeze(l30), l31), l50, cetus_clmm_worker::is_reserve_consistent());
+    let l52 = *(table::borrow(&l0.shares, l5));
+    let l37 = l52;
+    assert!(cetus_clmm_worker::share_to_balance(freeze(l0), l37) > l45, C36)
 }
 
 public entry fun add_collateral_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut GlobalStorage, l2: &mut Storage, l3: &GlobalConfig, l4: &mut Pool<T1, T0>, l5: u64, l6: Coin<T0>, l7: Coin<T1>, l8: bool, l9: u8, l10: vector<u8>, l11: &Aggregator, l12: &Aggregator, l13: &Clock, l14: &mut TxContext) {
@@ -296,53 +289,46 @@ public entry fun add_collateral_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
     let l33 = l4;
     let l24 = l1;
     let l49 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l24), freeze(l33), l39, l40, l41);
-    if (table::contains(&l0.shares, l5)) {
-        let l53 = *(table::borrow(&l0.shares, l5));
-        let l42 = l53;
-        let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l42);
-        let l23 = &l0.position_operator_cap;
-        let l22 = l1;
-        let l21 = l2;
-        let l20 = &l51;
-        let l19 = l5;
-        let l18 = l6;
-        let l17 = l8;
-        let l16 = l5;
-        let l15 = l4;
-        let l43 = l0;
-        let l44 = vault::before_add_collateral(l23, l22, l21, l20, l19, l18, l17, cetus_clmm_worker::health_reverse(freeze(l43), freeze(l15), l16), l49, cetus_clmm_worker::is_reserve_consistent(), l13, l14);
-        let l46 = vault::extract_add_collateral_context_coin_send(&mut l44, l14);
-        let l48 = vault::get_add_collateral_context_debt(&l44);
-        let l47 = cetus_clmm_worker::work_inner_reverse(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
-        if (coin::value(&l47) == 0u64) {
-            coin::destroy_zero(l47)
-        } else {
-            pay::keep(l47, freeze(l14))
-        };
-        let l29 = l13;
-        let l28 = l12;
-        let l27 = l11;
-        let l26 = l4;
-        let l25 = l1;
-        let l50 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l25), freeze(l26), l27, l28, l29);
-        let l37 = &l0.position_operator_cap;
-        let l36 = l1;
-        let l35 = l44;
-        let l34 = l8;
-        let l32 = l5;
-        let l31 = l4;
-        let l30 = l0;
-        vault::after_add_collateral(l37, l36, l35, l34, cetus_clmm_worker::health_reverse(freeze(l30), freeze(l31), l32), l50, cetus_clmm_worker::is_reserve_consistent());
-        let l52 = *(table::borrow(&l0.shares, l5));
-        let l38 = l52;
-        if (cetus_clmm_worker::share_to_balance(freeze(l0), l38) > l45) {
-            
-        } else {
-            abort C36
-        }
+    assert!(table::contains(&l0.shares, l5), C35);
+    let l53 = *(table::borrow(&l0.shares, l5));
+    let l42 = l53;
+    let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l42);
+    let l23 = &l0.position_operator_cap;
+    let l22 = l1;
+    let l21 = l2;
+    let l20 = &l51;
+    let l19 = l5;
+    let l18 = l6;
+    let l17 = l8;
+    let l16 = l5;
+    let l15 = l4;
+    let l43 = l0;
+    let l44 = vault::before_add_collateral(l23, l22, l21, l20, l19, l18, l17, cetus_clmm_worker::health_reverse(freeze(l43), freeze(l15), l16), l49, cetus_clmm_worker::is_reserve_consistent(), l13, l14);
+    let l46 = vault::extract_add_collateral_context_coin_send(&mut l44, l14);
+    let l48 = vault::get_add_collateral_context_debt(&l44);
+    let l47 = cetus_clmm_worker::work_inner_reverse(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
+    if (coin::value(&l47) == 0u64) {
+        coin::destroy_zero(l47)
     } else {
-        abort C35
-    }
+        pay::keep(l47, freeze(l14))
+    };
+    let l29 = l13;
+    let l28 = l12;
+    let l27 = l11;
+    let l26 = l4;
+    let l25 = l1;
+    let l50 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l25), freeze(l26), l27, l28, l29);
+    let l37 = &l0.position_operator_cap;
+    let l36 = l1;
+    let l35 = l44;
+    let l34 = l8;
+    let l32 = l5;
+    let l31 = l4;
+    let l30 = l0;
+    vault::after_add_collateral(l37, l36, l35, l34, cetus_clmm_worker::health_reverse(freeze(l30), freeze(l31), l32), l50, cetus_clmm_worker::is_reserve_consistent());
+    let l52 = *(table::borrow(&l0.shares, l5));
+    let l38 = l52;
+    assert!(cetus_clmm_worker::share_to_balance(freeze(l0), l38) > l45, C36)
 }
 
 fun add_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64, l2: u128, l3: u128) {
@@ -350,23 +336,18 @@ fun add_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64, l2: u128, l3
         let l5 = l3;
         let l4 = l2;
         let l9 = cetus_clmm_worker::balance_to_share_inner(freeze(l0), l4, l5);
-        if (l9 > 0u128) {
-            let l10 = &mut l0.shares;
-            let l6 = l1;
-            let l7 = if (table::contains(freeze(l10), l6)) {
-                table::borrow_mut(l10, l1)
-            } else {
-                table::add(l10, l1, 0u128);
-                table::borrow_mut(l10, l1)
-            };
-            let l8 = l7;
-            *l8 = *l8 + l9;
-            *(&mut l0.total_share) = *(&l0.total_share) + l9
+        assert!(l9 > 0u128, C3);
+        let l10 = &mut l0.shares;
+        let l6 = l1;
+        let l7 = if (table::contains(freeze(l10), l6)) {
+            table::borrow_mut(l10, l1)
         } else {
-            abort C3
-        }
-    } else {
-        
+            table::add(l10, l1, 0u128);
+            table::borrow_mut(l10, l1)
+        };
+        let l8 = l7;
+        *l8 = *l8 + l9;
+        *(&mut l0.total_share) = *(&l0.total_share) + l9
     }
 }
 
@@ -379,17 +360,12 @@ fun balance_to_share_inner<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u128, l2
     let l3 = *(&l0.total_share);
     if (l3 == 0u128) {
         return l1
-    } else {
-        return mole_math::mul_div_u128(l1, l3, l2)
-    }
+    };
+    return mole_math::mul_div_u128(l1, l3, l2)
 }
 
 public fun checked_package_version<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>) {
-    if (*(&l0.package_version) == C2) {
-        
-    } else {
-        abort C32
-    }
+    assert!(*(&l0.package_version) == C2, C32)
 }
 
 public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut RewarderGlobalVault, l3: &mut Pool<T0, T1>, l4: &mut Pool<T0, T3>, l5: bool, l6: bool, l7: bool, l8: &Clock, l9: &mut TxContext): ( u64, u64) {
@@ -427,8 +403,6 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -468,8 +442,6 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -521,8 +493,6 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -574,8 +544,6 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -605,8 +573,6 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -658,8 +624,6 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -699,8 +663,6 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -752,8 +714,6 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -805,8 +765,6 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -836,8 +794,6 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -877,8 +833,6 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -930,8 +884,6 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -983,8 +935,6 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -1014,8 +964,6 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1067,8 +1015,6 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -1098,8 +1044,6 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1122,8 +1066,6 @@ public fun collect_reward_without_swap<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1146,8 +1088,6 @@ public fun collect_reward_without_swap_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1160,21 +1100,17 @@ public fun get_max_reinvestor_bounty_bps<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>
 fun get_mkt_sell_amount(l0: u64, l1: u64, l2: u64): u64 {
     if (l0 == 0u64) {
         return 0u64
+    };
+    let l3 = if (l1 > 0u64) {
+        l2 > 0u64
     } else {
-        let l3 = if (l1 > 0u64) {
-            l2 > 0u64
-        } else {
-            false
-        };
-        if (l3) {
-            let l4 = l0 * 9980u64;
-            let l6 = l4as u128 * l2as u128;
-            let l5 = l1as u128 * 10000u128 + l4as u128;
-            return l6 / l5as u64
-        } else {
-            abort C5
-        }
-    }
+        false
+    };
+    assert!(l3, C5);
+    let l4 = l0 * 9980u64;
+    let l6 = l4as u128 * l2as u128;
+    let l5 = l1as u128 * 10000u128 + l4as u128;
+    return l6 / l5as u64
 }
 
 public fun get_mole_cetus_worker_addr(): address {
@@ -1197,8 +1133,6 @@ public fun health<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T0, T1>, l2
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-    } else {
-        
     };
     let l9 = position::liquidity(option::borrow(&l0.position_nft));
     let l6 = cetus_clmm_worker::share_to_balance_inner(l9, *(&l0.total_share), l7);
@@ -1228,8 +1162,6 @@ public fun health_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T1,
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-    } else {
-        
     };
     let l9 = position::liquidity(option::borrow(&l0.position_nft));
     let l6 = cetus_clmm_worker::share_to_balance_inner(l9, *(&l0.total_share), l7);
@@ -1260,51 +1192,33 @@ fun init(l0: &mut TxContext) {
 public entry fun initialize<T0, T1, T2>(l0: &AdminCap, l1: &x5_AdminCap, l2: &x3_AdminCap, l3: &mut GlobalStorage, l4: &mut WorkerInfoStore, l5: &CoinMetadata<T0>, l6: &CoinMetadata<T1>, l7: &GlobalConfig, l8: &mut Pool<T0, T1>, l9: address, l10: u64, l11: address, l12: u64, l13: u32, l14: u32, l15: &mut TxContext) {
     let l18 = cetus_clmm_worker::get_mole_cetus_worker_addr();
     let l16 = l18;
-    if (!(worker_config::is_worker_info_registered(freeze(l4), l16))) {
-        if (vault::is_vault_initialized(freeze(l3))) {
-            let l20 = vault::acquire_position_operator_cap(l1);
-            let l17 = C44;
-            if (l10 <= l17) {
-                let l19 = pool::open_position(l7, l8, l13, l14, l15);
-                let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
-                let l22 = object::uid_to_address(&(&l21).id);
-                transfer::share_object(l21);
-                worker_config::register_worker_info(l2, l4, l18);
-                event::emit(InitializeEvent { worker_info: l22 })
-            } else {
-                abort C14
-            }
-        } else {
-            abort C12
-        }
-    } else {
-        abort C1
-    }
+    assert!(!(worker_config::is_worker_info_registered(freeze(l4), l16)), C1);
+    assert!(vault::is_vault_initialized(freeze(l3)), C12);
+    let l20 = vault::acquire_position_operator_cap(l1);
+    let l17 = C44;
+    assert!(l10 <= l17, C14);
+    let l19 = pool::open_position(l7, l8, l13, l14, l15);
+    let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
+    let l22 = object::uid_to_address(&(&l21).id);
+    transfer::share_object(l21);
+    worker_config::register_worker_info(l2, l4, l18);
+    event::emit(InitializeEvent { worker_info: l22 })
 }
 
 public entry fun initialize_reverse<T0, T1, T2>(l0: &AdminCap, l1: &x5_AdminCap, l2: &x3_AdminCap, l3: &mut GlobalStorage, l4: &mut WorkerInfoStore, l5: &CoinMetadata<T0>, l6: &CoinMetadata<T1>, l7: &GlobalConfig, l8: &mut Pool<T1, T0>, l9: address, l10: u64, l11: address, l12: u64, l13: u32, l14: u32, l15: &mut TxContext) {
     let l18 = cetus_clmm_worker::get_mole_cetus_worker_addr();
     let l16 = l18;
-    if (!(worker_config::is_worker_info_registered(freeze(l4), l16))) {
-        if (vault::is_vault_initialized(freeze(l3))) {
-            let l20 = vault::acquire_position_operator_cap(l1);
-            let l17 = C44;
-            if (l10 <= l17) {
-                let l19 = pool::open_position(l7, l8, l13, l14, l15);
-                let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
-                let l22 = object::uid_to_address(&(&l21).id);
-                transfer::share_object(l21);
-                worker_config::register_worker_info(l2, l4, l18);
-                event::emit(InitializeEvent { worker_info: l22 })
-            } else {
-                abort C14
-            }
-        } else {
-            abort C12
-        }
-    } else {
-        abort C1
-    }
+    assert!(!(worker_config::is_worker_info_registered(freeze(l4), l16)), C1);
+    assert!(vault::is_vault_initialized(freeze(l3)), C12);
+    let l20 = vault::acquire_position_operator_cap(l1);
+    let l17 = C44;
+    assert!(l10 <= l17, C14);
+    let l19 = pool::open_position(l7, l8, l13, l14, l15);
+    let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
+    let l22 = object::uid_to_address(&(&l21).id);
+    transfer::share_object(l21);
+    worker_config::register_worker_info(l2, l4, l18);
+    event::emit(InitializeEvent { worker_info: l22 })
 }
 
 public fun is_rebalancer<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: address): bool {
@@ -1346,21 +1260,19 @@ public fun is_stable<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &GlobalStorage
     let l12 = cetus_clmm_worker::now_seconds(l5);
     if (l8 + 86400u64 <= l12) {
         return false
+    };
+    let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
+    let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
+    let l11 = worker_config::get_max_price_diff_scale();
+    let l6 = if (l9 * l11 > l14 * l10) {
+        true
     } else {
-        let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
-        let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
-        let l11 = worker_config::get_max_price_diff_scale();
-        let l6 = if (l9 * l11 > l14 * l10) {
-            true
-        } else {
-            l9 * l10 < l14 * l11
-        };
-        if (l6) {
-            return false
-        } else {
-            return true
-        }
-    }
+        l9 * l10 < l14 * l11
+    };
+    if (l6) {
+        return false
+    };
+    return true
 }
 
 public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &GlobalStorage, l2: &Pool<T1, T0>, l3: &Aggregator, l4: &Aggregator, l5: &Clock): bool {
@@ -1376,21 +1288,19 @@ public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Globa
     let l12 = cetus_clmm_worker::now_seconds(l5);
     if (l8 + 86400u64 <= l12) {
         return false
+    };
+    let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
+    let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
+    let l11 = worker_config::get_max_price_diff_scale();
+    let l6 = if (l9 * l11 > l14 * l10) {
+        true
     } else {
-        let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
-        let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
-        let l11 = worker_config::get_max_price_diff_scale();
-        let l6 = if (l9 * l11 > l14 * l10) {
-            true
-        } else {
-            l9 * l10 < l14 * l11
-        };
-        if (l6) {
-            return false
-        } else {
-            return true
-        }
-    }
+        l9 * l10 < l14 * l11
+    };
+    if (l6) {
+        return false
+    };
+    return true
 }
 
 public fun is_strategy_ok<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u8): bool {
@@ -1465,12 +1375,9 @@ fun liquidate<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Pool<T0, T1>
     let (reg_17, reg_18) = cetus_clmm_worker::strategy_execute(l0, l2, l1, coin::zero(l5), coin::zero(l5), l6, 0u64, C39, coder::encode_u64(0u64), l4, l5);
     let l8 = reg_18;
     let l7 = reg_17;
-    if (coin::value(&l8) == 0u64) {
-        coin::destroy_zero(l8);
-        return l7
-    } else {
-        abort C23
-    }
+    assert!(coin::value(&l8) == 0u64, C23);
+    coin::destroy_zero(l8);
+    return l7
 }
 
 fun liquidate_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Pool<T1, T0>, l2: &GlobalConfig, l3: u64, l4: &Clock, l5: &mut TxContext): Coin<T0> {
@@ -1478,12 +1385,9 @@ fun liquidate_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Pool
     let (reg_17, reg_18) = cetus_clmm_worker::strategy_execute_reverse(l0, l2, l1, coin::zero(l5), coin::zero(l5), l6, 0u64, C39, coder::encode_u64(0u64), l4, l5);
     let l8 = reg_18;
     let l7 = reg_17;
-    if (coin::value(&l8) == 0u64) {
-        coin::destroy_zero(l8);
-        return l7
-    } else {
-        abort C23
-    }
+    assert!(coin::value(&l8) == 0u64, C23);
+    coin::destroy_zero(l8);
+    return l7
 }
 
 fun now_seconds(l0: &Clock): u64 {
@@ -1526,130 +1430,104 @@ public entry fun rebalance_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
 
 fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
-    if (cetus_clmm_worker::is_rebalancer(freeze(l0), l11)) {
-        let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-        let l25 = reg_17;
-        let l12 = if (i32::as_u32(reg_16) == l3) {
-            i32::as_u32(l25) == l4
+    assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
+    let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
+    let l25 = reg_17;
+    let l12 = if (i32::as_u32(reg_16) == l3) {
+        i32::as_u32(l25) == l4
+    } else {
+        false
+    };
+    assert!(!(l12), C25);
+    let (l13, l14);
+    let l23 = pool::open_position(l1, l2, l3, l4, l10);
+    let l24 = option::extract(&mut l0.position_nft);
+    let l21 = position::liquidity(&l24);
+    l13 = if (l21 > 0u128) {
+        let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
+        l14 = reg_53;
+        reg_52
+    } else {
+        l14 = balance::zero();
+        balance::zero()
+    };
+    let l18 = l14;
+    let l17 = l13;
+    pool::close_position(l1, l2, l24);
+    option::fill(&mut l0.position_nft, l23);
+    let l15 = if (balance::value(&l17) > 0u64) {
+        true
+    } else {
+        balance::value(&l18) > 0u64
+    };
+    if (l15) {
+        let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
+        let l20 = reg_100;
+        let l19 = reg_99;
+        let l16 = if (coin::value(&l19) <= l6) {
+            coin::value(&l20) <= l7
         } else {
             false
         };
-        if (l12) {
-            abort C25
-        } else {
-            let (l13, l14);
-            let l23 = pool::open_position(l1, l2, l3, l4, l10);
-            let l24 = option::extract(&mut l0.position_nft);
-            let l21 = position::liquidity(&l24);
-            l13 = if (l21 > 0u128) {
-                let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
-                l14 = reg_53;
-                reg_52
-            } else {
-                l14 = balance::zero();
-                balance::zero()
-            };
-            let l18 = l14;
-            let l17 = l13;
-            pool::close_position(l1, l2, l24);
-            option::fill(&mut l0.position_nft, l23);
-            let l15 = if (balance::value(&l17) > 0u64) {
-                true
-            } else {
-                balance::value(&l18) > 0u64
-            };
-            if (l15) {
-                let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-                let l20 = reg_100;
-                let l19 = reg_99;
-                let l16 = if (coin::value(&l19) <= l6) {
-                    coin::value(&l20) <= l7
-                } else {
-                    false
-                };
-                if (l16) {
-                    
-                } else {
-                    abort C26
-                }
-            } else {
-                balance::destroy_zero(l17);
-                balance::destroy_zero(l18)
-            };
-            let l22 = position::liquidity(option::borrow(&l0.position_nft));
-            if (l22 >= l5) {
-                event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
-            } else {
-                abort C27
-            }
-        }
+        assert!(l16, C26)
     } else {
-        abort C31
-    }
+        balance::destroy_zero(l17);
+        balance::destroy_zero(l18)
+    };
+    let l22 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l22 >= l5, C27);
+    event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
 }
 
 fun rebalance_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
-    if (cetus_clmm_worker::is_rebalancer(freeze(l0), l11)) {
-        let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-        let l25 = reg_17;
-        let l12 = if (i32::as_u32(reg_16) == l3) {
-            i32::as_u32(l25) == l4
+    assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
+    let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
+    let l25 = reg_17;
+    let l12 = if (i32::as_u32(reg_16) == l3) {
+        i32::as_u32(l25) == l4
+    } else {
+        false
+    };
+    assert!(!(l12), C25);
+    let (l13, l14);
+    let l23 = pool::open_position(l1, l2, l3, l4, l10);
+    let l24 = option::extract(&mut l0.position_nft);
+    let l21 = position::liquidity(&l24);
+    l13 = if (l21 > 0u128) {
+        let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
+        l14 = reg_53;
+        reg_52
+    } else {
+        l14 = balance::zero();
+        balance::zero()
+    };
+    let l17 = l14;
+    let l18 = l13;
+    pool::close_position(l1, l2, l24);
+    option::fill(&mut l0.position_nft, l23);
+    let l15 = if (balance::value(&l17) > 0u64) {
+        true
+    } else {
+        balance::value(&l18) > 0u64
+    };
+    if (l15) {
+        let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
+        let l20 = reg_100;
+        let l19 = reg_99;
+        let l16 = if (coin::value(&l19) <= l6) {
+            coin::value(&l20) <= l7
         } else {
             false
         };
-        if (l12) {
-            abort C25
-        } else {
-            let (l13, l14);
-            let l23 = pool::open_position(l1, l2, l3, l4, l10);
-            let l24 = option::extract(&mut l0.position_nft);
-            let l21 = position::liquidity(&l24);
-            l13 = if (l21 > 0u128) {
-                let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
-                l14 = reg_53;
-                reg_52
-            } else {
-                l14 = balance::zero();
-                balance::zero()
-            };
-            let l17 = l14;
-            let l18 = l13;
-            pool::close_position(l1, l2, l24);
-            option::fill(&mut l0.position_nft, l23);
-            let l15 = if (balance::value(&l17) > 0u64) {
-                true
-            } else {
-                balance::value(&l18) > 0u64
-            };
-            if (l15) {
-                let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-                let l20 = reg_100;
-                let l19 = reg_99;
-                let l16 = if (coin::value(&l19) <= l6) {
-                    coin::value(&l20) <= l7
-                } else {
-                    false
-                };
-                if (l16) {
-                    
-                } else {
-                    abort C26
-                }
-            } else {
-                balance::destroy_zero(l17);
-                balance::destroy_zero(l18)
-            };
-            let l22 = position::liquidity(option::borrow(&l0.position_nft));
-            if (l22 >= l5) {
-                event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
-            } else {
-                abort C27
-            }
-        }
+        assert!(l16, C26)
     } else {
-        abort C31
-    }
+        balance::destroy_zero(l17);
+        balance::destroy_zero(l18)
+    };
+    let l22 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l22 >= l5, C27);
+    event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
 }
 
 public entry fun rebalance_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut RewarderGlobalVault, l3: &mut Pool<T0, T1>, l4: &mut Pool<T0, T3>, l5: &mut Pool<T1, T3>, l6: bool, l7: bool, l8: bool, l9: u32, l10: u32, l11: u128, l12: u64, l13: u64, l14: vector<u8>, l15: bool, l16: &Clock, l17: &mut TxContext) {
@@ -1738,78 +1616,54 @@ public entry fun reinvest_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
 
 fun reinvest_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
-    if (cetus_clmm_worker::is_reinvestor(freeze(l0), l9)) {
-        let l16 = position::liquidity(option::borrow(&l0.position_nft));
-        let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
-        let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-        let l10 = if (balance::value(&l12) == 0u64) {
-            balance::value(&l13) == 0u64
-        } else {
-            false
-        };
-        if (l10) {
-            abort C28
-        } else {
-            let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-            let l15 = reg_55;
-            let l14 = reg_54;
-            let l11 = if (coin::value(&l14) <= l4) {
-                coin::value(&l15) <= l5
-            } else {
-                false
-            };
-            if (l11) {
-                let l17 = position::liquidity(option::borrow(&l0.position_nft));
-                if (l17 >= l16 + l3) {
-                    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
-                } else {
-                    abort C27
-                }
-            } else {
-                abort C26
-            }
-        }
+    assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
+    let l16 = position::liquidity(option::borrow(&l0.position_nft));
+    let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
+    let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
+    let l10 = if (balance::value(&l12) == 0u64) {
+        balance::value(&l13) == 0u64
     } else {
-        abort C19
-    }
+        false
+    };
+    assert!(!(l10), C28);
+    let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
+    let l15 = reg_55;
+    let l14 = reg_54;
+    let l11 = if (coin::value(&l14) <= l4) {
+        coin::value(&l15) <= l5
+    } else {
+        false
+    };
+    assert!(l11, C26);
+    let l17 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l17 >= l16 + l3, C27);
+    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
 }
 
 fun reinvest_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
-    if (cetus_clmm_worker::is_reinvestor(freeze(l0), l9)) {
-        let l16 = position::liquidity(option::borrow(&l0.position_nft));
-        let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
-        let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-        let l10 = if (balance::value(&l12) == 0u64) {
-            balance::value(&l13) == 0u64
-        } else {
-            false
-        };
-        if (l10) {
-            abort C28
-        } else {
-            let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-            let l15 = reg_55;
-            let l14 = reg_54;
-            let l11 = if (coin::value(&l14) <= l4) {
-                coin::value(&l15) <= l5
-            } else {
-                false
-            };
-            if (l11) {
-                let l17 = position::liquidity(option::borrow(&l0.position_nft));
-                if (l17 >= l16 + l3) {
-                    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
-                } else {
-                    abort C27
-                }
-            } else {
-                abort C26
-            }
-        }
+    assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
+    let l16 = position::liquidity(option::borrow(&l0.position_nft));
+    let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
+    let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
+    let l10 = if (balance::value(&l12) == 0u64) {
+        balance::value(&l13) == 0u64
     } else {
-        abort C19
-    }
+        false
+    };
+    assert!(!(l10), C28);
+    let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
+    let l15 = reg_55;
+    let l14 = reg_54;
+    let l11 = if (coin::value(&l14) <= l4) {
+        coin::value(&l15) <= l5
+    } else {
+        false
+    };
+    assert!(l11, C26);
+    let l17 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l17 >= l16 + l3, C27);
+    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
 }
 
 public entry fun reinvest_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut RewarderGlobalVault, l3: &mut Pool<T0, T1>, l4: &mut Pool<T0, T3>, l5: &mut Pool<T1, T3>, l6: bool, l7: bool, l8: bool, l9: u128, l10: u64, l11: u64, l12: vector<u8>, l13: bool, l14: &Clock, l15: &mut TxContext) {
@@ -1880,22 +1734,15 @@ fun remove_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64): u128 {
             *(&mut l0.total_share) = *(&l0.total_share) - l3;
             *(table::borrow_mut(&mut l0.shares, l1)) = 0u128;
             return l2
-        } else {
-            
         }
-    } else {
-        
     };
     return 0u128
 }
 
 public entry fun set_max_reinvestor_bounty_bps<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: u64) {
     cetus_clmm_worker::checked_package_version(freeze(l1));
-    if (l2 >= *(&l1.reinvest_bounty_bps)) {
-        *(&mut l1.max_reinvest_bounty_bps) = l2
-    } else {
-        abort C15
-    }
+    assert!(l2 >= *(&l1.reinvest_bounty_bps), C15);
+    *(&mut l1.max_reinvest_bounty_bps) = l2
 }
 
 public entry fun set_rebalancers_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: vector<address>, l3: bool) {
@@ -1922,11 +1769,8 @@ public entry fun set_reinvest_threshold<T0, T1, T2>(l0: &AdminCap, l1: &mut Work
 
 public entry fun set_reinvestor_bounty_bps<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: u64) {
     cetus_clmm_worker::checked_package_version(freeze(l1));
-    if (l2 <= *(&l1.max_reinvest_bounty_bps)) {
-        *(&mut l1.reinvest_bounty_bps) = l2
-    } else {
-        abort C14
-    }
+    assert!(l2 <= *(&l1.max_reinvest_bounty_bps), C14);
+    *(&mut l1.reinvest_bounty_bps) = l2
 }
 
 public entry fun set_reinvestor_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: address, l3: bool) {
@@ -1998,9 +1842,8 @@ public fun share_to_balance<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u128): 
 fun share_to_balance_inner<T0>(l0: u128, l1: u128, l2: u128): u128 {
     if (l1 == 0u128) {
         return l2
-    } else {
-        return mole_math::mul_div_u128(l2, l0, l1)
-    }
+    };
+    return mole_math::mul_div_u128(l2, l0, l1)
 }
 
 fun strategy_execute<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: Coin<T0>, l4: Coin<T1>, l5: u128, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): ( Coin<T0>, Coin<T1>) {
@@ -2008,34 +1851,26 @@ fun strategy_execute<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalCon
     if (l7 == C37) {
         let (reg_20, reg_21) = cetus_clmm_strategy_add_base_coin_only::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
         return (reg_20, reg_21)
-    } else {
-        if (l7 == C38) {
-            let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-            return (reg_39, reg_40)
-        } else {
-            if (l7 == C39) {
-                let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                return (reg_58, reg_59)
-            } else {
-                if (l7 == C40) {
-                    let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                    return (reg_77, reg_78)
-                } else {
-                    if (l7 == C41) {
-                        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                        return (reg_96, reg_97)
-                    } else {
-                        if (l7 == C42) {
-                            let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                            return (reg_115, reg_116)
-                        } else {
-                            abort C4
-                        }
-                    }
-                }
-            }
-        }
-    }
+    };
+    if (l7 == C38) {
+        let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_39, reg_40)
+    };
+    if (l7 == C39) {
+        let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_58, reg_59)
+    };
+    if (l7 == C40) {
+        let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_77, reg_78)
+    };
+    if (l7 == C41) {
+        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_96, reg_97)
+    };
+    assert!(l7 == C42, C4);
+    let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+    return (reg_115, reg_116)
 }
 
 fun strategy_execute_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: Coin<T0>, l4: Coin<T1>, l5: u128, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): ( Coin<T0>, Coin<T1>) {
@@ -2043,34 +1878,26 @@ fun strategy_execute_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &G
     if (l7 == C37) {
         let (reg_20, reg_21) = cetus_clmm_strategy_add_base_coin_only::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
         return (reg_20, reg_21)
-    } else {
-        if (l7 == C38) {
-            let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-            return (reg_39, reg_40)
-        } else {
-            if (l7 == C39) {
-                let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                return (reg_58, reg_59)
-            } else {
-                if (l7 == C40) {
-                    let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                    return (reg_77, reg_78)
-                } else {
-                    if (l7 == C41) {
-                        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                        return (reg_96, reg_97)
-                    } else {
-                        if (l7 == C42) {
-                            let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                            return (reg_115, reg_116)
-                        } else {
-                            abort C4
-                        }
-                    }
-                }
-            }
-        }
-    }
+    };
+    if (l7 == C38) {
+        let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_39, reg_40)
+    };
+    if (l7 == C39) {
+        let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_58, reg_59)
+    };
+    if (l7 == C40) {
+        let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_77, reg_78)
+    };
+    if (l7 == C41) {
+        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_96, reg_97)
+    };
+    assert!(l7 == C42, C4);
+    let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+    return (reg_115, reg_116)
 }
 
 entry fun upgrade_package_version<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: u64) {
@@ -2083,15 +1910,8 @@ public entry fun withdraw_rewards_bounty<T0, T1, T2>(l0: &AdminCap, l1: &mut Wor
         l3 = balance::value(&l1.tiny_coin_base_bounty);
         l4 = balance::value(&l1.tiny_coin_farming_bounty);
     } else {
-        if (l3 <= balance::value(&l1.tiny_coin_base_bounty)) {
-            if (l4 <= balance::value(&l1.tiny_coin_farming_bounty)) {
-                
-            } else {
-                abort C34
-            }
-        } else {
-            abort C33
-        }
+        assert!(l3 <= balance::value(&l1.tiny_coin_base_bounty), C33);
+        assert!(l4 <= balance::value(&l1.tiny_coin_farming_bounty), C34)
     };
     let l6 = balance::split(&mut l1.tiny_coin_base_bounty, l3);
     let l7 = balance::split(&mut l1.tiny_coin_farming_bounty, l4);
@@ -2114,26 +1934,20 @@ fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l
     } else {
         false
     };
-    if (l11) {
-        if (object::id(freeze(l2)) == *(&l0.pool_id)) {
-            let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
-            let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
-            let l16 = reg_52;
-            let l15 = reg_51;
-            let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
-            if (coin::value(&l16) == 0u64) {
-                coin::destroy_zero(l16)
-            } else {
-                pay::keep(l16, freeze(l10))
-            };
-            cetus_clmm_worker::add_share(l0, l3, l13, l14);
-            return l15
-        } else {
-            abort C24
-        }
+    assert!(l11, C21);
+    assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
+    let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
+    let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
+    let l16 = reg_52;
+    let l15 = reg_51;
+    let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
+    if (coin::value(&l16) == 0u64) {
+        coin::destroy_zero(l16)
     } else {
-        abort C21
-    }
+        pay::keep(l16, freeze(l10))
+    };
+    cetus_clmm_worker::add_share(l0, l3, l13, l14);
+    return l15
 }
 
 fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u64, l4: Coin<T0>, l5: Coin<T1>, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): Coin<T0> {
@@ -2144,26 +1958,20 @@ fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalC
     } else {
         false
     };
-    if (l11) {
-        if (object::id(freeze(l2)) == *(&l0.pool_id)) {
-            let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
-            let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
-            let l16 = reg_52;
-            let l15 = reg_51;
-            let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
-            if (coin::value(&l16) == 0u64) {
-                coin::destroy_zero(l16)
-            } else {
-                pay::keep(l16, freeze(l10))
-            };
-            cetus_clmm_worker::add_share(l0, l3, l13, l14);
-            return l15
-        } else {
-            abort C24
-        }
+    assert!(l11, C21);
+    assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
+    let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
+    let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
+    let l16 = reg_52;
+    let l15 = reg_51;
+    let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
+    if (coin::value(&l16) == 0u64) {
+        coin::destroy_zero(l16)
     } else {
-        abort C21
-    }
+        pay::keep(l16, freeze(l10))
+    };
+    cetus_clmm_worker::add_share(l0, l3, l13, l14);
+    return l15
 }
 
 public entry fun work_none<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut GlobalStorage, l2: &mut Storage, l3: &GlobalConfig, l4: &mut Pool<T0, T1>, l5: u64, l6: u64, l7: u64, l8: u8, l9: vector<u8>, l10: &Aggregator, l11: &Aggregator, l12: &Clock, l13: &mut TxContext) {
@@ -2228,8 +2036,6 @@ public entry fun work_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &m
         let l28 = l4;
         let l27 = l0;
         vault::set_work_context_health(l16, cetus_clmm_worker::health(freeze(l27), freeze(l28), l29))
-    } else {
-        
     };
     let l21 = l14;
     let l20 = l13;
@@ -2271,8 +2077,6 @@ public entry fun work_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>
         let l28 = l4;
         let l27 = l0;
         vault::set_work_context_health(l16, cetus_clmm_worker::health_reverse(freeze(l27), freeze(l28), l29))
-    } else {
-        
     };
     let l21 = l14;
     let l20 = l13;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/crank.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/crank.mv.snap
@@ -145,103 +145,69 @@ public(friend) fun update_config(l0: &mut CrankConfig, l1: u64, l2: u64, l3: u64
 
 public fun validate_heartbeat<T0>(l0: &mut CrankConfig, l1: &mut Vault<T0>, l2: &StrategyRegistry, l3: &Clock) {
     let l11 = clock::timestamp_ms(l3);
-    if (l11 - *(&l0.last_heartbeat_ms) >= *(&l0.min_heartbeat_interval_ms)) {
-        let l9 = strategy::borrow_protocol_access_cap(l2);
-        vault::update_heartbeat_tvl(l1, l3, l9);
-        *(&mut l0.last_heartbeat_ms) = l11;
-        let l10 = vault::last_heartbeat_tvl(freeze(l1));
-        let l5 = string::utf8(C14);
-        let l7 = string::utf8(C15);
-        if (!(dynamic_field::exists_(&l0.id, l5))) {
-            dynamic_field::add(&mut l0.id, l5, l10);
-            dynamic_field::add(&mut l0.id, l7, l11)
-        } else {
-            let l6 = *(dynamic_field::borrow(&l0.id, l7));
-            if (l11 - l6 > C13) {
-                let l13 = dynamic_field::borrow_mut(&mut l0.id, l5);
-                *l13 = l10;
-                let l12 = dynamic_field::borrow_mut(&mut l0.id, l7);
-                *l12 = l11
-            } else {
-                let l8 = *(dynamic_field::borrow(&l0.id, l5));
-                if (l8 > 0u64) {
-                    let l4 = if (l10 > l8) {
-                        l10 - l8
-                    } else {
-                        l8 - l10
-                    };
-                    if (l4as u128 * 10000u128 / l8as u128as u64 <= C12) {
-                        
-                    } else {
-                        abort C10
-                    }
-                }
-            }
-        };
-        event::emit(HeartbeatEvent { timestamp_ms: l11 })
+    assert!(l11 - *(&l0.last_heartbeat_ms) >= *(&l0.min_heartbeat_interval_ms), C6);
+    let l9 = strategy::borrow_protocol_access_cap(l2);
+    vault::update_heartbeat_tvl(l1, l3, l9);
+    *(&mut l0.last_heartbeat_ms) = l11;
+    let l10 = vault::last_heartbeat_tvl(freeze(l1));
+    let l5 = string::utf8(C14);
+    let l7 = string::utf8(C15);
+    if (!(dynamic_field::exists_(&l0.id, l5))) {
+        dynamic_field::add(&mut l0.id, l5, l10);
+        dynamic_field::add(&mut l0.id, l7, l11)
     } else {
-        abort C6
-    }
+        let l6 = *(dynamic_field::borrow(&l0.id, l7));
+        if (l11 - l6 > C13) {
+            let l13 = dynamic_field::borrow_mut(&mut l0.id, l5);
+            *l13 = l10;
+            let l12 = dynamic_field::borrow_mut(&mut l0.id, l7);
+            *l12 = l11
+        } else {
+            let l8 = *(dynamic_field::borrow(&l0.id, l5));
+            if (l8 > 0u64) {
+                let l4 = if (l10 > l8) {
+                    l10 - l8
+                } else {
+                    l8 - l10
+                };
+                assert!(l4as u128 * 10000u128 / l8as u128as u64 <= C12, C10)
+            }
+        }
+    };
+    event::emit(HeartbeatEvent { timestamp_ms: l11 })
 }
 
 public fun validate_reroute<T0>(l0: &mut CrankConfig, l1: &ApyRegistry, l2: &StrategyRegistry, l3: &Vault<T0>, l4: u8, l5: u8, l6: &Clock) {
     let l10 = clock::timestamp_ms(l6);
-    if (strategy::count_available(l2) >= 2u64) {
-        if (strategy::is_available(l2, l5)) {
-            if (l4 != l5) {
-                let l8 = apy::get_total_apy(l1, l4);
-                let l12 = apy::get_total_apy(l1, l5);
-                if (l12 > l8) {
-                    let l7 = if (l8 == 0u64) {
-                        10000u64
-                    } else {
-                        l12 - l8 * 10000u64 / l8
-                    };
-                    let l11 = l7;
-                    if (l11 >= *(&l0.min_spread_bps)) {
-                        floors::assert_spread(l11);
-                        if (l12 >= *(&l0.min_apy_bps)) {
-                            floors::assert_min_apy(l12);
-                            let l9 = l10 - *(&l0.last_reroute_ms);
-                            if (l9 >= *(&l0.reroute_cooldown_ms)) {
-                                floors::assert_cooldown(l9);
-                                if (l4 != 0u8) {
-                                    apy::assert_not_stale(l1, l4, l6)
-                                };
-                                apy::assert_not_stale(l1, l5, l6);
-                                let reg_103;
-                                (reg_102, reg_103) = strategy::decode_strategy(l5);
-                                let l13 = reg_103;
-                                if (l13 == 2u8) {
-                                    if (!(vault::is_depeg_active(l3))) {
-                                        
-                                    } else {
-                                        abort C11
-                                    }
-                                } else {
-                                    
-                                };
-                                *(&mut l0.last_reroute_ms) = l10;
-                                event::emit(RerouteValidatedEvent { current_strategy: l4, target_strategy: l5, current_apy: l8, target_apy: l12, spread_bps: l11, timestamp_ms: l10 })
-                            } else {
-                                abort C5
-                            }
-                        } else {
-                            abort C4
-                        }
-                    } else {
-                        abort C3
-                    }
-                } else {
-                    abort C7
-                }
-            } else {
-                abort C2
-            }
-        } else {
-            abort C1
-        }
+    assert!(strategy::count_available(l2) >= 2u64, C0);
+    assert!(strategy::is_available(l2, l5), C1);
+    assert!(l4 != l5, C2);
+    let l8 = apy::get_total_apy(l1, l4);
+    let l12 = apy::get_total_apy(l1, l5);
+    assert!(l12 > l8, C7);
+    let l7 = if (l8 == 0u64) {
+        10000u64
     } else {
-        abort C0
-    }
+        l12 - l8 * 10000u64 / l8
+    };
+    let l11 = l7;
+    assert!(l11 >= *(&l0.min_spread_bps), C3);
+    floors::assert_spread(l11);
+    assert!(l12 >= *(&l0.min_apy_bps), C4);
+    floors::assert_min_apy(l12);
+    let l9 = l10 - *(&l0.last_reroute_ms);
+    assert!(l9 >= *(&l0.reroute_cooldown_ms), C5);
+    floors::assert_cooldown(l9);
+    if (l4 != 0u8) {
+        apy::assert_not_stale(l1, l4, l6)
+    };
+    apy::assert_not_stale(l1, l5, l6);
+    let reg_103;
+    (reg_102, reg_103) = strategy::decode_strategy(l5);
+    let l13 = reg_103;
+    if (l13 == 2u8) {
+        assert!(!(vault::is_depeg_active(l3)), C11)
+    };
+    *(&mut l0.last_reroute_ms) = l10;
+    event::emit(RerouteValidatedEvent { current_strategy: l4, target_strategy: l5, current_apy: l8, target_apy: l12, spread_bps: l11, timestamp_ms: l10 })
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
@@ -37,10 +37,9 @@ public fun cao_s<T0, T1>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &Tr
     let l7 = sq::css(l4, l5, true, false, l6);
     if (l7 != ct::e_no_error()) {
         return l7
-    } else {
-        pool::cancel_all_orders(l0, l1, l2, l3, l6);
-        return 0u64
-    }
+    };
+    pool::cancel_all_orders(l0, l1, l2, l3, l6);
+    return 0u64
 }
 
 public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &TradeProof, l3: &Clock, l4: u64, l5: &mut TxContext): Coin<T2> {
@@ -120,77 +119,73 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                 event::emit(EE { e: ct::e_order_expired(), l: 348u64 });
                 l28 = l28 + 1u64;
                 continue
-            } else {
-                let l34 = *(&(&l9)[l28]);
-                let l47 = *(&(&l10)[l28]);
-                let l27 = *(&(&l11)[l28]);
-                let l40 = *(&(&l12)[l28]);
-                let l29 = *(&(&l13)[l28]);
-                if (l29) {
-                    if (l44 <= l8) {
-                        event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    }
-                } else {
-                    if (l21 < u64::max(l32, l7)) {
-                        event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    }
-                };
-                let l30 = dbke::cim(l34);
-                let l37 = l27;
-                if (l34 == ct::cpsos()) {
-                    if (!(l50)) {
-                        let (reg_134, reg_136);
-                        (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
-                        let l18 = reg_136;
-                        l22 = reg_134;
-                        l19 = l18;
-                        l50 = true;
-                    };
-                    let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
-                    if (l49 == 0u64) {
-                        event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    } else {
-                        l37 = l49;
-                        l34 = constants::post_only();
-                    }
-                } else {
-                    let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
-                    let l24 = reg_171;
-                    let l53 = reg_170;
-                    if (l24 != ct::e_no_error()) {
-                        event::emit(EE { e: l24, l: 404u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    } else {
-                        let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
-                        let l35 = order_info::original_quantity(&l33);
-                        let l25 = order_info::executed_quantity(&l33);
-                        let l36 = order_info::paid_fees(&l33);
-                        l44 = if (l29) {
-                            let l41 = l35as u128;
-                            let l38 = l37as u128;
-                            let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
-                            l21 = l21 + l25;
-                            l44 - l46as u64
-                        } else {
-                            let l42 = l25as u128;
-                            let l39 = l37as u128;
-                            let l45 = l42 * l39 / constants::float_scaling_u128();
-                            l21 = l21 - l35;
-                            l44 + l45as u64
-                        };
-                        l23 = l23 - l36;
-                        l28 = l28 + 1u64;
-                        continue
-                    }
+            };
+            let l34 = *(&(&l9)[l28]);
+            let l47 = *(&(&l10)[l28]);
+            let l27 = *(&(&l11)[l28]);
+            let l40 = *(&(&l12)[l28]);
+            let l29 = *(&(&l13)[l28]);
+            if (l29) {
+                if (l44 <= l8) {
+                    event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
+                    l28 = l28 + 1u64;
+                    continue
                 }
-            }
+            } else {
+                if (l21 < u64::max(l32, l7)) {
+                    event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
+                    l28 = l28 + 1u64;
+                    continue
+                }
+            };
+            let l30 = dbke::cim(l34);
+            let l37 = l27;
+            if (!(l34 == ct::cpsos())) {
+                let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
+                let l24 = reg_171;
+                let l53 = reg_170;
+                if (l24 != ct::e_no_error()) {
+                    event::emit(EE { e: l24, l: 404u64 });
+                    l28 = l28 + 1u64;
+                    continue
+                };
+                let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
+                let l35 = order_info::original_quantity(&l33);
+                let l25 = order_info::executed_quantity(&l33);
+                let l36 = order_info::paid_fees(&l33);
+                l44 = if (l29) {
+                    let l41 = l35as u128;
+                    let l38 = l37as u128;
+                    let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
+                    l21 = l21 + l25;
+                    l44 - l46as u64
+                } else {
+                    let l42 = l25as u128;
+                    let l39 = l37as u128;
+                    let l45 = l42 * l39 / constants::float_scaling_u128();
+                    l21 = l21 - l35;
+                    l44 + l45as u64
+                };
+                l23 = l23 - l36;
+                l28 = l28 + 1u64;
+                continue
+            };
+            if (!(l50)) {
+                let (reg_134, reg_136);
+                (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
+                let l18 = reg_136;
+                l22 = reg_134;
+                l19 = l18;
+                l50 = true;
+            };
+            let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
+            if (l49 == 0u64) {
+                event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
+                l28 = l28 + 1u64;
+                continue
+            };
+            l37 = l49;
+            l34 = constants::post_only();
         }
     }
 }
@@ -198,107 +193,91 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
 fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
-    } else {
-        let l5;
-        let l6 = l4;
-        if (*(&l6)) {
-            if (l1.len() == 0u64) {
-                return l3
-            } else {
-                let l8 = *(&l1[0u64]);
-                if (l3 < l8) {
-                    return l3
-                } else {
-                    let l9 = l8 - l2;
-                    if (l9 < l2) {
-                        return 0u64
-                    } else {
-                        l5 = l9;
-                    }
-                }
-            }
-        } else {
-            if (l0.len() == 0u64) {
-                return l3
-            } else {
-                let l7 = *(&l0[0u64]);
-                if (l3 > l7) {
-                    return l3
-                } else {
-                    let l10 = l7 + l2;
-                    if (l10 > constants::max_u64() - l2) {
-                        return 0u64
-                    } else {
-                        l5 = l10;
-                    }
-                }
-            }
+    };
+    let l6 = l4;
+    let l5 = if (*(&l6)) {
+        if (l1.len() == 0u64) {
+            return l3
         };
-        return l5
-    }
+        let l8 = *(&l1[0u64]);
+        if (l3 < l8) {
+            return l3
+        };
+        let l9 = l8 - l2;
+        if (l9 < l2) {
+            return 0u64
+        };
+        l9
+    } else {
+        if (l0.len() == 0u64) {
+            return l3
+        };
+        let l7 = *(&l0[0u64]);
+        if (l3 > l7) {
+            return l3
+        };
+        let l10 = l7 + l2;
+        if (l10 > constants::max_u64() - l2) {
+            return 0u64
+        };
+        l10
+    };
+    return l5
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
     if (l7 == 0u64) {
         return (0u64, ct::e_invalid_price())
+    };
+    if (l7 % l4 != 0u64) {
+        return (0u64, ct::e_invalid_price())
+    };
+    let l12 = if (!(l9)) {
+        l1 < l6
     } else {
-        if (l7 % l4 != 0u64) {
-            return (0u64, ct::e_invalid_price())
+        false
+    };
+    if (l12) {
+        return (0u64, ct::e_insufficient_base_balance())
+    };
+    if (l8 < l6) {
+        return (0u64, ct::e_insufficient_quantity())
+    };
+    let l16 = l9;
+    let l15 = if (*(&l16)) {
+        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
+        let l21 = l25 % l5 + l5;
+        if (l25 < l21) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l22 = l25 - l21;
+        if (l22 < l6) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l19 = u64::max(l6, u64::min(l8, l22as u64));
+        l19 - l19 % l5
+    } else {
+        let l20 = u64::max(l6, u64::min(l8, l1));
+        l20 - l20 % l5
+    };
+    let l26 = l15;
+    let l17 = l11;
+    let l14 = if (*(&l17)) {
+        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
+        let l23 = reg_90;
+        let l24 = reg_89;
+        let l18 = l10;
+        let l13 = if (*(&l18)) {
+            l23
         } else {
-            let l12 = if (!(l9)) {
-                l1 < l6
-            } else {
-                false
-            };
-            if (l12) {
-                return (0u64, ct::e_insufficient_base_balance())
-            } else {
-                if (l8 < l6) {
-                    return (0u64, ct::e_insufficient_quantity())
-                } else {
-                    let l15;
-                    let l16 = l9;
-                    if (*(&l16)) {
-                        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
-                        let l21 = l25 % l5 + l5;
-                        if (l25 < l21) {
-                            return (0u64, ct::e_insufficient_quote_balance())
-                        } else {
-                            let l22 = l25 - l21;
-                            if (l22 < l6) {
-                                return (0u64, ct::e_insufficient_quote_balance())
-                            } else {
-                                let l19 = u64::max(l6, u64::min(l8, l22as u64));
-                                l15 = l19 - l19 % l5;
-                            }
-                        }
-                    } else {
-                        let l20 = u64::max(l6, u64::min(l8, l1));
-                        l15 = l20 - l20 % l5;
-                    };
-                    let l26 = l15;
-                    let l17 = l11;
-                    let l14 = if (*(&l17)) {
-                        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-                        let l23 = reg_90;
-                        let l24 = reg_89;
-                        let l18 = l10;
-                        let l13 = if (*(&l18)) {
-                            l23
-                        } else {
-                            l24
-                        };
-                        l13
-                    } else {
-                        0u64
-                    };
-                    if (l14 > l3) {
-                        return (0u64, ct::e_insufficient_deep_balance())
-                    } else {
-                        return (l26, 0u64)
-                    }
-                }
-            }
-        }
-    }
+            l24
+        };
+        l13
+    } else {
+        0u64
+    };
+    if (l14 > l3) {
+        return (0u64, ct::e_insufficient_deep_balance())
+    };
+    return (l26, 0u64)
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house.mv.snap
@@ -138,58 +138,40 @@ const C20: u64 = 40u64;
 // -- functions -- 
 
 public fun accept_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l13 = reg_23 : u16;
-        let l23 = reg_22 : u8;
-        let l15 = reg_21 : 0x1::option::Option<address>;
-        let l14 = reg_20 : u64;
-        let l20 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
-        let l19 = reg_17 : 0x2::object::ID;
-        let l17 = reg_16 : 0x2::object::ID;
-        let l22 = reg_15 : address;
-        let l16 = reg_14 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l5)) == l22) {
-            if (l23 == C0) {
-                if (object::id(freeze(l3)) == l17) {
-                    if (option::is_some(&l15)) {
-                        let l9 = option::extract(&mut l15);
-                        if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
-                            let Bid { id: reg_81, bidder: reg_82, amount: reg_83, timestamp: reg_84 } = dynamic_object_field::remove(&mut l0.id, l9);
-                            let l7 = reg_83 : 0x2::balance::Balance<0x2::sui::SUI>;
-                            let l8 = reg_81 : 0x2::object::UID;
-                            let l11 = balance::value(&l7) * l13as u64 / 10000u64;
-                            let l12 = balance::split(&mut l7, l11);
-                            auctionhouse::add_fee(l1, l12);
-                            transfer::public_transfer(coin::from_balance(l7, l5), l22);
-                            let (reg_109, reg_110) = kiosk::purchase_with_cap(l3, l20, coin::zero(l5));
-                            let l21 = reg_110;
-                            let l18 = reg_109;
-                            (reg_113, reg_114, reg_115) = transfer_policy::confirm_request(l4, l21);
-                            let l10 = tx_context::epoch(freeze(l5));
-                            let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l9, nft: l18, timestamp: l10 };
-                            dynamic_object_field::add(&mut l0.id, l2, l6);
-                            object::delete(l16);
-                            object::delete(l8);
-                            event::emit(BidReadyForClaim { listing_id: l2, seller: l22, bidder: l9, amount: l14, nft_id: l19, timestamp: l10 })
-                        } else {
-                            abort C8
-                        }
-                    } else {
-                        abort C8
-                    }
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C6
-        }
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l13 = reg_23 : u16;
+    let l23 = reg_22 : u8;
+    let l15 = reg_21 : 0x1::option::Option<address>;
+    let l14 = reg_20 : u64;
+    let l20 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
+    let l19 = reg_17 : 0x2::object::ID;
+    let l17 = reg_16 : 0x2::object::ID;
+    let l22 = reg_15 : address;
+    let l16 = reg_14 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l5)) == l22, C6);
+    assert!(l23 == C0, C4);
+    assert!(object::id(freeze(l3)) == l17, C12);
+    assert!(option::is_some(&l15), C8);
+    let l9 = option::extract(&mut l15);
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l9), C8);
+    let Bid { id: reg_81, bidder: reg_82, amount: reg_83, timestamp: reg_84 } = dynamic_object_field::remove(&mut l0.id, l9);
+    let l7 = reg_83 : 0x2::balance::Balance<0x2::sui::SUI>;
+    let l8 = reg_81 : 0x2::object::UID;
+    let l11 = balance::value(&l7) * l13as u64 / 10000u64;
+    let l12 = balance::split(&mut l7, l11);
+    auctionhouse::add_fee(l1, l12);
+    transfer::public_transfer(coin::from_balance(l7, l5), l22);
+    let (reg_109, reg_110) = kiosk::purchase_with_cap(l3, l20, coin::zero(l5));
+    let l21 = reg_110;
+    let l18 = reg_109;
+    (reg_113, reg_114, reg_115) = transfer_policy::confirm_request(l4, l21);
+    let l10 = tx_context::epoch(freeze(l5));
+    let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l9, nft: l18, timestamp: l10 };
+    dynamic_object_field::add(&mut l0.id, l2, l6);
+    object::delete(l16);
+    object::delete(l8);
+    event::emit(BidReadyForClaim { listing_id: l2, seller: l22, bidder: l9, amount: l14, nft_id: l19, timestamp: l10 })
 }
 
 public entry fun accept_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
@@ -209,17 +191,14 @@ public entry fun buy_nft<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut
 }
 
 public entry fun buy_nft_to_existing_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &mut Kiosk, l5: &KioskOwnerCap, l6: &mut TransferPolicy<T0>, l7: Coin<SUI>, l8: Coin<SUI>, l9: &mut TxContext) {
-    if (kiosk::has_access(l4, l5)) {
-        let (reg_19, reg_20) = kiosk_bidding_house::buy_nft_with_request(l0, l1, l2, l3, freeze(l6), l7, l9);
-        let l11 = reg_20;
-        let l10 = reg_19;
-        kiosk::lock(l4, l5, freeze(l6), l10);
-        royalty_rule::pay(l6, &mut l11, l8);
-        kiosk_lock_rule::prove(&mut l11, freeze(l4));
-        (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l6), l11);
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l4, l5), C11);
+    let (reg_19, reg_20) = kiosk_bidding_house::buy_nft_with_request(l0, l1, l2, l3, freeze(l6), l7, l9);
+    let l11 = reg_20;
+    let l10 = reg_19;
+    kiosk::lock(l4, l5, freeze(l6), l10);
+    royalty_rule::pay(l6, &mut l11, l8);
+    kiosk_lock_rule::prove(&mut l11, freeze(l4));
+    (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l6), l11);
 }
 
 public entry fun buy_nft_to_new_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &mut TransferPolicy<T0>, l5: Coin<SUI>, l6: Coin<SUI>, l7: &mut TxContext) {
@@ -239,106 +218,71 @@ public entry fun buy_nft_to_new_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_St
 }
 
 public fun buy_nft_with_request<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: Coin<SUI>, l6: &mut TxContext): ( T0, TransferRequest<T0>) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l10 = reg_24 : u64;
-        let l12 = reg_22 : u16;
-        let l24 = reg_21 : u8;
-        let l14 = reg_20 : 0x1::option::Option<address>;
-        let l9 = reg_18 : u64;
-        let l21 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
-        let l18 = reg_16 : 0x2::object::ID;
-        let l16 = reg_15 : 0x2::object::ID;
-        let l23 = reg_14 : address;
-        let l15 = reg_13 : 0x2::object::UID;
-        if (l24 == C0) {
-            if (tx_context::epoch(freeze(l6)) <= l10) {
-                if (object::id(freeze(l3)) == l16) {
-                    let l19 = coin::value(&l5);
-                    if (l19 >= l9) {
-                        let l11 = l19 * l12as u64 / 10000u64;
-                        let l13 = coin::split(&mut l5, l11, l6);
-                        auctionhouse::add_fee(l1, coin::into_balance(l13));
-                        if (option::is_some(&l14)) {
-                            let l20 = option::extract(&mut l14);
-                            if (dynamic_object_field::exists_with_type(&l0.id, l20)) {
-                                let Bid { id: reg_88, bidder: reg_89, amount: reg_90, timestamp: reg_91 } = dynamic_object_field::remove(&mut l0.id, l20);
-                                let l7 = reg_90 : 0x2::balance::Balance<0x2::sui::SUI>;
-                                let l8 = reg_88 : 0x2::object::UID;
-                                transfer::public_transfer(coin::from_balance(l7, l6), l20);
-                                object::delete(l8)
-                            } else {
-                                
-                            }
-                        } else {
-                            
-                        };
-                        let (reg_103, reg_104) = kiosk::purchase_with_cap(l3, l21, coin::zero(l6));
-                        let l22 = reg_104;
-                        let l17 = reg_103;
-                        object::delete(l15);
-                        event::emit(NftBoughtOut { listing_id: l2, seller: l23, buyer: tx_context::sender(freeze(l6)), amount: l9, nft_id: l18 });
-                        transfer::public_transfer(l5, l23);
-                        return (l17, l22)
-                    } else {
-                        abort C13
-                    }
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C15
-            }
-        } else {
-            abort C4
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l10 = reg_24 : u64;
+    let l12 = reg_22 : u16;
+    let l24 = reg_21 : u8;
+    let l14 = reg_20 : 0x1::option::Option<address>;
+    let l9 = reg_18 : u64;
+    let l21 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
+    let l18 = reg_16 : 0x2::object::ID;
+    let l16 = reg_15 : 0x2::object::ID;
+    let l23 = reg_14 : address;
+    let l15 = reg_13 : 0x2::object::UID;
+    assert!(l24 == C0, C4);
+    assert!(tx_context::epoch(freeze(l6)) <= l10, C15);
+    assert!(object::id(freeze(l3)) == l16, C12);
+    let l19 = coin::value(&l5);
+    assert!(l19 >= l9, C13);
+    let l11 = l19 * l12as u64 / 10000u64;
+    let l13 = coin::split(&mut l5, l11, l6);
+    auctionhouse::add_fee(l1, coin::into_balance(l13));
+    if (option::is_some(&l14)) {
+        let l20 = option::extract(&mut l14);
+        if (dynamic_object_field::exists_with_type(&l0.id, l20)) {
+            let Bid { id: reg_88, bidder: reg_89, amount: reg_90, timestamp: reg_91 } = dynamic_object_field::remove(&mut l0.id, l20);
+            let l7 = reg_90 : 0x2::balance::Balance<0x2::sui::SUI>;
+            let l8 = reg_88 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l7, l6), l20);
+            object::delete(l8)
         }
-    } else {
-        abort C7
-    }
+    };
+    let (reg_103, reg_104) = kiosk::purchase_with_cap(l3, l21, coin::zero(l6));
+    let l22 = reg_104;
+    let l17 = reg_103;
+    object::delete(l15);
+    event::emit(NftBoughtOut { listing_id: l2, seller: l23, buyer: tx_context::sender(freeze(l6)), amount: l9, nft_id: l18 });
+    transfer::public_transfer(l5, l23);
+    return (l17, l22)
 }
 
 public fun cancel_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l13 = reg_20 : u8;
-        let l7 = reg_19 : 0x1::option::Option<address>;
-        let l11 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
-        let l10 = reg_15 : 0x2::object::ID;
-        let l9 = reg_14 : 0x2::object::ID;
-        let l12 = reg_13 : address;
-        let l8 = reg_12 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l3)) == l12) {
-            if (l13 == C0) {
-                if (object::id(freeze(l2)) == l9) {
-                    if (option::is_some(&l7)) {
-                        let l6 = option::extract(&mut l7);
-                        if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
-                            let Bid { id: reg_61, bidder: reg_62, amount: reg_63, timestamp: reg_64 } = dynamic_object_field::remove(&mut l0.id, l6);
-                            let l4 = reg_63 : 0x2::balance::Balance<0x2::sui::SUI>;
-                            let l5 = reg_61 : 0x2::object::UID;
-                            transfer::public_transfer(coin::from_balance(l4, l3), l6);
-                            object::delete(l5)
-                        } else {
-                            
-                        }
-                    } else {
-                        
-                    };
-                    kiosk::return_purchase_cap(l2, l11);
-                    object::delete(l8);
-                    event::emit(ListingCancelled { listing_id: l1, seller: l12, nft_id: l10 })
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C6
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l13 = reg_20 : u8;
+    let l7 = reg_19 : 0x1::option::Option<address>;
+    let l11 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
+    let l10 = reg_15 : 0x2::object::ID;
+    let l9 = reg_14 : 0x2::object::ID;
+    let l12 = reg_13 : address;
+    let l8 = reg_12 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l3)) == l12, C6);
+    assert!(l13 == C0, C4);
+    assert!(object::id(freeze(l2)) == l9, C12);
+    if (option::is_some(&l7)) {
+        let l6 = option::extract(&mut l7);
+        if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
+            let Bid { id: reg_61, bidder: reg_62, amount: reg_63, timestamp: reg_64 } = dynamic_object_field::remove(&mut l0.id, l6);
+            let l4 = reg_63 : 0x2::balance::Balance<0x2::sui::SUI>;
+            let l5 = reg_61 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l4, l3), l6);
+            object::delete(l5)
         }
-    } else {
-        abort C7
-    }
+    };
+    kiosk::return_purchase_cap(l2, l11);
+    object::delete(l8);
+    event::emit(ListingCancelled { listing_id: l1, seller: l12, nft_id: l10 })
 }
 
 public entry fun cancel_listing_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
@@ -346,22 +290,16 @@ public entry fun cancel_listing_entry<T0: key + store>(l0: &mut Kiosk_Bidding_St
 }
 
 public fun claim_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext): T0 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l6 = reg_14 : T0;
-        let l3 = reg_13 : address;
-        let l5 = reg_12 : 0x2::object::ID;
-        let l4 = reg_11 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l2)) == l3) {
-            object::delete(l4);
-            event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
-            return l6
-        } else {
-            abort C18
-        }
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l6 = reg_14 : T0;
+    let l3 = reg_13 : address;
+    let l5 = reg_12 : 0x2::object::ID;
+    let l4 = reg_11 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l2)) == l3, C18);
+    object::delete(l4);
+    event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
+    return l6
 }
 
 public entry fun claim_accepted_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext) {
@@ -369,17 +307,14 @@ public entry fun claim_accepted_bid_entry<T0: key + store>(l0: &mut Kiosk_Biddin
 }
 
 public entry fun claim_accepted_bid_to_existing_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &KioskOwnerCap, l4: &mut TransferPolicy<T0>, l5: Coin<SUI>, l6: &mut TxContext) {
-    if (kiosk::has_access(l2, l3)) {
-        let l7 = kiosk_bidding_house::claim_accepted_bid(l0, l1, l6);
-        let l8 = object::id(&l7);
-        kiosk::lock(l2, l3, freeze(l4), l7);
-        let l9 = transfer_policy::new_request(l8, 0u64, object::id(freeze(l2)));
-        royalty_rule::pay(l4, &mut l9, l5);
-        kiosk_lock_rule::prove(&mut l9, freeze(l2));
-        (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l4), l9);
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l2, l3), C11);
+    let l7 = kiosk_bidding_house::claim_accepted_bid(l0, l1, l6);
+    let l8 = object::id(&l7);
+    kiosk::lock(l2, l3, freeze(l4), l7);
+    let l9 = transfer_policy::new_request(l8, 0u64, object::id(freeze(l2)));
+    royalty_rule::pay(l4, &mut l9, l5);
+    kiosk_lock_rule::prove(&mut l9, freeze(l2));
+    (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l4), l9);
 }
 
 public entry fun claim_accepted_bid_to_new_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TransferPolicy<T0>, l3: Coin<SUI>, l4: &mut TxContext) {
@@ -404,47 +339,29 @@ public entry fun create_and_share_kiosk_bidding_house_store(l0: &AuctionHouse, l
 
 public fun create_kiosk_bidding_house(l0: &AuctionHouse, l1: &mut TxContext): Kiosk_Bidding_Store {
     let l2 = tx_context::sender(freeze(l1));
-    if (auctionhouse::is_admin(l0, l2)) {
-        let l4 = object::new(l1);
-        let l5 = object::uid_to_inner(&l4);
-        let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
-        event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
-        return l3
-    } else {
-        abort C14
-    }
+    assert!(auctionhouse::is_admin(l0, l2), C14);
+    let l4 = object::new(l1);
+    let l5 = object::uid_to_inner(&l4);
+    let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
+    event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
+    return l3
 }
 
 public fun create_nft_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: u64, l7: &mut TxContext): ID {
-    if (l5 <= 10000u16) {
-        if (kiosk::has_item(freeze(l1), l3)) {
-            if (kiosk::has_access(l1, l2)) {
-                if (l4 > 0u64) {
-                    if (l6 > 0u64) {
-                        let l8 = tx_context::epoch(freeze(l7));
-                        let l9 = l8 + l6;
-                        let l13 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
-                        let l11 = object::new(l7);
-                        let l12 = object::uid_to_inner(&l11);
-                        let l10 = NftListing { id: l11, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l13, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l8, expires_at: l9 };
-                        dynamic_object_field::add(&mut l0.id, l12, l10);
-                        event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l12, expires_at: l9 });
-                        return l12
-                    } else {
-                        abort C17
-                    }
-                } else {
-                    abort C9
-                }
-            } else {
-                abort C11
-            }
-        } else {
-            abort C10
-        }
-    } else {
-        abort C20
-    }
+    assert!(l5 <= 10000u16, C20);
+    assert!(kiosk::has_item(freeze(l1), l3), C10);
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(l4 > 0u64, C9);
+    assert!(l6 > 0u64, C17);
+    let l8 = tx_context::epoch(freeze(l7));
+    let l9 = l8 + l6;
+    let l13 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
+    let l11 = object::new(l7);
+    let l12 = object::uid_to_inner(&l11);
+    let l10 = NftListing { id: l11, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l13, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l8, expires_at: l9 };
+    dynamic_object_field::add(&mut l0.id, l12, l10);
+    event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l12, expires_at: l9 });
+    return l12
 }
 
 public entry fun create_nft_listing_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: &mut TxContext) {}
@@ -472,142 +389,98 @@ public fun create_personal_kiosk_ptb(l0: &mut TxContext): ( ID, PersonalKioskCap
 
 public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l5 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l5)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l8 = reg_20 : T0;
-            let l4 = reg_19 : address;
-            let l7 = reg_18 : 0x2::object::ID;
-            let l6 = reg_17 : 0x2::object::UID;
-            let l9 = object::id(&l8);
-            transfer::public_transfer(l8, l4);
-            object::delete(l6);
-            event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l5), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l8 = reg_20 : T0;
+        let l4 = reg_19 : address;
+        let l7 = reg_18 : 0x2::object::ID;
+        let l6 = reg_17 : 0x2::object::UID;
+        let l9 = object::id(&l8);
+        transfer::public_transfer(l8, l4);
+        object::delete(l6);
+        event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     }
 }
 
 public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l7 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l7)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l8 = reg_24 : 0x1::option::Option<address>;
-            let l13 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
-            let l11 = reg_20 : 0x2::object::ID;
-            let l10 = reg_19 : 0x2::object::ID;
-            let l14 = reg_18 : address;
-            let l9 = reg_17 : 0x2::object::UID;
-            let l12 = OrphanedPurchaseCap { id: object::new(l3), cap: l13, kiosk_id: l10, orphaned_at: tx_context::epoch(freeze(l3)) };
-            dynamic_object_field::add(&mut l0.orphaned_caps, l11, l12);
-            event::emit(PurchaseCapOrphaned { nft_id: l11, kiosk_id: l10, timestamp: tx_context::epoch(freeze(l3)) });
-            if (option::is_some(&l8)) {
-                let l6 = option::extract(&mut l8);
-                if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
-                    let Bid { id: reg_59, bidder: reg_60, amount: reg_61, timestamp: reg_62 } = dynamic_object_field::remove(&mut l0.id, l6);
-                    let l4 = reg_61 : 0x2::balance::Balance<0x2::sui::SUI>;
-                    let l5 = reg_59 : 0x2::object::UID;
-                    transfer::public_transfer(coin::from_balance(l4, l3), l6);
-                    object::delete(l5)
-                } else {
-                    
-                }
-            } else {
-                
-            };
-            object::delete(l9);
-            event::emit(ListingCancelled { listing_id: l2, seller: l14, nft_id: l11 })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l7), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l8 = reg_24 : 0x1::option::Option<address>;
+        let l13 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
+        let l11 = reg_20 : 0x2::object::ID;
+        let l10 = reg_19 : 0x2::object::ID;
+        let l14 = reg_18 : address;
+        let l9 = reg_17 : 0x2::object::UID;
+        let l12 = OrphanedPurchaseCap { id: object::new(l3), cap: l13, kiosk_id: l10, orphaned_at: tx_context::epoch(freeze(l3)) };
+        dynamic_object_field::add(&mut l0.orphaned_caps, l11, l12);
+        event::emit(PurchaseCapOrphaned { nft_id: l11, kiosk_id: l10, timestamp: tx_context::epoch(freeze(l3)) });
+        if (option::is_some(&l8)) {
+            let l6 = option::extract(&mut l8);
+            if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
+                let Bid { id: reg_59, bidder: reg_60, amount: reg_61, timestamp: reg_62 } = dynamic_object_field::remove(&mut l0.id, l6);
+                let l4 = reg_61 : 0x2::balance::Balance<0x2::sui::SUI>;
+                let l5 = reg_59 : 0x2::object::UID;
+                transfer::public_transfer(coin::from_balance(l4, l3), l6);
+                object::delete(l5)
+            }
+        };
+        object::delete(l9);
+        event::emit(ListingCancelled { listing_id: l2, seller: l14, nft_id: l11 })
     }
 }
 
 public fun get_accepted_bid_bidder<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): address {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).bidder)
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).bidder)
 }
 
 public fun get_accepted_bid_timestamp<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).timestamp)
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).timestamp)
 }
 
 public fun get_buyout_price<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
 }
 
 public fun get_highest_bid<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
 }
 
 public fun get_highest_bidder<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): Option<address> {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
 }
 
 public fun get_listing_expiration<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
 }
 
 public fun get_listing_status<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u8 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
 }
 
 public fun get_nft_id<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): ID {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
 }
 
 public fun get_seller<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): address {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
 }
 
 public fun is_listing_expired<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID, l2: &TxContext): bool {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l1);
-        return tx_context::epoch(l2) > *(&l3.expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l3 = dynamic_object_field::borrow(&l0.id, l1);
+    return tx_context::epoch(l2) > *(&l3.expires_at)
 }
 
 public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bool {
@@ -615,56 +488,41 @@ public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bo
 }
 
 public fun place_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<SUI>, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l7 = coin::value(&l2);
-        let l8 = tx_context::sender(freeze(l3));
-        let l9 = tx_context::epoch(freeze(l3));
-        let l11 = dynamic_object_field::borrow(&l0.id, l1);
-        if (*(&l11.status) == C0) {
-            if (l9 <= *(&l11.expires_at)) {
-                if (l7 > 0u64) {
-                    let l4 = if (*(&l11.highest_bid) == 0u64) {
-                        1u64
-                    } else {
-                        *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64
-                    };
-                    let l13 = l4;
-                    if (l7 >= l13) {
-                        let l15 = option::none();
-                        let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
-                        if (option::is_some(&l12.highest_bidder)) {
-                            l15 = option::some(*(option::borrow(&l12.highest_bidder)));
-                        };
-                        *(&mut l12.highest_bid) = l7;
-                        *(&mut l12.highest_bidder) = option::some(l8);
-                        if (option::is_some(&l15)) {
-                            let l14 = option::extract(&mut l15);
-                            if (dynamic_object_field::exists_with_type(&l0.id, l14)) {
-                                let Bid { id: reg_105, bidder: reg_106, amount: reg_107, timestamp: reg_108 } = dynamic_object_field::remove(&mut l0.id, l14);
-                                let l5 = reg_107 : 0x2::balance::Balance<0x2::sui::SUI>;
-                                let l10 = reg_105 : 0x2::object::UID;
-                                transfer::public_transfer(coin::from_balance(l5, l3), l14);
-                                object::delete(l10)
-                            }
-                        };
-                        let l6 = Bid { id: object::new(l3), bidder: l8, amount: coin::into_balance(l2), timestamp: l9 };
-                        dynamic_object_field::add(&mut l0.id, l8, l6);
-                        event::emit(BidPlaced { listing_id: l1, bidder: l8, amount: l7, timestamp: l9 })
-                    } else {
-                        abort C5
-                    }
-                } else {
-                    abort C3
-                }
-            } else {
-                abort C15
-            }
-        } else {
-            abort C4
-        }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l7 = coin::value(&l2);
+    let l8 = tx_context::sender(freeze(l3));
+    let l9 = tx_context::epoch(freeze(l3));
+    let l11 = dynamic_object_field::borrow(&l0.id, l1);
+    assert!(*(&l11.status) == C0, C4);
+    assert!(l9 <= *(&l11.expires_at), C15);
+    assert!(l7 > 0u64, C3);
+    let l4 = if (*(&l11.highest_bid) == 0u64) {
+        1u64
     } else {
-        abort C7
-    }
+        *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64
+    };
+    let l13 = l4;
+    assert!(l7 >= l13, C5);
+    let l15 = option::none();
+    let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
+    if (option::is_some(&l12.highest_bidder)) {
+        l15 = option::some(*(option::borrow(&l12.highest_bidder)));
+    };
+    *(&mut l12.highest_bid) = l7;
+    *(&mut l12.highest_bidder) = option::some(l8);
+    if (option::is_some(&l15)) {
+        let l14 = option::extract(&mut l15);
+        if (dynamic_object_field::exists_with_type(&l0.id, l14)) {
+            let Bid { id: reg_105, bidder: reg_106, amount: reg_107, timestamp: reg_108 } = dynamic_object_field::remove(&mut l0.id, l14);
+            let l5 = reg_107 : 0x2::balance::Balance<0x2::sui::SUI>;
+            let l10 = reg_105 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l5, l3), l14);
+            object::delete(l10)
+        }
+    };
+    let l6 = Bid { id: object::new(l3), bidder: l8, amount: coin::into_balance(l2), timestamp: l9 };
+    dynamic_object_field::add(&mut l0.id, l8, l6);
+    event::emit(BidPlaced { listing_id: l1, bidder: l8, amount: l7, timestamp: l9 })
 }
 
 public entry fun place_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<SUI>, l3: &mut TxContext) {
@@ -672,23 +530,14 @@ public entry fun place_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, 
 }
 
 public entry fun recover_orphaned_cap<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: &mut TxContext) {
-    if (kiosk::has_access(l1, l2)) {
-        if (dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3)) {
-            let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
-            let l7 = reg_21 : 0x2::object::ID;
-            let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
-            let l6 = reg_19 : 0x2::object::UID;
-            if (object::id(freeze(l1)) == l7) {
-                kiosk::return_purchase_cap(l1, l5);
-                object::delete(l6);
-                event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
-            } else {
-                abort C12
-            }
-        } else {
-            abort C16
-        }
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3), C16);
+    let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
+    let l7 = reg_21 : 0x2::object::ID;
+    let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
+    let l6 = reg_19 : 0x2::object::UID;
+    assert!(object::id(freeze(l1)) == l7, C12);
+    kiosk::return_purchase_cap(l1, l5);
+    object::delete(l6);
+    event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house_dynamic_coins.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house_dynamic_coins.mv.snap
@@ -159,63 +159,42 @@ const C22: u64 = 42u64;
 // -- functions -- 
 
 public fun accept_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25, coin_type: reg_26 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l11 = reg_26 : 0x1::type_name::TypeName;
-        let l14 = reg_23 : u16;
-        let l24 = reg_22 : u8;
-        let l16 = reg_21 : 0x1::option::Option<address>;
-        let l15 = reg_20 : u64;
-        let l21 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
-        let l20 = reg_17 : 0x2::object::ID;
-        let l18 = reg_16 : 0x2::object::ID;
-        let l23 = reg_15 : address;
-        let l17 = reg_14 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l5)) == l23) {
-            if (l24 == C0) {
-                if (object::id(freeze(l3)) == l18) {
-                    if (option::is_some(&l16)) {
-                        let l10 = option::extract(&mut l16);
-                        let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l10);
-                        if (l11 == type_name::get()) {
-                            if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
-                                let Bid { id: reg_94, bidder: reg_95, amount: reg_96, timestamp: reg_97 } = dynamic_object_field::remove(&mut l0.id, l9);
-                                let l7 = reg_96 : 0x2::balance::Balance<T1>;
-                                let l8 = reg_94 : 0x2::object::UID;
-                                let l13 = balance::value(&l7) * l14as u64 / 10000u64;
-                                transfer::public_transfer(coin::from_balance(balance::split(&mut l7, l13), l5), auctionhouse::get_owner(freeze(l1)));
-                                transfer::public_transfer(coin::from_balance(l7, l5), l23);
-                                let (reg_125, reg_126) = kiosk::purchase_with_cap(l3, l21, coin::zero(l5));
-                                let l22 = reg_126;
-                                let l19 = reg_125;
-                                (reg_129, reg_130, reg_131) = transfer_policy::confirm_request(l4, l22);
-                                let l12 = tx_context::epoch(freeze(l5));
-                                let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l10, nft: l19, timestamp: l12, coin_type: l11 };
-                                dynamic_object_field::add(&mut l0.id, l2, l6);
-                                object::delete(l17);
-                                object::delete(l8);
-                                event::emit(BidReadyForClaim { listing_id: l2, seller: l23, bidder: l10, amount: l15, nft_id: l20, timestamp: l12, coin_type: l11 })
-                            } else {
-                                abort C8
-                            }
-                        } else {
-                            abort C22
-                        }
-                    } else {
-                        abort C8
-                    }
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C6
-        }
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25, coin_type: reg_26 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l11 = reg_26 : 0x1::type_name::TypeName;
+    let l14 = reg_23 : u16;
+    let l24 = reg_22 : u8;
+    let l16 = reg_21 : 0x1::option::Option<address>;
+    let l15 = reg_20 : u64;
+    let l21 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
+    let l20 = reg_17 : 0x2::object::ID;
+    let l18 = reg_16 : 0x2::object::ID;
+    let l23 = reg_15 : address;
+    let l17 = reg_14 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l5)) == l23, C6);
+    assert!(l24 == C0, C4);
+    assert!(object::id(freeze(l3)) == l18, C12);
+    assert!(option::is_some(&l16), C8);
+    let l10 = option::extract(&mut l16);
+    let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l10);
+    assert!(l11 == type_name::get(), C22);
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l9), C8);
+    let Bid { id: reg_94, bidder: reg_95, amount: reg_96, timestamp: reg_97 } = dynamic_object_field::remove(&mut l0.id, l9);
+    let l7 = reg_96 : 0x2::balance::Balance<T1>;
+    let l8 = reg_94 : 0x2::object::UID;
+    let l13 = balance::value(&l7) * l14as u64 / 10000u64;
+    transfer::public_transfer(coin::from_balance(balance::split(&mut l7, l13), l5), auctionhouse::get_owner(freeze(l1)));
+    transfer::public_transfer(coin::from_balance(l7, l5), l23);
+    let (reg_125, reg_126) = kiosk::purchase_with_cap(l3, l21, coin::zero(l5));
+    let l22 = reg_126;
+    let l19 = reg_125;
+    (reg_129, reg_130, reg_131) = transfer_policy::confirm_request(l4, l22);
+    let l12 = tx_context::epoch(freeze(l5));
+    let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l10, nft: l19, timestamp: l12, coin_type: l11 };
+    dynamic_object_field::add(&mut l0.id, l2, l6);
+    object::delete(l17);
+    object::delete(l8);
+    event::emit(BidReadyForClaim { listing_id: l2, seller: l23, bidder: l10, amount: l15, nft_id: l20, timestamp: l12, coin_type: l11 })
 }
 
 public entry fun accept_bid_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
@@ -236,117 +215,76 @@ public entry fun buy_nft<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: 
 }
 
 public fun buy_nft_with_request<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: Coin<T1>, l6: &mut TxContext): ( T0, TransferRequest<T0>) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24, coin_type: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l11 = reg_25 : 0x1::type_name::TypeName;
-        let l12 = reg_24 : u64;
-        let l14 = reg_22 : u16;
-        let l25 = reg_21 : u8;
-        let l15 = reg_20 : 0x1::option::Option<address>;
-        let l10 = reg_18 : u64;
-        let l22 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
-        let l19 = reg_16 : 0x2::object::ID;
-        let l17 = reg_15 : 0x2::object::ID;
-        let l24 = reg_14 : address;
-        let l16 = reg_13 : 0x2::object::UID;
-        if (l11 == type_name::get()) {
-            if (l25 == C0) {
-                if (tx_context::epoch(freeze(l6)) <= l12) {
-                    if (object::id(freeze(l3)) == l17) {
-                        let l20 = coin::value(&l5);
-                        if (l20 >= l10) {
-                            let l13 = l20 * l14as u64 / 10000u64;
-                            transfer::public_transfer(coin::split(&mut l5, l13, l6), auctionhouse::get_owner(freeze(l1)));
-                            if (option::is_some(&l15)) {
-                                let l21 = option::extract(&mut l15);
-                                let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l21);
-                                if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
-                                    let Bid { id: reg_100, bidder: reg_101, amount: reg_102, timestamp: reg_103 } = dynamic_object_field::remove(&mut l0.id, l9);
-                                    let l7 = reg_102 : 0x2::balance::Balance<T1>;
-                                    let l8 = reg_100 : 0x2::object::UID;
-                                    transfer::public_transfer(coin::from_balance(l7, l6), l21);
-                                    object::delete(l8)
-                                } else {
-                                    
-                                }
-                            } else {
-                                
-                            };
-                            let (reg_115, reg_116) = kiosk::purchase_with_cap(l3, l22, coin::zero(l6));
-                            let l23 = reg_116;
-                            let l18 = reg_115;
-                            object::delete(l16);
-                            event::emit(NftBoughtOut { listing_id: l2, seller: l24, buyer: tx_context::sender(freeze(l6)), amount: l10, nft_id: l19, coin_type: l11 });
-                            transfer::public_transfer(l5, l24);
-                            return (l18, l23)
-                        } else {
-                            abort C13
-                        }
-                    } else {
-                        abort C12
-                    }
-                } else {
-                    abort C15
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C22
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24, coin_type: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l11 = reg_25 : 0x1::type_name::TypeName;
+    let l12 = reg_24 : u64;
+    let l14 = reg_22 : u16;
+    let l25 = reg_21 : u8;
+    let l15 = reg_20 : 0x1::option::Option<address>;
+    let l10 = reg_18 : u64;
+    let l22 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
+    let l19 = reg_16 : 0x2::object::ID;
+    let l17 = reg_15 : 0x2::object::ID;
+    let l24 = reg_14 : address;
+    let l16 = reg_13 : 0x2::object::UID;
+    assert!(l11 == type_name::get(), C22);
+    assert!(l25 == C0, C4);
+    assert!(tx_context::epoch(freeze(l6)) <= l12, C15);
+    assert!(object::id(freeze(l3)) == l17, C12);
+    let l20 = coin::value(&l5);
+    assert!(l20 >= l10, C13);
+    let l13 = l20 * l14as u64 / 10000u64;
+    transfer::public_transfer(coin::split(&mut l5, l13, l6), auctionhouse::get_owner(freeze(l1)));
+    if (option::is_some(&l15)) {
+        let l21 = option::extract(&mut l15);
+        let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l21);
+        if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
+            let Bid { id: reg_100, bidder: reg_101, amount: reg_102, timestamp: reg_103 } = dynamic_object_field::remove(&mut l0.id, l9);
+            let l7 = reg_102 : 0x2::balance::Balance<T1>;
+            let l8 = reg_100 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l7, l6), l21);
+            object::delete(l8)
         }
-    } else {
-        abort C7
-    }
+    };
+    let (reg_115, reg_116) = kiosk::purchase_with_cap(l3, l22, coin::zero(l6));
+    let l23 = reg_116;
+    let l18 = reg_115;
+    object::delete(l16);
+    event::emit(NftBoughtOut { listing_id: l2, seller: l24, buyer: tx_context::sender(freeze(l6)), amount: l10, nft_id: l19, coin_type: l11 });
+    transfer::public_transfer(l5, l24);
+    return (l18, l23)
 }
 
 public fun cancel_listing<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23, coin_type: reg_24 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l8 = reg_24 : 0x1::type_name::TypeName;
-        let l15 = reg_20 : u8;
-        let l9 = reg_19 : 0x1::option::Option<address>;
-        let l13 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
-        let l12 = reg_15 : 0x2::object::ID;
-        let l11 = reg_14 : 0x2::object::ID;
-        let l14 = reg_13 : address;
-        let l10 = reg_12 : 0x2::object::UID;
-        if (l8 == type_name::get()) {
-            if (tx_context::sender(freeze(l3)) == l14) {
-                if (l15 == C0) {
-                    if (object::id(freeze(l2)) == l11) {
-                        if (option::is_some(&l9)) {
-                            let l7 = option::extract(&mut l9);
-                            let l6 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l7);
-                            if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
-                                let Bid { id: reg_72, bidder: reg_73, amount: reg_74, timestamp: reg_75 } = dynamic_object_field::remove(&mut l0.id, l6);
-                                let l4 = reg_74 : 0x2::balance::Balance<T1>;
-                                let l5 = reg_72 : 0x2::object::UID;
-                                transfer::public_transfer(coin::from_balance(l4, l3), l7);
-                                object::delete(l5)
-                            } else {
-                                
-                            }
-                        } else {
-                            
-                        };
-                        kiosk::return_purchase_cap(l2, l13);
-                        object::delete(l10);
-                        event::emit(ListingCancelled { listing_id: l1, seller: l14, nft_id: l12, coin_type: l8 })
-                    } else {
-                        abort C12
-                    }
-                } else {
-                    abort C4
-                }
-            } else {
-                abort C6
-            }
-        } else {
-            abort C22
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23, coin_type: reg_24 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l8 = reg_24 : 0x1::type_name::TypeName;
+    let l15 = reg_20 : u8;
+    let l9 = reg_19 : 0x1::option::Option<address>;
+    let l13 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
+    let l12 = reg_15 : 0x2::object::ID;
+    let l11 = reg_14 : 0x2::object::ID;
+    let l14 = reg_13 : address;
+    let l10 = reg_12 : 0x2::object::UID;
+    assert!(l8 == type_name::get(), C22);
+    assert!(tx_context::sender(freeze(l3)) == l14, C6);
+    assert!(l15 == C0, C4);
+    assert!(object::id(freeze(l2)) == l11, C12);
+    if (option::is_some(&l9)) {
+        let l7 = option::extract(&mut l9);
+        let l6 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l7);
+        if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
+            let Bid { id: reg_72, bidder: reg_73, amount: reg_74, timestamp: reg_75 } = dynamic_object_field::remove(&mut l0.id, l6);
+            let l4 = reg_74 : 0x2::balance::Balance<T1>;
+            let l5 = reg_72 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l4, l3), l7);
+            object::delete(l5)
         }
-    } else {
-        abort C7
-    }
+    };
+    kiosk::return_purchase_cap(l2, l13);
+    object::delete(l10);
+    event::emit(ListingCancelled { listing_id: l1, seller: l14, nft_id: l12, coin_type: l8 })
 }
 
 public entry fun cancel_listing_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
@@ -354,22 +292,16 @@ public entry fun cancel_listing_entry<T0: key + store, T1>(l0: &mut Kiosk_Biddin
 }
 
 public fun claim_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext): T0 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15, coin_type: reg_16 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l6 = reg_14 : T0;
-        let l3 = reg_13 : address;
-        let l5 = reg_12 : 0x2::object::ID;
-        let l4 = reg_11 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l2)) == l3) {
-            object::delete(l4);
-            event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
-            return l6
-        } else {
-            abort C18
-        }
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15, coin_type: reg_16 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l6 = reg_14 : T0;
+    let l3 = reg_13 : address;
+    let l5 = reg_12 : 0x2::object::ID;
+    let l4 = reg_11 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l2)) == l3, C18);
+    object::delete(l4);
+    event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
+    return l6
 }
 
 public entry fun claim_accepted_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext) {
@@ -402,48 +334,30 @@ fun create_bid_key(l0: ID, l1: address): BidKey {
 
 public fun create_kiosk_bidding_house(l0: &AuctionHouse, l1: &mut TxContext): Kiosk_Bidding_Store {
     let l2 = tx_context::sender(freeze(l1));
-    if (auctionhouse::is_admin(l0, l2)) {
-        let l4 = object::new(l1);
-        let l5 = object::uid_to_inner(&l4);
-        let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
-        event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
-        return l3
-    } else {
-        abort C14
-    }
+    assert!(auctionhouse::is_admin(l0, l2), C14);
+    let l4 = object::new(l1);
+    let l5 = object::uid_to_inner(&l4);
+    let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
+    event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
+    return l3
 }
 
 public fun create_nft_listing<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: u64, l7: &mut TxContext): ID {
-    if (l5 <= 10000u16) {
-        if (kiosk::has_item(freeze(l1), l3)) {
-            if (kiosk::has_access(l1, l2)) {
-                if (l4 > 0u64) {
-                    if (l6 > 0u64) {
-                        let l9 = tx_context::epoch(freeze(l7));
-                        let l10 = l9 + l6;
-                        let l14 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
-                        let l12 = object::new(l7);
-                        let l13 = object::uid_to_inner(&l12);
-                        let l8 = type_name::get();
-                        let l11 = NftListing { id: l12, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l14, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l9, expires_at: l10, coin_type: l8 };
-                        dynamic_object_field::add(&mut l0.id, l13, l11);
-                        event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l13, expires_at: l10, coin_type: l8 });
-                        return l13
-                    } else {
-                        abort C17
-                    }
-                } else {
-                    abort C9
-                }
-            } else {
-                abort C11
-            }
-        } else {
-            abort C10
-        }
-    } else {
-        abort C20
-    }
+    assert!(l5 <= 10000u16, C20);
+    assert!(kiosk::has_item(freeze(l1), l3), C10);
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(l4 > 0u64, C9);
+    assert!(l6 > 0u64, C17);
+    let l9 = tx_context::epoch(freeze(l7));
+    let l10 = l9 + l6;
+    let l14 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
+    let l12 = object::new(l7);
+    let l13 = object::uid_to_inner(&l12);
+    let l8 = type_name::get();
+    let l11 = NftListing { id: l12, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l14, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l9, expires_at: l10, coin_type: l8 };
+    dynamic_object_field::add(&mut l0.id, l13, l11);
+    event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l13, expires_at: l10, coin_type: l8 });
+    return l13
 }
 
 public entry fun create_nft_listing_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: &mut TxContext) {}
@@ -471,95 +385,67 @@ public fun create_personal_kiosk_ptb(l0: &mut TxContext): ( ID, PersonalKioskCap
 
 public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l5 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l5)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21, coin_type: reg_22 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l8 = reg_20 : T0;
-            let l4 = reg_19 : address;
-            let l7 = reg_18 : 0x2::object::ID;
-            let l6 = reg_17 : 0x2::object::UID;
-            let l9 = object::id(&l8);
-            transfer::public_transfer(l8, l4);
-            object::delete(l6);
-            event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l5), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21, coin_type: reg_22 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l8 = reg_20 : T0;
+        let l4 = reg_19 : address;
+        let l7 = reg_18 : 0x2::object::ID;
+        let l6 = reg_17 : 0x2::object::UID;
+        let l9 = object::id(&l8);
+        transfer::public_transfer(l8, l4);
+        object::delete(l6);
+        event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     }
 }
 
 public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l4 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l4)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28, coin_type: reg_29 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l5 = reg_29 : 0x1::type_name::TypeName;
-            let l10 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
-            let l8 = reg_20 : 0x2::object::ID;
-            let l7 = reg_19 : 0x2::object::ID;
-            let l11 = reg_18 : address;
-            let l6 = reg_17 : 0x2::object::UID;
-            let l9 = OrphanedPurchaseCap { id: object::new(l3), cap: l10, kiosk_id: l7, orphaned_at: tx_context::epoch(freeze(l3)) };
-            dynamic_object_field::add(&mut l0.orphaned_caps, l8, l9);
-            event::emit(PurchaseCapOrphaned { nft_id: l8, kiosk_id: l7, timestamp: tx_context::epoch(freeze(l3)) });
-            object::delete(l6);
-            event::emit(ListingCancelled { listing_id: l2, seller: l11, nft_id: l8, coin_type: l5 })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l4), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28, coin_type: reg_29 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l5 = reg_29 : 0x1::type_name::TypeName;
+        let l10 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
+        let l8 = reg_20 : 0x2::object::ID;
+        let l7 = reg_19 : 0x2::object::ID;
+        let l11 = reg_18 : address;
+        let l6 = reg_17 : 0x2::object::UID;
+        let l9 = OrphanedPurchaseCap { id: object::new(l3), cap: l10, kiosk_id: l7, orphaned_at: tx_context::epoch(freeze(l3)) };
+        dynamic_object_field::add(&mut l0.orphaned_caps, l8, l9);
+        event::emit(PurchaseCapOrphaned { nft_id: l8, kiosk_id: l7, timestamp: tx_context::epoch(freeze(l3)) });
+        object::delete(l6);
+        event::emit(ListingCancelled { listing_id: l2, seller: l11, nft_id: l8, coin_type: l5 })
     }
 }
 
 public fun get_buyout_price<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
 }
 
 public fun get_coin_type<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): TypeName {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).coin_type)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).coin_type)
 }
 
 public fun get_highest_bid<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
 }
 
 public fun get_highest_bidder<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): Option<address> {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
 }
 
 public fun get_listing_expiration<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
 }
 
 public fun get_listing_status<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u8 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
 }
 
 public fun get_listings_by_coin_type<T0>(l0: &Kiosk_Bidding_Store): vector<ID> {
@@ -571,28 +457,19 @@ public fun get_listings_by_nft_type<T0: key + store>(l0: &Kiosk_Bidding_Store): 
 }
 
 public fun get_nft_id<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): ID {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
 }
 
 public fun get_seller<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): address {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
 }
 
 public fun is_listing_expired<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID, l2: &TxContext): bool {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l1);
-        return tx_context::epoch(l2) > *(&l3.expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l3 = dynamic_object_field::borrow(&l0.id, l1);
+    return tx_context::epoch(l2) > *(&l3.expires_at)
 }
 
 public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bool {
@@ -600,63 +477,45 @@ public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bo
 }
 
 public fun place_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<T1>, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l7 = coin::value(&l2);
-        let l10 = tx_context::sender(freeze(l3));
-        let l12 = tx_context::epoch(freeze(l3));
-        let l14 = dynamic_object_field::borrow(&l0.id, l1);
-        if (*(&l14.status) == C0) {
-            if (l12 <= *(&l14.expires_at)) {
-                let l11 = *(&l14.coin_type);
-                if (l11 == type_name::get()) {
-                    if (l7 > 0u64) {
-                        let l4 = if (*(&l14.highest_bid) == 0u64) {
-                            1u64
-                        } else {
-                            *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64
-                        };
-                        let l16 = l4;
-                        if (l7 >= l16) {
-                            let l18 = option::none();
-                            let l15 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
-                            if (option::is_some(&l15.highest_bidder)) {
-                                l18 = option::some(*(option::borrow(&l15.highest_bidder)));
-                            };
-                            *(&mut l15.highest_bid) = l7;
-                            *(&mut l15.highest_bidder) = option::some(l10);
-                            if (option::is_some(&l18)) {
-                                let l17 = option::extract(&mut l18);
-                                let l8 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l17);
-                                if (dynamic_object_field::exists_with_type(&l0.id, l8)) {
-                                    let Bid { id: reg_118, bidder: reg_119, amount: reg_120, timestamp: reg_121 } = dynamic_object_field::remove(&mut l0.id, l8);
-                                    let l5 = reg_120 : 0x2::balance::Balance<T1>;
-                                    let l13 = reg_118 : 0x2::object::UID;
-                                    transfer::public_transfer(coin::from_balance(l5, l3), l17);
-                                    object::delete(l13)
-                                }
-                            };
-                            let l6 = Bid { id: object::new(l3), bidder: l10, amount: coin::into_balance(l2), timestamp: l12 };
-                            let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l10);
-                            dynamic_object_field::add(&mut l0.id, l9, l6);
-                            event::emit(BidPlaced { listing_id: l1, bidder: l10, amount: l7, timestamp: l12, coin_type: l11 })
-                        } else {
-                            abort C5
-                        }
-                    } else {
-                        abort C3
-                    }
-                } else {
-                    abort C22
-                }
-            } else {
-                abort C15
-            }
-        } else {
-            abort C4
-        }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l7 = coin::value(&l2);
+    let l10 = tx_context::sender(freeze(l3));
+    let l12 = tx_context::epoch(freeze(l3));
+    let l14 = dynamic_object_field::borrow(&l0.id, l1);
+    assert!(*(&l14.status) == C0, C4);
+    assert!(l12 <= *(&l14.expires_at), C15);
+    let l11 = *(&l14.coin_type);
+    assert!(l11 == type_name::get(), C22);
+    assert!(l7 > 0u64, C3);
+    let l4 = if (*(&l14.highest_bid) == 0u64) {
+        1u64
     } else {
-        abort C7
-    }
+        *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64
+    };
+    let l16 = l4;
+    assert!(l7 >= l16, C5);
+    let l18 = option::none();
+    let l15 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
+    if (option::is_some(&l15.highest_bidder)) {
+        l18 = option::some(*(option::borrow(&l15.highest_bidder)));
+    };
+    *(&mut l15.highest_bid) = l7;
+    *(&mut l15.highest_bidder) = option::some(l10);
+    if (option::is_some(&l18)) {
+        let l17 = option::extract(&mut l18);
+        let l8 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l17);
+        if (dynamic_object_field::exists_with_type(&l0.id, l8)) {
+            let Bid { id: reg_118, bidder: reg_119, amount: reg_120, timestamp: reg_121 } = dynamic_object_field::remove(&mut l0.id, l8);
+            let l5 = reg_120 : 0x2::balance::Balance<T1>;
+            let l13 = reg_118 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l5, l3), l17);
+            object::delete(l13)
+        }
+    };
+    let l6 = Bid { id: object::new(l3), bidder: l10, amount: coin::into_balance(l2), timestamp: l12 };
+    let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l10);
+    dynamic_object_field::add(&mut l0.id, l9, l6);
+    event::emit(BidPlaced { listing_id: l1, bidder: l10, amount: l7, timestamp: l12, coin_type: l11 })
 }
 
 public entry fun place_bid_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<T1>, l3: &mut TxContext) {
@@ -664,23 +523,14 @@ public entry fun place_bid_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Sto
 }
 
 public entry fun recover_orphaned_cap<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: &mut TxContext) {
-    if (kiosk::has_access(l1, l2)) {
-        if (dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3)) {
-            let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
-            let l7 = reg_21 : 0x2::object::ID;
-            let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
-            let l6 = reg_19 : 0x2::object::UID;
-            if (object::id(freeze(l1)) == l7) {
-                kiosk::return_purchase_cap(l1, l5);
-                object::delete(l6);
-                event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
-            } else {
-                abort C12
-            }
-        } else {
-            abort C16
-        }
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3), C16);
+    let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
+    let l7 = reg_21 : 0x2::object::ID;
+    let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
+    let l6 = reg_19 : 0x2::object::UID;
+    assert!(object::id(freeze(l1)) == l7, C12);
+    kiosk::return_purchase_cap(l1, l5);
+    object::delete(l6);
+    event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/nft_claim.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/nft_claim.mv.snap
@@ -84,11 +84,8 @@ public entry fun mint_batch(l0: &mut ClaimCap, l1: vector<address>, l2: &mut TxC
 }
 
 public fun mint_single(l0: &mut ClaimCap, l1: address, l2: &mut TxContext) {
-    if (!(vec_set::contains(&l0.claimed, &l1))) {
-        let l3 = DEEPClaimNFT { id: object::new(l2), name: string::utf8(C3), description: string::utf8(C4), image_url: string::utf8(C5) };
-        vec_set::insert(&mut l0.claimed, l1);
-        transfer::transfer(l3, l1)
-    } else {
-        abort 0u64
-    }
+    assert!(!(vec_set::contains(&l0.claimed, &l1)), 0u64);
+    let l3 = DEEPClaimNFT { id: object::new(l2), name: string::utf8(C3), description: string::utf8(C4), image_url: string::utf8(C5) };
+    vec_set::insert(&mut l0.claimed, l1);
+    transfer::transfer(l3, l1)
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x3001c0d95f0498b8e92fe95878b25e1c2e85ff213f3ff5b1ef088390ed185fc1/cetus_clmm_worker.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x3001c0d95f0498b8e92fe95878b25e1c2e85ff213f3ff5b1ef088390ed185fc1/cetus_clmm_worker.move
@@ -247,40 +247,33 @@ public entry fun add_collateral_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
     let l44 = vault::before_add_collateral(l21, l20, l19, l18, l17, l16, l15, cetus_clmm_worker::health(freeze(l41), freeze(l42), l43), l49, cetus_clmm_worker::is_reserve_consistent(), l13, l14);
     let l46 = vault::extract_add_collateral_context_coin_send(&mut l44, l14);
     let l48 = vault::get_add_collateral_context_debt(&l44);
-    if (table::contains(&l0.shares, l5)) {
-        let l53 = *(table::borrow(&l0.shares, l5));
-        let l22 = l53;
-        let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l22);
-        let l47 = cetus_clmm_worker::work_inner(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
-        if (coin::value(&l47) == 0u64) {
-            coin::destroy_zero(l47)
-        } else {
-            pay::keep(l47, freeze(l14))
-        };
-        let l28 = l13;
-        let l27 = l12;
-        let l26 = l11;
-        let l25 = l4;
-        let l24 = l1;
-        let l50 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l24), freeze(l25), l26, l27, l28);
-        let l36 = &l0.position_operator_cap;
-        let l35 = l1;
-        let l34 = l44;
-        let l33 = l8;
-        let l31 = l5;
-        let l30 = l4;
-        let l29 = l0;
-        vault::after_add_collateral(l36, l35, l34, l33, cetus_clmm_worker::health(freeze(l29), freeze(l30), l31), l50, cetus_clmm_worker::is_reserve_consistent());
-        let l52 = *(table::borrow(&l0.shares, l5));
-        let l37 = l52;
-        if (cetus_clmm_worker::share_to_balance(freeze(l0), l37) > l45) {
-            
-        } else {
-            abort C36
-        }
+    assert!(table::contains(&l0.shares, l5), C35);
+    let l53 = *(table::borrow(&l0.shares, l5));
+    let l22 = l53;
+    let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l22);
+    let l47 = cetus_clmm_worker::work_inner(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
+    if (coin::value(&l47) == 0u64) {
+        coin::destroy_zero(l47)
     } else {
-        abort C35
-    }
+        pay::keep(l47, freeze(l14))
+    };
+    let l28 = l13;
+    let l27 = l12;
+    let l26 = l11;
+    let l25 = l4;
+    let l24 = l1;
+    let l50 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l24), freeze(l25), l26, l27, l28);
+    let l36 = &l0.position_operator_cap;
+    let l35 = l1;
+    let l34 = l44;
+    let l33 = l8;
+    let l31 = l5;
+    let l30 = l4;
+    let l29 = l0;
+    vault::after_add_collateral(l36, l35, l34, l33, cetus_clmm_worker::health(freeze(l29), freeze(l30), l31), l50, cetus_clmm_worker::is_reserve_consistent());
+    let l52 = *(table::borrow(&l0.shares, l5));
+    let l37 = l52;
+    assert!(cetus_clmm_worker::share_to_balance(freeze(l0), l37) > l45, C36)
 }
 
 public entry fun add_collateral_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut GlobalStorage, l2: &mut Storage, l3: &GlobalConfig, l4: &mut Pool<T1, T0>, l5: u64, l6: Coin<T0>, l7: Coin<T1>, l8: bool, l9: u8, l10: vector<u8>, l11: &Aggregator, l12: &Aggregator, l13: &Clock, l14: &mut TxContext) {
@@ -293,53 +286,46 @@ public entry fun add_collateral_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
     let l33 = l4;
     let l24 = l1;
     let l49 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l24), freeze(l33), l39, l40, l41);
-    if (table::contains(&l0.shares, l5)) {
-        let l53 = *(table::borrow(&l0.shares, l5));
-        let l42 = l53;
-        let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l42);
-        let l23 = &l0.position_operator_cap;
-        let l22 = l1;
-        let l21 = l2;
-        let l20 = &l51;
-        let l19 = l5;
-        let l18 = l6;
-        let l17 = l8;
-        let l16 = l5;
-        let l15 = l4;
-        let l43 = l0;
-        let l44 = vault::before_add_collateral(l23, l22, l21, l20, l19, l18, l17, cetus_clmm_worker::health_reverse(freeze(l43), freeze(l15), l16), l49, cetus_clmm_worker::is_reserve_consistent(), l13, l14);
-        let l46 = vault::extract_add_collateral_context_coin_send(&mut l44, l14);
-        let l48 = vault::get_add_collateral_context_debt(&l44);
-        let l47 = cetus_clmm_worker::work_inner_reverse(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
-        if (coin::value(&l47) == 0u64) {
-            coin::destroy_zero(l47)
-        } else {
-            pay::keep(l47, freeze(l14))
-        };
-        let l29 = l13;
-        let l28 = l12;
-        let l27 = l11;
-        let l26 = l4;
-        let l25 = l1;
-        let l50 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l25), freeze(l26), l27, l28, l29);
-        let l37 = &l0.position_operator_cap;
-        let l36 = l1;
-        let l35 = l44;
-        let l34 = l8;
-        let l32 = l5;
-        let l31 = l4;
-        let l30 = l0;
-        vault::after_add_collateral(l37, l36, l35, l34, cetus_clmm_worker::health_reverse(freeze(l30), freeze(l31), l32), l50, cetus_clmm_worker::is_reserve_consistent());
-        let l52 = *(table::borrow(&l0.shares, l5));
-        let l38 = l52;
-        if (cetus_clmm_worker::share_to_balance(freeze(l0), l38) > l45) {
-            
-        } else {
-            abort C36
-        }
+    assert!(table::contains(&l0.shares, l5), C35);
+    let l53 = *(table::borrow(&l0.shares, l5));
+    let l42 = l53;
+    let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l42);
+    let l23 = &l0.position_operator_cap;
+    let l22 = l1;
+    let l21 = l2;
+    let l20 = &l51;
+    let l19 = l5;
+    let l18 = l6;
+    let l17 = l8;
+    let l16 = l5;
+    let l15 = l4;
+    let l43 = l0;
+    let l44 = vault::before_add_collateral(l23, l22, l21, l20, l19, l18, l17, cetus_clmm_worker::health_reverse(freeze(l43), freeze(l15), l16), l49, cetus_clmm_worker::is_reserve_consistent(), l13, l14);
+    let l46 = vault::extract_add_collateral_context_coin_send(&mut l44, l14);
+    let l48 = vault::get_add_collateral_context_debt(&l44);
+    let l47 = cetus_clmm_worker::work_inner_reverse(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
+    if (coin::value(&l47) == 0u64) {
+        coin::destroy_zero(l47)
     } else {
-        abort C35
-    }
+        pay::keep(l47, freeze(l14))
+    };
+    let l29 = l13;
+    let l28 = l12;
+    let l27 = l11;
+    let l26 = l4;
+    let l25 = l1;
+    let l50 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l25), freeze(l26), l27, l28, l29);
+    let l37 = &l0.position_operator_cap;
+    let l36 = l1;
+    let l35 = l44;
+    let l34 = l8;
+    let l32 = l5;
+    let l31 = l4;
+    let l30 = l0;
+    vault::after_add_collateral(l37, l36, l35, l34, cetus_clmm_worker::health_reverse(freeze(l30), freeze(l31), l32), l50, cetus_clmm_worker::is_reserve_consistent());
+    let l52 = *(table::borrow(&l0.shares, l5));
+    let l38 = l52;
+    assert!(cetus_clmm_worker::share_to_balance(freeze(l0), l38) > l45, C36)
 }
 
 fun add_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64, l2: u128, l3: u128) {
@@ -347,23 +333,18 @@ fun add_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64, l2: u128, l3
         let l5 = l3;
         let l4 = l2;
         let l9 = cetus_clmm_worker::balance_to_share_inner(freeze(l0), l4, l5);
-        if (l9 > 0u128) {
-            let l10 = &mut l0.shares;
-            let l6 = l1;
-            let l7 = if (table::contains(freeze(l10), l6)) {
-                table::borrow_mut(l10, l1)
-            } else {
-                table::add(l10, l1, 0u128);
-                table::borrow_mut(l10, l1)
-            };
-            let l8 = l7;
-            *l8 = *l8 + l9;
-            *(&mut l0.total_share) = *(&l0.total_share) + l9
+        assert!(l9 > 0u128, C3);
+        let l10 = &mut l0.shares;
+        let l6 = l1;
+        let l7 = if (table::contains(freeze(l10), l6)) {
+            table::borrow_mut(l10, l1)
         } else {
-            abort C3
-        }
-    } else {
-        
+            table::add(l10, l1, 0u128);
+            table::borrow_mut(l10, l1)
+        };
+        let l8 = l7;
+        *l8 = *l8 + l9;
+        *(&mut l0.total_share) = *(&l0.total_share) + l9
     }
 }
 
@@ -376,17 +357,12 @@ fun balance_to_share_inner<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u128, l2
     let l3 = *(&l0.total_share);
     if (l3 == 0u128) {
         return l1
-    } else {
-        return mole_math::mul_div_u128(l1, l3, l2)
-    }
+    };
+    return mole_math::mul_div_u128(l1, l3, l2)
 }
 
 public fun checked_package_version<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>) {
-    if (*(&l0.package_version) == C2) {
-        
-    } else {
-        abort C32
-    }
+    assert!(*(&l0.package_version) == C2, C32)
 }
 
 public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut RewarderGlobalVault, l3: &mut Pool<T0, T1>, l4: &mut Pool<T0, T3>, l5: bool, l6: bool, l7: bool, l8: &Clock, l9: &mut TxContext): ( u64, u64) {
@@ -424,8 +400,6 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -465,8 +439,6 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -518,8 +490,6 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -571,8 +541,6 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -602,8 +570,6 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -655,8 +621,6 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -696,8 +660,6 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -749,8 +711,6 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -802,8 +762,6 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -833,8 +791,6 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -874,8 +830,6 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         } else {
             coin::destroy_zero(coin::from_balance(l16, l9))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -927,8 +881,6 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         } else {
             coin::destroy_zero(coin::from_balance(l19, l11))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -980,8 +932,6 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -1011,8 +961,6 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1064,8 +1012,6 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         } else {
             coin::destroy_zero(coin::from_balance(l26, l15))
         }
-    } else {
-        
     };
     if (l11) {
         let l27 = pool::collect_reward(l1, l3, option::borrow(&l0.position_nft), l2, true, l14);
@@ -1095,8 +1041,6 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         } else {
             coin::destroy_zero(coin::from_balance(l27, l15))
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1119,8 +1063,6 @@ public fun collect_reward_without_swap<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1143,8 +1085,6 @@ public fun collect_reward_without_swap_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
         }
-    } else {
-        
     };
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
 }
@@ -1157,21 +1097,17 @@ public fun get_max_reinvestor_bounty_bps<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>
 fun get_mkt_sell_amount(l0: u64, l1: u64, l2: u64): u64 {
     if (l0 == 0u64) {
         return 0u64
+    };
+    let l3 = if (l1 > 0u64) {
+        l2 > 0u64
     } else {
-        let l3 = if (l1 > 0u64) {
-            l2 > 0u64
-        } else {
-            false
-        };
-        if (l3) {
-            let l4 = l0 * 9980u64;
-            let l6 = l4as u128 * l2as u128;
-            let l5 = l1as u128 * 10000u128 + l4as u128;
-            return l6 / l5as u64
-        } else {
-            abort C5
-        }
-    }
+        false
+    };
+    assert!(l3, C5);
+    let l4 = l0 * 9980u64;
+    let l6 = l4as u128 * l2as u128;
+    let l5 = l1as u128 * 10000u128 + l4as u128;
+    return l6 / l5as u64
 }
 
 public fun get_mole_cetus_worker_addr(): address {
@@ -1194,8 +1130,6 @@ public fun health<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T0, T1>, l2
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-    } else {
-        
     };
     let l9 = position::liquidity(option::borrow(&l0.position_nft));
     let l6 = cetus_clmm_worker::share_to_balance_inner(l9, *(&l0.total_share), l7);
@@ -1225,8 +1159,6 @@ public fun health_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T1,
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-    } else {
-        
     };
     let l9 = position::liquidity(option::borrow(&l0.position_nft));
     let l6 = cetus_clmm_worker::share_to_balance_inner(l9, *(&l0.total_share), l7);
@@ -1257,51 +1189,33 @@ fun init(l0: &mut TxContext) {
 public entry fun initialize<T0, T1, T2>(l0: &AdminCap, l1: &x5_AdminCap, l2: &x3_AdminCap, l3: &mut GlobalStorage, l4: &mut WorkerInfoStore, l5: &CoinMetadata<T0>, l6: &CoinMetadata<T1>, l7: &GlobalConfig, l8: &mut Pool<T0, T1>, l9: address, l10: u64, l11: address, l12: u64, l13: u32, l14: u32, l15: &mut TxContext) {
     let l18 = cetus_clmm_worker::get_mole_cetus_worker_addr();
     let l16 = l18;
-    if (!(worker_config::is_worker_info_registered(freeze(l4), l16))) {
-        if (vault::is_vault_initialized(freeze(l3))) {
-            let l20 = vault::acquire_position_operator_cap(l1);
-            let l17 = C44;
-            if (l10 <= l17) {
-                let l19 = pool::open_position(l7, l8, l13, l14, l15);
-                let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
-                let l22 = object::uid_to_address(&(&l21).id);
-                transfer::share_object(l21);
-                worker_config::register_worker_info(l2, l4, l18);
-                event::emit(InitializeEvent { worker_info: l22 })
-            } else {
-                abort C14
-            }
-        } else {
-            abort C12
-        }
-    } else {
-        abort C1
-    }
+    assert!(!(worker_config::is_worker_info_registered(freeze(l4), l16)), C1);
+    assert!(vault::is_vault_initialized(freeze(l3)), C12);
+    let l20 = vault::acquire_position_operator_cap(l1);
+    let l17 = C44;
+    assert!(l10 <= l17, C14);
+    let l19 = pool::open_position(l7, l8, l13, l14, l15);
+    let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
+    let l22 = object::uid_to_address(&(&l21).id);
+    transfer::share_object(l21);
+    worker_config::register_worker_info(l2, l4, l18);
+    event::emit(InitializeEvent { worker_info: l22 })
 }
 
 public entry fun initialize_reverse<T0, T1, T2>(l0: &AdminCap, l1: &x5_AdminCap, l2: &x3_AdminCap, l3: &mut GlobalStorage, l4: &mut WorkerInfoStore, l5: &CoinMetadata<T0>, l6: &CoinMetadata<T1>, l7: &GlobalConfig, l8: &mut Pool<T1, T0>, l9: address, l10: u64, l11: address, l12: u64, l13: u32, l14: u32, l15: &mut TxContext) {
     let l18 = cetus_clmm_worker::get_mole_cetus_worker_addr();
     let l16 = l18;
-    if (!(worker_config::is_worker_info_registered(freeze(l4), l16))) {
-        if (vault::is_vault_initialized(freeze(l3))) {
-            let l20 = vault::acquire_position_operator_cap(l1);
-            let l17 = C44;
-            if (l10 <= l17) {
-                let l19 = pool::open_position(l7, l8, l13, l14, l15);
-                let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
-                let l22 = object::uid_to_address(&(&l21).id);
-                transfer::share_object(l21);
-                worker_config::register_worker_info(l2, l4, l18);
-                event::emit(InitializeEvent { worker_info: l22 })
-            } else {
-                abort C14
-            }
-        } else {
-            abort C12
-        }
-    } else {
-        abort C1
-    }
+    assert!(!(worker_config::is_worker_info_registered(freeze(l4), l16)), C1);
+    assert!(vault::is_vault_initialized(freeze(l3)), C12);
+    let l20 = vault::acquire_position_operator_cap(l1);
+    let l17 = C44;
+    assert!(l10 <= l17, C14);
+    let l19 = pool::open_position(l7, l8, l13, l14, l15);
+    let l21 = WorkerInfo { id: object::new(l15), reinvest_bounty_bps: l10, max_reinvest_bounty_bps: l17, ok_reinvestors: table::new(l15), ok_rebalancers: table::new(l15), ok_strategies: table::new(l15), treasury_account: l11, reinvest_path: vector[], reinvest_threshold: l12, shares: table::new(l15), total_share: 0u128, config: l9, position_nft: option::some(l19), position_operator_cap: l20, coin_base_decimals: coin::get_decimals(l5), coin_farming_decimals: coin::get_decimals(l6), tiny_coin_base: balance::zero(), tiny_coin_farming: balance::zero(), pool_id: object::id(freeze(l8)), package_version: C2, tiny_coin_base_bounty: balance::zero(), tiny_coin_farming_bounty: balance::zero() };
+    let l22 = object::uid_to_address(&(&l21).id);
+    transfer::share_object(l21);
+    worker_config::register_worker_info(l2, l4, l18);
+    event::emit(InitializeEvent { worker_info: l22 })
 }
 
 public fun is_rebalancer<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: address): bool {
@@ -1343,21 +1257,19 @@ public fun is_stable<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &GlobalStorage
     let l12 = cetus_clmm_worker::now_seconds(l5);
     if (l8 + 86400u64 <= l12) {
         return false
+    };
+    let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
+    let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
+    let l11 = worker_config::get_max_price_diff_scale();
+    let l6 = if (l9 * l11 > l14 * l10) {
+        true
     } else {
-        let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
-        let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
-        let l11 = worker_config::get_max_price_diff_scale();
-        let l6 = if (l9 * l11 > l14 * l10) {
-            true
-        } else {
-            l9 * l10 < l14 * l11
-        };
-        if (l6) {
-            return false
-        } else {
-            return true
-        }
-    }
+        l9 * l10 < l14 * l11
+    };
+    if (l6) {
+        return false
+    };
+    return true
 }
 
 public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &GlobalStorage, l2: &Pool<T1, T0>, l3: &Aggregator, l4: &Aggregator, l5: &Clock): bool {
@@ -1373,21 +1285,19 @@ public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Globa
     let l12 = cetus_clmm_worker::now_seconds(l5);
     if (l8 + 86400u64 <= l12) {
         return false
+    };
+    let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
+    let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
+    let l11 = worker_config::get_max_price_diff_scale();
+    let l6 = if (l9 * l11 > l14 * l10) {
+        true
     } else {
-        let l9 = l16 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / l15 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
-        let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
-        let l11 = worker_config::get_max_price_diff_scale();
-        let l6 = if (l9 * l11 > l14 * l10) {
-            true
-        } else {
-            l9 * l10 < l14 * l11
-        };
-        if (l6) {
-            return false
-        } else {
-            return true
-        }
-    }
+        l9 * l10 < l14 * l11
+    };
+    if (l6) {
+        return false
+    };
+    return true
 }
 
 public fun is_strategy_ok<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u8): bool {
@@ -1462,12 +1372,9 @@ fun liquidate<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Pool<T0, T1>
     let (reg_17, reg_18) = cetus_clmm_worker::strategy_execute(l0, l2, l1, coin::zero(l5), coin::zero(l5), l6, 0u64, C39, coder::encode_u64(0u64), l4, l5);
     let l8 = reg_18;
     let l7 = reg_17;
-    if (coin::value(&l8) == 0u64) {
-        coin::destroy_zero(l8);
-        return l7
-    } else {
-        abort C23
-    }
+    assert!(coin::value(&l8) == 0u64, C23);
+    coin::destroy_zero(l8);
+    return l7
 }
 
 fun liquidate_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Pool<T1, T0>, l2: &GlobalConfig, l3: u64, l4: &Clock, l5: &mut TxContext): Coin<T0> {
@@ -1475,12 +1382,9 @@ fun liquidate_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Pool
     let (reg_17, reg_18) = cetus_clmm_worker::strategy_execute_reverse(l0, l2, l1, coin::zero(l5), coin::zero(l5), l6, 0u64, C39, coder::encode_u64(0u64), l4, l5);
     let l8 = reg_18;
     let l7 = reg_17;
-    if (coin::value(&l8) == 0u64) {
-        coin::destroy_zero(l8);
-        return l7
-    } else {
-        abort C23
-    }
+    assert!(coin::value(&l8) == 0u64, C23);
+    coin::destroy_zero(l8);
+    return l7
 }
 
 fun now_seconds(l0: &Clock): u64 {
@@ -1523,130 +1427,104 @@ public entry fun rebalance_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
 
 fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
-    if (cetus_clmm_worker::is_rebalancer(freeze(l0), l11)) {
-        let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-        let l25 = reg_17;
-        let l12 = if (i32::as_u32(reg_16) == l3) {
-            i32::as_u32(l25) == l4
+    assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
+    let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
+    let l25 = reg_17;
+    let l12 = if (i32::as_u32(reg_16) == l3) {
+        i32::as_u32(l25) == l4
+    } else {
+        false
+    };
+    assert!(!(l12), C25);
+    let (l13, l14);
+    let l23 = pool::open_position(l1, l2, l3, l4, l10);
+    let l24 = option::extract(&mut l0.position_nft);
+    let l21 = position::liquidity(&l24);
+    l13 = if (l21 > 0u128) {
+        let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
+        l14 = reg_53;
+        reg_52
+    } else {
+        l14 = balance::zero();
+        balance::zero()
+    };
+    let l18 = l14;
+    let l17 = l13;
+    pool::close_position(l1, l2, l24);
+    option::fill(&mut l0.position_nft, l23);
+    let l15 = if (balance::value(&l17) > 0u64) {
+        true
+    } else {
+        balance::value(&l18) > 0u64
+    };
+    if (l15) {
+        let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
+        let l20 = reg_100;
+        let l19 = reg_99;
+        let l16 = if (coin::value(&l19) <= l6) {
+            coin::value(&l20) <= l7
         } else {
             false
         };
-        if (l12) {
-            abort C25
-        } else {
-            let (l13, l14);
-            let l23 = pool::open_position(l1, l2, l3, l4, l10);
-            let l24 = option::extract(&mut l0.position_nft);
-            let l21 = position::liquidity(&l24);
-            l13 = if (l21 > 0u128) {
-                let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
-                l14 = reg_53;
-                reg_52
-            } else {
-                l14 = balance::zero();
-                balance::zero()
-            };
-            let l18 = l14;
-            let l17 = l13;
-            pool::close_position(l1, l2, l24);
-            option::fill(&mut l0.position_nft, l23);
-            let l15 = if (balance::value(&l17) > 0u64) {
-                true
-            } else {
-                balance::value(&l18) > 0u64
-            };
-            if (l15) {
-                let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-                let l20 = reg_100;
-                let l19 = reg_99;
-                let l16 = if (coin::value(&l19) <= l6) {
-                    coin::value(&l20) <= l7
-                } else {
-                    false
-                };
-                if (l16) {
-                    
-                } else {
-                    abort C26
-                }
-            } else {
-                balance::destroy_zero(l17);
-                balance::destroy_zero(l18)
-            };
-            let l22 = position::liquidity(option::borrow(&l0.position_nft));
-            if (l22 >= l5) {
-                event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
-            } else {
-                abort C27
-            }
-        }
+        assert!(l16, C26)
     } else {
-        abort C31
-    }
+        balance::destroy_zero(l17);
+        balance::destroy_zero(l18)
+    };
+    let l22 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l22 >= l5, C27);
+    event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
 }
 
 fun rebalance_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
-    if (cetus_clmm_worker::is_rebalancer(freeze(l0), l11)) {
-        let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-        let l25 = reg_17;
-        let l12 = if (i32::as_u32(reg_16) == l3) {
-            i32::as_u32(l25) == l4
+    assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
+    let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
+    let l25 = reg_17;
+    let l12 = if (i32::as_u32(reg_16) == l3) {
+        i32::as_u32(l25) == l4
+    } else {
+        false
+    };
+    assert!(!(l12), C25);
+    let (l13, l14);
+    let l23 = pool::open_position(l1, l2, l3, l4, l10);
+    let l24 = option::extract(&mut l0.position_nft);
+    let l21 = position::liquidity(&l24);
+    l13 = if (l21 > 0u128) {
+        let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
+        l14 = reg_53;
+        reg_52
+    } else {
+        l14 = balance::zero();
+        balance::zero()
+    };
+    let l17 = l14;
+    let l18 = l13;
+    pool::close_position(l1, l2, l24);
+    option::fill(&mut l0.position_nft, l23);
+    let l15 = if (balance::value(&l17) > 0u64) {
+        true
+    } else {
+        balance::value(&l18) > 0u64
+    };
+    if (l15) {
+        let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
+        let l20 = reg_100;
+        let l19 = reg_99;
+        let l16 = if (coin::value(&l19) <= l6) {
+            coin::value(&l20) <= l7
         } else {
             false
         };
-        if (l12) {
-            abort C25
-        } else {
-            let (l13, l14);
-            let l23 = pool::open_position(l1, l2, l3, l4, l10);
-            let l24 = option::extract(&mut l0.position_nft);
-            let l21 = position::liquidity(&l24);
-            l13 = if (l21 > 0u128) {
-                let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
-                l14 = reg_53;
-                reg_52
-            } else {
-                l14 = balance::zero();
-                balance::zero()
-            };
-            let l17 = l14;
-            let l18 = l13;
-            pool::close_position(l1, l2, l24);
-            option::fill(&mut l0.position_nft, l23);
-            let l15 = if (balance::value(&l17) > 0u64) {
-                true
-            } else {
-                balance::value(&l18) > 0u64
-            };
-            if (l15) {
-                let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-                let l20 = reg_100;
-                let l19 = reg_99;
-                let l16 = if (coin::value(&l19) <= l6) {
-                    coin::value(&l20) <= l7
-                } else {
-                    false
-                };
-                if (l16) {
-                    
-                } else {
-                    abort C26
-                }
-            } else {
-                balance::destroy_zero(l17);
-                balance::destroy_zero(l18)
-            };
-            let l22 = position::liquidity(option::borrow(&l0.position_nft));
-            if (l22 >= l5) {
-                event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
-            } else {
-                abort C27
-            }
-        }
+        assert!(l16, C26)
     } else {
-        abort C31
-    }
+        balance::destroy_zero(l17);
+        balance::destroy_zero(l18)
+    };
+    let l22 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l22 >= l5, C27);
+    event::emit(RebalanceEvent { tick_lower_idx: l3, tick_upper_idx: l4, liquidity_before: l21, liquidity_after: l22 })
 }
 
 public entry fun rebalance_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut RewarderGlobalVault, l3: &mut Pool<T0, T1>, l4: &mut Pool<T0, T3>, l5: &mut Pool<T1, T3>, l6: bool, l7: bool, l8: bool, l9: u32, l10: u32, l11: u128, l12: u64, l13: u64, l14: vector<u8>, l15: bool, l16: &Clock, l17: &mut TxContext) {
@@ -1735,78 +1613,54 @@ public entry fun reinvest_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
 
 fun reinvest_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
-    if (cetus_clmm_worker::is_reinvestor(freeze(l0), l9)) {
-        let l16 = position::liquidity(option::borrow(&l0.position_nft));
-        let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
-        let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-        let l10 = if (balance::value(&l12) == 0u64) {
-            balance::value(&l13) == 0u64
-        } else {
-            false
-        };
-        if (l10) {
-            abort C28
-        } else {
-            let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-            let l15 = reg_55;
-            let l14 = reg_54;
-            let l11 = if (coin::value(&l14) <= l4) {
-                coin::value(&l15) <= l5
-            } else {
-                false
-            };
-            if (l11) {
-                let l17 = position::liquidity(option::borrow(&l0.position_nft));
-                if (l17 >= l16 + l3) {
-                    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
-                } else {
-                    abort C27
-                }
-            } else {
-                abort C26
-            }
-        }
+    assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
+    let l16 = position::liquidity(option::borrow(&l0.position_nft));
+    let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
+    let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
+    let l10 = if (balance::value(&l12) == 0u64) {
+        balance::value(&l13) == 0u64
     } else {
-        abort C19
-    }
+        false
+    };
+    assert!(!(l10), C28);
+    let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
+    let l15 = reg_55;
+    let l14 = reg_54;
+    let l11 = if (coin::value(&l14) <= l4) {
+        coin::value(&l15) <= l5
+    } else {
+        false
+    };
+    assert!(l11, C26);
+    let l17 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l17 >= l16 + l3, C27);
+    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
 }
 
 fun reinvest_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
-    if (cetus_clmm_worker::is_reinvestor(freeze(l0), l9)) {
-        let l16 = position::liquidity(option::borrow(&l0.position_nft));
-        let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
-        let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-        let l10 = if (balance::value(&l12) == 0u64) {
-            balance::value(&l13) == 0u64
-        } else {
-            false
-        };
-        if (l10) {
-            abort C28
-        } else {
-            let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-            let l15 = reg_55;
-            let l14 = reg_54;
-            let l11 = if (coin::value(&l14) <= l4) {
-                coin::value(&l15) <= l5
-            } else {
-                false
-            };
-            if (l11) {
-                let l17 = position::liquidity(option::borrow(&l0.position_nft));
-                if (l17 >= l16 + l3) {
-                    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
-                } else {
-                    abort C27
-                }
-            } else {
-                abort C26
-            }
-        }
+    assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
+    let l16 = position::liquidity(option::borrow(&l0.position_nft));
+    let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
+    let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
+    let l10 = if (balance::value(&l12) == 0u64) {
+        balance::value(&l13) == 0u64
     } else {
-        abort C19
-    }
+        false
+    };
+    assert!(!(l10), C28);
+    let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
+    let l15 = reg_55;
+    let l14 = reg_54;
+    let l11 = if (coin::value(&l14) <= l4) {
+        coin::value(&l15) <= l5
+    } else {
+        false
+    };
+    assert!(l11, C26);
+    let l17 = position::liquidity(option::borrow(&l0.position_nft));
+    assert!(l17 >= l16 + l3, C27);
+    event::emit(ReinvestEvent { liquidity_before: l16, liquidity_after: l17 })
 }
 
 public entry fun reinvest_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut RewarderGlobalVault, l3: &mut Pool<T0, T1>, l4: &mut Pool<T0, T3>, l5: &mut Pool<T1, T3>, l6: bool, l7: bool, l8: bool, l9: u128, l10: u64, l11: u64, l12: vector<u8>, l13: bool, l14: &Clock, l15: &mut TxContext) {
@@ -1877,22 +1731,15 @@ fun remove_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64): u128 {
             *(&mut l0.total_share) = *(&l0.total_share) - l3;
             *(table::borrow_mut(&mut l0.shares, l1)) = 0u128;
             return l2
-        } else {
-            
         }
-    } else {
-        
     };
     return 0u128
 }
 
 public entry fun set_max_reinvestor_bounty_bps<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: u64) {
     cetus_clmm_worker::checked_package_version(freeze(l1));
-    if (l2 >= *(&l1.reinvest_bounty_bps)) {
-        *(&mut l1.max_reinvest_bounty_bps) = l2
-    } else {
-        abort C15
-    }
+    assert!(l2 >= *(&l1.reinvest_bounty_bps), C15);
+    *(&mut l1.max_reinvest_bounty_bps) = l2
 }
 
 public entry fun set_rebalancers_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: vector<address>, l3: bool) {
@@ -1919,11 +1766,8 @@ public entry fun set_reinvest_threshold<T0, T1, T2>(l0: &AdminCap, l1: &mut Work
 
 public entry fun set_reinvestor_bounty_bps<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: u64) {
     cetus_clmm_worker::checked_package_version(freeze(l1));
-    if (l2 <= *(&l1.max_reinvest_bounty_bps)) {
-        *(&mut l1.reinvest_bounty_bps) = l2
-    } else {
-        abort C14
-    }
+    assert!(l2 <= *(&l1.max_reinvest_bounty_bps), C14);
+    *(&mut l1.reinvest_bounty_bps) = l2
 }
 
 public entry fun set_reinvestor_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: address, l3: bool) {
@@ -1995,9 +1839,8 @@ public fun share_to_balance<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u128): 
 fun share_to_balance_inner<T0>(l0: u128, l1: u128, l2: u128): u128 {
     if (l1 == 0u128) {
         return l2
-    } else {
-        return mole_math::mul_div_u128(l2, l0, l1)
-    }
+    };
+    return mole_math::mul_div_u128(l2, l0, l1)
 }
 
 fun strategy_execute<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: Coin<T0>, l4: Coin<T1>, l5: u128, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): ( Coin<T0>, Coin<T1>) {
@@ -2005,34 +1848,26 @@ fun strategy_execute<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalCon
     if (l7 == C37) {
         let (reg_20, reg_21) = cetus_clmm_strategy_add_base_coin_only::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
         return (reg_20, reg_21)
-    } else {
-        if (l7 == C38) {
-            let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-            return (reg_39, reg_40)
-        } else {
-            if (l7 == C39) {
-                let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                return (reg_58, reg_59)
-            } else {
-                if (l7 == C40) {
-                    let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                    return (reg_77, reg_78)
-                } else {
-                    if (l7 == C41) {
-                        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                        return (reg_96, reg_97)
-                    } else {
-                        if (l7 == C42) {
-                            let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                            return (reg_115, reg_116)
-                        } else {
-                            abort C4
-                        }
-                    }
-                }
-            }
-        }
-    }
+    };
+    if (l7 == C38) {
+        let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_39, reg_40)
+    };
+    if (l7 == C39) {
+        let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_58, reg_59)
+    };
+    if (l7 == C40) {
+        let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_77, reg_78)
+    };
+    if (l7 == C41) {
+        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_96, reg_97)
+    };
+    assert!(l7 == C42, C4);
+    let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+    return (reg_115, reg_116)
 }
 
 fun strategy_execute_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: Coin<T0>, l4: Coin<T1>, l5: u128, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): ( Coin<T0>, Coin<T1>) {
@@ -2040,34 +1875,26 @@ fun strategy_execute_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &G
     if (l7 == C37) {
         let (reg_20, reg_21) = cetus_clmm_strategy_add_base_coin_only::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
         return (reg_20, reg_21)
-    } else {
-        if (l7 == C38) {
-            let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-            return (reg_39, reg_40)
-        } else {
-            if (l7 == C39) {
-                let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                return (reg_58, reg_59)
-            } else {
-                if (l7 == C40) {
-                    let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                    return (reg_77, reg_78)
-                } else {
-                    if (l7 == C41) {
-                        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                        return (reg_96, reg_97)
-                    } else {
-                        if (l7 == C42) {
-                            let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
-                            return (reg_115, reg_116)
-                        } else {
-                            abort C4
-                        }
-                    }
-                }
-            }
-        }
-    }
+    };
+    if (l7 == C38) {
+        let (reg_39, reg_40) = cetus_clmm_strategy_add_two_sides_optimal::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_39, reg_40)
+    };
+    if (l7 == C39) {
+        let (reg_58, reg_59) = cetus_clmm_strategy_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_58, reg_59)
+    };
+    if (l7 == C40) {
+        let (reg_77, reg_78) = cetus_clmm_strategy_withdraw_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_77, reg_78)
+    };
+    if (l7 == C41) {
+        let (reg_96, reg_97) = cetus_clmm_strategy_partial_close_liquidate::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+        return (reg_96, reg_97)
+    };
+    assert!(l7 == C42, C4);
+    let (reg_115, reg_116) = cetus_clmm_strategy_partial_close_minimize_trading::execute_reverse(l1, l2, l3, l4, l5, l11, l6, l8, &mut l0.tiny_coin_base, &mut l0.tiny_coin_farming, l9, l10);
+    return (reg_115, reg_116)
 }
 
 entry fun upgrade_package_version<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<T0, T1, T2>, l2: u64) {
@@ -2080,15 +1907,8 @@ public entry fun withdraw_rewards_bounty<T0, T1, T2>(l0: &AdminCap, l1: &mut Wor
         l3 = balance::value(&l1.tiny_coin_base_bounty);
         l4 = balance::value(&l1.tiny_coin_farming_bounty);
     } else {
-        if (l3 <= balance::value(&l1.tiny_coin_base_bounty)) {
-            if (l4 <= balance::value(&l1.tiny_coin_farming_bounty)) {
-                
-            } else {
-                abort C34
-            }
-        } else {
-            abort C33
-        }
+        assert!(l3 <= balance::value(&l1.tiny_coin_base_bounty), C33);
+        assert!(l4 <= balance::value(&l1.tiny_coin_farming_bounty), C34)
     };
     let l6 = balance::split(&mut l1.tiny_coin_base_bounty, l3);
     let l7 = balance::split(&mut l1.tiny_coin_farming_bounty, l4);
@@ -2111,26 +1931,20 @@ fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l
     } else {
         false
     };
-    if (l11) {
-        if (object::id(freeze(l2)) == *(&l0.pool_id)) {
-            let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
-            let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
-            let l16 = reg_52;
-            let l15 = reg_51;
-            let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
-            if (coin::value(&l16) == 0u64) {
-                coin::destroy_zero(l16)
-            } else {
-                pay::keep(l16, freeze(l10))
-            };
-            cetus_clmm_worker::add_share(l0, l3, l13, l14);
-            return l15
-        } else {
-            abort C24
-        }
+    assert!(l11, C21);
+    assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
+    let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
+    let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
+    let l16 = reg_52;
+    let l15 = reg_51;
+    let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
+    if (coin::value(&l16) == 0u64) {
+        coin::destroy_zero(l16)
     } else {
-        abort C21
-    }
+        pay::keep(l16, freeze(l10))
+    };
+    cetus_clmm_worker::add_share(l0, l3, l13, l14);
+    return l15
 }
 
 fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u64, l4: Coin<T0>, l5: Coin<T1>, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): Coin<T0> {
@@ -2141,26 +1955,20 @@ fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalC
     } else {
         false
     };
-    if (l11) {
-        if (object::id(freeze(l2)) == *(&l0.pool_id)) {
-            let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
-            let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
-            let l16 = reg_52;
-            let l15 = reg_51;
-            let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
-            if (coin::value(&l16) == 0u64) {
-                coin::destroy_zero(l16)
-            } else {
-                pay::keep(l16, freeze(l10))
-            };
-            cetus_clmm_worker::add_share(l0, l3, l13, l14);
-            return l15
-        } else {
-            abort C24
-        }
+    assert!(l11, C21);
+    assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
+    let l14 = position::liquidity(option::borrow(&l0.position_nft)) - l12;
+    let (reg_51, reg_52) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, l4, l5, l12, l6, l7, l8, l9, l10);
+    let l16 = reg_52;
+    let l15 = reg_51;
+    let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
+    if (coin::value(&l16) == 0u64) {
+        coin::destroy_zero(l16)
     } else {
-        abort C21
-    }
+        pay::keep(l16, freeze(l10))
+    };
+    cetus_clmm_worker::add_share(l0, l3, l13, l14);
+    return l15
 }
 
 public entry fun work_none<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut GlobalStorage, l2: &mut Storage, l3: &GlobalConfig, l4: &mut Pool<T0, T1>, l5: u64, l6: u64, l7: u64, l8: u8, l9: vector<u8>, l10: &Aggregator, l11: &Aggregator, l12: &Clock, l13: &mut TxContext) {
@@ -2225,8 +2033,6 @@ public entry fun work_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &m
         let l28 = l4;
         let l27 = l0;
         vault::set_work_context_health(l16, cetus_clmm_worker::health(freeze(l27), freeze(l28), l29))
-    } else {
-        
     };
     let l21 = l14;
     let l20 = l13;
@@ -2268,8 +2074,6 @@ public entry fun work_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>
         let l28 = l4;
         let l27 = l0;
         vault::set_work_context_health(l16, cetus_clmm_worker::health_reverse(freeze(l27), freeze(l28), l29))
-    } else {
-        
     };
     let l21 = l14;
     let l20 = l13;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5c00961b77fad9e563bbf817c5cf8f49f7db8aa7b12bf6799ee00a837816a3d8/nft_claim.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5c00961b77fad9e563bbf817c5cf8f49f7db8aa7b12bf6799ee00a837816a3d8/nft_claim.move
@@ -81,12 +81,9 @@ public entry fun mint_batch(l0: &mut ClaimCap, l1: vector<address>, l2: &mut TxC
 }
 
 public fun mint_single(l0: &mut ClaimCap, l1: address, l2: &mut TxContext) {
-    if (!(vec_set::contains(&l0.claimed, &l1))) {
-        let l3 = DEEPClaimNFT { id: object::new(l2), name: string::utf8(C3), description: string::utf8(C4), image_url: string::utf8(C5) };
-        vec_set::insert(&mut l0.claimed, l1);
-        transfer::transfer(l3, l1)
-    } else {
-        abort 0u64
-    }
+    assert!(!(vec_set::contains(&l0.claimed, &l1)), 0u64);
+    let l3 = DEEPClaimNFT { id: object::new(l2), name: string::utf8(C3), description: string::utf8(C4), image_url: string::utf8(C5) };
+    vec_set::insert(&mut l0.claimed, l1);
+    transfer::transfer(l3, l1)
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
@@ -34,10 +34,9 @@ public fun cao_s<T0, T1>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &Tr
     let l7 = sq::css(l4, l5, true, false, l6);
     if (l7 != ct::e_no_error()) {
         return l7
-    } else {
-        pool::cancel_all_orders(l0, l1, l2, l3, l6);
-        return 0u64
-    }
+    };
+    pool::cancel_all_orders(l0, l1, l2, l3, l6);
+    return 0u64
 }
 
 public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &TradeProof, l3: &Clock, l4: u64, l5: &mut TxContext): Coin<T2> {
@@ -117,77 +116,73 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                 event::emit(EE { e: ct::e_order_expired(), l: 348u64 });
                 l28 = l28 + 1u64;
                 continue
-            } else {
-                let l34 = *(&(&l9)[l28]);
-                let l47 = *(&(&l10)[l28]);
-                let l27 = *(&(&l11)[l28]);
-                let l40 = *(&(&l12)[l28]);
-                let l29 = *(&(&l13)[l28]);
-                if (l29) {
-                    if (l44 <= l8) {
-                        event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    }
-                } else {
-                    if (l21 < u64::max(l32, l7)) {
-                        event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    }
-                };
-                let l30 = dbke::cim(l34);
-                let l37 = l27;
-                if (l34 == ct::cpsos()) {
-                    if (!(l50)) {
-                        let (reg_134, reg_136);
-                        (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
-                        let l18 = reg_136;
-                        l22 = reg_134;
-                        l19 = l18;
-                        l50 = true;
-                    };
-                    let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
-                    if (l49 == 0u64) {
-                        event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    } else {
-                        l37 = l49;
-                        l34 = constants::post_only();
-                    }
-                } else {
-                    let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
-                    let l24 = reg_171;
-                    let l53 = reg_170;
-                    if (l24 != ct::e_no_error()) {
-                        event::emit(EE { e: l24, l: 404u64 });
-                        l28 = l28 + 1u64;
-                        continue
-                    } else {
-                        let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
-                        let l35 = order_info::original_quantity(&l33);
-                        let l25 = order_info::executed_quantity(&l33);
-                        let l36 = order_info::paid_fees(&l33);
-                        l44 = if (l29) {
-                            let l41 = l35as u128;
-                            let l38 = l37as u128;
-                            let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
-                            l21 = l21 + l25;
-                            l44 - l46as u64
-                        } else {
-                            let l42 = l25as u128;
-                            let l39 = l37as u128;
-                            let l45 = l42 * l39 / constants::float_scaling_u128();
-                            l21 = l21 - l35;
-                            l44 + l45as u64
-                        };
-                        l23 = l23 - l36;
-                        l28 = l28 + 1u64;
-                        continue
-                    }
+            };
+            let l34 = *(&(&l9)[l28]);
+            let l47 = *(&(&l10)[l28]);
+            let l27 = *(&(&l11)[l28]);
+            let l40 = *(&(&l12)[l28]);
+            let l29 = *(&(&l13)[l28]);
+            if (l29) {
+                if (l44 <= l8) {
+                    event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
+                    l28 = l28 + 1u64;
+                    continue
                 }
-            }
+            } else {
+                if (l21 < u64::max(l32, l7)) {
+                    event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
+                    l28 = l28 + 1u64;
+                    continue
+                }
+            };
+            let l30 = dbke::cim(l34);
+            let l37 = l27;
+            if (!(l34 == ct::cpsos())) {
+                let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
+                let l24 = reg_171;
+                let l53 = reg_170;
+                if (l24 != ct::e_no_error()) {
+                    event::emit(EE { e: l24, l: 404u64 });
+                    l28 = l28 + 1u64;
+                    continue
+                };
+                let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
+                let l35 = order_info::original_quantity(&l33);
+                let l25 = order_info::executed_quantity(&l33);
+                let l36 = order_info::paid_fees(&l33);
+                l44 = if (l29) {
+                    let l41 = l35as u128;
+                    let l38 = l37as u128;
+                    let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
+                    l21 = l21 + l25;
+                    l44 - l46as u64
+                } else {
+                    let l42 = l25as u128;
+                    let l39 = l37as u128;
+                    let l45 = l42 * l39 / constants::float_scaling_u128();
+                    l21 = l21 - l35;
+                    l44 + l45as u64
+                };
+                l23 = l23 - l36;
+                l28 = l28 + 1u64;
+                continue
+            };
+            if (!(l50)) {
+                let (reg_134, reg_136);
+                (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
+                let l18 = reg_136;
+                l22 = reg_134;
+                l19 = l18;
+                l50 = true;
+            };
+            let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
+            if (l49 == 0u64) {
+                event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
+                l28 = l28 + 1u64;
+                continue
+            };
+            l37 = l49;
+            l34 = constants::post_only();
         }
     }
 }
@@ -195,108 +190,92 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
 fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
-    } else {
-        let l5;
-        let l6 = l4;
-        if (*(&l6)) {
-            if (l1.len() == 0u64) {
-                return l3
-            } else {
-                let l8 = *(&l1[0u64]);
-                if (l3 < l8) {
-                    return l3
-                } else {
-                    let l9 = l8 - l2;
-                    if (l9 < l2) {
-                        return 0u64
-                    } else {
-                        l5 = l9;
-                    }
-                }
-            }
-        } else {
-            if (l0.len() == 0u64) {
-                return l3
-            } else {
-                let l7 = *(&l0[0u64]);
-                if (l3 > l7) {
-                    return l3
-                } else {
-                    let l10 = l7 + l2;
-                    if (l10 > constants::max_u64() - l2) {
-                        return 0u64
-                    } else {
-                        l5 = l10;
-                    }
-                }
-            }
+    };
+    let l6 = l4;
+    let l5 = if (*(&l6)) {
+        if (l1.len() == 0u64) {
+            return l3
         };
-        return l5
-    }
+        let l8 = *(&l1[0u64]);
+        if (l3 < l8) {
+            return l3
+        };
+        let l9 = l8 - l2;
+        if (l9 < l2) {
+            return 0u64
+        };
+        l9
+    } else {
+        if (l0.len() == 0u64) {
+            return l3
+        };
+        let l7 = *(&l0[0u64]);
+        if (l3 > l7) {
+            return l3
+        };
+        let l10 = l7 + l2;
+        if (l10 > constants::max_u64() - l2) {
+            return 0u64
+        };
+        l10
+    };
+    return l5
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
     if (l7 == 0u64) {
         return (0u64, ct::e_invalid_price())
+    };
+    if (l7 % l4 != 0u64) {
+        return (0u64, ct::e_invalid_price())
+    };
+    let l12 = if (!(l9)) {
+        l1 < l6
     } else {
-        if (l7 % l4 != 0u64) {
-            return (0u64, ct::e_invalid_price())
+        false
+    };
+    if (l12) {
+        return (0u64, ct::e_insufficient_base_balance())
+    };
+    if (l8 < l6) {
+        return (0u64, ct::e_insufficient_quantity())
+    };
+    let l16 = l9;
+    let l15 = if (*(&l16)) {
+        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
+        let l21 = l25 % l5 + l5;
+        if (l25 < l21) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l22 = l25 - l21;
+        if (l22 < l6) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l19 = u64::max(l6, u64::min(l8, l22as u64));
+        l19 - l19 % l5
+    } else {
+        let l20 = u64::max(l6, u64::min(l8, l1));
+        l20 - l20 % l5
+    };
+    let l26 = l15;
+    let l17 = l11;
+    let l14 = if (*(&l17)) {
+        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
+        let l23 = reg_90;
+        let l24 = reg_89;
+        let l18 = l10;
+        let l13 = if (*(&l18)) {
+            l23
         } else {
-            let l12 = if (!(l9)) {
-                l1 < l6
-            } else {
-                false
-            };
-            if (l12) {
-                return (0u64, ct::e_insufficient_base_balance())
-            } else {
-                if (l8 < l6) {
-                    return (0u64, ct::e_insufficient_quantity())
-                } else {
-                    let l15;
-                    let l16 = l9;
-                    if (*(&l16)) {
-                        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
-                        let l21 = l25 % l5 + l5;
-                        if (l25 < l21) {
-                            return (0u64, ct::e_insufficient_quote_balance())
-                        } else {
-                            let l22 = l25 - l21;
-                            if (l22 < l6) {
-                                return (0u64, ct::e_insufficient_quote_balance())
-                            } else {
-                                let l19 = u64::max(l6, u64::min(l8, l22as u64));
-                                l15 = l19 - l19 % l5;
-                            }
-                        }
-                    } else {
-                        let l20 = u64::max(l6, u64::min(l8, l1));
-                        l15 = l20 - l20 % l5;
-                    };
-                    let l26 = l15;
-                    let l17 = l11;
-                    let l14 = if (*(&l17)) {
-                        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-                        let l23 = reg_90;
-                        let l24 = reg_89;
-                        let l18 = l10;
-                        let l13 = if (*(&l18)) {
-                            l23
-                        } else {
-                            l24
-                        };
-                        l13
-                    } else {
-                        0u64
-                    };
-                    if (l14 > l3) {
-                        return (0u64, ct::e_insufficient_deep_balance())
-                    } else {
-                        return (l26, 0u64)
-                    }
-                }
-            }
-        }
-    }
+            l24
+        };
+        l13
+    } else {
+        0u64
+    };
+    if (l14 > l3) {
+        return (0u64, ct::e_insufficient_deep_balance())
+    };
+    return (l26, 0u64)
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1672e093ccbb2f477e460361040e1c7dd62e4b23615caafe05b7b3cf5ce7e25/crank.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1672e093ccbb2f477e460361040e1c7dd62e4b23615caafe05b7b3cf5ce7e25/crank.move
@@ -142,104 +142,70 @@ public(friend) fun update_config(l0: &mut CrankConfig, l1: u64, l2: u64, l3: u64
 
 public fun validate_heartbeat<T0>(l0: &mut CrankConfig, l1: &mut Vault<T0>, l2: &StrategyRegistry, l3: &Clock) {
     let l11 = clock::timestamp_ms(l3);
-    if (l11 - *(&l0.last_heartbeat_ms) >= *(&l0.min_heartbeat_interval_ms)) {
-        let l9 = strategy::borrow_protocol_access_cap(l2);
-        vault::update_heartbeat_tvl(l1, l3, l9);
-        *(&mut l0.last_heartbeat_ms) = l11;
-        let l10 = vault::last_heartbeat_tvl(freeze(l1));
-        let l5 = string::utf8(C14);
-        let l7 = string::utf8(C15);
-        if (!(dynamic_field::exists_(&l0.id, l5))) {
-            dynamic_field::add(&mut l0.id, l5, l10);
-            dynamic_field::add(&mut l0.id, l7, l11)
-        } else {
-            let l6 = *(dynamic_field::borrow(&l0.id, l7));
-            if (l11 - l6 > C13) {
-                let l13 = dynamic_field::borrow_mut(&mut l0.id, l5);
-                *l13 = l10;
-                let l12 = dynamic_field::borrow_mut(&mut l0.id, l7);
-                *l12 = l11
-            } else {
-                let l8 = *(dynamic_field::borrow(&l0.id, l5));
-                if (l8 > 0u64) {
-                    let l4 = if (l10 > l8) {
-                        l10 - l8
-                    } else {
-                        l8 - l10
-                    };
-                    if (l4as u128 * 10000u128 / l8as u128as u64 <= C12) {
-                        
-                    } else {
-                        abort C10
-                    }
-                }
-            }
-        };
-        event::emit(HeartbeatEvent { timestamp_ms: l11 })
+    assert!(l11 - *(&l0.last_heartbeat_ms) >= *(&l0.min_heartbeat_interval_ms), C6);
+    let l9 = strategy::borrow_protocol_access_cap(l2);
+    vault::update_heartbeat_tvl(l1, l3, l9);
+    *(&mut l0.last_heartbeat_ms) = l11;
+    let l10 = vault::last_heartbeat_tvl(freeze(l1));
+    let l5 = string::utf8(C14);
+    let l7 = string::utf8(C15);
+    if (!(dynamic_field::exists_(&l0.id, l5))) {
+        dynamic_field::add(&mut l0.id, l5, l10);
+        dynamic_field::add(&mut l0.id, l7, l11)
     } else {
-        abort C6
-    }
+        let l6 = *(dynamic_field::borrow(&l0.id, l7));
+        if (l11 - l6 > C13) {
+            let l13 = dynamic_field::borrow_mut(&mut l0.id, l5);
+            *l13 = l10;
+            let l12 = dynamic_field::borrow_mut(&mut l0.id, l7);
+            *l12 = l11
+        } else {
+            let l8 = *(dynamic_field::borrow(&l0.id, l5));
+            if (l8 > 0u64) {
+                let l4 = if (l10 > l8) {
+                    l10 - l8
+                } else {
+                    l8 - l10
+                };
+                assert!(l4as u128 * 10000u128 / l8as u128as u64 <= C12, C10)
+            }
+        }
+    };
+    event::emit(HeartbeatEvent { timestamp_ms: l11 })
 }
 
 public fun validate_reroute<T0>(l0: &mut CrankConfig, l1: &ApyRegistry, l2: &StrategyRegistry, l3: &Vault<T0>, l4: u8, l5: u8, l6: &Clock) {
     let l10 = clock::timestamp_ms(l6);
-    if (strategy::count_available(l2) >= 2u64) {
-        if (strategy::is_available(l2, l5)) {
-            if (l4 != l5) {
-                let l8 = apy::get_total_apy(l1, l4);
-                let l12 = apy::get_total_apy(l1, l5);
-                if (l12 > l8) {
-                    let l7 = if (l8 == 0u64) {
-                        10000u64
-                    } else {
-                        l12 - l8 * 10000u64 / l8
-                    };
-                    let l11 = l7;
-                    if (l11 >= *(&l0.min_spread_bps)) {
-                        floors::assert_spread(l11);
-                        if (l12 >= *(&l0.min_apy_bps)) {
-                            floors::assert_min_apy(l12);
-                            let l9 = l10 - *(&l0.last_reroute_ms);
-                            if (l9 >= *(&l0.reroute_cooldown_ms)) {
-                                floors::assert_cooldown(l9);
-                                if (l4 != 0u8) {
-                                    apy::assert_not_stale(l1, l4, l6)
-                                };
-                                apy::assert_not_stale(l1, l5, l6);
-                                let reg_103;
-                                (reg_102, reg_103) = strategy::decode_strategy(l5);
-                                let l13 = reg_103;
-                                if (l13 == 2u8) {
-                                    if (!(vault::is_depeg_active(l3))) {
-                                        
-                                    } else {
-                                        abort C11
-                                    }
-                                } else {
-                                    
-                                };
-                                *(&mut l0.last_reroute_ms) = l10;
-                                event::emit(RerouteValidatedEvent { current_strategy: l4, target_strategy: l5, current_apy: l8, target_apy: l12, spread_bps: l11, timestamp_ms: l10 })
-                            } else {
-                                abort C5
-                            }
-                        } else {
-                            abort C4
-                        }
-                    } else {
-                        abort C3
-                    }
-                } else {
-                    abort C7
-                }
-            } else {
-                abort C2
-            }
-        } else {
-            abort C1
-        }
+    assert!(strategy::count_available(l2) >= 2u64, C0);
+    assert!(strategy::is_available(l2, l5), C1);
+    assert!(l4 != l5, C2);
+    let l8 = apy::get_total_apy(l1, l4);
+    let l12 = apy::get_total_apy(l1, l5);
+    assert!(l12 > l8, C7);
+    let l7 = if (l8 == 0u64) {
+        10000u64
     } else {
-        abort C0
-    }
+        l12 - l8 * 10000u64 / l8
+    };
+    let l11 = l7;
+    assert!(l11 >= *(&l0.min_spread_bps), C3);
+    floors::assert_spread(l11);
+    assert!(l12 >= *(&l0.min_apy_bps), C4);
+    floors::assert_min_apy(l12);
+    let l9 = l10 - *(&l0.last_reroute_ms);
+    assert!(l9 >= *(&l0.reroute_cooldown_ms), C5);
+    floors::assert_cooldown(l9);
+    if (l4 != 0u8) {
+        apy::assert_not_stale(l1, l4, l6)
+    };
+    apy::assert_not_stale(l1, l5, l6);
+    let reg_103;
+    (reg_102, reg_103) = strategy::decode_strategy(l5);
+    let l13 = reg_103;
+    if (l13 == 2u8) {
+        assert!(!(vault::is_depeg_active(l3)), C11)
+    };
+    *(&mut l0.last_reroute_ms) = l10;
+    event::emit(RerouteValidatedEvent { current_strategy: l4, target_strategy: l5, current_apy: l8, target_apy: l12, spread_bps: l11, timestamp_ms: l10 })
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house.move
@@ -135,58 +135,40 @@ const C20: u64 = 40u64;
 // -- functions -- 
 
 public fun accept_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l13 = reg_23 : u16;
-        let l23 = reg_22 : u8;
-        let l15 = reg_21 : 0x1::option::Option<address>;
-        let l14 = reg_20 : u64;
-        let l20 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
-        let l19 = reg_17 : 0x2::object::ID;
-        let l17 = reg_16 : 0x2::object::ID;
-        let l22 = reg_15 : address;
-        let l16 = reg_14 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l5)) == l22) {
-            if (l23 == C0) {
-                if (object::id(freeze(l3)) == l17) {
-                    if (option::is_some(&l15)) {
-                        let l9 = option::extract(&mut l15);
-                        if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
-                            let Bid { id: reg_81, bidder: reg_82, amount: reg_83, timestamp: reg_84 } = dynamic_object_field::remove(&mut l0.id, l9);
-                            let l7 = reg_83 : 0x2::balance::Balance<0x2::sui::SUI>;
-                            let l8 = reg_81 : 0x2::object::UID;
-                            let l11 = balance::value(&l7) * l13as u64 / 10000u64;
-                            let l12 = balance::split(&mut l7, l11);
-                            auctionhouse::add_fee(l1, l12);
-                            transfer::public_transfer(coin::from_balance(l7, l5), l22);
-                            let (reg_109, reg_110) = kiosk::purchase_with_cap(l3, l20, coin::zero(l5));
-                            let l21 = reg_110;
-                            let l18 = reg_109;
-                            (reg_113, reg_114, reg_115) = transfer_policy::confirm_request(l4, l21);
-                            let l10 = tx_context::epoch(freeze(l5));
-                            let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l9, nft: l18, timestamp: l10 };
-                            dynamic_object_field::add(&mut l0.id, l2, l6);
-                            object::delete(l16);
-                            object::delete(l8);
-                            event::emit(BidReadyForClaim { listing_id: l2, seller: l22, bidder: l9, amount: l14, nft_id: l19, timestamp: l10 })
-                        } else {
-                            abort C8
-                        }
-                    } else {
-                        abort C8
-                    }
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C6
-        }
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l13 = reg_23 : u16;
+    let l23 = reg_22 : u8;
+    let l15 = reg_21 : 0x1::option::Option<address>;
+    let l14 = reg_20 : u64;
+    let l20 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
+    let l19 = reg_17 : 0x2::object::ID;
+    let l17 = reg_16 : 0x2::object::ID;
+    let l22 = reg_15 : address;
+    let l16 = reg_14 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l5)) == l22, C6);
+    assert!(l23 == C0, C4);
+    assert!(object::id(freeze(l3)) == l17, C12);
+    assert!(option::is_some(&l15), C8);
+    let l9 = option::extract(&mut l15);
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l9), C8);
+    let Bid { id: reg_81, bidder: reg_82, amount: reg_83, timestamp: reg_84 } = dynamic_object_field::remove(&mut l0.id, l9);
+    let l7 = reg_83 : 0x2::balance::Balance<0x2::sui::SUI>;
+    let l8 = reg_81 : 0x2::object::UID;
+    let l11 = balance::value(&l7) * l13as u64 / 10000u64;
+    let l12 = balance::split(&mut l7, l11);
+    auctionhouse::add_fee(l1, l12);
+    transfer::public_transfer(coin::from_balance(l7, l5), l22);
+    let (reg_109, reg_110) = kiosk::purchase_with_cap(l3, l20, coin::zero(l5));
+    let l21 = reg_110;
+    let l18 = reg_109;
+    (reg_113, reg_114, reg_115) = transfer_policy::confirm_request(l4, l21);
+    let l10 = tx_context::epoch(freeze(l5));
+    let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l9, nft: l18, timestamp: l10 };
+    dynamic_object_field::add(&mut l0.id, l2, l6);
+    object::delete(l16);
+    object::delete(l8);
+    event::emit(BidReadyForClaim { listing_id: l2, seller: l22, bidder: l9, amount: l14, nft_id: l19, timestamp: l10 })
 }
 
 public entry fun accept_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
@@ -206,17 +188,14 @@ public entry fun buy_nft<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut
 }
 
 public entry fun buy_nft_to_existing_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &mut Kiosk, l5: &KioskOwnerCap, l6: &mut TransferPolicy<T0>, l7: Coin<SUI>, l8: Coin<SUI>, l9: &mut TxContext) {
-    if (kiosk::has_access(l4, l5)) {
-        let (reg_19, reg_20) = kiosk_bidding_house::buy_nft_with_request(l0, l1, l2, l3, freeze(l6), l7, l9);
-        let l11 = reg_20;
-        let l10 = reg_19;
-        kiosk::lock(l4, l5, freeze(l6), l10);
-        royalty_rule::pay(l6, &mut l11, l8);
-        kiosk_lock_rule::prove(&mut l11, freeze(l4));
-        (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l6), l11);
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l4, l5), C11);
+    let (reg_19, reg_20) = kiosk_bidding_house::buy_nft_with_request(l0, l1, l2, l3, freeze(l6), l7, l9);
+    let l11 = reg_20;
+    let l10 = reg_19;
+    kiosk::lock(l4, l5, freeze(l6), l10);
+    royalty_rule::pay(l6, &mut l11, l8);
+    kiosk_lock_rule::prove(&mut l11, freeze(l4));
+    (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l6), l11);
 }
 
 public entry fun buy_nft_to_new_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &mut TransferPolicy<T0>, l5: Coin<SUI>, l6: Coin<SUI>, l7: &mut TxContext) {
@@ -236,106 +215,71 @@ public entry fun buy_nft_to_new_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_St
 }
 
 public fun buy_nft_with_request<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: Coin<SUI>, l6: &mut TxContext): ( T0, TransferRequest<T0>) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l10 = reg_24 : u64;
-        let l12 = reg_22 : u16;
-        let l24 = reg_21 : u8;
-        let l14 = reg_20 : 0x1::option::Option<address>;
-        let l9 = reg_18 : u64;
-        let l21 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
-        let l18 = reg_16 : 0x2::object::ID;
-        let l16 = reg_15 : 0x2::object::ID;
-        let l23 = reg_14 : address;
-        let l15 = reg_13 : 0x2::object::UID;
-        if (l24 == C0) {
-            if (tx_context::epoch(freeze(l6)) <= l10) {
-                if (object::id(freeze(l3)) == l16) {
-                    let l19 = coin::value(&l5);
-                    if (l19 >= l9) {
-                        let l11 = l19 * l12as u64 / 10000u64;
-                        let l13 = coin::split(&mut l5, l11, l6);
-                        auctionhouse::add_fee(l1, coin::into_balance(l13));
-                        if (option::is_some(&l14)) {
-                            let l20 = option::extract(&mut l14);
-                            if (dynamic_object_field::exists_with_type(&l0.id, l20)) {
-                                let Bid { id: reg_88, bidder: reg_89, amount: reg_90, timestamp: reg_91 } = dynamic_object_field::remove(&mut l0.id, l20);
-                                let l7 = reg_90 : 0x2::balance::Balance<0x2::sui::SUI>;
-                                let l8 = reg_88 : 0x2::object::UID;
-                                transfer::public_transfer(coin::from_balance(l7, l6), l20);
-                                object::delete(l8)
-                            } else {
-                                
-                            }
-                        } else {
-                            
-                        };
-                        let (reg_103, reg_104) = kiosk::purchase_with_cap(l3, l21, coin::zero(l6));
-                        let l22 = reg_104;
-                        let l17 = reg_103;
-                        object::delete(l15);
-                        event::emit(NftBoughtOut { listing_id: l2, seller: l23, buyer: tx_context::sender(freeze(l6)), amount: l9, nft_id: l18 });
-                        transfer::public_transfer(l5, l23);
-                        return (l17, l22)
-                    } else {
-                        abort C13
-                    }
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C15
-            }
-        } else {
-            abort C4
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l10 = reg_24 : u64;
+    let l12 = reg_22 : u16;
+    let l24 = reg_21 : u8;
+    let l14 = reg_20 : 0x1::option::Option<address>;
+    let l9 = reg_18 : u64;
+    let l21 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
+    let l18 = reg_16 : 0x2::object::ID;
+    let l16 = reg_15 : 0x2::object::ID;
+    let l23 = reg_14 : address;
+    let l15 = reg_13 : 0x2::object::UID;
+    assert!(l24 == C0, C4);
+    assert!(tx_context::epoch(freeze(l6)) <= l10, C15);
+    assert!(object::id(freeze(l3)) == l16, C12);
+    let l19 = coin::value(&l5);
+    assert!(l19 >= l9, C13);
+    let l11 = l19 * l12as u64 / 10000u64;
+    let l13 = coin::split(&mut l5, l11, l6);
+    auctionhouse::add_fee(l1, coin::into_balance(l13));
+    if (option::is_some(&l14)) {
+        let l20 = option::extract(&mut l14);
+        if (dynamic_object_field::exists_with_type(&l0.id, l20)) {
+            let Bid { id: reg_88, bidder: reg_89, amount: reg_90, timestamp: reg_91 } = dynamic_object_field::remove(&mut l0.id, l20);
+            let l7 = reg_90 : 0x2::balance::Balance<0x2::sui::SUI>;
+            let l8 = reg_88 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l7, l6), l20);
+            object::delete(l8)
         }
-    } else {
-        abort C7
-    }
+    };
+    let (reg_103, reg_104) = kiosk::purchase_with_cap(l3, l21, coin::zero(l6));
+    let l22 = reg_104;
+    let l17 = reg_103;
+    object::delete(l15);
+    event::emit(NftBoughtOut { listing_id: l2, seller: l23, buyer: tx_context::sender(freeze(l6)), amount: l9, nft_id: l18 });
+    transfer::public_transfer(l5, l23);
+    return (l17, l22)
 }
 
 public fun cancel_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l13 = reg_20 : u8;
-        let l7 = reg_19 : 0x1::option::Option<address>;
-        let l11 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
-        let l10 = reg_15 : 0x2::object::ID;
-        let l9 = reg_14 : 0x2::object::ID;
-        let l12 = reg_13 : address;
-        let l8 = reg_12 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l3)) == l12) {
-            if (l13 == C0) {
-                if (object::id(freeze(l2)) == l9) {
-                    if (option::is_some(&l7)) {
-                        let l6 = option::extract(&mut l7);
-                        if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
-                            let Bid { id: reg_61, bidder: reg_62, amount: reg_63, timestamp: reg_64 } = dynamic_object_field::remove(&mut l0.id, l6);
-                            let l4 = reg_63 : 0x2::balance::Balance<0x2::sui::SUI>;
-                            let l5 = reg_61 : 0x2::object::UID;
-                            transfer::public_transfer(coin::from_balance(l4, l3), l6);
-                            object::delete(l5)
-                        } else {
-                            
-                        }
-                    } else {
-                        
-                    };
-                    kiosk::return_purchase_cap(l2, l11);
-                    object::delete(l8);
-                    event::emit(ListingCancelled { listing_id: l1, seller: l12, nft_id: l10 })
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C6
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l13 = reg_20 : u8;
+    let l7 = reg_19 : 0x1::option::Option<address>;
+    let l11 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
+    let l10 = reg_15 : 0x2::object::ID;
+    let l9 = reg_14 : 0x2::object::ID;
+    let l12 = reg_13 : address;
+    let l8 = reg_12 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l3)) == l12, C6);
+    assert!(l13 == C0, C4);
+    assert!(object::id(freeze(l2)) == l9, C12);
+    if (option::is_some(&l7)) {
+        let l6 = option::extract(&mut l7);
+        if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
+            let Bid { id: reg_61, bidder: reg_62, amount: reg_63, timestamp: reg_64 } = dynamic_object_field::remove(&mut l0.id, l6);
+            let l4 = reg_63 : 0x2::balance::Balance<0x2::sui::SUI>;
+            let l5 = reg_61 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l4, l3), l6);
+            object::delete(l5)
         }
-    } else {
-        abort C7
-    }
+    };
+    kiosk::return_purchase_cap(l2, l11);
+    object::delete(l8);
+    event::emit(ListingCancelled { listing_id: l1, seller: l12, nft_id: l10 })
 }
 
 public entry fun cancel_listing_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
@@ -343,22 +287,16 @@ public entry fun cancel_listing_entry<T0: key + store>(l0: &mut Kiosk_Bidding_St
 }
 
 public fun claim_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext): T0 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l6 = reg_14 : T0;
-        let l3 = reg_13 : address;
-        let l5 = reg_12 : 0x2::object::ID;
-        let l4 = reg_11 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l2)) == l3) {
-            object::delete(l4);
-            event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
-            return l6
-        } else {
-            abort C18
-        }
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l6 = reg_14 : T0;
+    let l3 = reg_13 : address;
+    let l5 = reg_12 : 0x2::object::ID;
+    let l4 = reg_11 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l2)) == l3, C18);
+    object::delete(l4);
+    event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
+    return l6
 }
 
 public entry fun claim_accepted_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext) {
@@ -366,17 +304,14 @@ public entry fun claim_accepted_bid_entry<T0: key + store>(l0: &mut Kiosk_Biddin
 }
 
 public entry fun claim_accepted_bid_to_existing_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &KioskOwnerCap, l4: &mut TransferPolicy<T0>, l5: Coin<SUI>, l6: &mut TxContext) {
-    if (kiosk::has_access(l2, l3)) {
-        let l7 = kiosk_bidding_house::claim_accepted_bid(l0, l1, l6);
-        let l8 = object::id(&l7);
-        kiosk::lock(l2, l3, freeze(l4), l7);
-        let l9 = transfer_policy::new_request(l8, 0u64, object::id(freeze(l2)));
-        royalty_rule::pay(l4, &mut l9, l5);
-        kiosk_lock_rule::prove(&mut l9, freeze(l2));
-        (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l4), l9);
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l2, l3), C11);
+    let l7 = kiosk_bidding_house::claim_accepted_bid(l0, l1, l6);
+    let l8 = object::id(&l7);
+    kiosk::lock(l2, l3, freeze(l4), l7);
+    let l9 = transfer_policy::new_request(l8, 0u64, object::id(freeze(l2)));
+    royalty_rule::pay(l4, &mut l9, l5);
+    kiosk_lock_rule::prove(&mut l9, freeze(l2));
+    (reg_35, reg_36, reg_37) = transfer_policy::confirm_request(freeze(l4), l9);
 }
 
 public entry fun claim_accepted_bid_to_new_kiosk<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TransferPolicy<T0>, l3: Coin<SUI>, l4: &mut TxContext) {
@@ -401,47 +336,29 @@ public entry fun create_and_share_kiosk_bidding_house_store(l0: &AuctionHouse, l
 
 public fun create_kiosk_bidding_house(l0: &AuctionHouse, l1: &mut TxContext): Kiosk_Bidding_Store {
     let l2 = tx_context::sender(freeze(l1));
-    if (auctionhouse::is_admin(l0, l2)) {
-        let l4 = object::new(l1);
-        let l5 = object::uid_to_inner(&l4);
-        let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
-        event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
-        return l3
-    } else {
-        abort C14
-    }
+    assert!(auctionhouse::is_admin(l0, l2), C14);
+    let l4 = object::new(l1);
+    let l5 = object::uid_to_inner(&l4);
+    let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
+    event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
+    return l3
 }
 
 public fun create_nft_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: u64, l7: &mut TxContext): ID {
-    if (l5 <= 10000u16) {
-        if (kiosk::has_item(freeze(l1), l3)) {
-            if (kiosk::has_access(l1, l2)) {
-                if (l4 > 0u64) {
-                    if (l6 > 0u64) {
-                        let l8 = tx_context::epoch(freeze(l7));
-                        let l9 = l8 + l6;
-                        let l13 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
-                        let l11 = object::new(l7);
-                        let l12 = object::uid_to_inner(&l11);
-                        let l10 = NftListing { id: l11, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l13, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l8, expires_at: l9 };
-                        dynamic_object_field::add(&mut l0.id, l12, l10);
-                        event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l12, expires_at: l9 });
-                        return l12
-                    } else {
-                        abort C17
-                    }
-                } else {
-                    abort C9
-                }
-            } else {
-                abort C11
-            }
-        } else {
-            abort C10
-        }
-    } else {
-        abort C20
-    }
+    assert!(l5 <= 10000u16, C20);
+    assert!(kiosk::has_item(freeze(l1), l3), C10);
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(l4 > 0u64, C9);
+    assert!(l6 > 0u64, C17);
+    let l8 = tx_context::epoch(freeze(l7));
+    let l9 = l8 + l6;
+    let l13 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
+    let l11 = object::new(l7);
+    let l12 = object::uid_to_inner(&l11);
+    let l10 = NftListing { id: l11, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l13, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l8, expires_at: l9 };
+    dynamic_object_field::add(&mut l0.id, l12, l10);
+    event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l12, expires_at: l9 });
+    return l12
 }
 
 public entry fun create_nft_listing_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: &mut TxContext) {}
@@ -469,142 +386,98 @@ public fun create_personal_kiosk_ptb(l0: &mut TxContext): ( ID, PersonalKioskCap
 
 public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l5 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l5)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l8 = reg_20 : T0;
-            let l4 = reg_19 : address;
-            let l7 = reg_18 : 0x2::object::ID;
-            let l6 = reg_17 : 0x2::object::UID;
-            let l9 = object::id(&l8);
-            transfer::public_transfer(l8, l4);
-            object::delete(l6);
-            event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l5), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l8 = reg_20 : T0;
+        let l4 = reg_19 : address;
+        let l7 = reg_18 : 0x2::object::ID;
+        let l6 = reg_17 : 0x2::object::UID;
+        let l9 = object::id(&l8);
+        transfer::public_transfer(l8, l4);
+        object::delete(l6);
+        event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     }
 }
 
 public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l7 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l7)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l8 = reg_24 : 0x1::option::Option<address>;
-            let l13 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
-            let l11 = reg_20 : 0x2::object::ID;
-            let l10 = reg_19 : 0x2::object::ID;
-            let l14 = reg_18 : address;
-            let l9 = reg_17 : 0x2::object::UID;
-            let l12 = OrphanedPurchaseCap { id: object::new(l3), cap: l13, kiosk_id: l10, orphaned_at: tx_context::epoch(freeze(l3)) };
-            dynamic_object_field::add(&mut l0.orphaned_caps, l11, l12);
-            event::emit(PurchaseCapOrphaned { nft_id: l11, kiosk_id: l10, timestamp: tx_context::epoch(freeze(l3)) });
-            if (option::is_some(&l8)) {
-                let l6 = option::extract(&mut l8);
-                if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
-                    let Bid { id: reg_59, bidder: reg_60, amount: reg_61, timestamp: reg_62 } = dynamic_object_field::remove(&mut l0.id, l6);
-                    let l4 = reg_61 : 0x2::balance::Balance<0x2::sui::SUI>;
-                    let l5 = reg_59 : 0x2::object::UID;
-                    transfer::public_transfer(coin::from_balance(l4, l3), l6);
-                    object::delete(l5)
-                } else {
-                    
-                }
-            } else {
-                
-            };
-            object::delete(l9);
-            event::emit(ListingCancelled { listing_id: l2, seller: l14, nft_id: l11 })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l7), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l8 = reg_24 : 0x1::option::Option<address>;
+        let l13 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
+        let l11 = reg_20 : 0x2::object::ID;
+        let l10 = reg_19 : 0x2::object::ID;
+        let l14 = reg_18 : address;
+        let l9 = reg_17 : 0x2::object::UID;
+        let l12 = OrphanedPurchaseCap { id: object::new(l3), cap: l13, kiosk_id: l10, orphaned_at: tx_context::epoch(freeze(l3)) };
+        dynamic_object_field::add(&mut l0.orphaned_caps, l11, l12);
+        event::emit(PurchaseCapOrphaned { nft_id: l11, kiosk_id: l10, timestamp: tx_context::epoch(freeze(l3)) });
+        if (option::is_some(&l8)) {
+            let l6 = option::extract(&mut l8);
+            if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
+                let Bid { id: reg_59, bidder: reg_60, amount: reg_61, timestamp: reg_62 } = dynamic_object_field::remove(&mut l0.id, l6);
+                let l4 = reg_61 : 0x2::balance::Balance<0x2::sui::SUI>;
+                let l5 = reg_59 : 0x2::object::UID;
+                transfer::public_transfer(coin::from_balance(l4, l3), l6);
+                object::delete(l5)
+            }
+        };
+        object::delete(l9);
+        event::emit(ListingCancelled { listing_id: l2, seller: l14, nft_id: l11 })
     }
 }
 
 public fun get_accepted_bid_bidder<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): address {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).bidder)
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).bidder)
 }
 
 public fun get_accepted_bid_timestamp<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).timestamp)
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).timestamp)
 }
 
 public fun get_buyout_price<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
 }
 
 public fun get_highest_bid<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
 }
 
 public fun get_highest_bidder<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): Option<address> {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
 }
 
 public fun get_listing_expiration<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
 }
 
 public fun get_listing_status<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u8 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
 }
 
 public fun get_nft_id<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): ID {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
 }
 
 public fun get_seller<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): address {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
 }
 
 public fun is_listing_expired<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID, l2: &TxContext): bool {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l1);
-        return tx_context::epoch(l2) > *(&l3.expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l3 = dynamic_object_field::borrow(&l0.id, l1);
+    return tx_context::epoch(l2) > *(&l3.expires_at)
 }
 
 public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bool {
@@ -612,56 +485,41 @@ public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bo
 }
 
 public fun place_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<SUI>, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l7 = coin::value(&l2);
-        let l8 = tx_context::sender(freeze(l3));
-        let l9 = tx_context::epoch(freeze(l3));
-        let l11 = dynamic_object_field::borrow(&l0.id, l1);
-        if (*(&l11.status) == C0) {
-            if (l9 <= *(&l11.expires_at)) {
-                if (l7 > 0u64) {
-                    let l4 = if (*(&l11.highest_bid) == 0u64) {
-                        1u64
-                    } else {
-                        *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64
-                    };
-                    let l13 = l4;
-                    if (l7 >= l13) {
-                        let l15 = option::none();
-                        let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
-                        if (option::is_some(&l12.highest_bidder)) {
-                            l15 = option::some(*(option::borrow(&l12.highest_bidder)));
-                        };
-                        *(&mut l12.highest_bid) = l7;
-                        *(&mut l12.highest_bidder) = option::some(l8);
-                        if (option::is_some(&l15)) {
-                            let l14 = option::extract(&mut l15);
-                            if (dynamic_object_field::exists_with_type(&l0.id, l14)) {
-                                let Bid { id: reg_105, bidder: reg_106, amount: reg_107, timestamp: reg_108 } = dynamic_object_field::remove(&mut l0.id, l14);
-                                let l5 = reg_107 : 0x2::balance::Balance<0x2::sui::SUI>;
-                                let l10 = reg_105 : 0x2::object::UID;
-                                transfer::public_transfer(coin::from_balance(l5, l3), l14);
-                                object::delete(l10)
-                            }
-                        };
-                        let l6 = Bid { id: object::new(l3), bidder: l8, amount: coin::into_balance(l2), timestamp: l9 };
-                        dynamic_object_field::add(&mut l0.id, l8, l6);
-                        event::emit(BidPlaced { listing_id: l1, bidder: l8, amount: l7, timestamp: l9 })
-                    } else {
-                        abort C5
-                    }
-                } else {
-                    abort C3
-                }
-            } else {
-                abort C15
-            }
-        } else {
-            abort C4
-        }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l7 = coin::value(&l2);
+    let l8 = tx_context::sender(freeze(l3));
+    let l9 = tx_context::epoch(freeze(l3));
+    let l11 = dynamic_object_field::borrow(&l0.id, l1);
+    assert!(*(&l11.status) == C0, C4);
+    assert!(l9 <= *(&l11.expires_at), C15);
+    assert!(l7 > 0u64, C3);
+    let l4 = if (*(&l11.highest_bid) == 0u64) {
+        1u64
     } else {
-        abort C7
-    }
+        *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64
+    };
+    let l13 = l4;
+    assert!(l7 >= l13, C5);
+    let l15 = option::none();
+    let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
+    if (option::is_some(&l12.highest_bidder)) {
+        l15 = option::some(*(option::borrow(&l12.highest_bidder)));
+    };
+    *(&mut l12.highest_bid) = l7;
+    *(&mut l12.highest_bidder) = option::some(l8);
+    if (option::is_some(&l15)) {
+        let l14 = option::extract(&mut l15);
+        if (dynamic_object_field::exists_with_type(&l0.id, l14)) {
+            let Bid { id: reg_105, bidder: reg_106, amount: reg_107, timestamp: reg_108 } = dynamic_object_field::remove(&mut l0.id, l14);
+            let l5 = reg_107 : 0x2::balance::Balance<0x2::sui::SUI>;
+            let l10 = reg_105 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l5, l3), l14);
+            object::delete(l10)
+        }
+    };
+    let l6 = Bid { id: object::new(l3), bidder: l8, amount: coin::into_balance(l2), timestamp: l9 };
+    dynamic_object_field::add(&mut l0.id, l8, l6);
+    event::emit(BidPlaced { listing_id: l1, bidder: l8, amount: l7, timestamp: l9 })
 }
 
 public entry fun place_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<SUI>, l3: &mut TxContext) {
@@ -669,24 +527,15 @@ public entry fun place_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, 
 }
 
 public entry fun recover_orphaned_cap<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: &mut TxContext) {
-    if (kiosk::has_access(l1, l2)) {
-        if (dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3)) {
-            let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
-            let l7 = reg_21 : 0x2::object::ID;
-            let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
-            let l6 = reg_19 : 0x2::object::UID;
-            if (object::id(freeze(l1)) == l7) {
-                kiosk::return_purchase_cap(l1, l5);
-                object::delete(l6);
-                event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
-            } else {
-                abort C12
-            }
-        } else {
-            abort C16
-        }
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3), C16);
+    let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
+    let l7 = reg_21 : 0x2::object::ID;
+    let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
+    let l6 = reg_19 : 0x2::object::UID;
+    assert!(object::id(freeze(l1)) == l7, C12);
+    kiosk::return_purchase_cap(l1, l5);
+    object::delete(l6);
+    event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house_dynamic_coins.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house_dynamic_coins.move
@@ -156,63 +156,42 @@ const C22: u64 = 42u64;
 // -- functions -- 
 
 public fun accept_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25, coin_type: reg_26 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l11 = reg_26 : 0x1::type_name::TypeName;
-        let l14 = reg_23 : u16;
-        let l24 = reg_22 : u8;
-        let l16 = reg_21 : 0x1::option::Option<address>;
-        let l15 = reg_20 : u64;
-        let l21 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
-        let l20 = reg_17 : 0x2::object::ID;
-        let l18 = reg_16 : 0x2::object::ID;
-        let l23 = reg_15 : address;
-        let l17 = reg_14 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l5)) == l23) {
-            if (l24 == C0) {
-                if (object::id(freeze(l3)) == l18) {
-                    if (option::is_some(&l16)) {
-                        let l10 = option::extract(&mut l16);
-                        let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l10);
-                        if (l11 == type_name::get()) {
-                            if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
-                                let Bid { id: reg_94, bidder: reg_95, amount: reg_96, timestamp: reg_97 } = dynamic_object_field::remove(&mut l0.id, l9);
-                                let l7 = reg_96 : 0x2::balance::Balance<T1>;
-                                let l8 = reg_94 : 0x2::object::UID;
-                                let l13 = balance::value(&l7) * l14as u64 / 10000u64;
-                                transfer::public_transfer(coin::from_balance(balance::split(&mut l7, l13), l5), auctionhouse::get_owner(freeze(l1)));
-                                transfer::public_transfer(coin::from_balance(l7, l5), l23);
-                                let (reg_125, reg_126) = kiosk::purchase_with_cap(l3, l21, coin::zero(l5));
-                                let l22 = reg_126;
-                                let l19 = reg_125;
-                                (reg_129, reg_130, reg_131) = transfer_policy::confirm_request(l4, l22);
-                                let l12 = tx_context::epoch(freeze(l5));
-                                let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l10, nft: l19, timestamp: l12, coin_type: l11 };
-                                dynamic_object_field::add(&mut l0.id, l2, l6);
-                                object::delete(l17);
-                                object::delete(l8);
-                                event::emit(BidReadyForClaim { listing_id: l2, seller: l23, bidder: l10, amount: l15, nft_id: l20, timestamp: l12, coin_type: l11 })
-                            } else {
-                                abort C8
-                            }
-                        } else {
-                            abort C22
-                        }
-                    } else {
-                        abort C8
-                    }
-                } else {
-                    abort C12
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C6
-        }
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_14, seller: reg_15, kiosk_id: reg_16, nft_id: reg_17, purchase_cap: reg_18, buyout_price: reg_19, highest_bid: reg_20, highest_bidder: reg_21, status: reg_22, fee_bps: reg_23, created_at: reg_24, expires_at: reg_25, coin_type: reg_26 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l11 = reg_26 : 0x1::type_name::TypeName;
+    let l14 = reg_23 : u16;
+    let l24 = reg_22 : u8;
+    let l16 = reg_21 : 0x1::option::Option<address>;
+    let l15 = reg_20 : u64;
+    let l21 = reg_18 : 0x2::kiosk::PurchaseCap<T0>;
+    let l20 = reg_17 : 0x2::object::ID;
+    let l18 = reg_16 : 0x2::object::ID;
+    let l23 = reg_15 : address;
+    let l17 = reg_14 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l5)) == l23, C6);
+    assert!(l24 == C0, C4);
+    assert!(object::id(freeze(l3)) == l18, C12);
+    assert!(option::is_some(&l16), C8);
+    let l10 = option::extract(&mut l16);
+    let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l10);
+    assert!(l11 == type_name::get(), C22);
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l9), C8);
+    let Bid { id: reg_94, bidder: reg_95, amount: reg_96, timestamp: reg_97 } = dynamic_object_field::remove(&mut l0.id, l9);
+    let l7 = reg_96 : 0x2::balance::Balance<T1>;
+    let l8 = reg_94 : 0x2::object::UID;
+    let l13 = balance::value(&l7) * l14as u64 / 10000u64;
+    transfer::public_transfer(coin::from_balance(balance::split(&mut l7, l13), l5), auctionhouse::get_owner(freeze(l1)));
+    transfer::public_transfer(coin::from_balance(l7, l5), l23);
+    let (reg_125, reg_126) = kiosk::purchase_with_cap(l3, l21, coin::zero(l5));
+    let l22 = reg_126;
+    let l19 = reg_125;
+    (reg_129, reg_130, reg_131) = transfer_policy::confirm_request(l4, l22);
+    let l12 = tx_context::epoch(freeze(l5));
+    let l6 = AcceptedBid { id: object::new(l5), listing_id: l2, bidder: l10, nft: l19, timestamp: l12, coin_type: l11 };
+    dynamic_object_field::add(&mut l0.id, l2, l6);
+    object::delete(l17);
+    object::delete(l8);
+    event::emit(BidReadyForClaim { listing_id: l2, seller: l23, bidder: l10, amount: l15, nft_id: l20, timestamp: l12, coin_type: l11 })
 }
 
 public entry fun accept_bid_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: &mut TxContext) {
@@ -233,117 +212,76 @@ public entry fun buy_nft<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: 
 }
 
 public fun buy_nft_with_request<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut AuctionHouse, l2: ID, l3: &mut Kiosk, l4: &TransferPolicy<T0>, l5: Coin<T1>, l6: &mut TxContext): ( T0, TransferRequest<T0>) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-        let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24, coin_type: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
-        let l11 = reg_25 : 0x1::type_name::TypeName;
-        let l12 = reg_24 : u64;
-        let l14 = reg_22 : u16;
-        let l25 = reg_21 : u8;
-        let l15 = reg_20 : 0x1::option::Option<address>;
-        let l10 = reg_18 : u64;
-        let l22 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
-        let l19 = reg_16 : 0x2::object::ID;
-        let l17 = reg_15 : 0x2::object::ID;
-        let l24 = reg_14 : address;
-        let l16 = reg_13 : 0x2::object::UID;
-        if (l11 == type_name::get()) {
-            if (l25 == C0) {
-                if (tx_context::epoch(freeze(l6)) <= l12) {
-                    if (object::id(freeze(l3)) == l17) {
-                        let l20 = coin::value(&l5);
-                        if (l20 >= l10) {
-                            let l13 = l20 * l14as u64 / 10000u64;
-                            transfer::public_transfer(coin::split(&mut l5, l13, l6), auctionhouse::get_owner(freeze(l1)));
-                            if (option::is_some(&l15)) {
-                                let l21 = option::extract(&mut l15);
-                                let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l21);
-                                if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
-                                    let Bid { id: reg_100, bidder: reg_101, amount: reg_102, timestamp: reg_103 } = dynamic_object_field::remove(&mut l0.id, l9);
-                                    let l7 = reg_102 : 0x2::balance::Balance<T1>;
-                                    let l8 = reg_100 : 0x2::object::UID;
-                                    transfer::public_transfer(coin::from_balance(l7, l6), l21);
-                                    object::delete(l8)
-                                } else {
-                                    
-                                }
-                            } else {
-                                
-                            };
-                            let (reg_115, reg_116) = kiosk::purchase_with_cap(l3, l22, coin::zero(l6));
-                            let l23 = reg_116;
-                            let l18 = reg_115;
-                            object::delete(l16);
-                            event::emit(NftBoughtOut { listing_id: l2, seller: l24, buyer: tx_context::sender(freeze(l6)), amount: l10, nft_id: l19, coin_type: l11 });
-                            transfer::public_transfer(l5, l24);
-                            return (l18, l23)
-                        } else {
-                            abort C13
-                        }
-                    } else {
-                        abort C12
-                    }
-                } else {
-                    abort C15
-                }
-            } else {
-                abort C4
-            }
-        } else {
-            abort C22
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l2), C7);
+    let NftListing { id: reg_13, seller: reg_14, kiosk_id: reg_15, nft_id: reg_16, purchase_cap: reg_17, buyout_price: reg_18, highest_bid: reg_19, highest_bidder: reg_20, status: reg_21, fee_bps: reg_22, created_at: reg_23, expires_at: reg_24, coin_type: reg_25 } = dynamic_object_field::remove(&mut l0.id, l2);
+    let l11 = reg_25 : 0x1::type_name::TypeName;
+    let l12 = reg_24 : u64;
+    let l14 = reg_22 : u16;
+    let l25 = reg_21 : u8;
+    let l15 = reg_20 : 0x1::option::Option<address>;
+    let l10 = reg_18 : u64;
+    let l22 = reg_17 : 0x2::kiosk::PurchaseCap<T0>;
+    let l19 = reg_16 : 0x2::object::ID;
+    let l17 = reg_15 : 0x2::object::ID;
+    let l24 = reg_14 : address;
+    let l16 = reg_13 : 0x2::object::UID;
+    assert!(l11 == type_name::get(), C22);
+    assert!(l25 == C0, C4);
+    assert!(tx_context::epoch(freeze(l6)) <= l12, C15);
+    assert!(object::id(freeze(l3)) == l17, C12);
+    let l20 = coin::value(&l5);
+    assert!(l20 >= l10, C13);
+    let l13 = l20 * l14as u64 / 10000u64;
+    transfer::public_transfer(coin::split(&mut l5, l13, l6), auctionhouse::get_owner(freeze(l1)));
+    if (option::is_some(&l15)) {
+        let l21 = option::extract(&mut l15);
+        let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l2, l21);
+        if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
+            let Bid { id: reg_100, bidder: reg_101, amount: reg_102, timestamp: reg_103 } = dynamic_object_field::remove(&mut l0.id, l9);
+            let l7 = reg_102 : 0x2::balance::Balance<T1>;
+            let l8 = reg_100 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l7, l6), l21);
+            object::delete(l8)
         }
-    } else {
-        abort C7
-    }
+    };
+    let (reg_115, reg_116) = kiosk::purchase_with_cap(l3, l22, coin::zero(l6));
+    let l23 = reg_116;
+    let l18 = reg_115;
+    object::delete(l16);
+    event::emit(NftBoughtOut { listing_id: l2, seller: l24, buyer: tx_context::sender(freeze(l6)), amount: l10, nft_id: l19, coin_type: l11 });
+    transfer::public_transfer(l5, l24);
+    return (l18, l23)
 }
 
 public fun cancel_listing<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23, coin_type: reg_24 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l8 = reg_24 : 0x1::type_name::TypeName;
-        let l15 = reg_20 : u8;
-        let l9 = reg_19 : 0x1::option::Option<address>;
-        let l13 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
-        let l12 = reg_15 : 0x2::object::ID;
-        let l11 = reg_14 : 0x2::object::ID;
-        let l14 = reg_13 : address;
-        let l10 = reg_12 : 0x2::object::UID;
-        if (l8 == type_name::get()) {
-            if (tx_context::sender(freeze(l3)) == l14) {
-                if (l15 == C0) {
-                    if (object::id(freeze(l2)) == l11) {
-                        if (option::is_some(&l9)) {
-                            let l7 = option::extract(&mut l9);
-                            let l6 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l7);
-                            if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
-                                let Bid { id: reg_72, bidder: reg_73, amount: reg_74, timestamp: reg_75 } = dynamic_object_field::remove(&mut l0.id, l6);
-                                let l4 = reg_74 : 0x2::balance::Balance<T1>;
-                                let l5 = reg_72 : 0x2::object::UID;
-                                transfer::public_transfer(coin::from_balance(l4, l3), l7);
-                                object::delete(l5)
-                            } else {
-                                
-                            }
-                        } else {
-                            
-                        };
-                        kiosk::return_purchase_cap(l2, l13);
-                        object::delete(l10);
-                        event::emit(ListingCancelled { listing_id: l1, seller: l14, nft_id: l12, coin_type: l8 })
-                    } else {
-                        abort C12
-                    }
-                } else {
-                    abort C4
-                }
-            } else {
-                abort C6
-            }
-        } else {
-            abort C22
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let NftListing { id: reg_12, seller: reg_13, kiosk_id: reg_14, nft_id: reg_15, purchase_cap: reg_16, buyout_price: reg_17, highest_bid: reg_18, highest_bidder: reg_19, status: reg_20, fee_bps: reg_21, created_at: reg_22, expires_at: reg_23, coin_type: reg_24 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l8 = reg_24 : 0x1::type_name::TypeName;
+    let l15 = reg_20 : u8;
+    let l9 = reg_19 : 0x1::option::Option<address>;
+    let l13 = reg_16 : 0x2::kiosk::PurchaseCap<T0>;
+    let l12 = reg_15 : 0x2::object::ID;
+    let l11 = reg_14 : 0x2::object::ID;
+    let l14 = reg_13 : address;
+    let l10 = reg_12 : 0x2::object::UID;
+    assert!(l8 == type_name::get(), C22);
+    assert!(tx_context::sender(freeze(l3)) == l14, C6);
+    assert!(l15 == C0, C4);
+    assert!(object::id(freeze(l2)) == l11, C12);
+    if (option::is_some(&l9)) {
+        let l7 = option::extract(&mut l9);
+        let l6 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l7);
+        if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
+            let Bid { id: reg_72, bidder: reg_73, amount: reg_74, timestamp: reg_75 } = dynamic_object_field::remove(&mut l0.id, l6);
+            let l4 = reg_74 : 0x2::balance::Balance<T1>;
+            let l5 = reg_72 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l4, l3), l7);
+            object::delete(l5)
         }
-    } else {
-        abort C7
-    }
+    };
+    kiosk::return_purchase_cap(l2, l13);
+    object::delete(l10);
+    event::emit(ListingCancelled { listing_id: l1, seller: l14, nft_id: l12, coin_type: l8 })
 }
 
 public entry fun cancel_listing_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut Kiosk, l3: &mut TxContext) {
@@ -351,22 +289,16 @@ public entry fun cancel_listing_entry<T0: key + store, T1>(l0: &mut Kiosk_Biddin
 }
 
 public fun claim_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext): T0 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15, coin_type: reg_16 } = dynamic_object_field::remove(&mut l0.id, l1);
-        let l6 = reg_14 : T0;
-        let l3 = reg_13 : address;
-        let l5 = reg_12 : 0x2::object::ID;
-        let l4 = reg_11 : 0x2::object::UID;
-        if (tx_context::sender(freeze(l2)) == l3) {
-            object::delete(l4);
-            event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
-            return l6
-        } else {
-            abort C18
-        }
-    } else {
-        abort C19
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C19);
+    let AcceptedBid { id: reg_11, listing_id: reg_12, bidder: reg_13, nft: reg_14, timestamp: reg_15, coin_type: reg_16 } = dynamic_object_field::remove(&mut l0.id, l1);
+    let l6 = reg_14 : T0;
+    let l3 = reg_13 : address;
+    let l5 = reg_12 : 0x2::object::ID;
+    let l4 = reg_11 : 0x2::object::UID;
+    assert!(tx_context::sender(freeze(l2)) == l3, C18);
+    object::delete(l4);
+    event::emit(BidClaimed { listing_id: l5, bidder: l3, nft_id: object::id(&l6), timestamp: tx_context::epoch(freeze(l2)) });
+    return l6
 }
 
 public entry fun claim_accepted_bid_entry<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: &mut TxContext) {
@@ -399,48 +331,30 @@ fun create_bid_key(l0: ID, l1: address): BidKey {
 
 public fun create_kiosk_bidding_house(l0: &AuctionHouse, l1: &mut TxContext): Kiosk_Bidding_Store {
     let l2 = tx_context::sender(freeze(l1));
-    if (auctionhouse::is_admin(l0, l2)) {
-        let l4 = object::new(l1);
-        let l5 = object::uid_to_inner(&l4);
-        let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
-        event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
-        return l3
-    } else {
-        abort C14
-    }
+    assert!(auctionhouse::is_admin(l0, l2), C14);
+    let l4 = object::new(l1);
+    let l5 = object::uid_to_inner(&l4);
+    let l3 = Kiosk_Bidding_Store { id: l4, auction_house: object::id(l0), orphaned_caps: object::new(l1) };
+    event::emit(BiddingStoreCreated { store_id: l5, auction_house: object::id(l0), creator: l2 });
+    return l3
 }
 
 public fun create_nft_listing<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: u64, l7: &mut TxContext): ID {
-    if (l5 <= 10000u16) {
-        if (kiosk::has_item(freeze(l1), l3)) {
-            if (kiosk::has_access(l1, l2)) {
-                if (l4 > 0u64) {
-                    if (l6 > 0u64) {
-                        let l9 = tx_context::epoch(freeze(l7));
-                        let l10 = l9 + l6;
-                        let l14 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
-                        let l12 = object::new(l7);
-                        let l13 = object::uid_to_inner(&l12);
-                        let l8 = type_name::get();
-                        let l11 = NftListing { id: l12, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l14, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l9, expires_at: l10, coin_type: l8 };
-                        dynamic_object_field::add(&mut l0.id, l13, l11);
-                        event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l13, expires_at: l10, coin_type: l8 });
-                        return l13
-                    } else {
-                        abort C17
-                    }
-                } else {
-                    abort C9
-                }
-            } else {
-                abort C11
-            }
-        } else {
-            abort C10
-        }
-    } else {
-        abort C20
-    }
+    assert!(l5 <= 10000u16, C20);
+    assert!(kiosk::has_item(freeze(l1), l3), C10);
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(l4 > 0u64, C9);
+    assert!(l6 > 0u64, C17);
+    let l9 = tx_context::epoch(freeze(l7));
+    let l10 = l9 + l6;
+    let l14 = kiosk::list_with_purchase_cap(l1, l2, l3, 0u64, l7);
+    let l12 = object::new(l7);
+    let l13 = object::uid_to_inner(&l12);
+    let l8 = type_name::get();
+    let l11 = NftListing { id: l12, seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, purchase_cap: l14, buyout_price: l4, highest_bid: 0u64, highest_bidder: option::none(), status: C0, fee_bps: l5, created_at: l9, expires_at: l10, coin_type: l8 };
+    dynamic_object_field::add(&mut l0.id, l13, l11);
+    event::emit(NftListingCreated { seller: tx_context::sender(freeze(l7)), kiosk_id: object::id(freeze(l1)), nft_id: l3, buyout_price: l4, fee_bps: l5, listing_id: l13, expires_at: l10, coin_type: l8 });
+    return l13
 }
 
 public entry fun create_nft_listing_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: u64, l5: u16, l6: &mut TxContext) {}
@@ -468,95 +382,67 @@ public fun create_personal_kiosk_ptb(l0: &mut TxContext): ( ID, PersonalKioskCap
 
 public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l5 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l5)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21, coin_type: reg_22 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l8 = reg_20 : T0;
-            let l4 = reg_19 : address;
-            let l7 = reg_18 : 0x2::object::ID;
-            let l6 = reg_17 : 0x2::object::UID;
-            let l9 = object::id(&l8);
-            transfer::public_transfer(l8, l4);
-            object::delete(l6);
-            event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l5), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let AcceptedBid { id: reg_17, listing_id: reg_18, bidder: reg_19, nft: reg_20, timestamp: reg_21, coin_type: reg_22 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l8 = reg_20 : T0;
+        let l4 = reg_19 : address;
+        let l7 = reg_18 : 0x2::object::ID;
+        let l6 = reg_17 : 0x2::object::UID;
+        let l9 = object::id(&l8);
+        transfer::public_transfer(l8, l4);
+        object::delete(l6);
+        event::emit(BidClaimed { listing_id: l7, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     }
 }
 
 public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &AuctionHouse, l2: ID, l3: &mut TxContext) {
     let l4 = tx_context::sender(freeze(l3));
-    if (auctionhouse::is_admin(l1, l4)) {
-        if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
-            let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28, coin_type: reg_29 } = dynamic_object_field::remove(&mut l0.id, l2);
-            let l5 = reg_29 : 0x1::type_name::TypeName;
-            let l10 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
-            let l8 = reg_20 : 0x2::object::ID;
-            let l7 = reg_19 : 0x2::object::ID;
-            let l11 = reg_18 : address;
-            let l6 = reg_17 : 0x2::object::UID;
-            let l9 = OrphanedPurchaseCap { id: object::new(l3), cap: l10, kiosk_id: l7, orphaned_at: tx_context::epoch(freeze(l3)) };
-            dynamic_object_field::add(&mut l0.orphaned_caps, l8, l9);
-            event::emit(PurchaseCapOrphaned { nft_id: l8, kiosk_id: l7, timestamp: tx_context::epoch(freeze(l3)) });
-            object::delete(l6);
-            event::emit(ListingCancelled { listing_id: l2, seller: l11, nft_id: l8, coin_type: l5 })
-        } else {
-            
-        }
-    } else {
-        abort C14
+    assert!(auctionhouse::is_admin(l1, l4), C14);
+    if (dynamic_object_field::exists_with_type(&l0.id, l2)) {
+        let NftListing { id: reg_17, seller: reg_18, kiosk_id: reg_19, nft_id: reg_20, purchase_cap: reg_21, buyout_price: reg_22, highest_bid: reg_23, highest_bidder: reg_24, status: reg_25, fee_bps: reg_26, created_at: reg_27, expires_at: reg_28, coin_type: reg_29 } = dynamic_object_field::remove(&mut l0.id, l2);
+        let l5 = reg_29 : 0x1::type_name::TypeName;
+        let l10 = reg_21 : 0x2::kiosk::PurchaseCap<T0>;
+        let l8 = reg_20 : 0x2::object::ID;
+        let l7 = reg_19 : 0x2::object::ID;
+        let l11 = reg_18 : address;
+        let l6 = reg_17 : 0x2::object::UID;
+        let l9 = OrphanedPurchaseCap { id: object::new(l3), cap: l10, kiosk_id: l7, orphaned_at: tx_context::epoch(freeze(l3)) };
+        dynamic_object_field::add(&mut l0.orphaned_caps, l8, l9);
+        event::emit(PurchaseCapOrphaned { nft_id: l8, kiosk_id: l7, timestamp: tx_context::epoch(freeze(l3)) });
+        object::delete(l6);
+        event::emit(ListingCancelled { listing_id: l2, seller: l11, nft_id: l8, coin_type: l5 })
     }
 }
 
 public fun get_buyout_price<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).buyout_price)
 }
 
 public fun get_coin_type<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): TypeName {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).coin_type)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).coin_type)
 }
 
 public fun get_highest_bid<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bid)
 }
 
 public fun get_highest_bidder<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): Option<address> {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).highest_bidder)
 }
 
 public fun get_listing_expiration<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u64 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).expires_at)
 }
 
 public fun get_listing_status<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): u8 {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).status)
 }
 
 public fun get_listings_by_coin_type<T0>(l0: &Kiosk_Bidding_Store): vector<ID> {
@@ -568,28 +454,19 @@ public fun get_listings_by_nft_type<T0: key + store>(l0: &Kiosk_Bidding_Store): 
 }
 
 public fun get_nft_id<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): ID {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).nft_id)
 }
 
 public fun get_seller<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): address {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    return *(&(dynamic_object_field::borrow(&l0.id, l1)).seller)
 }
 
 public fun is_listing_expired<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID, l2: &TxContext): bool {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l1);
-        return tx_context::epoch(l2) > *(&l3.expires_at)
-    } else {
-        abort C7
-    }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l3 = dynamic_object_field::borrow(&l0.id, l1);
+    return tx_context::epoch(l2) > *(&l3.expires_at)
 }
 
 public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bool {
@@ -597,63 +474,45 @@ public fun listing_exists<T0: key + store>(l0: &Kiosk_Bidding_Store, l1: ID): bo
 }
 
 public fun place_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<T1>, l3: &mut TxContext) {
-    if (dynamic_object_field::exists_with_type(&l0.id, l1)) {
-        let l7 = coin::value(&l2);
-        let l10 = tx_context::sender(freeze(l3));
-        let l12 = tx_context::epoch(freeze(l3));
-        let l14 = dynamic_object_field::borrow(&l0.id, l1);
-        if (*(&l14.status) == C0) {
-            if (l12 <= *(&l14.expires_at)) {
-                let l11 = *(&l14.coin_type);
-                if (l11 == type_name::get()) {
-                    if (l7 > 0u64) {
-                        let l4 = if (*(&l14.highest_bid) == 0u64) {
-                            1u64
-                        } else {
-                            *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64
-                        };
-                        let l16 = l4;
-                        if (l7 >= l16) {
-                            let l18 = option::none();
-                            let l15 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
-                            if (option::is_some(&l15.highest_bidder)) {
-                                l18 = option::some(*(option::borrow(&l15.highest_bidder)));
-                            };
-                            *(&mut l15.highest_bid) = l7;
-                            *(&mut l15.highest_bidder) = option::some(l10);
-                            if (option::is_some(&l18)) {
-                                let l17 = option::extract(&mut l18);
-                                let l8 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l17);
-                                if (dynamic_object_field::exists_with_type(&l0.id, l8)) {
-                                    let Bid { id: reg_118, bidder: reg_119, amount: reg_120, timestamp: reg_121 } = dynamic_object_field::remove(&mut l0.id, l8);
-                                    let l5 = reg_120 : 0x2::balance::Balance<T1>;
-                                    let l13 = reg_118 : 0x2::object::UID;
-                                    transfer::public_transfer(coin::from_balance(l5, l3), l17);
-                                    object::delete(l13)
-                                }
-                            };
-                            let l6 = Bid { id: object::new(l3), bidder: l10, amount: coin::into_balance(l2), timestamp: l12 };
-                            let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l10);
-                            dynamic_object_field::add(&mut l0.id, l9, l6);
-                            event::emit(BidPlaced { listing_id: l1, bidder: l10, amount: l7, timestamp: l12, coin_type: l11 })
-                        } else {
-                            abort C5
-                        }
-                    } else {
-                        abort C3
-                    }
-                } else {
-                    abort C22
-                }
-            } else {
-                abort C15
-            }
-        } else {
-            abort C4
-        }
+    assert!(dynamic_object_field::exists_with_type(&l0.id, l1), C7);
+    let l7 = coin::value(&l2);
+    let l10 = tx_context::sender(freeze(l3));
+    let l12 = tx_context::epoch(freeze(l3));
+    let l14 = dynamic_object_field::borrow(&l0.id, l1);
+    assert!(*(&l14.status) == C0, C4);
+    assert!(l12 <= *(&l14.expires_at), C15);
+    let l11 = *(&l14.coin_type);
+    assert!(l11 == type_name::get(), C22);
+    assert!(l7 > 0u64, C3);
+    let l4 = if (*(&l14.highest_bid) == 0u64) {
+        1u64
     } else {
-        abort C7
-    }
+        *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64
+    };
+    let l16 = l4;
+    assert!(l7 >= l16, C5);
+    let l18 = option::none();
+    let l15 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
+    if (option::is_some(&l15.highest_bidder)) {
+        l18 = option::some(*(option::borrow(&l15.highest_bidder)));
+    };
+    *(&mut l15.highest_bid) = l7;
+    *(&mut l15.highest_bidder) = option::some(l10);
+    if (option::is_some(&l18)) {
+        let l17 = option::extract(&mut l18);
+        let l8 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l17);
+        if (dynamic_object_field::exists_with_type(&l0.id, l8)) {
+            let Bid { id: reg_118, bidder: reg_119, amount: reg_120, timestamp: reg_121 } = dynamic_object_field::remove(&mut l0.id, l8);
+            let l5 = reg_120 : 0x2::balance::Balance<T1>;
+            let l13 = reg_118 : 0x2::object::UID;
+            transfer::public_transfer(coin::from_balance(l5, l3), l17);
+            object::delete(l13)
+        }
+    };
+    let l6 = Bid { id: object::new(l3), bidder: l10, amount: coin::into_balance(l2), timestamp: l12 };
+    let l9 = kiosk_bidding_house_dynamic_coins::create_bid_key(l1, l10);
+    dynamic_object_field::add(&mut l0.id, l9, l6);
+    event::emit(BidPlaced { listing_id: l1, bidder: l10, amount: l7, timestamp: l12, coin_type: l11 })
 }
 
 public entry fun place_bid_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: Coin<T1>, l3: &mut TxContext) {
@@ -661,24 +520,15 @@ public entry fun place_bid_entry<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Sto
 }
 
 public entry fun recover_orphaned_cap<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: &mut Kiosk, l2: &KioskOwnerCap, l3: ID, l4: &mut TxContext) {
-    if (kiosk::has_access(l1, l2)) {
-        if (dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3)) {
-            let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
-            let l7 = reg_21 : 0x2::object::ID;
-            let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
-            let l6 = reg_19 : 0x2::object::UID;
-            if (object::id(freeze(l1)) == l7) {
-                kiosk::return_purchase_cap(l1, l5);
-                object::delete(l6);
-                event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
-            } else {
-                abort C12
-            }
-        } else {
-            abort C16
-        }
-    } else {
-        abort C11
-    }
+    assert!(kiosk::has_access(l1, l2), C11);
+    assert!(dynamic_object_field::exists_with_type(&l0.orphaned_caps, l3), C16);
+    let OrphanedPurchaseCap { id: reg_19, cap: reg_20, kiosk_id: reg_21, orphaned_at: reg_22 } = dynamic_object_field::remove(&mut l0.orphaned_caps, l3);
+    let l7 = reg_21 : 0x2::object::ID;
+    let l5 = reg_20 : 0x2::kiosk::PurchaseCap<T0>;
+    let l6 = reg_19 : 0x2::object::UID;
+    assert!(object::id(freeze(l1)) == l7, C12);
+    kiosk::return_purchase_cap(l1, l5);
+    object::delete(l6);
+    event::emit(OrphanedCapRecovered { nft_id: l3, kiosk_id: l7, recoverer: tx_context::sender(freeze(l4)), timestamp: tx_context::epoch(freeze(l4)) })
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/move/basic/vec.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/basic/vec.snap
@@ -4,16 +4,10 @@ source: crates/move-decompiler/tests/tests.rs
 module vec {
     public fun t () {
         let l2 = Constant { type_: Vector(U8), data: [4, 1, 2, 3, 4] };
-        &mut l2.push_back(10u8)        if (        &l2.length() == 4u64) {
-            &mut l2.swap(0u64, 1u64)            let l1 =         &&l2[0u64];
-            let l0 = 2u8;
-            if (l1 == &l0) {
-            } else {
-                abort 1u64;
-            }
-        } else {
-            abort 0u64;
-        }
+        &mut l2.push_back(10u8)        assert!(        &l2.length() == 4u64, 0u64)
+        &mut l2.swap(0u64, 1u64)        let l1 =         &&l2[0u64];
+        let l0 = 2u8;
+        assert!(l1 == &l0, 1u64)
     }
 
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/basic/vec@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/basic/vec@full.snap
@@ -16,16 +16,9 @@ const C1: vector<u8> = vector[1u8, 2u8, 3u8, 4u8];
 fun t() {
     let l2 = C1;
     (&mut l2).push_back(10u8);
-    if (&l2.len() == 4u64) {
-        (&mut l2).swap(0u64, 1u64);
-        let l1 = &(&l2)[0u64];
-        let l0 = 2u8;
-        if (l1 == &l0) {
-            
-        } else {
-            abort 1u64
-        }
-    } else {
-        abort 0u64
-    }
+    assert!(&l2.len() == 4u64, 0u64);
+    (&mut l2).swap(0u64, 1u64);
+    let l1 = &(&l2)[0u64];
+    let l0 = 2u8;
+    assert!(l1 == &l0, 1u64)
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
@@ -8,8 +8,6 @@ module loop_cases {
             l0 = l0 + 1u64;
             if (l0 >= 10u64) {
                 break;
-            } else {
-                continue;
             }
         }
     }
@@ -26,8 +24,6 @@ module loop_cases {
             }
             if (l0 == 10u64) {
                 break;
-            } else {
-                continue;
             }
         }
     }
@@ -69,8 +65,6 @@ module loop_cases {
             l1 = l1 * 2u64 + l0;
             if (l0 >= 10u64) {
                 break;
-            } else {
-                continue;
             }
         }
     }
@@ -86,8 +80,6 @@ module loop_cases {
             }
             if (l0 >= 10u64) {
                 break;
-            } else {
-                continue;
             }
         }
     }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
@@ -13,8 +13,6 @@ public fun loop_test() {
         l0 = l0 + 1u64;
         if (l0 >= 10u64) {
             break
-        } else {
-            continue
         }
     }
 }
@@ -30,8 +28,6 @@ public fun loop_test_2() {
         };
         if (l0 == 10u64) {
             break
-        } else {
-            continue
         }
     }
 }
@@ -75,8 +71,6 @@ public fun loop_test_8() {
         l1 = l1 * 2u64 + l0;
         if (l0 >= 10u64) {
             break
-        } else {
-            continue
         }
     }
 }
@@ -92,8 +86,6 @@ public fun loop_test_9() {
         };
         if (l0 >= 10u64) {
             break
-        } else {
-            continue
         }
     }
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
@@ -20,9 +20,8 @@ module while_cases {
             if (l0) {
                 l1 = l1 + 1u64;
                 continue;
-            } else {
-                break;
             }
+            break;
         }
     }
 
@@ -32,10 +31,8 @@ module while_cases {
             if (l0 % 2u64 == 0u64) {
                 l0 = l0 + 1u64;
                 continue;
-            } else {
-                l0 = l0 + 2u64;
-                continue;
             }
+            l0 = l0 + 2u64;
         }
     }
 
@@ -51,13 +48,11 @@ module while_cases {
                 if (l1 % 2u64 == 0u64) {
                     l1 = l1 + 1u64;
                     continue;
-                } else {
-                    l1 = l1 + 2u64;
-                    continue;
                 }
-            } else {
-                break;
+                l1 = l1 + 2u64;
+                continue;
             }
+            break;
         }
     }
 
@@ -66,9 +61,13 @@ module while_cases {
         let l1 = 0u64;
         let l2 = 0u64;
         while(l0 < 10u64) {
-            while(l1 < 10u64) {
-                l2 = l2 + l0 * l1 + l1;
-                l1 = l1 + 1u64;
+            loop {
+                if (l1 < 10u64) {
+                    l2 = l2 + l0 * l1 + l1;
+                    l1 = l1 + 1u64;
+                    continue;
+                }
+                break;
             }
             l0 = l0 + 1u64;
         }
@@ -85,9 +84,8 @@ module while_cases {
             if (l0) {
                 l1 = l1 + 1u64;
                 continue;
-            } else {
-                break;
             }
+            break;
         }
     }
 

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
@@ -25,9 +25,8 @@ public fun while_test_2() {
         if (l0) {
             l1 = l1 + 1u64;
             continue
-        } else {
-            break
-        }
+        };
+        break
     }
 }
 
@@ -37,10 +36,8 @@ public fun while_test_3() {
         if (l0 % 2u64 == 0u64) {
             l0 = l0 + 1u64;
             continue
-        } else {
-            l0 = l0 + 2u64;
-            continue
-        }
+        };
+        l0 = l0 + 2u64;
     }
 }
 
@@ -56,13 +53,11 @@ public fun while_test_4() {
             if (l1 % 2u64 == 0u64) {
                 l1 = l1 + 1u64;
                 continue
-            } else {
-                l1 = l1 + 2u64;
-                continue
-            }
-        } else {
-            break
-        }
+            };
+            l1 = l1 + 2u64;
+            continue
+        };
+        break
     }
 }
 
@@ -71,9 +66,13 @@ public fun while_test_5() {
     let l1 = 0u64;
     let l2 = 0u64;
     while (l0 < 10u64) {
-        while (l1 < 10u64) {
-            l2 = l2 + l0 * l1 + l1;
-            l1 = l1 + 1u64;
+        loop {
+            if (l1 < 10u64) {
+                l2 = l2 + l0 * l1 + l1;
+                l1 = l1 + 1u64;
+                continue
+            };
+            break
         };
         l0 = l0 + 1u64;
     }
@@ -90,8 +89,7 @@ public fun while_test_6() {
         if (l0) {
             l1 = l1 + 1u64;
             continue
-        } else {
-            break
-        }
+        };
+        break
     }
 }


### PR DESCRIPTION
## Description 

Two refinements on `IfElse`, stacked so the four assert shapes the structurer can produce all collapse to `assert!(cond, code); rest`. 

**1. `simplify_if` — hoist the non-terminating arm when the other arm always terminates.** Three local rewrites on `IfElse`:

  - then-arm `always_terminates` (`abort`/`return`/`break`/`continue`, or a `Seq`/`IfElse` that recursively does), else non-empty →
 hoist else out: `if (t) { terminator } else alt` → `if (t) { terminator }; alt`.
  - else-arm `always_terminates`, then non-empty → negate, swap, hoist: `if (t) { rest } else { terminator }` → `if (!t) { terminator }; rest`.
  - empty else → drop it.

When both arms terminate and rules 1 and 2 could both fire, the tiebreak prefers keeping an `Abort` in the conditional.

**2. Recover `assert!` from if/abort patterns.** A `recover_asserts` refinement rewrites the two empty-arm shapes:
  - `if (cond) { } else { abort code }`        →  `assert!(cond, code)`
  - `if (cond) { abort code }` (no/empty else) →  `assert!(!cond, code)`

These together recover a ton of the `assert!` patterns in the decompiled modules, looking like realistic `Move` code.

Also fixed:
- The `Exp::Call` Display impl was missing comma separators between arguments — latent until multi-arg `assert!` exercised it.
- Reorder `remove_trailing_continue`/`remove_trailing_return` to run before `simplify_if`. The structurer emits explicit empty `return` markers at function tails that `remove_trailing_return` strips; with the old order, `simplify_if`'s `always_terminates` predicate would see the not-yet-stripped trailing `return` and fire rule 1 on then-arms whose true Move-level shape is just statements falling off the function.

## Test plan

Updated tests to look great

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
