### PR TITLE
ci: add standalone homebrew-bump workflow for manual sui formula bumps

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -18,6 +18,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ inputs.sui_tag }}
 
+permissions:
+  contents: read
+
 jobs:
   bump:
     name: Run brew bump-formula-pr for sui

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,0 +1,86 @@
+name: Bump Homebrew sui formula
+
+run-name: Bump Homebrew sui formula → ${{ inputs.sui_tag }}
+
+# Standalone, workflow_dispatch-only counterpart to the `update-homebrew-formula`
+# job inside release.yml. Use this to manually bump the homebrew-core sui
+# formula for any release tag — useful when the in-release job failed (e.g. a
+# transient homebrew error) or for tags that the in-release job skips
+# (release.yml's job is gated to `contains(..., 'testnet')`).
+
+on:
+  workflow_dispatch:
+    inputs:
+      sui_tag:
+        description: "Sui release tag (e.g. testnet-v1.72.2 or mainnet-v1.72.2)"
+        type: string
+        required: true
+
+concurrency: ${{ github.workflow }}-${{ inputs.sui_tag }}
+
+jobs:
+  bump:
+    name: Run brew bump-formula-pr for sui
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag + derive versionless tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          sui_tag="${{ inputs.sui_tag }}"
+          if [[ ! "${sui_tag}" =~ ^(testnet|mainnet|devnet)-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Invalid tag: '${sui_tag}'. Expected: {testnet|mainnet|devnet}-v<X.Y.Z>"
+            exit 1
+          fi
+          versionless_tag="${sui_tag#*-v}"
+          echo "sui_tag=${sui_tag}" >> "$GITHUB_OUTPUT"
+          echo "versionless_tag=${versionless_tag}" >> "$GITHUB_OUTPUT"
+          echo "::notice::sui_tag=${sui_tag} versionless_tag=${versionless_tag}"
+
+      - name: Confirm the release tarball exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="https://github.com/MystenLabs/sui/archive/refs/tags/${{ steps.tag.outputs.sui_tag }}.tar.gz"
+          if ! curl -fsSL -o /dev/null -I "${url}"; then
+            echo "❌ Release tarball not found at ${url}"
+            echo "Create the GitHub release for ${{ steps.tag.outputs.sui_tag }} before running this workflow."
+            exit 1
+          fi
+          echo "✅ Tarball available: ${url}"
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@8eb7f2efa6ab636da09aef605b497fd5b8a7587d # pin@master 2026-05-16
+        with:
+          core: true
+
+      - name: Bump sui formula on Homebrew/homebrew-core
+        env:
+          # PAT with public_repo,workflow scopes
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GH_FORMULA_BUMP }}
+          HOMEBREW_NO_INSTALL_FROM_API: "1"
+          HOMEBREW_NO_ANALYTICS: "1"
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Derive commit author from the PAT owner so the homebrew-core PR
+          # shows the right "Verified" attribution and survives token rotation
+          # without editing this file.
+          user_info=$(curl -fsSL -H "Authorization: Bearer ${HOMEBREW_GITHUB_API_TOKEN}" \
+            -H "Accept: application/vnd.github+json" https://api.github.com/user)
+          gh_login=$(echo "$user_info" | jq -r '.login')
+          gh_id=$(echo "$user_info" | jq -r '.id')
+          git config --global user.name "${gh_login}"
+          git config --global user.email "${gh_id}+${gh_login}@users.noreply.github.com"
+
+          # Sui's formula in Homebrew/homebrew-core is URL+sha256 style, not tag+revision,
+          # so pass --url/--version (brew bump-formula-pr cannot switch styles).
+          url="https://github.com/MystenLabs/sui/archive/refs/tags/${{ steps.tag.outputs.sui_tag }}.tar.gz"
+          brew bump-formula-pr \
+            --no-browse \
+            --url="${url}" \
+            --version="${{ steps.tag.outputs.versionless_tag }}" \
+            --message="Manually triggered: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            sui


### PR DESCRIPTION
## Summary

Adds `.github/workflows/homebrew-bump.yml` — a `workflow_dispatch`-only companion to `release.yml`'s `update-homebrew-formula` job. Use it when:

1. The in-release homebrew job fails on a specific tag and we want to retry just the brew bump without re-running the rest of `release.yml`.
2. We want to bump homebrew for a tag that `release.yml` skips (the existing job is gated to `contains(..., 'testnet')`, so mainnet tags never get a homebrew bump automatically).

The job is lifted from the same direct `brew bump-formula-pr` invocation introduced in #26706 — same `Homebrew/actions/setup-homebrew` SHA pin, same `HOMEBREW_GH_FORMULA_BUMP` secret, same PAT-derived commit author. Added two pre-checks:

- regex guard on the `sui_tag` input (must match `{testnet|mainnet|devnet}-v<X.Y.Z>`)
- HTTP HEAD on `https://github.com/MystenLabs/sui/archive/refs/tags/<tag>.tar.gz` so a missing/typoed tag fails fast with a clear message instead of going through homebrew setup first.

### Motivating cases (this week)

- Re-run brew bump for `testnet-v1.72.2` — the in-release job failed with the old `mislav` action ([run 26122662356](https://github.com/MystenLabs/sui/actions/runs/26122662356)) before #26706 merged. Re-running the failed job uses the original (pre-fix) workflow YAML, so it would fail again. Workflow_dispatch on `release.yml` would re-fire all the binary-build/upload jobs.
- Run brew bump for `mainnet-v1.72.2` tomorrow once the release is cut. `release.yml`'s job is gated to testnet only.

## Test plan

- [x] Validates input format with regex
- [x] HEAD-checks the release tarball before invoking brew
- [ ] After merge: dispatch with `sui_tag=testnet-v1.72.2`, confirm `brew bump-formula-pr` opens a homebrew-core PR against the right formula version
- [ ] After mainnet-v1.72.2 release tomorrow: dispatch with `sui_tag=mainnet-v1.72.2`, confirm same

🤖 Generated with [Claude Code](https://claude.com/claude-code)