### PR TITLE
fix(faucet): make `sui start --with-faucet` shut down on Ctrl+C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14839,6 +14839,7 @@ dependencies = [
  "serde_json",
  "shared-crypto",
  "sui-config",
+ "sui-futures",
  "sui-keys",
  "sui-rpc-api",
  "sui-sdk",

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -23,6 +23,7 @@ tracing.workspace = true
 sui-sdk.workspace = true
 sui-rpc-api.workspace = true
 sui-config.workspace = true
+sui-futures.workspace = true
 sui-keys.workspace = true
 shared-crypto.workspace = true
 

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use sui_config::sui_config_dir;
 use sui_faucet::{AppState, create_wallet_context, start_faucet};
 use sui_faucet::{FaucetConfig, LocalFaucet};
+use sui_futures::service::Error as ServiceError;
 
 // Define the `GIT_REVISION` and `VERSION` consts
 bin_version::bin_version!();
@@ -26,5 +27,9 @@ async fn main() -> Result<(), anyhow::Error> {
         config,
     });
 
-    start_faucet(app_state).await
+    match start_faucet(app_state).await?.main().await {
+        Ok(()) | Err(ServiceError::Terminated) => Ok(()),
+        Err(ServiceError::Aborted) => Err(anyhow::anyhow!("Faucet aborted during shutdown")),
+        Err(ServiceError::Task(e)) => Err(e),
+    }
 }

--- a/crates/sui-faucet/src/server.rs
+++ b/crates/sui-faucet/src/server.rs
@@ -3,6 +3,7 @@
 
 use crate::types::*;
 use crate::{AppState, FaucetConfig, FaucetError, FaucetRequest};
+use anyhow::Context;
 use axum::{
     BoxError, Extension, Json, Router,
     error_handling::HandleErrorLayer,
@@ -19,7 +20,9 @@ use std::{
     time::Duration,
 };
 use sui_config::SUI_CLIENT_CONFIG;
+use sui_futures::service::Service;
 use sui_sdk::wallet_context::WalletContext;
+use tokio::sync::oneshot;
 use tower::ServiceBuilder;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
@@ -101,14 +104,13 @@ async fn handle_error(error: BoxError) -> impl IntoResponse {
 
 /// Start a faucet that is run locally. This should only be used for starting a local network, and
 /// not for devnet/testnet deployments!
-pub async fn start_faucet(app_state: Arc<AppState>) -> Result<(), anyhow::Error> {
+pub async fn start_faucet(app_state: Arc<AppState>) -> anyhow::Result<Service> {
     let cors = CorsLayer::new()
         .allow_methods(vec![Method::GET, Method::POST])
         .allow_headers(Any)
         .allow_origin(Any);
     let FaucetConfig { port, host_ip, .. } = app_state.config;
 
-    info!("Starting faucet in local mode");
     let app = Router::new()
         .route("/", get(health))
         .route("/v2/gas", post(request_local_gas))
@@ -124,15 +126,28 @@ pub async fn start_faucet(app_state: Arc<AppState>) -> Result<(), anyhow::Error>
         );
 
     let addr = SocketAddr::new(IpAddr::V4(host_ip), port);
-    info!("listening on {}", addr);
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await?;
+    info!("Starting local faucet service on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .context("Failed to bind faucet to listen address")?;
 
-    Ok(())
+    let (stx, srx) = oneshot::channel::<()>();
+    Ok(Service::new()
+        .with_shutdown_signal(async move {
+            let _ = stx.send(());
+        })
+        .spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                let _ = srx.await;
+                info!("Shutdown received, shutting down faucet service");
+            })
+            .await
+            .context("Failed to start faucet service")
+        }))
 }
 
 #[cfg(test)]
@@ -162,12 +177,10 @@ mod tests {
             config,
         });
 
-        // Spawn the faucet in a background task
-        let handle = tokio::spawn(async move {
-            start_faucet(app_state)
-                .await
-                .expect("Failed to start faucet");
-        });
+        // Start the faucet as a background Service
+        let service = start_faucet(app_state)
+            .await
+            .expect("Failed to start faucet");
 
         // Give the server a moment to start
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -201,6 +214,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-        handle.abort();
+        service
+            .shutdown()
+            .await
+            .expect("Failed to shut down faucet");
     }
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1275,7 +1275,13 @@ async fn start(
             config,
         });
 
-        start_faucet(app_state).await?;
+        rpc_services = rpc_services.merge(
+            start_faucet(app_state)
+                .await
+                .context("Failed to start faucet")?,
+        );
+
+        info!("Faucet started at {faucet_address}");
     }
 
     // Run health check loop until Ctrl+C or failure


### PR DESCRIPTION
## Summary

`start_faucet` calls `axum::serve(...).await` inline with no graceful-shutdown signal wired up, so it blocks forever. As a result, the ctrl-c branch of the health-check loop in `sui_commands::start` is never reached, and `rpc_services.shutdown()` never runs — so `sui start --with-faucet` either appears to ignore SIGINT or exits without cleanly stopping the indexer / GraphQL / consistent-store / faucet.

Verified on `main`: with `--with-faucet`, sending SIGINT to the process never produces the `"Received Ctrl+C, shutting down..."` log line that the health-check loop emits — confirming the loop is unreachable.

## Fix

Refactor `start_faucet` to return a `sui_futures::service::Service` that wraps `axum::serve(...).with_graceful_shutdown(...)`, matching the shape of `start_graphql`, `start_consistent_store`, and the indexer. `sui_commands::start` merges the returned `Service` into `rpc_services`, so the faucet shuts down through the same `rpc_services.shutdown()` path as everything else.

The standalone `sui-faucet` binary now drives the returned `Service` via `Service::main()`, which already handles SIGINT/SIGTERM with a grace period.

## Test plan

- [x] `cargo check -p sui-faucet -p sui` clean
- [x] `cargo xclippy` clean for `sui-faucet` and `sui`
- [x] `cargo nextest run -p sui-faucet` — all 3 tests pass, including the server endpoint test that now uses the new `Service`-based API
- [ ] Reviewer to confirm Ctrl+C cleanly shuts down `sui start --with-faucet` in their environment

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `sui start --with-faucet` now responds to Ctrl+C / SIGINT and shuts down all subservices gracefully.
- [ ] Rust SDK:
- [ ] Indexing Framework: