### PR TITLE
[move][move-decompiler] Normalize continue-bearing IfElses inside loops

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/refinement/hoist_dual_continue.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/hoist_dual_continue.rs
@@ -1,19 +1,13 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Rewrite `IfElse(t, e0;continue 'L, Some(e0';continue 'L))` — both arms continuing to the
-// same loop — into `Seq([IfElse(t, e0, Some(e0')), continue 'L])`. The continue is moved
-// outside the `IfElse` and lives in a trailing position where `remove_trailing_continue`
-// can drop it (when at a loop tail).
+// Hoist a shared trailing `continue` out of both arms of an `IfElse`:
+// `if (t) { e0; continue 'L; } else { e0'; continue 'L; }` => `if (t) { e0 } else { e0' }; continue 'L;`
 //
-// Applies anywhere, not just at a loop tail: hoisting a shared trailing continue out of
-// matching arms is always a sound normalization. Whether the relocated continue ultimately
-// disappears is the trailing-continue pass's concern.
+// Applies anywhere; the relocated continue is `remove_trailing_continue`'s concern.
 //
-// Locality: the two arms must continue to the *same* label. We don't constrain that label
-// to be the immediate enclosing loop — the AST already encodes which loop each continue
-// targets, and preserving the label keeps semantics intact wherever the rewritten
-// expression sits in the tree.
+// Preconditions:
+//   - Both arms end in `Continue` for the same label.
 
 use crate::{
     ast::Exp,

--- a/external-crates/move/crates/move-decompiler/src/refinement/hoist_dual_continue.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/hoist_dual_continue.rs
@@ -1,0 +1,62 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Rewrite `IfElse(t, e0;continue 'L, Some(e0';continue 'L))` — both arms continuing to the
+// same loop — into `Seq([IfElse(t, e0, Some(e0')), continue 'L])`. The continue is moved
+// outside the `IfElse` and lives in a trailing position where `remove_trailing_continue`
+// can drop it (when at a loop tail).
+//
+// Applies anywhere, not just at a loop tail: hoisting a shared trailing continue out of
+// matching arms is always a sound normalization. Whether the relocated continue ultimately
+// disappears is the trailing-continue pass's concern.
+//
+// Locality: the two arms must continue to the *same* label. We don't constrain that label
+// to be the immediate enclosing loop — the AST already encodes which loop each continue
+// targets, and preserving the label keeps semantics intact wherever the rewritten
+// expression sits in the tree.
+
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{seq_or_singleton, strip_trailing_continue_into_seq, trailing_continue_label},
+    },
+};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    HoistDualContinue.refine(exp)
+}
+
+struct HoistDualContinue;
+
+impl Refine for HoistDualContinue {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Exp::IfElse(_, then_b, else_b) = exp else {
+            return false;
+        };
+        let Some(else_b) = else_b.as_ref().as_ref() else {
+            return false;
+        };
+        let Some(then_label) = trailing_continue_label(then_b) else {
+            return false;
+        };
+        let Some(else_label) = trailing_continue_label(else_b) else {
+            return false;
+        };
+        if then_label != else_label {
+            return false;
+        }
+        let label = then_label;
+
+        exp.map_mut(|e| {
+            let Exp::IfElse(test, then_b, else_b) = e else {
+                unreachable!()
+            };
+            let then_b = seq_or_singleton(strip_trailing_continue_into_seq(*then_b));
+            let else_b = seq_or_singleton(strip_trailing_continue_into_seq(else_b.unwrap()));
+            let new_if = Exp::IfElse(test, Box::new(then_b), Box::new(Some(else_b)));
+            Exp::Seq(vec![new_if, Exp::Continue(label)])
+        });
+        true
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/hoist_tail_continue.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/hoist_tail_continue.rs
@@ -1,0 +1,88 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Drop a trailing `continue` from one arm of an `IfElse` at loop tail; the implicit
+// fall-through at the body's end is itself iteration:
+// `if (t) { e; continue; } else { e' }` => `if (t) { e } else { e' }`
+// (and symmetric for an else-arm continue).
+//
+// Preconditions:
+//   - The `IfElse` is the last item of the loop's body `Seq`.
+//   - Exactly one arm ends in `Continue(loop_label)`.
+//   - When the other arm is exactly `Break(loop_label)`, defer to `swap_continue_break_else`.
+
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{
+            ends_with_continue, loop_body_seq_mut, seq_or_singleton,
+            strip_trailing_continue_into_seq,
+        },
+    },
+};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    HoistTailContinue.refine(exp)
+}
+
+struct HoistTailContinue;
+
+impl Refine for HoistTailContinue {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Some((loop_label, seq)) = loop_body_seq_mut(exp) else {
+            return false;
+        };
+        if seq.is_empty() {
+            return false;
+        }
+        let if_idx = seq.len() - 1;
+        let Exp::IfElse(_, then_b, else_b) = &seq[if_idx] else {
+            return false;
+        };
+
+        let then_has_cont = ends_with_continue(then_b, loop_label);
+        let else_has_cont = else_b
+            .as_ref()
+            .as_ref()
+            .is_some_and(|e| ends_with_continue(e, loop_label));
+
+        // Dual-continue is `hoist_dual_continue`'s job.
+        if then_has_cont && else_has_cont {
+            return false;
+        }
+        if !then_has_cont && !else_has_cont {
+            return false;
+        }
+        // The continue-then / break-else shape goes to `swap_continue_break_else`, which
+        // produces a guard form we prefer there.
+        if then_has_cont
+            && matches!(else_b.as_ref().as_ref(), Some(Exp::Break(b)) if *b == loop_label)
+        {
+            return false;
+        }
+
+        let Exp::IfElse(test, then_b, else_b) =
+            std::mem::replace(&mut seq[if_idx], Exp::Seq(vec![]))
+        else {
+            unreachable!()
+        };
+        let (new_then, new_else) = if then_has_cont {
+            let then_b = seq_or_singleton(strip_trailing_continue_into_seq(*then_b));
+            (Box::new(then_b), else_b)
+        } else {
+            // else_has_cont: peel the Option, strip, rewrap. Collapse an emptied else to
+            // `None` so the rendered output doesn't carry a vestigial `else { }`.
+            let stripped = seq_or_singleton(strip_trailing_continue_into_seq(else_b.unwrap()));
+            let stripped_else = if matches!(&stripped, Exp::Seq(items) if items.is_empty()) {
+                None
+            } else {
+                Some(stripped)
+            };
+            (then_b, Box::new(stripped_else))
+        };
+        seq[if_idx] = Exp::IfElse(test, new_then, new_else);
+        seq.push(Exp::Continue(loop_label));
+        true
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -8,6 +8,7 @@ mod flatten_seq;
 mod fuse_let;
 mod hoist_arm_assignments;
 mod hoist_dual_continue;
+mod hoist_tail_continue;
 mod introduce_while;
 mod loop_to_seq;
 mod reconstruct_match;
@@ -17,6 +18,7 @@ mod remove_trailing_return;
 mod simplify_if;
 mod strip_loop_labels;
 mod swap_continue_break;
+mod swap_continue_break_else;
 mod swap_continue_fallthrough;
 mod utils;
 
@@ -29,6 +31,7 @@ const REFINEMENTS: &[Refinement] = &[
     fuse_let::refine,
     hoist_arm_assignments::refine,
     hoist_dual_continue::refine,
+    hoist_tail_continue::refine,
     introduce_while::refine,
     loop_to_seq::refine,
     reconstruct_match::refine,
@@ -41,6 +44,7 @@ const REFINEMENTS: &[Refinement] = &[
     recover_asserts::refine,
     strip_loop_labels::refine,
     swap_continue_break::refine,
+    swap_continue_break_else::refine,
     swap_continue_fallthrough::refine,
 ];
 

--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -7,6 +7,7 @@ mod collect_uses;
 mod flatten_seq;
 mod fuse_let;
 mod hoist_arm_assignments;
+mod hoist_dual_continue;
 mod introduce_while;
 mod loop_to_seq;
 mod reconstruct_match;
@@ -15,6 +16,8 @@ mod remove_trailing_continue;
 mod remove_trailing_return;
 mod simplify_if;
 mod strip_loop_labels;
+mod swap_continue_break;
+mod swap_continue_fallthrough;
 mod utils;
 
 pub use collect_uses::{collect_local_names, collect_uses};
@@ -25,6 +28,7 @@ const REFINEMENTS: &[Refinement] = &[
     flatten_seq::refine,
     fuse_let::refine,
     hoist_arm_assignments::refine,
+    hoist_dual_continue::refine,
     introduce_while::refine,
     loop_to_seq::refine,
     reconstruct_match::refine,
@@ -36,6 +40,8 @@ const REFINEMENTS: &[Refinement] = &[
     simplify_if::refine,
     recover_asserts::refine,
     strip_loop_labels::refine,
+    swap_continue_break::refine,
+    swap_continue_fallthrough::refine,
 ];
 
 // -------------------------------------------------------------------------------------------------

--- a/external-crates/move/crates/move-decompiler/src/refinement/remove_trailing_continue.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/remove_trailing_continue.rs
@@ -1,8 +1,20 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// Drop a `Continue(loop_label)` reachable from a loop body's tail. Walks the last item of
+// a `Seq`, both arms of an `IfElse`, every case of a `Switch`/`Match`, and through `Block`
+// wrappers — anywhere the implicit fall-through at the loop's true tail is itself
+// iteration:
+// `loop { …; if (t) { …; continue } else { …; continue } }` => same loop without the continues
+//
+// Preconditions:
+//   - The `Continue`'s label matches the enclosing loop's (label equality).
+//   - The `IfElse`-with-`then;continue`-and-`else=Break` shape is deferred to
+//     `swap_continue_break_else`, which produces a guard form we prefer.
+//   - We don't descend through nested `Loop`/`While`; their continues target themselves.
+
 use crate::{
-    ast::Exp,
+    ast::{Exp, Label},
     refinement::{
         Refine,
         utils::{peek, peek_mut},
@@ -15,9 +27,6 @@ pub fn refine(exp: &mut Exp) -> bool {
     r1 || r2
 }
 
-// -------------------------------------------------------------------------------------------------
-// Refinement
-
 struct LoopRemoveTrailingContinue;
 
 impl Refine for LoopRemoveTrailingContinue {
@@ -26,28 +35,9 @@ impl Refine for LoopRemoveTrailingContinue {
             return false;
         };
         let loop_label = *loop_label;
-
-        match peek_mut(body) {
-            Exp::Seq(seq) if !seq.is_empty() => {
-                // Only drop a trailing continue if it targets this loop (label matches).
-                if matches!(seq.last().map(peek), Some(Exp::Continue(l)) if *l == loop_label) {
-                    seq.pop();
-                    true
-                } else {
-                    false
-                }
-            }
-            Exp::Continue(l) if *l == loop_label => {
-                *peek_mut(body) = Exp::Seq(vec![]);
-                true
-            }
-            _ => false,
-        }
+        elide_tail_continue(peek_mut(body), loop_label)
     }
 }
-
-// -------------------------------------------------------------------------------------------------
-// Refinement
 
 struct WhileRemoveTrailingContinue;
 
@@ -57,21 +47,76 @@ impl Refine for WhileRemoveTrailingContinue {
             return false;
         };
         let loop_label = *loop_label;
+        elide_tail_continue(peek_mut(body), loop_label)
+    }
+}
 
-        match peek_mut(body) {
-            Exp::Seq(seq) if !seq.is_empty() => {
-                if matches!(seq.last().map(peek), Some(Exp::Continue(l)) if *l == loop_label) {
-                    seq.pop();
-                    true
-                } else {
-                    false
-                }
-            }
-            Exp::Continue(l) if *l == loop_label => {
-                *peek_mut(body) = Exp::Seq(vec![]);
-                true
-            }
-            _ => false,
+/// Recursively elide `Continue(label)` from any tail position of `exp`. The recursion
+/// descends through tail-position containers (`Seq` last item, both arms of `IfElse`, every
+/// `Switch`/`Match` arm, transparent `Block` wrapper) and stops at nested `Loop`/`While`.
+fn elide_tail_continue(exp: &mut Exp, label: Option<Label>) -> bool {
+    match exp {
+        Exp::Continue(l) if *l == label => {
+            *exp = Exp::Seq(vec![]);
+            true
         }
+        Exp::Seq(seq) => seq
+            .last_mut()
+            .map(|last| elide_tail_continue(peek_mut(last), label))
+            .unwrap_or(false),
+        Exp::IfElse(_, then_b, else_b) => {
+            // Defer the `then;continue / else=Break` shape to `swap_continue_break_else`.
+            let then_has_cont = matches!(
+                tail_continue_label(peek(then_b)),
+                Some(l) if l == label
+            );
+            let else_is_break = matches!(
+                else_b.as_ref().as_ref().map(peek),
+                Some(Exp::Break(b)) if *b == label
+            );
+            if then_has_cont && else_is_break {
+                return false;
+            }
+            let r1 = elide_tail_continue(peek_mut(then_b), label);
+            let r2 = else_b
+                .as_mut()
+                .as_mut()
+                .map(|e| elide_tail_continue(peek_mut(e), label))
+                .unwrap_or(false);
+            // Collapse an emptied else to `None` so the renderer doesn't carry an
+            // `else { }` shell.
+            if matches!(else_b.as_ref().as_ref(), Some(Exp::Seq(items)) if items.is_empty()) {
+                **else_b = None;
+            }
+            r1 || r2
+        }
+        Exp::Switch(_, _, cases) => {
+            let mut changed = false;
+            for (_, body) in cases.iter_mut() {
+                changed |= elide_tail_continue(peek_mut(body), label);
+            }
+            changed
+        }
+        Exp::Match(_, _, arms) => {
+            let mut changed = false;
+            for (_, _, body) in arms.iter_mut() {
+                changed |= elide_tail_continue(peek_mut(body), label);
+            }
+            changed
+        }
+        Exp::Block(_, body) => elide_tail_continue(body, label),
+        _ => false,
+    }
+}
+
+/// Final-position `Continue` label, if any. Walks through `Seq.last` and `Block` only —
+/// doesn't descend into `IfElse`/`Switch` (those have multiple arms; an "ends in continue"
+/// answer at that level is per-arm).
+fn tail_continue_label(exp: &Exp) -> Option<Option<Label>> {
+    match exp {
+        Exp::Continue(l) => Some(*l),
+        Exp::Seq(items) => items.last().and_then(tail_continue_label),
+        Exp::Block(_, body) => tail_continue_label(body),
+        _ => None,
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break.rs
@@ -3,6 +3,11 @@
 
 // Swap the tail of a loop body:
 // `if (t) { e0; continue; } e1; break;` => `if (!t) { e1; break; } e0; continue;`
+// `if (t) { e0; continue; } break;`     => `if (!t) { break; } e0; continue;`
+//
+// The optional `e1` between the `IfElse` and the trailing `Break` is hoisted into the new
+// then-arm when present; otherwise the new then-arm is just the `Break` itself. In both
+// cases the relocated `continue` at the tail is left for `remove_trailing_continue` to strip.
 //
 // Preconditions:
 //   - The pattern sits at the tail of the loop's body `Seq`.
@@ -30,12 +35,10 @@ impl Refine for SwapContinueBreak {
         let Some((loop_label, seq)) = loop_body_seq_mut(exp) else {
             return false;
         };
-        if seq.len() < 3 {
+        if seq.len() < 2 {
             return false;
         }
-        let last = seq.len() - 1;
-        let break_idx = last;
-        let if_idx = last - 2;
+        let break_idx = seq.len() - 1;
 
         // Trailing `Break` must target this loop.
         let Exp::Break(b) = &seq[break_idx] else {
@@ -44,9 +47,20 @@ impl Refine for SwapContinueBreak {
         if *b != loop_label {
             return false;
         }
+
+        // Locate the IfElse: directly before the break (no e1) or one position earlier
+        // (e1 sits between). Without e1, `if_idx == break_idx - 1`; with e1, `break_idx - 2`.
+        let (if_idx, has_e1) = if matches!(&seq[break_idx - 1], Exp::IfElse(_, _, _)) {
+            (break_idx - 1, false)
+        } else if break_idx >= 2 && matches!(&seq[break_idx - 2], Exp::IfElse(_, _, _)) {
+            (break_idx - 2, true)
+        } else {
+            return false;
+        };
+
         // `IfElse` must have empty/missing else and a then-arm ending in `Continue(loop_label)`.
         let Exp::IfElse(_, then_b, else_b) = &seq[if_idx] else {
-            return false;
+            unreachable!("if_idx selected by matches!()")
         };
         if !else_is_empty_or_missing(else_b.as_ref().as_ref()) {
             return false;
@@ -55,11 +69,16 @@ impl Refine for SwapContinueBreak {
             return false;
         }
 
-        // Rewrite. Pop the trailing `[e1, break]`; rebuild the `IfElse` with the negated
-        // test and `[e1, break]` as the new then-arm; append the old then-arm's leading
-        // items (everything before its trailing continue) and a relocated `continue`.
+        // Rewrite. Pop trailing items down to (but not including) the IfElse; rebuild the
+        // IfElse with the negated test and the popped tail (`[e1, break]` or just `break`)
+        // as the new then-arm; append the old then-arm's leading items and a relocated
+        // `continue`.
         let break_exp = seq.pop().unwrap();
-        let e1 = seq.pop().unwrap();
+        let e1_opt = if has_e1 {
+            Some(seq.pop().unwrap())
+        } else {
+            None
+        };
         let Exp::IfElse(test, then_b, _) = std::mem::replace(&mut seq[if_idx], Exp::Seq(vec![]))
         else {
             unreachable!()
@@ -67,11 +86,11 @@ impl Refine for SwapContinueBreak {
         let mut test = test;
         negate(&mut test);
         let e0_seq = strip_trailing_continue_into_seq(*then_b);
-        seq[if_idx] = Exp::IfElse(
-            test,
-            Box::new(Exp::Seq(vec![e1, break_exp])),
-            Box::new(None),
-        );
+        let new_then = match e1_opt {
+            Some(e1) => Exp::Seq(vec![e1, break_exp]),
+            None => break_exp,
+        };
+        seq[if_idx] = Exp::IfElse(test, Box::new(new_then), Box::new(None));
         seq.extend(e0_seq);
         seq.push(Exp::Continue(loop_label));
         true

--- a/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break.rs
@@ -1,30 +1,20 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Swap the tail of a loop body shaped as `[…, IfElse(t, e0;continue, ∅), e1, break]`
-// into `[…, IfElse(!t, e1;break, ∅), e0, continue]`. The flipped form puts the `break`
-// inside the then-arm — reads more naturally as "exit when the test fails" — and lifts the
-// `continue` to a trailing position so `remove_trailing_continue` can drop it. The continue
-// is preserved (relocated, never deleted): elision is owned by the one canonical pass.
+// Swap the tail of a loop body:
+// `if (t) { e0; continue; } e1; break;` => `if (!t) { e1; break; } e0; continue;`
 //
 // Preconditions:
-//   - The pattern sits at the tail of a `Loop` body (last three items of the body's `Seq`),
-//     so dropping the `break` and the subsequent trailing `continue` is semantically
-//     equivalent to the original loop iteration.
-//   - The `IfElse` has no else-arm (or an empty one) — when both arms continue, that's
-//     `hoist_dual_continue`'s territory; mixing the two would either oscillate or change
-//     semantics.
+//   - The pattern sits at the tail of the loop's body `Seq`.
 //   - The inner `continue` and the trailing `break` target the immediate enclosing loop.
-//     Label equality (`*l == loop_label`) handles both the labeled form and the
-//     post-`strip_loop_labels` `None == None` form. The continue sits inside an `IfElse`
-//     directly under the body — no nested loop between, so the label check is sound.
 
 use crate::{
     ast::Exp,
     refinement::{
         Refine,
         utils::{
-            else_is_empty_or_missing, ends_with_continue, negate, strip_trailing_continue_into_seq,
+            else_is_empty_or_missing, ends_with_continue, loop_body_seq_mut, negate,
+            strip_trailing_continue_into_seq,
         },
     },
 };
@@ -37,11 +27,7 @@ struct SwapContinueBreak;
 
 impl Refine for SwapContinueBreak {
     fn refine_custom(&mut self, exp: &mut Exp) -> bool {
-        let Exp::Loop(loop_label, body) = exp else {
-            return false;
-        };
-        let loop_label = *loop_label;
-        let Exp::Seq(seq) = body.as_mut() else {
+        let Some((loop_label, seq)) = loop_body_seq_mut(exp) else {
             return false;
         };
         if seq.len() < 3 {

--- a/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break.rs
@@ -1,0 +1,93 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Swap the tail of a loop body shaped as `[…, IfElse(t, e0;continue, ∅), e1, break]`
+// into `[…, IfElse(!t, e1;break, ∅), e0, continue]`. The flipped form puts the `break`
+// inside the then-arm — reads more naturally as "exit when the test fails" — and lifts the
+// `continue` to a trailing position so `remove_trailing_continue` can drop it. The continue
+// is preserved (relocated, never deleted): elision is owned by the one canonical pass.
+//
+// Preconditions:
+//   - The pattern sits at the tail of a `Loop` body (last three items of the body's `Seq`),
+//     so dropping the `break` and the subsequent trailing `continue` is semantically
+//     equivalent to the original loop iteration.
+//   - The `IfElse` has no else-arm (or an empty one) — when both arms continue, that's
+//     `hoist_dual_continue`'s territory; mixing the two would either oscillate or change
+//     semantics.
+//   - The inner `continue` and the trailing `break` target the immediate enclosing loop.
+//     Label equality (`*l == loop_label`) handles both the labeled form and the
+//     post-`strip_loop_labels` `None == None` form. The continue sits inside an `IfElse`
+//     directly under the body — no nested loop between, so the label check is sound.
+
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{
+            else_is_empty_or_missing, ends_with_continue, negate, strip_trailing_continue_into_seq,
+        },
+    },
+};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    SwapContinueBreak.refine(exp)
+}
+
+struct SwapContinueBreak;
+
+impl Refine for SwapContinueBreak {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Exp::Loop(loop_label, body) = exp else {
+            return false;
+        };
+        let loop_label = *loop_label;
+        let Exp::Seq(seq) = body.as_mut() else {
+            return false;
+        };
+        if seq.len() < 3 {
+            return false;
+        }
+        let last = seq.len() - 1;
+        let break_idx = last;
+        let if_idx = last - 2;
+
+        // Trailing `Break` must target this loop.
+        let Exp::Break(b) = &seq[break_idx] else {
+            return false;
+        };
+        if *b != loop_label {
+            return false;
+        }
+        // `IfElse` must have empty/missing else and a then-arm ending in `Continue(loop_label)`.
+        let Exp::IfElse(_, then_b, else_b) = &seq[if_idx] else {
+            return false;
+        };
+        if !else_is_empty_or_missing(else_b.as_ref().as_ref()) {
+            return false;
+        }
+        if !ends_with_continue(then_b, loop_label) {
+            return false;
+        }
+
+        // Rewrite. Pop the trailing `[e1, break]`; rebuild the `IfElse` with the negated
+        // test and `[e1, break]` as the new then-arm; append the old then-arm's leading
+        // items (everything before its trailing continue) and a relocated `continue`.
+        let break_exp = seq.pop().unwrap();
+        let e1 = seq.pop().unwrap();
+        let Exp::IfElse(test, then_b, _) = std::mem::replace(&mut seq[if_idx], Exp::Seq(vec![]))
+        else {
+            unreachable!()
+        };
+        let mut test = test;
+        negate(&mut test);
+        let e0_seq = strip_trailing_continue_into_seq(*then_b);
+        seq[if_idx] = Exp::IfElse(
+            test,
+            Box::new(Exp::Seq(vec![e1, break_exp])),
+            Box::new(None),
+        );
+        seq.extend(e0_seq);
+        seq.push(Exp::Continue(loop_label));
+        true
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break_else.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_break_else.rs
@@ -1,0 +1,66 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Swap a continue-then / break-else at loop tail into a break guard followed by the work:
+// `if (t) { e; continue; } else { break; }` => `if (!t) { break; } e`
+//
+// Both arms of the original definitively exit the if, so relocating `e` outside is sound;
+// the implicit fall-through at the loop's true tail replaces the original `continue`.
+//
+// Preconditions:
+//   - The `IfElse` is the last item of the loop's body `Seq`.
+//   - The else-arm is exactly `Break(loop_label)`.
+//   - The then-arm ends in `Continue(loop_label)`.
+
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{ends_with_continue, loop_body_seq_mut, negate, strip_trailing_continue_into_seq},
+    },
+};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    SwapContinueBreakElse.refine(exp)
+}
+
+struct SwapContinueBreakElse;
+
+impl Refine for SwapContinueBreakElse {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Some((loop_label, seq)) = loop_body_seq_mut(exp) else {
+            return false;
+        };
+        if seq.is_empty() {
+            return false;
+        }
+        let if_idx = seq.len() - 1;
+        let Exp::IfElse(_, then_b, else_b) = &seq[if_idx] else {
+            return false;
+        };
+        // The else-arm must be exactly `Break(loop_label)`.
+        let Some(Exp::Break(b)) = else_b.as_ref().as_ref() else {
+            return false;
+        };
+        if *b != loop_label {
+            return false;
+        }
+        // The then-arm must end in `Continue(loop_label)`.
+        if !ends_with_continue(then_b, loop_label) {
+            return false;
+        }
+
+        // Rewrite. Replace the `IfElse` in place with the inverted guard `if (!t) { break }`,
+        // then append the original then-arm's prefix (`e`) as siblings.
+        let Exp::IfElse(test, then_b, _) = std::mem::replace(&mut seq[if_idx], Exp::Seq(vec![]))
+        else {
+            unreachable!()
+        };
+        let mut test = test;
+        negate(&mut test);
+        let e_items = strip_trailing_continue_into_seq(*then_b);
+        seq[if_idx] = Exp::IfElse(test, Box::new(Exp::Break(loop_label)), Box::new(None));
+        seq.extend(e_items);
+        true
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_fallthrough.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_fallthrough.rs
@@ -1,26 +1,21 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Swap the tail of a loop body shaped as `[…, IfElse(t, e0;continue, ∅), e1]` into
-// `[…, IfElse(t, e0, Some(e1)), continue]`. `e1` was the implicit else of the original
-// `IfElse` (reached when `t` is false and the if falls through); promote it into the
-// actual else-arm so the source structure makes the branching explicit, and lift the
-// `continue` to a trailing position where `remove_trailing_continue` can drop it.
+// Promote a sibling fallthrough into the empty else-arm of an `IfElse` at loop tail:
+// `if (t) { e0; continue; } e1` => `if (t) { e0 } else { e1 }; continue;`
 //
-// Preconditions (analogous to `swap_continue_break`, just without the trailing `break`):
-//   - Pattern at the tail of a `Loop` body (last two items). `e1` is the last item.
-//   - The last item is *not* a `Break` — that's `swap_continue_break`'s shape; we don't
-//     want both rules grabbing the same input.
-//   - The `IfElse` has no else-arm (or an empty one) — `hoist_dual_continue` handles the
-//     case where both arms continue.
-//   - The inner `continue` targets the immediate enclosing loop, via label equality.
+// Preconditions:
+//   - Pattern sits at the tail of the loop's body `Seq` (last two items).
+//   - The last item is not a `Break` (that's `swap_continue_break`'s shape).
+//   - The `IfElse` has no else-arm (or an empty one).
+//   - The inner `continue` targets the immediate enclosing loop.
 
 use crate::{
     ast::Exp,
     refinement::{
         Refine,
         utils::{
-            else_is_empty_or_missing, ends_with_continue, seq_or_singleton,
+            else_is_empty_or_missing, ends_with_continue, loop_body_seq_mut, seq_or_singleton,
             strip_trailing_continue_into_seq,
         },
     },
@@ -34,11 +29,7 @@ struct SwapContinueFallthrough;
 
 impl Refine for SwapContinueFallthrough {
     fn refine_custom(&mut self, exp: &mut Exp) -> bool {
-        let Exp::Loop(loop_label, body) = exp else {
-            return false;
-        };
-        let loop_label = *loop_label;
-        let Exp::Seq(seq) = body.as_mut() else {
+        let Some((loop_label, seq)) = loop_body_seq_mut(exp) else {
             return false;
         };
         if seq.len() < 2 {

--- a/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_fallthrough.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/swap_continue_fallthrough.rs
@@ -1,0 +1,76 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Swap the tail of a loop body shaped as `[…, IfElse(t, e0;continue, ∅), e1]` into
+// `[…, IfElse(t, e0, Some(e1)), continue]`. `e1` was the implicit else of the original
+// `IfElse` (reached when `t` is false and the if falls through); promote it into the
+// actual else-arm so the source structure makes the branching explicit, and lift the
+// `continue` to a trailing position where `remove_trailing_continue` can drop it.
+//
+// Preconditions (analogous to `swap_continue_break`, just without the trailing `break`):
+//   - Pattern at the tail of a `Loop` body (last two items). `e1` is the last item.
+//   - The last item is *not* a `Break` — that's `swap_continue_break`'s shape; we don't
+//     want both rules grabbing the same input.
+//   - The `IfElse` has no else-arm (or an empty one) — `hoist_dual_continue` handles the
+//     case where both arms continue.
+//   - The inner `continue` targets the immediate enclosing loop, via label equality.
+
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{
+            else_is_empty_or_missing, ends_with_continue, seq_or_singleton,
+            strip_trailing_continue_into_seq,
+        },
+    },
+};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    SwapContinueFallthrough.refine(exp)
+}
+
+struct SwapContinueFallthrough;
+
+impl Refine for SwapContinueFallthrough {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Exp::Loop(loop_label, body) = exp else {
+            return false;
+        };
+        let loop_label = *loop_label;
+        let Exp::Seq(seq) = body.as_mut() else {
+            return false;
+        };
+        if seq.len() < 2 {
+            return false;
+        }
+        let last = seq.len() - 1;
+        let if_idx = last - 1;
+
+        // Cede the `[IfElse, e1, Break]` shape to `swap_continue_break`.
+        if matches!(&seq[last], Exp::Break(_)) {
+            return false;
+        }
+        let Exp::IfElse(_, then_b, else_b) = &seq[if_idx] else {
+            return false;
+        };
+        if !else_is_empty_or_missing(else_b.as_ref().as_ref()) {
+            return false;
+        }
+        if !ends_with_continue(then_b, loop_label) {
+            return false;
+        }
+
+        // Rewrite. Pop `e1`; rebuild the `IfElse` with `e0` (then-arm minus trailing
+        // continue) as the new then-arm and `e1` as the new else; append a `continue`.
+        let e1 = seq.pop().unwrap();
+        let Exp::IfElse(test, then_b, _) = std::mem::replace(&mut seq[if_idx], Exp::Seq(vec![]))
+        else {
+            unreachable!()
+        };
+        let e0 = seq_or_singleton(strip_trailing_continue_into_seq(*then_b));
+        seq[if_idx] = Exp::IfElse(test, Box::new(e0), Box::new(Some(e1)));
+        seq.push(Exp::Continue(loop_label));
+        true
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
@@ -3,7 +3,7 @@
 
 //! Helpers shared between refinements.
 
-use crate::ast::Exp;
+use crate::ast::{Exp, Label};
 use move_stackless_bytecode_2::ast::PrimitiveOp;
 
 /// Look through any `Exp::Block` wrappers to reach the inner expression. Used by refinements
@@ -49,5 +49,76 @@ pub(super) fn negate(exp: &mut Exp) {
                 args: vec![exp.clone()],
             };
         }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// IfElse / continue tail-position helpers
+//
+// Shared across the swap-with-break, swap-with-fallthrough, and hoist-dual-continue
+// refinements. Each treats a `Continue` sitting at the trailing position of an arm body as
+// the canonical relocation target; these helpers locate it and reshape the surrounding
+// structure consistently.
+
+/// True iff `else_b` is missing (`None`) or an empty `Seq` — the shapes the swap-* rules
+/// treat as "no else-arm." A non-empty else is the hoist-dual-continue rule's territory
+/// (when it also ends in `continue`) or out of scope.
+pub(super) fn else_is_empty_or_missing(else_b: Option<&Exp>) -> bool {
+    match else_b {
+        None => true,
+        Some(Exp::Seq(items)) => items.is_empty(),
+        Some(_) => false,
+    }
+}
+
+/// True iff the final statement of `exp` is `Continue(label)` matching `expected`. Walks
+/// the last item of `Seq`; doesn't descend into `IfElse`/`Switch`/etc.
+pub(super) fn ends_with_continue(exp: &Exp, expected: Option<Label>) -> bool {
+    match exp {
+        Exp::Continue(l) => *l == expected,
+        Exp::Seq(items) => items
+            .last()
+            .is_some_and(|last| ends_with_continue(last, expected)),
+        _ => false,
+    }
+}
+
+/// If `exp`'s last statement is `Continue(L)`, return `L`. Otherwise return `None`. Used
+/// by `hoist_dual_continue` to detect a shared trailing continue and recover its label
+/// without committing to which loop encloses us.
+pub(super) fn trailing_continue_label(exp: &Exp) -> Option<Option<Label>> {
+    match exp {
+        Exp::Continue(l) => Some(*l),
+        Exp::Seq(items) => items.last().and_then(trailing_continue_label),
+        _ => None,
+    }
+}
+
+/// Consume `exp` (typically an arm body), drop a trailing `Continue`, and return the
+/// remaining leading items as a `Vec<Exp>`. Callers splice them back as they wish — extend
+/// an enclosing `Seq` directly, or rebuild a single `Exp` via `seq_or_singleton`. The
+/// continue's identity is the caller's concern; this helper only handles structure.
+pub(super) fn strip_trailing_continue_into_seq(exp: Exp) -> Vec<Exp> {
+    match exp {
+        Exp::Continue(_) => vec![],
+        Exp::Seq(mut items) => {
+            // Trim a single trailing `Continue` — preceding refinements have already run
+            // `flatten_seq`, so nested `Seq`s aren't expected here.
+            if matches!(items.last(), Some(Exp::Continue(_))) {
+                items.pop();
+            }
+            items
+        }
+        other => vec![other],
+    }
+}
+
+/// Reshape a `Vec<Exp>` back into a single `Exp` for arm positions: `[]` becomes
+/// `Seq([])`, a singleton unwraps to its element, and longer lists stay as a `Seq`.
+pub(super) fn seq_or_singleton(mut items: Vec<Exp>) -> Exp {
+    match items.len() {
+        0 => Exp::Seq(vec![]),
+        1 => items.pop().unwrap(),
+        _ => Exp::Seq(items),
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
@@ -52,6 +52,25 @@ pub(super) fn negate(exp: &mut Exp) {
     }
 }
 
+/// Unify `Exp::Loop(label, body)` and `Exp::While(label, _, body)`: if `exp` is one of them
+/// and its body is a `Seq`, return the loop's label and a mutable reference to the body's
+/// items. Returns `None` otherwise (including loops whose body has been collapsed to a
+/// single non-`Seq` `Exp`).
+///
+/// `introduce_while` runs before the swap refinements, so by the time they look any
+/// already-promoted `While` would be invisible without this helper. We need to match both.
+pub(super) fn loop_body_seq_mut(exp: &mut Exp) -> Option<(Option<Label>, &mut Vec<Exp>)> {
+    let (label, body) = match exp {
+        Exp::Loop(label, body) => (*label, body),
+        Exp::While(label, _, body) => (*label, body),
+        _ => return None,
+    };
+    match body.as_mut() {
+        Exp::Seq(seq) => Some((label, seq)),
+        _ => None,
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 // IfElse / continue tail-position helpers
 //

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
@@ -37,9 +37,10 @@ public fun cao_s<T0, T1>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &Tr
     let l7 = sq::css(l4, l5, true, false, l6);
     if (l7 != ct::e_no_error()) {
         return l7
-    };
-    pool::cancel_all_orders(l0, l1, l2, l3, l6);
-    return 0u64
+    } else {
+        pool::cancel_all_orders(l0, l1, l2, l3, l6);
+        return 0u64
+    }
 }
 
 public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &TradeProof, l3: &Clock, l4: u64, l5: &mut TxContext): Coin<T2> {
@@ -119,73 +120,76 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                 event::emit(EE { e: ct::e_order_expired(), l: 348u64 });
                 l28 = l28 + 1u64;
                 continue
-            };
-            let l34 = *(&(&l9)[l28]);
-            let l47 = *(&(&l10)[l28]);
-            let l27 = *(&(&l11)[l28]);
-            let l40 = *(&(&l12)[l28]);
-            let l29 = *(&(&l13)[l28]);
-            if (l29) {
-                if (l44 <= l8) {
-                    event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
-                    l28 = l28 + 1u64;
-                    continue
-                }
             } else {
-                if (l21 < u64::max(l32, l7)) {
-                    event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
-                    l28 = l28 + 1u64;
+                let l34 = *(&(&l9)[l28]);
+                let l47 = *(&(&l10)[l28]);
+                let l27 = *(&(&l11)[l28]);
+                let l40 = *(&(&l12)[l28]);
+                let l29 = *(&(&l13)[l28]);
+                if (l29) {
+                    if (l44 <= l8) {
+                        event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
+                        l28 = l28 + 1u64;
+                        continue
+                    }
+                } else {
+                    if (l21 < u64::max(l32, l7)) {
+                        event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
+                        l28 = l28 + 1u64;
+                        continue
+                    }
+                };
+                let l30 = dbke::cim(l34);
+                let l37 = l27;
+                if (l34 == ct::cpsos()) {
+                    if (!(l50)) {
+                        let (reg_134, reg_136);
+                        (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
+                        let l18 = reg_136;
+                        l22 = reg_134;
+                        l19 = l18;
+                        l50 = true;
+                    };
+                    let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
+                    if (l49 == 0u64) {
+                        event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
+                        l28 = l28 + 1u64;
+                        continue
+                    } else {
+                        l37 = l49;
+                        l34 = constants::post_only();
+                    }
+                } else {
+                    let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
+                    let l24 = reg_171;
+                    let l53 = reg_170;
+                    l28 = if (l24 != ct::e_no_error()) {
+                        event::emit(EE { e: l24, l: 404u64 });
+                        l28 + 1u64
+                    } else {
+                        let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
+                        let l35 = order_info::original_quantity(&l33);
+                        let l25 = order_info::executed_quantity(&l33);
+                        let l36 = order_info::paid_fees(&l33);
+                        l44 = if (l29) {
+                            let l41 = l35as u128;
+                            let l38 = l37as u128;
+                            let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
+                            l21 = l21 + l25;
+                            l44 - l46as u64
+                        } else {
+                            let l42 = l25as u128;
+                            let l39 = l37as u128;
+                            let l45 = l42 * l39 / constants::float_scaling_u128();
+                            l21 = l21 - l35;
+                            l44 + l45as u64
+                        };
+                        l23 = l23 - l36;
+                        l28 + 1u64
+                    };
                     continue
                 }
-            };
-            let l30 = dbke::cim(l34);
-            let l37 = l27;
-            if (!(l34 == ct::cpsos())) {
-                let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
-                let l24 = reg_171;
-                let l53 = reg_170;
-                if (l24 != ct::e_no_error()) {
-                    event::emit(EE { e: l24, l: 404u64 });
-                    l28 = l28 + 1u64;
-                    continue
-                };
-                let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
-                let l35 = order_info::original_quantity(&l33);
-                let l25 = order_info::executed_quantity(&l33);
-                let l36 = order_info::paid_fees(&l33);
-                l44 = if (l29) {
-                    let l41 = l35as u128;
-                    let l38 = l37as u128;
-                    let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
-                    l21 = l21 + l25;
-                    l44 - l46as u64
-                } else {
-                    let l42 = l25as u128;
-                    let l39 = l37as u128;
-                    let l45 = l42 * l39 / constants::float_scaling_u128();
-                    l21 = l21 - l35;
-                    l44 + l45as u64
-                };
-                l23 = l23 - l36;
-                l28 = l28 + 1u64;
-                continue
-            };
-            if (!(l50)) {
-                let (reg_134, reg_136);
-                (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
-                let l18 = reg_136;
-                l22 = reg_134;
-                l19 = l18;
-                l50 = true;
-            };
-            let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
-            if (l49 == 0u64) {
-                event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
-                l28 = l28 + 1u64;
-                continue
-            };
-            l37 = l49;
-            l34 = constants::post_only();
+            }
         }
     }
 }
@@ -193,91 +197,107 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
 fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
-    };
-    let l6 = l4;
-    let l5 = if (*(&l6)) {
-        if (l1.len() == 0u64) {
-            return l3
-        };
-        let l8 = *(&l1[0u64]);
-        if (l3 < l8) {
-            return l3
-        };
-        let l9 = l8 - l2;
-        if (l9 < l2) {
-            return 0u64
-        };
-        l9
     } else {
-        if (l0.len() == 0u64) {
-            return l3
+        let l5;
+        let l6 = l4;
+        if (*(&l6)) {
+            if (l1.len() == 0u64) {
+                return l3
+            } else {
+                let l8 = *(&l1[0u64]);
+                if (l3 < l8) {
+                    return l3
+                } else {
+                    let l9 = l8 - l2;
+                    if (l9 < l2) {
+                        return 0u64
+                    } else {
+                        l5 = l9;
+                    }
+                }
+            }
+        } else {
+            if (l0.len() == 0u64) {
+                return l3
+            } else {
+                let l7 = *(&l0[0u64]);
+                if (l3 > l7) {
+                    return l3
+                } else {
+                    let l10 = l7 + l2;
+                    if (l10 > constants::max_u64() - l2) {
+                        return 0u64
+                    } else {
+                        l5 = l10;
+                    }
+                }
+            }
         };
-        let l7 = *(&l0[0u64]);
-        if (l3 > l7) {
-            return l3
-        };
-        let l10 = l7 + l2;
-        if (l10 > constants::max_u64() - l2) {
-            return 0u64
-        };
-        l10
-    };
-    return l5
+        return l5
+    }
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
     if (l7 == 0u64) {
         return (0u64, ct::e_invalid_price())
-    };
-    if (l7 % l4 != 0u64) {
-        return (0u64, ct::e_invalid_price())
-    };
-    let l12 = if (!(l9)) {
-        l1 < l6
     } else {
-        false
-    };
-    if (l12) {
-        return (0u64, ct::e_insufficient_base_balance())
-    };
-    if (l8 < l6) {
-        return (0u64, ct::e_insufficient_quantity())
-    };
-    let l16 = l9;
-    let l15 = if (*(&l16)) {
-        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
-        let l21 = l25 % l5 + l5;
-        if (l25 < l21) {
-            return (0u64, ct::e_insufficient_quote_balance())
-        };
-        let l22 = l25 - l21;
-        if (l22 < l6) {
-            return (0u64, ct::e_insufficient_quote_balance())
-        };
-        let l19 = u64::max(l6, u64::min(l8, l22as u64));
-        l19 - l19 % l5
-    } else {
-        let l20 = u64::max(l6, u64::min(l8, l1));
-        l20 - l20 % l5
-    };
-    let l26 = l15;
-    let l17 = l11;
-    let l14 = if (*(&l17)) {
-        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-        let l23 = reg_90;
-        let l24 = reg_89;
-        let l18 = l10;
-        let l13 = if (*(&l18)) {
-            l23
+        if (l7 % l4 != 0u64) {
+            return (0u64, ct::e_invalid_price())
         } else {
-            l24
-        };
-        l13
-    } else {
-        0u64
-    };
-    if (l14 > l3) {
-        return (0u64, ct::e_insufficient_deep_balance())
-    };
-    return (l26, 0u64)
+            let l12 = if (!(l9)) {
+                l1 < l6
+            } else {
+                false
+            };
+            if (l12) {
+                return (0u64, ct::e_insufficient_base_balance())
+            } else {
+                if (l8 < l6) {
+                    return (0u64, ct::e_insufficient_quantity())
+                } else {
+                    let l15;
+                    let l16 = l9;
+                    if (*(&l16)) {
+                        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
+                        let l21 = l25 % l5 + l5;
+                        if (l25 < l21) {
+                            return (0u64, ct::e_insufficient_quote_balance())
+                        } else {
+                            let l22 = l25 - l21;
+                            if (l22 < l6) {
+                                return (0u64, ct::e_insufficient_quote_balance())
+                            } else {
+                                let l19 = u64::max(l6, u64::min(l8, l22as u64));
+                                l15 = l19 - l19 % l5;
+                            }
+                        }
+                    } else {
+                        let l20 = u64::max(l6, u64::min(l8, l1));
+                        l15 = l20 - l20 % l5;
+                    };
+                    let l26 = l15;
+                    let l17 = l11;
+                    let l14 = if (*(&l17)) {
+                        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
+                        let l23 = reg_90;
+                        let l24 = reg_89;
+                        let l18 = l10;
+                        let l13 = if (*(&l18)) {
+                            l23
+                        } else {
+                            l24
+                        };
+                        l13
+                    } else {
+                        0u64
+                    };
+                    if (l14 > l3) {
+                        return (0u64, ct::e_insufficient_deep_balance())
+                    } else {
+                        return (l26, 0u64)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
@@ -37,10 +37,9 @@ public fun cao_s<T0, T1>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &Tr
     let l7 = sq::css(l4, l5, true, false, l6);
     if (l7 != ct::e_no_error()) {
         return l7
-    } else {
-        pool::cancel_all_orders(l0, l1, l2, l3, l6);
-        return 0u64
-    }
+    };
+    pool::cancel_all_orders(l0, l1, l2, l3, l6);
+    return 0u64
 }
 
 public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &TradeProof, l3: &Clock, l4: u64, l5: &mut TxContext): Coin<T2> {
@@ -153,7 +152,6 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                     if (l49 == 0u64) {
                         event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
                         l28 = l28 + 1u64;
-                        continue
                     } else {
                         l37 = l49;
                         l34 = constants::post_only();
@@ -186,7 +184,6 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                         l23 = l23 - l36;
                         l28 + 1u64
                     };
-                    continue
                 }
             }
         }
@@ -196,107 +193,91 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
 fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
-    } else {
-        let l5;
-        let l6 = l4;
-        if (*(&l6)) {
-            if (l1.len() == 0u64) {
-                return l3
-            } else {
-                let l8 = *(&l1[0u64]);
-                if (l3 < l8) {
-                    return l3
-                } else {
-                    let l9 = l8 - l2;
-                    if (l9 < l2) {
-                        return 0u64
-                    } else {
-                        l5 = l9;
-                    }
-                }
-            }
-        } else {
-            if (l0.len() == 0u64) {
-                return l3
-            } else {
-                let l7 = *(&l0[0u64]);
-                if (l3 > l7) {
-                    return l3
-                } else {
-                    let l10 = l7 + l2;
-                    if (l10 > constants::max_u64() - l2) {
-                        return 0u64
-                    } else {
-                        l5 = l10;
-                    }
-                }
-            }
+    };
+    let l6 = l4;
+    let l5 = if (*(&l6)) {
+        if (l1.len() == 0u64) {
+            return l3
         };
-        return l5
-    }
+        let l8 = *(&l1[0u64]);
+        if (l3 < l8) {
+            return l3
+        };
+        let l9 = l8 - l2;
+        if (l9 < l2) {
+            return 0u64
+        };
+        l9
+    } else {
+        if (l0.len() == 0u64) {
+            return l3
+        };
+        let l7 = *(&l0[0u64]);
+        if (l3 > l7) {
+            return l3
+        };
+        let l10 = l7 + l2;
+        if (l10 > constants::max_u64() - l2) {
+            return 0u64
+        };
+        l10
+    };
+    return l5
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
     if (l7 == 0u64) {
         return (0u64, ct::e_invalid_price())
+    };
+    if (l7 % l4 != 0u64) {
+        return (0u64, ct::e_invalid_price())
+    };
+    let l12 = if (!(l9)) {
+        l1 < l6
     } else {
-        if (l7 % l4 != 0u64) {
-            return (0u64, ct::e_invalid_price())
+        false
+    };
+    if (l12) {
+        return (0u64, ct::e_insufficient_base_balance())
+    };
+    if (l8 < l6) {
+        return (0u64, ct::e_insufficient_quantity())
+    };
+    let l16 = l9;
+    let l15 = if (*(&l16)) {
+        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
+        let l21 = l25 % l5 + l5;
+        if (l25 < l21) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l22 = l25 - l21;
+        if (l22 < l6) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l19 = u64::max(l6, u64::min(l8, l22as u64));
+        l19 - l19 % l5
+    } else {
+        let l20 = u64::max(l6, u64::min(l8, l1));
+        l20 - l20 % l5
+    };
+    let l26 = l15;
+    let l17 = l11;
+    let l14 = if (*(&l17)) {
+        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
+        let l23 = reg_90;
+        let l24 = reg_89;
+        let l18 = l10;
+        let l13 = if (*(&l18)) {
+            l23
         } else {
-            let l12 = if (!(l9)) {
-                l1 < l6
-            } else {
-                false
-            };
-            if (l12) {
-                return (0u64, ct::e_insufficient_base_balance())
-            } else {
-                if (l8 < l6) {
-                    return (0u64, ct::e_insufficient_quantity())
-                } else {
-                    let l15;
-                    let l16 = l9;
-                    if (*(&l16)) {
-                        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
-                        let l21 = l25 % l5 + l5;
-                        if (l25 < l21) {
-                            return (0u64, ct::e_insufficient_quote_balance())
-                        } else {
-                            let l22 = l25 - l21;
-                            if (l22 < l6) {
-                                return (0u64, ct::e_insufficient_quote_balance())
-                            } else {
-                                let l19 = u64::max(l6, u64::min(l8, l22as u64));
-                                l15 = l19 - l19 % l5;
-                            }
-                        }
-                    } else {
-                        let l20 = u64::max(l6, u64::min(l8, l1));
-                        l15 = l20 - l20 % l5;
-                    };
-                    let l26 = l15;
-                    let l17 = l11;
-                    let l14 = if (*(&l17)) {
-                        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-                        let l23 = reg_90;
-                        let l24 = reg_89;
-                        let l18 = l10;
-                        let l13 = if (*(&l18)) {
-                            l23
-                        } else {
-                            l24
-                        };
-                        l13
-                    } else {
-                        0u64
-                    };
-                    if (l14 > l3) {
-                        return (0u64, ct::e_insufficient_deep_balance())
-                    } else {
-                        return (l26, 0u64)
-                    }
-                }
-            }
-        }
-    }
+            l24
+        };
+        l13
+    } else {
+        0u64
+    };
+    if (l14 > l3) {
+        return (0u64, ct::e_insufficient_deep_balance())
+    };
+    return (l26, 0u64)
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
@@ -119,7 +119,6 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
             if (l26 < clock::timestamp_ms(l3)) {
                 event::emit(EE { e: ct::e_order_expired(), l: 348u64 });
                 l28 = l28 + 1u64;
-                continue
             } else {
                 let l34 = *(&(&l9)[l28]);
                 let l47 = *(&(&l10)[l28]);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
@@ -34,10 +34,9 @@ public fun cao_s<T0, T1>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &Tr
     let l7 = sq::css(l4, l5, true, false, l6);
     if (l7 != ct::e_no_error()) {
         return l7
-    } else {
-        pool::cancel_all_orders(l0, l1, l2, l3, l6);
-        return 0u64
-    }
+    };
+    pool::cancel_all_orders(l0, l1, l2, l3, l6);
+    return 0u64
 }
 
 public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &TradeProof, l3: &Clock, l4: u64, l5: &mut TxContext): Coin<T2> {
@@ -150,7 +149,6 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                     if (l49 == 0u64) {
                         event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
                         l28 = l28 + 1u64;
-                        continue
                     } else {
                         l37 = l49;
                         l34 = constants::post_only();
@@ -183,7 +181,6 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                         l23 = l23 - l36;
                         l28 + 1u64
                     };
-                    continue
                 }
             }
         }
@@ -193,108 +190,92 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
 fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
-    } else {
-        let l5;
-        let l6 = l4;
-        if (*(&l6)) {
-            if (l1.len() == 0u64) {
-                return l3
-            } else {
-                let l8 = *(&l1[0u64]);
-                if (l3 < l8) {
-                    return l3
-                } else {
-                    let l9 = l8 - l2;
-                    if (l9 < l2) {
-                        return 0u64
-                    } else {
-                        l5 = l9;
-                    }
-                }
-            }
-        } else {
-            if (l0.len() == 0u64) {
-                return l3
-            } else {
-                let l7 = *(&l0[0u64]);
-                if (l3 > l7) {
-                    return l3
-                } else {
-                    let l10 = l7 + l2;
-                    if (l10 > constants::max_u64() - l2) {
-                        return 0u64
-                    } else {
-                        l5 = l10;
-                    }
-                }
-            }
+    };
+    let l6 = l4;
+    let l5 = if (*(&l6)) {
+        if (l1.len() == 0u64) {
+            return l3
         };
-        return l5
-    }
+        let l8 = *(&l1[0u64]);
+        if (l3 < l8) {
+            return l3
+        };
+        let l9 = l8 - l2;
+        if (l9 < l2) {
+            return 0u64
+        };
+        l9
+    } else {
+        if (l0.len() == 0u64) {
+            return l3
+        };
+        let l7 = *(&l0[0u64]);
+        if (l3 > l7) {
+            return l3
+        };
+        let l10 = l7 + l2;
+        if (l10 > constants::max_u64() - l2) {
+            return 0u64
+        };
+        l10
+    };
+    return l5
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
     if (l7 == 0u64) {
         return (0u64, ct::e_invalid_price())
+    };
+    if (l7 % l4 != 0u64) {
+        return (0u64, ct::e_invalid_price())
+    };
+    let l12 = if (!(l9)) {
+        l1 < l6
     } else {
-        if (l7 % l4 != 0u64) {
-            return (0u64, ct::e_invalid_price())
+        false
+    };
+    if (l12) {
+        return (0u64, ct::e_insufficient_base_balance())
+    };
+    if (l8 < l6) {
+        return (0u64, ct::e_insufficient_quantity())
+    };
+    let l16 = l9;
+    let l15 = if (*(&l16)) {
+        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
+        let l21 = l25 % l5 + l5;
+        if (l25 < l21) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l22 = l25 - l21;
+        if (l22 < l6) {
+            return (0u64, ct::e_insufficient_quote_balance())
+        };
+        let l19 = u64::max(l6, u64::min(l8, l22as u64));
+        l19 - l19 % l5
+    } else {
+        let l20 = u64::max(l6, u64::min(l8, l1));
+        l20 - l20 % l5
+    };
+    let l26 = l15;
+    let l17 = l11;
+    let l14 = if (*(&l17)) {
+        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
+        let l23 = reg_90;
+        let l24 = reg_89;
+        let l18 = l10;
+        let l13 = if (*(&l18)) {
+            l23
         } else {
-            let l12 = if (!(l9)) {
-                l1 < l6
-            } else {
-                false
-            };
-            if (l12) {
-                return (0u64, ct::e_insufficient_base_balance())
-            } else {
-                if (l8 < l6) {
-                    return (0u64, ct::e_insufficient_quantity())
-                } else {
-                    let l15;
-                    let l16 = l9;
-                    if (*(&l16)) {
-                        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
-                        let l21 = l25 % l5 + l5;
-                        if (l25 < l21) {
-                            return (0u64, ct::e_insufficient_quote_balance())
-                        } else {
-                            let l22 = l25 - l21;
-                            if (l22 < l6) {
-                                return (0u64, ct::e_insufficient_quote_balance())
-                            } else {
-                                let l19 = u64::max(l6, u64::min(l8, l22as u64));
-                                l15 = l19 - l19 % l5;
-                            }
-                        }
-                    } else {
-                        let l20 = u64::max(l6, u64::min(l8, l1));
-                        l15 = l20 - l20 % l5;
-                    };
-                    let l26 = l15;
-                    let l17 = l11;
-                    let l14 = if (*(&l17)) {
-                        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-                        let l23 = reg_90;
-                        let l24 = reg_89;
-                        let l18 = l10;
-                        let l13 = if (*(&l18)) {
-                            l23
-                        } else {
-                            l24
-                        };
-                        l13
-                    } else {
-                        0u64
-                    };
-                    if (l14 > l3) {
-                        return (0u64, ct::e_insufficient_deep_balance())
-                    } else {
-                        return (l26, 0u64)
-                    }
-                }
-            }
-        }
-    }
+            l24
+        };
+        l13
+    } else {
+        0u64
+    };
+    if (l14 > l3) {
+        return (0u64, ct::e_insufficient_deep_balance())
+    };
+    return (l26, 0u64)
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
@@ -34,9 +34,10 @@ public fun cao_s<T0, T1>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &Tr
     let l7 = sq::css(l4, l5, true, false, l6);
     if (l7 != ct::e_no_error()) {
         return l7
-    };
-    pool::cancel_all_orders(l0, l1, l2, l3, l6);
-    return 0u64
+    } else {
+        pool::cancel_all_orders(l0, l1, l2, l3, l6);
+        return 0u64
+    }
 }
 
 public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &TradeProof, l3: &Clock, l4: u64, l5: &mut TxContext): Coin<T2> {
@@ -116,73 +117,76 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
                 event::emit(EE { e: ct::e_order_expired(), l: 348u64 });
                 l28 = l28 + 1u64;
                 continue
-            };
-            let l34 = *(&(&l9)[l28]);
-            let l47 = *(&(&l10)[l28]);
-            let l27 = *(&(&l11)[l28]);
-            let l40 = *(&(&l12)[l28]);
-            let l29 = *(&(&l13)[l28]);
-            if (l29) {
-                if (l44 <= l8) {
-                    event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
-                    l28 = l28 + 1u64;
-                    continue
-                }
             } else {
-                if (l21 < u64::max(l32, l7)) {
-                    event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
-                    l28 = l28 + 1u64;
+                let l34 = *(&(&l9)[l28]);
+                let l47 = *(&(&l10)[l28]);
+                let l27 = *(&(&l11)[l28]);
+                let l40 = *(&(&l12)[l28]);
+                let l29 = *(&(&l13)[l28]);
+                if (l29) {
+                    if (l44 <= l8) {
+                        event::emit(EE { e: ct::e_insufficient_quote_balance(), l: 363u64 });
+                        l28 = l28 + 1u64;
+                        continue
+                    }
+                } else {
+                    if (l21 < u64::max(l32, l7)) {
+                        event::emit(EE { e: ct::e_insufficient_base_balance(), l: 354u64 });
+                        l28 = l28 + 1u64;
+                        continue
+                    }
+                };
+                let l30 = dbke::cim(l34);
+                let l37 = l27;
+                if (l34 == ct::cpsos()) {
+                    if (!(l50)) {
+                        let (reg_134, reg_136);
+                        (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
+                        let l18 = reg_136;
+                        l22 = reg_134;
+                        l19 = l18;
+                        l50 = true;
+                    };
+                    let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
+                    if (l49 == 0u64) {
+                        event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
+                        l28 = l28 + 1u64;
+                        continue
+                    } else {
+                        l37 = l49;
+                        l34 = constants::post_only();
+                    }
+                } else {
+                    let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
+                    let l24 = reg_171;
+                    let l53 = reg_170;
+                    l28 = if (l24 != ct::e_no_error()) {
+                        event::emit(EE { e: l24, l: 404u64 });
+                        l28 + 1u64
+                    } else {
+                        let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
+                        let l35 = order_info::original_quantity(&l33);
+                        let l25 = order_info::executed_quantity(&l33);
+                        let l36 = order_info::paid_fees(&l33);
+                        l44 = if (l29) {
+                            let l41 = l35as u128;
+                            let l38 = l37as u128;
+                            let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
+                            l21 = l21 + l25;
+                            l44 - l46as u64
+                        } else {
+                            let l42 = l25as u128;
+                            let l39 = l37as u128;
+                            let l45 = l42 * l39 / constants::float_scaling_u128();
+                            l21 = l21 - l35;
+                            l44 + l45as u64
+                        };
+                        l23 = l23 - l36;
+                        l28 + 1u64
+                    };
                     continue
                 }
-            };
-            let l30 = dbke::cim(l34);
-            let l37 = l27;
-            if (!(l34 == ct::cpsos())) {
-                let (reg_170, reg_171) = dbke::vbac(freeze(l0), l21, l44, l23, l51, l31, l32, l37, l40, l29, l30, true);
-                let l24 = reg_171;
-                let l53 = reg_170;
-                if (l24 != ct::e_no_error()) {
-                    event::emit(EE { e: l24, l: 404u64 });
-                    l28 = l28 + 1u64;
-                    continue
-                };
-                let l33 = pool::place_limit_order(l0, l2, &l52, l28, l34, l47, l37, l53, l29, true, l26, l3, freeze(l15));
-                let l35 = order_info::original_quantity(&l33);
-                let l25 = order_info::executed_quantity(&l33);
-                let l36 = order_info::paid_fees(&l33);
-                l44 = if (l29) {
-                    let l41 = l35as u128;
-                    let l38 = l37as u128;
-                    let l46 = l41 * l38 / constants::float_scaling_u128() + 1u128;
-                    l21 = l21 + l25;
-                    l44 - l46as u64
-                } else {
-                    let l42 = l25as u128;
-                    let l39 = l37as u128;
-                    let l45 = l42 * l39 / constants::float_scaling_u128();
-                    l21 = l21 - l35;
-                    l44 + l45as u64
-                };
-                l23 = l23 - l36;
-                l28 = l28 + 1u64;
-                continue
-            };
-            if (!(l50)) {
-                let (reg_134, reg_136);
-                (reg_134, reg_135, reg_136, reg_137) = pool::get_level2_ticks_from_mid(freeze(l0), 1u64, l3);
-                let l18 = reg_136;
-                l22 = reg_134;
-                l19 = l18;
-                l50 = true;
-            };
-            let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
-            if (l49 == 0u64) {
-                event::emit(EE { e: ct::e_invalid_price(), l: 379u64 });
-                l28 = l28 + 1u64;
-                continue
-            };
-            l37 = l49;
-            l34 = constants::post_only();
+            }
         }
     }
 }
