### PR TITLE
docs: validate gasless token table against lib.rs at build time

### DIFF
--- a/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
+++ b/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
@@ -4,12 +4,6 @@ description: Gasless stablecoin transfers on Sui enable peer-to-peer payments of
 keywords: [ usdc, stablecoins, sui dollar, usdsui, usdy, ausd, fdusd, buck, ysld, gasless, free tier ]
 ---
 
-:::caution 
-
-Gasless stablecoin transfers are currently only available on Testnet. They will be available on Mainnet in the future.
-
-:::
-
 Chain-specific gas fees can introduce several points of friction to end users and complicate institutional compliance for asset trading or payments. Eliminating chain-specific gas is a major simplification for regulated institutions to conduct payments without the burden of holding digital assets that might fluctuate in value.
 
 Gasless stablecoin transfers on Sui enable peer-to-peer payments of qualified stablecoins to execute without paying gas fees in SUI. The sender of the transaction does not need to hold SUI in their wallet. When the network is congested, the network prioritizes transactions that pay gas fees over gasless stablecoin transfers.
@@ -30,7 +24,7 @@ The stablecoins eligible for gasless stablecoin transfers are governed by the pr
 | AUSD | Agora | 0x2053d08c1e2bd02791056171aab0fd12bd7cd7efad2ab8f6b9c8902f14df2ff2::ausd::AUSD |
 | USDB | Bucket Protocol | 0xe14726c336e81b32328e92afc37345d159f5b550b09fa92bd43640cfdd0a0cfd::usdb::USDB |
 
-[COMING SOON] To query the current allowlist programmatically, call `get_gasless_allowed_token_types` from the protocol config.
+To query the current allowlist programmatically, call `get_gasless_allowed_token_types` from the protocol config.
 
 ## What gasless stablecoin transfers don't cover
 
@@ -58,11 +52,11 @@ To integrate gasless stablecoins into wallets, wallet builders need to detect el
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { Transaction } from '@mysten/sui/transactions';
 
-const USDC = '0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC';
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
 
 const client = new SuiGrpcClient({
-	network: 'testnet',
-	baseUrl: 'https://fullnode.testnet.sui.io:443',
+	network: 'mainnet',
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 });
 
 const tx = new Transaction();

--- a/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
+++ b/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
@@ -18,9 +18,11 @@ Gasless stablecoin transfers on Sui enable peer-to-peer payments of qualified st
 
 The stablecoins eligible for gasless stablecoin transfers are governed by the protocol configuration (`get_gasless_allowed_token_types` in `sui-types`) and can change across protocol versions. The current allowlist is 
 
+{/* TABLE:GASLESS_TOKENS — validated by scripts/validate-gasless-tokens.mjs against lib.rs */}
+
 | Symbol | Issuer | Package Address |
-| --------|--------------|--------------| 
-| USDC   | Circle | 0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC |
+| --------|--------------|--------------|
+| USDC | Circle | 0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC |
 | USDSUI | Bridge/Stripe | 0x44f838219cf67b058f3b37907b655f226153c18e33dfcd0da559a844fea9b1c1::usdsui::USDSUI |
 | SUI_USDE | Ethena | 0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402::sui_usde::SUI_USDE |
 | USDY | Ondo | 0x960b531667636f39e85867775f52f6b1f220a058c4de786905bdf761e06a56bb::usdy::USDY |

--- a/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
+++ b/docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx
@@ -24,7 +24,6 @@ The stablecoins eligible for gasless stablecoin transfers are governed by the pr
 | AUSD | Agora | 0x2053d08c1e2bd02791056171aab0fd12bd7cd7efad2ab8f6b9c8902f14df2ff2::ausd::AUSD |
 | USDB | Bucket Protocol | 0xe14726c336e81b32328e92afc37345d159f5b550b09fa92bd43640cfdd0a0cfd::usdb::USDB |
 
-To query the current allowlist programmatically, call `get_gasless_allowed_token_types` from the protocol config.
 
 ## What gasless stablecoin transfers don't cover
 

--- a/docs/site/scripts/build-and-check.sh
+++ b/docs/site/scripts/build-and-check.sh
@@ -14,6 +14,7 @@ fi
 
 # Pre-build generation steps
 echo "Running pre-build generation..."
+node scripts/validate-gasless-tokens.mjs || { echo "❌ validate-gasless-tokens failed"; exit 1; }
 node scripts/generate-import-context.js || { echo "❌ generate-import-context failed"; exit 1; }
 node scripts/generate-resolved-pages.js || { echo "❌ generate-resolved-pages failed"; exit 1; }
 node scripts/grpc-download.js || { echo "❌ grpc-download failed"; exit 1; }

