### PR TITLE
[simulate] Refactor the simulate transaction code into its own module (2/2)

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -71,6 +71,7 @@ use std::{
 };
 use sui_config::NodeConfig;
 use sui_config::node::{AuthorityOverloadConfig, StateDebugDumpConfig};
+use sui_config::transaction_deny_config::TransactionDenyConfig;
 use sui_execution::Executor;
 use sui_protocol_config::PerObjectCongestionControlMode;
 use sui_types::accumulator_root::AccumulatorObjId;
@@ -133,7 +134,7 @@ use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
 use sui_types::accumulator_root::AccumulatorValue;
 use sui_types::authenticator_state::get_authenticator_state;
 use sui_types::balance::Balance;
-use sui_types::coin_reservation;
+use sui_types::coin_reservation::{self, CoinReservationResolverTrait};
 use sui_types::committee::{EpochId, ProtocolVersion};
 use sui_types::crypto::{AuthoritySignInfo, Signer};
 use sui_types::deny_list_v1::check_coin_deny_list_v1;
@@ -994,6 +995,46 @@ impl SimulateTransactionReader for AuthoritySimulateTransactionReader<'_> {
     }
 }
 
+/// Runs deny list checks and processes funds withdrawals. Called before loading input
+/// objects, since these checks don't depend on object state.
+pub(crate) fn pre_object_load_checks(
+    tx_data: &TransactionData,
+    tx_signatures: &[GenericSignature],
+    input_object_kinds: &[InputObjectKind],
+    receiving_objects_refs: &[ObjectRef],
+    protocol_config: &ProtocolConfig,
+    transaction_deny_config: &TransactionDenyConfig,
+    package_store: &dyn BackingPackageStore,
+    chain_identifier: ChainIdentifier,
+    coin_reservation_resolver: &dyn CoinReservationResolverTrait,
+    account_funds_read: &dyn AccountFundsRead,
+) -> SuiResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+    // Note: the deny checks may do redundant package loads but:
+    // - they only load packages when there is an active package deny map
+    // - the loads are cached anyway
+    sui_transaction_checks::deny::check_transaction_for_signing(
+        tx_data,
+        tx_signatures,
+        input_object_kinds,
+        receiving_objects_refs,
+        transaction_deny_config,
+        package_store,
+    )?;
+
+    let declared_withdrawals = tx_data
+        .process_funds_withdrawals_for_signing(chain_identifier, coin_reservation_resolver)?;
+
+    account_funds_read.check_amounts_available(&declared_withdrawals)?;
+
+    if protocol_config.gasless_verify_remaining_balance() && tx_data.is_gasless_transaction() {
+        let min_amounts = sui_types::transaction::get_gasless_allowed_token_types(protocol_config);
+        account_funds_read
+            .check_remaining_amounts_after_withdrawal(&declared_withdrawals, &min_amounts)?;
+    }
+
+    Ok(declared_withdrawals)
+}
+
 /// The authority state encapsulates all state, drives execution, and ensures safety.
 ///
 /// Note the authority operations can be accessed through a read ref (&) and do not
@@ -1055,48 +1096,6 @@ impl AuthorityState {
         self.checkpoint_store.get_epoch_state_commitments(epoch)
     }
 
