### PR TITLE
[chore] Update tidehunter to 8ca8eed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=9a0472f81e71e821e1f4f71e308c2580f16f9e05#9a0472f81e71e821e1f4f71e308c2580f16f9e05"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=8ca8eede6639a57029a16abc4285c5c5b635902b#8ca8eede6639a57029a16abc4285c5c5b635902b"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17968,7 +17968,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=9a0472f81e71e821e1f4f71e308c2580f16f9e05#9a0472f81e71e821e1f4f71e308c2580f16f9e05"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=8ca8eede6639a57029a16abc4285c5c5b635902b#8ca8eede6639a57029a16abc4285c5c5b635902b"
 dependencies = [
  "anyhow",
  "clap",
@@ -17982,7 +17982,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=9a0472f81e71e821e1f4f71e308c2580f16f9e05#9a0472f81e71e821e1f4f71e308c2580f16f9e05"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=8ca8eede6639a57029a16abc4285c5c5b635902b#8ca8eede6639a57029a16abc4285c5c5b635902b"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -52,7 +52,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "9a0472f81e71e821e1f4f71e308c2580f16f9e05", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "8ca8eede6639a57029a16abc4285c5c5b635902b", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "9a0472f81e71e821e1f4f71e308c2580f16f9e05", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "8ca8eede6639a57029a16abc4285c5c5b635902b", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }


### PR DESCRIPTION
## Summary
- Updates tidehunter git dependency to `8ca8eede6639a57029a16abc4285c5c5b635902b`

## Test plan
- [ ] Deploy to private-testnet with `build_with_tidehunter=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)