### PR TITLE
[chore] gate staging-only streaming items to silence clippy warnings

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -45,7 +45,7 @@ impl Subscription {
                             processed.clone(),
                         );
                         yield Ok(Checkpoint {
-                            sequence_number: processed.sequence_number,
+                            sequence_number: processed.summary.sequence_number,
                             scope,
                             streamed_data: Some(processed),
                         });
@@ -134,6 +134,10 @@ impl Subscription {
                             processed.clone(),
                         );
                         for tx in &processed.transactions {
+                            let digest = tx
+                                .contents
+                                .digest()
+                                .expect("ExecutedTransaction digest is infallible");
                             let events = tx.contents.events().unwrap_or_default();
                             for (idx, native) in events.into_iter().enumerate() {
                                 if !filter.matches(&native) {
@@ -141,11 +145,11 @@ impl Subscription {
                                 }
                                 yield Ok(Event {
                                     scope: scope.with_active_transaction_contents(
-                                        tx.digest,
+                                        digest,
                                         tx.contents.clone(),
                                     ),
                                     native,
-                                    transaction_digest: tx.digest,
+                                    transaction_digest: digest,
                                     sequence_number: idx as u64,
                                     timestamp_ms,
                                 });

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -25,9 +25,16 @@ use sui_types::object::Object as NativeObject;
 
 use crate::config::Limits;
 use crate::error::RpcError;
-use crate::task::streaming::ProcessedCheckpoint;
-use crate::task::streaming::StreamingPackageStore;
 use crate::task::watermark::Watermarks;
+
+#[cfg(feature = "staging")]
+mod staging {
+    pub(super) use crate::task::streaming::ProcessedCheckpoint;
+    pub(super) use crate::task::streaming::StreamingPackageStore;
+}
+
+#[cfg(feature = "staging")]
+use staging::*;
 
 /// A map of objects from an executed transaction, keyed by (ObjectID, SequenceNumber).
 /// None values indicate tombstones for deleted/wrapped objects.
@@ -50,6 +57,7 @@ pub(crate) enum DataSource {
     /// A streamed checkpoint with all per-tx contents and a checkpoint-wide execution-objects
     /// map. If the scope is anchored to a particular transaction in the checkpoint, its digest
     /// is in [`Scope::effects_viewed_at_digest`].
+    #[cfg(feature = "staging")]
     Streamed {
         checkpoint: Arc<ProcessedCheckpoint>,
     },
@@ -147,6 +155,7 @@ impl Scope {
 
     /// Create a scope for streamed checkpoint data. Sets `checkpoint_viewed_at` to `None`
     /// because streamed data is resolved from memory, not bounded by an indexed checkpoint.
+    #[cfg(feature = "staging")]
     pub(crate) fn for_streamed_checkpoint(
         package_store: Arc<StreamingPackageStore>,
         resolver_limits: sui_package_resolver::Limits,
@@ -348,6 +357,7 @@ impl Scope {
         match &self.data_source {
             DataSource::Indexed => None,
             DataSource::Executed { execution_objects } => Some(execution_objects),
+            #[cfg(feature = "staging")]
             DataSource::Streamed { checkpoint } => Some(&checkpoint.execution_objects),
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -56,7 +56,6 @@
 //! the recovery target, the next live message is itself a gap, and detection
 //! fires again.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -74,15 +73,11 @@ use sui_rpc::proto::sui::rpc::v2::Checkpoint as ProtoCheckpoint;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction as ProtoExecutedTransaction;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsResponse;
-use sui_rpc::proto::sui::rpc::v2::changed_object::OutputObjectState;
 use sui_rpc::proto::sui::rpc::v2::subscription_service_client::SubscriptionServiceClient;
 use sui_sdk_types::ValidatorAggregatedSignature;
-use sui_types::base_types::ObjectID;
-use sui_types::base_types::SequenceNumber;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::crypto::ToFromBytes;
 use sui_types::effects::TransactionEffects;
-use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::TransactionEvents;
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointSummary;
@@ -106,6 +101,18 @@ use super::SubscriptionReadiness;
 use super::gap_recovery::recover_gap;
 use super::processed_checkpoint::ProcessedCheckpoint;
 use super::processed_checkpoint::ProcessedTransaction;
+
+#[cfg(feature = "staging")]
+mod staging {
+    pub(super) use std::collections::BTreeMap;
+
+    pub(super) use sui_rpc::proto::sui::rpc::v2::changed_object::OutputObjectState;
+    pub(super) use sui_types::base_types::ObjectID;
+    pub(super) use sui_types::base_types::SequenceNumber;
+}
+
+#[cfg(feature = "staging")]
+use staging::*;
 
 // TODO: Make these configurable via SubscriptionConfig.
 const MAX_GRPC_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
@@ -399,11 +406,13 @@ pub(super) fn process_checkpoint(
     let timestamp_ms = summary.timestamp_ms;
     let cp_sequence_number = sequence_number;
     let tx_lo = summary.network_total_transactions - checkpoint.transactions.len() as u64;
+    #[cfg(feature = "staging")]
     let checkpoint_objects = deserialize_checkpoint_objects(&checkpoint)?;
 
     // Seed the checkpoint-wide execution-objects map with every existing object version
     // carried by the proto. Tombstones for deleted/wrapped outputs are added below from each
     // transaction's effects because the proto doesn't carry deleted-object payloads.
+    #[cfg(feature = "staging")]
     let mut execution_objects: BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>> =
         checkpoint_objects
             .iter()
@@ -412,6 +421,7 @@ pub(super) fn process_checkpoint(
 
     let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
     for (i, proto) in checkpoint.transactions.iter().enumerate() {
+        #[cfg(feature = "staging")]
         add_tombstones(&mut execution_objects, proto)?;
         transactions.push(process_transaction(
             proto,
@@ -422,11 +432,11 @@ pub(super) fn process_checkpoint(
     }
 
     Ok(ProcessedCheckpoint {
-        sequence_number,
         summary,
         contents,
         signature,
         transactions,
+        #[cfg(feature = "staging")]
         execution_objects: Arc::new(execution_objects),
     })
 }
@@ -481,8 +491,6 @@ fn process_transaction(
         })
         .collect::<anyhow::Result<_>>()?;
 
-    let digest = *effects.transaction_digest();
-
     let contents = NativeTransactionContents::ExecutedTransaction(
         sui_indexer_alt_reader::kv_loader::ExecutedTransactionData {
             effects: Box::new(effects),
@@ -499,7 +507,6 @@ fn process_transaction(
 
     Ok(ProcessedTransaction {
         tx_sequence_number,
-        digest,
         contents: Arc::new(contents),
     })
 }
@@ -528,6 +535,7 @@ fn extract_packages(checkpoint: &ProtoCheckpoint) -> Vec<Arc<Package>> {
 }
 
 /// Deserialize all objects from the checkpoint-level ObjectSet.
+#[cfg(feature = "staging")]
 fn deserialize_checkpoint_objects(
     checkpoint: &ProtoCheckpoint,
 ) -> anyhow::Result<BTreeMap<(ObjectID, SequenceNumber), NativeObject>> {
@@ -550,6 +558,7 @@ fn deserialize_checkpoint_objects(
 /// carry payloads for deleted/wrapped objects, so tombstones must come from effects; without
 /// them, `execution_output_object_latest` would return the pre-deletion version of an object
 /// that no longer exists at end-of-checkpoint.
+#[cfg(feature = "staging")]
 fn add_tombstones(
     map: &mut BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>>,
     proto_tx: &ProtoExecutedTransaction,

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -325,7 +325,7 @@ mod tests {
     fn drain_broadcast(receiver: &mut broadcast::Receiver<Arc<ProcessedCheckpoint>>) -> Vec<u64> {
         let mut received = Vec::new();
         while let Ok(cp) = receiver.try_recv() {
-            received.push(cp.sequence_number);
+            received.push(cp.summary.sequence_number);
         }
         received
     }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 
+#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::CheckpointBroadcaster;
 pub(crate) use checkpoint_stream_task::CheckpointStreamTask;
 pub(crate) use package_eviction_task::PackageEvictionTask;

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -5,15 +5,14 @@ use std::sync::Arc;
 
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
-use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointSummary;
 
+#[cfg(feature = "staging")]
 use crate::scope::ExecutionObjectMap;
 
 /// A checkpoint received from gRPC with pre-deserialized data for subscriber consumption.
 pub(crate) struct ProcessedCheckpoint {
-    pub(crate) sequence_number: u64,
     pub(crate) summary: CheckpointSummary,
     pub(crate) contents: CheckpointContents,
     pub(crate) signature: AuthorityStrongQuorumSignInfo,
@@ -21,13 +20,13 @@ pub(crate) struct ProcessedCheckpoint {
     /// Checkpoint-wide execution objects (inputs and outputs across all transactions in the
     /// checkpoint, including tombstones for deleted/wrapped objects). Object visibility in a
     /// streamed scope is end-of-checkpoint, matching what the indexed Query API exposes.
+    #[cfg(feature = "staging")]
     pub(crate) execution_objects: ExecutionObjectMap,
 }
 
 /// A transaction from a streamed checkpoint with pre-deserialized contents.
 pub(crate) struct ProcessedTransaction {
     pub(crate) tx_sequence_number: u64,
-    pub(crate) digest: TransactionDigest,
     /// Wrapped in `Arc` so that subscribers (and resolvers within them) share a single deep
     /// copy of the per-tx contents instead of each cloning the whole `TransactionContents`.
     pub(crate) contents: Arc<TransactionContents>,


### PR DESCRIPTION
## Description 

 - `Subscription` and the streaming e2e tests are gated behind the `staging` feature, so any streaming code only consumed from those paths warns as dead under the default build.
 - Date the dead items inline and group otherwise-orphaned imports via the `mod staging { pub use ...; } use staging::*;` pattern

## Test plan 

How did you test the new or updated feature?
- cargo check in staging and non-staging - zero warnings

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
