### PR TITLE
docker/stress: switch runtime to debian-slim, drop bundled repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ target/
 build/
 storage/
 docker/
+!docker/stress/entrypoint.sh

--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -55,6 +55,10 @@ COPY crates/sui-benchmark/src/workloads/data /sui/crates/sui-benchmark/src/workl
 COPY crates/sui-framework/packages/sui-framework /sui/crates/sui-framework/packages/sui-framework
 COPY crates/sui-framework/packages/move-stdlib /sui/crates/sui-framework/packages/move-stdlib
 
+# publish_basics_package callers (shared_counter etc.) read examples/move/basics at runtime.
+ENV MOVE_EXAMPLES_DIR=/sui/examples/move
+COPY examples/move/basics /sui/examples/move/basics
+
 ARG BUILD_DATE
 ARG GIT_REVISION
 LABEL build-date=$BUILD_DATE

--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -19,24 +19,31 @@ COPY crates crates
 # layer cache key stable across commits when source content is unchanged.
 RUN cargo build --locked --profile ${PROFILE} --bin stress
 
-FROM rust:1.92-bullseye
+# Production Image
+#
+# Mirrors the docker/sui-node and docker/sui-tools pattern: slim base + only
+# the runtime tools consumers actually invoke. Previously this stage used
+# `rust:1.92-bullseye` plus a `git clone` of the full repo, producing a
+# ~1.2 GB compressed image (vs sui-node's ~114 MB). The oversized export
+# made BuildKit's `#28 exporting to client directory` step prone to gRPC
+# transport hangs under PVC/network contention.
+FROM debian:bullseye-slim AS runtime
+# Runtime needs:
+#   - sui-network-aux mounts its own entry.sh and runs `aws s3 cp` to fetch
+#     genesis + keystore, with a `curl` fallback.
+#   - sui-antithesis uses the in-image entrypoint below (curl + bash only).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl awscli \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /sui
 ARG PROFILE=release