@@ -190,92 +194,108 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
 fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
-    };
-    let l6 = l4;
-    let l5 = if (*(&l6)) {
-        if (l1.len() == 0u64) {
-            return l3
-        };
-        let l8 = *(&l1[0u64]);
-        if (l3 < l8) {
-            return l3
-        };
-        let l9 = l8 - l2;
-        if (l9 < l2) {
-            return 0u64
-        };
-        l9
     } else {
-        if (l0.len() == 0u64) {
-            return l3
+        let l5;
+        let l6 = l4;
+        if (*(&l6)) {
+            if (l1.len() == 0u64) {
+                return l3
+            } else {
+                let l8 = *(&l1[0u64]);
+                if (l3 < l8) {
+                    return l3
+                } else {
+                    let l9 = l8 - l2;
+                    if (l9 < l2) {
+                        return 0u64
+                    } else {
+                        l5 = l9;
+                    }
+                }
+            }
+        } else {
+            if (l0.len() == 0u64) {
+                return l3
+            } else {
+                let l7 = *(&l0[0u64]);
+                if (l3 > l7) {
+                    return l3
+                } else {
+                    let l10 = l7 + l2;
+                    if (l10 > constants::max_u64() - l2) {
+                        return 0u64
+                    } else {
+                        l5 = l10;
+                    }
+                }
+            }
         };
-        let l7 = *(&l0[0u64]);
-        if (l3 > l7) {
-            return l3
-        };
-        let l10 = l7 + l2;
-        if (l10 > constants::max_u64() - l2) {
-            return 0u64
-        };
-        l10
-    };
-    return l5
+        return l5
+    }
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
     if (l7 == 0u64) {
         return (0u64, ct::e_invalid_price())
-    };
-    if (l7 % l4 != 0u64) {
-        return (0u64, ct::e_invalid_price())
-    };
-    let l12 = if (!(l9)) {
-        l1 < l6
     } else {
-        false
-    };
-    if (l12) {
-        return (0u64, ct::e_insufficient_base_balance())
-    };
-    if (l8 < l6) {
-        return (0u64, ct::e_insufficient_quantity())
-    };
-    let l16 = l9;
-    let l15 = if (*(&l16)) {
-        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
-        let l21 = l25 % l5 + l5;
-        if (l25 < l21) {
-            return (0u64, ct::e_insufficient_quote_balance())
-        };
-        let l22 = l25 - l21;
-        if (l22 < l6) {
-            return (0u64, ct::e_insufficient_quote_balance())
-        };
-        let l19 = u64::max(l6, u64::min(l8, l22as u64));
-        l19 - l19 % l5
-    } else {
-        let l20 = u64::max(l6, u64::min(l8, l1));
-        l20 - l20 % l5
-    };
-    let l26 = l15;
-    let l17 = l11;
-    let l14 = if (*(&l17)) {
-        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-        let l23 = reg_90;
-        let l24 = reg_89;
-        let l18 = l10;
-        let l13 = if (*(&l18)) {
-            l23
+        if (l7 % l4 != 0u64) {
+            return (0u64, ct::e_invalid_price())
         } else {
-            l24
-        };
-        l13
-    } else {
-        0u64
-    };
-    if (l14 > l3) {
-        return (0u64, ct::e_insufficient_deep_balance())
-    };
-    return (l26, 0u64)
+            let l12 = if (!(l9)) {
+                l1 < l6
+            } else {
+                false
+            };
+            if (l12) {
+                return (0u64, ct::e_insufficient_base_balance())
+            } else {
+                if (l8 < l6) {
+                    return (0u64, ct::e_insufficient_quantity())
+                } else {
+                    let l15;
+                    let l16 = l9;
+                    if (*(&l16)) {
+                        let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
+                        let l21 = l25 % l5 + l5;
+                        if (l25 < l21) {
+                            return (0u64, ct::e_insufficient_quote_balance())
+                        } else {
+                            let l22 = l25 - l21;
+                            if (l22 < l6) {
+                                return (0u64, ct::e_insufficient_quote_balance())
+                            } else {
+                                let l19 = u64::max(l6, u64::min(l8, l22as u64));
+                                l15 = l19 - l19 % l5;
+                            }
+                        }
+                    } else {
+                        let l20 = u64::max(l6, u64::min(l8, l1));
+                        l15 = l20 - l20 % l5;
+                    };
+                    let l26 = l15;
+                    let l17 = l11;
+                    let l14 = if (*(&l17)) {
+                        let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
+                        let l23 = reg_90;
+                        let l24 = reg_89;
+                        let l18 = l10;
+                        let l13 = if (*(&l18)) {
+                            l23
+                        } else {
+                            l24
+                        };
+                        l13
+                    } else {
+                        0u64
+                    };
+                    if (l14 > l3) {
+                        return (0u64, ct::e_insufficient_deep_balance())
+                    } else {
+                        return (l26, 0u64)
+                    }
+                }
+            }
+        }
+    }
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
@@ -116,7 +116,6 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
             if (l26 < clock::timestamp_ms(l3)) {
                 event::emit(EE { e: ct::e_order_expired(), l: 348u64 });
                 l28 = l28 + 1u64;
-                continue
             } else {
                 let l34 = *(&(&l9)[l28]);
                 let l47 = *(&(&l10)[l28]);

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
@@ -8,6 +8,8 @@ module loop_cases {
             l0 = l0 + 1u64;
             if (l0 >= 10u64) {
                 break;
+            } else {
+                continue;
             }
         }
     }
