### PR TITLE
Enable gas priority tx admission queue by default

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1485,7 +1485,7 @@ fn default_admission_queue_bypass_fraction() -> f64 {
 }
 
 fn default_admission_queue_enabled() -> bool {
-    false
+    true
 }
 
 fn default_admission_queue_failover_timeout() -> Duration {

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -154,7 +154,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
       admission-queue-bypass-fraction: 0.9
-      admission-queue-enabled: false
+      admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
@@ -333,7 +333,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
       admission-queue-bypass-fraction: 0.9
-      admission-queue-enabled: false
+      admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
@@ -512,7 +512,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
       admission-queue-bypass-fraction: 0.9
-      admission-queue-enabled: false
+      admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
@@ -691,7 +691,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
       admission-queue-bypass-fraction: 0.9
-      admission-queue-enabled: false
+      admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
@@ -870,7 +870,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
       admission-queue-bypass-fraction: 0.9
-      admission-queue-enabled: false
+      admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
@@ -1049,7 +1049,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
       admission-queue-bypass-fraction: 0.9
-      admission-queue-enabled: false
+      admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
@@ -1228,7 +1228,7 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
       admission-queue-bypass-fraction: 0.9
-      admission-queue-enabled: false
+      admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0


### PR DESCRIPTION
Flips `admission_queue_enabled` to default `true`.

When consensus is saturated, transactions are now load-shed through the priority queue (evicting the lowest gas-price entries) rather than being rejected outright with `TooManyTransactionsPendingConsensus`. The queue still has a failover path that reverts to the reject behavior if it stops making forward progress.

The `network_config_snapshot_matches` snapshot is updated to reflect the new default.