-    /// Runs deny list checks and processes funds withdrawals. Called before loading input
-    /// objects, since these checks don't depend on object state.
-    fn pre_object_load_checks(
-        &self,
-        tx_data: &TransactionData,
-        tx_signatures: &[GenericSignature],
-        input_object_kinds: &[InputObjectKind],
-        receiving_objects_refs: &[ObjectRef],
-        protocol_config: &ProtocolConfig,
-    ) -> SuiResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
-        // Note: the deny checks may do redundant package loads but:
-        // - they only load packages when there is an active package deny map
-        // - the loads are cached anyway
-        sui_transaction_checks::deny::check_transaction_for_signing(
-            tx_data,
-            tx_signatures,
-            input_object_kinds,
-            receiving_objects_refs,
-            &self.config.transaction_deny_config,
-            self.get_backing_package_store().as_ref(),
-        )?;
-
-        let declared_withdrawals = tx_data.process_funds_withdrawals_for_signing(
-            self.chain_identifier,
-            self.coin_reservation_resolver.as_ref(),
-        )?;
-
-        self.execution_cache_trait_pointers
-            .account_funds_read
-            .check_amounts_available(&declared_withdrawals)?;
-
-        if protocol_config.gasless_verify_remaining_balance() && tx_data.is_gasless_transaction() {
-            let min_amounts =
-                sui_types::transaction::get_gasless_allowed_token_types(protocol_config);
-            self.execution_cache_trait_pointers
-                .account_funds_read
-                .check_remaining_amounts_after_withdrawal(&declared_withdrawals, &min_amounts)?;
-        }
-
-        Ok(declared_withdrawals)
-    }
-
     fn handle_transaction_deny_checks(
         &self,
         transaction: &VerifiedTransaction,
@@ -1108,12 +1107,17 @@ impl AuthorityState {
         let input_object_kinds = tx_data.input_objects()?;
         let receiving_objects_refs = tx_data.receiving_objects();
 
-        self.pre_object_load_checks(
+        pre_object_load_checks(
             tx_data,
             transaction.tx_signatures(),
             &input_object_kinds,
             &receiving_objects_refs,
             epoch_store.protocol_config(),
+            &self.config.transaction_deny_config,
+            self.get_backing_package_store().as_ref(),
+            self.chain_identifier,
+            self.coin_reservation_resolver.as_ref(),
+            self.get_account_funds_read().as_ref(),
         )?;
 
         let (input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -19,6 +19,10 @@ use crate::execution_scheduler::funds_withdraw_scheduler::FundsSettlement;
 use crate::gasless_rate_limiter::ConsensusGaslessCounter;
 use crate::jsonrpc_index::CoinIndexKey2;
 use crate::rpc_index::RpcIndexStore;
+use crate::simulation::{
+    SimulateTransactionContext, SimulateTransactionOptions, SimulateTransactionReader,
+    simulate_transaction_with_context,
+};
 use crate::traffic_controller::TrafficController;
 use crate::traffic_controller::metrics::TrafficControllerMetrics;
 use crate::transaction_outputs::TransactionOutputs;
@@ -142,7 +146,6 @@ use sui_types::effects::{
 use sui_types::error::{ExecutionError, SuiErrorKind, UserInputError};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::execution_status::ExecutionErrorKind;
 use sui_types::gas::{GasCostSummary, SuiGasStatus};
 use sui_types::inner_temporary_store::{InnerTemporaryStore, ObjectMap, TxCoins, WrittenObjects};
 use sui_types::message_envelope::Message;
@@ -157,7 +160,7 @@ use sui_types::messages_grpc::{
     TransactionInfoRequest, TransactionInfoResponse, TransactionStatus,
 };
 use sui_types::metrics::{BytecodeVerifierMetrics, ExecutionMetrics};
-use sui_types::object::{MoveObject, OBJECT_START_VERSION, Owner, PastObjectRead};
+use sui_types::object::{Owner, PastObjectRead};
 use sui_types::signature::GenericSignature;
 use sui_types::storage::{
     BackingPackageStore, BackingStore, ObjectKey, ObjectOrTombstone, ObjectStore, WriteKind,
@@ -963,6 +966,34 @@ pub struct AuthorityState {
     post_processing_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
+struct AuthoritySimulateTransactionReader<'a> {
+    state: &'a AuthorityState,
+    epoch_store: &'a AuthorityPerEpochStore,
+}
+
+impl SimulateTransactionReader for AuthoritySimulateTransactionReader<'_> {
+    fn read_inputs_for_simulation(
+        &self,
+        _tx_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        receiving_object_refs: &[ObjectRef],
+    ) -> SuiResult<(InputObjects, ReceivingObjects)> {
+        self.state.input_loader.read_objects_for_signing(
+            // We don't want to cache this transaction since it's a simulation.
+            None,
+            input_object_kinds,
+            receiving_object_refs,
+            self.epoch_store.epoch(),
+        )
+    }
+
+    fn suggested_gas_price(&self, transaction: &TransactionData) -> Option<u64> {
+        self.state
+            .congestion_tracker
+            .get_suggested_gas_prices(transaction)
+    }
+}
+
 /// The authority state encapsulates all state, drives execution, and ensures safety.
 ///
 /// Note the authority operations can be accessed through a read ref (&) and do not
@@ -980,6 +1011,29 @@ impl AuthorityState {
 
     pub fn is_fullnode(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
         epoch_store.node_role().is_fullnode()
+    }
+
+    fn simulate_transaction_context<'a>(
+        &'a self,
+        epoch_store: &'a AuthorityPerEpochStore,
+    ) -> SimulateTransactionContext<'a> {
+        let epoch_data = epoch_store.epoch_start_config().epoch_data();
+        SimulateTransactionContext {
+            protocol_config: epoch_store.protocol_config(),
+            reference_gas_price: epoch_store.reference_gas_price(),
+            epoch_id: epoch_data.epoch_id(),
+            epoch_timestamp_ms: epoch_data.epoch_start_timestamp(),
+            chain_identifier: self.chain_identifier,
+            transaction_deny_config: &self.config.transaction_deny_config,
+            verifier_signing_config: &self.config.verifier_signing_config,
+            certificate_deny_set: self.config.certificate_deny_config.certificate_deny_set(),
+            bytecode_verifier_metrics: self.metrics.bytecode_verifier_metrics.clone(),
+            execution_metrics: self.metrics.execution_metrics.clone(),
+            package_store: self.get_backing_package_store().as_ref(),
+            backing_store: self.get_backing_store().as_ref(),
+            coin_reservation_resolver: self.coin_reservation_resolver.as_ref(),
+            account_funds_read: self.get_account_funds_read().as_ref(),
+        }
     }
 
     pub fn committee_store(&self) -> &Arc<CommitteeStore> {
@@ -2369,7 +2423,7 @@ impl AuthorityState {
 
     pub fn simulate_transaction(
         &self,
-        mut transaction: TransactionData,
+        transaction: TransactionData,
         checks: TransactionChecks,
         allow_mock_gas_coin: bool,
     ) -> SuiResult<SimulateTransactionResult> {
@@ -2396,245 +2450,20 @@ impl AuthorityState {
             .into());
         }
 
-        // Reject coin reservations in gas payment when the execution engine
-        // doesn't support them.
-        let protocol_config = epoch_store.protocol_config();
-        if !protocol_config.enable_coin_reservation_obj_refs()
-            && transaction.gas().iter().any(|obj_ref| {
-                sui_types::coin_reservation::ParsedDigest::is_coin_reservation_digest(&obj_ref.2)
-            })
-        {
-            return Err(SuiErrorKind::UnsupportedFeatureError {
-                error:
-                    "coin reservations in gas payment are not supported at this protocol version"
-                        .to_string(),
-            }
-            .into());
-        }
-
-        // Cheap validity checks for a transaction, including input size limits.
-        transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
-
-        let input_object_kinds = transaction.input_objects()?;
-        let receiving_object_refs = transaction.receiving_objects();
-
-        // Create and inject mock gas coin before pre_object_load_checks so that
-        // funds withdrawal processing sees non-empty payment and doesn't incorrectly
-        // create an address balance withdrawal for gas.
-        // Skip mock gas for gasless transactions — they don't use gas coins.
-        let is_gasless = protocol_config.enable_gasless() && transaction.is_gasless_transaction();
-        let mock_gas_object = if allow_mock_gas_coin && transaction.gas().is_empty() && !is_gasless
-        {
-            let obj = Object::new_move(
-                MoveObject::new_gas_coin(
-                    OBJECT_START_VERSION,
-                    ObjectID::MAX,
-                    DEV_INSPECT_GAS_COIN_VALUE,
-                ),
-                Owner::AddressOwner(transaction.gas_data().owner),
-                TransactionDigest::genesis_marker(),
-            );
-            transaction.gas_data_mut().payment = vec![obj.compute_object_reference()];
-            Some(obj)
-        } else {
-            None
+        let context = self.simulate_transaction_context(&epoch_store);
+        let reader = AuthoritySimulateTransactionReader {
+            state: self,
+            epoch_store: epoch_store.as_ref(),
         };
-
-        let declared_withdrawals = self.pre_object_load_checks(
-            &transaction,
-            &[],
-            &input_object_kinds,
-            &receiving_object_refs,
-            epoch_store.protocol_config(),
-        )?;
-        let address_funds: BTreeSet<_> = declared_withdrawals.keys().cloned().collect();
-
-        let (mut input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(
-            // We don't want to cache this transaction since it's a simulation.
-            None,
-            &input_object_kinds,
-            &receiving_object_refs,
-            epoch_store.epoch(),
-        )?;
-
-        // Add mock gas to input objects after loading (it doesn't exist in the store).
-        let mock_gas_id = mock_gas_object.map(|obj| {
-            let id = obj.id();
-            input_objects.push(ObjectReadResult::new_from_gas_object(&obj));
-            id
-        });
-
-        let protocol_config = epoch_store.protocol_config();
-
-        let (gas_status, checked_input_objects) = if dev_inspect {
-            sui_transaction_checks::check_dev_inspect_input(
-                protocol_config,
-                &transaction,
-                input_objects,
-                receiving_objects,
-                epoch_store.reference_gas_price(),
-            )?
-        } else {
-            sui_transaction_checks::check_transaction_input(
-                epoch_store.protocol_config(),
-                epoch_store.reference_gas_price(),
-                &transaction,
-                input_objects,
-                &receiving_objects,
-                &self.metrics.bytecode_verifier_metrics,
-                &self.config.verifier_signing_config,
-            )?
-        };
-
-        // TODO see if we can spin up a VM once and reuse it
-        let executor = sui_execution::executor(
-            protocol_config,
-            true, // silent
+        simulate_transaction_with_context(
+            &context,
+            &reader,
+            transaction,
+            SimulateTransactionOptions {
+                checks,
+                allow_mock_gas_coin,
+            },
         )
-        .expect("Creating an executor should not fail here");
-
-        let (mut kind, signer, gas_data) = transaction.execution_parts();
-        let rewritten_inputs = rewrite_transaction_for_coin_reservations(
-            self.chain_identifier,
-            &*self.coin_reservation_resolver,
-            signer,
-            &mut kind,
-            None,
-        )?;
-        let early_execution_error = get_early_execution_error(
-            &transaction.digest(),
-            &checked_input_objects,
-            self.config.certificate_deny_config.certificate_deny_set(),
-            &FundsWithdrawStatus::MaybeSufficient,
-        );
-        let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
-        };
-
-        let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
-
-        // Clone inputs for potential retry if object funds check fails post-execution.
-        let cloned_input_objects = checked_input_objects.clone();
-        let cloned_gas = gas_data.clone();
-        let cloned_kind = kind.clone();
-        let tx_digest = transaction.digest();
-        let epoch_id = epoch_store.epoch_start_config().epoch_data().epoch_id();
-        let epoch_timestamp_ms = epoch_store
-            .epoch_start_config()
-            .epoch_data()
-            .epoch_start_timestamp();
-        let (inner_temp_store, _, effects, execution_result) = executor.dev_inspect_transaction(
-            &tracking_store,
-            protocol_config,
-            self.metrics.execution_metrics.clone(),
-            false, // expensive_checks
-            execution_params,
-            &epoch_id,
-            epoch_timestamp_ms,
-            checked_input_objects,
-            gas_data,
-            gas_status,
-            kind,
-            rewritten_inputs.clone(),
-            signer,
-            tx_digest,
-            dev_inspect,
-        );
-
-        // Post-execution: check object funds (non-address withdrawals discovered during execution).
-        let (inner_temp_store, effects, execution_result) = if execution_result.is_ok() {
-            let has_insufficient_object_funds = inner_temp_store
-                .accumulator_running_max_withdraws
-                .iter()
-                .filter(|(id, _)| !address_funds.contains(id))
-                .any(|(id, max_withdraw)| {
-                    let (balance, _) = self.get_account_funds_read().get_latest_account_amount(id);
-                    balance < *max_withdraw
-                });
-
-            if has_insufficient_object_funds {
-                let retry_gas_status = SuiGasStatus::new(
-                    cloned_gas.budget,
-                    cloned_gas.price,
-                    epoch_store.reference_gas_price(),
-                    protocol_config,
-                )?;
-                let (store, _, effects, result) = executor.dev_inspect_transaction(
-                    &tracking_store,
-                    protocol_config,
-                    self.metrics.execution_metrics.clone(),
-                    false,
-                    ExecutionOrEarlyError::Err(ExecutionErrorKind::InsufficientFundsForWithdraw),
-                    &epoch_id,
-                    epoch_timestamp_ms,
-                    cloned_input_objects,
-                    cloned_gas,
-                    retry_gas_status,
-                    cloned_kind,
-                    rewritten_inputs,
-                    signer,
-                    tx_digest,
-                    dev_inspect,
-                );
-                (store, effects, result)
-            } else {
-                (inner_temp_store, effects, execution_result)
-            }
-        } else {
-            (inner_temp_store, effects, execution_result)
-        };
-
-        let loaded_runtime_objects = tracking_store.into_read_objects();
-        let unchanged_loaded_runtime_objects =
-            crate::transaction_outputs::unchanged_loaded_runtime_objects(
-                &transaction,
-                &effects,
-                &loaded_runtime_objects,
-            );
-
-        let object_set = {
-            let objects = {
-                let mut objects = loaded_runtime_objects;
-
-                for o in inner_temp_store
-                    .input_objects
-                    .into_values()
-                    .chain(inner_temp_store.written.into_values())
-                {
-                    objects.insert(o);
-                }
-
-                objects
-            };
-
-            let object_keys = sui_types::storage::get_transaction_object_set(
-                &transaction,
-                &effects,
-                &unchanged_loaded_runtime_objects,
-            );
-
-            let mut set = sui_types::full_checkpoint_content::ObjectSet::default();
-            for k in object_keys {
-                if let Some(o) = objects.get(&k) {
-                    set.insert(o.clone());
-                }
-            }
-
-            set
-        };
-
-        Ok(SimulateTransactionResult {
-            objects: object_set,
-            events: effects.events_digest().map(|_| inner_temp_store.events),
-            effects,
-            execution_result,
-            mock_gas_id,
-            unchanged_loaded_runtime_objects,
-            suggested_gas_price: self
-                .congestion_tracker
-                .get_suggested_gas_prices(&transaction),
-        })
     }
 
     /// The object ID for gas can be any object ID, even for an uncreated object

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod rpc_index;
 pub mod runtime;
 pub mod safe_client;
 pub mod signature_verifier;
+pub mod simulation;
 mod stake_aggregator;
 mod status_aggregator;
 pub mod storage;

--- a/crates/sui-core/src/simulation.rs
+++ b/crates/sui-core/src/simulation.rs
@@ -1,14 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::sync::Arc;
 
-use move_core_types::language_storage::TypeTag;
 use sui_config::transaction_deny_config::TransactionDenyConfig;
 use sui_config::verifier_signing_config::VerifierSigningConfig;
 use sui_protocol_config::ProtocolConfig;
-use sui_types::accumulator_root::AccumulatorObjId;
 use sui_types::base_types::{EpochId, ObjectID, ObjectRef, TransactionDigest};
 use sui_types::coin_reservation::{CoinReservationResolverTrait, ParsedDigest};
 use sui_types::digests::ChainIdentifier;
@@ -21,7 +19,6 @@ use sui_types::execution_status::ExecutionErrorKind;
 use sui_types::gas::SuiGasStatus;
 use sui_types::metrics::{BytecodeVerifierMetrics, ExecutionMetrics};
 use sui_types::object::{MoveObject, OBJECT_START_VERSION, Object, Owner};
-use sui_types::signature::GenericSignature;
 use sui_types::storage::{BackingPackageStore, BackingStore, TrackingBackingStore};
 use sui_types::transaction::{
     InputObjectKind, InputObjects, ObjectReadResult, ReceivingObjects, TransactionData,
@@ -31,7 +28,7 @@ use sui_types::transaction_executor::{SimulateTransactionResult, TransactionChec
 
 use crate::accumulators::funds_read::AccountFundsRead;
 use crate::accumulators::transaction_rewriting::rewrite_transaction_for_coin_reservations;
-use crate::authority::DEV_INSPECT_GAS_COIN_VALUE;
+use crate::authority::{DEV_INSPECT_GAS_COIN_VALUE, pre_object_load_checks};
 
 /// Unconditional dependencies needed by transaction simulation.
 ///
@@ -125,11 +122,16 @@ pub fn simulate_transaction_with_context<R: SimulateTransactionReader + ?Sized>(
         };
 
     let declared_withdrawals = pre_object_load_checks(
-        context,
         &transaction,
         &[],
         &input_object_kinds,
         &receiving_object_refs,
+        context.protocol_config,
+        context.transaction_deny_config,
+        context.package_store,
+        context.chain_identifier,
+        context.coin_reservation_resolver,
+        context.account_funds_read,
     )?;
     let address_funds: BTreeSet<_> = declared_withdrawals.keys().cloned().collect();
     let tx_digest = transaction.digest();
@@ -309,45 +311,4 @@ pub fn simulate_transaction_with_context<R: SimulateTransactionReader + ?Sized>(
         unchanged_loaded_runtime_objects,
         suggested_gas_price: reader.suggested_gas_price(&transaction),
     })
-}
-
-fn pre_object_load_checks(
-    context: &SimulateTransactionContext<'_>,
-    tx_data: &TransactionData,
-    tx_signatures: &[GenericSignature],
-    input_object_kinds: &[InputObjectKind],
-    receiving_objects_refs: &[ObjectRef],
-) -> SuiResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
-    // Note: the deny checks may do redundant package loads but:
-    // - they only load packages when there is an active package deny map
-    // - the loads are cached anyway
-    sui_transaction_checks::deny::check_transaction_for_signing(
-        tx_data,
-        tx_signatures,
-        input_object_kinds,
-        receiving_objects_refs,
-        context.transaction_deny_config,
-        context.package_store,
-    )?;
-
-    let declared_withdrawals = tx_data.process_funds_withdrawals_for_signing(
-        context.chain_identifier,
-        context.coin_reservation_resolver,
-    )?;
-
-    context
-        .account_funds_read
-        .check_amounts_available(&declared_withdrawals)?;
-
-    if context.protocol_config.gasless_verify_remaining_balance()
-        && tx_data.is_gasless_transaction()
-    {
-        let min_amounts =
-            sui_types::transaction::get_gasless_allowed_token_types(context.protocol_config);
-        context
-            .account_funds_read
-            .check_remaining_amounts_after_withdrawal(&declared_withdrawals, &min_amounts)?;
-    }
-
-    Ok(declared_withdrawals)
 }

--- a/crates/sui-core/src/simulation.rs
+++ b/crates/sui-core/src/simulation.rs
@@ -1,0 +1,353 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::Arc;
+
+use move_core_types::language_storage::TypeTag;
+use sui_config::transaction_deny_config::TransactionDenyConfig;
+use sui_config::verifier_signing_config::VerifierSigningConfig;
+use sui_protocol_config::ProtocolConfig;
+use sui_types::accumulator_root::AccumulatorObjId;
+use sui_types::base_types::{EpochId, ObjectID, ObjectRef, TransactionDigest};
+use sui_types::coin_reservation::{CoinReservationResolverTrait, ParsedDigest};
+use sui_types::digests::ChainIdentifier;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::error::{SuiErrorKind, SuiResult};
+use sui_types::execution_params::{
+    ExecutionOrEarlyError, FundsWithdrawStatus, get_early_execution_error,
+};
+use sui_types::execution_status::ExecutionErrorKind;
+use sui_types::gas::SuiGasStatus;
+use sui_types::metrics::{BytecodeVerifierMetrics, ExecutionMetrics};
+use sui_types::object::{MoveObject, OBJECT_START_VERSION, Object, Owner};
+use sui_types::signature::GenericSignature;
+use sui_types::storage::{BackingPackageStore, BackingStore, TrackingBackingStore};
+use sui_types::transaction::{
+    InputObjectKind, InputObjects, ObjectReadResult, ReceivingObjects, TransactionData,
+    TransactionDataAPI,
+};
+use sui_types::transaction_executor::{SimulateTransactionResult, TransactionChecks};
+
+use crate::accumulators::funds_read::AccountFundsRead;
+use crate::accumulators::transaction_rewriting::rewrite_transaction_for_coin_reservations;
+use crate::authority::DEV_INSPECT_GAS_COIN_VALUE;
+
+/// Unconditional dependencies needed by transaction simulation.
+///
+/// Keep this as plain data so callers that are not authority-backed can provide equivalent
+/// services without pretending to own an `AuthorityState`.
+pub struct SimulateTransactionContext<'a> {
+    pub protocol_config: &'a ProtocolConfig,
+    pub reference_gas_price: u64,
+    pub epoch_id: EpochId,
+    pub epoch_timestamp_ms: u64,
+    pub chain_identifier: ChainIdentifier,
+    pub transaction_deny_config: &'a TransactionDenyConfig,
+    pub verifier_signing_config: &'a VerifierSigningConfig,
+    pub certificate_deny_set: &'a HashSet<TransactionDigest>,
+    pub bytecode_verifier_metrics: Arc<BytecodeVerifierMetrics>,
+    pub execution_metrics: Arc<ExecutionMetrics>,
+    pub package_store: &'a dyn BackingPackageStore,
+    pub backing_store: &'a dyn BackingStore,
+    pub coin_reservation_resolver: &'a dyn CoinReservationResolverTrait,
+    pub account_funds_read: &'a dyn AccountFundsRead,
+}
+
+/// Caller-specific behavior that simulation cannot derive from plain context data.
+pub trait SimulateTransactionReader {
+    fn read_inputs_for_simulation(
+        &self,
+        tx_digest: &TransactionDigest,
+        input_object_kinds: &[InputObjectKind],
+        receiving_object_refs: &[ObjectRef],
+    ) -> SuiResult<(InputObjects, ReceivingObjects)>;
+
+    fn suggested_gas_price(&self, _transaction: &TransactionData) -> Option<u64> {
+        None
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct SimulateTransactionOptions {
+    pub checks: TransactionChecks,
+    pub allow_mock_gas_coin: bool,
+}
+
+pub fn simulate_transaction_with_context<R: SimulateTransactionReader + ?Sized>(
+    context: &SimulateTransactionContext<'_>,
+    reader: &R,
+    mut transaction: TransactionData,
+    options: SimulateTransactionOptions,
+) -> SuiResult<SimulateTransactionResult> {
+    // Reject coin reservations in gas payment when the execution engine
+    // doesn't support them.
+    if !context.protocol_config.enable_coin_reservation_obj_refs()
+        && transaction
+            .gas()
+            .iter()
+            .any(|obj_ref| ParsedDigest::is_coin_reservation_digest(&obj_ref.2))
+    {
+        return Err(SuiErrorKind::UnsupportedFeatureError {
+            error: "coin reservations in gas payment are not supported at this protocol version"
+                .to_string(),
+        }
+        .into());
+    }
+
+    // Cheap validity checks for a transaction, including input size limits.
+    transaction.validity_check_no_gas_check(context.protocol_config)?;
+
+    let input_object_kinds = transaction.input_objects()?;
+    let receiving_object_refs = transaction.receiving_objects();
+
+    // Create and inject mock gas coin before pre_object_load_checks so that
+    // funds withdrawal processing sees non-empty payment and doesn't incorrectly
+    // create an address balance withdrawal for gas.
+    // Skip mock gas for gasless transactions; they don't use gas coins.
+    let is_gasless =
+        context.protocol_config.enable_gasless() && transaction.is_gasless_transaction();
+    let mock_gas_object =
+        if options.allow_mock_gas_coin && transaction.gas().is_empty() && !is_gasless {
+            let obj = Object::new_move(
+                MoveObject::new_gas_coin(
+                    OBJECT_START_VERSION,
+                    ObjectID::MAX,
+                    DEV_INSPECT_GAS_COIN_VALUE,
+                ),
+                Owner::AddressOwner(transaction.gas_data().owner),
+                TransactionDigest::genesis_marker(),
+            );
+            transaction.gas_data_mut().payment = vec![obj.compute_object_reference()];
+            Some(obj)
+        } else {
+            None
+        };
+
+    let declared_withdrawals = pre_object_load_checks(
+        context,
+        &transaction,
+        &[],
+        &input_object_kinds,
+        &receiving_object_refs,
+    )?;
+    let address_funds: BTreeSet<_> = declared_withdrawals.keys().cloned().collect();
+    let tx_digest = transaction.digest();
+
+    let (mut input_objects, receiving_objects) = reader.read_inputs_for_simulation(
+        &tx_digest,
+        &input_object_kinds,
+        &receiving_object_refs,
+    )?;
+
+    // Add mock gas to input objects after loading; it does not exist in the backing store.
+    let mock_gas_id = mock_gas_object.map(|obj| {
+        let id = obj.id();
+        input_objects.push(ObjectReadResult::new_from_gas_object(&obj));
+        id
+    });
+
+    let dev_inspect = options.checks.disabled();
+    let (gas_status, checked_input_objects) = if dev_inspect {
+        sui_transaction_checks::check_dev_inspect_input(
+            context.protocol_config,
+            &transaction,
+            input_objects,
+            receiving_objects,
+            context.reference_gas_price,
+        )?
+    } else {
+        sui_transaction_checks::check_transaction_input(
+            context.protocol_config,
+            context.reference_gas_price,
+            &transaction,
+            input_objects,
+            &receiving_objects,
+            &context.bytecode_verifier_metrics,
+            context.verifier_signing_config,
+        )?
+    };
+
+    // TODO see if we can spin up a VM once and reuse it
+    let executor = sui_execution::executor(
+        context.protocol_config,
+        true, // silent
+    )
+    .expect("Creating an executor should not fail here");
+
+    let (mut kind, signer, gas_data) = transaction.execution_parts();
+    let rewritten_inputs = rewrite_transaction_for_coin_reservations(
+        context.chain_identifier,
+        context.coin_reservation_resolver,
+        signer,
+        &mut kind,
+        None,
+    )?;
+    let early_execution_error = get_early_execution_error(
+        &tx_digest,
+        &checked_input_objects,
+        context.certificate_deny_set,
+        &FundsWithdrawStatus::MaybeSufficient,
+    );
+    let execution_params = match early_execution_error {
+        Some(error) => ExecutionOrEarlyError::Err(error),
+        None => ExecutionOrEarlyError::Ok(()),
+    };
+
+    let tracking_store = TrackingBackingStore::new(context.backing_store);
+
+    // Clone inputs for potential retry if object funds check fails post-execution.
+    let cloned_input_objects = checked_input_objects.clone();
+    let cloned_gas = gas_data.clone();
+    let cloned_kind = kind.clone();
+    let (inner_temp_store, _, effects, execution_result) = executor.dev_inspect_transaction(
+        &tracking_store,
+        context.protocol_config,
+        context.execution_metrics.clone(),
+        false, // expensive_checks
+        execution_params,
+        &context.epoch_id,
+        context.epoch_timestamp_ms,
+        checked_input_objects,
+        gas_data,
+        gas_status,
+        kind,
+        rewritten_inputs.clone(),
+        signer,
+        tx_digest,
+        dev_inspect,
+    );
+
+    // Post-execution: check object funds (non-address withdrawals discovered during execution).
+    let (inner_temp_store, effects, execution_result) = if execution_result.is_ok() {
+        let has_insufficient_object_funds = inner_temp_store
+            .accumulator_running_max_withdraws
+            .iter()
+            .filter(|(id, _)| !address_funds.contains(id))
+            .any(|(id, max_withdraw)| {
+                let (balance, _) = context.account_funds_read.get_latest_account_amount(id);
+                balance < *max_withdraw
+            });
+
+        if has_insufficient_object_funds {
+            let retry_gas_status = SuiGasStatus::new(
+                cloned_gas.budget,
+                cloned_gas.price,
+                context.reference_gas_price,
+                context.protocol_config,
+            )?;
+            let (store, _, effects, result) = executor.dev_inspect_transaction(
+                &tracking_store,
+                context.protocol_config,
+                context.execution_metrics.clone(),
+                false,
+                ExecutionOrEarlyError::Err(ExecutionErrorKind::InsufficientFundsForWithdraw),
+                &context.epoch_id,
+                context.epoch_timestamp_ms,
+                cloned_input_objects,
+                cloned_gas,
+                retry_gas_status,
+                cloned_kind,
+                rewritten_inputs,
+                signer,
+                tx_digest,
+                dev_inspect,
+            );
+            (store, effects, result)
+        } else {
+            (inner_temp_store, effects, execution_result)
+        }
+    } else {
+        (inner_temp_store, effects, execution_result)
+    };
+
+    let loaded_runtime_objects = tracking_store.into_read_objects();
+    let unchanged_loaded_runtime_objects =
+        crate::transaction_outputs::unchanged_loaded_runtime_objects(
+            &transaction,
+            &effects,
+            &loaded_runtime_objects,
+        );
+
+    let object_set = {
+        let objects = {
+            let mut objects = loaded_runtime_objects;
+
+            for object in inner_temp_store
+                .input_objects
+                .into_values()
+                .chain(inner_temp_store.written.into_values())
+            {
+                objects.insert(object);
+            }
+
+            objects
+        };
+
+        let object_keys = sui_types::storage::get_transaction_object_set(
+            &transaction,
+            &effects,
+            &unchanged_loaded_runtime_objects,
+        );
+
+        let mut set = sui_types::full_checkpoint_content::ObjectSet::default();
+        for key in object_keys {
+            if let Some(object) = objects.get(&key) {
+                set.insert(object.clone());
+            }
+        }
+
+        set
+    };
+
+    Ok(SimulateTransactionResult {
+        objects: object_set,
+        events: effects.events_digest().map(|_| inner_temp_store.events),
+        effects,
+        execution_result,
+        mock_gas_id,
+        unchanged_loaded_runtime_objects,
+        suggested_gas_price: reader.suggested_gas_price(&transaction),
+    })
+}
+
+fn pre_object_load_checks(
+    context: &SimulateTransactionContext<'_>,
+    tx_data: &TransactionData,
+    tx_signatures: &[GenericSignature],
+    input_object_kinds: &[InputObjectKind],
+    receiving_objects_refs: &[ObjectRef],
+) -> SuiResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+    // Note: the deny checks may do redundant package loads but:
+    // - they only load packages when there is an active package deny map
+    // - the loads are cached anyway
+    sui_transaction_checks::deny::check_transaction_for_signing(
+        tx_data,
+        tx_signatures,
+        input_object_kinds,
+        receiving_objects_refs,
+        context.transaction_deny_config,
+        context.package_store,
+    )?;
+
+    let declared_withdrawals = tx_data.process_funds_withdrawals_for_signing(
+        context.chain_identifier,
+        context.coin_reservation_resolver,
+    )?;
+
+    context
+        .account_funds_read
+        .check_amounts_available(&declared_withdrawals)?;
+
+    if context.protocol_config.gasless_verify_remaining_balance()
+        && tx_data.is_gasless_transaction()
+    {
+        let min_amounts =
+            sui_types::transaction::get_gasless_allowed_token_types(context.protocol_config);
+        context
+            .account_funds_read
+            .check_remaining_amounts_after_withdrawal(&declared_withdrawals, &min_amounts)?;
+    }
+
+    Ok(declared_withdrawals)
+}

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -57,7 +57,7 @@ use sui_types::{
     base_types::{FullObjectRef, dbg_addr},
     crypto::{AccountKeyPair, AuthorityKeyPair},
     crypto::{Signature, get_key_pair},
-    object::{GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION, Owner},
+    object::{GAS_VALUE_FOR_TESTING, MoveObject, OBJECT_START_VERSION, Owner},
     transaction::PlainTransactionWithClaims,
 };
 use sui_types::{SUI_CLOCK_OBJECT_SHARED_VERSION, digests::Digest};

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::*;
@@ -12,7 +13,9 @@ use crate::authority::authority_test_utils::{
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
+use sui_framework::BuiltInFramework;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+use sui_move_build::BuildConfig;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::FullObjectRef;
 use sui_types::collection_types::Table as TableType;
@@ -23,7 +26,9 @@ use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{GAS_VALUE_FOR_TESTING, MoveObject, OBJECT_START_VERSION};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::transaction::{Argument, Command, GenesisTransaction};
+use sui_types::transaction::{
+    Argument, Command, GenesisTransaction, TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+};
 use sui_types::transaction_executor::{SimulateTransactionResult, TransactionChecks};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID};
@@ -361,10 +366,8 @@ async fn test_simulate_transaction_result_payloads() {
         .unwrap();
     assert!(result.effects.status().is_ok());
     assert_eq!(result.mock_gas_id, None);
-    assert_eq!(
-        result.events.is_some(),
-        result.effects.events_digest().is_some()
-    );
+    assert!(result.effects.events_digest().is_none());
+    assert!(result.events.is_none());
     assert!(
         result
             .objects
@@ -408,6 +411,41 @@ async fn test_simulate_transaction_result_payloads() {
             .iter()
             .any(|object| object.id() == ObjectID::MAX),
         "mock gas does not exist in storage, so simulation must carry it in the result object set",
+    );
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/unit_tests/data/publish_with_event");
+    let modules = BuildConfig::new_for_testing()
+        .build(&path)
+        .unwrap()
+        .get_package_bytes(false);
+
+    let event_tx = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish_immutable(modules, BuiltInFramework::all_package_ids());
+        TransactionData::new_with_gas_coins(
+            TransactionKind::programmable(builder.finish()),
+            env.sender,
+            vec![],
+            TEST_ONLY_GAS_UNIT_FOR_PUBLISH * env.rgp,
+            env.rgp,
+        )
+    };
+
+    let event_result = env
+        .fullnode
+        .simulate_transaction(event_tx, TransactionChecks::Enabled, true)
+        .unwrap();
+    assert!(event_result.effects.status().is_ok());
+    assert!(event_result.effects.events_digest().is_some());
+    let events = event_result
+        .events
+        .as_ref()
+        .expect("event digest should be accompanied by event data");
+    assert_eq!(events.data.len(), 1);
+    assert_eq!(
+        "PublishEvent".to_string(),
+        events.data[0].type_.name.to_string()
     );
 }
 

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -9,21 +9,22 @@ use super::*;
 use crate::authority::authority_test_utils::{
     init_state_validator_with_fullnode, submit_and_execute,
 };
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::FullObjectRef;
 use sui_types::collection_types::Table as TableType;
-use sui_types::crypto::{AccountKeyPair, get_key_pair};
+use sui_types::crypto::{AccountKeyPair, get_authority_key_pair, get_key_pair};
 use sui_types::effects::TransactionEffectsAPI;
-use sui_types::error::{SuiError, SuiErrorKind, UserInputError};
+use sui_types::error::{SuiError, SuiErrorKind, SuiResult, UserInputError};
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{GAS_VALUE_FOR_TESTING, MoveObject, OBJECT_START_VERSION};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::transaction::Command;
-use sui_types::transaction_executor::TransactionChecks;
+use sui_types::transaction::{Argument, Command, GenesisTransaction};
+use sui_types::transaction_executor::{SimulateTransactionResult, TransactionChecks};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID};
 
@@ -334,9 +335,226 @@ fn assert_ok(results: &[EntryPointResult], entry_point: NodeEntryPoint) {
     );
 }
 
+fn assert_simulate_err(
+    result: SuiResult<SimulateTransactionResult>,
+    check: impl Fn(&SuiErrorKind) -> bool,
+    expected_desc: &str,
+) {
+    match result {
+        Err(e) => assert!(check(e.as_inner()), "expected {expected_desc}, got: {e:?}"),
+        Ok(_) => panic!("expected {expected_desc}, got Ok"),
+    }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
+
+#[tokio::test]
+async fn test_simulate_transaction_result_payloads() {
+    let env = setup_test_env().await;
+    let data = build_transfer(&env, TEST_GAS_BUDGET, env.rgp);
+
+    let result = env
+        .fullnode
+        .simulate_transaction(data.clone(), TransactionChecks::Enabled, false)
+        .unwrap();
+    assert!(result.effects.status().is_ok());
+    assert_eq!(result.mock_gas_id, None);
+    assert_eq!(
+        result.events.is_some(),
+        result.effects.events_digest().is_some()
+    );
+    assert!(
+        result
+            .objects
+            .iter()
+            .any(|object| object.id() == env.object_ref.0)
+    );
+    assert!(
+        result
+            .objects
+            .iter()
+            .any(|object| object.id() == env.gas_object_ref.0)
+    );
+
+    let mut no_payment = data;
+    no_payment.gas_data_mut().payment.clear();
+    let without_mock =
+        env.fullnode
+            .simulate_transaction(no_payment.clone(), TransactionChecks::Enabled, false);
+    assert_simulate_err(
+        without_mock,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UserInputError {
+                    error: UserInputError::InvalidWithdrawReservation { .. }
+                }
+            )
+        },
+        "InvalidWithdrawReservation",
+    );
+
+    let with_mock = env
+        .fullnode
+        .simulate_transaction(no_payment, TransactionChecks::Enabled, true)
+        .unwrap();
+    assert!(with_mock.effects.status().is_ok());
+    assert_eq!(with_mock.mock_gas_id, Some(ObjectID::MAX));
+    assert!(
+        with_mock
+            .objects
+            .iter()
+            .any(|object| object.id() == ObjectID::MAX),
+        "mock gas does not exist in storage, so simulation must carry it in the result object set",
+    );
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_preserves_command_outputs() {
+    let env = setup_test_env().await;
+    let recipient = SuiAddress::random_for_testing_only();
+    let amount = 500;
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_sui(vec![recipient], vec![amount]).unwrap();
+        builder.finish()
+    };
+    let data = TransactionData::new_programmable(env.sender, vec![], pt, TEST_GAS_BUDGET, env.rgp);
+
+    let result = env
+        .fullnode
+        .simulate_transaction(data, TransactionChecks::Disabled, true)
+        .unwrap();
+    assert!(result.effects.status().is_ok());
+
+    let mut command_outputs = result.execution_result.unwrap();
+    assert_eq!(command_outputs.len(), 2);
+
+    // The first PaySui command is SplitCoins(GasCoin, ...). It is the compact regression target
+    // for both categories of command output: a by-reference gas coin update and a returned coin.
+    let (mutated_by_ref, mut return_values) = command_outputs.remove(0);
+    assert_eq!(mutated_by_ref.len(), 1);
+    let (argument, gas_coin_bytes, gas_coin_type) = &mutated_by_ref[0];
+    assert_eq!(argument, &Argument::GasCoin);
+    assert_gas_coin_output(gas_coin_bytes, gas_coin_type);
+
+    assert_eq!(return_values.len(), 1);
+    let (split_coin_bytes, split_coin_type) = return_values.pop().unwrap();
+    assert_gas_coin_output(&split_coin_bytes, &split_coin_type);
+    let split_coin: GasCoin = bcs::from_bytes(&split_coin_bytes).unwrap();
+    assert_eq!(split_coin.value(), amount);
+
+    let (mutated_by_ref, return_values) = command_outputs.remove(0);
+    assert!(mutated_by_ref.is_empty());
+    assert!(return_values.is_empty());
+}
+
+fn assert_gas_coin_output(actual_value: &[u8], actual_type: &TypeTag) {
+    assert_eq!(actual_type, &TypeTag::Struct(Box::new(GasCoin::type_())));
+    let _: GasCoin = bcs::from_bytes(actual_value).unwrap();
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_guard_errors() {
+    let env = setup_test_env().await;
+    let data = build_transfer(&env, TEST_GAS_BUDGET, env.rgp);
+
+    let validator_result =
+        env.validator
+            .simulate_transaction(data, TransactionChecks::Enabled, false);
+    assert_simulate_err(
+        validator_result,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UnsupportedFeatureError { error }
+                    if error == "simulate is only supported on fullnodes"
+            )
+        },
+        "fullnode-only unsupported feature error",
+    );
+
+    let system_transaction = TransactionData::new(
+        TransactionKind::Genesis(GenesisTransaction { objects: vec![] }),
+        env.sender,
+        env.gas_object_ref,
+        TEST_GAS_BUDGET,
+        env.rgp,
+    );
+    let system_result =
+        env.fullnode
+            .simulate_transaction(system_transaction, TransactionChecks::Enabled, false);
+    assert_simulate_err(
+        system_result,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UnsupportedFeatureError { error }
+                    if error == "simulate does not support system transactions"
+            )
+        },
+        "system transaction unsupported feature error",
+    );
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_dev_inspect_disabled_guard() {
+    let (sender, _sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object =
+        Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, GAS_VALUE_FOR_TESTING);
+    let transfer_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+    let transfer_object_ref = transfer_object.compute_object_reference();
+    let starting_objects = [gas_object, transfer_object];
+
+    let fullnode_key_pair = get_authority_key_pair().1;
+    let fullnode = TestAuthorityBuilder::new()
+        .with_dev_inspect_disabled()
+        .with_keypair(&fullnode_key_pair)
+        .with_starting_objects(&starting_objects)
+        .build()
+        .await;
+
+    let recipient = SuiAddress::random_for_testing_only();
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .transfer_object(
+                recipient,
+                FullObjectRef::from_fastpath_ref(transfer_object_ref),
+            )
+            .unwrap();
+        builder.finish()
+    };
+    let data = TransactionData::new(
+        TransactionKind::ProgrammableTransaction(pt),
+        sender,
+        gas_object_ref,
+        TEST_GAS_BUDGET,
+        fullnode.reference_gas_price_for_testing().unwrap(),
+    );
+
+    let disabled = fullnode.simulate_transaction(data.clone(), TransactionChecks::Disabled, false);
+    assert_simulate_err(
+        disabled,
+        |e| {
+            matches!(
+                e,
+                SuiErrorKind::UnsupportedFeatureError { error }
+                    if error == "simulate with checks disabled is not allowed on this node"
+            )
+        },
+        "checks-disabled unsupported feature error",
+    );
+
+    let enabled = fullnode
+        .simulate_transaction(data, TransactionChecks::Enabled, false)
+        .unwrap();
+    assert!(enabled.effects.status().is_ok());
+}
 
 #[tokio::test]
 async fn test_simple_transfer_gas_all_paths() {

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -15,7 +15,7 @@ use sui_types::crypto::AccountKeyPair;
 use sui_types::effects::SignedTransactionEffects;
 use sui_types::execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
-use sui_types::object::GAS_VALUE_FOR_TESTING;
+use sui_types::object::{GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -20,6 +20,7 @@ use sui_rpc::proto::sui::rpc::v2::TransactionExpiration as ProtoTransactionExpir
 use sui_rpc::proto::sui::rpc::v2::TransactionKind;
 use sui_rpc::proto::sui::rpc::v2::TransferObjects;
 use sui_rpc::proto::sui::rpc::v2::UserSignature;
+use sui_rpc::proto::sui::rpc::v2::simulate_transaction_request::TransactionChecks as ProtoTransactionChecks;
 use sui_rpc::proto::sui::rpc::v2::transaction_execution_service_client::TransactionExecutionServiceClient;
 use sui_rpc::proto::sui::rpc::v2::transaction_expiration::TransactionExpirationKind;
 use sui_rpc_api::Client;
@@ -120,6 +121,61 @@ async fn resolve_transaction_simple_transfer() {
 
     assert!(effects.status().is_ok());
     assert_eq!(effects_from_simulation, effects);
+}
+
+#[sim_test]
+async fn simulate_transaction_read_mask_selects_command_outputs_without_transaction() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
+    let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
+    gas.sort_by_key(|object_ref| object_ref.0);
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .pay_sui(vec![SuiAddress::random_for_testing_only()], vec![500])
+        .unwrap();
+    let transaction_data = TransactionData::new_programmable(
+        sender,
+        vec![gas[0]],
+        builder.finish(),
+        50_000_000,
+        test_cluster.wallet.get_reference_gas_price().await.unwrap(),
+    );
+
+    let mut transaction = Transaction::default();
+    transaction.bcs = Some(Bcs::serialize(&transaction_data).unwrap());
+
+    let mut request = SimulateTransactionRequest::new(transaction);
+    request.set_checks(ProtoTransactionChecks::Disabled);
+    request.read_mask = Some(FieldMask {
+        paths: vec![
+            "command_outputs".to_owned(),
+            "suggested_gas_price".to_owned(),
+        ],
+    });
+
+    let response = alpha_client
+        .simulate_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    // This mask is intentionally narrow. The command outputs require VM execution data, but the
+    // executed transaction wrapper is expensive and should stay absent unless explicitly requested.
+    assert!(response.transaction.is_none());
+    assert_eq!(response.command_outputs.len(), 2);
+    assert!(!response.command_outputs[0].mutated_by_ref.is_empty());
+    assert!(!response.command_outputs[0].return_values.is_empty());
+    assert!(response.command_outputs[1].mutated_by_ref.is_empty());
+    assert!(response.command_outputs[1].return_values.is_empty());
+    assert!(response.suggested_gas_price.is_none());
 }
 
 #[sim_test]

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -155,10 +155,7 @@ async fn simulate_transaction_read_mask_selects_command_outputs_without_transact
     let mut request = SimulateTransactionRequest::new(transaction);
     request.set_checks(ProtoTransactionChecks::Disabled);
     request.read_mask = Some(FieldMask {
-        paths: vec![
-            "command_outputs".to_owned(),
-            "suggested_gas_price".to_owned(),
-        ],
+        paths: vec!["command_outputs".to_owned()],
     });
 
     let response = alpha_client
@@ -175,7 +172,6 @@ async fn simulate_transaction_read_mask_selects_command_outputs_without_transact
     assert!(!response.command_outputs[0].return_values.is_empty());
     assert!(response.command_outputs[1].mutated_by_ref.is_empty());
     assert!(response.command_outputs[1].return_values.is_empty());
-    assert!(response.suggested_gas_price.is_none());
 }
 
 #[sim_test]


### PR DESCRIPTION
## Description 

This PR moves the `simulate_transaction` logic out from `AuthorityState` into its own module to make it easier to reuse. It also moves the `pre_object_load_checks` function out from `AuthorityState` type and into a free function that simulation module can import and call.

Stack:
https://github.com/MystenLabs/sui/pull/26691 -- add more tests
https://github.com/MystenLabs/sui/pull/26692 -- move the simulate code into its own module

## Test plan 

Existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