@@ -20,10 +22,12 @@ module loop_cases {
         loop {
             l0 = l0 + 1u64;
             if (l0 % 2u64 == 1u64) {
-                continue;
-            }
-            if (l0 == 10u64) {
-                break;
+            } else {
+                if (l0 == 10u64) {
+                    break;
+                } else {
+                    continue;
+                }
             }
         }
     }
@@ -65,6 +69,8 @@ module loop_cases {
             l1 = l1 * 2u64 + l0;
             if (l0 >= 10u64) {
                 break;
+            } else {
+                continue;
             }
         }
     }
@@ -80,6 +86,8 @@ module loop_cases {
             }
             if (l0 >= 10u64) {
                 break;
+            } else {
+                continue;
             }
         }
     }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
@@ -8,8 +8,6 @@ module loop_cases {
             l0 = l0 + 1u64;
             if (l0 >= 10u64) {
                 break;
-            } else {
-                continue;
             }
         }
     }
@@ -25,8 +23,6 @@ module loop_cases {
             } else {
                 if (l0 == 10u64) {
                     break;
-                } else {
-                    continue;
                 }
             }
         }
@@ -69,8 +65,6 @@ module loop_cases {
             l1 = l1 * 2u64 + l0;
             if (l0 >= 10u64) {
                 break;
-            } else {
-                continue;
             }
         }
     }
