### PR TITLE
[consensus][tidehunter] Enable compressed batch WAL frames for consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d#3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c17cbc45e75bde6714a021fcc3f309c1572e1e61#c17cbc45e75bde6714a021fcc3f309c1572e1e61"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17970,7 +17970,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d#3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c17cbc45e75bde6714a021fcc3f309c1572e1e61#c17cbc45e75bde6714a021fcc3f309c1572e1e61"
 dependencies = [
  "anyhow",
  "clap",
@@ -17984,7 +17984,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d#3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c17cbc45e75bde6714a021fcc3f309c1572e1e61#c17cbc45e75bde6714a021fcc3f309c1572e1e61"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f6b9ad0503156208c8f6903563a965c456ab17a7#f6b9ad0503156208c8f6903563a965c456ab17a7"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d#3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17970,7 +17970,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f6b9ad0503156208c8f6903563a965c456ab17a7#f6b9ad0503156208c8f6903563a965c456ab17a7"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d#3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d"
 dependencies = [
  "anyhow",
  "clap",
@@ -17984,7 +17984,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f6b9ad0503156208c8f6903563a965c456ab17a7#f6b9ad0503156208c8f6903563a965c456ab17a7"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d#3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",
@@ -17994,6 +17994,7 @@ dependencies = [
  "crc32fast",
  "libc",
  "lru 0.12.5",
+ "lz4_flex",
  "memmap2 0.7.1",
  "minibytes",
  "parking_lot 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c17cbc45e75bde6714a021fcc3f309c1572e1e61#c17cbc45e75bde6714a021fcc3f309c1572e1e61"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17970,7 +17970,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c17cbc45e75bde6714a021fcc3f309c1572e1e61#c17cbc45e75bde6714a021fcc3f309c1572e1e61"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
 dependencies = [
  "anyhow",
  "clap",
@@ -17984,7 +17984,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c17cbc45e75bde6714a021fcc3f309c1572e1e61#c17cbc45e75bde6714a021fcc3f309c1572e1e61"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -156,7 +156,8 @@ impl RocksDBStore {
         Self::open_tables_read_write(
             path.into(),
             MetricConf::new("consensus")
-                .with_sampling(SamplingInterval::new(Duration::from_secs(60), 0)),
+                .with_sampling(SamplingInterval::new(Duration::from_secs(60), 0))
+                .with_th_batch_compression(),
             configs.into_iter().collect(),
         )
     }

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -52,7 +52,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "c17cbc45e75bde6714a021fcc3f309c1572e1e61", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -52,7 +52,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "c17cbc45e75bde6714a021fcc3f309c1572e1e61", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "14b04e9d8130c20fdc03a629c02fe50f628cb789", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -52,7 +52,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f6b9ad0503156208c8f6903563a965c456ab17a7", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -382,7 +382,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                         )*
                     );
                     let key_shape = builder.build();
-                    let (inner_db, registry_id) = typed_store::tidehunter_util::open(path.as_path(), key_shape, metric_conf.db_name.clone());
+                    let (inner_db, registry_id) = typed_store::tidehunter_util::open(path.as_path(), key_shape, &metric_conf);
                     let db = std::sync::Arc::new(typed_store::rocks::Database::new(
                         typed_store::rocks::Storage::TideHunter(inner_db),
                         metric_conf,

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "c17cbc45e75bde6714a021fcc3f309c1572e1e61", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f6b9ad0503156208c8f6903563a965c456ab17a7", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "3cbbae1b3e7a8df18e46ce0cc5e7c7033424063d", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "c17cbc45e75bde6714a021fcc3f309c1572e1e61", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "14b04e9d8130c20fdc03a629c02fe50f628cb789", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -548,6 +548,9 @@ pub struct MetricConf {
     pub read_sample_interval: SamplingInterval,
     pub write_sample_interval: SamplingInterval,
     pub iter_sample_interval: SamplingInterval,
+    /// When true and the database is opened with the tidehunter backend, each
+    /// committed `WriteBatch` is written as a single lz4-compressed WAL entry.
+    pub enable_th_batch_compression: bool,
 }
 
 impl MetricConf {
@@ -560,16 +563,18 @@ impl MetricConf {
             read_sample_interval: SamplingInterval::default(),
             write_sample_interval: SamplingInterval::default(),
             iter_sample_interval: SamplingInterval::default(),
+            enable_th_batch_compression: false,
         }
     }
 
-    pub fn with_sampling(self, read_interval: SamplingInterval) -> Self {
-        Self {
-            db_name: self.db_name,
-            read_sample_interval: read_interval,
-            write_sample_interval: SamplingInterval::default(),
-            iter_sample_interval: SamplingInterval::default(),
-        }
+    pub fn with_sampling(mut self, read_interval: SamplingInterval) -> Self {
+        self.read_sample_interval = read_interval;
+        self
+    }
+
+    pub fn with_th_batch_compression(mut self) -> Self {
+        self.enable_th_batch_compression = true;
+        self
     }
 }
 const CF_METRICS_REPORT_PERIOD_SECS: u64 = 30;

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{DBMetrics, StorageType, util::ensure_database_type};
+use crate::{DBMetrics, StorageType, rocks::MetricConf, util::ensure_database_type};
 use bincode::Options;
 use mysten_metrics::RegistryID;
 use prometheus::{HistogramTimer, Registry};
@@ -9,6 +9,7 @@ use serde::de::DeserializeOwned;
 use std::env;
 use std::path::Path;
 use std::sync::Arc;
+use tidehunter::compressed_batch::BatchCodec;
 use tidehunter::config::Config;
 use tidehunter::db::Db;
 use tidehunter::iterators::db_iterator::DbIterator;
@@ -30,14 +31,14 @@ pub struct ThConfig {
     pub prefix: Option<Vec<u8>>,
 }
 
-pub fn open(path: &Path, key_shape: KeyShape, db_name: String) -> (Arc<Db>, RegistryID) {
+pub fn open(path: &Path, key_shape: KeyShape, metric_conf: &MetricConf) -> (Arc<Db>, RegistryID) {
     std::fs::create_dir_all(path).expect("failed to open tidehunter db");
     let registry_service = &DBMetrics::get().registry_serivce;
-    let registry = new_db_registry(db_name);
+    let registry = new_db_registry(metric_conf.db_name.clone());
     let registry_id = registry_service.add(registry.clone());
     let metrics = Metrics::new_in(&registry);
     ensure_database_type(path, StorageType::TideHunter).expect("failed to open tidehunter db");
-    let db = Db::open(path, key_shape, Arc::new(thdb_config()), metrics)
+    let db = Db::open(path, key_shape, Arc::new(thdb_config(metric_conf)), metrics)
         .expect("failed to open tidehunter db");
     db.start_periodic_snapshot();
     (db, registry_id)
@@ -83,7 +84,7 @@ pub fn default_max_dirty_keys() -> usize {
     parse_env_usize("TH_DEFAULT_MAX_DIRTY_KEYS", 1).unwrap_or(1024)
 }
 
-fn thdb_config() -> Config {
+fn thdb_config(metric_conf: &MetricConf) -> Config {
     let frag_size = if let Ok(frag_size) = env::var("TH_FRAG_SIZE") {
         let frag_size = frag_size.parse().expect("Failed to parse TH_FRAG_SIZE");
         assert!(frag_size > 0, "TH_FRAG_SIZE must be more then 0");
@@ -117,6 +118,9 @@ fn thdb_config() -> Config {
     let num_flusher_threads = 1;
     #[cfg(not(debug_assertions))]
     let num_flusher_threads = 4;
+    let batch_codec = metric_conf
+        .enable_th_batch_compression
+        .then_some(BatchCodec::Lz4);
     let mut config = Config {
         frag_size,
         // run snapshot every 64 Gb written to wal
@@ -131,6 +135,7 @@ fn thdb_config() -> Config {
         max_index_maps,
         commit_pool_size,
         num_flusher_threads,
+        batch_codec,
         ..Config::default()
     };
 


### PR DESCRIPTION
## Summary
- Adds `MetricConf::with_th_batch_compression()` opt-in.
- When set, the tidehunter `Config` is opened with `batch_codec = Lz4`, so each `WriteBatch` becomes a single lz4-compressed WAL frame instead of per-record `BatchStart + N` frames.
- Consensus enables it; other stores keep the existing framing.
- Plumbing change: `tidehunter_util::open()` now takes `&MetricConf` (was just `db_name: String`); the derive macro passes `&metric_conf`.
- Bumps tidehunter to `14b04e9d8130c20fdc03a629c02fe50f628cb789`.

## Test plan
- [ ] Deploy to private-testnet with `build_with_tidehunter=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)