### PR TITLE
[simulate] Add more tests for simulate tx (1/2)

### DIFF
--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::*;
@@ -12,7 +13,9 @@ use crate::authority::authority_test_utils::{
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
+use sui_framework::BuiltInFramework;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+use sui_move_build::BuildConfig;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::FullObjectRef;
 use sui_types::collection_types::Table as TableType;
@@ -23,7 +26,9 @@ use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{GAS_VALUE_FOR_TESTING, MoveObject, OBJECT_START_VERSION};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::transaction::{Argument, Command, GenesisTransaction};
+use sui_types::transaction::{
+    Argument, Command, GenesisTransaction, TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+};
 use sui_types::transaction_executor::{SimulateTransactionResult, TransactionChecks};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID};
@@ -361,10 +366,8 @@ async fn test_simulate_transaction_result_payloads() {
         .unwrap();
     assert!(result.effects.status().is_ok());
     assert_eq!(result.mock_gas_id, None);
-    assert_eq!(
-        result.events.is_some(),
-        result.effects.events_digest().is_some()
-    );
+    assert!(result.effects.events_digest().is_none());
+    assert!(result.events.is_none());
     assert!(
         result
             .objects
@@ -408,6 +411,41 @@ async fn test_simulate_transaction_result_payloads() {
             .iter()
             .any(|object| object.id() == ObjectID::MAX),
         "mock gas does not exist in storage, so simulation must carry it in the result object set",
+    );
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/unit_tests/data/publish_with_event");
+    let modules = BuildConfig::new_for_testing()
+        .build(&path)
+        .unwrap()
+        .get_package_bytes(false);
+
+    let event_tx = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish_immutable(modules, BuiltInFramework::all_package_ids());
+        TransactionData::new_with_gas_coins(
+            TransactionKind::programmable(builder.finish()),
+            env.sender,
+            vec![],
+            TEST_ONLY_GAS_UNIT_FOR_PUBLISH * env.rgp,
+            env.rgp,
+        )
+    };
+
+    let event_result = env
+        .fullnode
+        .simulate_transaction(event_tx, TransactionChecks::Enabled, true)
+        .unwrap();
+    assert!(event_result.effects.status().is_ok());
+    assert!(event_result.effects.events_digest().is_some());
+    let events = event_result
+        .events
+        .as_ref()
+        .expect("event digest should be accompanied by event data");
+    assert_eq!(events.data.len(), 1);
+    assert_eq!(
+        "PublishEvent".to_string(),
+        events.data[0].type_.name.to_string()
     );
 }
 

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -356,7 +356,7 @@ fn assert_simulate_err(
 // =============================================================================
 
 #[tokio::test]
-async fn test_simulate_transaction_result_payloads() {
+async fn test_simulate_transaction_returns_objects_with_real_gas() {
     let env = setup_test_env().await;
     let data = build_transfer(&env, TEST_GAS_BUDGET, env.rgp);
 
@@ -380,12 +380,16 @@ async fn test_simulate_transaction_result_payloads() {
             .iter()
             .any(|object| object.id() == env.gas_object_ref.0)
     );
+}
 
-    let mut no_payment = data;
+#[tokio::test]
+async fn test_simulate_transaction_without_payment_fails_without_mock_gas() {
+    let env = setup_test_env().await;
+    let mut no_payment = build_transfer(&env, TEST_GAS_BUDGET, env.rgp);
     no_payment.gas_data_mut().payment.clear();
     let without_mock =
         env.fullnode
-            .simulate_transaction(no_payment.clone(), TransactionChecks::Enabled, false);
+            .simulate_transaction(no_payment, TransactionChecks::Enabled, false);
     assert_simulate_err(
         without_mock,
         |e| {
@@ -398,7 +402,13 @@ async fn test_simulate_transaction_result_payloads() {
         },
         "InvalidWithdrawReservation",
     );
+}
 
+#[tokio::test]
+async fn test_simulate_transaction_with_mock_gas_returns_mock_object() {
+    let env = setup_test_env().await;
+    let mut no_payment = build_transfer(&env, TEST_GAS_BUDGET, env.rgp);
+    no_payment.gas_data_mut().payment.clear();
     let with_mock = env
         .fullnode
         .simulate_transaction(no_payment, TransactionChecks::Enabled, true)
@@ -412,7 +422,11 @@ async fn test_simulate_transaction_result_payloads() {
             .any(|object| object.id() == ObjectID::MAX),
         "mock gas does not exist in storage, so simulation must carry it in the result object set",
     );
+}
 
+#[tokio::test]
+async fn test_simulate_transaction_returns_events_when_effects_have_event_digest() {
+    let env = setup_test_env().await;
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/publish_with_event");
     let modules = BuildConfig::new_for_testing()

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -9,21 +9,22 @@ use super::*;
 use crate::authority::authority_test_utils::{
     init_state_validator_with_fullnode, submit_and_execute,
 };
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::FullObjectRef;
 use sui_types::collection_types::Table as TableType;
-use sui_types::crypto::{AccountKeyPair, get_key_pair};
+use sui_types::crypto::{AccountKeyPair, get_authority_key_pair, get_key_pair};
 use sui_types::effects::TransactionEffectsAPI;
-use sui_types::error::{SuiError, SuiErrorKind, UserInputError};
+use sui_types::error::{SuiError, SuiErrorKind, SuiResult, UserInputError};
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{GAS_VALUE_FOR_TESTING, MoveObject, OBJECT_START_VERSION};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::transaction::Command;
-use sui_types::transaction_executor::TransactionChecks;
+use sui_types::transaction::{Argument, Command, GenesisTransaction};
+use sui_types::transaction_executor::{SimulateTransactionResult, TransactionChecks};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID};
 
@@ -334,9 +335,226 @@ fn assert_ok(results: &[EntryPointResult], entry_point: NodeEntryPoint) {
     );
 }
 
+fn assert_simulate_err(
+    result: SuiResult<SimulateTransactionResult>,
+    check: impl Fn(&SuiErrorKind) -> bool,
+    expected_desc: &str,
+) {
+    match result {
+        Err(e) => assert!(check(e.as_inner()), "expected {expected_desc}, got: {e:?}"),
+        Ok(_) => panic!("expected {expected_desc}, got Ok"),
+    }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
+
+#[tokio::test]
+async fn test_simulate_transaction_result_payloads() {
+    let env = setup_test_env().await;
+    let data = build_transfer(&env, TEST_GAS_BUDGET, env.rgp);
+
+    let result = env
+        .fullnode
+        .simulate_transaction(data.clone(), TransactionChecks::Enabled, false)
+        .unwrap();
+    assert!(result.effects.status().is_ok());
+    assert_eq!(result.mock_gas_id, None);
+    assert_eq!(
+        result.events.is_some(),
+        result.effects.events_digest().is_some()
+    );
+    assert!(
+        result
+            .objects
+            .iter()
+            .any(|object| object.id() == env.object_ref.0)
+    );
+    assert!(
+        result
+            .objects
+            .iter()
+            .any(|object| object.id() == env.gas_object_ref.0)
+    );
+
+    let mut no_payment = data;
+    no_payment.gas_data_mut().payment.clear();
+    let without_mock =
+        env.fullnode
+            .simulate_transaction(no_payment.clone(), TransactionChecks::Enabled, false);
+    assert_simulate_err(
+        without_mock,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UserInputError {
+                    error: UserInputError::InvalidWithdrawReservation { .. }
+                }
+            )
+        },
+        "InvalidWithdrawReservation",
+    );
+
+    let with_mock = env
+        .fullnode
+        .simulate_transaction(no_payment, TransactionChecks::Enabled, true)
+        .unwrap();
+    assert!(with_mock.effects.status().is_ok());
+    assert_eq!(with_mock.mock_gas_id, Some(ObjectID::MAX));
+    assert!(
+        with_mock
+            .objects
+            .iter()
+            .any(|object| object.id() == ObjectID::MAX),
+        "mock gas does not exist in storage, so simulation must carry it in the result object set",
+    );
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_preserves_command_outputs() {
+    let env = setup_test_env().await;
+    let recipient = SuiAddress::random_for_testing_only();
+    let amount = 500;
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_sui(vec![recipient], vec![amount]).unwrap();
+        builder.finish()
+    };
+    let data = TransactionData::new_programmable(env.sender, vec![], pt, TEST_GAS_BUDGET, env.rgp);
+
+    let result = env
+        .fullnode
+        .simulate_transaction(data, TransactionChecks::Disabled, true)
+        .unwrap();
+    assert!(result.effects.status().is_ok());
+
+    let mut command_outputs = result.execution_result.unwrap();
+    assert_eq!(command_outputs.len(), 2);
+
+    // The first PaySui command is SplitCoins(GasCoin, ...). It is the compact regression target
+    // for both categories of command output: a by-reference gas coin update and a returned coin.
+    let (mutated_by_ref, mut return_values) = command_outputs.remove(0);
+    assert_eq!(mutated_by_ref.len(), 1);
+    let (argument, gas_coin_bytes, gas_coin_type) = &mutated_by_ref[0];
+    assert_eq!(argument, &Argument::GasCoin);
+    assert_gas_coin_output(gas_coin_bytes, gas_coin_type);
+
+    assert_eq!(return_values.len(), 1);
+    let (split_coin_bytes, split_coin_type) = return_values.pop().unwrap();
+    assert_gas_coin_output(&split_coin_bytes, &split_coin_type);
+    let split_coin: GasCoin = bcs::from_bytes(&split_coin_bytes).unwrap();
+    assert_eq!(split_coin.value(), amount);
+
+    let (mutated_by_ref, return_values) = command_outputs.remove(0);
+    assert!(mutated_by_ref.is_empty());
+    assert!(return_values.is_empty());
+}
+
+fn assert_gas_coin_output(actual_value: &[u8], actual_type: &TypeTag) {
+    assert_eq!(actual_type, &TypeTag::Struct(Box::new(GasCoin::type_())));
+    let _: GasCoin = bcs::from_bytes(actual_value).unwrap();
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_guard_errors() {
+    let env = setup_test_env().await;
+    let data = build_transfer(&env, TEST_GAS_BUDGET, env.rgp);
+
+    let validator_result =
+        env.validator
+            .simulate_transaction(data, TransactionChecks::Enabled, false);
+    assert_simulate_err(
+        validator_result,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UnsupportedFeatureError { error }
+                    if error == "simulate is only supported on fullnodes"
+            )
+        },
+        "fullnode-only unsupported feature error",
+    );
+
+    let system_transaction = TransactionData::new(
+        TransactionKind::Genesis(GenesisTransaction { objects: vec![] }),
+        env.sender,
+        env.gas_object_ref,
+        TEST_GAS_BUDGET,
+        env.rgp,
+    );
+    let system_result =
+        env.fullnode
+            .simulate_transaction(system_transaction, TransactionChecks::Enabled, false);
+    assert_simulate_err(
+        system_result,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UnsupportedFeatureError { error }
+                    if error == "simulate does not support system transactions"
+            )
+        },
+        "system transaction unsupported feature error",
+    );
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_dev_inspect_disabled_guard() {
+    let (sender, _sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object =
+        Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, GAS_VALUE_FOR_TESTING);
+    let transfer_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+    let transfer_object_ref = transfer_object.compute_object_reference();
+    let starting_objects = [gas_object, transfer_object];
+
+    let fullnode_key_pair = get_authority_key_pair().1;
+    let fullnode = TestAuthorityBuilder::new()
+        .with_dev_inspect_disabled()
+        .with_keypair(&fullnode_key_pair)
+        .with_starting_objects(&starting_objects)
+        .build()
+        .await;
+
+    let recipient = SuiAddress::random_for_testing_only();
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .transfer_object(
+                recipient,
+                FullObjectRef::from_fastpath_ref(transfer_object_ref),
+            )
+            .unwrap();
+        builder.finish()
+    };
+    let data = TransactionData::new(
+        TransactionKind::ProgrammableTransaction(pt),
+        sender,
+        gas_object_ref,
+        TEST_GAS_BUDGET,
+        fullnode.reference_gas_price_for_testing().unwrap(),
+    );
+
+    let disabled = fullnode.simulate_transaction(data.clone(), TransactionChecks::Disabled, false);
+    assert_simulate_err(
+        disabled,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UnsupportedFeatureError { error }
+                    if error == "simulate with checks disabled is not allowed on this node"
+            )
+        },
+        "checks-disabled unsupported feature error",
+    );
+
+    let enabled = fullnode
+        .simulate_transaction(data, TransactionChecks::Enabled, false)
+        .unwrap();
+    assert!(enabled.effects.status().is_ok());
+}
 
 #[tokio::test]
 async fn test_simple_transfer_gas_all_paths() {

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -153,7 +153,7 @@ async fn simulate_transaction_read_mask_selects_command_outputs_without_transact
     transaction.bcs = Some(Bcs::serialize(&transaction_data).unwrap());
 
     let mut request = SimulateTransactionRequest::new(transaction);
-    request.set_checks(ProtoTransactionChecks::Disabled);
+    request.set_checks(ProtoTransactionChecks::Enabled);
     request.read_mask = Some(FieldMask {
         paths: vec!["command_outputs".to_owned()],
     });

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -20,6 +20,7 @@ use sui_rpc::proto::sui::rpc::v2::TransactionExpiration as ProtoTransactionExpir
 use sui_rpc::proto::sui::rpc::v2::TransactionKind;
 use sui_rpc::proto::sui::rpc::v2::TransferObjects;
 use sui_rpc::proto::sui::rpc::v2::UserSignature;
+use sui_rpc::proto::sui::rpc::v2::simulate_transaction_request::TransactionChecks as ProtoTransactionChecks;
 use sui_rpc::proto::sui::rpc::v2::transaction_execution_service_client::TransactionExecutionServiceClient;
 use sui_rpc::proto::sui::rpc::v2::transaction_expiration::TransactionExpirationKind;
 use sui_rpc_api::Client;
@@ -120,6 +121,61 @@ async fn resolve_transaction_simple_transfer() {
 
     assert!(effects.status().is_ok());
     assert_eq!(effects_from_simulation, effects);
+}
+
+#[sim_test]
+async fn simulate_transaction_read_mask_selects_command_outputs_without_transaction() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
+    let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
+    gas.sort_by_key(|object_ref| object_ref.0);
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .pay_sui(vec![SuiAddress::random_for_testing_only()], vec![500])
+        .unwrap();
+    let transaction_data = TransactionData::new_programmable(
+        sender,
+        vec![gas[0]],
+        builder.finish(),
+        50_000_000,
+        test_cluster.wallet.get_reference_gas_price().await.unwrap(),
+    );
+
+    let mut transaction = Transaction::default();
+    transaction.bcs = Some(Bcs::serialize(&transaction_data).unwrap());
+
+    let mut request = SimulateTransactionRequest::new(transaction);
+    request.set_checks(ProtoTransactionChecks::Disabled);
+    request.read_mask = Some(FieldMask {
+        paths: vec![
+            "command_outputs".to_owned(),
+            "suggested_gas_price".to_owned(),
+        ],
+    });
+
+    let response = alpha_client
+        .simulate_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    // This mask is intentionally narrow. The command outputs require VM execution data, but the
+    // executed transaction wrapper is expensive and should stay absent unless explicitly requested.
+    assert!(response.transaction.is_none());
+    assert_eq!(response.command_outputs.len(), 2);
+    assert!(!response.command_outputs[0].mutated_by_ref.is_empty());
+    assert!(!response.command_outputs[0].return_values.is_empty());
+    assert!(response.command_outputs[1].mutated_by_ref.is_empty());
+    assert!(response.command_outputs[1].return_values.is_empty());
+    assert!(response.suggested_gas_price.is_none());
 }
 
 #[sim_test]

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -155,10 +155,7 @@ async fn simulate_transaction_read_mask_selects_command_outputs_without_transact
     let mut request = SimulateTransactionRequest::new(transaction);
     request.set_checks(ProtoTransactionChecks::Disabled);
     request.read_mask = Some(FieldMask {
-        paths: vec![
-            "command_outputs".to_owned(),
-            "suggested_gas_price".to_owned(),
-        ],
+        paths: vec!["command_outputs".to_owned()],
     });
 
     let response = alpha_client
@@ -175,7 +172,6 @@ async fn simulate_transaction_read_mask_selects_command_outputs_without_transact
     assert!(!response.command_outputs[0].return_values.is_empty());
     assert!(response.command_outputs[1].mutated_by_ref.is_empty());
     assert!(response.command_outputs[1].return_values.is_empty());
-    assert!(response.suggested_gas_price.is_none());
 }
 
 #[sim_test]


### PR DESCRIPTION
## Description 

This PR adds a few more simulate transaction related tests before refactoring that code.

Stack:
https://github.com/MystenLabs/sui/pull/26691 -- add more tests
https://github.com/MystenLabs/sui/pull/26692 -- move the simulate code into its own module

## Test plan 

CI & new tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