@@ -86,8 +80,6 @@ module loop_cases {
             }
             if (l0 >= 10u64) {
                 break;
-            } else {
-                continue;
             }
         }
     }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
@@ -13,6 +13,8 @@ public fun loop_test() {
         l0 = l0 + 1u64;
         if (l0 >= 10u64) {
             break
+        } else {
+            continue
         }
     }
 }
@@ -24,10 +26,13 @@ public fun loop_test_2() {
     loop {
         l0 = l0 + 1u64;
         if (l0 % 2u64 == 1u64) {
-            continue
-        };
-        if (l0 == 10u64) {
-            break
+            
+        } else {
+            if (l0 == 10u64) {
+                break
+            } else {
+                continue
+            }
         }
     }
 }
@@ -71,6 +76,8 @@ public fun loop_test_8() {
         l1 = l1 * 2u64 + l0;
         if (l0 >= 10u64) {
             break
+        } else {
+            continue
         }
     }
 }
@@ -86,6 +93,8 @@ public fun loop_test_9() {
         };
         if (l0 >= 10u64) {
             break
+        } else {
+            continue
         }
     }
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
@@ -13,8 +13,6 @@ public fun loop_test() {
         l0 = l0 + 1u64;
         if (l0 >= 10u64) {
             break
-        } else {
-            continue
         }
     }
 }
