### PR TITLE
ci(release): make homebrew-bump.yml reusable, replace inline job in release.yml

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -2,11 +2,15 @@ name: Bump Homebrew sui formula
 
 run-name: Bump Homebrew sui formula → ${{ inputs.sui_tag }}
 
-# Standalone, workflow_dispatch-only counterpart to the `update-homebrew-formula`
-# job inside release.yml. Use this to manually bump the homebrew-core sui
-# formula for any release tag — useful when the in-release job failed (e.g. a
-# transient homebrew error) or for tags that the in-release job skips
-# (release.yml's job is gated to `contains(..., 'testnet')`).
+# Bumps the sui formula in Homebrew/homebrew-core. Two ways to invoke:
+#
+#   1. workflow_call: release.yml's `update-homebrew-formula` job calls this
+#      after the release-build matrix finishes, so the standard release path
+#      stays single-button.
+#   2. workflow_dispatch: a release captain can also fire this manually for
+#      any release tag — useful when the in-release call failed (e.g. a
+#      transient homebrew error) or for tags release.yml skips (its job is
+#      gated to `contains(..., 'testnet')`, so mainnet bumps need this).
 
 on:
   workflow_dispatch:
@@ -14,6 +18,16 @@ on:
       sui_tag:
         description: "Sui release tag (e.g. testnet-v1.72.2 or mainnet-v1.72.2)"
         type: string
+        required: true
+  workflow_call:
+    inputs:
+      sui_tag:
+        description: "Sui release tag (e.g. testnet-v1.72.2 or mainnet-v1.72.2)"
+        type: string
+        required: true
+    secrets:
+      HOMEBREW_GH_FORMULA_BUMP:
+        description: "PAT with public_repo,workflow scopes — opens the homebrew-core PR"
         required: true
 
 concurrency: ${{ github.workflow }}-${{ inputs.sui_tag }}
@@ -85,5 +99,5 @@ jobs:
             --no-browse \
             --url="${url}" \
             --version="${{ steps.tag.outputs.versionless_tag }}" \
-            --message="Manually triggered: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --message="Triggered from: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             sui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,52 +233,15 @@ jobs:
           client-payload: '{"new_tag": "${{ env.sui_tag }}"}'
 
   update-homebrew-formula:
-    name: Run brew bump-formula-pr for sui on testnet releases
+    name: Bump sui formula on Homebrew/homebrew-core
     needs: release-build
-    runs-on: ubuntu-latest
     # releasing sui cli on testnet releases because it lags `main` less than mainnet, but is more likely to be stable than devnet
     if: ${{ contains( inputs.sui_tag, 'testnet') || contains( github.ref_name, 'testnet') }}
-    steps:
-      - name: Clean up tag name ${{ env.TAG_NAME }}
-        shell: bash
-        run: |
-          echo "sui_tag=$(echo ${{ env.TAG_NAME }} | sed s/'refs\/tags\/'//)" >> $GITHUB_ENV
-          echo "versionless_tag=$(echo ${{ env.TAG_NAME }} | sed s/'refs\/tags\/'// | sed s/'testnet\-v'//)" >> $GITHUB_ENV
-
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@8eb7f2efa6ab636da09aef605b497fd5b8a7587d # pin@master 2026-05-16
-        with:
-          # Explicitly fetch homebrew-core so `brew bump-formula-pr sui`
-          # finds the formula without relying on its retry-and-install fallback.
-          core: true
-
-      - name: Bump sui formula on Homebrew/homebrew-core
-        env:
-          # PAT with public_repo,workflow scopes — same secret previously used as COMMITTER_TOKEN
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GH_FORMULA_BUMP }}
-          HOMEBREW_NO_INSTALL_FROM_API: "1"
-          HOMEBREW_NO_ANALYTICS: "1"
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-        run: |
-          # Derive commit author from the PAT owner so the homebrew-core PR
-          # shows the right "Verified" attribution and survives token rotation
-          # without editing this file.
-          user_info=$(curl -fsSL -H "Authorization: Bearer ${HOMEBREW_GITHUB_API_TOKEN}" \
-            -H "Accept: application/vnd.github+json" https://api.github.com/user)
-          gh_login=$(echo "$user_info" | jq -r '.login')
-          gh_id=$(echo "$user_info" | jq -r '.id')
-          git config --global user.name "${gh_login}"
-          git config --global user.email "${gh_id}+${gh_login}@users.noreply.github.com"
-
-          # Sui's formula in Homebrew/homebrew-core is URL+sha256 style, not tag+revision,
-          # so pass --url/--version (brew bump-formula-pr cannot switch styles).
-          url="https://github.com/MystenLabs/sui/archive/refs/tags/${{ env.sui_tag }}.tar.gz"
-          brew bump-formula-pr \
-            --no-browse \
-            --url="${url}" \
-            --version="${{ env.versionless_tag }}" \
-            --message="From release: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            sui
+    uses: ./.github/workflows/homebrew-bump.yml
+    with:
+      sui_tag: ${{ inputs.sui_tag || github.ref_name }}
+    secrets:
+      HOMEBREW_GH_FORMULA_BUMP: ${{ secrets.HOMEBREW_GH_FORMULA_BUMP }}
 
   # Tag all sui images with release tag, so that they can be easily found
   tag-docker-hub-images:


### PR DESCRIPTION
## Summary

Stop duplicating the brew bump logic. Wire `release.yml`'s `update-homebrew-formula` job to `homebrew-bump.yml` via `uses:` instead.

**Before** (after #26706 + #26711):
- `release.yml` had ~40 lines of brew setup/bump steps inline.
- `homebrew-bump.yml` (added in #26711) was a separate `workflow_dispatch`-only copy of the same logic, used to retry/manual-trigger brew bumps.
- Any future tweak to the brew flow had to land in both files.

**After this PR:**
- `homebrew-bump.yml` is now dual-trigger (`workflow_dispatch` + `workflow_call`) and is the single source of truth.
- `release.yml`'s job collapses to a 6-line `uses:` block. Same `needs: release-build`, same testnet `if:` gate, secret threaded through.
- `--message` string is now neutral (`Triggered from: <run-url>`) so it reads correctly whether invoked manually or from release.yml.

## Tradeoff

The brew bump now shows up as its own run in the Actions tab (a "called workflow"), rather than inline in the release.yml run page. Easier to navigate and re-run when the step fails, very slightly more clicks for the happy path.

The standalone manual-dispatch path (just used in [run 26134683041](https://github.com/MystenLabs/sui/actions/runs/26134683041) to retry testnet-v1.72.2 → [homebrew-core#283670](https://github.com/Homebrew/homebrew-core/pull/283670)) is unchanged — same inputs, same regex validation, same tarball precheck, same brew invocation.

## Test plan

- [x] Diff is purely structural — no behavior change to the brew code, only the wrapper around it
- [x] `inputs.sui_tag` and `github.ref_name` both produce clean tags (no `refs/tags/` prefix); the standalone workflow's regex catches any garbage anyway
- [x] Secret threading explicit (`secrets: HOMEBREW_GH_FORMULA_BUMP:`) — required for reusable workflows
- [ ] After merge: next testnet release (testnet-v1.72.3) will exercise the workflow_call path end-to-end. If anything's off, we can still hit the workflow_dispatch path as a fallback.
- [ ] Tomorrow's `mainnet-v1.72.2` homebrew bump goes via `workflow_dispatch` on `homebrew-bump.yml` directly (unchanged from the current plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)