--- a/docs/site/scripts/validate-gasless-tokens.mjs
+++ b/docs/site/scripts/validate-gasless-tokens.mjs
@@ -1,0 +1,165 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Validates that the gasless stablecoin table in the docs matches the
+// MAINNET_* token constants in crates/sui-protocol-config/src/lib.rs.
+//
+// Exits 0 if the table is up-to-date, exits 1 with a diff if not.
+// Wired into the build pipeline via build-and-check.sh.
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const LIB_RS = path.resolve(
+  __dirname,
+  "../../../crates/sui-protocol-config/src/lib.rs",
+);
+const MDX_FILE = path.resolve(
+  __dirname,
+  "../../content/develop/transaction-payment/gasless-stablecoin-transfers.mdx",
+);
+
+// Human-readable issuer names keyed by the Rust constant name.
+// Update this map when a new token is added to lib.rs.
+const ISSUER_MAP = new Map([
+  ["MAINNET_USDC", "Circle"],
+  ["MAINNET_USDSUI", "Bridge/Stripe"],
+  ["MAINNET_SUI_USDE", "Ethena"],
+  ["MAINNET_USDY", "Ondo"],
+  ["MAINNET_FDUSD", "First Digital"],
+  ["MAINNET_AUSD", "Agora"],
+  ["MAINNET_USDB", "Bucket Protocol"],
+]);
+
+// ---------------------------------------------------------------------------
+// Parse lib.rs
+// ---------------------------------------------------------------------------
+
+let src;
+try {
+  src = fs.readFileSync(LIB_RS, "utf8");
+} catch {
+  console.warn(
+    "⚠️  validate-gasless-tokens: could not read lib.rs — skipping validation",
+  );
+  process.exit(0);
+}
+
+// 1. Extract every `const MAINNET_*: &str = "…";` constant.
+const CONST_RE = /const\s+(MAINNET_\w+):\s*&str\s*=\s*\n?\s*"([^"]+)"/g;
+const constants = new Map();
+let m;
+while ((m = CONST_RE.exec(src))) {
+  constants.set(m[1], m[2]);
+}
+
+if (constants.size === 0) {
+  console.error(
+    "❌ validate-gasless-tokens: no MAINNET_* constants found in lib.rs",
+  );
+  process.exit(1);
+}
+
+// 2. Find which constants are in the active mainnet allowlist.
+const allowlistBlock = src.match(
+  /if\s+chain\s*==\s*Chain::Mainnet\s*\{[^}]*gasless_allowed_token_types\s*=\s*Some\(vec!\[([^\]]*)\]/s,
+);
+
+const activeNames = new Set();
+if (allowlistBlock) {
+  const refs = allowlistBlock[1].matchAll(/\b(MAINNET_\w+)\b/g);
+  for (const ref of refs) {
+    activeNames.add(ref[1]);
+  }
+}
+
+// 3. Build expected rows from active allowlist tokens.
+const expectedRows = [];
+for (const [name, addr] of constants) {
+  if (activeNames.size > 0 && !activeNames.has(name)) continue;
+
+  const symbol = addr.split("::").pop();
+  const issuer = ISSUER_MAP.get(name);
+  if (!issuer) {
+    console.warn(
+      `⚠️  validate-gasless-tokens: no issuer mapping for ${name} — add it to ISSUER_MAP in this script`,
+    );
+  }
+  expectedRows.push(`| ${symbol} | ${issuer || "Unknown"} | ${addr} |`);
+}
+
+if (expectedRows.length === 0) {
+  console.error(
+    "❌ validate-gasless-tokens: no active mainnet tokens found",
+  );
+  process.exit(1);
+}
+
+const expectedTable = [
+  "| Symbol | Issuer | Package Address |",
+  "| --------|--------------|--------------|",
+  ...expectedRows,
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Parse the existing table from the MDX file
+// ---------------------------------------------------------------------------
+
+let mdx;
+try {
+  mdx = fs.readFileSync(MDX_FILE, "utf8");
+} catch {
+  console.error(
+    `❌ validate-gasless-tokens: could not read ${MDX_FILE}`,
+  );
+  process.exit(1);
+}
+
+// Extract the table block: starts with "| Symbol" header row, ends when
+// we hit a line that doesn't start with "|".
+const lines = mdx.split("\n");
+const tableStart = lines.findIndex((l) => /^\|\s*Symbol\s*\|/.test(l));
+if (tableStart === -1) {
+  console.error(
+    "❌ validate-gasless-tokens: could not find gasless token table in MDX file",
+  );
+  process.exit(1);
+}
+
+let tableEnd = tableStart + 1;
+while (tableEnd < lines.length && lines[tableEnd].trimStart().startsWith("|")) {
+  tableEnd++;
+}
+
+const actualTable = lines
+  .slice(tableStart, tableEnd)
+  .map((l) => l.trim())
+  .join("\n");
+
+// ---------------------------------------------------------------------------
+// Compare
+// ---------------------------------------------------------------------------
+
+if (actualTable === expectedTable) {
+  console.log(
+    `✅ validate-gasless-tokens: table is up-to-date (${expectedRows.length} tokens)`,
+  );
+  process.exit(0);
+}
+
+// Mismatch — show diff and fail.
+console.error(
+  "❌ validate-gasless-tokens: gasless token table is out of date!\n",
+);
+console.error("Expected (from lib.rs):");
+console.error(expectedTable);
+console.error("\nActual (in MDX):");
+console.error(actualTable);
+console.error(
+  "\nUpdate the table in docs/content/develop/transaction-payment/gasless-stablecoin-transfers.mdx to match lib.rs.",
+);
+process.exit(1);


### PR DESCRIPTION
## Summary
- Add `validate-gasless-tokens.mjs` build script that parses `MAINNET_*` constants and the active `Chain::Mainnet` allowlist from `crates/sui-protocol-config/src/lib.rs` and compares them against the token table in the gasless stablecoin transfers doc page
- Build fails with a side-by-side diff if the table is out of date, preventing docs from going stale when tokens are added or removed from the protocol config
- Table stays inline in the MDX (not a snippet/import) so it renders correctly in markdown exports and LLM ingestion (`llms.txt`)
- Issuer-to-token mapping is maintained in the script since issuer names are not in the Rust source

## Test plan
- [x] `node scripts/validate-gasless-tokens.mjs` passes with current table
- [x] Validation correctly fails (exit 1) when table content is modified
- [ ] `bash scripts/build-and-check.sh` runs validation as part of the pre-build steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)