@@ -30,8 +28,6 @@ public fun loop_test_2() {
         } else {
             if (l0 == 10u64) {
                 break
-            } else {
-                continue
             }
         }
     }
@@ -76,8 +72,6 @@ public fun loop_test_8() {
         l1 = l1 * 2u64 + l0;
         if (l0 >= 10u64) {
             break
-        } else {
-            continue
         }
     }
 }
@@ -93,8 +87,6 @@ public fun loop_test_9() {
         };
         if (l0 >= 10u64) {
             break
-        } else {
-            continue
         }
     }
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
@@ -17,10 +17,11 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (!(l0)) {
-                break;
+            if (l0) {
+                l1 = l1 + 1u64;
+                continue;
             }
-            l1 = l1 + 1u64;
+            break;
         }
     }
 
@@ -43,14 +44,15 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (!(l0)) {
-                break;
+            if (l0) {
+                l1 = if (l1 % 2u64 == 0u64) {
+                    l1 + 1u64
+                } else {
+                    l1 + 2u64
+                };
+                continue;
             }
-            l1 = if (l1 % 2u64 == 0u64) {
-                l1 + 1u64
-            } else {
-                l1 + 2u64
-            };
+            break;
         }
     }
 
@@ -59,9 +61,13 @@ module while_cases {
         let l1 = 0u64;
         let l2 = 0u64;
         while(l0 < 10u64) {
-            while(l1 < 10u64) {
-                l2 = l2 + l0 * l1 + l1;
-                l1 = l1 + 1u64;
+            loop {
+                if (l1 < 10u64) {
+                    l2 = l2 + l0 * l1 + l1;
+                    l1 = l1 + 1u64;
+                    continue;
+                }
+                break;
             }
             l0 = l0 + 1u64;
         }
@@ -75,10 +81,11 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (!(l0)) {
-                break;
+            if (l0) {
+                l1 = l1 + 1u64;
+                continue;
             }
-            l1 = l1 + 1u64;
+            break;
         }
     }
 

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
@@ -17,12 +17,10 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (l0) {
-                l1 = l1 + 1u64;
-                continue;
-            } else {
+            if (!(l0)) {
                 break;
             }
+            l1 = l1 + 1u64;
         }
     }
 
