### PR TITLE
nickv/misc kv index

### DIFF
--- a/crates/sui-inverted-index/src/dimensions.rs
+++ b/crates/sui-inverted-index/src/dimensions.rs
@@ -45,6 +45,14 @@ pub enum IndexDimension {
     /// any transaction that wrote to the stream; event-space matches the
     /// individual events committed to the stream.
     EventStreamHead = 0x07,
+    /// Internal existence marker (not user-queryable, not exposed via
+    /// `filter.rs`): one bit per real event, recording that an `event_seq`
+    /// position is occupied. Event-space only — it gives the read side a
+    /// concrete universe of real events to subtract from when evaluating
+    /// unanchored negation (`NOT D` == `E \ D`), since the packed `event_seq`
+    /// namespace is far too sparse to synthesize a dense complement. Carries no
+    /// value payload, so its encoded key is just the tag byte.
+    EventExtant = 0x08,
 }
 
 impl IndexDimension {
@@ -61,12 +69,18 @@ impl IndexDimension {
             tag if tag == Self::EmitModule.tag_byte() => Some(Self::EmitModule),
             tag if tag == Self::EventType.tag_byte() => Some(Self::EventType),
             tag if tag == Self::EventStreamHead.tag_byte() => Some(Self::EventStreamHead),
+            tag if tag == Self::EventExtant.tag_byte() => Some(Self::EventExtant),
             _ => None,
         }
     }
 }
 
 const COMPOUND_VALUE_SEPARATOR: u8 = 0x00;
+
+/// Singleton value for the internal [`IndexDimension::EventExtant`] marker:
+/// every real event maps to the same key, so it carries no payload and its
+/// encoded row key is just the tag byte.
+const EVENT_EXTANT_VALUE: &[u8] = &[];
 
 /// Visit all tx-space dimensions for a transaction.
 ///
@@ -123,7 +137,14 @@ pub fn for_each_transaction_dimension(
         f(IndexDimension::MoveCall, &scratch);
     }
 
