### PR TITLE
[consensus] add LeaderSlotDecider for v3 commit rule

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -82,7 +82,8 @@ pub trait BlockAPI {
     /// Votes on if a transaction should be accepted or rejected.
     fn transaction_votes(&self) -> &[BlockTransactionVotes];
 
-    /// The author's local GC round at the time the block was proposed.
+    /// Transactions in this blocks' casual history at and before the cutoff round
+    /// will not receive accept votes from this block.
     /// Only `BlockV3` carries this — earlier variants panic.
     fn transaction_votes_cutoff_round(&self) -> Round;
 

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -11,7 +11,7 @@ use std::{
     vec,
 };
 
-use consensus_config::{AuthorityIndex, Stake};
+use consensus_config::AuthorityIndex;
 use consensus_types::block::{BlockDigest, BlockRef, BlockTimestampMs, Round, TransactionIndex};
 use itertools::Itertools as _;
 use mysten_common::ZipDebugEqIteratorExt;
@@ -27,6 +27,7 @@ use crate::{
     },
     context::Context,
     leader_scoring::{ReputationScores, ScoringSubdag},
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
@@ -368,12 +369,10 @@ impl DagState {
                         ancestor, block_ref
                     )
                 });
-                if block_info.children.insert(block_ref)
-                    && block_info.children_authorities.insert(block_ref.author)
-                {
-                    let child_stake = self.context.committee.stake(block_ref.author);
-                    block_info.total_children_stake += child_stake;
-                }
+                block_info.children.insert(block_ref);
+                block_info
+                    .children_stake
+                    .add_unique(block_ref.author, &self.context.committee);
             }
             self.update_round_info(block);
         }
@@ -485,6 +484,25 @@ impl DagState {
         blocks
     }
 
+    /// Gets all block infos in the slot.
+    /// Must be called on slots above gc_round, otherwise the result may be misleading due to GC eviction.
+    pub(crate) fn get_block_info_at_slot(&self, slot: Slot) -> Vec<BlockInfo> {
+        assert!(
+            slot.round > self.gc_round(),
+            "get_block_info_at_slot() should only be called for slots above gc_round: slot {}, gc_round {}",
+            slot,
+            self.gc_round()
+        );
+        let mut results = vec![];
+        for (_block_ref, block_info) in self.recent_blocks.range((
+            Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MIN)),
+            Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MAX)),
+        )) {
+            results.push(block_info.clone());
+        }
+        results
+    }
+
     /// Gets all uncommitted blocks in a slot.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
     pub(crate) fn get_uncommitted_blocks_at_slot(&self, slot: Slot) -> Vec<VerifiedBlock> {
@@ -542,17 +560,20 @@ impl DagState {
         }
         self.recent_blocks
             .get(block_ref)
-            .map(|block_info| block_info.children_authorities.clone())
+            .map(|block_info| block_info.children_stake.authorities().clone())
     }
 
     #[cfg(test)]