@@ -45,16 +43,14 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (l0) {
-                l1 = if (l1 % 2u64 == 0u64) {
-                    l1 + 1u64
-                } else {
-                    l1 + 2u64
-                };
-                continue;
-            } else {
+            if (!(l0)) {
                 break;
             }
+            l1 = if (l1 % 2u64 == 0u64) {
+                l1 + 1u64
+            } else {
+                l1 + 2u64
+            };
         }
     }
 
@@ -79,12 +75,10 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (l0) {
-                l1 = l1 + 1u64;
-                continue;
-            } else {
+            if (!(l0)) {
                 break;
             }
+            l1 = l1 + 1u64;
         }
     }
 

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
@@ -17,11 +17,10 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (l0) {
-                l1 = l1 + 1u64;
-                continue;
+            if (!(l0)) {
+                break;
             }
-            break;
+            l1 = l1 + 1u64;
         }
     }
 
@@ -44,15 +43,14 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (l0) {
-                l1 = if (l1 % 2u64 == 0u64) {
-                    l1 + 1u64
-                } else {
-                    l1 + 2u64
-                };
-                continue;
+            if (!(l0)) {
+                break;
             }
-            break;
+            l1 = if (l1 % 2u64 == 0u64) {
+                l1 + 1u64
+            } else {
+                l1 + 2u64
+            };
         }
     }
 