-    for_each_event_dimension(tx, |_idx, dim, key| f(dim, key));
+    // Event attributes are also indexed in tx-space so callers can find the
+    // transactions that emitted a given event. The EventExtant existence marker
+    // is event-space only (it backs event negation), so don't forward it here.
+    for_each_event_dimension(tx, |_idx, dim, key| {
+        if dim != IndexDimension::EventExtant {
+            f(dim, key);
+        }
+    });
 
     for acc in tx.effects.accumulator_events() {
         if Balance::is_balance_type(&acc.write.address.ty)
@@ -147,6 +168,9 @@ pub fn for_each_transaction_dimension(
 /// Like [`for_each_transaction_dimension`], this keeps the ownership boundary
 /// inside the visitor call so compound event keys can borrow a reused scratch
 /// buffer while the caller consumes each value synchronously.
+///
+/// Every real event also yields one [`IndexDimension::EventExtant`] candidate
+/// (an empty-keyed existence marker) at its own `event_idx`.
 pub fn for_each_event_dimension(
     tx: &ExecutedTransaction,
     mut f: impl FnMut(u32, IndexDimension, &[u8]),
@@ -157,6 +181,11 @@ pub fn for_each_event_dimension(
 
     for (idx, ev) in tx.events.iter().flat_map(|evs| evs.data.iter()).enumerate() {
         let event_idx = u32::try_from(idx).expect("event index exceeds u32::MAX");
+
+        // Existence marker: one bit per real event, independent of its
+        // attributes. Records that this `event_seq` position is occupied so the
+        // read side has a universe `E` to subtract from for event negation.
+        f(event_idx, IndexDimension::EventExtant, EVENT_EXTANT_VALUE);
 
         f(event_idx, IndexDimension::Sender, sender.as_ref());
 
@@ -456,6 +485,79 @@ mod tests {
 
         assert!(!keys.iter().any(|(_, k)| k == &move_call_key));
         assert!(!keys.iter().any(|(_, k)| k == &affected_object_key));
+    }
+
+    #[test]
+    fn event_visitor_emits_existence_marker_per_event() {
+        let sender = TestCheckpointBuilder::derive_address(1);
+        let package = ObjectID::ZERO;
+        let event_type = GAS::type_();
+        let ev = || {
+            Event::new(
+                &package,
+                ident_str!("emit_mod"),
+                sender,
+                event_type.clone(),
+                vec![],
+            )
+        };
+        let checkpoint = TestCheckpointBuilder::new(0)
+            .start_transaction(1)
+            .with_events(vec![ev(), ev(), ev()])
+            .finish_transaction()
+            .build_checkpoint();
+        let tx = &checkpoint.transactions[0];
+
+        let mut extant_idxs = Vec::new();
+        for_each_event_dimension(tx, |event_idx, dim, value| {
+            if dim == IndexDimension::EventExtant {
+                assert!(value.is_empty(), "existence marker carries no payload");
+                extant_idxs.push(event_idx);
+            }
+        });
+
+        // Exactly one existence bit per real event, at each event's own index.
+        assert_eq!(extant_idxs, vec![0, 1, 2]);
+        // The encoded key is just the tag byte (empty value).
+        assert_eq!(
+            encode_dimension_key(IndexDimension::EventExtant, EVENT_EXTANT_VALUE),
+            vec![IndexDimension::EventExtant.tag_byte()]
+        );
+    }
+
+    #[test]
+    fn transaction_visitor_omits_event_existence_marker() {
+        let sender = TestCheckpointBuilder::derive_address(1);
+        let package = ObjectID::ZERO;
+        let checkpoint = TestCheckpointBuilder::new(0)
+            .start_transaction(1)
+            .with_events(vec![Event::new(
+                &package,
+                ident_str!("emit_mod"),
+                sender,
+                GAS::type_(),
+                vec![],
+            )])
+            .finish_transaction()
+            .build_checkpoint();
+        let tx = &checkpoint.transactions[0];
+
+        let mut saw_extant = false;
+        for_each_transaction_dimension(tx, &checkpoint.object_set, |dim, _value| {
+            saw_extant |= dim == IndexDimension::EventExtant;
+        });
+        assert!(
+            !saw_extant,
+            "EventExtant is event-space only and must not appear in tx-space"
+        );
+    }
+
+    #[test]
+    fn event_extant_tag_byte_round_trips() {
+        assert_eq!(
+            IndexDimension::from_tag_byte(IndexDimension::EventExtant.tag_byte()),
+            Some(IndexDimension::EventExtant)
+        );
     }
 
     #[test]

--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -42,6 +42,7 @@ use sui_inverted_index::ScanDirection;
 use sui_inverted_index::eval_bitmap_query_stream;
 use sui_kvstore::BigTableBitmapSource;
 use sui_kvstore::BitmapIndexSpec;
+use sui_kvstore::CheckpointData;
 use sui_kvstore::RowFilter;
 use sui_kvstore::TransactionData;
 use sui_kvstore::TxSeqDigestData;
@@ -319,6 +320,35 @@ impl BigTableClient {
             .await
             .map_err(RpcError::from)?;
         Ok(gate_stream(permit, inner.boxed()))
+    }
+
+    pub(crate) async fn scan_tx_seq_digests_stream(
+        &self,
+        range: Range<u64>,
+        direction: ScanDirection,
+        rows_limit: usize,
+    ) -> Result<BoxStream<'static, Result<TxSeqDigestData, anyhow::Error>>, RpcError> {
+        self.inner
+            .clone()
+            .scan_tx_seq_digests_stream(range, direction, rows_limit)
+            .await
+            .map(|stream| stream.boxed())
+            .map_err(RpcError::from)
+    }
+
+    pub(crate) async fn scan_checkpoints_stream(
+        &self,
+        range: Range<u64>,
+        direction: ScanDirection,
+        rows_limit: usize,
+        filter: Option<RowFilter>,
+    ) -> Result<BoxStream<'static, Result<(u64, CheckpointData), anyhow::Error>>, RpcError> {
+        self.inner
+            .clone()
+            .scan_checkpoints_stream(range, direction, rows_limit, filter)
+            .await
+            .map(|stream| stream.boxed())
+            .map_err(RpcError::from)
     }
 
     pub(crate) async fn checkpoint_to_tx_range(

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -157,42 +157,42 @@ pub(crate) async fn list_checkpoints(
     let cp_columns: Arc<[&'static str]> = list_checkpoint_columns(&read_mask, needs_full).into();
 
     let request_bigtable_concurrency = ctx.request_bigtable_concurrency();
-    let scan_budget = ctx.scan_budget(BitmapIndexSpec::tx());
 
-    // Stage A: discover cp_seq values for the requested response. Filtered
-    // requests use bitmap-eval; the tx_seq watermarks it emits are
-    // translated to cp_seq watermarks by `filtered_checkpoint_seq_stream`
-    // before they reach the handler's loop. Unfiltered requests produce the
-    // cp range directly (cheap, no IO); every cp_seq becomes an item, so the
-    // last item watermark is the final resume cursor.
-    let seq_stream: BoxStream<'static, Result<Watermarked<u64>, anyhow::Error>> =
-        if let Some(filter) = &request.filter {
-            let tx_range = client.checkpoint_to_tx_range(cp_range.clone()).await?;
-            filtered_checkpoint_seq_stream(
-                &ctx,
-                filter,
-                tx_range,
-                limit_items,
-                options.clone(),
-                scan_budget,
-            )
-            .await?
-        } else {
-            // Unfiltered: items cover the resolved cp range densely;
-            // the last item's cursor is a sufficient resume point.
-            range_stream(cp_range.clone(), &options)
-                .map(|r| r.map(Watermarked::Item).map_err(anyhow::Error::new))
-                .boxed()
-        };
-    let seq_stream = take_items(seq_stream, limit_items);
-
-    // Stage B: Watermarked<cp_seq> -> Watermarked<(cp_seq, CheckpointData)>. One
-    // multi_get per chunk against the checkpoints table.
-    let cp_data_stream = pipelined_chunks(seq_stream, CHUNK_MAX, request_bigtable_concurrency, {
-        let client = client.clone();
-        let columns = cp_columns.clone();
-        move |seqs| fetch_checkpoint_data(client.clone(), columns.clone(), seqs)
-    });
+    // Stage A: discover checkpoint rows for the requested response. Filtered
+    // requests use sparse bitmap-eval over transactions and then fetch the
+    // deduped checkpoint rows. Unfiltered requests scan the dense checkpoint
+    // keyspace directly, bounded by limit_items.
+    let cp_data_stream: BoxStream<
+        'static,
+        Result<Watermarked<(u64, CheckpointData)>, anyhow::Error>,
+    > = if let Some(filter) = &request.filter {
+        let scan_budget = ctx.scan_budget(BitmapIndexSpec::tx());
+        let tx_range = client.checkpoint_to_tx_range(cp_range.clone()).await?;
+        let seq_stream = filtered_checkpoint_seq_stream(
+            &ctx,
+            filter,
+            tx_range,
+            limit_items,
+            options.clone(),
+            scan_budget,
+        )
+        .await?;
+        let seq_stream = take_items(seq_stream, limit_items);
+        pipelined_chunks(seq_stream, CHUNK_MAX, request_bigtable_concurrency, {
+            let client = client.clone();
+            let columns = cp_columns.clone();
+            move |seqs| fetch_checkpoint_data(client.clone(), columns.clone(), seqs)
+        })
+    } else {
+        scan_checkpoint_data(
+            client.clone(),
+            cp_columns.clone(),
+            cp_range.clone(),
+            limit_items,
+            &options,
+        )
+        .await?
+    };
 
     // Fast path: read_mask doesn't request transactions or objects → render
     // directly from CheckpointData via the existing `checkpoint_to_response`
@@ -438,6 +438,21 @@ fn watermark_response(watermark: Watermark) -> ListCheckpointsResponse {
     let mut response = ListCheckpointsResponse::default();
     response.response = Some(list_checkpoints_response::Response::Watermark(watermark));
     response
+}
+
+async fn scan_checkpoint_data(
+    client: BigTableClient,
+    columns: Arc<[&'static str]>,
+    range: std::ops::Range<u64>,
+    limit: usize,
+    options: &QueryOptions,
+) -> Result<BoxStream<'static, Result<Watermarked<(u64, CheckpointData)>, anyhow::Error>>, RpcError>
+{
+    let column_filter = BigTableClient::column_filter(&columns);
+    let rows = client
+        .scan_checkpoints_stream(range, options.scan_direction(), limit, Some(column_filter))
+        .await?;
+    Ok(rows.map_ok(Watermarked::Item).boxed())
 }
 
 async fn fetch_checkpoint_data(
@@ -879,17 +894,6 @@ fn decode_checkpoint_row_key(key: &Bytes) -> Result<u64, RpcError> {
         .try_into()
         .map_err(|_| RpcError::new(tonic::Code::Internal, "invalid checkpoint row key length"))?;
     Ok(u64::from_be_bytes(bytes))
-}
-
-fn range_stream(
-    range: std::ops::Range<u64>,
-    options: &QueryOptions,
-) -> BoxStream<'static, Result<u64, RpcError>> {
-    if options.is_ascending() {
-        stream::iter(range.map(Ok::<_, RpcError>)).boxed()
-    } else {
-        stream::iter(range.rev().map(Ok::<_, RpcError>)).boxed()
-    }
 }
 
 /// Clamp a translated cp frontier so the emitted Boundary cursor never

--- a/crates/sui-kv-rpc/src/v2alpha/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_events.rs
@@ -133,10 +133,8 @@ pub(crate) async fn list_events(
 
     // Stage A: stream of EventRefs. Filtered requests discover event_seq
     // values through the event bitmap (per-bucket and periodic-frontier
-    // watermarks). Unfiltered requests discover eventful transactions through
-    // point-lookups on tx_seq_digest with adaptive in-flight buffering; they
-    // wrap each EventRef as `Watermarked::Item` and rely on item watermarks for
-    // resume.
+    // watermarks). Unfiltered requests scan tx_seq_digest rows and expand
+    // each row's event_count into concrete EventRefs.
     let request_bigtable_concurrency = ctx.request_bigtable_concurrency();
     let event_ref_stream: BoxStream<'static, Result<Watermarked<EventRef>, anyhow::Error>> =
         if let Some(filter) = &request.filter {
@@ -163,13 +161,7 @@ pub(crate) async fn list_events(
                 })
                 .boxed()
         } else {
-            unfiltered_event_refs(
-                client.clone(),
-                event_range.clone(),
-                limit_items,
-                options.clone(),
-                request_bigtable_concurrency,
-            )
+            unfiltered_event_refs(client.clone(), event_range.clone(), options.clone())
         };
     let ref_stream = take_items(event_ref_stream, limit_items);
 
@@ -508,111 +500,70 @@ struct EventRef {
     tx_seq_digest: Option<TxSeqDigestData>,
 }
 
-/// Point-lookup `tx_seq_digest` across the tx range covered by `event_range`,
+/// Range-scan `tx_seq_digest` across the tx range covered by `event_range`,
 /// using each row's `event_count` to enumerate real event_seqs per tx without
-/// touching the tx body. Wraps every emitted ref as `Watermarked::Item`; the
-/// unfiltered path doesn't emit watermarks because there's no
-/// bitmap-vs-render race — items come directly from the same row scan.
+/// touching the tx body.
 fn unfiltered_event_refs(
     client: BigTableClient,
     event_range: std::ops::Range<u64>,
-    target: usize,
     options: QueryOptions,
-    request_bigtable_concurrency: usize,
 ) -> BoxStream<'static, Result<Watermarked<EventRef>, anyhow::Error>> {
-    let lower_bound = event_range.start;
-    let upper_bound = event_range.end;
-    let tx_seq_stream = tx_seq_stream_for_event_range(event_range, &options)
-        .map_ok(Watermarked::Item)
-        .map_err(anyhow::Error::new)
-        .boxed();
-    let discovery_concurrency_limit =
-        discovery_concurrency_limit(target, request_bigtable_concurrency);
-    let chunked = pipelined_chunks(tx_seq_stream, CHUNK_MAX, discovery_concurrency_limit, {
-        move |seqs| {
-            fetch_event_refs_from_tx_seq_digests(
-                client.clone(),
-                lower_bound,
-                upper_bound,
-                options.clone(),
-                seqs,
-            )
+    async_stream::try_stream! {
+        let lower_bound = event_range.start;
+        let upper_bound = event_range.end;
+        let Some(tx_range) = tx_range_for_event_range(event_range) else {
+            return;
+        };
+        let source_limit = MAX_LIMIT_ITEMS as usize;
+        let (scan_range, scan_limited, frontier_tx) =
+            clamp_tx_scan_range(tx_range, source_limit, &options);
+        let rows = client
+            .scan_tx_seq_digests_stream(scan_range, options.scan_direction(), source_limit)
+            .await?;
+
+        futures::pin_mut!(rows);
+        while let Some(row) = rows.next().await {
+            for event_ref in expand_event_refs(row?, lower_bound, upper_bound, &options) {
+                yield Watermarked::Item(event_ref);
+            }
         }
-    });
-    take_items(chunked, target)
+
+        if scan_limited {
+            yield Watermarked::Watermark(event_bitmap_index::event_seq_lo(frontier_tx));
+            Err(anyhow::Error::new(BitmapScanLimitExceeded))?;
+        }
+    }
+    .boxed()
 }
 
-/// Pick a chunk concurrency limit for the unfiltered event-discovery pipeline.
-/// There is an average of ~1.3 events/txn over chain history, so assuming
-/// 1 per txn here is reasonable: roughly one chunk per `CHUNK_MAX` events
-/// requested, capped at the request's downstream BigTable budget.
-fn discovery_concurrency_limit(target: usize, request_bigtable_concurrency: usize) -> usize {
-    target
-        .div_ceil(CHUNK_MAX)
-        .clamp(1, request_bigtable_concurrency)
-}
-
-fn tx_seq_stream_for_event_range(
-    event_range: std::ops::Range<u64>,
-    options: &QueryOptions,
-) -> BoxStream<'static, Result<u64, RpcError>> {
-    let Some(last_event_seq) = event_range.end.checked_sub(1) else {
-        return futures::stream::empty().boxed();
-    };
+fn tx_range_for_event_range(event_range: std::ops::Range<u64>) -> Option<std::ops::Range<u64>> {
+    let last_event_seq = event_range.end.checked_sub(1)?;
     let start_tx = event_bitmap_index::decode_event_seq(event_range.start).0;
-    let Some(end_tx) = event_bitmap_index::decode_event_seq(last_event_seq)
+    let end_tx = event_bitmap_index::decode_event_seq(last_event_seq)
         .0
-        .checked_add(1)
-    else {
-        return futures::stream::empty().boxed();
-    };
-    if start_tx >= end_tx {
-        return futures::stream::empty().boxed();
-    }
-
-    if options.is_ascending() {
-        futures::stream::iter((start_tx..end_tx).map(Ok::<_, RpcError>)).boxed()
-    } else {
-        futures::stream::iter((start_tx..end_tx).rev().map(Ok::<_, RpcError>)).boxed()
-    }
+        .checked_add(1)?;
+    (start_tx < end_tx).then_some(start_tx..end_tx)
 }
 
-async fn fetch_event_refs_from_tx_seq_digests(
-    client: BigTableClient,
-    lower_bound: u64,
-    upper_bound: u64,
-    options: QueryOptions,
-    tx_seqs: Vec<u64>,
-) -> Result<BoxStream<'static, Result<EventRef, anyhow::Error>>, anyhow::Error> {
-    if tx_seqs.is_empty() {
-        return Ok(futures::stream::empty().boxed());
+fn clamp_tx_scan_range(
+    tx_range: std::ops::Range<u64>,
+    source_limit: usize,
+    options: &QueryOptions,
+) -> (std::ops::Range<u64>, bool, u64) {
+    let source_limit = source_limit as u64;
+    if options.is_ascending() {
+        let end = tx_range
+            .start
+            .saturating_add(source_limit)
+            .min(tx_range.end);
+        (tx_range.start..end, end < tx_range.end, end)
+    } else {
+        let start = tx_range
+            .end
+            .saturating_sub(source_limit)
+            .max(tx_range.start);
+        (start..tx_range.end, start > tx_range.start, start)
     }
-
-    let digest_stream = client.resolve_tx_digests_stream(tx_seqs.clone()).await?;
-
-    Ok(async_stream::try_stream! {
-        let mut emitter: InputOrderEmitter<u64, TxSeqDigestData> =
-            InputOrderEmitter::new(tx_seqs);
-        futures::pin_mut!(digest_stream);
-        while let Some(row) = digest_stream.next().await {
-            let row = row?;
-            for row in emitter.push(
-                row.tx_sequence_number,
-                row,
-                "list_events: transaction digest lookup during event discovery",
-            )? {
-                for event_ref in expand_event_refs(row, lower_bound, upper_bound, &options) {
-                    yield event_ref;
-                }
-            }
-        }
-        for row in emitter.finish("list_events: missing transaction digest during event discovery")? {
-            for event_ref in expand_event_refs(row, lower_bound, upper_bound, &options) {
-                yield event_ref;
-            }
-        }
-    }
-    .boxed())
 }
 
 fn expand_event_refs(
@@ -709,7 +660,6 @@ async fn checkpoint_to_tx_boundary(
 
 #[cfg(test)]
 mod tests {
-    use futures::TryStreamExt;
     use sui_types::digests::TransactionDigest;
 
     use super::*;
@@ -796,42 +746,31 @@ mod tests {
         assert_eq!(event_refs(&refs), vec![(10, 3), (10, 2), (10, 1)]);
     }
 
-    #[tokio::test]
-    async fn tx_seq_stream_for_event_range_respects_ordering() {
+    #[test]
+    fn tx_range_for_event_range_covers_partial_endpoint_transactions() {
         let range =
             event_bitmap_index::encode_event_seq(10, 2)..event_bitmap_index::event_seq_lo(13);
 
-        let asc = tx_seq_stream_for_event_range(range.clone(), &options(Ordering::Ascending))
-            .try_collect::<Vec<_>>()
-            .await
-            .expect("ascending stream");
-        assert_eq!(asc, vec![10, 11, 12]);
-
-        let desc = tx_seq_stream_for_event_range(range, &options(Ordering::Descending))
-            .try_collect::<Vec<_>>()
-            .await
-            .expect("descending stream");
-        assert_eq!(desc, vec![12, 11, 10]);
+        assert_eq!(tx_range_for_event_range(range), Some(10..13));
     }
 
     #[test]
-    fn discovery_concurrency_limit_scales_with_requested_limit() {
-        const REQUEST_CONCURRENCY: usize = 15;
-        assert_eq!(discovery_concurrency_limit(1, REQUEST_CONCURRENCY), 1);
+    fn clamp_tx_scan_range_limits_ascending_frontier() {
+        let options = options(Ordering::Ascending);
+        assert_eq!(clamp_tx_scan_range(10..20, 4, &options), (10..14, true, 14));
         assert_eq!(
-            discovery_concurrency_limit(CHUNK_MAX, REQUEST_CONCURRENCY),
-            1
+            clamp_tx_scan_range(10..14, 4, &options),
+            (10..14, false, 14)
         );
+    }
+
+    #[test]
+    fn clamp_tx_scan_range_limits_descending_frontier() {
+        let options = options(Ordering::Descending);
+        assert_eq!(clamp_tx_scan_range(10..20, 4, &options), (16..20, true, 16));
         assert_eq!(
-            discovery_concurrency_limit(CHUNK_MAX + 1, REQUEST_CONCURRENCY),
-            2
-        );
-        assert_eq!(
-            discovery_concurrency_limit(
-                CHUNK_MAX * (REQUEST_CONCURRENCY + 10),
-                REQUEST_CONCURRENCY
-            ),
-            REQUEST_CONCURRENCY
+            clamp_tx_scan_range(16..20, 4, &options),
+            (16..20, false, 16)
         );
     }
 }

--- a/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
@@ -127,43 +127,32 @@ pub(crate) async fn list_transactions(
         .boxed());
     }
 
-    let scan_budget = ctx.scan_budget(BitmapIndexSpec::tx());
+    let request_bigtable_concurrency = ctx.request_bigtable_concurrency();
 
-    // Stage 1: discover tx_seq values for the requested response. Filtered
-    // requests stream from the bitmap eval (which emits per-bucket and
-    // periodic-frontier watermarks). Unfiltered requests synthesize Item-only
-    // output over the resolved range; every tx_seq becomes an item, so the last
-    // item watermark is the final resume cursor. `take_items` counts Items
-    // toward limit_items but lets watermarks pass through. Error type is
-    // `anyhow::Error` throughout so `BitmapScanLimitExceeded` survives in-band
-    // for the handler to downcast.
-    let seq_stream: BoxStream<'static, Result<Watermarked<u64>, anyhow::Error>> =
+    // Stage 1: discover tx_seq_digest rows for the requested response.
+    // Filtered requests are sparse bitmap hits and still use chunked
+    // multi_get lookups. Unfiltered requests scan the dense tx_seq_digest
+    // keyspace directly, bounded by limit_items.
+    let digest_stream: BoxStream<'static, Result<Watermarked<TxSeqDigestData>, anyhow::Error>> =
         if let Some(filter) = &request.filter {
+            let scan_budget = ctx.scan_budget(BitmapIndexSpec::tx());
             let query = ctx.transaction_filter_query(filter)?;
-            client.eval_bitmap_query_stream(
+            let seq_stream = client.eval_bitmap_query_stream(
                 query,
                 tx_range.clone(),
                 BitmapIndexSpec::tx(),
                 options.scan_direction(),
                 scan_budget,
                 ctx.bitmap_scan_observer(),
-            )
+            );
+            let seq_stream = take_items(seq_stream, limit_items);
+            pipelined_chunks(seq_stream, CHUNK_MAX, request_bigtable_concurrency, {
+                let client = client.clone();
+                move |seqs| fetch_tx_seq_digests(client.clone(), seqs)
+            })
         } else {
-            range_stream(tx_range.clone(), &options)
-                .map(|r| r.map(Watermarked::Item).map_err(anyhow::Error::new))
-                .boxed()
+            scan_tx_seq_digests(client.clone(), tx_range.clone(), limit_items, &options).await?
         };
-    let seq_stream = take_items(seq_stream, limit_items);
-
-    let request_bigtable_concurrency = ctx.request_bigtable_concurrency();
-
-    // Stage 2: tx_seq -> tx_seq_digest rows. Pipelined_chunks groups Items
-    // into BigTable multi_get chunks and passes watermarks through in
-    // input order.
-    let digest_stream = pipelined_chunks(seq_stream, CHUNK_MAX, request_bigtable_concurrency, {
-        let client = client.clone();
-        move |seqs| fetch_tx_seq_digests(client.clone(), seqs)
-    });
 
     let render_transaction_contents = should_render_transaction_contents(&read_mask);
     if !render_transaction_contents {
@@ -345,6 +334,18 @@ fn watermark_response(watermark: Watermark) -> ListTransactionsResponse {
     response
 }
 
+async fn scan_tx_seq_digests(
+    client: BigTableClient,
+    range: std::ops::Range<u64>,
+    limit: usize,
+    options: &QueryOptions,
+) -> Result<BoxStream<'static, Result<Watermarked<TxSeqDigestData>, anyhow::Error>>, RpcError> {
+    let rows = client
+        .scan_tx_seq_digests_stream(range, options.scan_direction(), limit)
+        .await?;
+    Ok(rows.map_ok(Watermarked::Item).boxed())
+}
+
 async fn fetch_tx_seq_digests(
     client: BigTableClient,
     seqs: Vec<u64>,
@@ -521,17 +522,6 @@ fn end_response(reason: QueryEndReason) -> ListTransactionsResponse {
     let mut response = ListTransactionsResponse::default();
     response.response = Some(list_transactions_response::Response::End(end));
     response
-}
-
-fn range_stream(
-    range: std::ops::Range<u64>,
-    options: &QueryOptions,
-) -> BoxStream<'static, Result<u64, RpcError>> {
-    if options.is_ascending() {
-        futures::stream::iter(range.map(Ok::<_, RpcError>)).boxed()
-    } else {
-        futures::stream::iter(range.rev().map(Ok::<_, RpcError>)).boxed()
-    }
 }
 
 #[cfg(test)]

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -10,6 +10,8 @@ use std::future::Future;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -18,8 +20,10 @@ use anyhow::Result;
 use anyhow::bail;
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::StreamExt;
 use gcp_auth::TokenProvider;
 use prometheus::Registry;
+use sui_inverted_index::ScanDirection;
 use sui_types::base_types::EpochId;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::TransactionDigest;
@@ -126,6 +130,32 @@ pub struct BigTableClient {
     metrics: Option<Arc<KvMetrics>>,
     app_profile_id: Option<String>,
 }
+
+struct AbortOnDrop<T> {
+    handle: tokio::task::JoinHandle<T>,
+}
+
+impl<T> AbortOnDrop<T> {
+    fn new(handle: tokio::task::JoinHandle<T>) -> Self {
+        Self { handle }
+    }
+}
+
+impl<T> Future for AbortOnDrop<T> {
+    type Output = std::result::Result<T, tokio::task::JoinError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.get_mut().handle).poll(cx)
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl<T> Unpin for AbortOnDrop<T> {}
 
 impl BigTableClient {
     pub async fn new_local(host: String, instance_id: String) -> Result<Self> {
@@ -352,6 +382,45 @@ impl BigTableClient {
             checkpoints.push(tables::checkpoints::decode(&row)?);
         }
         Ok(checkpoints)
+    }
+
+    /// Stream checkpoints over a dense sequence-number range in scan order.
+    pub async fn scan_checkpoints_stream(
+        &mut self,
+        checkpoint_range: Range<CheckpointSequenceNumber>,
+        direction: ScanDirection,
+        rows_limit: usize,
+        filter: Option<RowFilter>,
+    ) -> Result<
+        futures::stream::BoxStream<'static, Result<(CheckpointSequenceNumber, CheckpointData)>>,
+    > {
+        if checkpoint_range.is_empty() || rows_limit == 0 {
+            return Ok(futures::stream::empty().boxed());
+        }
+
+        let rows_limit = i64::try_from(rows_limit).context("checkpoint scan limit exceeds i64")?;
+        let start_key = tables::checkpoints::encode_key(checkpoint_range.start);
+        let end_key = tables::checkpoints::encode_key(checkpoint_range.end - 1);
+        let rows = self
+            .range_scan_stream(
+                tables::checkpoints::NAME,
+                Some(Bytes::from(start_key)),
+                Some(Bytes::from(end_key)),
+                rows_limit,
+                !direction.is_ascending(),
+                filter,
+            )
+            .await?;
+
+        Ok(validate_dense_scan(
+            rows,
+            checkpoint_range,
+            direction,
+            rows_limit,
+            decode_checkpoint_scan_row,
+            "checkpoint",
+        )
+        .boxed())
     }
 
     /// Fetch a checkpoint by digest with an optional column filter.
@@ -635,7 +704,6 @@ impl BigTableClient {
         request: ReadRowsRequest,
         table_name: &str,
     ) -> Result<Vec<(Bytes, Vec<(Bytes, Bytes)>)>> {
-        use futures::StreamExt;
         let stream = self.read_rows_stream(request, table_name).await?;
         futures::pin_mut!(stream);
         let mut result = vec![];
@@ -870,7 +938,6 @@ impl BigTableClient {
         keys: Vec<Vec<u8>>,
         filter: Option<RowFilter>,
     ) -> Result<futures::stream::BoxStream<'static, Result<(Bytes, Vec<(Bytes, Bytes)>)>>> {
-        use futures::StreamExt;
         let request = self.build_multi_get_request(table_name, keys, filter);
         let stream = self.read_rows_stream(request, table_name).await?;
         Ok(stream.boxed())
@@ -1056,7 +1123,6 @@ impl BigTableClient {
             .await?;
 
         Ok(async_stream::try_stream! {
-            use futures::StreamExt;
             futures::pin_mut!(rows);
             while let Some(row) = rows.next().await {
                 let (row_key, cells) = row?;
@@ -1071,6 +1137,67 @@ impl BigTableClient {
                 };
             }
         })
+    }
+
+    /// Stream `tx_seq_digest` rows over a dense tx_sequence_number range in scan order.
+    pub async fn scan_tx_seq_digests_stream(
+        &mut self,
+        tx_sequence_range: Range<u64>,
+        direction: ScanDirection,
+        rows_limit: usize,
+    ) -> Result<futures::stream::BoxStream<'static, Result<TxSeqDigestData>>> {
+        if tx_sequence_range.is_empty() || rows_limit == 0 {
+            return Ok(futures::stream::empty().boxed());
+        }
+
+        let descending = !direction.is_ascending();
+        let tx_sequence_range =
+            tx_seq_digest::clamp_range_to_limit(tx_sequence_range, descending, rows_limit);
+        let bucket_ranges = tx_seq_digest::split_range_by_bucket(tx_sequence_range, descending);
+        let client = self.clone();
+
+        Ok(async_stream::try_stream! {
+            let mut bucket_ranges = bucket_ranges.into_iter();
+            let Some(first_bucket_range) = bucket_ranges.next() else {
+                return;
+            };
+
+            let mut current = Some(spawn_tx_seq_digest_bucket_scan(
+                client.clone(),
+                first_bucket_range,
+                direction,
+                descending,
+            ));
+            let mut next = bucket_ranges.next().map(|bucket_range| {
+                spawn_tx_seq_digest_bucket_scan(
+                    client.clone(),
+                    bucket_range,
+                    direction,
+                    descending,
+                )
+            });
+
+            while let Some(current_task) = current.take() {
+                let dense_rows = current_task
+                    .await
+                    .context("tx_seq_digest bucket scan task failed")??;
+                futures::pin_mut!(dense_rows);
+                while let Some(row) = dense_rows.next().await {
+                    yield row?;
+                }
+
+                current = next.take();
+                next = bucket_ranges.next().map(|bucket_range| {
+                    spawn_tx_seq_digest_bucket_scan(
+                        client.clone(),
+                        bucket_range,
+                        direction,
+                        descending,
+                    )
+                });
+            }
+        }
+        .boxed())
     }
 
     /// Resolve tx_sequence_numbers to their containing checkpoint numbers.
@@ -1122,7 +1249,6 @@ impl BigTableClient {
             .await?;
 
         Ok(async_stream::try_stream! {
-            use futures::StreamExt;
             futures::pin_mut!(rows);
             while let Some(row) = rows.next().await {
                 let (key, cells) = row?;
@@ -1147,7 +1273,6 @@ impl BigTableClient {
             .await?;
 
         Ok(async_stream::try_stream! {
-            use futures::StreamExt;
             futures::pin_mut!(rows);
             while let Some(row) = rows.next().await {
                 let (_key, cells) = row?;
@@ -1236,6 +1361,151 @@ impl BigTableClient {
             })
             .collect())
     }
+}
+
+type TxSeqDigestScanStream = futures::stream::BoxStream<'static, Result<TxSeqDigestData>>;
+type TxSeqDigestScanTask = AbortOnDrop<Result<TxSeqDigestScanStream>>;
+
+fn spawn_tx_seq_digest_bucket_scan(
+    mut client: BigTableClient,
+    bucket_range: Range<u64>,
+    direction: ScanDirection,
+    descending: bool,
+) -> TxSeqDigestScanTask {
+    AbortOnDrop::new(tokio::spawn(async move {
+        open_tx_seq_digest_bucket_scan(&mut client, bucket_range, direction, descending).await
+    }))
+}
+
+async fn open_tx_seq_digest_bucket_scan(
+    client: &mut BigTableClient,
+    bucket_range: Range<u64>,
+    direction: ScanDirection,
+    descending: bool,
+) -> Result<TxSeqDigestScanStream> {
+    let rows_limit = i64::try_from(bucket_range.end - bucket_range.start)
+        .context("tx_seq_digest bucket scan limit exceeds i64")?;
+    let start_key = tx_seq_digest::encode_key(bucket_range.start);
+    let end_key = tx_seq_digest::encode_key(bucket_range.end - 1);
+    let rows = client
+        .range_scan_stream(
+            tx_seq_digest::NAME,
+            Some(Bytes::from(start_key)),
+            Some(Bytes::from(end_key)),
+            rows_limit,
+            descending,
+            None,
+        )
+        .await?;
+    Ok(validate_dense_scan(
+        rows,
+        bucket_range,
+        direction,
+        rows_limit,
+        decode_tx_seq_digest_scan_row,
+        "tx_seq_digest",
+    ))
+}
+
+fn validate_dense_scan<S, T, F>(
+    rows: S,
+    range: Range<u64>,
+    direction: ScanDirection,
+    rows_limit: i64,
+    decode: F,
+    name: &'static str,
+) -> futures::stream::BoxStream<'static, Result<T>>
+where
+    S: futures::Stream<Item = Result<(Bytes, Vec<(Bytes, Bytes)>)>> + Send + 'static,
+    T: Send + 'static,
+    F: Fn(Bytes, Vec<(Bytes, Bytes)>) -> Result<(u64, T)> + Send + 'static,
+{
+    async_stream::try_stream! {
+        let mut expected = next_expected_in_range(None, &range, direction);
+        let mut rows_seen = 0i64;
+        futures::pin_mut!(rows);
+        while let Some(row) = rows.next().await {
+            let (key, cells) = row?;
+            let (sequence, item) = decode(key, cells)?;
+            let expected_sequence = match expected {
+                Some(expected_sequence) => expected_sequence,
+                None => {
+                    Err(anyhow::anyhow!(
+                        "{name} scan returned row {sequence} after range was exhausted"
+                    ))?;
+                    unreachable!();
+                }
+            };
+            if sequence != expected_sequence {
+                Err(anyhow::anyhow!(
+                    "{name} scan expected dense row {expected_sequence}, got {sequence}"
+                ))?;
+            }
+            rows_seen += 1;
+            expected = next_expected_in_range(Some(sequence), &range, direction);
+            yield item;
+        }
+
+        if rows_seen < rows_limit
+            && let Some(expected_sequence) = expected
+        {
+            Err(anyhow::anyhow!("{name} scan ended before dense row {expected_sequence}"))?;
+        }
+    }
+    .boxed()
+}
+
+fn next_expected_in_range(
+    previous: Option<u64>,
+    range: &Range<u64>,
+    direction: ScanDirection,
+) -> Option<u64> {
+    match (previous, direction) {
+        (None, ScanDirection::Ascending) => Some(range.start),
+        (None, ScanDirection::Descending) => range.end.checked_sub(1),
+        (Some(previous), ScanDirection::Ascending) => {
+            let next = previous.checked_add(1)?;
+            (next < range.end).then_some(next)
+        }
+        (Some(previous), ScanDirection::Descending) => {
+            if previous > range.start {
+                Some(previous - 1)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn decode_checkpoint_scan_row(
+    row_key: Bytes,
+    cells: Vec<(Bytes, Bytes)>,
+) -> Result<(u64, (CheckpointSequenceNumber, CheckpointData))> {
+    let bytes: [u8; 8] = row_key
+        .as_ref()
+        .try_into()
+        .context("invalid checkpoint row key length")?;
+    let sequence_number = u64::from_be_bytes(bytes);
+    let checkpoint = tables::checkpoints::decode(&cells)?;
+    Ok((sequence_number, (sequence_number, checkpoint)))
+}
+
+fn decode_tx_seq_digest_scan_row(
+    row_key: Bytes,
+    cells: Vec<(Bytes, Bytes)>,
+) -> Result<(u64, TxSeqDigestData)> {
+    let tx_sequence_number = tx_seq_digest::decode_key(row_key.as_ref())?;
+    let (digest, event_count, tx_offset, checkpoint_number) = tx_seq_digest::decode(&cells)?;
+    Ok((
+        tx_sequence_number,
+        TxSeqDigestData {
+            tx_sequence_number,
+            digest,
+            event_count,
+            tx_offset,
+            checkpoint_number,
+        },
+    ))
 }
 
 fn report_bt_stats_inner(
@@ -1713,5 +1983,91 @@ fn column_exists_filter(column: &str) -> RowFilter {
                 },
             ],
         })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::TryStreamExt;
+    use futures::stream;
+
+    use super::*;
+
+    fn row(sequence: u64) -> Result<(Bytes, Vec<(Bytes, Bytes)>)> {
+        Ok((Bytes::from(sequence.to_be_bytes().to_vec()), Vec::new()))
+    }
+
+    fn decode_sequence_only(key: Bytes, _cells: Vec<(Bytes, Bytes)>) -> Result<(u64, u64)> {
+        let bytes: [u8; 8] = key.as_ref().try_into().context("invalid key")?;
+        let sequence = u64::from_be_bytes(bytes);
+        Ok((sequence, sequence))
+    }
+
+    #[tokio::test]
+    async fn dense_scan_validator_accepts_ascending_rows() {
+        let rows = stream::iter([row(3), row(4), row(5)]);
+        let got = validate_dense_scan(
+            rows,
+            3..6,
+            ScanDirection::Ascending,
+            10,
+            decode_sequence_only,
+            "test",
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("dense scan");
+        assert_eq!(got, vec![3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn dense_scan_validator_accepts_descending_rows() {
+        let rows = stream::iter([row(5), row(4), row(3)]);
+        let got = validate_dense_scan(
+            rows,
+            3..6,
+            ScanDirection::Descending,
+            10,
+            decode_sequence_only,
+            "test",
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("dense scan");
+        assert_eq!(got, vec![5, 4, 3]);
+    }
+
+    #[tokio::test]
+    async fn dense_scan_validator_rejects_gaps_before_limit() {
+        let rows = stream::iter([row(3), row(5)]);
+        let err = validate_dense_scan(
+            rows,
+            3..6,
+            ScanDirection::Ascending,
+            10,
+            decode_sequence_only,
+            "test",
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .expect_err("gap should fail");
+        assert!(err.to_string().contains("expected dense row 4"));
+    }
+
+    #[tokio::test]
+    async fn dense_scan_validator_allows_limit_truncated_tail() {
+        let rows = stream::iter([row(3), row(4)]);
+        let got = validate_dense_scan(
+            rows,
+            3..10,
+            ScanDirection::Ascending,
+            2,
+            decode_sequence_only,
+            "test",
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("rows_limit can stop before range end");
+        assert_eq!(got, vec![3, 4]);
     }
 }

--- a/crates/sui-kvstore/src/handlers/bitmap/event_bitmap.rs
+++ b/crates/sui-kvstore/src/handlers/bitmap/event_bitmap.rs
@@ -165,6 +165,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn emits_existence_bit_for_every_event() {
+        let checkpoint = TestCheckpointBuilder::new(0)
+            .with_network_total_transactions(100)
+            .start_transaction(1)
+            .with_events(vec![event(1), event(2)])
+            .finish_transaction()
+            .start_transaction(1)
+            .with_events(vec![event(3)])
+            .finish_transaction()
+            .build_checkpoint();
+
+        let values = BitmapIndexHandler::new(EventBitmapProcessor)
+            .process(&Arc::new(checkpoint))
+            .await
+            .unwrap();
+
+        let extant_key = event_bitmap_index::encode_row_key(
+            event_bitmap_index::SCHEMA_VERSION,
+            &encode_dimension_key(IndexDimension::EventExtant, &[]),
+            0,
+        );
+        let value = row(&values, &extant_key);
+        assert_eq!(value.bucket_id, 0);
+        // tx 100 emits 2 events (idx 0,1), tx 101 emits 1 (idx 0): 3 bits total,
+        // independent of the events' attributes.
+        assert_eq!(value.bitmap.len(), 3);
+        for (tx_seq, event_idx) in [(100, 0), (100, 1), (101, 0)] {
+            assert!(
+                value
+                    .bitmap
+                    .contains(event_bitmap_index::encode_event_seq(tx_seq, event_idx) as u32)
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn transactions_crossing_event_bucket_boundary_emit_distinct_bucket_rows() {
         let txs_per_bucket =
             event_bitmap_index::BUCKET_SIZE / event_bitmap_index::MAX_EVENTS_PER_TX as u64;

--- a/crates/sui-kvstore/src/handlers/tx_seq_digest.rs
+++ b/crates/sui-kvstore/src/handlers/tx_seq_digest.rs
@@ -11,8 +11,7 @@ use crate::tables;
 
 use super::handler::BigTableProcessor;
 
-/// Pipeline that writes one row per transaction keyed by bit-reversed
-/// tx_sequence_number.
+/// Pipeline that writes tx_sequence_number lookup rows.
 pub struct TxSeqDigestPipeline;
 
 #[async_trait::async_trait]

--- a/crates/sui-kvstore/src/tables/event_bitmap_index.rs
+++ b/crates/sui-kvstore/src/tables/event_bitmap_index.rs
@@ -20,17 +20,17 @@
 //! bump would be needed.
 //!
 //! The packed namespace is sparse: most transactions use only a tiny prefix of
-//! their reserved event slots. Each row spans 33,554,432 packed event positions
-//! (`BUCKET_SIZE = 2^23`), which is exactly 128 transactions worth of event
+//! their reserved event slots. Each row spans 268,435,456 packed event positions
+//! (`BUCKET_SIZE = 2^28`), which is exactly 4,096 transactions worth of event
 //! namespace at `EVENT_BITS = 16`, while leaving bucket-relative bit positions
-//! well within RoaringBitmap's `u32` limit.
+//! (max `2^28 - 1`) well within RoaringBitmap's `u32` limit.
 
 pub const NAME: &str = "event_bitmap_index";
 
 pub const SCHEMA_VERSION: u32 = 1;
 pub const BUCKET_ID_WIDTH: usize = 12;
 /// Number of packed `event_seq`s per bitmap bucket.
-pub const BUCKET_SIZE: u64 = 8_388_608;
+pub const BUCKET_SIZE: u64 = 268_435_456;
 
 /// Number of low bits of `event_seq` reserved for the per-tx event index.
 pub const EVENT_BITS: u32 = 16;

--- a/crates/sui-kvstore/src/tables/tx_seq_digest.rs
+++ b/crates/sui-kvstore/src/tables/tx_seq_digest.rs
@@ -3,9 +3,10 @@
 
 //! Direct mapping from `tx_sequence_number → (TransactionDigest, event_count, tx_offset, checkpoint_number)`.
 //!
-//! Row key layout: `[bit_reversed_tx_seq_be_u64]` — 8 bytes. Bit reversal
-//! spreads monotonic transaction sequence numbers across the keyspace while
-//! preserving a reversible point-lookup key.
+//! Row key layout: `v{version}#{bucket_prefix:016x}#{bucket_id:020}#{tx_seq:020}`.
+//! `bucket_prefix` is a deterministic bit-reversal of `bucket_id`, spreading
+//! active write buckets across BigTable's keyspace. Readers scan bucket-local
+//! row ranges in logical bucket order.
 //!
 //! `event_count` lets readers enumerate a transaction's event_seqs without
 //! reading the tx row itself — used by unfiltered event listing to discover
@@ -21,10 +22,17 @@ use anyhow::bail;
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use integer_encoding::VarInt;
+use std::ops::Range;
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 pub const NAME: &str = "tx_seq_digest";
+pub const SCHEMA_VERSION: u32 = 1;
+/// Number of tx_sequence_numbers per forward-scan bucket. Tied to
+/// SCHEMA_VERSION; changing it requires a version bump and backfill.
+pub const FORWARD_BUCKET_SIZE: u64 = 1_000;
+const FORWARD_KEY_NUMBER_WIDTH: usize = 20;
+const FORWARD_BUCKET_PREFIX_WIDTH: usize = 16;
 
 pub mod col {
     /// Raw 32-byte TransactionDigest.
@@ -37,17 +45,111 @@ pub mod col {
     pub const CHECKPOINT_NUMBER: &str = "c";
 }
 
-/// Row key: `tx_seq.reverse_bits().to_be_bytes()`.
 pub fn encode_key(tx_seq: u64) -> Vec<u8> {
-    tx_seq.reverse_bits().to_be_bytes().to_vec()
+    encode_key_for_version(SCHEMA_VERSION, tx_seq)
 }
 
-/// Decode a bit-reversed row key.
-pub fn decode_key(key: &[u8]) -> Result<u64> {
-    if key.len() != 8 {
-        anyhow::bail!("tx_seq_digest key not 8 bytes (got {})", key.len());
+pub fn forward_bucket_id(tx_seq: u64) -> u64 {
+    tx_seq / FORWARD_BUCKET_SIZE
+}
+
+pub fn distributed_bucket_prefix(bucket_id: u64) -> u64 {
+    bucket_id.reverse_bits()
+}
+
+fn encode_key_for_version(version: u32, tx_seq: u64) -> Vec<u8> {
+    let bucket_id = forward_bucket_id(tx_seq);
+    format!(
+        "v{}#{:0prefix_width$x}#{:0number_width$}#{:0number_width$}",
+        version,
+        distributed_bucket_prefix(bucket_id),
+        bucket_id,
+        tx_seq,
+        prefix_width = FORWARD_BUCKET_PREFIX_WIDTH,
+        number_width = FORWARD_KEY_NUMBER_WIDTH,
+    )
+    .into_bytes()
+}
+
+pub fn clamp_range_to_limit(range: Range<u64>, descending: bool, limit: usize) -> Range<u64> {
+    if range.is_empty() || limit == 0 {
+        return range.start..range.start;
     }
-    Ok(u64::from_be_bytes(key.try_into().unwrap()).reverse_bits())
+
+    let limit = limit as u64;
+    if descending {
+        range.end.saturating_sub(limit).max(range.start)..range.end
+    } else {
+        range.start..range.start.saturating_add(limit).min(range.end)
+    }
+}
+
+pub fn split_range_by_bucket(range: Range<u64>, descending: bool) -> Vec<Range<u64>> {
+    if range.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::new();
+    let mut start = range.start;
+    while start < range.end {
+        let next_bucket_start = forward_bucket_id(start)
+            .saturating_add(1)
+            .saturating_mul(FORWARD_BUCKET_SIZE);
+        let end = next_bucket_start.min(range.end);
+        ranges.push(start..end);
+        start = end;
+    }
+
+    if descending {
+        ranges.reverse();
+    }
+    ranges
+}
+
+pub fn decode_key(key: &[u8]) -> Result<u64> {
+    let key = std::str::from_utf8(key).context("tx_seq_digest key is not utf8")?;
+    let mut parts = key.split('#');
+    let version = parts.next().context("tx_seq_digest key missing version")?;
+    let bucket_prefix = parts
+        .next()
+        .context("tx_seq_digest key missing bucket prefix")?;
+    let bucket = parts.next().context("tx_seq_digest key missing bucket")?;
+    let tx_seq = parts.next().context("tx_seq_digest key missing tx_seq")?;
+    if parts.next().is_some() {
+        bail!("tx_seq_digest key has too many parts");
+    }
+    if !version.starts_with('v') || version.len() == 1 {
+        bail!("tx_seq_digest key version missing v-prefix");
+    }
+    let version: u32 = version[1..]
+        .parse()
+        .context("tx_seq_digest key version is not a u32")?;
+    if version != SCHEMA_VERSION {
+        bail!(
+            "tx_seq_digest key version {version} does not match current version {SCHEMA_VERSION}"
+        );
+    }
+    if bucket_prefix.len() != FORWARD_BUCKET_PREFIX_WIDTH {
+        bail!("tx_seq_digest key bucket prefix width is invalid");
+    }
+    let bucket_prefix = u64::from_str_radix(bucket_prefix, 16)
+        .context("tx_seq_digest key bucket prefix is not hex u64")?;
+    if bucket.len() != FORWARD_KEY_NUMBER_WIDTH || tx_seq.len() != FORWARD_KEY_NUMBER_WIDTH {
+        bail!("tx_seq_digest key number width is invalid");
+    }
+    let bucket_id: u64 = bucket
+        .parse()
+        .context("tx_seq_digest key bucket is not a u64")?;
+    let tx_seq: u64 = tx_seq
+        .parse()
+        .context("tx_seq_digest key tx_seq is not a u64")?;
+    if bucket_id != forward_bucket_id(tx_seq) {
+        bail!("tx_seq_digest key bucket does not match tx_seq");
+    }
+    if bucket_prefix != distributed_bucket_prefix(bucket_id) {
+        bail!("tx_seq_digest key bucket prefix does not match bucket");
+    }
+    Ok(tx_seq)
 }
 
 pub fn encode(
@@ -136,13 +238,23 @@ fn decode_canonical_varint<T: VarInt>(value: &Bytes, field: &str) -> Result<T> {
 mod tests {
     use super::*;
 
+    fn expected_key(tx_seq: u64) -> Vec<u8> {
+        let bucket_id = forward_bucket_id(tx_seq);
+        format!(
+            "v1#{:016x}#{:020}#{:020}",
+            distributed_bucket_prefix(bucket_id),
+            bucket_id,
+            tx_seq,
+        )
+        .into_bytes()
+    }
+
     #[test]
     fn encode_key_layout() {
-        for tx_seq in [0u64, 1, 63, 64, 65, 1_000_000, u64::MAX] {
-            let k = encode_key(tx_seq);
-            assert_eq!(k.len(), 8, "key must be 8 bytes for tx_seq={tx_seq}");
-            assert_eq!(&k, &tx_seq.reverse_bits().to_be_bytes());
-        }
+        assert_eq!(encode_key(0), expected_key(0));
+        assert_eq!(encode_key(999), expected_key(999));
+        assert_eq!(encode_key(1_000), expected_key(1_000));
+        assert_eq!(encode_key(1_001), expected_key(1_001));
     }
 
     #[test]
@@ -152,6 +264,51 @@ mod tests {
             let got = decode_key(&k).expect("decode must accept freshly encoded key");
             assert_eq!(got, tx_seq);
         }
+    }
+
+    #[test]
+    fn encode_key_preserves_tx_order_within_bucket() {
+        let tx_seqs = [0u64, 1, 998, 999];
+        for pair in tx_seqs.windows(2) {
+            assert!(
+                encode_key(pair[0]) < encode_key(pair[1]),
+                "key order must match tx_seq order within a bucket for {pair:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn forward_bucket_boundaries() {
+        assert_eq!(forward_bucket_id(0), 0);
+        assert_eq!(forward_bucket_id(999), 0);
+        assert_eq!(forward_bucket_id(1_000), 1);
+        assert_eq!(forward_bucket_id(1_001), 1);
+    }
+
+    #[test]
+    fn distributed_bucket_prefix_distributes_adjacent_buckets() {
+        assert_ne!(distributed_bucket_prefix(0), distributed_bucket_prefix(1));
+        assert_ne!(encode_key(999)[..20], encode_key(1_000)[..20]);
+    }
+
+    #[test]
+    fn split_range_by_bucket_respects_direction() {
+        assert_eq!(
+            split_range_by_bucket(995..2_005, false),
+            vec![995..1_000, 1_000..2_000, 2_000..2_005]
+        );
+        assert_eq!(
+            split_range_by_bucket(995..2_005, true),
+            vec![2_000..2_005, 1_000..2_000, 995..1_000]
+        );
+    }
+
+    #[test]
+    fn clamp_range_to_limit_respects_direction() {
+        assert_eq!(clamp_range_to_limit(10..20, false, 4), 10..14);
+        assert_eq!(clamp_range_to_limit(10..20, true, 4), 16..20);
+        assert_eq!(clamp_range_to_limit(10..20, false, 100), 10..20);
+        assert_eq!(clamp_range_to_limit(10..20, true, 100), 10..20);
     }
 
     #[test]
@@ -203,9 +360,14 @@ mod tests {
     }
 
     #[test]
-    fn decode_key_rejects_wrong_length() {
+    fn decode_key_rejects_invalid_keys() {
         assert!(decode_key(&[0u8; 7]).is_err());
         assert!(decode_key(&[0u8; 9]).is_err());
         assert!(decode_key(&[]).is_err());
+        assert!(decode_key(b"v2#00000000000000000000#00000000000000000000").is_err());
+        assert!(decode_key(b"v1#00000000000000000001#00000000000000000999").is_err());
+        assert!(
+            decode_key(b"v1#0000000000000000#00000000000000000001#00000000000000001000").is_err()
+        );
     }
 }


### PR DESCRIPTION
## Description

Couple of misc things for the branch cut.

1. Increase event bucket size.
2. Add a "extant" dimension to support negative event queries
3. Bucket the tx_seq_digest table It looks like sequential keys give _way_ better read performance than random keys, and the bucketing should be good enough to spread the load. 
