### PR TITLE
Simplify bitmap evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15479,7 +15479,6 @@ dependencies = [
  "async-stream",
  "bcs",
  "futures",
- "itertools 0.13.0",
  "move-core-types",
  "roaring",
  "sui-types",

--- a/crates/sui-inverted-index/Cargo.toml
+++ b/crates/sui-inverted-index/Cargo.toml
@@ -17,7 +17,6 @@ anyhow.workspace = true
 async-stream.workspace = true
 bcs.workspace = true
 futures.workspace = true
-itertools.workspace = true
 move-core-types.workspace = true
 roaring.workspace = true
 sui-types.workspace = true

--- a/crates/sui-inverted-index/src/bitmap_query/iter.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/iter.rs
@@ -3,43 +3,44 @@
 
 //! Synchronous iterator evaluator for DNF bitmap queries.
 //!
-//! Mirrors the async [`super::stream`] evaluator's merge-joins and watermark
-//! propagation, but stays fully synchronous so request-local backends (e.g.
-//! RocksDB) can drive it from the blocking task that owns their iterators. Like
-//! the stream evaluator it emits matching members as [`Watermarked`] items
-//! interleaved with progress watermarks: each leaf brackets every bucket with
-//! `Watermark(pre), Item, Watermark(post)` and caps natural EOF with a
-//! range-terminus watermark, and the combinators merge per-child watermarks
-//! (min ascending / max descending) so sparse scans still report progress at the
-//! rate the slowest source advances.
+//! A single flat driver merge-joins every leaf scan against one shared *floor*
+//! (the slowest leaf's position). At the floor bucket it evaluates the query —
+//! intersect each term's included dimensions, subtract its excluded ones, then
+//! union across terms — and emits a watermark at the floor. Because leaves only
+//! ever advance at the floor (peeked one bucket ahead), no branch can run ahead
+//! of the others: the resume cursor is always within one sparse read of every
+//! leaf, and there is no windowing/parking machinery to get wrong. Mirrors the
+//! async [`super::stream`] evaluator, which shares the per-bucket evaluation
+//! ([`eval_term_at_bucket`]) and is cross-checked against this one in tests.
+//!
+//! Budget accounting lives in the request layer for the iterator path (each
+//! backend leaf iterator charges its own per-request budget and yields an error
+//! on exhaustion), so this evaluator only propagates those errors.
 
 use std::collections::VecDeque;
 use std::iter::Peekable as IterPeekable;
 use std::ops::Range;
 
-use anyhow::Result;
-use anyhow::bail;
-use itertools::Itertools;
 use roaring::RoaringBitmap;
 
 use super::BitmapBucketIteratorSource;
 use super::BitmapQuery;
-use super::BitmapTerm;
 use super::BucketItem;
+use super::LeafHead;
 use super::MultiError;
 use super::ScanDirection;
+use super::TermSpec;
 use super::Watermarked;
 use super::WatermarkedBucket;
 use super::bound_in_direction;
-use super::complete_peeks;
+use super::bucket_edges;
+use super::eval_term_at_bucket;
 use super::frontier_advanced;
-use super::merge_watermarks;
-use super::merge_with_ceiling;
 use super::split_term_literals;
 
-/// Evaluate a DNF `BitmapQuery` as an ordered iterator of marked bucket
-/// bitmaps. Output emits `Watermarked::Item((bucket_id, bitmap))` interleaved
-/// with `Watermarked::Watermark(p)` merged from the leaf scans.
+/// Evaluate a DNF `BitmapQuery` as an ordered iterator of marked bucket bitmaps.
+/// Output emits `Watermarked::Item((bucket_id, bitmap))` interleaved with
+/// `Watermarked::Watermark(p)` derived from the slowest leaf's progress.
 pub fn eval_bitmap_query_bucket_iter<'a, S>(
     source: S,
     query: BitmapQuery,
@@ -50,318 +51,57 @@ pub fn eval_bitmap_query_bucket_iter<'a, S>(
 where
     S: BitmapBucketIteratorSource<'a>,
 {
-    let scan_bucket_iter = move |dimension_key, range, direction| {
-        source.scan_bucket_iter(dimension_key, range, direction)
-    };
-    let iters: Vec<_> = query
-        .terms
-        .into_iter()
-        .map(|term| {
-            term_bucket_iter_with(
-                scan_bucket_iter.clone(),
-                term,
-                range.clone(),
-                bucket_size,
-                direction,
-            )
-        })
-        .collect();
-    union_n_iter(iters, direction)
-}
-
-/// Synchronous term evaluator for borrowed/local storage iterators. This
-/// mirrors the stream merge-joins, but does not adapt iterators through a stream.
-fn term_bucket_iter_with<'a, F, I>(
-    scan_bucket_iter: F,
-    term: BitmapTerm,
-    range: Range<u64>,
-    bucket_size: u64,
-    direction: ScanDirection,
-) -> Box<dyn Iterator<Item = WatermarkedBucket> + 'a>
-where
-    F: Fn(Vec<u8>, Range<u64>, ScanDirection) -> I + Clone + 'a,
-    I: Iterator<Item = BucketItem> + 'a,
-{
-    let (include, exclude) = split_term_literals(term);
-    let include_iters: Vec<_> = include
-        .into_iter()
-        .map(|key| {
-            marked_bucket_iter(
-                scan_bucket_iter(key, range.clone(), direction),
-                range.clone(),
-                bucket_size,
-                direction,
-            )
-        })
-        .collect();
-    let include_iter = intersect_n_iter(include_iters, direction);
-
-    // Skip subtract when nothing to exclude. `union_n_iter` of zero iterators
-    // emits nothing — not even a terminal watermark — which would leave
-    // `subtract_two_iter`'s `b_watermark` slot `None` forever and suppress every
-    // merged watermark for this term.
-    if exclude.is_empty() {
-        return Box::new(include_iter);
+    // One peekable leaf per literal; terms reference them by index. Each leaf
+    // iterator borrows the backend's `'a` store, not `source`, so the thin
+    // `source` handle is dropped once the leaves are built.
+    let mut leaves: Vec<IterPeekable<S::Iter>> = Vec::new();
+    let mut terms: Vec<TermSpec> = Vec::new();
+    for term in query.terms {
+        let (includes, excludes) = split_term_literals(term);
+        let mut include_idx = Vec::with_capacity(includes.len());
+        for key in includes {
+            include_idx.push(leaves.len());
+            leaves.push(
+                source
+                    .scan_bucket_iter(key, range.clone(), direction)
+                    .peekable(),
+            );
+        }
+        let mut exclude_idx = Vec::with_capacity(excludes.len());
+        for key in excludes {
+            exclude_idx.push(leaves.len());
+            leaves.push(
+                source
+                    .scan_bucket_iter(key, range.clone(), direction)
+                    .peekable(),
+            );
+        }
+        terms.push(TermSpec {
+            includes: include_idx,
+            excludes: exclude_idx,
+            dead: false,
+        });
     }
-    let exclude_iters: Vec<_> = exclude
-        .into_iter()
-        .map(|key| {
-            marked_bucket_iter(
-                scan_bucket_iter(key, range.clone(), direction),
-                range.clone(),
-                bucket_size,
-                direction,
-            )
-        })
-        .collect();
-    let exclude_iter = union_n_iter(exclude_iters, direction);
-    Box::new(subtract_two_iter(include_iter, exclude_iter, direction))
-}
 
-enum LeafState {
-    Active,
-    Terminus,
-    Done,
-}
-
-/// Wrap a per-dimension raw bucket iterator into a marked iterator, emitting
-/// `Watermark(pre), Item, Watermark(post)` per bucket and a final
-/// `Watermark(range_terminus)` on natural EOF. On error it yields the error and
-/// stops without synthesizing a terminus — the scan did NOT reach it.
-///
-/// The synchronous analogue of [`super::stream`]'s `budget_limited_bucket_stream`;
-/// budget accounting lives in the request layer for the iterator path.
-fn marked_bucket_iter<'a, I>(
-    inner: I,
-    range: Range<u64>,
-    bucket_size: u64,
-    direction: ScanDirection,
-) -> impl Iterator<Item = WatermarkedBucket> + 'a
-where
-    I: Iterator<Item = BucketItem> + 'a,
-{
-    let range_terminus = if direction.is_ascending() {
+    let leaf_count = leaves.len();
+    let terminus = if direction.is_ascending() {
         range.end
     } else {
         range.start
     };
-    let mut inner = inner;
-    let mut pending: VecDeque<WatermarkedBucket> = VecDeque::new();
-    let mut state = LeafState::Active;
-
-    std::iter::from_fn(move || {
-        loop {
-            if let Some(out) = pending.pop_front() {
-                return Some(out);
-            }
-            match state {
-                LeafState::Done => return None,
-                LeafState::Terminus => {
-                    state = LeafState::Done;
-                    return Some(Ok(Watermarked::Watermark(range_terminus)));
-                }
-                LeafState::Active => match inner.next() {
-                    None => state = LeafState::Terminus,
-                    Some(Err(e)) => {
-                        state = LeafState::Done;
-                        return Some(Err(e));
-                    }
-                    Some(Ok(item)) => {
-                        let (bucket_id, _) = &item;
-                        let bucket_start = bucket_id.saturating_mul(bucket_size);
-                        let bucket_end_exclusive = bucket_start.saturating_add(bucket_size);
-                        // Clamp to the request range: cursors round-trip into
-                        // subsequent requests with different ranges, so an
-                        // out-of-bound watermark would be a foot-gun.
-                        let (pre, post) = if direction.is_ascending() {
-                            (
-                                bucket_start.max(range.start),
-                                bucket_end_exclusive.min(range.end),
-                            )
-                        } else {
-                            (
-                                bucket_end_exclusive.min(range.end),
-                                bucket_start.max(range.start),
-                            )
-                        };
-                        pending.push_back(Ok(Watermarked::Watermark(pre)));
-                        pending.push_back(Ok(Watermarked::Item(item)));
-                        pending.push_back(Ok(Watermarked::Watermark(post)));
-                    }
-                },
-            }
-        }
-    })
-}
-
-/// Multi-way merge intersection. Emits bucket_ids present in every child, with
-/// the bitwise AND of their bitmaps; drops empty results. Per-child watermarks
-/// drain each iteration; the min/max merged across children emits when it
-/// advances.
-fn intersect_n_iter<'a, I>(
-    iters: Vec<I>,
-    direction: ScanDirection,
-) -> impl Iterator<Item = WatermarkedBucket> + 'a
-where
-    I: Iterator<Item = WatermarkedBucket> + 'a,
-{
-    let mut children: Vec<IterPeekable<I>> = iters.into_iter().map(Iterator::peekable).collect();
-    let mut child_watermarks: Vec<Option<u64>> = vec![None; children.len()];
+    let request_floor = if direction.is_ascending() {
+        range.start
+    } else {
+        range.end
+    };
+    // `gone[i]`: leaf retired (its term died or it is a spent exclude).
+    let mut gone = vec![false; leaf_count];
+    // `front[i]`: clamped position each leaf has provably scanned to. Bounds the
+    // resume cursor when a leaf errors before it can advance.
+    let mut front = vec![request_floor; leaf_count];
     let mut last_emitted: Option<u64> = None;
-    let mut pending: VecDeque<WatermarkedBucket> = VecDeque::new();
     let mut done = false;
-
-    std::iter::from_fn(move || {
-        loop {
-            if let Some(out) = pending.pop_front() {
-                return Some(out);
-            }
-            if done || children.is_empty() {
-                return None;
-            }
-
-            // Drain pending watermarks from each child; defer errors until AFTER
-            // emitting the merged watermark so progress up to the error point
-            // still reaches the consumer.
-            let mut deferred_errors: Vec<anyhow::Error> = Vec::new();
-            for (i, child) in children.iter_mut().enumerate() {
-                let outcome = drain_pending_watermarks_iter(child);
-                if let Some(p) = outcome.last_watermark {
-                    child_watermarks[i] = Some(p);
-                }
-                if let Some(e) = outcome.error {
-                    deferred_errors.push(e);
-                }
-            }
-            if let Some(merged) = merge_watermarks(&child_watermarks, direction)
-                && frontier_advanced(last_emitted, merged, direction)
-            {
-                pending.push_back(Ok(Watermarked::Watermark(merged)));
-                last_emitted = Some(merged);
-            }
-            if !deferred_errors.is_empty() {
-                done = true;
-                pending.push_back(Err(MultiError::collapse(deferred_errors)));
-                continue;
-            }
-
-            let peeks = match peek_buckets_iter(&mut children) {
-                Ok(peeks) => peeks,
-                Err(e) => {
-                    done = true;
-                    pending.push_back(Err(e));
-                    continue;
-                }
-            };
-            let Some((peeks, max_bucket)) = complete_peeks(peeks) else {
-                done = true;
-                continue;
-            };
-            let target_bucket = match direction {
-                ScanDirection::Ascending => max_bucket,
-                ScanDirection::Descending => peeks.iter().copied().min().expect("non-empty peeks"),
-            };
-
-            if peeks.iter().all(|&b| b == target_bucket) {
-                let mut acc: Option<RoaringBitmap> = None;
-                let mut err = None;
-                for child in children.iter_mut() {
-                    match take_bucket_item_iter(child) {
-                        Ok((bid, bitmap)) => {
-                            debug_assert_eq!(bid, target_bucket);
-                            acc = Some(match acc {
-                                None => bitmap,
-                                Some(a) => a & bitmap,
-                            });
-                        }
-                        Err(e) => {
-                            err = Some(e);
-                            break;
-                        }
-                    }
-                }
-                if let Some(e) = err {
-                    done = true;
-                    pending.push_back(Err(e));
-                    continue;
-                }
-                let bitmap = acc.expect("children non-empty");
-                if !bitmap.is_empty() {
-                    pending.push_back(Ok(Watermarked::Item((target_bucket, bitmap))));
-                }
-            } else {
-                // Sparse bitmap rows encode only non-empty buckets. A child
-                // lagging the alignment target intersects with an implicit
-                // all-zero bitmap at that bucket → empty result. Consume the
-                // lagging bucket and re-peek.
-                for (i, child) in children.iter_mut().enumerate() {
-                    let drop_bucket = match direction {
-                        ScanDirection::Ascending => peeks[i] < target_bucket,
-                        ScanDirection::Descending => peeks[i] > target_bucket,
-                    };
-                    if drop_bucket && let Err(e) = take_bucket_item_iter(child) {
-                        done = true;
-                        pending.push_back(Err(e));
-                        break;
-                    }
-                }
-            }
-        }
-    })
-}
-
-/// Mark a union iterator done, flushing any stashed retired-branch errors
-/// (plus an optional fresh terminal error) as one collapsed error AFTER the
-/// last watermark already queued this iteration. Ordering matters: a consumer
-/// resuming on error relies on the final on-wire watermark, so the watermark
-/// must precede the error.
-fn finish_union(
-    done: &mut bool,
-    pending: &mut VecDeque<WatermarkedBucket>,
-    pending_errors: &mut Vec<anyhow::Error>,
-    extra: Option<anyhow::Error>,
-) {
-    *done = true;
-    if let Some(e) = extra {
-        pending_errors.push(e);
-    }
-    if !pending_errors.is_empty() {
-        pending.push_back(Err(MultiError::collapse(std::mem::take(pending_errors))));
-    }
-}
-
-/// Multi-way merge union. Emits every bucket_id produced by any child, with the
-/// bitwise OR of bitmaps at that bucket. Per-child watermarks drain each
-/// iteration; the min/max merged across live children emits when it advances.
-///
-/// Flush-on-error mirrors [`super::stream`]'s `union_n`: a budget-exhausted
-/// child is an `OR` branch that died, not a reason to discard its siblings.
-/// Such a child is *retired* — removed from the live set, its final position
-/// frozen as a `resume_ceiling`, its error stashed. The union keeps emitting
-/// the surviving branches' already-fetched buckets UP TO that ceiling, then
-/// propagates the error. Buckets at or below the ceiling are inside the region
-/// every branch jointly scanned, so they resume cleanly; buckets PAST it are
-/// withheld — they sit ahead of the resumable frontier (pinned at the dead
-/// branch's floor) and would be re-scanned, hence double-delivered, on resume.
-/// Without this, a dead branch would discard a live sibling's first-bucket
-/// result and pin the cursor at the request floor (a livelock).
-fn union_n_iter<'a, I>(
-    iters: Vec<I>,
-    direction: ScanDirection,
-) -> impl Iterator<Item = WatermarkedBucket> + 'a
-where
-    I: Iterator<Item = WatermarkedBucket> + 'a,
-{
-    let mut children: Vec<IterPeekable<I>> = iters.into_iter().map(Iterator::peekable).collect();
-    let mut child_watermarks: Vec<Option<u64>> = vec![None; children.len()];
-    let mut last_emitted: Option<u64> = None;
     let mut pending: VecDeque<WatermarkedBucket> = VecDeque::new();
-    let mut done = false;
-    // Frozen floor + stashed errors from retired (errored) branches.
-    // `resume_ceiling` caps how far the surviving branches may be emitted;
-    // `pending_errors` propagate once the flush completes.
-    let mut resume_ceiling: Option<u64> = None;
-    let mut pending_errors: Vec<anyhow::Error> = Vec::new();
 
     std::iter::from_fn(move || {
         loop {
@@ -372,375 +112,181 @@ where
                 return None;
             }
 
-            // Drain pending watermarks, then retire any child that errored:
-            // freeze its final position into the resume ceiling and stash its
-            // error to propagate once the survivors have been flushed.
-            let outcomes: Vec<DrainOutcome> = children
-                .iter_mut()
-                .map(drain_pending_watermarks_iter)
-                .collect();
-            let mut live_children = Vec::with_capacity(children.len());
-            let mut live_watermarks = Vec::with_capacity(children.len());
-            for ((child, outcome), prev) in std::mem::take(&mut children)
-                .into_iter()
-                .zip_eq(outcomes)
-                .zip_eq(std::mem::take(&mut child_watermarks))
-            {
-                let wm = outcome.last_watermark.or(prev);
-                match outcome.error {
-                    Some(e) => {
-                        pending_errors.push(e);
-                        if let Some(f) = wm {
-                            resume_ceiling = Some(match resume_ceiling {
-                                None => f,
-                                Some(c) => bound_in_direction(c, f, direction),
-                            });
-                        }
+            // Peek every active leaf (non-consuming); record its head and the
+            // position it has now scanned to.
+            let mut class: Vec<Option<LeafHead>> = (0..leaf_count).map(|_| None).collect();
+            for i in 0..leaf_count {
+                if gone[i] {
+                    continue;
+                }
+                match leaves[i].peek() {
+                    Some(Ok((bucket, _))) => {
+                        let (pre, _post) = bucket_edges(*bucket, bucket_size, &range, direction);
+                        front[i] = pre;
+                        class[i] = Some(LeafHead::Bucket(*bucket));
                     }
                     None => {
-                        live_children.push(child);
-                        live_watermarks.push(wm);
+                        front[i] = terminus;
+                        class[i] = Some(LeafHead::Eof);
                     }
-                }
-            }
-            children = live_children;
-            child_watermarks = live_watermarks;
-
-            if let Some(merged) = merge_with_ceiling(&child_watermarks, resume_ceiling, direction)
-                && frontier_advanced(last_emitted, merged, direction)
-            {
-                pending.push_back(Ok(Watermarked::Watermark(merged)));
-                last_emitted = Some(merged);
-            }
-
-            // No live branch left to emit from.
-            if children.is_empty() {
-                finish_union(&mut done, &mut pending, &mut pending_errors, None);
-                continue;
-            }
-
-            let peeks = match peek_buckets_iter(&mut children) {
-                Ok(peeks) => peeks,
-                Err(e) => {
-                    finish_union(&mut done, &mut pending, &mut pending_errors, Some(e));
-                    continue;
-                }
-            };
-
-            // Evict exhausted children. The evicted child's last watermark
-            // already drained into the merge above, so dropping its slot is safe.
-            let mut surviving_children = Vec::with_capacity(children.len());
-            let mut surviving_peeks = Vec::with_capacity(peeks.len());
-            let mut surviving_watermarks = Vec::with_capacity(child_watermarks.len());
-            for ((child, peek), wm) in std::mem::take(&mut children)
-                .into_iter()
-                .zip_eq(peeks)
-                .zip_eq(std::mem::take(&mut child_watermarks))
-            {
-                if let Some(b) = peek {
-                    surviving_children.push(child);
-                    surviving_peeks.push(b);
-                    surviving_watermarks.push(wm);
-                }
-            }
-            children = surviving_children;
-            child_watermarks = surviving_watermarks;
-
-            if surviving_peeks.is_empty() {
-                finish_union(&mut done, &mut pending, &mut pending_errors, None);
-                continue;
-            }
-            let next_bucket = match direction {
-                ScanDirection::Ascending => *surviving_peeks
-                    .iter()
-                    .min()
-                    .expect("non-empty after evicting None peeks"),
-                ScanDirection::Descending => *surviving_peeks
-                    .iter()
-                    .max()
-                    .expect("non-empty after evicting None peeks"),
-            };
-
-            // Resume-ceiling gate: once a branch has died, withhold any bucket
-            // sitting past its frozen floor — on resume from the ceiling it
-            // would be re-scanned and so re-emitted. A bucket's leading `pre`
-            // watermark (recorded per child during the drain) is its position;
-            // the child at `next_bucket` carries the direction-min/max one.
-            if let Some(ceil) = resume_ceiling {
-                let next_pre = surviving_peeks
-                    .iter()
-                    .position(|&b| b == next_bucket)
-                    .and_then(|i| child_watermarks[i]);
-                let past_ceiling = match (next_pre, direction) {
-                    (Some(p), ScanDirection::Ascending) => p >= ceil,
-                    (Some(p), ScanDirection::Descending) => p <= ceil,
-                    (None, _) => false,
-                };
-                if past_ceiling {
-                    finish_union(&mut done, &mut pending, &mut pending_errors, None);
-                    continue;
+                    // Budget exhaustion: leave `front[i]` at its last scanned
+                    // position so the resume cursor cannot claim past it.
+                    Some(Err(_)) => class[i] = Some(LeafHead::Error),
                 }
             }
 
-            let mut acc: Option<RoaringBitmap> = None;
-            let mut err = None;
-            for (i, child) in children.iter_mut().enumerate() {
-                if surviving_peeks[i] == next_bucket {
-                    match take_bucket_item_iter(child) {
-                        Ok((_, bitmap)) => {
-                            acc = Some(match acc {
-                                None => bitmap,
-                                Some(a) => a | bitmap,
-                            });
-                        }
-                        Err(e) => {
-                            err = Some(e);
-                            break;
+            // An include at EOF kills its term (the intersection is permanently
+            // empty); drop all of that term's leaves so they stop being polled.
+            for term in terms.iter_mut() {
+                if !term.dead
+                    && term
+                        .includes
+                        .iter()
+                        .any(|&i| matches!(class[i], Some(LeafHead::Eof)))
+                {
+                    term.dead = true;
+                }
+            }
+            for term in &terms {
+                if term.dead {
+                    for &i in term.includes.iter().chain(term.excludes.iter()) {
+                        gone[i] = true;
+                    }
+                } else {
+                    // A spent exclude just stops contributing subtractions.
+                    for &i in &term.excludes {
+                        if matches!(class[i], Some(LeafHead::Eof)) {
+                            gone[i] = true;
                         }
                     }
                 }
             }
-            if let Some(e) = err {
-                finish_union(&mut done, &mut pending, &mut pending_errors, Some(e));
-                continue;
-            }
-            if let Some(bitmap) = acc
-                && !bitmap.is_empty()
-            {
-                pending.push_back(Ok(Watermarked::Item((next_bucket, bitmap))));
-            }
-        }
-    })
-}
 
-/// Merge-join subtraction for an anchored negative literal: `a AND NOT b`. For
-/// each bucket in `a`, emits `a_bm - b_bm` if `b` has the same bucket, else emits
-/// `a_bm` unchanged; drops empty results. Watermarks from both sides merge as
-/// "both sources past P."
-fn subtract_two_iter<'a, A, B>(
-    a: A,
-    b: B,
-    direction: ScanDirection,
-) -> impl Iterator<Item = WatermarkedBucket> + 'a
-where
-    A: Iterator<Item = WatermarkedBucket> + 'a,
-    B: Iterator<Item = WatermarkedBucket> + 'a,
-{
-    let mut a = a.peekable();
-    let mut b = b.peekable();
-    let mut a_watermark: Option<u64> = None;
-    let mut b_watermark: Option<u64> = None;
-    let mut last_emitted: Option<u64> = None;
-    let mut pending: VecDeque<WatermarkedBucket> = VecDeque::new();
-    let mut done = false;
-
-    std::iter::from_fn(move || {
-        loop {
-            if let Some(out) = pending.pop_front() {
-                return Some(out);
+            // Consume any budget-error frame so the error surfaces (after the
+            // floor watermark below).
+            let mut errors: Vec<anyhow::Error> = Vec::new();
+            for i in 0..leaf_count {
+                if !gone[i] && matches!(class[i], Some(LeafHead::Error)) {
+                    match leaves[i].next() {
+                        Some(Err(e)) => errors.push(e),
+                        _ => unreachable!("peek classified Error"),
+                    }
+                }
             }
-            if done {
+
+            let active: Vec<usize> = (0..leaf_count).filter(|&i| !gone[i]).collect();
+            if active.is_empty() {
+                // Every term retired naturally: cap the scan at the range
+                // terminus so the client learns it covered the whole range.
+                done = true;
+                if frontier_advanced(last_emitted, terminus, direction) {
+                    return Some(Ok(Watermarked::Watermark(terminus)));
+                }
                 return None;
             }
 
-            let a_outcome = drain_pending_watermarks_iter(&mut a);
-            let b_outcome = drain_pending_watermarks_iter(&mut b);
-            if let Some(p) = a_outcome.last_watermark {
-                a_watermark = Some(p);
+            // The floor is the slowest active leaf's scanned-to position; it is
+            // the merged "every source has scanned past here" watermark.
+            let floor_pos = active
+                .iter()
+                .map(|&i| front[i])
+                .reduce(|a, b| bound_in_direction(a, b, direction))
+                .expect("active non-empty");
+            if frontier_advanced(last_emitted, floor_pos, direction) {
+                pending.push_back(Ok(Watermarked::Watermark(floor_pos)));
+                last_emitted = Some(floor_pos);
             }
-            if let Some(p) = b_outcome.last_watermark {
-                b_watermark = Some(p);
-            }
-            let mut deferred_errors: Vec<anyhow::Error> = Vec::new();
-            if let Some(e) = a_outcome.error {
-                deferred_errors.push(e);
-            }
-            if let Some(e) = b_outcome.error {
-                deferred_errors.push(e);
-            }
-            if let Some(merged) = merge_watermarks(&[a_watermark, b_watermark], direction)
-                && frontier_advanced(last_emitted, merged, direction)
-            {
-                pending.push_back(Ok(Watermarked::Watermark(merged)));
-                last_emitted = Some(merged);
-            }
-            if !deferred_errors.is_empty() {
+
+            // Budget exhausted: the floor watermark above is the resume cursor;
+            // everything below it was fully evaluated in prior rounds.
+            if !errors.is_empty() {
                 done = true;
-                pending.push_back(Err(MultiError::collapse(deferred_errors)));
+                pending.push_back(Err(MultiError::collapse(errors)));
                 continue;
             }
 
-            let a_peek = match peek_bucket_iter(&mut a) {
-                Ok(peek) => peek,
-                Err(e) => {
-                    done = true;
-                    pending.push_back(Err(e));
-                    continue;
-                }
-            };
-            let b_peek = match peek_bucket_iter(&mut b) {
-                Ok(peek) => peek,
-                Err(e) => {
-                    done = true;
-                    pending.push_back(Err(e));
-                    continue;
-                }
-            };
-            let Some(a_bucket) = a_peek else {
-                done = true;
-                continue;
-            };
+            // Evaluate the DNF at the nearest bucket any active leaf sits on.
+            let floor_bucket = active
+                .iter()
+                .filter_map(|&i| match class[i] {
+                    Some(LeafHead::Bucket(b)) => Some(b),
+                    _ => None,
+                })
+                .reduce(|a, b| match direction {
+                    ScanDirection::Ascending => a.min(b),
+                    ScanDirection::Descending => a.max(b),
+                })
+                .expect("active leaves carry buckets when there is no error");
+            let (_pre, post) = bucket_edges(floor_bucket, bucket_size, &range, direction);
 
-            match b_peek {
-                None => emit_a_unchanged(&mut a, &mut pending, &mut done),
-                Some(bb)
-                    if (direction.is_ascending() && bb > a_bucket)
-                        || (!direction.is_ascending() && bb < a_bucket) =>
-                {
-                    // b is ahead, emit a unchanged.
-                    emit_a_unchanged(&mut a, &mut pending, &mut done)
+            let mut result: Option<RoaringBitmap> = None;
+            for term in &terms {
+                if term.dead {
+                    continue;
                 }
-                Some(bb)
-                    if (direction.is_ascending() && bb < a_bucket)
-                        || (!direction.is_ascending() && bb > a_bucket) =>
-                {
-                    // b is behind; skip it.
-                    if let Err(e) = take_bucket_item_iter(&mut b) {
-                        done = true;
-                        pending.push_back(Err(e));
-                    }
+                let includes = take_term_side(
+                    &term.includes,
+                    floor_bucket,
+                    post,
+                    &class,
+                    &mut front,
+                    &mut leaves,
+                );
+                let excludes = take_term_side(
+                    &term.excludes,
+                    floor_bucket,
+                    post,
+                    &class,
+                    &mut front,
+                    &mut leaves,
+                );
+                if let Some(bitmap) = eval_term_at_bucket(includes, excludes) {
+                    result = Some(match result {
+                        None => bitmap,
+                        Some(acc) => acc | bitmap,
+                    });
                 }
-                Some(_) => {
-                    // Same bucket: subtract.
-                    let a_item = take_bucket_item_iter(&mut a);
-                    let b_item = take_bucket_item_iter(&mut b);
-                    match (a_item, b_item) {
-                        (Ok((bid, a_bm)), Ok((_, b_bm))) => {
-                            let diff = a_bm - b_bm;
-                            if !diff.is_empty() {
-                                pending.push_back(Ok(Watermarked::Item((bid, diff))));
-                            }
-                        }
-                        (Err(e), _) | (_, Err(e)) => {
-                            done = true;
-                            pending.push_back(Err(e));
-                        }
-                    }
-                }
+            }
+
+            if let Some(bitmap) = result {
+                pending.push_back(Ok(Watermarked::Item((floor_bucket, bitmap))));
+            }
+            if frontier_advanced(last_emitted, post, direction) {
+                pending.push_back(Ok(Watermarked::Watermark(post)));
+                last_emitted = Some(post);
             }
         }
     })
 }
 
-/// Consume the next `a` bucket and queue it unchanged (skipping empties).
-fn emit_a_unchanged<A>(
-    a: &mut IterPeekable<A>,
-    pending: &mut VecDeque<WatermarkedBucket>,
-    done: &mut bool,
-) where
-    A: Iterator<Item = WatermarkedBucket>,
-{
-    match take_bucket_item_iter(a) {
-        Ok((bid, bitmap)) => {
-            if !bitmap.is_empty() {
-                pending.push_back(Ok(Watermarked::Item((bid, bitmap))));
-            }
-        }
-        Err(e) => {
-            *done = true;
-            pending.push_back(Err(e));
-        }
-    }
-}
-
-/// Outcome of `drain_pending_watermarks_iter`: latest watermark consumed (if
-/// any) AND any terminal error at the same head. Combinators apply the watermark
-/// before propagating the error so mid-drain progress still surfaces.
-struct DrainOutcome {
-    last_watermark: Option<u64>,
-    error: Option<anyhow::Error>,
-}
-
-/// Drain consecutive `Watermark` frames from the head of a peekable marked
-/// iterator. Combinators call this at the top of each loop iteration so
-/// subsequent peeks see Items only.
-fn drain_pending_watermarks_iter<I>(s: &mut IterPeekable<I>) -> DrainOutcome
+/// Gather one term side's bitmaps at `floor_bucket`, consuming the leaves that
+/// sit there (and advancing their `front` to the bucket's trailing edge) and
+/// recording `None` for leaves that sit on a later bucket.
+fn take_term_side<I>(
+    indices: &[usize],
+    floor_bucket: u64,
+    post: u64,
+    class: &[Option<LeafHead>],
+    front: &mut [u64],
+    leaves: &mut [IterPeekable<I>],
+) -> Vec<Option<RoaringBitmap>>
 where
-    I: Iterator<Item = WatermarkedBucket>,
+    I: Iterator<Item = BucketItem>,
 {
-    let mut last: Option<u64> = None;
-    loop {
-        match s.peek() {
-            None | Some(Ok(Watermarked::Item(_))) => {
-                return DrainOutcome {
-                    last_watermark: last,
-                    error: None,
-                };
-            }
-            Some(Ok(Watermarked::Watermark(_))) => match s.next() {
-                Some(Ok(Watermarked::Watermark(p))) => last = Some(p),
-                _ => unreachable!("peek confirmed Watermark"),
-            },
-            Some(Err(_)) => match s.next() {
-                Some(Err(e)) => {
-                    return DrainOutcome {
-                        last_watermark: last,
-                        error: Some(e),
-                    };
+    indices
+        .iter()
+        .map(|&i| {
+            if matches!(class[i], Some(LeafHead::Bucket(b)) if b == floor_bucket) {
+                front[i] = post;
+                match leaves[i].next() {
+                    Some(Ok((_, bitmap))) => Some(bitmap),
+                    _ => None,
                 }
-                _ => unreachable!("peek confirmed Err"),
-            },
-        }
-    }
-}
-
-/// Consume the next bucket Item. Caller must have confirmed via `peek_bucket_iter`
-/// that the head is an Item — a watermark or EOF here is a logic error.
-fn take_bucket_item_iter<I>(s: &mut IterPeekable<I>) -> Result<(u64, RoaringBitmap)>
-where
-    I: Iterator<Item = WatermarkedBucket>,
-{
-    match s.next() {
-        Some(Ok(Watermarked::Item(it))) => Ok(it),
-        Some(Ok(Watermarked::Watermark(_))) => {
-            unreachable!("take_bucket_item_iter on Watermark — drain should have run first")
-        }
-        Some(Err(e)) => Err(e),
-        None => unreachable!("take_bucket_item_iter on EOF — peek should have caught it"),
-    }
-}
-
-/// Peek the next bucket_id. Caller MUST have run `drain_pending_watermarks_iter`
-/// this iteration — a Watermark at the head means the drain step was skipped,
-/// which is a refactor bug, not a runtime condition. `None` on EOF; errors via
-/// `?`.
-fn peek_bucket_iter<I>(s: &mut IterPeekable<I>) -> Result<Option<u64>>
-where
-    I: Iterator<Item = WatermarkedBucket>,
-{
-    match s.peek() {
-        None => Ok(None),
-        Some(Ok(Watermarked::Item((b, _)))) => Ok(Some(*b)),
-        Some(Ok(Watermarked::Watermark(_))) => {
-            // Surface rather than silently consume: a stray WM here means the
-            // per-iteration drain contract was violated by a future refactor.
-            bail!(
-                "peek_bucket_iter observed a stray Watermark — drain_pending_watermarks_iter \
-                 must run first in each combinator loop iteration"
-            );
-        }
-        Some(Err(_)) => match s.next() {
-            Some(Err(e)) => Err(e),
-            _ => unreachable!("peek confirmed Err"),
-        },
-    }
-}
-
-fn peek_buckets_iter<I>(iters: &mut [IterPeekable<I>]) -> Result<Vec<Option<u64>>>
-where
-    I: Iterator<Item = WatermarkedBucket>,
-{
-    iters.iter_mut().map(peek_bucket_iter).collect()
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -752,6 +298,7 @@ mod tests {
 
     use super::*;
     use crate::bitmap_query::BitmapScanBudget;
+    use crate::bitmap_query::BitmapTerm;
     use crate::bitmap_query::eval_bitmap_query_bucket_stream;
     use crate::bitmap_query::test_utils::*;
 
@@ -803,9 +350,9 @@ mod tests {
 
     /// The iterator evaluator must produce the exact same `Watermarked` sequence
     /// — items AND progress watermarks — as the stream evaluator for the same
-    /// query, since both share the merge/watermark logic.
+    /// query, since both share the per-bucket DNF evaluation and floor logic.
     #[tokio::test]
-    async fn eval_bitmap_query_bucket_iter_matches_stream_for_or_terms_descending() {
+    async fn eval_bitmap_query_bucket_iter_matches_stream_for_or_terms() {
         let source = TestBucketSource {
             buckets: Arc::new(BTreeMap::from([
                 (
@@ -847,11 +394,64 @@ mod tests {
             )
             .collect();
 
-            let stream_marked = collect_marked(stream_out);
-            let iter_marked = collect_marked(iter_out);
             assert_eq!(
-                stream_marked, iter_marked,
+                collect_marked(stream_out),
+                collect_marked(iter_out),
                 "iter and stream marked sequences diverged for {direction:?}"
+            );
+        }
+    }
+
+    /// Parity holds even when buckets are spread far apart (sparse gaps, leaves
+    /// leapfrogging) — the regime where a naive merge could drift between the two
+    /// evaluators.
+    #[tokio::test]
+    async fn eval_bitmap_query_bucket_iter_matches_stream_over_sparse_gaps() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([
+                (
+                    test_key(b"a"),
+                    vec![(0, vec![1, 2, 3]), (5, vec![5, 6]), (9, vec![9])],
+                ),
+                (
+                    test_key(b"b"),
+                    vec![(0, vec![2, 3]), (5, vec![6]), (9, vec![9, 10])],
+                ),
+                (test_key(b"c"), vec![(0, vec![3]), (9, vec![9])]),
+                (test_key(b"d"), vec![(3, vec![1, 8]), (7, vec![7])]),
+                (test_key(b"e"), vec![(3, vec![8])]),
+            ])),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), include(b"b"), exclude(b"c")]).unwrap(),
+            BitmapTerm::new(vec![include(b"d"), exclude(b"e")]).unwrap(),
+        ])
+        .unwrap();
+
+        for direction in [ScanDirection::Ascending, ScanDirection::Descending] {
+            let stream_out: Vec<_> = eval_bitmap_query_bucket_stream(
+                source.clone(),
+                query.clone(),
+                0..(10 * BUCKET_SIZE),
+                BUCKET_SIZE,
+                direction,
+                BitmapScanBudget::new(1_000_000),
+            )
+            .collect()
+            .await;
+            let iter_out: Vec<_> = eval_bitmap_query_bucket_iter(
+                source.clone(),
+                query.clone(),
+                0..(10 * BUCKET_SIZE),
+                BUCKET_SIZE,
+                direction,
+            )
+            .collect();
+
+            assert_eq!(
+                collect_marked(stream_out),
+                collect_marked(iter_out),
+                "iter and stream diverged over sparse gaps for {direction:?}"
             );
         }
     }
@@ -902,142 +502,5 @@ mod tests {
             Some(300_000),
             "final watermark must reach the range terminus"
         );
-    }
-
-    fn wm(pos: u64) -> WatermarkedBucket {
-        Ok(Watermarked::Watermark(pos))
-    }
-
-    fn item(bucket: u64, bits: &[u32]) -> WatermarkedBucket {
-        Ok(Watermarked::Item((bucket, make_bitmap(bits))))
-    }
-
-    fn scan_limit() -> WatermarkedBucket {
-        Err(crate::bitmap_query::BitmapScanLimitExceeded.into())
-    }
-
-    fn union_items(out: &[WatermarkedBucket]) -> Vec<(u64, Vec<u32>)> {
-        out.iter()
-            .filter_map(|r| match r {
-                Ok(Watermarked::Item((b, bm))) => Some((*b, bm.iter().collect())),
-                _ => None,
-            })
-            .collect()
-    }
-
-    fn last_watermark(out: &[WatermarkedBucket]) -> Option<u64> {
-        out.iter().rev().find_map(|r| match r {
-            Ok(Watermarked::Watermark(p)) => Some(*p),
-            _ => None,
-        })
-    }
-
-    /// Flush-on-error: when a sibling `OR` branch dies, `union_n_iter` flushes a
-    /// surviving branch's already-fetched buckets that lie *below* the dead
-    /// branch's frozen floor before propagating the error. The dying branch
-    /// reached `2*BS` then budget-errored; the survivor's match sits in bucket 0
-    /// (below the floor), so it must be DELIVERED and the resume frontier must
-    /// advance to the dead branch's floor — not pin at the request floor (the
-    /// livelock the flush exists to prevent). The delivered bucket stays below
-    /// the final watermark, so resuming from that cursor won't re-emit it.
-    /// Mirrors the stream evaluator's
-    /// `flush_on_error_delivers_below_ceiling_sibling_result`.
-    #[test]
-    fn union_flush_on_error_delivers_below_ceiling_sibling() {
-        const BS: u64 = BUCKET_SIZE;
-        let dying: Vec<WatermarkedBucket> = vec![wm(2 * BS), scan_limit()];
-        let live: Vec<WatermarkedBucket> = vec![wm(0), item(0, &[7]), wm(BS), wm(60 * BS)];
-
-        let out: Vec<WatermarkedBucket> = union_n_iter(
-            vec![dying.into_iter(), live.into_iter()],
-            ScanDirection::Ascending,
-        )
-        .collect();
-
-        assert_eq!(
-            union_items(&out),
-            vec![(0, vec![7])],
-            "below-floor sibling match must be delivered despite the sibling dying"
-        );
-        let frontier = last_watermark(&out).expect("a frontier watermark must surface");
-        assert_eq!(
-            frontier,
-            2 * BS,
-            "frontier must advance to the dead branch's floor, not the request floor"
-        );
-        assert!(
-            union_items(&out).iter().all(|(b, _)| b * BS < frontier),
-            "delivered buckets must sit below the resume frontier (no re-emit on resume)"
-        );
-        let err = out
-            .last()
-            .expect("non-empty")
-            .as_ref()
-            .expect_err("scan must terminate with an error");
-        assert!(
-            crate::bitmap_query::error_contains::<crate::bitmap_query::BitmapScanLimitExceeded>(
-                err
-            )
-            .is_some(),
-            "expected BitmapScanLimitExceeded, got {err:?}"
-        );
-    }
-
-    /// A union whose live sibling sits ENTIRELY above the dead branch's floor
-    /// must still surface an advancing frontier before the error, rather than a
-    /// cursorless `ScanLimit`. The survivor's bucket is past the ceiling, so it
-    /// is withheld (it would be re-scanned on resume), but the frontier advances
-    /// to the dead branch's floor so the client has a real resume point. Mirrors
-    /// the stream evaluator's
-    /// `nested_term_starvation_emits_frontier_before_scan_limit`.
-    #[test]
-    fn union_emits_frontier_before_scan_limit() {
-        const BS: u64 = BUCKET_SIZE;
-        let dying: Vec<WatermarkedBucket> = vec![wm(2 * BS), scan_limit()];
-        let live: Vec<WatermarkedBucket> = vec![wm(40 * BS), item(40, &[7]), wm(60 * BS)];
-
-        let out: Vec<WatermarkedBucket> = union_n_iter(
-            vec![dying.into_iter(), live.into_iter()],
-            ScanDirection::Ascending,
-        )
-        .collect();
-
-        assert!(
-            union_items(&out).is_empty(),
-            "above-ceiling sibling buckets must be withheld for clean resume"
-        );
-        let frontier = last_watermark(&out)
-            .expect("a frontier watermark must surface before the (otherwise cursorless) error");
-        assert_eq!(
-            frontier,
-            2 * BS,
-            "frontier must reflect real progress past the request floor"
-        );
-        let err = out
-            .last()
-            .expect("non-empty")
-            .as_ref()
-            .expect_err("scan must terminate with an error");
-        assert!(
-            crate::bitmap_query::error_contains::<crate::bitmap_query::BitmapScanLimitExceeded>(
-                err
-            )
-            .is_some(),
-            "expected BitmapScanLimitExceeded, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn peek_bucket_iter_propagates_errors_without_panicking() {
-        let mut iter = vec![Err::<Watermarked<(u64, RoaringBitmap)>, anyhow::Error>(
-            anyhow::anyhow!("boom"),
-        )]
-        .into_iter()
-        .peekable();
-
-        let err = peek_bucket_iter(&mut iter).unwrap_err();
-
-        assert!(err.to_string().contains("boom"));
-        assert!(iter.next().is_none());
     }
 }

--- a/crates/sui-inverted-index/src/bitmap_query/mod.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/mod.rs
@@ -42,9 +42,6 @@ pub use stream::BitmapScanMetrics;
 pub use stream::buckets_with_watermarks;
 pub use stream::eval_bitmap_query_stream;
 pub use stream::flatten_watermarked_buckets;
-pub use stream::intersect_n;
-pub use stream::subtract_two;
-pub use stream::union_n;
 
 // Cross-checked against the iterative evaluator in iter.rs tests.
 #[cfg(test)]
@@ -54,19 +51,19 @@ pub(crate) use stream::eval_bitmap_query_bucket_stream;
 
 /// Terminal signal: the per-request bucket-fetch budget is exhausted.
 /// Surfaced as `anyhow::Error` so it short-circuits `try_stream!`
-/// pipelines through the existing error path. A silent EOF would let
-/// `subtract_two` emit unfiltered include rows past the exclude side's
-/// last fetched bucket.
+/// pipelines through the existing error path. A silent EOF would be
+/// indistinguishable from a leaf reaching the range terminus, so the
+/// driver would advance the cursor to the end and claim full coverage
+/// instead of truncating the scan at the current floor.
 #[derive(Debug, thiserror::Error)]
 #[error("bitmap scan budget exhausted")]
 pub struct BitmapScanLimitExceeded;
 
-/// Aggregate of multiple terminal errors raised during the same poll
-/// cycle of a multi-way combinator (e.g. two children of `intersect_n`
-/// both error before the next loop iteration). The single-error
-/// shortcut returns the inner error directly so existing downcasts on
-/// the wire keep working — `MultiError` only appears when 2+ errors
-/// coincide, in which case downstream consumers should use
+/// Aggregate of multiple terminal errors raised in the same driver round
+/// (e.g. two leaves both exhaust the shared budget before the next round).
+/// The single-error shortcut returns the inner error directly so existing
+/// downcasts on the wire keep working — `MultiError` only appears when 2+
+/// errors coincide, in which case downstream consumers should use
 /// [`error_contains`] to interrogate the aggregate.
 #[derive(Debug)]
 pub struct MultiError(Vec<anyhow::Error>);
@@ -103,8 +100,8 @@ impl std::error::Error for MultiError {}
 /// Downcast probe that looks through a `MultiError` aggregate. Returns
 /// the first inner `T` whether the top-level error is `T` directly or a
 /// `MultiError` containing one. Use this instead of `downcast_ref::<T>`
-/// at sites that may receive aggregated errors from the bitmap
-/// combinators.
+/// at sites that may receive aggregated errors from the bitmap eval
+/// driver.
 pub fn error_contains<T: std::error::Error + Send + Sync + 'static>(
     err: &anyhow::Error,
 ) -> Option<&T> {
@@ -143,10 +140,9 @@ impl<T> Watermarked<T> {
 pub type BucketItem = Result<(u64, RoaringBitmap)>;
 pub type BucketStream = BoxStream<'static, BucketItem>;
 
-/// A bucket stream that interleaves data buckets with per-source progress
-/// watermarks. Combinators (`intersect_n`, `union_n`, `subtract_two`)
-/// merge child watermarks structurally so the output always reflects
-/// "every source has scanned past P."
+/// A bucket stream that interleaves data buckets with progress watermarks.
+/// The flat DNF driver derives each watermark from the slowest leaf's
+/// position, so the output always reflects "every source has scanned past P."
 pub(crate) type WatermarkedBucket = Result<Watermarked<(u64, RoaringBitmap)>>;
 pub type WatermarkedBucketStream = BoxStream<'static, WatermarkedBucket>;
 
@@ -311,35 +307,6 @@ fn split_term_literals(term: BitmapTerm) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
     (include, exclude)
 }
 
-fn complete_peeks(peeks: Vec<Option<u64>>) -> Option<(Vec<u64>, u64)> {
-    let mut buckets = Vec::with_capacity(peeks.len());
-    let mut max_bucket = None;
-
-    for peek in peeks {
-        let bucket = peek?;
-        max_bucket = Some(max_bucket.map_or(bucket, |max: u64| max.max(bucket)));
-        buckets.push(bucket);
-    }
-
-    Some((buckets, max_bucket?))
-}
-
-/// Merge per-child watermark slots into the combinator's output.
-/// `None` if any child has yet to emit a first watermark — combinator
-/// must not claim progress past an unknown floor. Ascending min,
-/// descending max (the slowest source is the floor).
-fn merge_watermarks(slots: &[Option<u64>], direction: ScanDirection) -> Option<u64> {
-    // Short-circuits to None if any slot is None.
-    let all: Vec<u64> = slots.iter().copied().collect::<Option<Vec<_>>>()?;
-    if all.is_empty() {
-        return None;
-    }
-    Some(match direction {
-        ScanDirection::Ascending => *all.iter().min().expect("non-empty"),
-        ScanDirection::Descending => *all.iter().max().expect("non-empty"),
-    })
-}
-
 /// The less-advanced of two frontier positions in scan direction: the min
 /// ascending, the max descending. Used to keep a merged frontier bounded by
 /// the slowest contributor.
@@ -347,33 +314,6 @@ fn bound_in_direction(a: u64, b: u64, direction: ScanDirection) -> u64 {
     match direction {
         ScanDirection::Ascending => a.min(b),
         ScanDirection::Descending => a.max(b),
-    }
-}
-
-/// Like [`merge_watermarks`] but also folds in a `ceiling` frozen from
-/// errored (retired) union branches. A retired branch no longer polls, but
-/// the position it reached still bounds how far the union can claim progress,
-/// so it stays in the merge as a fixed floor. Live slots dominate as usual
-/// (any `None` live slot blocks progress); with no live slots left the
-/// ceiling alone is the frontier.
-fn merge_with_ceiling(
-    slots: &[Option<u64>],
-    ceiling: Option<u64>,
-    direction: ScanDirection,
-) -> Option<u64> {
-    // A live branch that has not yet reported blocks progress past its
-    // unknown floor.
-    if slots.iter().any(Option::is_none) {
-        return None;
-    }
-    let live = match direction {
-        ScanDirection::Ascending => slots.iter().flatten().copied().min(),
-        ScanDirection::Descending => slots.iter().flatten().copied().max(),
-    };
-    match (live, ceiling) {
-        (Some(l), Some(c)) => Some(bound_in_direction(l, c, direction)),
-        (Some(l), None) => Some(l),
-        (None, c) => c,
     }
 }
 
@@ -388,6 +328,69 @@ fn frontier_advanced(prev: Option<u64>, next: u64, direction: ScanDirection) -> 
             ScanDirection::Descending => next < prev,
         },
     }
+}
+
+/// Clamped member-id edges of `bucket` in scan direction: `(pre, post)` where
+/// `pre` is the leading edge (everything before it is already covered) and
+/// `post` is the trailing edge (everything up to and including the bucket is
+/// covered). Ascending: `(low, high)`; descending: `(high, low)`. Both clamped
+/// to the request range so cursors stay in-bounds when they round-trip into a
+/// follow-up request with a different range.
+pub(crate) fn bucket_edges(
+    bucket: u64,
+    bucket_size: u64,
+    range: &Range<u64>,
+    direction: ScanDirection,
+) -> (u64, u64) {
+    let start = bucket.saturating_mul(bucket_size);
+    let end = start.saturating_add(bucket_size);
+    match direction {
+        ScanDirection::Ascending => (start.max(range.start), end.min(range.end)),
+        ScanDirection::Descending => (end.min(range.end), start.max(range.start)),
+    }
+}
+
+/// Evaluate one DNF term at a single bucket from the per-leaf bitmaps present
+/// there: intersect the includes (any absent include ⇒ empty term), then
+/// subtract the union of the present excludes (`a AND NOT b`). Returns the
+/// term's matches at the bucket, or `None` if empty. Bitmaps are taken by value
+/// so the caller hands over the consumed leaf rows without cloning.
+pub(crate) fn eval_term_at_bucket(
+    includes: Vec<Option<RoaringBitmap>>,
+    excludes: Vec<Option<RoaringBitmap>>,
+) -> Option<RoaringBitmap> {
+    let mut acc: Option<RoaringBitmap> = None;
+    for include in includes {
+        // A missing include means the intersection is empty at this bucket.
+        let bitmap = include?;
+        acc = Some(match acc {
+            None => bitmap,
+            Some(a) => a & bitmap,
+        });
+    }
+    // Anchored terms always carry at least one include, so `acc` is `Some`.
+    let mut acc = acc?;
+    for exclude in excludes.into_iter().flatten() {
+        acc -= exclude;
+    }
+    (!acc.is_empty()).then_some(acc)
+}
+
+/// One DNF term, as index spans into the flat leaf vector. Shared by the stream
+/// and iterator drivers.
+pub(crate) struct TermSpec {
+    pub(crate) includes: Vec<usize>,
+    pub(crate) excludes: Vec<usize>,
+    /// Set once any include leaf hits EOF: the intersection can never match
+    /// again, so the whole term is retired and its leaves dropped.
+    pub(crate) dead: bool,
+}
+
+/// A leaf's head this round, from a non-consuming peek.
+pub(crate) enum LeafHead {
+    Bucket(u64),
+    Eof,
+    Error,
 }
 
 #[cfg(test)]

--- a/crates/sui-inverted-index/src/bitmap_query/stream.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/stream.rs
@@ -3,12 +3,16 @@
 
 //! Async stream evaluator for DNF bitmap queries.
 //!
-//! Emits matching members as [`Watermarked`] items interleaved with progress
-//! watermarks. The merge-join combinators (`intersect_n`, `union_n`,
-//! `subtract_two`) propagate per-source watermarks so sparse scans still report
-//! progress at the rate sources advance. Consumed by streaming backends such as
-//! BigTable; the synchronous [`super::eval_bitmap_query_bucket_iter`] mirrors it
-//! for request-local iterator backends.
+//! A single flat driver merge-joins every leaf scan against one shared *floor*
+//! (the slowest leaf's position). At the floor bucket it evaluates the query —
+//! intersect each term's included dimensions, subtract its excluded ones, then
+//! union across terms — and emits a watermark at the floor. Leaves only ever
+//! advance at the floor (peeked one bucket ahead, polled concurrently), so no
+//! branch can run ahead of the others: the resume cursor stays within one sparse
+//! read of every leaf, and there is no windowing/parking to get wrong. Consumed
+//! by streaming backends such as BigTable; the synchronous
+//! [`super::eval_bitmap_query_bucket_iter`] mirrors it and shares the per-bucket
+//! evaluation ([`eval_term_at_bucket`]).
 
 use std::ops::Range;
 use std::pin::Pin;
@@ -17,30 +21,28 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use anyhow::Result;
-use anyhow::bail;
 use futures::Stream;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 use futures::stream::Peekable;
-use itertools::Itertools;
 use roaring::RoaringBitmap;
 
 use super::BitmapBucketSource;
-use super::BitmapLiteral;
 use super::BitmapQuery;
 use super::BitmapScanLimitExceeded;
-use super::BitmapTerm;
 use super::BucketItem;
+use super::BucketStream;
+use super::LeafHead;
 use super::MultiError;
 use super::ScanDirection;
+use super::TermSpec;
 use super::Watermarked;
-use super::WatermarkedBucket;
 use super::WatermarkedBucketStream;
 use super::bound_in_direction;
-use super::complete_peeks;
+use super::bucket_edges;
+use super::eval_term_at_bucket;
 use super::frontier_advanced;
-use super::merge_watermarks;
-use super::merge_with_ceiling;
+use super::split_term_literals;
 
 /// Per-request bucket-scan accounting, delivered via the `on_metrics`
 /// callback passed to `eval_bitmap_query_stream`. Fires once when the
@@ -58,7 +60,7 @@ pub struct BitmapScanMetrics {
 
 /// Per-request evaluated-bucket budget shared across all dimension
 /// streams of one eval. Charges are post-poll — see
-/// `budget_limited_bucket_stream`.
+/// `budgeted_bucket_stream`.
 #[derive(Clone)]
 pub(crate) struct BitmapScanBudget {
     initial: u64,
@@ -86,10 +88,10 @@ impl BitmapScanBudget {
     /// when it can, but ALWAYS succeeds. The runtime guards `budget >=
     /// leaf_count`, but a *shared* atomic with concurrent leaves gives no
     /// ordering guarantee — a sparse term can drain the pool before a
-    /// slower sibling leaf charges its first bucket, leaving that leaf's
-    /// merged-watermark slot `None` forever (cursorless `SCAN_LIMIT`).
+    /// slower sibling leaf charges its first bucket, leaving that leaf
+    /// unable to report its first position (a cursorless `SCAN_LIMIT`).
     /// Reserving the first bucket per leaf makes the `leaf_count` floor's
-    /// promise — "every leaf emits its first watermark" — actually hold.
+    /// promise — "every leaf reaches its first bucket" — actually hold.
     /// Charging-when-possible keeps `buckets_evaluated` accurate in the
     /// common `budget >> leaves` case; it only undercounts a first bucket
     /// taken after the pool was already exhausted by other leaves.
@@ -132,9 +134,8 @@ impl<F: FnOnce(BitmapScanMetrics) + Send + 'static> Drop for ObserveOnDrop<F> {
 /// fires exactly once when the eval stream is dropped.
 ///
 /// Output emits `Watermarked::Item(absolute_member_id)` interleaved with
-/// `Watermarked::Watermark(p)` merged from the leaf streams — sparse
-/// intersects that drop every bucket still emit watermarks at the rate
-/// sources advance.
+/// `Watermarked::Watermark(p)` derived from the slowest leaf — sparse scans
+/// that match nothing still report progress at the rate sources advance.
 pub fn eval_bitmap_query_stream<S, F>(
     source: S,
     query: BitmapQuery,
@@ -178,39 +179,45 @@ where
         budget,
         callback: Some(on_metrics),
     };
-    let range_terminus = if direction.is_ascending() {
-        range.end
-    } else {
-        range.start
-    };
     async_stream::stream! {
         let _guard = guard;
         futures::pin_mut!(inner);
-        let mut last_emitted: Option<u64> = None;
         while let Some(item) = inner.next().await {
-            let is_err = item.is_err();
-            if let Ok(Watermarked::Watermark(p)) = &item {
-                last_emitted = Some(*p);
-            }
             yield item;
-            if is_err {
-                // Don't synthesize a final range-terminus watermark on
-                // error — the scan did NOT reach it.
-                return;
-            }
-        }
-        // Natural EOF: guarantee a final range-terminus watermark so
-        // clients learn "scan covered the entire range." Combinators that
-        // short-circuit early (e.g. intersect when one side EOFs) leave
-        // `last_emitted` short of the terminus; this fills the gap.
-        if frontier_advanced(last_emitted, range_terminus, direction) {
-            yield Ok(Watermarked::Watermark(range_terminus));
         }
     }
     .boxed()
 }
 
+/// Non-consuming peek of one leaf, paired with its index and the position it has
+/// now scanned to (`None` for an error head, which leaves the prior position).
+async fn peek_leaf<S>(
+    mut leaf: Pin<&mut Peekable<S>>,
+    idx: usize,
+    bucket_size: u64,
+    range: &Range<u64>,
+    direction: ScanDirection,
+    terminus: u64,
+) -> (usize, LeafHead, Option<u64>)
+where
+    S: Stream<Item = BucketItem>,
+{
+    match leaf.as_mut().peek().await {
+        Some(Ok((bucket, _))) => {
+            let (pre, _post) = bucket_edges(*bucket, bucket_size, range, direction);
+            (idx, LeafHead::Bucket(*bucket), Some(pre))
+        }
+        None => (idx, LeafHead::Eof, Some(terminus)),
+        Some(Err(_)) => (idx, LeafHead::Error, None),
+    }
+}
+
 /// Evaluate a DNF `BitmapQuery` as an ordered `WatermarkedBucketStream`.
+///
+/// The flat driver: each round peeks every active leaf concurrently, takes the
+/// slowest leaf's position as the floor (the merged watermark), evaluates the
+/// whole DNF at the floor bucket, and advances only the leaves sitting there.
+/// No leaf runs more than one peeked bucket ahead of the floor.
 pub(crate) fn eval_bitmap_query_bucket_stream<S>(
     source: S,
     query: BitmapQuery,
@@ -222,522 +229,236 @@ pub(crate) fn eval_bitmap_query_bucket_stream<S>(
 where
     S: BitmapBucketSource,
 {
-    let streams: Vec<WatermarkedBucketStream> = query
-        .terms
-        .into_iter()
-        .map(|term| {
-            term_bucket_stream(
-                source.clone(),
-                term,
-                range.clone(),
-                bucket_size,
-                direction,
-                budget.clone(),
-            )
-            .boxed()
-        })
-        .collect();
-    union_n(streams, direction).boxed()
-}
-
-/// Evaluate one DNF term: intersect all includes, then subtract excludes.
-fn term_bucket_stream<S>(
-    source: S,
-    term: BitmapTerm,
-    range: Range<u64>,
-    bucket_size: u64,
-    direction: ScanDirection,
-    budget: BitmapScanBudget,
-) -> WatermarkedBucketStream
-where
-    S: BitmapBucketSource,
-{
-    let mut include_streams: Vec<WatermarkedBucketStream> = Vec::new();
-    let mut exclude_streams: Vec<WatermarkedBucketStream> = Vec::new();
-
-    for literal in term.literals {
-        let (key, is_include) = match literal {
-            BitmapLiteral::Include(key) => (key.into_inner(), true),
-            BitmapLiteral::Exclude(key) => (key.into_inner(), false),
-        };
-        let stream = budget_limited_bucket_stream(
-            source.scan_bucket_stream(key, range.clone(), direction),
-            budget.clone(),
-            range.clone(),
-            bucket_size,
-            direction,
-        )
-        .boxed();
-        if is_include {
-            include_streams.push(stream);
-        } else {
-            exclude_streams.push(stream);
+    // One peekable leaf per literal; terms reference them by index. Budgeted
+    // bucket streams are `'static`, so `source` is only borrowed while building.
+    let mut leaves: Vec<Peekable<BucketStream>> = Vec::new();
+    let mut terms: Vec<TermSpec> = Vec::new();
+    for term in query.terms {
+        let (includes, excludes) = split_term_literals(term);
+        let mut include_idx = Vec::with_capacity(includes.len());
+        for key in includes {
+            include_idx.push(leaves.len());
+            let raw = source.scan_bucket_stream(key, range.clone(), direction);
+            leaves.push(
+                budgeted_bucket_stream(raw, budget.clone())
+                    .boxed()
+                    .peekable(),
+            );
         }
+        let mut exclude_idx = Vec::with_capacity(excludes.len());
+        for key in excludes {
+            exclude_idx.push(leaves.len());
+            let raw = source.scan_bucket_stream(key, range.clone(), direction);
+            leaves.push(
+                budgeted_bucket_stream(raw, budget.clone())
+                    .boxed()
+                    .peekable(),
+            );
+        }
+        terms.push(TermSpec {
+            includes: include_idx,
+            excludes: exclude_idx,
+            dead: false,
+        });
     }
 
-    let include_stream = intersect_n(include_streams, direction).boxed();
-    // Skip subtract when nothing to exclude. `union_n` of zero streams
-    // emits nothing, which would leave `subtract_two`'s `b_watermark`
-    // slot `None` forever and suppress every merged watermark.
-    if exclude_streams.is_empty() {
-        return include_stream;
-    }
-    let exclude_stream = union_n(exclude_streams, direction);
-
-    // `subtract_two` polls both sides with `try_join!`, so include and
-    // exclude scans are opened/read concurrently.
-    subtract_two(include_stream, exclude_stream, direction).boxed()
-}
-
-/// Wrap a per-dimension raw bucket stream into a `WatermarkedBucketStream`,
-/// emitting `Watermark(pre), Item, Watermark(post)` per bucket and a
-/// final `Watermark(range_terminus)` on natural EOF.
-///
-/// On budget exhaustion yields `Err(BitmapScanLimitExceeded)` — never
-/// silent EOF, which `subtract_two` would mistake for "no more excludes."
-/// Charge is post-poll so `budget == leaves` doesn't spuriously trip at
-/// natural EOF.
-///
-/// The post-poll timing also underwrites forward progress under
-/// `SCAN_LIMIT`: a bucket's `pre` and `post` are both emitted before the
-/// *next* bucket's charge can trip the limit. So a leaf that scans at
-/// least one bucket always surfaces an *advancing* `post` watermark, not
-/// just the first bucket's `pre` — which is clamped back to `range.start`
-/// (below) and would otherwise resume the client at their own request
-/// floor. Downstream `resolve_watermarks` flushes that in-flight `post`
-/// ahead of the `BitmapScanLimitExceeded`, so a truncated scan still
-/// hands back real progress.
-fn budget_limited_bucket_stream<S>(
-    inner: S,
-    budget: BitmapScanBudget,
-    range: Range<u64>,
-    bucket_size: u64,
-    direction: ScanDirection,
-) -> impl Stream<Item = WatermarkedBucket> + Send + 'static
-where
-    S: Stream<Item = BucketItem> + Send + 'static,
-{
-    let range_terminus = if direction.is_ascending() {
+    let leaf_count = leaves.len();
+    let terminus = if direction.is_ascending() {
         range.end
     } else {
         range.start
     };
+    let request_floor = if direction.is_ascending() {
+        range.start
+    } else {
+        range.end
+    };
+
+    async_stream::try_stream! {
+        // `gone[i]`: leaf retired (its term died or it is a spent exclude).
+        let mut gone = vec![false; leaf_count];
+        // `front[i]`: clamped position each leaf has provably scanned to. Bounds
+        // the resume cursor when a leaf errors before it can advance.
+        let mut front = vec![request_floor; leaf_count];
+        let mut last_emitted: Option<u64> = None;
+
+        loop {
+            // Peek every active leaf concurrently (preserves cross-scan
+            // parallelism), recording each head and the position it scanned to.
+            let mut peeks = Vec::new();
+            for (i, leaf) in leaves.iter_mut().enumerate() {
+                if !gone[i] {
+                    peeks.push(peek_leaf(
+                        Pin::new(leaf),
+                        i,
+                        bucket_size,
+                        &range,
+                        direction,
+                        terminus,
+                    ));
+                }
+            }
+            let results = futures::future::join_all(peeks).await;
+            let mut class: Vec<Option<LeafHead>> = (0..leaf_count).map(|_| None).collect();
+            for (i, head, scanned_to) in results {
+                if let Some(p) = scanned_to {
+                    front[i] = p;
+                }
+                class[i] = Some(head);
+            }
+
+            // An include at EOF kills its term (the intersection is permanently
+            // empty); drop all of that term's leaves so they stop being polled.
+            for term in terms.iter_mut() {
+                if !term.dead
+                    && term
+                        .includes
+                        .iter()
+                        .any(|&i| matches!(class[i], Some(LeafHead::Eof)))
+                {
+                    term.dead = true;
+                }
+            }
+            for term in &terms {
+                if term.dead {
+                    for &i in term.includes.iter().chain(term.excludes.iter()) {
+                        gone[i] = true;
+                    }
+                } else {
+                    // A spent exclude just stops contributing subtractions.
+                    for &i in &term.excludes {
+                        if matches!(class[i], Some(LeafHead::Eof)) {
+                            gone[i] = true;
+                        }
+                    }
+                }
+            }
+
+            // Consume any budget-error frame so the error surfaces (after the
+            // floor watermark below).
+            let mut errors: Vec<anyhow::Error> = Vec::new();
+            for i in 0..leaf_count {
+                if !gone[i] && matches!(class[i], Some(LeafHead::Error)) {
+                    match Pin::new(&mut leaves[i]).next().await {
+                        Some(Err(e)) => errors.push(e),
+                        _ => unreachable!("peek classified Error"),
+                    }
+                }
+            }
+
+            let active: Vec<usize> = (0..leaf_count).filter(|&i| !gone[i]).collect();
+            if active.is_empty() {
+                // Every term retired naturally: cap at the range terminus so the
+                // client learns the scan covered the whole range.
+                if frontier_advanced(last_emitted, terminus, direction) {
+                    yield Watermarked::Watermark(terminus);
+                }
+                return;
+            }
+
+            // The floor is the slowest active leaf's scanned-to position: the
+            // merged "every source has scanned past here" watermark.
+            let floor_pos = active
+                .iter()
+                .map(|&i| front[i])
+                .reduce(|a, b| bound_in_direction(a, b, direction))
+                .expect("active non-empty");
+            if frontier_advanced(last_emitted, floor_pos, direction) {
+                yield Watermarked::Watermark(floor_pos);
+                last_emitted = Some(floor_pos);
+            }
+
+            // Budget exhausted: the floor watermark above is the resume cursor;
+            // everything below it was fully evaluated in prior rounds.
+            if !errors.is_empty() {
+                Err(MultiError::collapse(errors))?;
+            }
+
+            // Evaluate the DNF at the nearest bucket any active leaf sits on.
+            let floor_bucket = active
+                .iter()
+                .filter_map(|&i| match class[i] {
+                    Some(LeafHead::Bucket(b)) => Some(b),
+                    _ => None,
+                })
+                .reduce(|a, b| match direction {
+                    ScanDirection::Ascending => a.min(b),
+                    ScanDirection::Descending => a.max(b),
+                })
+                .expect("active leaves carry buckets when there is no error");
+            let (_pre, post) = bucket_edges(floor_bucket, bucket_size, &range, direction);
+
+            // Take the bitmaps of a term side that sit on `floor_bucket`,
+            // consuming those leaves (and advancing their `front` past the
+            // bucket); leaves on a later bucket contribute `None`.
+            macro_rules! take_side {
+                ($side:expr) => {{
+                    let mut out = Vec::with_capacity($side.len());
+                    for &i in $side {
+                        if matches!(class[i], Some(LeafHead::Bucket(b)) if b == floor_bucket) {
+                            front[i] = post;
+                            out.push(match Pin::new(&mut leaves[i]).next().await {
+                                Some(Ok((_, bitmap))) => Some(bitmap),
+                                _ => None,
+                            });
+                        } else {
+                            out.push(None);
+                        }
+                    }
+                    out
+                }};
+            }
+
+            let mut result: Option<RoaringBitmap> = None;
+            for term in &terms {
+                if term.dead {
+                    continue;
+                }
+                let includes = take_side!(&term.includes);
+                let excludes = take_side!(&term.excludes);
+                if let Some(bitmap) = eval_term_at_bucket(includes, excludes) {
+                    result = Some(match result {
+                        None => bitmap,
+                        Some(acc) => acc | bitmap,
+                    });
+                }
+            }
+
+            if let Some(bitmap) = result {
+                yield Watermarked::Item((floor_bucket, bitmap));
+            }
+            if frontier_advanced(last_emitted, post, direction) {
+                yield Watermarked::Watermark(post);
+                last_emitted = Some(post);
+            }
+        }
+    }
+    .boxed()
+}
+
+/// Wrap a raw per-dimension bucket stream with the shared scan budget: charge
+/// one bucket per pull (the first via `take_first`, the rest via `try_take`),
+/// yielding [`BitmapScanLimitExceeded`] when the pool is empty. Never a silent
+/// EOF — the driver must see the error to truncate at the floor.
+fn budgeted_bucket_stream<S>(
+    inner: S,
+    budget: BitmapScanBudget,
+) -> impl Stream<Item = BucketItem> + Send + 'static
+where
+    S: Stream<Item = BucketItem> + Send + 'static,
+{
     async_stream::try_stream! {
         futures::pin_mut!(inner);
         let mut first = true;
         while let Some(item) = inner.next().await {
             let item = item?;
             if first {
-                // Reserved: a leaf's first bucket is always allowed so it
-                // always emits its first watermark, regardless of how the
-                // shared budget raced. See `BitmapScanBudget::take_first`.
                 budget.take_first();
                 first = false;
             } else if !budget.try_take() {
                 Err(anyhow::Error::new(BitmapScanLimitExceeded))?;
             }
-            let (bucket_id, _) = &item;
-            let bucket_start = bucket_id.saturating_mul(bucket_size);
-            let bucket_end_exclusive = bucket_start.saturating_add(bucket_size);
-            // Clamp to the request range: cursors round-trip into
-            // subsequent requests with different ranges, so an
-            // out-of-bound cursor would be a foot-gun.
-            let (pre, post) = if direction.is_ascending() {
-                (
-                    bucket_start.max(range.start),
-                    bucket_end_exclusive.min(range.end),
-                )
-            } else {
-                (
-                    bucket_end_exclusive.min(range.end),
-                    bucket_start.max(range.start),
-                )
-            };
-            yield Watermarked::Watermark(pre);
-            yield Watermarked::Item(item);
-            yield Watermarked::Watermark(post);
-        }
-        // Natural EOF: emit a final watermark at the range terminus so
-        // combinators learn this source covered the whole range.
-        yield Watermarked::Watermark(range_terminus);
-    }
-}
-
-/// Multi-way merge intersection. Emits bucket_ids present in every
-/// child, with the bitwise AND of their bitmaps; drops empty results.
-/// Per-child watermarks drain eagerly each iteration; the min/max
-/// merged across children emits when it advances.
-pub fn intersect_n<S>(
-    streams: Vec<S>,
-    direction: ScanDirection,
-) -> impl Stream<Item = WatermarkedBucket> + Send + 'static
-where
-    S: Stream<Item = WatermarkedBucket> + Send + Unpin + 'static,
-{
-    async_stream::try_stream! {
-        if streams.is_empty() {
-            return;
-        }
-        let mut children: Vec<Peekable<S>> =
-            streams.into_iter().map(|s| s.peekable()).collect();
-        let mut child_watermarks: Vec<Option<u64>> = vec![None; children.len()];
-        let mut last_emitted: Option<u64> = None;
-
-        loop {
-            // Drain pending watermarks concurrently so we don't serialize
-            // on the slowest child. Defer errors until AFTER emitting the
-            // merged watermark — progress up to the error point should
-            // still reach the client.
-            let outcomes = futures::future::join_all(
-                children
-                    .iter_mut()
-                    .map(|child| drain_pending_watermarks(Pin::new(child))),
-            )
-            .await;
-            let mut deferred_errors: Vec<anyhow::Error> = Vec::new();
-            for (i, outcome) in outcomes.into_iter().enumerate() {
-                if let Some(p) = outcome.last_watermark {
-                    child_watermarks[i] = Some(p);
-                }
-                if let Some(e) = outcome.error {
-                    deferred_errors.push(e);
-                }
-            }
-            if let Some(merged) = merge_watermarks(&child_watermarks, direction)
-                && frontier_advanced(last_emitted, merged, direction)
-            {
-                yield Watermarked::Watermark(merged);
-                last_emitted = Some(merged);
-            }
-            if !deferred_errors.is_empty() {
-                Err(MultiError::collapse(deferred_errors))?;
-            }
-
-            // Poll children together so independent backend scans run
-            // concurrently.
-            let Some((peeks, max_bucket)) = complete_peeks(peek_buckets(&mut children).await?)
-            else {
-                break;
-            };
-            let target_bucket = match direction {
-                ScanDirection::Ascending => max_bucket,
-                ScanDirection::Descending => peeks.iter().copied().min().expect("non-empty peeks"),
-            };
-
-            if peeks.iter().all(|&b| b == target_bucket) {
-                // All children at the same bucket: intersect and emit.
-                let mut acc: Option<RoaringBitmap> = None;
-                for child in children.iter_mut() {
-                    let (bid, bitmap) = take_bucket_item(Pin::new(child)).await?;
-                    debug_assert_eq!(bid, target_bucket);
-                    acc = Some(match acc {
-                        None => bitmap,
-                        Some(a) => a & bitmap,
-                    });
-                }
-                let bitmap = acc.expect("children non-empty");
-                if !bitmap.is_empty() {
-                    yield Watermarked::Item((target_bucket, bitmap));
-                }
-            } else {
-                // Sparse bitmap rows encode only non-empty buckets. A
-                // child lagging the alignment target intersects with an
-                // implicit all-zero bitmap at that bucket → empty result.
-                // Consume the lagging bucket and re-peek.
-                for (i, child) in children.iter_mut().enumerate() {
-                    let drop_bucket = match direction {
-                        ScanDirection::Ascending => peeks[i] < target_bucket,
-                        ScanDirection::Descending => peeks[i] > target_bucket,
-                    };
-                    if drop_bucket {
-                        let _ = take_bucket_item(Pin::new(child)).await?;
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Multi-way merge union. Emits every bucket_id produced by any child,
-/// with the bitwise OR of bitmaps at that bucket. Per-child watermarks
-/// drain eagerly; min/max merged across live children emits when it
-/// advances.
-///
-/// Flush-on-error: a budget-exhausted child is an `OR` branch that died,
-/// not a reason to discard its siblings. Such a child is *retired* —
-/// removed from the live set, its final position frozen as a
-/// `resume_ceiling`, its error stashed. The union keeps emitting the
-/// surviving branches' already-fetched buckets UP TO that ceiling, then
-/// propagates the error. Buckets at or below the ceiling are inside the
-/// region every branch jointly scanned, so they resume cleanly; buckets
-/// PAST it are withheld — they sit ahead of the resumable frontier (pinned
-/// at the dead branch's floor) and would be re-scanned, hence
-/// double-delivered, on resume. Without this, a dead branch would discard a
-/// live sibling's first-bucket result and pin the cursor at the request
-/// floor (a livelock).
-pub fn union_n<S>(
-    streams: Vec<S>,
-    direction: ScanDirection,
-) -> impl Stream<Item = WatermarkedBucket> + Send + 'static
-where
-    S: Stream<Item = WatermarkedBucket> + Send + Unpin + 'static,
-{
-    async_stream::try_stream! {
-        if streams.is_empty() {
-            return;
-        }
-        let mut children: Vec<Peekable<S>> =
-            streams.into_iter().map(|s| s.peekable()).collect();
-        let mut child_watermarks: Vec<Option<u64>> = vec![None; children.len()];
-        let mut last_emitted: Option<u64> = None;
-        // Frozen floor + stashed errors from retired (errored) branches.
-        // `resume_ceiling` caps how far the surviving branches may be
-        // emitted; `pending_errors` propagate once the flush completes.
-        let mut resume_ceiling: Option<u64> = None;
-        let mut pending_errors: Vec<anyhow::Error> = Vec::new();
-
-        loop {
-            // Drain pending watermarks concurrently to avoid serializing
-            // on the slowest child.
-            let outcomes = futures::future::join_all(
-                children
-                    .iter_mut()
-                    .map(|child| drain_pending_watermarks(Pin::new(child))),
-            )
-            .await;
-
-            // Apply watermarks; retire any child that errored — freeze its
-            // final position into the resume ceiling and stash its error to
-            // propagate once the survivors have been flushed.
-            let mut live_children = Vec::with_capacity(children.len());
-            let mut live_watermarks = Vec::with_capacity(children.len());
-            for ((child, outcome), prev) in children
-                .into_iter()
-                .zip_eq(outcomes)
-                .zip_eq(child_watermarks)
-            {
-                let wm = outcome.last_watermark.or(prev);
-                match outcome.error {
-                    Some(e) => {
-                        pending_errors.push(e);
-                        if let Some(f) = wm {
-                            resume_ceiling = Some(match resume_ceiling {
-                                None => f,
-                                Some(c) => bound_in_direction(c, f, direction),
-                            });
-                        }
-                    }
-                    None => {
-                        live_children.push(child);
-                        live_watermarks.push(wm);
-                    }
-                }
-            }
-            children = live_children;
-            child_watermarks = live_watermarks;
-
-            if let Some(merged) = merge_with_ceiling(&child_watermarks, resume_ceiling, direction)
-                && frontier_advanced(last_emitted, merged, direction)
-            {
-                yield Watermarked::Watermark(merged);
-                last_emitted = Some(merged);
-            }
-
-            // No live branch left to emit from.
-            if children.is_empty() {
-                break;
-            }
-
-            let peeks = peek_buckets(&mut children).await?;
-
-            // Evict exhausted children so their resources (e.g. semaphore
-            // permits) release promptly. The evicted child's last
-            // watermark already drained into `last_emitted`, so dropping
-            // its slot is safe.
-            let mut surviving_children = Vec::with_capacity(children.len());
-            let mut surviving_peeks = Vec::with_capacity(peeks.len());
-            let mut surviving_watermarks = Vec::with_capacity(child_watermarks.len());
-            for ((child, peek), wm) in children
-                .into_iter()
-                .zip_eq(peeks)
-                .zip_eq(child_watermarks.into_iter())
-            {
-                if let Some(b) = peek {
-                    surviving_children.push(child);
-                    surviving_peeks.push(b);
-                    surviving_watermarks.push(wm);
-                }
-            }
-            children = surviving_children;
-            child_watermarks = surviving_watermarks;
-
-            if surviving_peeks.is_empty() {
-                break;
-            }
-            let next_bucket = match direction {
-                ScanDirection::Ascending => *surviving_peeks
-                    .iter()
-                    .min()
-                    .expect("non-empty after evicting None peeks"),
-                ScanDirection::Descending => *surviving_peeks
-                    .iter()
-                    .max()
-                    .expect("non-empty after evicting None peeks"),
-            };
-
-            // Resume-ceiling gate: once a branch has died, withhold any
-            // bucket sitting past its frozen floor — on resume from the
-            // ceiling it would be re-scanned and so re-emitted. A bucket's
-            // leading `pre` watermark (recorded per child during the drain)
-            // is its position; the child at `next_bucket` carries the
-            // direction-min/max one.
-            if let Some(ceil) = resume_ceiling {
-                let next_pre = surviving_peeks
-                    .iter()
-                    .position(|&b| b == next_bucket)
-                    .and_then(|i| child_watermarks[i]);
-                let past_ceiling = match (next_pre, direction) {
-                    (Some(p), ScanDirection::Ascending) => p >= ceil,
-                    (Some(p), ScanDirection::Descending) => p <= ceil,
-                    (None, _) => false,
-                };
-                if past_ceiling {
-                    break;
-                }
-            }
-
-            let mut acc: Option<RoaringBitmap> = None;
-            for (i, child) in children.iter_mut().enumerate() {
-                if surviving_peeks[i] == next_bucket {
-                    let (_, bitmap) = take_bucket_item(Pin::new(child)).await?;
-                    acc = Some(match acc {
-                        None => bitmap,
-                        Some(a) => a | bitmap,
-                    });
-                }
-            }
-            if let Some(bitmap) = acc
-                && !bitmap.is_empty()
-            {
-                yield Watermarked::Item((next_bucket, bitmap));
-            }
-        }
-        if !pending_errors.is_empty() {
-            Err(MultiError::collapse(pending_errors))?;
-        }
-    }
-}
-
-/// Merge-join subtraction for an anchored negative literal.
-///
-/// A negative literal in a valid term is evaluated as `a AND NOT b`, where `a`
-/// is the already-anchored positive candidate stream. Bitmap subtraction
-/// (`a_bm - b_bm`) has the same truth table without materializing `NOT b` over
-/// the whole range:
-///
-/// ```text
-/// a b | a AND NOT b
-/// 1 0 | 1
-/// 0 1 | 0
-/// 0 0 | 0
-/// 1 1 | 0
-/// ```
-///
-/// For each bucket in `a`, emits `a_bm - b_bm` if `b` has the same bucket,
-/// else emits `a_bm` unchanged. Drops empty results.
-pub fn subtract_two<A, B>(
-    a: A,
-    b: B,
-    direction: ScanDirection,
-) -> impl Stream<Item = WatermarkedBucket> + Send + 'static
-where
-    A: Stream<Item = WatermarkedBucket> + Send + 'static,
-    B: Stream<Item = WatermarkedBucket> + Send + 'static,
-{
-    async_stream::try_stream! {
-        let a = a.peekable();
-        let b = b.peekable();
-        futures::pin_mut!(a);
-        futures::pin_mut!(b);
-        let mut a_watermark: Option<u64> = None;
-        let mut b_watermark: Option<u64> = None;
-        let mut last_emitted: Option<u64> = None;
-
-        loop {
-            // Drain both sides concurrently, emit merged "both past P"
-            // if it advanced. Defer errors until after the emit so
-            // mid-drain progress reaches the client.
-            let (a_outcome, b_outcome) = futures::future::join(
-                drain_pending_watermarks(a.as_mut()),
-                drain_pending_watermarks(b.as_mut()),
-            )
-            .await;
-            if let Some(p) = a_outcome.last_watermark {
-                a_watermark = Some(p);
-            }
-            if let Some(p) = b_outcome.last_watermark {
-                b_watermark = Some(p);
-            }
-            let mut deferred_errors: Vec<anyhow::Error> = Vec::new();
-            if let Some(e) = a_outcome.error {
-                deferred_errors.push(e);
-            }
-            if let Some(e) = b_outcome.error {
-                deferred_errors.push(e);
-            }
-            if let Some(merged) = merge_watermarks(&[a_watermark, b_watermark], direction)
-                && frontier_advanced(last_emitted, merged, direction)
-            {
-                yield Watermarked::Watermark(merged);
-                last_emitted = Some(merged);
-            }
-            if !deferred_errors.is_empty() {
-                Err(MultiError::collapse(deferred_errors))?;
-            }
-
-            // Concurrent peek buffers both head rows; the later `next()`
-            // calls consume them.
-            let (a_peek, b_peek) =
-                futures::try_join!(peek_bucket(a.as_mut()), peek_bucket(b.as_mut()))?;
-            let Some(a_bucket) = a_peek else {
-                return;
-            };
-
-            match b_peek {
-                None => {
-                    // No more negatives: flush a.
-                    let (bid, bitmap) = take_bucket_item(a.as_mut()).await?;
-                    if !bitmap.is_empty() {
-                        yield Watermarked::Item((bid, bitmap));
-                    }
-                }
-                Some(bb)
-                    if (direction.is_ascending() && bb > a_bucket)
-                        || (!direction.is_ascending() && bb < a_bucket) =>
-                {
-                    // b is ahead, emit a unchanged.
-                    let (bid, bitmap) = take_bucket_item(a.as_mut()).await?;
-                    if !bitmap.is_empty() {
-                        yield Watermarked::Item((bid, bitmap));
-                    }
-                }
-                Some(bb)
-                    if (direction.is_ascending() && bb < a_bucket)
-                        || (!direction.is_ascending() && bb > a_bucket) =>
-                {
-                    // b is behind; skip it.
-                    let _ = take_bucket_item(b.as_mut()).await?;
-                }
-                Some(_) => {
-                    // Same bucket: subtract.
-                    let (bid, a_bm) = take_bucket_item(a.as_mut()).await?;
-                    let (_, b_bm) = take_bucket_item(b.as_mut()).await?;
-                    let diff = a_bm - b_bm;
-                    if !diff.is_empty() {
-                        yield Watermarked::Item((bid, diff));
-                    }
-                }
-            }
+            yield item;
         }
     }
 }
@@ -746,10 +467,9 @@ where
 /// `WatermarkedBucketStream` with one `Watermark(post_bucket)` after each
 /// bucket plus one final at the range terminus on EOF.
 ///
-/// The DNF eval pipeline uses `budget_limited_bucket_stream` instead;
-/// this helper is for backend-side consumers (e.g. RocksDB
-/// single-dimension scans) that want bucket-level output without the
-/// full eval machinery.
+/// The DNF eval pipeline budgets and merges leaves itself; this helper is for
+/// backend-side consumers (e.g. RocksDB single-dimension scans) that want
+/// bucket-level output without the full eval machinery.
 pub fn buckets_with_watermarks<S>(
     stream: S,
     range: Range<u64>,
@@ -860,122 +580,6 @@ where
     }
 }
 
-/// Outcome of `drain_pending_watermarks`: latest watermark consumed (if
-/// any) AND any terminal error at the same head. Combinators apply the
-/// watermark before propagating the error so mid-drain progress still
-/// surfaces.
-struct DrainOutcome {
-    last_watermark: Option<u64>,
-    error: Option<anyhow::Error>,
-}
-
-/// Drain consecutive `Watermark` frames from the head of a
-/// `Peekable<WatermarkedBucketStream>`. Combinators call this at the top of
-/// each loop iteration so subsequent peeks see Items only.
-async fn drain_pending_watermarks<S>(mut s: Pin<&mut Peekable<S>>) -> DrainOutcome
-where
-    S: Stream<Item = WatermarkedBucket>,
-{
-    let mut last: Option<u64> = None;
-    loop {
-        let action = match s.as_mut().peek().await {
-            None => {
-                return DrainOutcome {
-                    last_watermark: last,
-                    error: None,
-                };
-            }
-            Some(Ok(Watermarked::Item(_))) => {
-                return DrainOutcome {
-                    last_watermark: last,
-                    error: None,
-                };
-            }
-            Some(Ok(Watermarked::Watermark(_))) => PeekAction::ConsumeWatermark,
-            Some(Err(_)) => PeekAction::ConsumeError,
-        };
-        match action {
-            PeekAction::ConsumeWatermark => match s.as_mut().next().await {
-                Some(Ok(Watermarked::Watermark(p))) => last = Some(p),
-                _ => unreachable!("peek confirmed Watermark"),
-            },
-            PeekAction::ConsumeError => match s.as_mut().next().await {
-                Some(Err(e)) => {
-                    return DrainOutcome {
-                        last_watermark: last,
-                        error: Some(e),
-                    };
-                }
-                _ => unreachable!("peek confirmed Err"),
-            },
-        }
-    }
-}
-
-enum PeekAction {
-    ConsumeWatermark,
-    ConsumeError,
-}
-
-/// Consume the next bucket Item. Caller must have confirmed via
-/// `peek_bucket` that the head is an Item — watermark or EOF here is a
-/// logic error.
-async fn take_bucket_item<S>(mut s: Pin<&mut Peekable<S>>) -> Result<(u64, RoaringBitmap)>
-where
-    S: Stream<Item = WatermarkedBucket>,
-{
-    match s.as_mut().next().await {
-        Some(Ok(Watermarked::Item(it))) => Ok(it),
-        Some(Ok(Watermarked::Watermark(_))) => {
-            unreachable!("take_bucket_item called on Watermark — drain should have run first")
-        }
-        Some(Err(e)) => Err(e),
-        None => unreachable!("take_bucket_item called on EOF — peek should have caught it"),
-    }
-}
-
-/// Peek the next bucket_id. Caller MUST have run `drain_pending_watermarks`
-/// in this loop iteration — a Watermark at the head here means the
-/// drain step was skipped, which is a refactor bug rather than a
-/// runtime condition. Returns `None` on EOF; surfaces errors via `?`.
-async fn peek_bucket<S>(mut s: Pin<&mut Peekable<S>>) -> Result<Option<u64>>
-where
-    S: Stream<Item = WatermarkedBucket>,
-{
-    match s.as_mut().peek().await {
-        None => Ok(None),
-        Some(Ok(Watermarked::Item((b, _)))) => Ok(Some(*b)),
-        Some(Ok(Watermarked::Watermark(_))) => {
-            // Surface rather than silently consume: a stray WM here means
-            // the per-iteration `drain_pending_watermarks` contract was
-            // violated by a future refactor. Eating the WM would turn
-            // that bug into "watermarks just stop appearing," which is
-            // exactly the silent-progress-loss class this whole pipeline
-            // is designed to avoid.
-            bail!(
-                "peek_bucket observed a stray Watermark — drain_pending_watermarks \
-                 must run first in each combinator loop iteration"
-            );
-        }
-        Some(Err(_)) => match s.as_mut().next().await {
-            Some(Err(e)) => Err(e),
-            _ => unreachable!("peek confirmed Err"),
-        },
-    }
-}
-
-async fn peek_buckets<S>(streams: &mut [Peekable<S>]) -> Result<Vec<Option<u64>>>
-where
-    S: Stream<Item = WatermarkedBucket> + Unpin,
-{
-    futures::future::try_join_all(
-        streams
-            .iter_mut()
-            .map(|stream| peek_bucket(Pin::new(stream))),
-    )
-    .await
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -985,6 +589,8 @@ mod tests {
     use futures::stream;
 
     use super::*;
+    use crate::bitmap_query::BitmapLiteral;
+    use crate::bitmap_query::BitmapTerm;
     use crate::bitmap_query::BucketStream;
     use crate::bitmap_query::error_contains;
 
@@ -1036,53 +642,6 @@ mod tests {
         stream::iter(items).boxed()
     }
 
-    /// Ascending `Watermark(pre)`, `Item`, `Watermark(post)` per bucket.
-    /// Feeds combinator tests without the real budget machinery.
-    fn make_marked_stream_asc(items: Vec<(u64, &[u32])>) -> WatermarkedBucketStream {
-        let frames: Vec<WatermarkedBucket> = items
-            .into_iter()
-            .flat_map(|(bid, bits)| {
-                let bm = make_bitmap(bits);
-                let pre = bid * BUCKET_SIZE;
-                let post = (bid + 1) * BUCKET_SIZE;
-                [
-                    Ok::<_, anyhow::Error>(Watermarked::Watermark(pre)),
-                    Ok(Watermarked::Item((bid, bm))),
-                    Ok(Watermarked::Watermark(post)),
-                ]
-            })
-            .collect();
-        stream::iter(frames).boxed()
-    }
-
-    /// Descending variant: pre = bucket high edge, post = bucket low edge.
-    fn make_marked_stream_desc(items: Vec<(u64, &[u32])>) -> WatermarkedBucketStream {
-        let frames: Vec<WatermarkedBucket> = items
-            .into_iter()
-            .flat_map(|(bid, bits)| {
-                let bm = make_bitmap(bits);
-                let pre = (bid + 1) * BUCKET_SIZE;
-                let post = bid * BUCKET_SIZE;
-                [
-                    Ok::<_, anyhow::Error>(Watermarked::Watermark(pre)),
-                    Ok(Watermarked::Item((bid, bm))),
-                    Ok(Watermarked::Watermark(post)),
-                ]
-            })
-            .collect();
-        stream::iter(frames).boxed()
-    }
-
-    fn collect_bitmap_items(items: Vec<WatermarkedBucket>) -> Vec<(u64, Vec<u32>)> {
-        items
-            .into_iter()
-            .filter_map(|r| match r.unwrap() {
-                Watermarked::Item((b, bm)) => Some((b, bm.iter().collect())),
-                Watermarked::Watermark(_) => None,
-            })
-            .collect()
-    }
-
     /// Drain into (items, watermarks) parallel vecs. Order between the
     /// two is lost; for ordering checks collect `Watermarked` directly.
     async fn drain_marked(
@@ -1112,16 +671,13 @@ mod tests {
         BitmapLiteral::exclude(test_key(value)).unwrap()
     }
 
-    /// Nested multi-term starvation. `term1 = (a AND b)` has disjoint
-    /// includes, so its intersect drops `a`'s buckets one by one, draining
-    /// the *shared* budget. `term2 = c` is a sibling whose only data sits
-    /// ahead of the request floor. With a synchronous source the top union
-    /// fully drains `term1` (burning the budget) before `c` is polled, so
-    /// without a per-leaf first-bucket reservation `c`'s merged-watermark
-    /// slot stays `None`, the union's min-merge stays `None`, and the
-    /// stream ends with a *cursorless* `SCAN_LIMIT` — no resume point, the
-    /// client livelocks. The reservation guarantees `c` emits its first
-    /// watermark, so a forward-progress frontier surfaces before the error.
+    /// Tightest-budget starvation. `term1 = (a AND b)` is disjoint (matches
+    /// nothing) and `term2 = c`'s only data sits far ahead of the request floor.
+    /// With `budget == leaf_count`, round 1 still fetches every leaf's first
+    /// bucket, so the driver derives a real floor watermark before the budget
+    /// exhausts advancing `a`. The scan therefore ends with that forward-progress
+    /// watermark ahead of `SCAN_LIMIT` — never a cursorless error that would
+    /// livelock the client on retry.
     #[tokio::test]
     async fn nested_term_starvation_emits_frontier_before_scan_limit() {
         let source = TestBucketSource {
@@ -1182,17 +738,20 @@ mod tests {
         );
     }
 
-    /// Flush-on-error: when a sibling `OR` branch dies, the union flushes a
-    /// surviving branch's already-fetched buckets that lie *below* the dead
-    /// branch's frozen floor before propagating the error. Same shape as
-    /// above, but `c`'s match sits in the FIRST bucket (below `(a AND b)`'s
-    /// death floor), so it is within the jointly-scanned region: its item
-    /// must be DELIVERED and the resume frontier must advance to the dead
-    /// branch's floor — not be pinned at the request floor (the livelock the
-    /// flush exists to prevent). The delivered item stays below the final
-    /// watermark, so resuming from that cursor will not re-emit it.
+    /// Flush-on-error: a budget error truncates the scan at the floor, but
+    /// matches at or below the floor were already emitted in earlier rounds.
+    /// Here `c` matches in the FIRST bucket — below where `(a AND b)` exhausts
+    /// the budget — so its item must be DELIVERED, and the resume cursor must
+    /// advance to that death floor rather than be pinned at the request floor
+    /// (the livelock this guards against). The delivered item stays below the
+    /// final watermark, so resuming from that cursor will not re-emit it.
+    ///
+    /// The death floor is `post` of bucket 0 (one `BUCKET_SIZE`): every leaf's
+    /// first bucket is reserved (`take_first`), so the shared budget is spent
+    /// reaching bucket 0 across the leaves and `(a AND b)` errors before it can
+    /// advance to bucket 1.
     #[tokio::test]
-    async fn flush_on_error_delivers_below_ceiling_sibling_result() {
+    async fn flush_on_error_delivers_below_floor_sibling_result() {
         let source = TestBucketSource {
             buckets: Arc::new(BTreeMap::from([
                 (
@@ -1236,7 +795,7 @@ mod tests {
             .collect();
         assert_eq!(items, vec![7], "c's below-floor match must be delivered");
 
-        // Resume frontier advances to term1's death floor (post of bucket 1),
+        // Resume frontier advances to term1's death floor (post of bucket 0),
         // not stuck at the request floor 0.
         let last_wm = all
             .iter()
@@ -1246,7 +805,7 @@ mod tests {
                 _ => None,
             })
             .expect("a frontier watermark must surface");
-        assert_eq!(last_wm, 2 * BUCKET_SIZE, "frontier must advance past floor");
+        assert_eq!(last_wm, BUCKET_SIZE, "frontier must advance past floor");
         // The delivered item is below the resume cursor, so a resume won't
         // re-emit it.
         assert!(
@@ -1331,206 +890,6 @@ mod tests {
         let (items, _watermarks) = drain_marked(stream).await.unwrap();
 
         assert_eq!(items, vec![BUCKET_SIZE + 5, 2]);
-    }
-
-    #[tokio::test]
-    async fn intersect_n_basic() {
-        let a = make_marked_stream_asc(vec![(0, &[1, 2, 3]), (1, &[4, 5]), (2, &[6])]);
-        let b = make_marked_stream_asc(vec![(0, &[2, 3]), (2, &[6, 7])]);
-        let c = make_marked_stream_asc(vec![(0, &[3, 4]), (2, &[6])]);
-        let out: Vec<_> = intersect_n(vec![a, b, c], ScanDirection::Ascending)
-            .collect()
-            .await;
-        let out = collect_bitmap_items(out);
-        // bucket 0: {1,2,3} intersect {2,3} intersect {3,4} = {3}
-        // bucket 1: only in a, dropped by AND
-        // bucket 2: {6} intersect {6,7} intersect {6} = {6}
-        assert_eq!(out, vec![(0, vec![3]), (2, vec![6])]);
-    }
-
-    #[tokio::test]
-    async fn intersect_n_descending() {
-        let a = make_marked_stream_desc(vec![(2, &[6]), (1, &[4, 5]), (0, &[1, 2, 3])]);
-        let b = make_marked_stream_desc(vec![(2, &[6, 7]), (0, &[2, 3])]);
-        let c = make_marked_stream_desc(vec![(2, &[6]), (0, &[3, 4])]);
-        let out: Vec<_> = intersect_n(vec![a, b, c], ScanDirection::Descending)
-            .collect()
-            .await;
-        let out = collect_bitmap_items(out);
-        assert_eq!(out, vec![(2, vec![6]), (0, vec![3])]);
-    }
-
-    #[tokio::test]
-    async fn peek_bucket_propagates_errors_without_panicking() {
-        let stream: WatermarkedBucketStream =
-            stream::iter(vec![Err(anyhow::anyhow!("boom"))]).boxed();
-        let mut stream = stream.peekable();
-
-        let err = peek_bucket(Pin::new(&mut stream)).await.unwrap_err();
-
-        assert!(err.to_string().contains("boom"));
-        assert!(stream.next().await.is_none());
-    }
-
-    #[tokio::test]
-    async fn intersect_n_disjoint_dropped() {
-        let a = make_marked_stream_asc(vec![(0, &[1])]);
-        let b = make_marked_stream_asc(vec![(0, &[2])]);
-        let out: Vec<_> = intersect_n(vec![a, b], ScanDirection::Ascending)
-            .collect()
-            .await;
-        let out = collect_bitmap_items(out);
-        // intersection is empty, bucket dropped
-        assert!(out.is_empty());
-    }
-
-    #[tokio::test]
-    async fn intersect_n_one_empty() {
-        let a = make_marked_stream_asc(vec![(0, &[1]), (1, &[2])]);
-        let b = make_marked_stream_asc(vec![]);
-        let out: Vec<_> = intersect_n(vec![a, b], ScanDirection::Ascending)
-            .collect()
-            .await;
-        assert!(out.is_empty());
-    }
-
-    #[tokio::test]
-    async fn union_n_basic() {
-        let a = make_marked_stream_asc(vec![(0, &[1, 2]), (2, &[6])]);
-        let b = make_marked_stream_asc(vec![(0, &[2, 3]), (1, &[4])]);
-        let out: Vec<_> = union_n(vec![a, b], ScanDirection::Ascending)
-            .collect()
-            .await;
-        let out = collect_bitmap_items(out);
-        assert_eq!(out, vec![(0, vec![1, 2, 3]), (1, vec![4]), (2, vec![6])]);
-    }
-
-    #[tokio::test]
-    async fn union_n_descending() {
-        let a = make_marked_stream_desc(vec![(2, &[6]), (0, &[1, 2])]);
-        let b = make_marked_stream_desc(vec![(1, &[4]), (0, &[2, 3])]);
-        let out: Vec<_> = union_n(vec![a, b], ScanDirection::Descending)
-            .collect()
-            .await;
-        let out = collect_bitmap_items(out);
-        assert_eq!(out, vec![(2, vec![6]), (1, vec![4]), (0, vec![1, 2, 3])]);
-    }
-
-    #[tokio::test]
-    async fn union_n_drops_exhausted_child() {
-        use std::sync::atomic::AtomicBool;
-        use std::sync::atomic::Ordering;
-        use std::task::Context;
-        use std::task::Poll;
-
-        struct ObserveDrop<S> {
-            inner: S,
-            dropped: Arc<AtomicBool>,
-        }
-
-        impl<S: Stream<Item = WatermarkedBucket> + Unpin> Stream for ObserveDrop<S> {
-            type Item = WatermarkedBucket;
-            fn poll_next(
-                mut self: Pin<&mut Self>,
-                cx: &mut Context<'_>,
-            ) -> Poll<Option<Self::Item>> {
-                Pin::new(&mut self.inner).poll_next(cx)
-            }
-        }
-
-        impl<S> Drop for ObserveDrop<S> {
-            fn drop(&mut self) {
-                self.dropped.store(true, Ordering::SeqCst);
-            }
-        }
-
-        let dropped = Arc::new(AtomicBool::new(false));
-        let short: WatermarkedBucketStream = ObserveDrop {
-            inner: stream::iter(vec![
-                Ok::<_, anyhow::Error>(Watermarked::Item((0u64, make_bitmap(&[1])))),
-                Ok(Watermarked::Watermark(BUCKET_SIZE)),
-            ]),
-            dropped: dropped.clone(),
-        }
-        .boxed();
-        let long = make_marked_stream_asc(vec![(0, &[2]), (1, &[3]), (2, &[4])]);
-
-        // Filter merged Watermark frames out — the test only checks the
-        // bucket-Item order and the drop timing relative to bucket pulls.
-        let mut merged = union_n(vec![short, long], ScanDirection::Ascending)
-            .try_filter_map(|m| async move {
-                Ok(match m {
-                    Watermarked::Item(it) => Some(it),
-                    Watermarked::Watermark(_) => None,
-                })
-            })
-            .boxed();
-
-        // Bucket 0 merges both children; the short stream still has its
-        // post-bucket Watermark pending. Eviction happens on the next
-        // iteration after the watermark drain returns None for short.
-        let (b, _) = merged.try_next().await.unwrap().unwrap();
-        assert_eq!(b, 0);
-        assert!(!dropped.load(Ordering::SeqCst));
-
-        // Pulling bucket 1 first drains short's pending Watermark (updating
-        // its slot), tries to peek a bucket and sees None for short, evicts
-        // it (dropping the Peekable and its inner ObserveDrop), then aligns
-        // and emits bucket 1 from the surviving long stream. The long stream
-        // still has bucket 2 pending — proving the drop happened mid-merge,
-        // not at completion.
-        let (b, _) = merged.try_next().await.unwrap().unwrap();
-        assert_eq!(b, 1);
-        assert!(dropped.load(Ordering::SeqCst));
-
-        let (b, _) = merged.try_next().await.unwrap().unwrap();
-        assert_eq!(b, 2);
-        assert!(merged.try_next().await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn subtract_two_basic() {
-        let a = make_marked_stream_asc(vec![(0, &[1, 2, 3]), (1, &[4, 5]), (2, &[6, 7])]);
-        let b = make_marked_stream_asc(vec![(0, &[2]), (2, &[7]), (3, &[100])]);
-        let out: Vec<_> = subtract_two(a, b, ScanDirection::Ascending).collect().await;
-        let out = collect_bitmap_items(out);
-        assert_eq!(
-            out,
-            vec![
-                (0, vec![1, 3]), // {1,2,3} - {2}
-                (1, vec![4, 5]), // unchanged
-                (2, vec![6]),    // {6,7} - {7}
-            ],
-        );
-    }
-
-    #[tokio::test]
-    async fn subtract_two_descending() {
-        let a = make_marked_stream_desc(vec![(2, &[6, 7]), (1, &[4, 5]), (0, &[1, 2, 3])]);
-        let b = make_marked_stream_desc(vec![(3, &[100]), (2, &[7]), (0, &[2])]);
-        let out: Vec<_> = subtract_two(a, b, ScanDirection::Descending)
-            .collect()
-            .await;
-        let out = collect_bitmap_items(out);
-        assert_eq!(out, vec![(2, vec![6]), (1, vec![4, 5]), (0, vec![1, 3]),],);
-    }
-
-    #[tokio::test]
-    async fn subtract_two_drops_fully_erased_buckets() {
-        let a = make_marked_stream_asc(vec![(0, &[1])]);
-        let b = make_marked_stream_asc(vec![(0, &[1])]);
-        let out: Vec<_> = subtract_two(a, b, ScanDirection::Ascending).collect().await;
-        let out = collect_bitmap_items(out);
-        assert!(out.is_empty());
-    }
-
-    #[tokio::test]
-    async fn subtract_two_empty_right() {
-        let a = make_marked_stream_asc(vec![(0, &[1, 2]), (5, &[3])]);
-        let b = make_marked_stream_asc(vec![]);
-        let out: Vec<_> = subtract_two(a, b, ScanDirection::Ascending).collect().await;
-        let out = collect_bitmap_items(out);
-        assert_eq!(out, vec![(0, vec![1, 2]), (5, vec![3])]);
     }
 
     /// End-to-end: `buckets_with_watermarks` injects watermarks, then
@@ -1728,16 +1087,15 @@ mod tests {
             error_contains::<BitmapScanLimitExceeded>(&err).is_some(),
             "expected BitmapScanLimitExceeded, got {err:?}"
         );
-        // All four buckets were evaluated through budget_limited_bucket_stream
+        // All four buckets were evaluated through budgeted_bucket_stream
         // before the fifth try_take() failed and surfaced BitmapScanLimitExceeded.
         assert_eq!(metrics.lock().unwrap().unwrap().buckets_evaluated, 4);
     }
 
-    /// Budget exhausting on the exclude side must NOT be interpreted as
-    /// "no more excludes" by `subtract_two`. With silent EOF semantics,
-    /// includes past the exclude cutoff would leak unfiltered. With
-    /// `ScanLimitExceeded`, the error propagates and the eval pipeline
-    /// short-circuits cleanly.
+    /// Budget exhausting on an exclude leaf must NOT be mistaken for the
+    /// exclude reaching its range terminus. With silent EOF semantics, includes
+    /// past the exclude cutoff would leak unfiltered. With `ScanLimitExceeded`,
+    /// the error propagates and the eval pipeline short-circuits cleanly.
     #[tokio::test]
     async fn scan_budget_exclude_side_exhaustion_does_not_leak_includes() {
         let source = TestBucketSource {
@@ -1761,8 +1119,8 @@ mod tests {
         // minimum the runtime guard allows; see
         // `scan_budget_below_leaf_count_yields_misconfig_error`). Once
         // the budget exhausts mid-scan, ScanLimitExceeded propagates
-        // without subtract_two interpreting exclude-side EOF as "no
-        // more excludes."
+        // without the driver mistaking the exclude leaf's error for a
+        // natural EOF.
         let stream = eval_bitmap_query_stream(
             source,
             query,
@@ -1782,16 +1140,15 @@ mod tests {
         );
     }
 
-    /// Disjoint-intersect: source streams advance but the combinator yields
-    /// no output bucket, so per-bucket watermarks (which fire only on output)
-    /// never advance. The eval root's periodic + on-error frontier injection
-    /// must surface real progress; otherwise handlers fall back to the
-    /// request lower bound and the client livelocks on retry.
+    /// Disjoint-intersect: the leaves advance but the term matches nothing, so
+    /// no item is ever emitted. The driver's floor watermark must still surface
+    /// real progress before the budget error; otherwise handlers fall back to
+    /// the request lower bound and the client livelocks on retry.
     #[tokio::test]
     async fn sparse_intersect_emits_frontier_watermark_before_scan_limit() {
         // include "a" at buckets [0, 1, 2, ...], include "b" at bucket 100 —
-        // disjoint, so intersect_n drops a's lagging buckets one by one and
-        // emits zero output. Budget=4 forces error mid-scan.
+        // disjoint, so the driver advances the floor through a's buckets one by
+        // one and emits zero output. Budget=4 forces error mid-scan.
         let source = TestBucketSource {
             buckets: Arc::new(BTreeMap::from([
                 (
@@ -1873,17 +1230,20 @@ mod tests {
 
         // Items at the bits within each of the three populated buckets.
         assert_eq!(items, vec![1, 3 * BUCKET_SIZE + 2, 7 * BUCKET_SIZE + 3]);
-        // Per-source watermarks: each drain pass collapses consecutive
-        // watermarks at the source into the latest, so post(b) and the
-        // immediately-following pre(b+gap) merge — only one watermark per
-        // gap surfaces. For buckets [0, 3, 7]:
-        // - Watermark(0): pre(0) before bucket 0.
-        // - Watermark(3*bs): collapsed post(0)=bs + pre(3)=3bs.
-        // - Watermark(7*bs): collapsed post(3)=4bs + pre(7)=7bs.
-        // - Watermark(8*bs): collapsed post(7)=8bs (=range.end) + EOF.
+        // The flat driver emits the floor bucket's leading edge (pre) and
+        // trailing edge (post) each round, so each populated bucket [0, 3, 7]
+        // contributes both: pre/post = (0, bs), (3bs, 4bs), (7bs, 8bs). The
+        // final post(7)=8bs is the range terminus.
         assert_eq!(
             watermarks,
-            vec![0, 3 * BUCKET_SIZE, 7 * BUCKET_SIZE, 8 * BUCKET_SIZE,]
+            vec![
+                0,
+                BUCKET_SIZE,
+                3 * BUCKET_SIZE,
+                4 * BUCKET_SIZE,
+                7 * BUCKET_SIZE,
+                8 * BUCKET_SIZE,
+            ]
         );
     }
 
@@ -1909,23 +1269,28 @@ mod tests {
         let (items, watermarks) = drain_marked(stream).await.unwrap();
 
         assert_eq!(items, vec![7 * BUCKET_SIZE + 3, 3 * BUCKET_SIZE + 2, 1]);
-        // Descending: drain collapses consecutive watermarks into the
-        // latest. For buckets [7, 3, 0]: pre(7)=8bs (=range.end),
-        // post(7)=7bs then drain collapses with pre(3)=4bs → 4bs is
-        // the merged value (smaller wins in descending). Etc.
+        // Descending pre/post per matched bucket [7, 3, 0]: pre is the high
+        // edge, post the low edge — (8bs, 7bs), (4bs, 3bs), (1bs, 0). pre(7)=8bs
+        // is range.end; post(0)=0 is the range terminus.
         assert_eq!(
             watermarks,
-            vec![8 * BUCKET_SIZE, 4 * BUCKET_SIZE, BUCKET_SIZE, 0,]
+            vec![
+                8 * BUCKET_SIZE,
+                7 * BUCKET_SIZE,
+                4 * BUCKET_SIZE,
+                3 * BUCKET_SIZE,
+                BUCKET_SIZE,
+                0,
+            ]
         );
     }
 
     #[tokio::test]
     async fn eval_emits_per_source_watermarks_and_final_eof_when_no_bucket_yielded() {
-        // Two include dimensions whose buckets never align -> intersect
-        // yields no Items. Per-source watermarks (pre+post per bucket)
-        // still propagate the actual scan progress through the
-        // combinators' min-merge, and the eval root caps the stream with a
-        // final range_end watermark on natural EOF so clients see "scan
+        // Two include dimensions whose buckets never align -> the term
+        // yields no Items. The floor watermark (pre+post per bucket) still
+        // propagates the actual scan progress, and the driver caps the stream
+        // with a final range_end watermark on natural EOF so clients see "scan
         // covered the range with no matches."
         let source = TestBucketSource {
             buckets: Arc::new(BTreeMap::from([
@@ -2114,22 +1479,5 @@ mod tests {
         let s = err.to_string();
         assert!(s.contains("alpha"));
         assert!(s.contains("beta"));
-    }
-
-    /// `peek_bucket` must surface a stray `Watermark` as an error rather
-    /// than silently consume it. Drain is the caller's contract; eating
-    /// the WM here would turn a refactor bug into "watermarks just stop
-    /// appearing," exactly the silent-progress-loss class this pipeline
-    /// is built to avoid.
-    #[tokio::test]
-    async fn peek_bucket_errors_on_stray_watermark() {
-        let stream: WatermarkedBucketStream =
-            stream::iter(vec![Ok(Watermarked::<(u64, RoaringBitmap)>::Watermark(42))]).boxed();
-        let mut stream = stream.peekable();
-        let err = peek_bucket(Pin::new(&mut stream)).await.unwrap_err();
-        assert!(
-            err.to_string().contains("stray Watermark"),
-            "expected stray-watermark error, got: {err}"
-        );
     }
 }

--- a/crates/sui-inverted-index/src/mod.rs
+++ b/crates/sui-inverted-index/src/mod.rs
@@ -23,7 +23,4 @@ pub use bitmap_query::error_contains;
 pub use bitmap_query::eval_bitmap_query_bucket_iter;
 pub use bitmap_query::eval_bitmap_query_stream;
 pub use bitmap_query::flatten_watermarked_buckets;
-pub use bitmap_query::intersect_n;
-pub use bitmap_query::subtract_two;
-pub use bitmap_query::union_n;
 pub use dimensions::*;

--- a/crates/sui-kv-rpc/src/pipeline.rs
+++ b/crates/sui-kv-rpc/src/pipeline.rs
@@ -5,7 +5,9 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Context;
 use std::task::Poll;
 
 use futures::StreamExt;
@@ -13,6 +15,11 @@ use futures::TryStreamExt;
 use futures::stream;
 use futures::stream::BoxStream;
 use sui_rpc_api::RpcError;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio::sync::mpsc;
+use tokio::task::JoinError;
+use tokio::task::JoinHandle;
 
 // Re-export so handler-layer code can spell the marker type without
 // directly importing from sui-inverted-index. The pipeline shape lives
@@ -20,23 +27,93 @@ use sui_rpc_api::RpcError;
 // type the bitmap eval already produces.
 pub(crate) use sui_inverted_index::Watermarked;
 
+/// Wraps a spawned task's `JoinHandle` so dropping the wrapper aborts the
+/// task — releasing any BigTable permit or drainer slot the task holds —
+/// while still allowing the handle to be awaited to surface a panic. Mirrors
+/// the pattern in `sui-kvstore`'s bigtable client (`AbortOnDrop`).
+struct AbortOnDrop<T> {
+    handle: JoinHandle<T>,
+}
+
+impl<T> AbortOnDrop<T> {
+    fn new(handle: JoinHandle<T>) -> Self {
+        Self { handle }
+    }
+}
+
+impl<T> Future for AbortOnDrop<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.get_mut().handle).poll(cx)
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl<T> Unpin for AbortOnDrop<T> {}
+
+/// One ordered frame handed from the [`pipelined_chunks`] dispatcher task to
+/// its consumer. `Items` carries a live row receiver (filled by a spawned
+/// drainer that owns the permit-holding BigTable stream), the drainer's
+/// abort/join handle, and the drainer slot held until the frame is fully
+/// consumed. Watermarks and terminal errors are zero-cost passthroughs.
+enum FrameHandle<O, E> {
+    Items {
+        rx: mpsc::UnboundedReceiver<Result<O, E>>,
+        drain: AbortOnDrop<()>,
+        _slot: OwnedSemaphorePermit,
+    },
+    Watermark(u64),
+    Err(E),
+}
+
+/// Resolve a drainer/dispatcher `JoinHandle` awaited at an EOF boundary.
+///
+/// A **panic** is re-raised: it fires during a live request (a bug in the work
+/// the drainer runs), and swallowing it would let the handler above emit its
+/// terminal `QueryEnd` — a clean "complete" over truncated data. The
+/// `with_deadline` wrapper turns the re-raised panic into an `Internal` status.
+///
+/// A **cancellation** is only reachable at runtime shutdown: we abort our own
+/// tasks via `Drop`, never while awaiting their handles, and nobody else holds
+/// an abort handle. The stack is tearing down and the client connection is
+/// already dead, so truncating is harmless — treat it as EOF.
+fn surface_panic(res: Result<(), JoinError>) {
+    match res {
+        Ok(()) => {}
+        Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+        Err(_) => {}
+    }
+}
+
 /// Chunk an upstream stream of `Watermarked<I>` and run an async fn over each
-/// chunk of Items, preserving upstream order in the output. Up to
-/// `max_concurrent_chunks` chunk futures run at a time.
+/// chunk of Items, preserving upstream order. Watermarks keep their position
+/// relative to Items: frames are consumed strictly in input order and a
+/// watermark frame is yielded only after the preceding chunk's rows have all
+/// been drained, so "every Item before me has been emitted" holds.
 ///
-/// `Watermarked::Watermark`s travel through with their original ordering
-/// relative to Items: a marker that arrived between Items A and B in the
-/// upstream will arrive between A's transformed output and B's transformed
-/// output downstream. The watermark's invariant — "every Item before me has
-/// been emitted" — is preserved across the chunk boundary because chunks
-/// complete in input order and watermarks are queued behind their preceding
-/// chunk.
+/// Each chunk is drained in a **spawned task** that owns the stream returned by
+/// the closure and pushes rows to the next stage via a non-blocking send. This
+/// lets rows flow as they are drained while ensuring the drainer never blocks on
+/// the consumer. If the returned stream holds a scarce resource (for example, a
+/// request-scoped BigTable permit), that resource is held only while the stream
+/// itself is being drained, never across downstream backpressure. The dispatcher
+/// is spawned eagerly (work may start before the first poll); dropping the
+/// returned stream aborts it and all live drainers, releasing their
+/// permits/slots.
 ///
-/// The closure returns a permit-holding BigTable stream. This helper drains
-/// it to a local `Vec` inside the chunk future, so the permit is released
-/// before any rows are emitted to the next stage. That avoids stacked
-/// `.buffered()` deadlocks where downstream futures are waiting on the same
-/// semaphore needed to drain upstream streams.
+/// The per-frame **row** channel is unbounded so those sends never block; it is
+/// unbounded in type only — the drainer sends one message per row in its chunk
+/// (≤ chunk_size under the ~1:1 call-site contract) plus an optional terminal
+/// error, so memory is O(chunk_size) per in-flight frame. The **handle** channel
+/// is bounded by `max_concurrent_chunks`, and a per-stage drainer slot caps
+/// in-flight *item* frames at `max_concurrent_chunks` (held until each frame is
+/// consumed).
 pub(crate) fn pipelined_chunks<I, O, E, F, Fut>(
     upstream: BoxStream<'static, Result<Watermarked<I>, E>>,
     chunk_size: usize,
@@ -50,47 +127,141 @@ where
     O: Send + 'static,
     E: Send + 'static,
 {
-    // Local-scope output enum — the `Items(rows)` carrier between the
-    // `.buffered()` boundary and the downstream `.flat_map` is private
-    // to this function; ChunkInput is shared with pipelined_keyed_batches,
-    // hence module-level.
-    enum ChunkOutput<O> {
-        Items(Vec<O>),
-        Watermark(u64),
-    }
+    assert!(
+        max_concurrent_chunks > 0,
+        "pipelined_chunks: max_concurrent_chunks must be > 0"
+    );
+    assert!(chunk_size > 0, "pipelined_chunks: chunk_size must be > 0");
 
     let f = Arc::new(f);
-    let inputs = chunks_with_watermarks(upstream, chunk_size);
-    inputs
-        .map(move |input| {
-            let f = f.clone();
-            async move {
-                match input? {
-                    ChunkInput::Items(items) => {
-                        let rows = f(items).await?.try_collect::<Vec<_>>().await?;
-                        Ok::<ChunkOutput<O>, E>(ChunkOutput::Items(rows))
+    // Per-stage cap on in-flight *item* frames (queued + being consumed),
+    // distinct from the shared BigTable request semaphore: it only bounds how
+    // far the dispatcher runs ahead, so a slow consumer can't pile up
+    // unbounded drained-but-unconsumed chunks. Held in each item frame until
+    // the consumer finishes it.
+    let drainer_slots = Arc::new(Semaphore::new(max_concurrent_chunks));
+    // Bounded so a sparse stream of watermark/error frames (which take no
+    // drainer slot) can't enqueue unboundedly at a stalled consumer.
+    let (frame_tx, frame_rx) = mpsc::channel::<FrameHandle<O, E>>(max_concurrent_chunks);
+
+    // Dispatcher: pull ordered frames, spawn a permit-owning drainer per item
+    // frame, hand ordered frame handles to the consumer. Spawned (not lazy) so
+    // drainers make progress — and release their BigTable permits at RPC
+    // completion — independently of whether the consumer is currently polling.
+    let dispatcher = tokio::spawn({
+        let f = f.clone();
+        let drainer_slots = drainer_slots.clone();
+        async move {
+            let mut chunker = chunks_with_watermarks(upstream, chunk_size);
+            while let Some(input) = chunker.next().await {
+                let frame = match input {
+                    Ok(ChunkInput::Items(items)) => {
+                        // Acquire a slot before opening so the dispatcher never
+                        // holds a BigTable permit while waiting on the
+                        // in-flight bound.
+                        let Ok(slot) = drainer_slots.clone().acquire_owned().await else {
+                            return;
+                        };
+                        // Invoke `f` synchronously in chunker order so the
+                        // closure's synchronous side effects stay ordered; only
+                        // the returned future's `.await` + drain run in the
+                        // spawned task.
+                        let fut = f(items);
+                        // Unbounded so the drainer's sends are non-blocking: the
+                        // drainer holds the BigTable permit while draining and
+                        // must NEVER block on the consumer — a bounded channel
+                        // would let a stalled consumer wedge the drainer and hold
+                        // the permit across downstream backpressure, the exact
+                        // deadlock class this design removes. Unbounded in type
+                        // only: the drainer sends one message per row in its
+                        // chunk (≤ chunk_size under the ~1:1 call-site contract)
+                        // plus an optional terminal error, so memory is
+                        // O(chunk_size) per in-flight frame.
+                        #[allow(clippy::disallowed_methods)]
+                        // non-blocking; bounded in practice by chunk_size
+                        let (row_tx, row_rx) = mpsc::unbounded_channel();
+                        let drain = tokio::spawn(async move {
+                            match fut.await {
+                                Ok(stream) => {
+                                    let mut stream = stream;
+                                    while let Some(row) = stream.next().await {
+                                        // The inner stream's item is exactly the
+                                        // channel's item (`Result<O, E>`), so
+                                        // forward it directly. An Err is terminal
+                                        // (prefix-then-error): send it, then stop.
+                                        let terminal = row.is_err();
+                                        if row_tx.send(row).is_err() {
+                                            // Consumer gone.
+                                            return;
+                                        }
+                                        if terminal {
+                                            return;
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    // Open failed: forward the single error.
+                                    let _ = row_tx.send(Err(e));
+                                }
+                            }
+                        });
+                        FrameHandle::Items {
+                            rx: row_rx,
+                            drain: AbortOnDrop::new(drain),
+                            _slot: slot,
+                        }
                     }
-                    ChunkInput::Watermark(pos) => Ok(ChunkOutput::Watermark(pos)),
+                    Ok(ChunkInput::Watermark(pos)) => FrameHandle::Watermark(pos),
+                    Err(e) => {
+                        // Terminal error: send in order, then stop.
+                        let _ = frame_tx.send(FrameHandle::Err(e)).await;
+                        return;
+                    }
+                };
+                // On send failure the consumer is gone: returning drops `frame`
+                // (and any item frame's drainer handle + slot inside it),
+                // aborting the drainer and releasing the slot.
+                if frame_tx.send(frame).await.is_err() {
+                    return;
                 }
             }
-        })
-        .buffered(max_concurrent_chunks)
-        .flat_map(|result| match result {
-            Ok(ChunkOutput::Items(rows)) => {
-                stream::iter(rows.into_iter().map(|r| Ok(Watermarked::Item(r)))).boxed()
+        }
+    });
+
+    // Built BEFORE the generator and moved in, so dropping the returned stream
+    // (even unpolled) drops the guard and tears the dispatcher down.
+    let dispatcher_guard = AbortOnDrop::new(dispatcher);
+
+    async_stream::try_stream! {
+        let dispatcher_guard = dispatcher_guard;
+        let mut frame_rx = frame_rx;
+        while let Some(frame) = frame_rx.recv().await {
+            match frame {
+                FrameHandle::Items { mut rx, drain, _slot } => {
+                    while let Some(row) = rx.recv().await {
+                        yield Watermarked::Item(row?);
+                    }
+                    // Row channel closed: the drainer finished (or panicked).
+                    // Await it so a hidden panic surfaces instead of a silently
+                    // truncated chunk. `_slot` releases when this arm's
+                    // bindings drop.
+                    surface_panic(drain.await);
+                }
+                FrameHandle::Watermark(pos) => yield Watermarked::Watermark(pos),
+                FrameHandle::Err(e) => Err(e)?,
             }
-            Ok(ChunkOutput::Watermark(pos)) => {
-                stream::once(async move { Ok(Watermarked::Watermark(pos)) }).boxed()
-            }
-            Err(err) => stream::once(async { Err(err) }).boxed(),
-        })
-        .boxed()
+        }
+        // Frame channel closed: the dispatcher finished. Surface a dispatcher
+        // panic the same way.
+        surface_panic(dispatcher_guard.await);
+    }
+    .boxed()
 }
 
 /// One unit of work for `pipelined_chunks`. Items are batched up to the
 /// caller-specified chunk size; watermarks are zero-cost passthroughs that
-/// occupy a slot in the input-order sequence so `buffered()` re-emits them
-/// in place.
+/// occupy a slot in the input-order sequence so the dispatcher forwards them
+/// in place between item frames.
 enum ChunkInput<I> {
     Items(Vec<I>),
     Watermark(u64),
@@ -118,9 +289,10 @@ enum ChunkInput<I> {
 /// dominates have already been emitted to the chunker's output. Items
 /// dominated by held_wm are either in earlier emitted chunks (already
 /// downstream) or in the current `sub` (flushed as a chunk just before the
-/// WM in the same Pending-path or next-Item-path). Downstream
-/// `.buffered(...)` preserves input order, so those chunks' multigets
-/// complete and their items reach the wire before the WM resolves.
+/// WM in the same Pending-path or next-Item-path). The dispatcher forwards
+/// frames in input order over a FIFO handle channel and the consumer drains
+/// each item frame's rows before the next frame, so those chunks' rows reach
+/// the wire before the WM resolves.
 ///
 /// Waker plumbing: the inner ready-drain loop uses `futures::poll!`,
 /// which does not install a waker on `Pending`. We rely on the outer
@@ -205,9 +377,9 @@ where
             // scans (long gaps between items) still surface fresh
             // progress to the wire before the request deadline. The
             // ordering invariant survives because the sub chunk is
-            // queued through `.buffered(...)` strictly before the WM
-            // future: any items the WM dominates are either already on
-            // the wire (earlier chunks) or in this just-flushed sub.
+            // forwarded as a frame strictly before the WM frame: any items
+            // the WM dominates are either already on the wire (earlier
+            // chunks) or in this just-flushed sub.
             if !sub.is_empty() {
                 yield ChunkInput::Items(std::mem::replace(&mut sub, Vec::with_capacity(chunk_size)));
             }
@@ -908,6 +1080,7 @@ where
 mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
@@ -1001,9 +1174,11 @@ mod tests {
         let seen_for_closure = seen.clone();
 
         let stream = pipelined_chunks(upstream, 4, 2, move |chunk: Vec<u64>| {
-            let seen = seen_for_closure.clone();
+            // Record in the SYNCHRONOUS part of the closure: the dispatcher
+            // invokes `f(chunk)` in chunker order, so this captures invocation
+            // order even though the per-chunk drains run concurrently after.
+            seen_for_closure.lock().unwrap().push(chunk.clone());
             async move {
-                seen.lock().unwrap().push(chunk.clone());
                 Ok::<_, RpcError>(stream::iter(chunk.into_iter().map(Ok::<_, RpcError>)).boxed())
             }
         });
@@ -1077,22 +1252,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn does_not_emit_rows_until_chunk_stream_drains() {
+    async fn emits_rows_as_chunk_stream_drains() {
+        // The drainer streams rows to the consumer as they arrive: row 0 must
+        // be observable while the closure's inner stream is still blocked
+        // before row 1 — i.e. WITHOUT the chunk being fully drained first. This
+        // is the whole point of the streaming-drainer design (no per-chunk
+        // drain barrier).
         let upstream = ok_items(0..2u64);
-        let (first_drained_tx, first_drained_rx) = oneshot::channel();
         let (release_second_tx, release_second_rx) = oneshot::channel();
-        let first_drained_tx = Arc::new(Mutex::new(Some(first_drained_tx)));
         let release_second_rx = Arc::new(Mutex::new(Some(release_second_rx)));
 
+        // chunk_size=2 groups [0, 1] into one chunk; the inner stream yields
+        // row 0, then blocks before row 1.
         let stream = pipelined_chunks(upstream, 2, 1, move |chunk: Vec<u64>| {
-            let first_drained_tx = first_drained_tx.clone();
             let release_second_rx = release_second_rx.clone();
             async move {
                 let inner = async_stream::try_stream! {
                     yield chunk[0];
-                    if let Some(tx) = first_drained_tx.lock().unwrap().take() {
-                        let _ = tx.send(());
-                    }
                     let release_second_rx = release_second_rx
                         .lock()
                         .unwrap()
@@ -1107,16 +1283,17 @@ mod tests {
 
         let stream = items_only(stream);
         futures::pin_mut!(stream);
-        let next = stream.try_next();
-        tokio::pin!(next);
-        tokio::select! {
-            item = &mut next => panic!("row emitted before chunk drained: {item:?}"),
-            res = first_drained_rx => res.expect("first row drained inside helper"),
-        }
 
-        release_second_tx.send(()).expect("release receiver alive");
-        let first = next.await.expect("ok").expect("some");
+        // Row 0 reaches the consumer before we release row 1.
+        let first = timeout(Duration::from_secs(1), stream.try_next())
+            .await
+            .expect("row 0 should be emitted before the chunk fully drains")
+            .expect("ok")
+            .expect("some");
         assert_eq!(first, 0);
+
+        // Release row 1; the rest streams through in order.
+        release_second_tx.send(()).expect("release receiver alive");
         let second = stream.try_next().await.expect("ok").expect("some");
         assert_eq!(second, 1);
         assert!(stream.try_next().await.expect("ok").is_none());
@@ -1124,6 +1301,8 @@ mod tests {
 
     #[tokio::test]
     async fn propagates_inner_stream_error() {
+        // Prefix-then-error: the row drained before the inner error must reach
+        // the consumer, followed by the error (not all-or-nothing).
         let upstream = ok_items(0..3u64);
         let stream = pipelined_chunks(upstream, 3, 1, |chunk: Vec<u64>| async move {
             let inner = async_stream::try_stream! {
@@ -1133,8 +1312,19 @@ mod tests {
             };
             Ok::<_, RpcError>(inner.boxed())
         });
-        let result: Result<Vec<u64>, RpcError> = items_only(stream).try_collect().await;
-        assert!(result.is_err());
+        let stream = items_only(stream);
+        futures::pin_mut!(stream);
+        assert_eq!(
+            stream.try_next().await.expect("prefix row emitted"),
+            Some(0),
+            "the prefix row before the inner error must reach the consumer"
+        );
+        let err = stream
+            .try_next()
+            .await
+            .expect_err("inner error after prefix");
+        let status: tonic::Status = err.into();
+        assert_eq!(status.message(), "inner stream boom");
     }
 
     #[tokio::test]
@@ -1195,6 +1385,203 @@ mod tests {
         handle.abort();
         let _ = handle.await;
         wait_for_available_permits(&limiter, 1).await;
+    }
+
+    #[tokio::test]
+    async fn drainer_does_not_block_on_stalled_consumer() {
+        // The drainer holds the BigTable permit while draining and MUST NOT
+        // block on the consumer: a bounded row channel would let a stalled
+        // consumer wedge the drainer and hold the permit across downstream
+        // backpressure (the deadlock class this design removes). With the
+        // consumer fully stalled, a chunk of several rows must still drain to
+        // completion. Guards the unbounded/non-blocking row channel choice — a
+        // bounded blocking channel would leave `drained` false.
+        struct SetOnDrop(Arc<AtomicBool>);
+        impl Drop for SetOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let drained = Arc::new(AtomicBool::new(false));
+        let upstream = ok_items(0..5u64); // chunk_size = 5 → one chunk of 5 rows
+        let stream = pipelined_chunks(upstream, 5, 1, {
+            let drained = drained.clone();
+            move |chunk: Vec<u64>| {
+                let drained = drained.clone();
+                async move {
+                    let inner = async_stream::try_stream! {
+                        // Dropped only once the drainer finishes draining every
+                        // row — which can't happen if a send blocked.
+                        let _done = SetOnDrop(drained.clone());
+                        for x in chunk {
+                            yield x;
+                        }
+                    };
+                    Ok::<_, RpcError>(inner.boxed())
+                }
+            }
+        });
+
+        // Hold the stream WITHOUT consuming; eager dispatch runs the drainer.
+        let _stream = stream;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            drained.load(Ordering::SeqCst),
+            "drainer failed to complete with a stalled consumer (blocked on send?)"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_releases_permit_of_queued_frame() {
+        // With N>1 and a consumer that never pulls, the eager dispatcher spawns
+        // drainers for queued frames ahead of consumption — each acquires a
+        // BigTable permit. Dropping the output must abort those queued drainers
+        // (via their FrameHandle's AbortOnDrop) and release their permits.
+        let upstream = ok_items(0..4u64);
+        let limiter = Arc::new(Semaphore::new(4));
+
+        let stream = pipelined_chunks(upstream, 1, 4, {
+            let limiter = limiter.clone();
+            move |chunk: Vec<u64>| {
+                let limiter = limiter.clone();
+                async move {
+                    let inner = async_stream::try_stream! {
+                        let permit = limiter.clone().acquire_owned().await.map_err(|_| {
+                            RpcError::new(tonic::Code::Internal, "test limiter closed")
+                        })?;
+                        let _permit = permit;
+                        yield chunk[0];
+                        // Hold the permit open after emitting so the frame stays
+                        // queued (unconsumed) with a live permit.
+                        std::future::pending::<()>().await;
+                    };
+                    Ok::<_, RpcError>(inner.boxed())
+                }
+            }
+        });
+
+        // Eager dispatch: drainers run and acquire all 4 permits without the
+        // consumer polling.
+        wait_for_available_permits(&limiter, 0).await;
+        drop(stream);
+        wait_for_available_permits(&limiter, 4).await;
+    }
+
+    #[tokio::test]
+    async fn bounded_in_flight_with_stalled_consumer() {
+        // Eager dispatch must not run unboundedly ahead of a stalled consumer:
+        // at most max_concurrent_chunks item-frame drainers active at once
+        // (the drainer-slot semaphore, held until each frame is consumed).
+        let upstream = ok_items(0..50u64);
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let stream = pipelined_chunks(upstream, 1, 3, {
+            let active = active.clone();
+            let peak = peak.clone();
+            move |chunk: Vec<u64>| {
+                let guard = ActiveGuard::new(active.clone(), peak.clone());
+                async move {
+                    let inner = async_stream::try_stream! {
+                        let _guard = guard;
+                        yield chunk[0];
+                        // Stay alive (slot held) so the consumer stall is what
+                        // bounds concurrency.
+                        std::future::pending::<()>().await;
+                    };
+                    Ok::<_, RpcError>(inner.boxed())
+                }
+            }
+        });
+
+        // Hold the stream (dispatcher eager) WITHOUT consuming.
+        let _stream = stream;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            peak.load(Ordering::SeqCst) <= 3,
+            "ran unboundedly ahead of a stalled consumer: peak {}",
+            peak.load(Ordering::SeqCst)
+        );
+        assert!(
+            peak.load(Ordering::SeqCst) >= 1,
+            "dispatcher should have started at least one drainer"
+        );
+    }
+
+    #[tokio::test]
+    async fn drainer_panic_surfaces_rather_than_truncating() {
+        use futures::FutureExt;
+        // A drainer task that panics mid-stream must surface to the consumer
+        // (via the joined handle), not silently truncate the chunk. The
+        // `black_box` keeps the panic out of the compiler's reachability
+        // analysis so the trailing `yield` stays statically reachable.
+        let upstream = ok_items(0..1u64);
+        let stream = pipelined_chunks(upstream, 1, 1, |_chunk: Vec<u64>| async move {
+            let inner = async_stream::try_stream! {
+                yield 0u64;
+                if std::hint::black_box(true) {
+                    panic!("drainer boom");
+                }
+                yield 1u64;
+            };
+            Ok::<_, RpcError>(inner.boxed())
+        });
+
+        let outcome = std::panic::AssertUnwindSafe(items_only(stream).try_collect::<Vec<u64>>())
+            .catch_unwind()
+            .await;
+        assert!(
+            outcome.is_err(),
+            "drainer panic must surface, not silently truncate the stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn sparse_watermarks_apply_backpressure() {
+        // A sparse stream of watermarks (no items, so no drainer slots) must
+        // still be bounded by the handle channel: with a stalled consumer the
+        // dispatcher pulls at most ~max_concurrent_chunks watermarks ahead, not
+        // the whole stream. Each watermark is separated by a real Pending (the
+        // sleep) so the chunker flushes them as individual frames rather than
+        // debouncing them all into one.
+        let pulled = Arc::new(AtomicUsize::new(0));
+        let total = 50u64;
+        let n = 3usize;
+        let upstream = {
+            let pulled = pulled.clone();
+            stream::unfold(0u64, move |i| {
+                let pulled = pulled.clone();
+                async move {
+                    if i >= total {
+                        return None;
+                    }
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    pulled.fetch_add(1, Ordering::SeqCst);
+                    Some((Ok::<_, RpcError>(Watermarked::Watermark(i)), i + 1))
+                }
+            })
+            .boxed()
+        };
+
+        // Closure never runs (no item frames); identity passthrough.
+        let stream = pipelined_chunks(upstream, 10, n, |chunk: Vec<u64>| async move {
+            Ok::<_, RpcError>(stream::iter(chunk.into_iter().map(Ok::<_, RpcError>)).boxed())
+        });
+
+        // Hold the stream without consuming; the dispatcher must stall on the
+        // bounded handle channel instead of draining all 50 watermarks.
+        let _stream = stream;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let pulled_now = pulled.load(Ordering::SeqCst);
+        assert!(
+            pulled_now <= n + 3,
+            "dispatcher ran unboundedly ahead of a stalled consumer: pulled {pulled_now} (bound ~{n})"
+        );
+        assert!(
+            pulled_now >= 1,
+            "dispatcher should have pulled at least one watermark"
+        );
     }
 
     #[tokio::test]

--- a/crates/sui-rpc-api/src/grpc/deadline.rs
+++ b/crates/sui-rpc-api/src/grpc/deadline.rs
@@ -116,10 +116,9 @@ where
                             )))?;
                         }
                         Err(_) => {
-                            // Cancellation — only possible if the abort
-                            // guard fired (which only happens on Drop), so
-                            // we shouldn't be polling. Treat as EOF.
-                            break;
+                            // Cancellation — only reachable at runtime shutdown
+                            // (our abort guard fires on Drop, when we wouldn't be
+                            // polling), so EOF is harmless.                             break;
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Rewriting the evaluation code in a simpler way that eliminates a bunch of possible problems. I initially designed this to be composable into arbitrarily nested queries, but since we force everything to be DNF at the proto level, that's not really necessary. This new design just scans each leaf up to the floor in lock-step (so branches in a disjunction can't run way ahead of each other).

This reduces the amount of potential re-scanning we have to do on a resumption requestion, and eliminates a lot of the watermark propagation complexity.