@@ -61,13 +59,9 @@ module while_cases {
         let l1 = 0u64;
         let l2 = 0u64;
         while(l0 < 10u64) {
-            loop {
-                if (l1 < 10u64) {
-                    l2 = l2 + l0 * l1 + l1;
-                    l1 = l1 + 1u64;
-                    continue;
-                }
-                break;
+            while(l1 < 10u64) {
+                l2 = l2 + l0 * l1 + l1;
+                l1 = l1 + 1u64;
             }
             l0 = l0 + 1u64;
         }
@@ -81,11 +75,10 @@ module while_cases {
             } else {
                 l1 == 7u64
             };
-            if (l0) {
-                l1 = l1 + 1u64;
-                continue;
+            if (!(l0)) {
+                break;
             }
-            break;
+            l1 = l1 + 1u64;
         }
     }
 

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases.snap
@@ -20,19 +20,20 @@ module while_cases {
             if (l0) {
                 l1 = l1 + 1u64;
                 continue;
+            } else {
+                break;
             }
-            break;
         }
     }
 
     public fun while_test_3 () {
         let l0 = 0u64;
         while(l0 < 10u64) {
-            if (l0 % 2u64 == 0u64) {
-                l0 = l0 + 1u64;
-                continue;
-            }
-            l0 = l0 + 2u64;
+            l0 = if (l0 % 2u64 == 0u64) {
+                l0 + 1u64
+            } else {
+                l0 + 2u64
+            };
         }
     }
 