-    pub(crate) fn get_block_total_children_stake(&self, block_ref: &BlockRef) -> Option<Stake> {
+    pub(crate) fn get_block_total_children_stake(
+        &self,
+        block_ref: &BlockRef,
+    ) -> Option<consensus_config::Stake> {
         if block_ref.round <= self.gc_round() {
             return None;
         }
         self.recent_blocks
             .get(block_ref)
-            .map(|block_info| block_info.total_children_stake)
+            .map(|block_info| block_info.children_stake.stake())
     }
 
     /// Gets all ancestors in the history of a block at a certain round.
@@ -935,10 +956,9 @@ impl DagState {
         self.highest_accepted_round
     }
 
-    /// Returns the `RoundInfo` for `round`, if retained. `None` if the round has
-    /// been evicted, Gc'ed or has not been reached yet.
-    #[cfg(test)]
-    pub(crate) fn round_info(&self, round: Round) -> Option<&RoundInfo> {
+    /// Returns the `RoundInfo` at `round`, if available. `None` if the round has
+    /// been evicted (<= gc_round) or has not been reached yet.
+    pub(crate) fn get_round_info(&self, round: Round) -> Option<&RoundInfo> {
         let front_round = self.round_info.front()?.round;
         if round < front_round || round <= self.gc_round() {
             return None;
@@ -977,11 +997,7 @@ impl DagState {
             "Attempted to update round info for block {block_ref} with round higher than next round {next_round}"
         );
         if block.round() == next_round {
-            self.round_info.push_back(RoundInfo {
-                round: block.round(),
-                authorities: BTreeSet::new(),
-                total_stake: 0,
-            });
+            self.round_info.push_back(RoundInfo::new(block.round()));
         }
 
         // Update the RoundInfo of the block round.
@@ -992,9 +1008,9 @@ impl DagState {
             .round;
         let index = (block.round() - front_round) as usize;
         let info = &mut self.round_info[index];
-        if info.authorities.insert(block_ref.author) {
-            info.total_stake += self.context.committee.stake(block_ref.author);
-        }
+        info.blocks.insert(block_ref);
+        info.total_stake
+            .add_unique(block_ref.author, &self.context.committee);
     }
 
     // Buffers a new commit in memory and updates last committed rounds.
@@ -1379,19 +1395,20 @@ impl DagState {
     }
 }
 
-struct BlockInfo {
-    block: VerifiedBlock,
+/// Information on a block accepted into the DAG.
+#[derive(Clone)]
+pub(crate) struct BlockInfo {
+    pub(crate) block: VerifiedBlock,
 
     /// Used in computing commits and leader schedule in Mysticeti v3.
     /// Next-round blocks which have this block as an ancestor.
-    children: BTreeSet<BlockRef>,
-    /// Distinct authorities that have authored one of the entries in `children`.
-    children_authorities: BTreeSet<AuthorityIndex>,
-    /// Sum of stake across `children_authorities`.
-    total_children_stake: Stake,
+    pub(crate) children: BTreeSet<BlockRef>,
+    /// Total stake from distinct authorities that have authored
+    /// one of the blocks in `children`.
+    pub(crate) children_stake: StakeAggregator<QuorumThreshold>,
 
     // Whether the block has been committed
-    committed: bool,
+    pub(crate) committed: bool,
     // Whether the block has been included in the causal history of an owned proposed block.
     ///
     /// There are two usages of this field:
@@ -1406,8 +1423,7 @@ impl BlockInfo {
         Self {
             block,
             children: BTreeSet::new(),
-            children_authorities: BTreeSet::new(),
-            total_children_stake: 0,
+            children_stake: StakeAggregator::new(),
             committed: false,
             included: false,
         }
@@ -1419,16 +1435,28 @@ impl BlockInfo {
 /// RoundInfo is only kept for rounds above GC round.
 pub(crate) struct RoundInfo {
     pub(crate) round: Round,
-    /// Distinct authorities that have authored at least one accepted block in `round`.
-    pub(crate) authorities: BTreeSet<AuthorityIndex>,
-    /// Sum of stake across `authorities`.
-    pub(crate) total_stake: Stake,
+    /// Blocks accepted at `round`.
+    pub(crate) blocks: BTreeSet<BlockRef>,
+    /// Total stake from distinct authorities that have authored
+    /// an accepted block in `round`.
+    pub(crate) total_stake: StakeAggregator<QuorumThreshold>,
+}
+
+impl RoundInfo {
+    fn new(round: Round) -> Self {
+        Self {
+            round,
+            blocks: BTreeSet::new(),
+            total_stake: StakeAggregator::new(),
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
     use std::vec;
 
+    use consensus_config::Stake;
     use consensus_types::block::{BlockDigest, BlockRef, BlockTimestampMs};
     use parking_lot::RwLock;
 
@@ -2037,6 +2065,99 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_get_block_info_at_slot() {
+        let (mut context, _) = Context::new_for_test(4);
+        // Children-stake tracking is v3-only; enable it so children_stake
+        // is non-zero when round-2 blocks reference the slot.
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = Arc::new(context);
+
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Use a non-own author for the slot under test so accept_block
+        // accepts the equivocating second block (the own-authority check
+        // rejects equivocations for the local validator only).
+        let author_1 = AuthorityIndex::new_for_test(1);
+        let author_2 = AuthorityIndex::new_for_test(2);
+        let slot_1_1 = Slot::new(1, author_1);
+
+        // Empty: no blocks accepted yet.
+        assert!(dag_state.get_block_info_at_slot(slot_1_1).is_empty());
+
+        // Single block at the slot: returns one entry; children_stake
+        // is still zero because no round-2 block has been accepted.
+        let block_1_1 = VerifiedBlock::new_for_test(TestBlock::new(1, 1).build());
+        dag_state.accept_block(block_1_1.clone());
+        let infos = dag_state.get_block_info_at_slot(slot_1_1);
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].block.reference(), block_1_1.reference());
+        assert_eq!(infos[0].children_stake.stake(), 0);
+
+        // Different slot still returns empty.
+        assert!(
+            dag_state
+                .get_block_info_at_slot(Slot::new(1, author_2))
+                .is_empty()
+        );
+
+        // Equivocation: a second round-1 block authored by 1 with a different
+        // timestamp yields a different digest, so both share the same slot.
+        let block_1_1_equiv =
+            VerifiedBlock::new_for_test(TestBlock::new(1, 1).set_timestamp_ms(1).build());
+        assert_ne!(block_1_1_equiv.reference(), block_1_1.reference());
+        dag_state.accept_block(block_1_1_equiv.clone());
+
+        let infos = dag_state.get_block_info_at_slot(slot_1_1);
+        assert_eq!(infos.len(), 2);
+        let returned_refs: BTreeSet<BlockRef> = infos.iter().map(|i| i.block.reference()).collect();
+        assert_eq!(
+            returned_refs,
+            BTreeSet::from([block_1_1.reference(), block_1_1_equiv.reference()])
+        );
+
+        // Children-stake propagation: a round-2 block from author 2 referencing
+        // block_1_1 but not the equivocating block must update only the
+        // former's children_stake.
+        let block_2_2 = VerifiedBlock::new_for_test(
+            TestBlock::new(2, 2)
+                .set_ancestors(vec![block_1_1.reference()])
+                .build(),
+        );
+        dag_state.accept_block(block_2_2);
+
+        let stake_2 = context.committee.stake(author_2);
+        let by_ref: BTreeMap<BlockRef, BlockInfo> = dag_state
+            .get_block_info_at_slot(slot_1_1)
+            .into_iter()
+            .map(|i| (i.block.reference(), i))
+            .collect();
+        assert_eq!(
+            by_ref[&block_1_1.reference()].children_stake.stake(),
+            stake_2
+        );
+        assert_eq!(
+            by_ref[&block_1_1_equiv.reference()].children_stake.stake(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(
+        expected = "get_block_info_at_slot() should only be called for slots above gc_round"
+    )]
+    async fn test_get_block_info_at_slot_panics_at_or_below_gc_round() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = DagState::new(context, store);
+
+        // gc_round() is 0 before any commit; querying round 0 fails the
+        // slot.round > gc_round() guard.
+        let _ = dag_state.get_block_info_at_slot(Slot::new(0, AuthorityIndex::new_for_test(0)));
+    }
+
+    #[tokio::test]
     async fn test_block_children_exclusion() {
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = 10;
@@ -2154,7 +2275,7 @@ mod test {
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
         // Before any blocks: no round_info entries exist.
-        assert!(dag_state.round_info(1).is_none());
+        assert!(dag_state.get_round_info(1).is_none());
 
         // Accept blocks for rounds 1..=4 with full participation. Each round
         // must aggregate every authority and stake equal to total_stake.
@@ -2166,34 +2287,36 @@ mod test {
             (0..4).map(AuthorityIndex::new_for_test).collect();
         for round in 1..=4 {
             let info = dag_state
-                .round_info(round)
+                .get_round_info(round)
                 .unwrap_or_else(|| panic!("round_info missing for round {round}"));
             assert_eq!(info.round, round);
             assert_eq!(
-                info.authorities, all_authorities,
+                info.total_stake.authorities(),
+                &all_authorities,
                 "round {round} authorities mismatch"
             );
             assert_eq!(
-                info.total_stake,
+                info.total_stake.stake(),
                 context.committee.total_stake(),
                 "round {round} total_stake mismatch"
             );
         }
 
         // Beyond highest_accepted_round: no entry yet.
-        assert!(dag_state.round_info(5).is_none());
+        assert!(dag_state.get_round_info(5).is_none());
 
         // Re-accepting the same blocks must not double-count stake. The
         // contains_block early-return inside accept_block guards this.
         dag_state.accept_blocks(dag_builder.all_blocks());
         for round in 1..=4 {
-            let info = dag_state.round_info(round).unwrap();
+            let info = dag_state.get_round_info(round).unwrap();
             assert_eq!(
-                info.authorities, all_authorities,
+                info.total_stake.authorities(),
+                &all_authorities,
                 "round {round} authorities changed after re-accept"
             );
             assert_eq!(
-                info.total_stake,
+                info.total_stake.stake(),
                 context.committee.total_stake(),
                 "round {round} total_stake changed after re-accept"
             );
@@ -2213,10 +2336,18 @@ mod test {
                 .build(),
         );
         dag_state.accept_block(round_5_block);
-        let info_5 = dag_state.round_info(5).expect("round 5 entry should exist");
+        let info_5 = dag_state
+            .get_round_info(5)
+            .expect("round 5 entry should exist");
         let author_0 = AuthorityIndex::new_for_test(0);
-        assert_eq!(info_5.authorities, BTreeSet::from([author_0]));
-        assert_eq!(info_5.total_stake, context.committee.stake(author_0));
+        assert_eq!(
+            info_5.total_stake.authorities(),
+            &BTreeSet::from([author_0])
+        );
+        assert_eq!(
+            info_5.total_stake.stake(),
+            context.committee.stake(author_0)
+        );
 
         // GC boundary: commit a round-5 leader so gc_round advances to 2,
         // then flush to evict round_info entries with round <= gc_round.
@@ -2241,7 +2372,7 @@ mod test {
         // round advances, even before flush physically removes stale entries.
         for round in 1..=2 {
             assert!(
-                dag_state.round_info(round).is_none(),
+                dag_state.get_round_info(round).is_none(),
                 "round {round} should be hidden before flush after GC advances"
             );
         }
@@ -2251,22 +2382,28 @@ mod test {
         // Rounds 1..=2 are evicted; rounds 3..=5 remain with their aggregates.
         for round in 1..=2 {
             assert!(
-                dag_state.round_info(round).is_none(),
+                dag_state.get_round_info(round).is_none(),
                 "round {round} should be evicted after flush"
             );
         }
         for round in 3..=4 {
             let info = dag_state
-                .round_info(round)
+                .get_round_info(round)
                 .unwrap_or_else(|| panic!("round_info missing for round {round} after flush"));
-            assert_eq!(info.authorities, all_authorities);
-            assert_eq!(info.total_stake, context.committee.total_stake());
+            assert_eq!(info.total_stake.authorities(), &all_authorities);
+            assert_eq!(info.total_stake.stake(), context.committee.total_stake());
         }
         let info_5 = dag_state
-            .round_info(5)
+            .get_round_info(5)
             .expect("round 5 should still be present after flush");
-        assert_eq!(info_5.authorities, BTreeSet::from([author_0]));
-        assert_eq!(info_5.total_stake, context.committee.stake(author_0));
+        assert_eq!(
+            info_5.total_stake.authorities(),
+            &BTreeSet::from([author_0])
+        );
+        assert_eq!(
+            info_5.total_stake.stake(),
+            context.committee.stake(author_0)
+        );
     }
 
     #[tokio::test]

--- a/consensus/core/src/leader_slot_decider.rs
+++ b/consensus/core/src/leader_slot_decider.rs
@@ -1,0 +1,210 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Production callers (FlexCommitter) land in a follow-up PR.
+#![allow(dead_code)]
+
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    sync::Arc,
+};
+
+use consensus_types::block::BlockRef;
+use parking_lot::RwLock;
+
+use crate::{
+    BlockAPI, VerifiedBlock,
+    block::Slot,
+    commit::LeaderStatus,
+    context::Context,
+    dag_state::DagState,
+    stake_aggregator::{CertificationThreshold, QuorumThreshold, StakeAggregator},
+};
+
+#[cfg(test)]
+#[path = "tests/leader_slot_decider_tests.rs"]
+mod leader_slot_decider_tests;
+
+/// Stateless decision logic for commit rule v3.
+pub(crate) struct LeaderSlotDecider {
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+}
+
+impl LeaderSlotDecider {
+    pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
+        Self { context, dag_state }
+    }
+
+    /// Evaluates if `slot` should be directly committed or skipped,
+    /// based on voting information from DagState.
+    ///
+    /// A block is directly committed if it has a quorum of commit votes,
+    /// and a block is directly skipped if it has a quorum of skip votes.
+    /// Misbehaviors are assumed to be under the fault tolerance threshold, but we also
+    /// try to detect if this assumption is broken, when it is convenient.
+    pub(crate) fn try_direct_decide(&self, slot: Slot) -> LeaderStatus {
+        let dag_state = self.dag_state.read();
+        let Some(voting_round_info) = dag_state.get_round_info(slot.round + 1) else {
+            // No blocks accepted in the next round yet, so there is no votes to the slot.
+            return LeaderStatus::Undecided(slot);
+        };
+        if !voting_round_info
+            .total_stake
+            .reached_threshold(&self.context.committee)
+        {
+            // Next round has insufficient stake to decide the slot.
+            return LeaderStatus::Undecided(slot);
+        }
+
+        let block_infos = dag_state.get_block_info_at_slot(slot);
+        let num_blocks = block_infos.len();
+        let mut committed = vec![];
+        let mut num_skipped = 0;
+        for block_info in block_infos {
+            // Commit the leader block if it has a quorum of commit votes.
+            if block_info
+                .children_stake
+                .reached_threshold(&self.context.committee)
+            {
+                committed.push(block_info.block.clone());
+                continue;
+            }
+            // Skip the leader block if it has a quorum of skip votes.
+            // Byzantine authorities that produce both vote and non-vote blocks
+            // can count on both sides, but at most once per side against a decision block.
+            let mut reject_votes = StakeAggregator::<QuorumThreshold>::new();
+            for block_ref in voting_round_info.blocks.difference(&block_info.children) {
+                reject_votes.add_unique(block_ref.author, &self.context.committee);
+            }
+            if reject_votes.reached_threshold(&self.context.committee) {
+                num_skipped += 1;
+            }
+        }
+
+        // When there is no block at the slot or all blocks at the slot are skipped,
+        // the whole slot is skipped.
+        // Even if new blocks arrive at the slot later, they are guaranteed to be
+        // skipped directly since a quorum already rejected them.
+        if num_skipped == num_blocks {
+            return LeaderStatus::Skip(slot);
+        }
+
+        // Under safety assumption, at most one block can be committed in a slot.
+        if committed.len() > 1 {
+            panic!(
+                "Multiple committed blocks found at leader slot {}: {:?}",
+                slot, committed
+            );
+        }
+        // When there is a committed block, assume no other block at the slot can be committed.
+        if committed.len() == 1 {
+            return LeaderStatus::Commit(committed.pop().unwrap());
+        }
+
+        // There are undecided blocks, so the slot is undecided.
+        LeaderStatus::Undecided(slot)
+    }
+
+    /// Evaluates every slot in `slots` (all at `decision_round`) for indirect commit.
+    /// Returns one LeaderStatus per `slots` entry, in the same order.
+    ///
+    /// Commit votes per decision block are counted from voting blocks reachable
+    /// via BFS from `anchor_block`. Then the commit votes on each decision block is
+    /// compared against `certification_threshold`.
+    ///
+    /// It is possible for a block to have both commit and skip certificates. But skip
+    /// votes and certificates are not tracked because they do not affect the decision
+    /// on the slot.
+    ///
+    /// When a slot has exactly one block with commit certificate, the slot is considered
+    /// committed. But if there are zero or multiple blocks with commit certificates,
+    /// the slot is considered skipped because there cannot have been a direct commit on
+    /// the slot.
+    ///
+    /// Each slot will be either committed or skipped, never undecided after applying the
+    /// indirect commit rule.
+    pub(crate) fn try_indirect_decide(
+        &self,
+        anchor_block: &VerifiedBlock,
+        decision_slots: &[Slot],
+    ) -> Vec<LeaderStatus> {
+        assert!(!decision_slots.is_empty());
+        let decision_round = decision_slots[0].round;
+        assert!(decision_slots.iter().all(|s| s.round == decision_round));
+
+        let dag_state = self.dag_state.read();
+
+        let decision_blocks: BTreeSet<BlockRef> = decision_slots
+            .iter()
+            .flat_map(|slot| {
+                dag_state
+                    .get_uncommitted_blocks_at_slot(*slot)
+                    .into_iter()
+                    .map(|block| block.reference())
+            })
+            .collect();
+
+        // BFS once from the anchor: collect votes from voting round blocks
+        // against decision round blocks.
+        let mut to_visit = VecDeque::new();
+        to_visit.push_back(anchor_block.clone());
+        let mut visited = BTreeSet::new();
+        visited.insert(anchor_block.reference());
+
+        // Count commit votes for decision blocks.
+        let mut votes = BTreeMap::<BlockRef, StakeAggregator<CertificationThreshold>>::new();
+        while let Some(block) = to_visit.pop_front() {
+            for ancestor in block.ancestors() {
+                if ancestor.round < decision_round {
+                    // This ancestor and its ancestors are irrelevant for voting.
+                    continue;
+                }
+                // Set up next setup of BFS.
+                if visited.insert(*ancestor) {
+                    let ancestor_block = dag_state
+                        .get_block(ancestor)
+                        .unwrap_or_else(|| panic!("Block {} must exist", ancestor));
+                    to_visit.push_back(ancestor_block);
+                }
+                // Continue to only if this is a vote from the block to a decision block.
+                if decision_blocks.contains(ancestor) && block.round() == decision_round + 1 {
+                    let commit_stake = votes.entry(*ancestor).or_default();
+                    commit_stake.add_unique(block.author(), &self.context.committee);
+                }
+            }
+        }
+
+        // Collect the blocks with commit certificates.
+        let mut commit_certificates = BTreeMap::<Slot, Vec<VerifiedBlock>>::new();
+        for (block_ref, commit_stake) in votes {
+            let slot = Slot {
+                round: block_ref.round,
+                authority: block_ref.author,
+            };
+            if commit_stake.reached_threshold(&self.context.committee) {
+                commit_certificates.entry(slot).or_default().push(
+                    dag_state
+                        .get_block(&block_ref)
+                        .unwrap_or_else(|| panic!("Block {} must exist", block_ref)),
+                );
+            }
+        }
+
+        // Make the decision on each slot.
+        decision_slots
+            .iter()
+            .map(|slot| {
+                let mut certified_blocks =
+                    commit_certificates.get(slot).cloned().unwrap_or_default();
+                // When there is no certified block at the slot, obviously the slot is skipped.
+                // When there are multiple certified blocks at the slot, there cannot have been a direct commit
+                // on the slot if there are <= f malicious stake. So it is also safe to skip the slot.
+                if certified_blocks.is_empty() || certified_blocks.len() > 1 {
+                    return LeaderStatus::Skip(*slot);
+                }
+                LeaderStatus::Commit(certified_blocks.pop().unwrap())
+            })
+            .collect()
+    }
+}

--- a/consensus/core/src/leader_slot_decider.rs
+++ b/consensus/core/src/leader_slot_decider.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use consensus_types::block::BlockRef;
+use consensus_types::block::{BlockRef, Round};
 use parking_lot::RwLock;
 
 use crate::{
@@ -24,6 +24,9 @@ use crate::{
 #[cfg(test)]
 #[path = "tests/leader_slot_decider_tests.rs"]
 mod leader_slot_decider_tests;
+
+/// Minimum number of rounds there an anchor block can indirectly decide a leader block.
+pub(crate) const INDIRECT_COMMIT_DEPTH: Round = 2;
 
 /// Stateless decision logic for commit rule v3.
 pub(crate) struct LeaderSlotDecider {
@@ -59,55 +62,53 @@ impl LeaderSlotDecider {
 
         let block_infos = dag_state.get_block_info_at_slot(slot);
         let num_blocks = block_infos.len();
-        let mut committed = vec![];
         let mut num_skipped = 0;
         for block_info in block_infos {
+            // Skip the leader block if it has a quorum of skip votes.
+            // Byzantine authorities can vote on both sides, but its votes count at most once per side
+            // against a decision block.
+            let mut reject_votes = StakeAggregator::<QuorumThreshold>::new();
+            // Add up votes skipping the block.
+            for block_ref in voting_round_info.blocks.difference(&block_info.children) {
+                reject_votes.add_unique(block_ref.author, &self.context.committee);
+            }
+            let mut block_rejected = false;
+            if reject_votes.reached_threshold(&self.context.committee) {
+                num_skipped += 1;
+                block_rejected = true;
+                // Continue checking if the block can be committed,
+                // to detect if there are too many misbehaving authorities.
+            }
             // Commit the leader block if it has a quorum of commit votes.
             if block_info
                 .children_stake
                 .reached_threshold(&self.context.committee)
             {
-                committed.push(block_info.block.clone());
-                continue;
-            }
-            // Skip the leader block if it has a quorum of skip votes.
-            // Byzantine authorities that produce both vote and non-vote blocks
-            // can count on both sides, but at most once per side against a decision block.
-            let mut reject_votes = StakeAggregator::<QuorumThreshold>::new();
-            for block_ref in voting_round_info.blocks.difference(&block_info.children) {
-                reject_votes.add_unique(block_ref.author, &self.context.committee);
-            }
-            if reject_votes.reached_threshold(&self.context.committee) {
-                num_skipped += 1;
+                assert!(
+                    !block_rejected,
+                    "Block {} cannot be both committed and skipped. Commit voters: {:?}, skip voters: {:?}",
+                    block_info.block.reference(),
+                    block_info.children_stake.authorities(),
+                    reject_votes.authorities(),
+                );
+                return LeaderStatus::Commit(block_info.block);
             }
         }
 
-        // When there is no block at the slot or all blocks at the slot are skipped,
+        // When there is no block in the slot or all blocks in the slot are skipped,
         // the whole slot is skipped.
         // Even if new blocks arrive at the slot later, they are guaranteed to be
-        // skipped directly since a quorum already rejected them.
+        // skipped directly since a quorum already skipped them.
         if num_skipped == num_blocks {
             return LeaderStatus::Skip(slot);
-        }
-
-        // Under safety assumption, at most one block can be committed in a slot.
-        if committed.len() > 1 {
-            panic!(
-                "Multiple committed blocks found at leader slot {}: {:?}",
-                slot, committed
-            );
-        }
-        // When there is a committed block, assume no other block at the slot can be committed.
-        if committed.len() == 1 {
-            return LeaderStatus::Commit(committed.pop().unwrap());
         }
 
         // There are undecided blocks, so the slot is undecided.
         LeaderStatus::Undecided(slot)
     }
 
-    /// Evaluates every slot in `slots` (all at `decision_round`) for indirect commit.
-    /// Returns one LeaderStatus per `slots` entry, in the same order.
+    /// Evaluates every slot in `decision_slots` for indirect commit.
+    /// Returns one LeaderStatus per `decision_slots` entry, in the same order.
     ///
     /// Commit votes per decision block are counted from voting blocks reachable
     /// via BFS from `anchor_block`. Then the commit votes on each decision block is
@@ -132,6 +133,12 @@ impl LeaderSlotDecider {
         assert!(!decision_slots.is_empty());
         let decision_round = decision_slots[0].round;
         assert!(decision_slots.iter().all(|s| s.round == decision_round));
+        assert!(
+            decision_round + INDIRECT_COMMIT_DEPTH <= anchor_block.round(),
+            "Anchor block {} is too close to decision round {}",
+            anchor_block.reference(),
+            decision_round,
+        );
 
         let dag_state = self.dag_state.read();
 
@@ -156,18 +163,14 @@ impl LeaderSlotDecider {
         let mut votes = BTreeMap::<BlockRef, StakeAggregator<CertificationThreshold>>::new();
         while let Some(block) = to_visit.pop_front() {
             for ancestor in block.ancestors() {
-                if ancestor.round < decision_round {
-                    // This ancestor and its ancestors are irrelevant for voting.
-                    continue;
-                }
-                // Set up next setup of BFS.
-                if visited.insert(*ancestor) {
+                // Set up next steps of BFS.
+                if ancestor.round > decision_round && visited.insert(*ancestor) {
                     let ancestor_block = dag_state
                         .get_block(ancestor)
                         .unwrap_or_else(|| panic!("Block {} must exist", ancestor));
                     to_visit.push_back(ancestor_block);
                 }
-                // Continue to only if this is a vote from the block to a decision block.
+                // Count only voting block to decision block votes.
                 if decision_blocks.contains(ancestor) && block.round() == decision_round + 1 {
                     let commit_stake = votes.entry(*ancestor).or_default();
                     commit_stake.add_unique(block.author(), &self.context.committee);
@@ -175,15 +178,15 @@ impl LeaderSlotDecider {
             }
         }
 
-        // Collect the blocks with commit certificates.
-        let mut commit_certificates = BTreeMap::<Slot, Vec<VerifiedBlock>>::new();
+        // Collect the blocks with commit certificates per slot.
+        let mut certified_slots = BTreeMap::<Slot, Vec<VerifiedBlock>>::new();
         for (block_ref, commit_stake) in votes {
             let slot = Slot {
                 round: block_ref.round,
                 authority: block_ref.author,
             };
             if commit_stake.reached_threshold(&self.context.committee) {
-                commit_certificates.entry(slot).or_default().push(
+                certified_slots.entry(slot).or_default().push(
                     dag_state
                         .get_block(&block_ref)
                         .unwrap_or_else(|| panic!("Block {} must exist", block_ref)),
@@ -195,8 +198,7 @@ impl LeaderSlotDecider {
         decision_slots
             .iter()
             .map(|slot| {
-                let mut certified_blocks =
-                    commit_certificates.get(slot).cloned().unwrap_or_default();
+                let mut certified_blocks = certified_slots.get(slot).cloned().unwrap_or_default();
                 // When there is no certified block at the slot, obviously the slot is skipped.
                 // When there are multiple certified blocks at the slot, there cannot have been a direct commit
                 // on the slot if there are <= f malicious stake. So it is also safe to skip the slot.

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -24,6 +24,7 @@ mod error;
 mod leader_schedule;
 mod leader_schedule_v3;
 mod leader_scoring;
+mod leader_slot_decider;
 mod leader_timeout;
 mod linearizer;
 mod metrics;

--- a/consensus/core/src/stake_aggregator.rs
+++ b/consensus/core/src/stake_aggregator.rs
@@ -10,11 +10,14 @@ pub(crate) trait CommitteeThreshold {
     fn threshold(committee: &Committee) -> Stake;
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct QuorumThreshold;
 
+#[derive(Clone, Default)]
+pub(crate) struct CertificationThreshold;
+
 #[cfg(test)]
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct ValidityThreshold;
 
 impl CommitteeThreshold for QuorumThreshold {
@@ -23,6 +26,15 @@ impl CommitteeThreshold for QuorumThreshold {
     }
     fn threshold(committee: &Committee) -> Stake {
         committee.quorum_threshold()
+    }
+}
+
+impl CommitteeThreshold for CertificationThreshold {
+    fn is_threshold(committee: &Committee, amount: Stake) -> bool {
+        amount >= committee.certification_threshold()
+    }
+    fn threshold(committee: &Committee) -> Stake {
+        committee.certification_threshold()
     }
 }
 
@@ -36,7 +48,7 @@ impl CommitteeThreshold for ValidityThreshold {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct StakeAggregator<T> {
     votes: BTreeSet<AuthorityIndex>,
     stake: Stake,
@@ -75,6 +87,11 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
 
     pub(crate) fn stake(&self) -> Stake {
         self.stake
+    }
+
+    #[cfg(test)]
+    pub(crate) fn authorities(&self) -> &BTreeSet<AuthorityIndex> {
+        &self.votes
     }
 
     pub(crate) fn reached_threshold(&self, committee: &Committee) -> bool {

--- a/consensus/core/src/stake_aggregator.rs
+++ b/consensus/core/src/stake_aggregator.rs
@@ -89,7 +89,6 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
         self.stake
     }
 
-    #[cfg(test)]
     pub(crate) fn authorities(&self) -> &BTreeSet<AuthorityIndex> {
         &self.votes
     }

--- a/consensus/core/src/tests/leader_slot_decider_tests.rs
+++ b/consensus/core/src/tests/leader_slot_decider_tests.rs
@@ -1,0 +1,543 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use consensus_config::{AuthorityIndex, Committee};
+use parking_lot::RwLock;
+
+use crate::{
+    block::{BlockAPI, Slot, TestBlock, Transaction, VerifiedBlock, genesis_blocks},
+    commit::LeaderStatus,
+    context::Context,
+    dag_state::DagState,
+    leader_slot_decider::LeaderSlotDecider,
+    storage::mem_store::MemStore,
+    test_dag::{build_dag, build_dag_layer},
+};
+
+/// Setup with a v3 Committee.
+fn setup(
+    committee_size: usize,
+    malicious_stake: u64,
+    crash_stake: u64,
+) -> (Arc<Context>, Arc<RwLock<DagState>>, LeaderSlotDecider) {
+    let (mut context, _) = Context::new_for_test(committee_size);
+    let v3_committee = Committee::new_v3(
+        context.committee.epoch(),
+        context.committee.authorities_slice().to_vec(),
+        malicious_stake,
+        crash_stake,
+    );
+    context = context.with_committee(v3_committee);
+    context.protocol_config.set_enable_v3_for_testing(true);
+    let context = Arc::new(context);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let decider = LeaderSlotDecider::new(context.clone(), dag_state.clone());
+    (context, dag_state, decider)
+}
+
+fn expect_commit(status: LeaderStatus, slot: Slot) -> VerifiedBlock {
+    match status {
+        LeaderStatus::Commit(block) => {
+            assert_eq!(block.author(), slot.authority);
+            assert_eq!(block.round(), slot.round);
+            block
+        }
+        other => panic!("Expected Commit, got {other:?}"),
+    }
+}
+
+fn expect_skip(status: LeaderStatus, slot: Slot) {
+    match status {
+        LeaderStatus::Skip(s) => assert_eq!(s, slot),
+        other => panic!("Expected Skip, got {other:?}"),
+    }
+}
+
+fn expect_undecided(status: LeaderStatus, slot: Slot) {
+    match status {
+        LeaderStatus::Undecided(s) => assert_eq!(s, slot),
+        other => panic!("Expected Undecided, got {other:?}"),
+    }
+}
+
+/// A fully connected round 2 commits the round-1 leader directly.
+#[tokio::test]
+async fn try_direct_decide_commit() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    build_dag(context, dag_state, None, 2);
+
+    let slot = Slot::new_for_test(1, 0);
+    let status = decider.try_direct_decide(slot);
+
+    expect_commit(status, slot);
+}
+
+/// When every round-2 block omits the round-1 leader, it is directly skipped.
+#[tokio::test]
+async fn try_direct_decide_skip() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .into_iter()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(0))
+        .collect();
+    build_dag(context, dag_state, Some(refs_without_leader), 2);
+
+    let slot = Slot::new_for_test(1, 0);
+    let status = decider.try_direct_decide(slot);
+
+    expect_skip(status, slot);
+}
+
+/// Without next-round quorum, no decision is possible — Undecided.
+#[tokio::test]
+async fn try_direct_decide_undecided_no_next_round_quorum() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+
+    let slot = Slot::new_for_test(1, 0);
+    expect_undecided(decider.try_direct_decide(slot), slot);
+
+    let connections = context
+        .committee
+        .authorities()
+        .take((context.committee.quorum_threshold() - 1) as usize)
+        .map(|authority| (authority.0, refs_round_1.clone()))
+        .collect();
+    build_dag_layer(connections, dag_state);
+
+    expect_undecided(decider.try_direct_decide(slot), slot);
+}
+
+/// Round 2 has neither quorum-many votes for nor quorum-many blames against
+/// the leader — direct decision must be Undecided.
+#[tokio::test]
+async fn try_direct_decide_undecided_split() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(9, 1, 1);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(0))
+        .collect();
+
+    // 4 round-2 blocks reference all of round 1 (votes for leader); 5 omit
+    // the leader. Total votes for leader = 4, against = 5 — neither side has
+    // quorum (7) of stake.
+    let mut authorities = context.committee.authorities();
+    let mut connections = vec![];
+    for _ in 0..4 {
+        connections.push((authorities.next().unwrap().0, refs_round_1.clone()));
+    }
+    for _ in 0..5 {
+        connections.push((authorities.next().unwrap().0, refs_without_leader.clone()));
+    }
+    build_dag_layer(connections, dag_state.clone());
+
+    let slot = Slot::new_for_test(1, 0);
+    let status = decider.try_direct_decide(slot);
+
+    expect_undecided(status, slot);
+}
+
+/// If no block exists at the leader slot, a quorum of next-round blocks
+/// directly skips the empty slot.
+#[tokio::test]
+async fn try_direct_decide_skip_empty_slot() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    let empty_slot = Slot::new_for_test(1, 0);
+    let genesis_refs: Vec<_> = genesis_blocks(context.as_ref())
+        .into_iter()
+        .map(|block| block.reference())
+        .collect();
+    let refs_round_1 = context
+        .committee
+        .authorities()
+        .filter(|authority| authority.0 != empty_slot.authority)
+        .map(|authority| (authority.0, genesis_refs.clone()))
+        .collect();
+    let refs_round_1 = build_dag_layer(refs_round_1, dag_state.clone());
+    let connections = context
+        .committee
+        .authorities()
+        .take(context.committee.quorum_threshold() as usize)
+        .map(|authority| (authority.0, refs_round_1.clone()))
+        .collect();
+    build_dag_layer(connections, dag_state);
+
+    expect_skip(decider.try_direct_decide(empty_slot), empty_slot);
+}
+
+/// Equivocating voters in the voting round must not be double-counted as
+/// separate blames for direct skip.
+#[tokio::test]
+async fn try_direct_decide_undecided_duplicate_reject_voter() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let slot = Slot::new_for_test(1, 0);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| r.author != slot.authority)
+        .collect();
+
+    let author_0 = AuthorityIndex::new_for_test(0);
+    let author_1 = AuthorityIndex::new_for_test(1);
+    let author_2 = AuthorityIndex::new_for_test(2);
+    let connections = vec![
+        (author_0, refs_round_1.clone()),
+        (author_1, refs_without_leader.clone()),
+        (author_2, refs_without_leader.clone()),
+        (AuthorityIndex::new_for_test(3), refs_without_leader.clone()),
+        (AuthorityIndex::new_for_test(4), refs_without_leader.clone()),
+    ];
+    build_dag_layer(connections, dag_state.clone());
+
+    let duplicate_non_vote = VerifiedBlock::new_for_test(
+        TestBlock::new(2, author_1.value() as u32)
+            .set_ancestors(refs_without_leader)
+            .set_transactions(vec![Transaction::new(vec![1])])
+            .build(),
+    );
+    dag_state.write().accept_block(duplicate_non_vote);
+
+    // The unique rejecting authorities are only 1..4, despite author 1's
+    // equivocation. A buggy block-counted reject tally would count author 1
+    // twice and incorrectly skip.
+    expect_undecided(decider.try_direct_decide(slot), slot);
+}
+
+/// A Byzantine voter with one voting block and one non-voting block counts on
+/// both sides of the direct rule.
+#[tokio::test]
+async fn try_direct_decide_skip_counts_mixed_byzantine_voter() {
+    telemetry_subscribers::init_for_testing();
+    // v3 committee with quorum=7. Six honest reject voters are not enough to
+    // skip by themselves, so this test depends on the mixed Byzantine voter
+    // being counted as a reject voter as well.
+    let (context, dag_state, decider) = setup(9, 1, 1);
+    assert_eq!(context.committee.certification_threshold(), 4);
+    assert_eq!(context.committee.quorum_threshold(), 7);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let slot = Slot::new_for_test(1, 0);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| r.author != slot.authority)
+        .collect();
+
+    let author_0 = AuthorityIndex::new_for_test(0);
+    let byzantine_author = AuthorityIndex::new_for_test(1);
+    let connections = vec![
+        (author_0, refs_round_1.clone()),
+        (byzantine_author, refs_round_1.clone()),
+        (AuthorityIndex::new_for_test(2), refs_without_leader.clone()),
+        (AuthorityIndex::new_for_test(3), refs_without_leader.clone()),
+        (AuthorityIndex::new_for_test(4), refs_without_leader.clone()),
+        (AuthorityIndex::new_for_test(5), refs_without_leader.clone()),
+        (AuthorityIndex::new_for_test(6), refs_without_leader.clone()),
+        (AuthorityIndex::new_for_test(7), refs_without_leader.clone()),
+    ];
+    build_dag_layer(connections, dag_state.clone());
+
+    let byzantine_non_vote = VerifiedBlock::new_for_test(
+        TestBlock::new(2, byzantine_author.value() as u32)
+            .set_ancestors(refs_without_leader)
+            .set_transactions(vec![Transaction::new(vec![1])])
+            .build(),
+    );
+    dag_state.write().accept_block(byzantine_non_vote);
+
+    expect_skip(decider.try_direct_decide(slot), slot);
+}
+
+/// Equivocation in the leader slot does not prevent directly committing the
+/// one block with quorum children.
+#[tokio::test]
+async fn try_direct_decide_equivocating_commit() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let slot = Slot::new_for_test(1, 1);
+    let leader_ref = refs_round_1
+        .iter()
+        .find(|r| r.author == slot.authority)
+        .copied()
+        .expect("leader block should exist");
+    let leader = dag_state
+        .read()
+        .get_block(&leader_ref)
+        .expect("leader block should be in dag");
+    let equivocating_leader = VerifiedBlock::new_for_test(
+        TestBlock::new(slot.round, slot.authority.value() as u32)
+            .set_ancestors(leader.ancestors().to_vec())
+            .set_transactions(vec![Transaction::new(vec![1])])
+            .build(),
+    );
+    let equivocating_leader_ref = equivocating_leader.reference();
+    dag_state.write().accept_block(equivocating_leader);
+
+    let refs_without_leader: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| *r != leader_ref)
+        .chain(std::iter::once(equivocating_leader_ref))
+        .collect();
+    let mut authorities = context.committee.authorities();
+    let mut connections = vec![];
+    for _ in 0..context.committee.quorum_threshold() {
+        connections.push((authorities.next().unwrap().0, refs_round_1.clone()));
+    }
+    connections.push((authorities.next().unwrap().0, refs_without_leader));
+    build_dag_layer(connections, dag_state.clone());
+
+    let committed = expect_commit(decider.try_direct_decide(slot), slot);
+    assert_eq!(committed.reference(), leader_ref);
+}
+
+/// Equivocation in the leader slot is directly skipped only when every block in
+/// the slot has quorum blame.
+#[tokio::test]
+async fn try_direct_decide_equivocating_skip() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let slot = Slot::new_for_test(1, 1);
+    let leader = dag_state
+        .read()
+        .get_block(
+            refs_round_1
+                .iter()
+                .find(|r| r.author == slot.authority)
+                .expect("leader block should exist"),
+        )
+        .expect("leader block should be in dag");
+    let equivocating_leader = VerifiedBlock::new_for_test(
+        TestBlock::new(slot.round, slot.authority.value() as u32)
+            .set_ancestors(leader.ancestors().to_vec())
+            .set_transactions(vec![Transaction::new(vec![1])])
+            .build(),
+    );
+    dag_state.write().accept_block(equivocating_leader);
+
+    let refs_without_slot: Vec<_> = refs_round_1
+        .into_iter()
+        .filter(|r| r.author != slot.authority)
+        .collect();
+    let connections = context
+        .committee
+        .authorities()
+        .map(|authority| (authority.0, refs_without_slot.clone()))
+        .collect();
+    build_dag_layer(connections, dag_state.clone());
+
+    expect_skip(decider.try_direct_decide(slot), slot);
+}
+
+/// An anchor whose causal history includes the round-1 leader certifies it
+/// indirectly — we must commit.
+#[tokio::test]
+async fn try_indirect_decide_commit() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    // Fully connected DAG up to round 4. Round 2 has all 4 round-1 blocks as
+    // ancestors, so the round-1 leader is certified. Anchor is any round-4
+    // block.
+    let refs_round_4 = build_dag(context.clone(), dag_state.clone(), None, 4);
+    let anchor = dag_state.read().get_block(&refs_round_4[0]).unwrap();
+
+    let slot = Slot::new_for_test(1, 0);
+    let statuses = decider.try_indirect_decide(&anchor, &[slot]);
+
+    assert_eq!(statuses.len(), 1);
+    expect_commit(statuses.into_iter().next().unwrap(), slot);
+}
+
+/// No round-2 block references the round-1 leader, so the anchor's causal
+/// history does not certify it — Skip.
+#[tokio::test]
+async fn try_indirect_decide_skip() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .into_iter()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(0))
+        .collect();
+    let refs_round_2 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(refs_without_leader),
+        2,
+    );
+    let refs_round_3 = build_dag(context.clone(), dag_state.clone(), Some(refs_round_2), 3);
+
+    let anchor = dag_state.read().get_block(&refs_round_3[0]).unwrap();
+
+    let slot = Slot::new_for_test(1, 0);
+    let statuses = decider.try_indirect_decide(&anchor, &[slot]);
+
+    assert_eq!(statuses.len(), 1);
+    expect_skip(statuses.into_iter().next().unwrap(), slot);
+}
+
+/// One call covers multiple slots at the same decision round; each slot is
+/// decided independently against the same BFS-collected vote map.
+#[tokio::test]
+async fn try_indirect_decide_multi_slot() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(6, 1, 0);
+
+    // Round 1 fully. Round 2 omits authority-0's round-1 block but includes
+    // the other authorities. Round 3 fully on top.
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_without_leader_0: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(0))
+        .collect();
+    let refs_round_2 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(refs_without_leader_0),
+        2,
+    );
+    let refs_round_3 = build_dag(context.clone(), dag_state.clone(), Some(refs_round_2), 3);
+
+    let anchor = dag_state.read().get_block(&refs_round_3[0]).unwrap();
+
+    let slots = vec![Slot::new_for_test(1, 0), Slot::new_for_test(1, 1)];
+    let statuses = decider.try_indirect_decide(&anchor, &slots);
+
+    assert_eq!(statuses.len(), 2);
+    let mut iter = statuses.into_iter();
+    // (1, 0) — never referenced → Skip.
+    expect_skip(iter.next().unwrap(), slots[0]);
+    // (1, 1) — referenced by all round-2 blocks → Commit.
+    expect_commit(iter.next().unwrap(), slots[1]);
+}
+
+/// A decision block can have both cert-threshold commit votes and at least
+/// cert-threshold blame votes. Blame votes are not tracked by the indirect
+/// rule, and a single commit certificate still commits the slot.
+#[tokio::test]
+async fn try_indirect_decide_commit_with_cert_threshold_blame_votes() {
+    telemetry_subscribers::init_for_testing();
+    // v3 committee with cert=4, quorum=7 — lets 4 commit votes and 5 blame
+    // votes coexist against a single block.
+    let (context, dag_state, decider) = setup(9, 1, 1);
+    assert_eq!(context.committee.certification_threshold(), 4);
+    assert_eq!(context.committee.quorum_threshold(), 7);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let leader_author = AuthorityIndex::new_for_test(0);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| r.author != leader_author)
+        .collect();
+
+    // 4 round-2 blocks reference the leader (commit votes = cert);
+    // 5 omit it (blame votes are also at least cert).
+    let mut authorities = context.committee.authorities();
+    let mut connections = vec![];
+    for _ in 0..4 {
+        connections.push((authorities.next().unwrap().0, refs_round_1.clone()));
+    }
+    for _ in 0..5 {
+        connections.push((authorities.next().unwrap().0, refs_without_leader.clone()));
+    }
+    let refs_round_2 = build_dag_layer(connections, dag_state.clone());
+    let refs_round_3 = build_dag(context.clone(), dag_state.clone(), Some(refs_round_2), 3);
+
+    let anchor = dag_state.read().get_block(&refs_round_3[0]).unwrap();
+
+    let slot = Slot::new_for_test(1, leader_author.value() as u32);
+    let statuses = decider.try_indirect_decide(&anchor, &[slot]);
+
+    assert_eq!(statuses.len(), 1);
+    expect_commit(statuses.into_iter().next().unwrap(), slot);
+}
+
+/// When two equivocating blocks at the same slot both meet the certification
+/// threshold, there cannot have been a direct commit on either; the indirect
+/// rule must Skip the slot.
+#[tokio::test]
+async fn try_indirect_decide_skip_multiple_certified_blocks() {
+    telemetry_subscribers::init_for_testing();
+    // v3 committee with cert=4, quorum=7 — lets two equivocating blocks each
+    // accumulate cert-threshold commit votes from disjoint voter sets.
+    let (context, dag_state, decider) = setup(9, 1, 1);
+    assert_eq!(context.committee.certification_threshold(), 4);
+    assert_eq!(context.committee.quorum_threshold(), 7);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    // Use a non-own author for the equivocation slot — accept_block rejects
+    // equivocations from the local authority (which is author 0).
+    let slot = Slot::new_for_test(1, 1);
+    let leader_a_ref = refs_round_1
+        .iter()
+        .find(|r| r.author == slot.authority)
+        .copied()
+        .expect("leader block should exist");
+    let leader_a = dag_state
+        .read()
+        .get_block(&leader_a_ref)
+        .expect("leader block should be in dag");
+    let leader_b = VerifiedBlock::new_for_test(
+        TestBlock::new(slot.round, slot.authority.value() as u32)
+            .set_ancestors(leader_a.ancestors().to_vec())
+            .set_transactions(vec![Transaction::new(vec![1])])
+            .build(),
+    );
+    let leader_b_ref = leader_b.reference();
+    dag_state.write().accept_block(leader_b);
+
+    // 4 round-2 voters reference leader_a; 5 reference leader_b. Both meet
+    // cert (4), so both are certified.
+    let refs_with_b: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| *r != leader_a_ref)
+        .chain(std::iter::once(leader_b_ref))
+        .collect();
+    let mut authorities = context.committee.authorities();
+    let mut connections = vec![];
+    for _ in 0..4 {
+        connections.push((authorities.next().unwrap().0, refs_round_1.clone()));
+    }
+    for _ in 0..5 {
+        connections.push((authorities.next().unwrap().0, refs_with_b.clone()));
+    }
+    let refs_round_2 = build_dag_layer(connections, dag_state.clone());
+    let refs_round_3 = build_dag(context.clone(), dag_state.clone(), Some(refs_round_2), 3);
+
+    let anchor = dag_state.read().get_block(&refs_round_3[0]).unwrap();
+
+    let statuses = decider.try_indirect_decide(&anchor, &[slot]);
+
+    assert_eq!(statuses.len(), 1);
+    expect_skip(statuses.into_iter().next().unwrap(), slot);
+}

--- a/consensus/core/src/tests/leader_slot_decider_tests.rs
+++ b/consensus/core/src/tests/leader_slot_decider_tests.rs
@@ -354,6 +354,50 @@ async fn try_direct_decide_equivocating_skip() {
     expect_skip(decider.try_direct_decide(slot), slot);
 }
 
+/// A leader simultaneously reaching the commit quorum and the skip quorum can
+/// only happen if Byzantine authorities equivocate in the voting round. The
+/// direct rule must detect this broken fault assumption and panic instead of
+/// returning a decision.
+#[tokio::test]
+#[should_panic(expected = "cannot be both committed and skipped")]
+async fn try_direct_decide_panics_when_committed_and_skipped() {
+    telemetry_subscribers::init_for_testing();
+    // v3 committee with quorum = 7 out of 9.
+    let (context, dag_state, decider) = setup(9, 1, 1);
+    assert_eq!(context.committee.quorum_threshold(), 7);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let slot = Slot::new_for_test(1, 1);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .iter()
+        .cloned()
+        .filter(|r| r.author != slot.authority)
+        .collect();
+
+    // All 9 authorities vote for the leader -> commit quorum (children_stake = 9).
+    build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(refs_round_1.clone()),
+        2,
+    );
+
+    // 7 Byzantine authorities (2..=8, skipping local author 0) also publish a
+    // round-2 block that omits the leader -> skip quorum (reject_votes = 7), so
+    // the leader is both committed and skipped.
+    for author in 2..=8u32 {
+        let non_vote = VerifiedBlock::new_for_test(
+            TestBlock::new(2, author)
+                .set_ancestors(refs_without_leader.clone())
+                .set_transactions(vec![Transaction::new(vec![1])])
+                .build(),
+        );
+        dag_state.write().accept_block(non_vote);
+    }
+
+    decider.try_direct_decide(slot);
+}
+
 /// An anchor whose causal history includes the round-1 leader certifies it
 /// indirectly — we must commit.
 #[tokio::test]
@@ -540,4 +584,48 @@ async fn try_indirect_decide_skip_multiple_certified_blocks() {
 
     assert_eq!(statuses.len(), 1);
     expect_skip(statuses.into_iter().next().unwrap(), slot);
+}
+
+/// `try_indirect_decide` requires at least one decision slot.
+#[tokio::test]
+#[should_panic(expected = "assertion failed: !decision_slots.is_empty()")]
+async fn try_indirect_decide_panics_on_empty_decision_slots() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(4, 1, 0);
+
+    let refs_round_2 = build_dag(context.clone(), dag_state.clone(), None, 2);
+    let anchor = dag_state.read().get_block(&refs_round_2[0]).unwrap();
+
+    decider.try_indirect_decide(&anchor, &[]);
+}
+
+/// All decision slots passed to `try_indirect_decide` must share the same round.
+#[tokio::test]
+#[should_panic(expected = "decision_slots.iter().all")]
+async fn try_indirect_decide_panics_on_mismatched_decision_rounds() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(4, 1, 0);
+
+    let refs_round_2 = build_dag(context.clone(), dag_state.clone(), None, 2);
+    let anchor = dag_state.read().get_block(&refs_round_2[0]).unwrap();
+
+    decider.try_indirect_decide(
+        &anchor,
+        &[Slot::new_for_test(1, 0), Slot::new_for_test(2, 0)],
+    );
+}
+
+/// The anchor block must be at least `INDIRECT_COMMIT_DEPTH` rounds above the
+/// decision round.
+#[tokio::test]
+#[should_panic(expected = "is too close to decision round")]
+async fn try_indirect_decide_panics_when_anchor_too_close() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, decider) = setup(4, 1, 0);
+
+    // Anchor at round 2; decision round 1 requires anchor.round() >= 1 + 2 = 3.
+    let refs_round_2 = build_dag(context.clone(), dag_state.clone(), None, 2);
+    let anchor = dag_state.read().get_block(&refs_round_2[0]).unwrap();
+
+    decider.try_indirect_decide(&anchor, &[Slot::new_for_test(1, 0)]);
 }


### PR DESCRIPTION
## Description 

Implements the stateless pure-decision rule for v3, plus the required DagState API.

LeaderSlotDecider has no production callers in this PR. FlexCommitter will wire it up in a follow-up PR. The new items are marked #[allow(dead_code)] to keep the build clean until then.

## Test plan 

CI
