### PR TITLE
ci(release): build only packaged binaries, stop building sui twice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,11 +167,20 @@ jobs:
         if: ${{ env.s3_existing_archive == '' }}
         shell: bash
         run: |
-          # Build everything except `sui` first, then build `sui` once with the
-          # tracing feature. Previously the bulk `cargo build --release` compiled
-          # `sui` without tracing and the next step immediately recompiled+overwrote
-          # it with tracing — a wasted compile+link of `sui` on every platform.
-          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release --workspace --exclude sui && cargo build --release --features tracing --bin sui && cargo build --profile=dev --bin sui --features tracing
+          [ -f ~/.cargo/env ] && source ~/.cargo/env
+          # Build only the binaries we actually package (the release_binaries in
+          # binary-build-list.json — the same list the rename step below moves),
+          # not the whole workspace. `sui` is built separately, once, with the
+          # tracing feature: a plain `cargo build --release` compiled `sui` without
+          # tracing and the next step overwrote it, wasting a compile+link of `sui`
+          # on every platform.
+          sui_bins=""
+          for b in $(jq -r '.release_binaries[] | select(. != "sui")' "${{ env.BINARY_LIST_FILE }}"); do
+            sui_bins="$sui_bins --bin $(echo "$b" | tr -d $'\r')"
+          done
+          cargo build --release $sui_bins
+          cargo build --release --features tracing --bin sui
+          cargo build --profile=dev --bin sui --features tracing
 
       - name: Rename binaries for ${{ matrix.os }}
         if: ${{ env.s3_existing_archive == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,11 @@ jobs:
         if: ${{ env.s3_existing_archive == '' }}
         shell: bash
         run: |
-          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release && cargo build --release --features tracing --bin sui && cargo build --profile=dev --bin sui --features tracing
+          # Build everything except `sui` first, then build `sui` once with the
+          # tracing feature. Previously the bulk `cargo build --release` compiled
+          # `sui` without tracing and the next step immediately recompiled+overwrote
+          # it with tracing — a wasted compile+link of `sui` on every platform.
+          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release --workspace --exclude sui && cargo build --release --features tracing --bin sui && cargo build --profile=dev --bin sui --features tracing
 
       - name: Rename binaries for ${{ matrix.os }}
         if: ${{ env.s3_existing_archive == '' }}

--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -92,13 +92,7 @@ jobs:
         shell: bash
         run: |
           [ -f ~/.cargo/env ] && source ~/.cargo/env
-          # Exclude `sui` from the bulk build and build it once with tracing.
-          # A plain `cargo build --release` compiles `sui` without tracing and the
-          # next step rebuilds it with tracing, so the non-tracing `sui` binary was
-          # wasted work — and release.yml only ever builds `sui` with tracing, so
-          # the non-tracing-release `sui` object warms a cache nothing consumes.
-          # The bulk build still warms the rest of the workspace in release mode.
-          cargo build --release --workspace --exclude sui
+          cargo build --release
           cargo build --release --features tracing --bin sui
           cargo build --profile=dev --bin sui --features tracing
 

--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -92,7 +92,13 @@ jobs:
         shell: bash
         run: |
           [ -f ~/.cargo/env ] && source ~/.cargo/env
-          cargo build --release
+          # Exclude `sui` from the bulk build and build it once with tracing.
+          # A plain `cargo build --release` compiles `sui` without tracing and the
+          # next step rebuilds it with tracing, so the non-tracing `sui` binary was
+          # wasted work — and release.yml only ever builds `sui` with tracing, so
+          # the non-tracing-release `sui` object warms a cache nothing consumes.
+          # The bulk build still warms the rest of the workspace in release mode.
+          cargo build --release --workspace --exclude sui
           cargo build --release --features tracing --bin sui
           cargo build --profile=dev --bin sui --features tracing
 


### PR DESCRIPTION
## Summary

`release.yml` compiled the `sui` binary **twice** per platform and built the **whole workspace** when only a handful of binaries are packaged:

```
cargo build --release                               # builds sui WITHOUT tracing + every workspace member
cargo build --release --features tracing --bin sui  # recompiles+overwrites sui WITH tracing
cargo build --profile=dev --bin sui --features tracing   # sui-debug
```

`--features tracing` doesn't change the output path, so the second invocation overwrote the first `sui` — the non-tracing `sui` was built then **discarded** on every platform (5×), never packaged.

This scopes the build to exactly the **`binary-build-list.json` `release_binaries`** (the same list the `Rename binaries` step moves) and builds `sui` once with tracing:

```bash
sui_bins=""
for b in $(jq -r '.release_binaries[] | select(. != "sui")' "$BINARY_LIST_FILE"); do
  sui_bins="$sui_bins --bin $(echo "$b" | tr -d $'\r')"
done
cargo build --release $sui_bins
cargo build --release --features tracing --bin sui
cargo build --profile=dev --bin sui --features tracing
```

**Wins:** `sui` compiled once instead of twice; the bulk build no longer compiles unpackaged workspace members (internal binaries, etc.).

## Safe / backwards-compatible

- **Output is identical**: same 8 `release_binaries` + `sui-debug`, `sui` still built `--features tracing`, same tarball / S3 upload / rename. The release artifact is unchanged.
- All 8 `release_binaries` (`sui, sui-node, sui-tool, sui-faucet, sui-bridge, sui-bridge-cli, sui-fork, move-analyzer`) are valid, unambiguous `--bin` targets in distinct packages — verified via `cargo metadata --no-deps` (`move-analyzer` → `sui-move-lsp`).
- No `default-members`, so the old bare `cargo build --release` built the whole workspace; we now build only the packaged subset.
- `jq` + `tr -d $'\r'` mirror the existing `Rename binaries` step (already runs `jq` on all 5 platforms incl. Windows git-bash).
- Edge case: if `binary-build-list.json` is missing, `$sui_bins` is empty → falls back to `cargo build --release` (whole workspace); the rename step already hard-fails on a missing file. No new failure mode.

## Caveats (low risk)

- **Feature unification**: building the packaged subset changes Cargo's feature-unification scope vs. a whole-workspace build. With `resolver = "2"` (this workspace) features are already isolated per-target, so a release binary would only differ if it relied on a feature *leaked* from a now-unbuilt member — a pre-existing latent bug, not introduced here. Flagged for sanity-check on first release.
- **Not exercisable by PR CI**: `release.yml` runs only on `release: created` / `workflow_dispatch`, so the Rust jobs show `skipping` (expected). This first runs on the next real release.

## sccache-warmup.yml — intentionally untouched

The warmup has the same `cargo build --release` + tracing-`sui` pattern, but there the compiled objects land in **sccache as cache entries that persist** (not discarded like release.yml's overwritten binary). Building both default and tracing variants is deliberate coverage — `rust.yml` builds default-features release `sui` (`cargo build --release …--bin sui --bin stress`), so that cache *is* consumed. "Fixing" the warmup would remove useful coverage, so it's left as-is.

## Test plan

- [x] Diff scope is `release.yml` only; mergeable/clean.
- [x] All 8 `release_binaries` confirmed valid, distinct `--bin` targets (`cargo metadata`).
- [x] `sui` built once (release+tracing); `sui-debug` (dev+tracing) preserved; rename step finds every artifact.
- [ ] **Next release (or a `workflow_dispatch` against an unbuilt tag)**: confirm the tarball contains all 8 `release_binaries` + `sui-debug`, and `sui --version`/behavior shows tracing is present.
- [ ] Sanity-check the released binaries behave identically to a prior release (guards against the feature-unification caveat).
- [ ] Confirm per-platform build time drops (one fewer `sui` compile+link, no unpackaged-member builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)