@@ -45,14 +46,15 @@ module while_cases {
                 l1 == 7u64
             };
             if (l0) {
-                if (l1 % 2u64 == 0u64) {
-                    l1 = l1 + 1u64;
-                    continue;
-                }
-                l1 = l1 + 2u64;
+                l1 = if (l1 % 2u64 == 0u64) {
+                    l1 + 1u64
+                } else {
+                    l1 + 2u64
+                };
                 continue;
+            } else {
+                break;
             }
-            break;
         }
     }
 
@@ -61,13 +63,9 @@ module while_cases {
         let l1 = 0u64;
         let l2 = 0u64;
         while(l0 < 10u64) {
-            loop {
-                if (l1 < 10u64) {
-                    l2 = l2 + l0 * l1 + l1;
-                    l1 = l1 + 1u64;
-                    continue;
-                }
-                break;
+            while(l1 < 10u64) {
+                l2 = l2 + l0 * l1 + l1;
+                l1 = l1 + 1u64;
             }
             l0 = l0 + 1u64;
         }
@@ -84,8 +82,9 @@ module while_cases {
             if (l0) {
                 l1 = l1 + 1u64;
                 continue;
+            } else {
+                break;
             }
-            break;
         }
     }
 

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
@@ -22,10 +22,11 @@ public fun while_test_2() {
         } else {
             l1 == 7u64
         };
-        if (!(l0)) {
-            break
+        if (l0) {
+            l1 = l1 + 1u64;
+            continue
         };
-        l1 = l1 + 1u64;
+        break
     }
 }
 
@@ -48,14 +49,15 @@ public fun while_test_4() {
         } else {
             l1 == 7u64
         };
-        if (!(l0)) {
-            break
+        if (l0) {
+            l1 = if (l1 % 2u64 == 0u64) {
+                l1 + 1u64
+            } else {
+                l1 + 2u64
+            };
+            continue
         };
-        l1 = if (l1 % 2u64 == 0u64) {
-            l1 + 1u64
-        } else {
-            l1 + 2u64
-        };
+        break
     }
 }
 
@@ -64,9 +66,13 @@ public fun while_test_5() {
     let l1 = 0u64;
     let l2 = 0u64;
     while (l0 < 10u64) {
-        while (l1 < 10u64) {
-            l2 = l2 + l0 * l1 + l1;
-            l1 = l1 + 1u64;
+        loop {
+            if (l1 < 10u64) {
+                l2 = l2 + l0 * l1 + l1;
+                l1 = l1 + 1u64;
+                continue
+            };
+            break
         };
         l0 = l0 + 1u64;
     }
@@ -80,9 +86,10 @@ public fun while_test_6() {
         } else {
             l1 == 7u64
         };
-        if (!(l0)) {
-            break
+        if (l0) {
+            l1 = l1 + 1u64;
+            continue
         };
-        l1 = l1 + 1u64;
+        break
     }
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
@@ -22,11 +22,10 @@ public fun while_test_2() {
         } else {
             l1 == 7u64
         };
-        if (l0) {
-            l1 = l1 + 1u64;
-            continue
+        if (!(l0)) {
+            break
         };
-        break
+        l1 = l1 + 1u64;
     }
 }
 
@@ -49,15 +48,14 @@ public fun while_test_4() {
         } else {
             l1 == 7u64
         };
-        if (l0) {
-            l1 = if (l1 % 2u64 == 0u64) {
-                l1 + 1u64
-            } else {
-                l1 + 2u64
-            };
-            continue
+        if (!(l0)) {
+            break
         };
-        break
+        l1 = if (l1 % 2u64 == 0u64) {
+            l1 + 1u64
+        } else {
+            l1 + 2u64
+        };
     }
 }
 
@@ -66,13 +64,9 @@ public fun while_test_5() {
     let l1 = 0u64;
     let l2 = 0u64;
     while (l0 < 10u64) {
-        loop {
-            if (l1 < 10u64) {
-                l2 = l2 + l0 * l1 + l1;
-                l1 = l1 + 1u64;
-                continue
-            };
-            break
+        while (l1 < 10u64) {
+            l2 = l2 + l0 * l1 + l1;
+            l1 = l1 + 1u64;
         };
         l0 = l0 + 1u64;
     }
@@ -86,10 +80,9 @@ public fun while_test_6() {
         } else {
             l1 == 7u64
         };
-        if (l0) {
-            l1 = l1 + 1u64;
-            continue
+        if (!(l0)) {
+            break
         };
-        break
+        l1 = l1 + 1u64;
     }
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
@@ -22,12 +22,10 @@ public fun while_test_2() {
         } else {
             l1 == 7u64
         };
-        if (l0) {
-            l1 = l1 + 1u64;
-            continue
-        } else {
+        if (!(l0)) {
             break
-        }
+        };
+        l1 = l1 + 1u64;
     }
 }
 
@@ -50,16 +48,14 @@ public fun while_test_4() {
         } else {
             l1 == 7u64
         };
-        if (l0) {
-            l1 = if (l1 % 2u64 == 0u64) {
-                l1 + 1u64
-            } else {
-                l1 + 2u64
-            };
-            continue
-        } else {
+        if (!(l0)) {
             break
-        }
+        };
+        l1 = if (l1 % 2u64 == 0u64) {
+            l1 + 1u64
+        } else {
+            l1 + 2u64
+        };
     }
 }
 
@@ -84,11 +80,9 @@ public fun while_test_6() {
         } else {
             l1 == 7u64
         };
-        if (l0) {
-            l1 = l1 + 1u64;
-            continue
-        } else {
+        if (!(l0)) {
             break
-        }
+        };
+        l1 = l1 + 1u64;
     }
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/while_cases@full.snap
@@ -25,19 +25,20 @@ public fun while_test_2() {
         if (l0) {
             l1 = l1 + 1u64;
             continue
-        };
-        break
+        } else {
+            break
+        }
     }
 }
 
 public fun while_test_3() {
     let l0 = 0u64;
     while (l0 < 10u64) {
-        if (l0 % 2u64 == 0u64) {
-            l0 = l0 + 1u64;
-            continue
+        l0 = if (l0 % 2u64 == 0u64) {
+            l0 + 1u64
+        } else {
+            l0 + 2u64
         };
-        l0 = l0 + 2u64;
     }
 }
 
@@ -50,14 +51,15 @@ public fun while_test_4() {
             l1 == 7u64
         };
         if (l0) {
-            if (l1 % 2u64 == 0u64) {
-                l1 = l1 + 1u64;
-                continue
+            l1 = if (l1 % 2u64 == 0u64) {
+                l1 + 1u64
+            } else {
+                l1 + 2u64
             };
-            l1 = l1 + 2u64;
             continue
-        };
-        break
+        } else {
+            break
+        }
     }
 }
 
@@ -66,13 +68,9 @@ public fun while_test_5() {
     let l1 = 0u64;
     let l2 = 0u64;
     while (l0 < 10u64) {
-        loop {
-            if (l1 < 10u64) {
-                l2 = l2 + l0 * l1 + l1;
-                l1 = l1 + 1u64;
-                continue
-            };
-            break
+        while (l1 < 10u64) {
+            l2 = l2 + l0 * l1 + l1;
+            l1 = l1 + 1u64;
         };
         l0 = l0 + 1u64;
     }
@@ -89,7 +87,8 @@ public fun while_test_6() {
         if (l0) {
             l1 = l1 + 1u64;
             continue
-        };
-        break
+        } else {
+            break
+        }
     }
 }


### PR DESCRIPTION
## Description 

This does two things to get rid of `continue` in loops: first, it if we have the option to swap a continue and a break, we do so. Second, if we can extract a continue into the tail of the loop, we also do that.

## Test plan 

Snapshot updates

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
