### PR TITLE
docs: add redirects for broken external links

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -2594,6 +2594,311 @@
       "source": "/concepts/data-access/indexer-runtime-perf",
       "destination": "/develop/accessing-data/custom-indexer/indexer-runtime-perf",
       "permanent": true
+    },
+    {
+      "source": "/build/programming-with-objects/",
+      "destination": "/develop/objects",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/transactions/prog-txn-blocks/",
+      "destination": "/develop/transactions/ptbs/prog-txn-blocks",
+      "permanent": true
+    },
+    {
+      "source": "/build/objects",
+      "destination": "/develop/sui-architecture/object-model",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/archival-store",
+      "destination": "/develop/accessing-data/archival-store",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/cryptography/nautilus",
+      "destination": "/sui-stack/nautilus",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/cryptography/transaction-auth/multisig",
+      "destination": "/develop/transactions/transaction-auth/multisig",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/custom-indexing-framework",
+      "destination": "/develop/accessing-data/custom-indexer",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/data-access/graphql-indexer",
+      "destination": "/develop/accessing-data/graphql",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/dynamic-fields",
+      "destination": "/develop/objects/dynamic-fields",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/dynamic-fields/transfers/transfer-to-object",
+      "destination": "/develop/objects/transfers/transfer-to-object",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/graphql-indexer",
+      "destination": "/develop/accessing-data/graphql",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/graphql-rpc",
+      "destination": "/develop/accessing-data/graphql/graphql-rpc",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/grpc-overview",
+      "destination": "/develop/accessing-data/grpc",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/object-model",
+      "destination": "/develop/sui-architecture/object-model",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/object-ownership",
+      "destination": "/develop/objects/object-ownership",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/object-ownership/address-owned",
+      "destination": "/develop/objects/object-ownership/address-owned",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/sui-architecture/indexer-functions",
+      "destination": "/develop/accessing-data/custom-indexer",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/sui-architecture/transaction-lifecycle",
+      "destination": "/develop/transactions/transaction-lifecycle",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/sui-move-concepts/packages",
+      "destination": "/develop/write-move/package-overview",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/sui-move-concepts/packages/custom-policies",
+      "destination": "/develop/publish-upgrade-packages/custom-policies",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/tokenomics/gas-pricing",
+      "destination": "/develop/transaction-payment/gas-in-sui",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/tokenomics/proof-of-stake",
+      "destination": "/develop/sui-architecture/tokenomics-overview",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/tokenomics/storage-fund",
+      "destination": "/develop/sui-architecture/tokenomics-overview",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/tokenomics/sui-coin",
+      "destination": "/develop/sui-architecture/tokenomics-overview",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/transactions/sponsored-transactions",
+      "destination": "/develop/transaction-payment/sponsor-txn",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/transfers/custom-rules",
+      "destination": "/develop/objects/transfers/custom-rules",
+      "permanent": true
+    },
+    {
+      "source": "/concepts/transfers/transfer-to-object",
+      "destination": "/develop/objects/transfers/transfer-to-object",
+      "permanent": true
+    },
+    {
+      "source": "/contribute",
+      "destination": "/references/contribute/contribution-process",
+      "permanent": true
+    },
+    {
+      "source": "/contribute/research-papers",
+      "destination": "/references/research-papers",
+      "permanent": true
+    },
+    {
+      "source": "/develop/sui-architecture/index",
+      "destination": "/develop/sui-architecture",
+      "permanent": true
+    },
+    {
+      "source": "/doc-updates/sui-migration-guide",
+      "destination": "/getting-started",
+      "permanent": true
+    },
+    {
+      "source": "/explore/devnet",
+      "destination": "/develop/sui-architecture/networks",
+      "permanent": true
+    },
+    {
+      "source": "/explore/wallet-browser",
+      "destination": "/onchain-finance/asset-custody/wallets",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer",
+      "destination": "/develop",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/accessing-data/custom-indexing-framework",
+      "destination": "/develop/accessing-data/custom-indexer",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/advanced/asset-tokenization",
+      "destination": "/onchain-finance/tokenized-assets/asset-tokenization",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/advanced/custom-indexer",
+      "destination": "/develop/accessing-data/custom-indexer",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/advanced/local-fee-markets",
+      "destination": "/develop/transaction-payment/local-fee-markets",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/advanced/randomness-onchain",
+      "destination": "/sui-stack/on-chain-primitives/randomness-onchain",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/getting-started/data-serving",
+      "destination": "/develop/accessing-data/data-serving",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/getting-started/graphql-rpc",
+      "destination": "/develop/accessing-data/graphql/graphql-rpc",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/nft-index",
+      "destination": "/onchain-finance/tokenized-assets",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/nft",
+      "destination": "/onchain-finance/tokenized-assets",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/nft/nft-soulbound",
+      "destination": "/onchain-finance/examples-patterns/soulbound-tokens",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/access-time",
+      "destination": "/sui-stack/on-chain-primitives/access-time",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/building-ptb",
+      "destination": "/develop/transactions/ptbs/building-ptb",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/coin-mgt",
+      "destination": "/onchain-finance/fungible-tokens",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/shared-owned",
+      "destination": "/develop/objects/object-ownership/shared",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/sponsor-txn",
+      "destination": "/develop/transaction-payment/sponsor-txn",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/using-events",
+      "destination": "/develop/accessing-data/using-events",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/working-with-ptbs",
+      "destination": "/develop/transactions/ptbs",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/move-package-management",
+      "destination": "/develop/manage-packages/move-package-management",
+      "permanent": true
+    },
+    {
+      "source": "/guides/developer/sui-101/sign-and-send-txn",
+      "destination": "/develop/transactions/transaction-auth/auth-overview",
+      "permanent": true
+    },
+    {
+      "source": "/learn/architecture/consensus",
+      "destination": "/develop/sui-architecture/consensus",
+      "permanent": true
+    },
+    {
+      "source": "/learn/cryptography/sui-wallet-specs",
+      "destination": "/onchain-finance/asset-custody/wallets",
+      "permanent": true
+    },
+    {
+      "source": "/learn/sui-glossary",
+      "destination": "/references/sui-glossary",
+      "permanent": true
+    },
+    {
+      "source": "/onchain-finance/display",
+      "destination": "/develop/objects/display",
+      "permanent": true
+    },
+    {
+      "source": "/references/framework/sui_sui/sui_sui/:path*",
+      "destination": "/references/framework/sui_sui",
+      "permanent": true
+    },
+    {
+      "source": "/references/framework/sui_sui/transferx",
+      "destination": "/references/framework/sui_sui",
+      "permanent": true
+    },
+    {
+      "source": "/references/sui-api/beta-graph-ql",
+      "destination": "/references/sui-graphql",
+      "permanent": true
+    },
+    {
+      "source": "/sui-jsonrpc",
+      "destination": "/references/sui-api",
+      "permanent": true
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary
- Add 62 new permanent redirects to `docs/site/vercel.json` for broken URLs found in blog posts, CLI error messages, READMEs, and external references
- Covers old paths from `/build/`, `/concepts/`, `/guides/developer/sui-101/`, `/guides/developer/advanced/`, `/learn/`, `/contribute/`, `/explore/`, `/onchain-finance/`, `/references/framework/`, and `/sui-jsonrpc` that were restructured in recent site reorganizations
- Includes trailing-slash variants for `/build/programming-with-objects/` and `/concepts/transactions/prog-txn-blocks/` where the non-trailing-slash redirects weren't matching

## Test plan
- [ ] Verify JSON is valid (`python3 -c "import json; json.load(open('vercel.json'))"` passes)
- [ ] Spot-check a sample of redirects after deploy (e.g., `/build/objects`, `/concepts/object-model`, `/guides/developer/sui-101/building-ptb`, `/sui-jsonrpc`)
- [ ] Confirm no duplicate source paths conflict with existing redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)