-ARG GIT_REVISION
-COPY --from=builder /sui/target/${PROFILE}/stress /usr/local/bin
-WORKDIR "$WORKDIR/sui"
-
-RUN apt-get update && apt-get -y --no-install-recommends install wget \
-        iputils-ping netcat procps bind9-host bind9-dnsutils curl iproute2 git ca-certificates awscli
-
-RUN git clone https://github.com/MystenLabs/sui.git ; \
-        cd sui ; \
-        git checkout $GIT_REVISION ; \
-        cd .. ; \
-        mv sui/* .
-
-RUN mkdir -p /docker/stress
-RUN cp docker/stress/entrypoint.sh /docker/stress/entrypoint.sh
+COPY --from=builder /sui/target/${PROFILE}/stress /usr/local/bin/stress
+COPY docker/stress/entrypoint.sh /docker/stress/entrypoint.sh
 RUN chmod +x /docker/stress/entrypoint.sh
-RUN echo ${GIT_REVISION:-$GIT_REVISION} > /var/run/sui_commit
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION
 
 CMD ["/docker/stress/entrypoint.sh"]

--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -41,6 +41,20 @@ COPY --from=builder /sui/target/${PROFILE}/stress /usr/local/bin/stress
 COPY docker/stress/entrypoint.sh /docker/stress/entrypoint.sh
 RUN chmod +x /docker/stress/entrypoint.sh
 
+# sui-benchmark workloads (composite/adversarial/party/slow/max_package) read
+# their Move source packages at runtime via BENCHMARK_MOVE_BASE_DIR (or the
+# env!("CARGO_MANIFEST_DIR") fallback in crates/sui-benchmark/src/workloads/
+# mod.rs). The previous runtime `git clone` made these visible incidentally;
+# now we ship only what those workloads actually publish. Each workload's
+# Move.toml has `Sui = { local = "../../../../../sui-framework/packages/
+# sui-framework" }`, which (relative to the Move.toml's parent dir) resolves
+# to /sui/crates/sui-framework/packages/sui-framework — so that tree plus its
+# move-stdlib dep must also be present. Total cost: ~2 MB.
+ENV BENCHMARK_MOVE_BASE_DIR=/sui/crates/sui-benchmark
+COPY crates/sui-benchmark/src/workloads/data /sui/crates/sui-benchmark/src/workloads/data
+COPY crates/sui-framework/packages/sui-framework /sui/crates/sui-framework/packages/sui-framework
+COPY crates/sui-framework/packages/move-stdlib /sui/crates/sui-framework/packages/move-stdlib
+
 ARG BUILD_DATE
 ARG GIT_REVISION
 LABEL build-date=$BUILD_DATE


### PR DESCRIPTION
## Summary

The `mysten/stress` image is currently **~1244 MB compressed** vs `mysten/sui-node`'s **~114 MB** at the same SHA. This bloat directly causes the recent buildkit/gRPC wedge failures in `Continuous` CI.

After this PR, the image is **75.6 MiB compressed** (1234.7 → 75.6 MiB, **94% smaller**, 21 → 10 layers).

## Symptom

On 2026-05-18, four consecutive Continuous runs failed at the stress build with the same signature:

> `rpc error: code = Unavailable ... error reading from server: EOF while exporting to the client directory`

Each took **~2–3h** before failing (sidecar timeout + buildkit graceful-terminate). Affected mp3 builds: **34721, 34765, 34787, 34858**. Most-recent broken run: https://github.com/MystenLabs/sui-operations/actions/runs/26068501485.

## Root cause

The current runtime stage uses `rust:1.92-bullseye` as its base (~1.5 GB) and does a `git clone https://github.com/MystenLabs/sui.git` at build time, dragging the entire repo into the runtime image. Plus apt-installs `wget iputils-ping netcat procps bind9-host bind9-dnsutils curl iproute2 git ca-certificates awscli` — most unused.

BuildKit's `#28 exporting to client directory` step writes the full image content to the buildkitd PVC. At ~3-4 GB uncompressed, the export takes minutes and is much more likely to hit a transient gRPC stream failure than sui-node's ~300 MB. The PVC cargo cache (helpful for the compile step) doesn't help the export step.

## Fix

Mirror the `docker/sui-node` and `docker/sui-tools` pattern:

- Runtime base: `debian:bullseye-slim`
- `COPY docker/stress/entrypoint.sh ...` from build context (no runtime `git clone`)
- Install only `ca-certificates curl awscli` (everything else is unused — see consumer audit below)
- Drop `/var/run/sui_commit` write (no consumer reads it; `LABEL git-revision` is the standard place)

Ship the minimal Move package tree the workloads load at runtime:

- `crates/sui-benchmark/src/workloads/data` (~320 KB) — `composite`/`adversarial`/`party`/`slow`/`max_package` packages
- `crates/sui-framework/packages/sui-framework` (~1.3 MB) — referenced by each workload's `Move.toml` via `local = "../../../../../sui-framework/packages/sui-framework"`
- `crates/sui-framework/packages/move-stdlib` (~352 KB) — Sui's transitive dep
- `examples/move/basics` (~32 KB) — read by `TestTransactionBuilder::publish_examples("basics")` via the `publish_basics_package` helper (called by `shared_counter`, `randomness`, `randomized_transaction`, `shared_object_deletion`)
- `ENV BENCHMARK_MOVE_BASE_DIR=/sui/crates/sui-benchmark` and `ENV MOVE_EXAMPLES_DIR=/sui/examples/move` so callers don't fall back to the build-time `CARGO_MANIFEST_DIR` path

Negate `docker/stress/entrypoint.sh` in `.dockerignore`. The repo-wide `docker/` exclusion was previously sidestepped by the runtime `git clone`; removing the clone forces an explicit COPY, which the existing ignore line blocks.

### Defects caught during validation

Two real defects surfaced under real-world testing that wouldn't have shown up in CI checks alone:

1. **`.dockerignore` excludes `docker/`** → first mp3 build (34958) failed at `COPY docker/stress/entrypoint.sh` after 132s with a `checksum calculation` error. Fixed by adding `!docker/stress/entrypoint.sh` exception (commit `9ace43189c`).
2. **Missing `examples/move/basics`** → second mp3 build (34960) succeeded and image deployed to staging, but the stress pod crashlooped with `Invalid directory at /sui/examples/move/basics` inside `SharedCounterWorkload::init`. `sui-test-transaction-builder::publish_examples("basics")` resolves its path via `env!("CARGO_MANIFEST_DIR")` — a build-time path that doesn't exist in the slim runtime. Fixed by COPY'ing `examples/move/basics` (32 KB) and setting `MOVE_EXAMPLES_DIR` (commit `4649ba4253`).

## Consumer audit

| Consumer | Path | What it uses from the image |
|---|---|---|
| **sui-network-aux** (K8s, devnet/staging/ci) | mounts `entry.sh` from a ConfigMap | `/usr/local/bin/stress`, `bash`, `aws s3 cp` (genesis + keystore), `curl` fallback. Doesn't use the in-image entrypoint. With `stress_shared_counter > 0`, **does** publish `examples/move/basics` at runtime via `publish_basics_package` — which is why the second commit's `examples/move/basics` COPY is required. |
| **sui-antithesis** (docker-compose) | uses in-image `/docker/stress/entrypoint.sh` | `/usr/local/bin/stress`, `bash`, `curl`, `grep`, `wc`, `sleep`. Mounts genesis/keystore from host. Sets `STRESS_COMPOSITE=5` — publishes the `composite` Move package, covered by the `workloads/data/composite` COPY. |
| **PTN bare-metal** (ansible) | pulls binary from `s3://sui-releases/{sha}/stress` | **Not affected by image changes.** Cargo build is unchanged → binary is byte-identical to main. |

Verified `sui-benchmark` has no `diesel`/`postgres`/`pq-sys` deps — `libpq5` is not needed at runtime.

## Validation

End-to-end on staging via `sui-network-aux`, pinned to PR head `4649ba4253` ([MystenLabs/sui-operations#7978](https://github.com/MystenLabs/sui-operations/pull/7978)):

- mp3 build (34965): succeeded, image published to GAR + DockerHub
- Compressed size: 1234.7 MiB → 75.6 MiB (94% reduction)
- Pod startup: genesis/keystore download → fullnode connection → reconfiguration to epoch 43 → bank initialization (563 coins) → `Publishing basics package` succeeded → bench driver running with 24 workers
- Steady-state behavior: ~50–55 TPS sustained (target 50), latency p50 ~240ms / p99 ~290–380ms, 0 error tx, 0 panics, 0 restarts over ~10 min

Workload coverage across consumers of this image:

| Env | shared_counter | transfer_object | other | enabled? |
|---|---|---|---|---|
| **staging** | 2 | 2 | 0 | validated directly |
| **devnet** | 2 | 2 | 0 | identical config to staging |
| **ci** | 2 | 2 | 0 | identical config to staging |
| **testnet** | – | – | – | `stress_enabled: false` |

All five referenced workload data dirs (`adversarial/composite/max_package/party/slow`) are present at this PR head and COPY'd. `examples/move/basics` is COPY'd. `sui-framework` + `move-stdlib` paths resolve correctly via the Move.toml relative-path chain.

## Pre-existing latent bug (noted, not fixed here)

`crates/sui-benchmark/src/workloads/adversarial.rs:581` pushes `src/workloads/data/really_big_package`, but the on-disk directory is named `max_package`. The codepath is only reached when `--adversarial` is non-zero; production runs (`sui-network-aux`, antithesis) both set it to `0`, so this latent mismatch doesn't trigger. Worth a separate small PR to rename.

## Test plan

- [x] mp3 build of PR head produces a much smaller `mysten/stress:<sha>` and completes in normal time. **Result: 75.6 MiB compressed, build 34965 finished in ~4 min.**
- [x] On a single sui-network-aux deploy, confirm the stress pod starts, `aws s3 cp` succeeds, and `/usr/local/bin/stress bench ...` runs. **Result: validated on staging, ~50 TPS, 0 errors, 0 restarts over 10 min.**
- [ ] Run an antithesis test cycle (sets `STRESS_COMPOSITE=5`) and verify the in-image entrypoint completes `rpc.discover` polling, publishes the composite Move package, and starts benchmarking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
