### PR TITLE
[graphql-stream] Add cursor field to Checkpoint [13/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15297,6 +15297,7 @@ name = "sui-indexer-alt-e2e-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-graphql",
  "async-stream",
  "async-trait",
  "bcs",

--- a/crates/sui-indexer-alt-e2e-tests/Cargo.toml
+++ b/crates/sui-indexer-alt-e2e-tests/Cargo.toml
@@ -62,6 +62,7 @@ sui-simulator.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+async-graphql.workspace = true
 async-trait.workspace = true
 coset.workspace = true
 prost-types.workspace = true

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
@@ -6,7 +6,9 @@
 //! `TestClusterBuilder` validator, neither of which works inside the simulator's
 //! deterministic runtime.
 
+use async_graphql::connection::CursorType;
 use serde_json::json;
+use sui_indexer_alt_graphql::CCheckpoint;
 use tokio_stream::StreamExt;
 
 use crate::testing::SubscriptionTestCluster;
@@ -23,7 +25,7 @@ async fn test_subscription_sequential() {
     let cluster = SubscriptionTestCluster::new().await;
 
     let items: Vec<_> = cluster
-        .subscribe("subscription { checkpoints { sequenceNumber } }")
+        .subscribe("subscription { checkpoints { node { sequenceNumber } } }")
         .await
         .take(3)
         .collect()
@@ -34,6 +36,25 @@ async fn test_subscription_sequential() {
 }
 
 #[tokio::test]
+async fn test_subscription_cursor() {
+    let cluster = SubscriptionTestCluster::new().await;
+
+    let items: Vec<_> = cluster
+        .subscribe("subscription { checkpoints { cursor node { sequenceNumber } } }")
+        .await
+        .take(3)
+        .collect()
+        .await;
+
+    for item in &items {
+        let edge = &item["data"]["checkpoints"];
+        let cursor = edge["cursor"].as_str().unwrap();
+        let seq = edge["node"]["sequenceNumber"].as_u64().unwrap();
+        assert_eq!(cursor, CCheckpoint::new(seq).encode_cursor());
+    }
+}
+
+#[tokio::test]
 async fn test_subscription_fields() {
     let cluster = SubscriptionTestCluster::new().await;
 
@@ -41,23 +62,25 @@ async fn test_subscription_fields() {
         .subscribe(
             r#"subscription {
                 checkpoints {
-                    sequenceNumber
-                    digest
-                    contentDigest
-                    timestamp
-                    networkTotalTransactions
-                    rollingGasSummary {
-                        computationCost
-                        storageCost
-                        storageRebate
-                        nonRefundableStorageFee
-                    }
-                    epoch {
-                        epochId
-                    }
-                    validatorSignatures {
-                        signature
-                        signersMap
+                    node {
+                        sequenceNumber
+                        digest
+                        contentDigest
+                        timestamp
+                        networkTotalTransactions
+                        rollingGasSummary {
+                            computationCost
+                            storageCost
+                            storageRebate
+                            nonRefundableStorageFee
+                        }
+                        epoch {
+                            epochId
+                        }
+                        validatorSignatures {
+                            signature
+                            signersMap
+                        }
                     }
                 }
             }"#,
@@ -81,19 +104,21 @@ async fn test_subscription_transactions() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 checkpoints {
-                    sequenceNumber
-                    transactions(filter: { sentAddress: $sender }) {
-                        nodes {
-                            digest
-                            sender { address }
-                            gasInput { gasBudget }
-                            effects {
-                                status
-                                balanceChanges {
-                                    nodes {
-                                        amount
-                                        coinType { repr }
-                                        owner { address }
+                    node {
+                        sequenceNumber
+                        transactions(filter: { sentAddress: $sender }) {
+                            nodes {
+                                digest
+                                sender { address }
+                                gasInput { gasBudget }
+                                effects {
+                                    status
+                                    balanceChanges {
+                                        nodes {
+                                            amount
+                                            coinType { repr }
+                                            owner { address }
+                                        }
                                     }
                                 }
                             }
@@ -122,22 +147,24 @@ async fn test_subscription_transactions_pagination_first() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 checkpoints {
-                    sequenceNumber
-                    transactions(first: 1, filter: { sentAddress: $sender }) {
-                        nodes {
-                            digest
-                            effects {
-                                status
-                                balanceChanges {
-                                    nodes {
-                                        amount
-                                        coinType { repr }
+                    node {
+                        sequenceNumber
+                        transactions(first: 1, filter: { sentAddress: $sender }) {
+                            nodes {
+                                digest
+                                effects {
+                                    status
+                                    balanceChanges {
+                                        nodes {
+                                            amount
+                                            coinType { repr }
+                                        }
                                     }
                                 }
                             }
+                            edges { cursor }
+                            pageInfo { hasNextPage hasPreviousPage }
                         }
-                        edges { cursor }
-                        pageInfo { hasNextPage hasPreviousPage }
                     }
                 }
             }"#,
@@ -161,22 +188,24 @@ async fn test_subscription_transactions_pagination_last() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 checkpoints {
-                    sequenceNumber
-                    transactions(last: 1, filter: { sentAddress: $sender }) {
-                        nodes {
-                            digest
-                            effects {
-                                status
-                                balanceChanges {
-                                    nodes {
-                                        amount
-                                        coinType { repr }
+                    node {
+                        sequenceNumber
+                        transactions(last: 1, filter: { sentAddress: $sender }) {
+                            nodes {
+                                digest
+                                effects {
+                                    status
+                                    balanceChanges {
+                                        nodes {
+                                            amount
+                                            coinType { repr }
+                                        }
                                     }
                                 }
                             }
+                            edges { cursor }
+                            pageInfo { hasNextPage hasPreviousPage }
                         }
-                        edges { cursor }
-                        pageInfo { hasNextPage hasPreviousPage }
                     }
                 }
             }"#,
@@ -203,27 +232,29 @@ async fn test_subscription_object_create() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 checkpoints {
-                    sequenceNumber
-                    transactions(filter: { sentAddress: $sender }) {
-                        nodes {
-                            digest
-                            effects {
-                                objectChanges {
-                                    nodes {
-                                        inputState {
-                                            address
-                                            version
-                                            digest
-                                            asMoveObject {
-                                                contents { type { repr } }
+                    node {
+                        sequenceNumber
+                        transactions(filter: { sentAddress: $sender }) {
+                            nodes {
+                                digest
+                                effects {
+                                    objectChanges {
+                                        nodes {
+                                            inputState {
+                                                address
+                                                version
+                                                digest
+                                                asMoveObject {
+                                                    contents { type { repr } }
+                                                }
                                             }
-                                        }
-                                        outputState {
-                                            address
-                                            version
-                                            digest
-                                            asMoveObject {
-                                                contents { type { repr } }
+                                            outputState {
+                                                address
+                                                version
+                                                digest
+                                                asMoveObject {
+                                                    contents { type { repr } }
+                                                }
                                             }
                                         }
                                     }
@@ -256,27 +287,29 @@ async fn test_subscription_object_lifecycle() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 checkpoints {
-                    sequenceNumber
-                    transactions(filter: { sentAddress: $sender }) {
-                        nodes {
-                            digest
-                            effects {
-                                objectChanges {
-                                    nodes {
-                                        inputState {
-                                            address
-                                            version
-                                            digest
-                                            asMoveObject {
-                                                contents { type { repr } }
+                    node {
+                        sequenceNumber
+                        transactions(filter: { sentAddress: $sender }) {
+                            nodes {
+                                digest
+                                effects {
+                                    objectChanges {
+                                        nodes {
+                                            inputState {
+                                                address
+                                                version
+                                                digest
+                                                asMoveObject {
+                                                    contents { type { repr } }
+                                                }
                                             }
-                                        }
-                                        outputState {
-                                            address
-                                            version
-                                            digest
-                                            asMoveObject {
-                                                contents { type { repr } }
+                                            outputState {
+                                                address
+                                                version
+                                                digest
+                                                asMoveObject {
+                                                    contents { type { repr } }
+                                                }
                                             }
                                         }
                                     }
@@ -323,25 +356,27 @@ async fn test_subscription_object_json() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 checkpoints {
-                    transactions(filter: { sentAddress: $sender }) {
-                        nodes {
-                            digest
-                            effects {
-                                objectChanges {
-                                    nodes {
-                                        inputState {
-                                            asMoveObject {
-                                                contents {
-                                                    type { repr }
-                                                    json
+                    node {
+                        transactions(filter: { sentAddress: $sender }) {
+                            nodes {
+                                digest
+                                effects {
+                                    objectChanges {
+                                        nodes {
+                                            inputState {
+                                                asMoveObject {
+                                                    contents {
+                                                        type { repr }
+                                                        json
+                                                    }
                                                 }
                                             }
-                                        }
-                                        outputState {
-                                            asMoveObject {
-                                                contents {
-                                                    type { repr }
-                                                    json
+                                            outputState {
+                                                asMoveObject {
+                                                    contents {
+                                                        type { repr }
+                                                        json
+                                                    }
                                                 }
                                             }
                                         }
@@ -391,7 +426,7 @@ async fn test_subscription_recovers_from_upstream_disconnect() {
     let (cluster, proxy) = SubscriptionTestCluster::new_with_disruption_proxy().await;
 
     let mut stream = cluster
-        .subscribe("subscription { checkpoints { sequenceNumber } }")
+        .subscribe("subscription { checkpoints { node { sequenceNumber } } }")
         .await;
 
     // Healthy streaming.

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -18,11 +18,11 @@ use crate::testing::emit_event_harness;
 use crate::testing::graphql_redactions;
 
 fn event_value(item: &Value) -> Option<&str> {
-    item["data"]["events"]["contents"]["json"]["value"].as_str()
+    item["data"]["events"]["node"]["contents"]["json"]["value"].as_str()
 }
 
 fn event_bcs(item: &Value) -> Option<&str> {
-    item["data"]["events"]["eventBcs"].as_str()
+    item["data"]["events"]["node"]["eventBcs"].as_str()
 }
 
 #[tokio::test]
@@ -34,14 +34,16 @@ async fn test_event_subscription() {
         .subscribe_with_variables(
             r#"subscription($pkg: SuiAddress!) {
                 events(filter: { type: $pkg }) {
-                    sender { address }
-                    transaction { digest }
-                    contents {
-                        type { repr }
-                        json
+                    node {
+                        sender { address }
+                        transaction { digest }
+                        contents {
+                            type { repr }
+                            json
+                        }
+                        sequenceNumber
+                        timestamp
                     }
-                    sequenceNumber
-                    timestamp
                 }
             }"#,
             Some(json!({ "pkg": package_id.to_string() })),
@@ -66,8 +68,10 @@ async fn test_event_subscription_sender_filter() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 events(filter: { sender: $sender }) {
-                    sender { address }
-                    contents { type { repr } }
+                    node {
+                        sender { address }
+                        contents { type { repr } }
+                    }
                 }
             }"#,
             Some(json!({ "sender": sender.to_string() })),
@@ -94,13 +98,15 @@ async fn test_event_subscription_transaction_fields() {
         .subscribe_with_variables(
             r#"subscription($pkg: SuiAddress!) {
                 events(filter: { type: $pkg }) {
-                    transaction {
-                        digest
-                        sender { address }
-                        kind { __typename }
-                        gasInput { gasBudget gasPrice }
+                    node {
+                        transaction {
+                            digest
+                            sender { address }
+                            kind { __typename }
+                            gasInput { gasBudget gasPrice }
+                        }
+                        contents { type { repr } }
                     }
-                    contents { type { repr } }
                 }
             }"#,
             Some(json!({ "pkg": package_id.to_string() })),
@@ -132,17 +138,19 @@ async fn test_event_subscription_as_transaction_object_change() {
         .subscribe_with_variables(
             r#"subscription($pkg: SuiAddress!) {
                 events(filter: { type: $pkg }) {
-                    contents {
-                        extract(path: "address_event_id") {
-                            asAddress {
-                                asTransactionObject {
-                                    __typename
-                                    ... on ObjectChange {
-                                        inputState {
-                                            asMoveObject { contents { json } }
-                                        }
-                                        outputState {
-                                            asMoveObject { contents { json } }
+                    node {
+                        contents {
+                            extract(path: "address_event_id") {
+                                asAddress {
+                                    asTransactionObject {
+                                        __typename
+                                        ... on ObjectChange {
+                                            inputState {
+                                                asMoveObject { contents { json } }
+                                            }
+                                            outputState {
+                                                asMoveObject { contents { json } }
+                                            }
                                         }
                                     }
                                 }
@@ -181,14 +189,16 @@ async fn test_event_subscription_as_transaction_object_consensus_read() {
         .subscribe_with_variables(
             r#"subscription($pkg: SuiAddress!) {
                 events(filter: { type: $pkg }) {
-                    contents {
-                        extract(path: "address_event_id") {
-                            asAddress {
-                                asTransactionObject {
-                                    __typename
-                                    ... on ConsensusObjectRead {
-                                        object {
-                                            asMoveObject { contents { type { repr } } }
+                    node {
+                        contents {
+                            extract(path: "address_event_id") {
+                                asAddress {
+                                    asTransactionObject {
+                                        __typename
+                                        ... on ConsensusObjectRead {
+                                            object {
+                                                asMoveObject { contents { type { repr } } }
+                                            }
                                         }
                                     }
                                 }
@@ -225,17 +235,19 @@ async fn test_event_subscription_object_changes() {
         .subscribe_with_variables(
             r#"subscription($pkg: SuiAddress!) {
                 events(filter: { type: $pkg }) {
-                    transaction {
-                        effects {
-                            status
-                            objectChanges {
-                                nodes {
-                                    outputState {
-                                        address
-                                        version
-                                        digest
-                                        asMoveObject {
-                                            contents { type { repr } }
+                    node {
+                        transaction {
+                            effects {
+                                status
+                                objectChanges {
+                                    nodes {
+                                        outputState {
+                                            address
+                                            version
+                                            digest
+                                            asMoveObject {
+                                                contents { type { repr } }
+                                            }
                                         }
                                     }
                                 }
@@ -265,7 +277,9 @@ async fn test_event_subscription_module_filter() {
         .subscribe_with_variables(
             r#"subscription($mod: String!) {
                 events(filter: { module: $mod }) {
-                    contents { type { repr } }
+                    node {
+                        contents { type { repr } }
+                    }
                 }
             }"#,
             Some(json!({ "mod": format!("{}::emit_test_event", package_id) })),
@@ -296,8 +310,10 @@ async fn test_event_subscription_recovers_from_upstream_disconnect() {
         .subscribe_with_variables(
             r#"subscription($pkg: SuiAddress!) {
                 events(filter: { type: $pkg }) {
-                    eventBcs
-                    contents { json }
+                    node {
+                        eventBcs
+                        contents { json }
+                    }
                 }
             }"#,
             Some(json!({ "pkg": package_id.to_string() })),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_fields.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_fields.snap
@@ -5,25 +5,27 @@ expression: item
 {
   "data": {
     "checkpoints": {
-      "sequenceNumber": "[seq]",
-      "digest": "[digest]",
-      "contentDigest": "[contentDigest]",
-      "timestamp": "[timestamp]",
-      "networkTotalTransactions": "[networkTotalTransactions]",
-      "rollingGasSummary": {
-        "computationCost": 0,
-        "storageCost": 0,
-        "storageRebate": 0,
-        "nonRefundableStorageFee": 0
-      },
-      "epoch": {
-        "epochId": 0
-      },
-      "validatorSignatures": {
-        "signature": "[signature]",
-        "signersMap": [
-          0
-        ]
+      "node": {
+        "sequenceNumber": "[seq]",
+        "digest": "[digest]",
+        "contentDigest": "[contentDigest]",
+        "timestamp": "[timestamp]",
+        "networkTotalTransactions": "[networkTotalTransactions]",
+        "rollingGasSummary": {
+          "computationCost": 0,
+          "storageCost": 0,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        },
+        "epoch": {
+          "epochId": 0
+        },
+        "validatorSignatures": {
+          "signature": "[signature]",
+          "signersMap": [
+            0
+          ]
+        }
       }
     }
   }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_object_create.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_object_create.snap
@@ -5,60 +5,62 @@ expression: item
 {
   "data": {
     "checkpoints": {
-      "sequenceNumber": "[seq]",
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "[digest]",
-            "effects": {
-              "objectChanges": {
-                "nodes": [
-                  {
-                    "inputState": {
-                      "address": "[address]",
-                      "version": "[version]",
-                      "digest": "[digest]",
-                      "asMoveObject": {
-                        "contents": {
-                          "type": {
-                            "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+      "node": {
+        "sequenceNumber": "[seq]",
+        "transactions": {
+          "nodes": [
+            {
+              "digest": "[digest]",
+              "effects": {
+                "objectChanges": {
+                  "nodes": [
+                    {
+                      "inputState": {
+                        "address": "[address]",
+                        "version": "[version]",
+                        "digest": "[digest]",
+                        "asMoveObject": {
+                          "contents": {
+                            "type": {
+                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                            }
+                          }
+                        }
+                      },
+                      "outputState": {
+                        "address": "[address]",
+                        "version": "[version]",
+                        "digest": "[digest]",
+                        "asMoveObject": {
+                          "contents": {
+                            "type": {
+                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                            }
                           }
                         }
                       }
                     },
-                    "outputState": {
-                      "address": "[address]",
-                      "version": "[version]",
-                      "digest": "[digest]",
-                      "asMoveObject": {
-                        "contents": {
-                          "type": {
-                            "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                    {
+                      "inputState": null,
+                      "outputState": {
+                        "address": "[address]",
+                        "version": "[version]",
+                        "digest": "[digest]",
+                        "asMoveObject": {
+                          "contents": {
+                            "type": {
+                              "repr": "[pkg]::wrapping::Item"
+                            }
                           }
                         }
                       }
                     }
-                  },
-                  {
-                    "inputState": null,
-                    "outputState": {
-                      "address": "[address]",
-                      "version": "[version]",
-                      "digest": "[digest]",
-                      "asMoveObject": {
-                        "contents": {
-                          "type": {
-                            "repr": "[pkg]::wrapping::Item"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
+                  ]
+                }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     }
   }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_object_json.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_object_json.snap
@@ -6,62 +6,64 @@ expression: "[cp1, cp2, cp3, cp4]"
   {
     "data": {
       "checkpoints": {
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "30000000000000000"
+        "node": {
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "30000000000000000"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "29999999996666800"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "29999999996666800"
+                      {
+                        "inputState": null,
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "value": "42"
+                              }
                             }
                           }
                         }
                       }
-                    },
-                    {
-                      "inputState": null,
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "value": "42"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }
@@ -69,143 +71,63 @@ expression: "[cp1, cp2, cp3, cp4]"
   {
     "data": {
       "checkpoints": {
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "30000000000000000"
+        "node": {
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "30000000000000000"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "29999999997998548"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "29999999997998548"
+                      {
+                        "inputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "value": "42"
+                              }
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "inputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "value": "42"
-                            }
-                          }
-                        }
-                      },
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "value": "100"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  {
-    "data": {
-      "checkpoints": {
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "30000000000000000"
-                            }
-                          }
-                        }
-                      },
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "29999999997732548"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "inputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "value": "100"
-                            }
-                          }
-                        }
-                      },
-                      "outputState": null
-                    },
-                    {
-                      "inputState": null,
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Wrapper"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "item": {
+                        },
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              },
+                              "json": {
                                 "id": "[id]",
                                 "value": "100"
                               }
@@ -213,12 +135,12 @@ expression: "[cp1, cp2, cp3, cp4]"
                           }
                         }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }
@@ -226,67 +148,135 @@ expression: "[cp1, cp2, cp3, cp4]"
   {
     "data": {
       "checkpoints": {
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "30000000000000000"
+        "node": {
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "30000000000000000"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "29999999997732548"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "balance": "29999999998261888"
+                      {
+                        "inputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "value": "100"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": null
+                      },
+                      {
+                        "inputState": null,
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Wrapper"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "item": {
+                                  "id": "[id]",
+                                  "value": "100"
+                                }
+                              }
                             }
                           }
                         }
                       }
-                    },
-                    {
-                      "inputState": null,
-                      "outputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "value": "100"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "data": {
+      "checkpoints": {
+        "node": {
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "30000000000000000"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "balance": "29999999998261888"
+                              }
                             }
                           }
                         }
-                      }
-                    },
-                    {
-                      "inputState": {
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Wrapper"
-                            },
-                            "json": {
-                              "id": "[id]",
-                              "item": {
+                      },
+                      {
+                        "inputState": null,
+                        "outputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              },
+                              "json": {
                                 "id": "[id]",
                                 "value": "100"
                               }
@@ -294,13 +284,31 @@ expression: "[cp1, cp2, cp3, cp4]"
                           }
                         }
                       },
-                      "outputState": null
-                    }
-                  ]
+                      {
+                        "inputState": {
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Wrapper"
+                              },
+                              "json": {
+                                "id": "[id]",
+                                "item": {
+                                  "id": "[id]",
+                                  "value": "100"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "outputState": null
+                      }
+                    ]
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_object_lifecycle.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_object_lifecycle.snap
@@ -6,60 +6,62 @@ expression: "[cp1, cp2, cp3, cp4]"
   {
     "data": {
       "checkpoints": {
-        "sequenceNumber": "[seq]",
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+        "node": {
+          "sequenceNumber": "[seq]",
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      {
+                        "inputState": null,
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              }
                             }
                           }
                         }
                       }
-                    },
-                    {
-                      "inputState": null,
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }
@@ -67,71 +69,73 @@ expression: "[cp1, cp2, cp3, cp4]"
   {
     "data": {
       "checkpoints": {
-        "sequenceNumber": "[seq]",
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+        "node": {
+          "sequenceNumber": "[seq]",
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      {
+                        "inputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              }
                             }
                           }
                         }
                       }
-                    },
-                    {
-                      "inputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            }
-                          }
-                        }
-                      },
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }
@@ -139,75 +143,77 @@ expression: "[cp1, cp2, cp3, cp4]"
   {
     "data": {
       "checkpoints": {
-        "sequenceNumber": "[seq]",
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+        "node": {
+          "sequenceNumber": "[seq]",
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      {
+                        "inputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              }
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "inputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            }
-                          }
-                        }
+                        },
+                        "outputState": null
                       },
-                      "outputState": null
-                    },
-                    {
-                      "inputState": null,
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Wrapper"
+                      {
+                        "inputState": null,
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Wrapper"
+                              }
                             }
                           }
                         }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }
@@ -215,75 +221,77 @@ expression: "[cp1, cp2, cp3, cp4]"
   {
     "data": {
       "checkpoints": {
-        "sequenceNumber": "[seq]",
-        "transactions": {
-          "nodes": [
-            {
-              "digest": "[digest]",
-              "effects": {
-                "objectChanges": {
-                  "nodes": [
-                    {
-                      "inputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+        "node": {
+          "sequenceNumber": "[seq]",
+          "transactions": {
+            "nodes": [
+              {
+                "digest": "[digest]",
+                "effects": {
+                  "objectChanges": {
+                    "nodes": [
+                      {
+                        "inputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "inputState": null,
-                      "outputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Item"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "inputState": {
-                        "address": "[address]",
-                        "version": "[version]",
-                        "digest": "[digest]",
-                        "asMoveObject": {
-                          "contents": {
-                            "type": {
-                              "repr": "[pkg]::wrapping::Wrapper"
+                      {
+                        "inputState": null,
+                        "outputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Item"
+                              }
                             }
                           }
                         }
                       },
-                      "outputState": null
-                    }
-                  ]
+                      {
+                        "inputState": {
+                          "address": "[address]",
+                          "version": "[version]",
+                          "digest": "[digest]",
+                          "asMoveObject": {
+                            "contents": {
+                              "type": {
+                                "repr": "[pkg]::wrapping::Wrapper"
+                              }
+                            }
+                          }
+                        },
+                        "outputState": null
+                      }
+                    ]
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_transactions.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_transactions.snap
@@ -5,44 +5,46 @@ expression: item
 {
   "data": {
     "checkpoints": {
-      "sequenceNumber": "[seq]",
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "[digest]",
-            "sender": {
-              "address": "[address]"
-            },
-            "gasInput": {
-              "gasBudget": "5000000000"
-            },
-            "effects": {
-              "status": "SUCCESS",
-              "balanceChanges": {
-                "nodes": [
-                  {
-                    "amount": "1000",
-                    "coinType": {
-                      "repr": "[pkg]::sui::SUI"
+      "node": {
+        "sequenceNumber": "[seq]",
+        "transactions": {
+          "nodes": [
+            {
+              "digest": "[digest]",
+              "sender": {
+                "address": "[address]"
+              },
+              "gasInput": {
+                "gasBudget": "5000000000"
+              },
+              "effects": {
+                "status": "SUCCESS",
+                "balanceChanges": {
+                  "nodes": [
+                    {
+                      "amount": "1000",
+                      "coinType": {
+                        "repr": "[pkg]::sui::SUI"
+                      },
+                      "owner": {
+                        "address": "[address]"
+                      }
                     },
-                    "owner": {
-                      "address": "[address]"
+                    {
+                      "amount": "-2977000",
+                      "coinType": {
+                        "repr": "[pkg]::sui::SUI"
+                      },
+                      "owner": {
+                        "address": "[address]"
+                      }
                     }
-                  },
-                  {
-                    "amount": "-2977000",
-                    "coinType": {
-                      "repr": "[pkg]::sui::SUI"
-                    },
-                    "owner": {
-                      "address": "[address]"
-                    }
-                  }
-                ]
+                  ]
+                }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     }
   }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_transactions_pagination_first.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_transactions_pagination_first.snap
@@ -5,40 +5,42 @@ expression: item
 {
   "data": {
     "checkpoints": {
-      "sequenceNumber": "[seq]",
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "[digest]",
-            "effects": {
-              "status": "SUCCESS",
-              "balanceChanges": {
-                "nodes": [
-                  {
-                    "amount": "100",
-                    "coinType": {
-                      "repr": "[pkg]::sui::SUI"
+      "node": {
+        "sequenceNumber": "[seq]",
+        "transactions": {
+          "nodes": [
+            {
+              "digest": "[digest]",
+              "effects": {
+                "status": "SUCCESS",
+                "balanceChanges": {
+                  "nodes": [
+                    {
+                      "amount": "100",
+                      "coinType": {
+                        "repr": "[pkg]::sui::SUI"
+                      }
+                    },
+                    {
+                      "amount": "-2976100",
+                      "coinType": {
+                        "repr": "[pkg]::sui::SUI"
+                      }
                     }
-                  },
-                  {
-                    "amount": "-2976100",
-                    "coinType": {
-                      "repr": "[pkg]::sui::SUI"
-                    }
-                  }
-                ]
+                  ]
+                }
               }
             }
+          ],
+          "edges": [
+            {
+              "cursor": "[cursor]"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": true,
+            "hasPreviousPage": false
           }
-        ],
-        "edges": [
-          {
-            "cursor": "[cursor]"
-          }
-        ],
-        "pageInfo": {
-          "hasNextPage": true,
-          "hasPreviousPage": false
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_transactions_pagination_last.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__checkpoint_subscription__subscription_transactions_pagination_last.snap
@@ -5,40 +5,42 @@ expression: item
 {
   "data": {
     "checkpoints": {
-      "sequenceNumber": "[seq]",
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "[digest]",
-            "effects": {
-              "status": "SUCCESS",
-              "balanceChanges": {
-                "nodes": [
-                  {
-                    "amount": "100",
-                    "coinType": {
-                      "repr": "[pkg]::sui::SUI"
+      "node": {
+        "sequenceNumber": "[seq]",
+        "transactions": {
+          "nodes": [
+            {
+              "digest": "[digest]",
+              "effects": {
+                "status": "SUCCESS",
+                "balanceChanges": {
+                  "nodes": [
+                    {
+                      "amount": "100",
+                      "coinType": {
+                        "repr": "[pkg]::sui::SUI"
+                      }
+                    },
+                    {
+                      "amount": "-2976100",
+                      "coinType": {
+                        "repr": "[pkg]::sui::SUI"
+                      }
                     }
-                  },
-                  {
-                    "amount": "-2976100",
-                    "coinType": {
-                      "repr": "[pkg]::sui::SUI"
-                    }
-                  }
-                ]
+                  ]
+                }
               }
             }
+          ],
+          "edges": [
+            {
+              "cursor": "[cursor]"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": true
           }
-        ],
-        "edges": [
-          {
-            "cursor": "[cursor]"
-          }
-        ],
-        "pageInfo": {
-          "hasNextPage": false,
-          "hasPreviousPage": true
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription.snap
@@ -5,22 +5,24 @@ expression: item
 {
   "data": {
     "events": {
-      "sender": {
-        "address": "[address]"
-      },
-      "transaction": {
-        "digest": "[digest]"
-      },
-      "contents": {
-        "type": {
-          "repr": "[pkg]::emit_test_event::TestEvent"
+      "node": {
+        "sender": {
+          "address": "[address]"
         },
-        "json": {
-          "value": "1"
-        }
-      },
-      "sequenceNumber": "[seq]",
-      "timestamp": "[timestamp]"
+        "transaction": {
+          "digest": "[digest]"
+        },
+        "contents": {
+          "type": {
+            "repr": "[pkg]::emit_test_event::TestEvent"
+          },
+          "json": {
+            "value": "1"
+          }
+        },
+        "sequenceNumber": "[seq]",
+        "timestamp": "[timestamp]"
+      }
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_change.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_change.snap
@@ -5,27 +5,29 @@ expression: item
 {
   "data": {
     "events": {
-      "contents": {
-        "extract": {
-          "asAddress": {
-            "asTransactionObject": {
-              "__typename": "ObjectChange",
-              "inputState": {
-                "asMoveObject": {
-                  "contents": {
-                    "json": {
-                      "id": "[json_id]",
-                      "value": "7"
+      "node": {
+        "contents": {
+          "extract": {
+            "asAddress": {
+              "asTransactionObject": {
+                "__typename": "ObjectChange",
+                "inputState": {
+                  "asMoveObject": {
+                    "contents": {
+                      "json": {
+                        "id": "[json_id]",
+                        "value": "7"
+                      }
                     }
                   }
-                }
-              },
-              "outputState": {
-                "asMoveObject": {
-                  "contents": {
-                    "json": {
-                      "id": "[json_id]",
-                      "value": "99"
+                },
+                "outputState": {
+                  "asMoveObject": {
+                    "contents": {
+                      "json": {
+                        "id": "[json_id]",
+                        "value": "99"
+                      }
                     }
                   }
                 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_consensus_read.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_consensus_read.snap
@@ -5,16 +5,18 @@ expression: item
 {
   "data": {
     "events": {
-      "contents": {
-        "extract": {
-          "asAddress": {
-            "asTransactionObject": {
-              "__typename": "ConsensusObjectRead",
-              "object": {
-                "asMoveObject": {
-                  "contents": {
-                    "type": {
-                      "repr": "[pkg]::clock::Clock"
+      "node": {
+        "contents": {
+          "extract": {
+            "asAddress": {
+              "asTransactionObject": {
+                "__typename": "ConsensusObjectRead",
+                "object": {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "[pkg]::clock::Clock"
+                      }
                     }
                   }
                 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_module_filter.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_module_filter.snap
@@ -5,9 +5,11 @@ expression: item
 {
   "data": {
     "events": {
-      "contents": {
-        "type": {
-          "repr": "[pkg]::emit_test_event::TestEvent"
+      "node": {
+        "contents": {
+          "type": {
+            "repr": "[pkg]::emit_test_event::TestEvent"
+          }
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_object_changes.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_object_changes.snap
@@ -5,40 +5,42 @@ expression: item
 {
   "data": {
     "events": {
-      "transaction": {
-        "effects": {
-          "status": "SUCCESS",
-          "objectChanges": {
-            "nodes": [
-              {
-                "outputState": {
-                  "address": "[address]",
-                  "version": "[version]",
-                  "digest": "[digest]",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+      "node": {
+        "transaction": {
+          "effects": {
+            "status": "SUCCESS",
+            "objectChanges": {
+              "nodes": [
+                {
+                  "outputState": {
+                    "address": "[address]",
+                    "version": "[version]",
+                    "digest": "[digest]",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "outputState": {
+                    "address": "[address]",
+                    "version": "[version]",
+                    "digest": "[digest]",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "[pkg]::emit_test_event::TestObject"
+                        }
                       }
                     }
                   }
                 }
-              },
-              {
-                "outputState": {
-                  "address": "[address]",
-                  "version": "[version]",
-                  "digest": "[digest]",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "[pkg]::emit_test_event::TestObject"
-                      }
-                    }
-                  }
-                }
-              }
-            ]
+              ]
+            }
           }
         }
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_sender_filter.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_sender_filter.snap
@@ -5,12 +5,14 @@ expression: item
 {
   "data": {
     "events": {
-      "sender": {
-        "address": "[address]"
-      },
-      "contents": {
-        "type": {
-          "repr": "[pkg]::emit_test_event::TestEvent"
+      "node": {
+        "sender": {
+          "address": "[address]"
+        },
+        "contents": {
+          "type": {
+            "repr": "[pkg]::emit_test_event::TestEvent"
+          }
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_transaction_fields.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_transaction_fields.snap
@@ -5,22 +5,24 @@ expression: item
 {
   "data": {
     "events": {
-      "transaction": {
-        "digest": "[digest]",
-        "sender": {
-          "address": "[address]"
+      "node": {
+        "transaction": {
+          "digest": "[digest]",
+          "sender": {
+            "address": "[address]"
+          },
+          "kind": {
+            "__typename": "ProgrammableTransaction"
+          },
+          "gasInput": {
+            "gasBudget": "5000000000",
+            "gasPrice": "1000"
+          }
         },
-        "kind": {
-          "__typename": "ProgrammableTransaction"
-        },
-        "gasInput": {
-          "gasBudget": "5000000000",
-          "gasPrice": "1000"
-        }
-      },
-      "contents": {
-        "type": {
-          "repr": "[pkg]::emit_test_event::TestEvent"
+        "contents": {
+          "type": {
+            "repr": "[pkg]::emit_test_event::TestEvent"
+          }
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__transaction_subscription__transaction_subscription.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__transaction_subscription__transaction_subscription.snap
@@ -5,36 +5,38 @@ expression: item
 {
   "data": {
     "transactions": {
-      "digest": "[digest]",
-      "sender": {
-        "address": "[address]"
-      },
-      "gasInput": {
-        "gasBudget": "5000000000"
-      },
-      "effects": {
-        "status": "SUCCESS",
-        "balanceChanges": {
-          "nodes": [
-            {
-              "amount": "1000",
-              "coinType": {
-                "repr": "[pkg]::sui::SUI"
+      "node": {
+        "digest": "[digest]",
+        "sender": {
+          "address": "[address]"
+        },
+        "gasInput": {
+          "gasBudget": "5000000000"
+        },
+        "effects": {
+          "status": "SUCCESS",
+          "balanceChanges": {
+            "nodes": [
+              {
+                "amount": "1000",
+                "coinType": {
+                  "repr": "[pkg]::sui::SUI"
+                },
+                "owner": {
+                  "address": "[address]"
+                }
               },
-              "owner": {
-                "address": "[address]"
+              {
+                "amount": "-2977000",
+                "coinType": {
+                  "repr": "[pkg]::sui::SUI"
+                },
+                "owner": {
+                  "address": "[address]"
+                }
               }
-            },
-            {
-              "amount": "-2977000",
-              "coinType": {
-                "repr": "[pkg]::sui::SUI"
-              },
-              "owner": {
-                "address": "[address]"
-              }
-            }
-          ]
+            ]
+          }
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__transaction_subscription__transaction_subscription_object_changes.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__transaction_subscription__transaction_subscription_object_changes.snap
@@ -5,52 +5,54 @@ expression: item
 {
   "data": {
     "transactions": {
-      "digest": "[digest]",
-      "effects": {
-        "objectChanges": {
-          "nodes": [
-            {
-              "inputState": {
-                "address": "[address]",
-                "version": "[version]",
-                "digest": "[digest]",
-                "asMoveObject": {
-                  "contents": {
-                    "type": {
-                      "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+      "node": {
+        "digest": "[digest]",
+        "effects": {
+          "objectChanges": {
+            "nodes": [
+              {
+                "inputState": {
+                  "address": "[address]",
+                  "version": "[version]",
+                  "digest": "[digest]",
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      }
+                    }
+                  }
+                },
+                "outputState": {
+                  "address": "[address]",
+                  "version": "[version]",
+                  "digest": "[digest]",
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      }
                     }
                   }
                 }
               },
-              "outputState": {
-                "address": "[address]",
-                "version": "[version]",
-                "digest": "[digest]",
-                "asMoveObject": {
-                  "contents": {
-                    "type": {
-                      "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              {
+                "inputState": null,
+                "outputState": {
+                  "address": "[address]",
+                  "version": "[version]",
+                  "digest": "[digest]",
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "[pkg]::wrapping::Item"
+                      }
                     }
                   }
                 }
               }
-            },
-            {
-              "inputState": null,
-              "outputState": {
-                "address": "[address]",
-                "version": "[version]",
-                "digest": "[digest]",
-                "asMoveObject": {
-                  "contents": {
-                    "type": {
-                      "repr": "[pkg]::wrapping::Item"
-                    }
-                  }
-                }
-              }
-            }
-          ]
+            ]
+          }
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -328,18 +328,18 @@ pub async fn wait_for_matching_item(
 }
 
 /// Extract digests from a checkpoint subscription response.
-/// Path: data.checkpoints.transactions.nodes[].digest
+/// Path: data.checkpoints.node.transactions.nodes[].digest
 pub fn checkpoint_tx_digests(item: &Value) -> Vec<&str> {
-    item["data"]["checkpoints"]["transactions"]["nodes"]
+    item["data"]["checkpoints"]["node"]["transactions"]["nodes"]
         .as_array()
         .map(|nodes| nodes.iter().filter_map(|n| n["digest"].as_str()).collect())
         .unwrap_or_default()
 }
 
 /// Extract `sequenceNumber` from a top-level checkpoint subscription response.
-/// Path: data.checkpoints.sequenceNumber
+/// Path: data.checkpoints.node.sequenceNumber
 pub fn checkpoint_seq(item: &Value) -> u64 {
-    item["data"]["checkpoints"]["sequenceNumber"]
+    item["data"]["checkpoints"]["node"]["sequenceNumber"]
         .as_u64()
         .expect("checkpoint payload missing sequenceNumber")
 }
@@ -406,9 +406,9 @@ pub fn graphql_redactions() -> insta::Settings {
 }
 
 /// Extract digest from a top-level transaction subscription response.
-/// Path: data.transactions.digest
+/// Path: data.transactions.node.digest
 pub fn transaction_digest(item: &Value) -> Vec<&str> {
-    item["data"]["transactions"]["digest"]
+    item["data"]["transactions"]["node"]["digest"]
         .as_str()
         .into_iter()
         .collect()

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/transaction_subscription.rs
@@ -24,16 +24,18 @@ async fn test_transaction_subscription() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 transactions(filter: { sentAddress: $sender }) {
-                    digest
-                    sender { address }
-                    gasInput { gasBudget }
-                    effects {
-                        status
-                        balanceChanges {
-                            nodes {
-                                amount
-                                coinType { repr }
-                                owner { address }
+                    node {
+                        digest
+                        sender { address }
+                        gasInput { gasBudget }
+                        effects {
+                            status
+                            balanceChanges {
+                                nodes {
+                                    amount
+                                    coinType { repr }
+                                    owner { address }
+                                }
                             }
                         }
                     }
@@ -61,24 +63,26 @@ async fn test_transaction_subscription_object_changes() {
         .subscribe_with_variables(
             r#"subscription($sender: SuiAddress!) {
                 transactions(filter: { sentAddress: $sender }) {
-                    digest
-                    effects {
-                        objectChanges {
-                            nodes {
-                                inputState {
-                                    address
-                                    version
-                                    digest
-                                    asMoveObject {
-                                        contents { type { repr } }
+                    node {
+                        digest
+                        effects {
+                            objectChanges {
+                                nodes {
+                                    inputState {
+                                        address
+                                        version
+                                        digest
+                                        asMoveObject {
+                                            contents { type { repr } }
+                                        }
                                     }
-                                }
-                                outputState {
-                                    address
-                                    version
-                                    digest
-                                    asMoveObject {
-                                        contents { type { repr } }
+                                    outputState {
+                                        address
+                                        version
+                                        digest
+                                        asMoveObject {
+                                            contents { type { repr } }
+                                        }
                                     }
                                 }
                             }

--- a/crates/sui-indexer-alt-graphql/src/api/scalars/cursor.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/cursor.rs
@@ -18,7 +18,7 @@ use serde::de::DeserializeOwned;
 ///
 /// In the GraphQL schema this will show up as a `String`.
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub(crate) struct JsonCursor<C>(C);
+pub struct JsonCursor<C>(C);
 
 /// Cursor that hides its value by serializing it to BCS and then encoding it as Base64.
 ///
@@ -27,7 +27,7 @@ pub(crate) struct JsonCursor<C>(C);
 pub(crate) struct BcsCursor<C>(C);
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum Error {
+pub enum Error {
     #[error("Invalid Base64")]
     BadBase64,
 
@@ -39,7 +39,7 @@ pub(crate) enum Error {
 }
 
 impl<C> JsonCursor<C> {
-    pub(crate) fn new(cursor: C) -> Self {
+    pub fn new(cursor: C) -> Self {
         Self(cursor)
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -4,12 +4,19 @@
 use std::sync::Arc;
 
 use async_graphql::Context;
+use async_graphql::connection::CursorType;
+use async_graphql::connection::Edge;
+use async_graphql::connection::EmptyFields;
 use tokio::sync::broadcast;
 use tracing::warn;
 
+use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
+use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
+use crate::api::types::event::EventCursor;
 use crate::api::types::event::filter::EventFilter;
+use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::config::Limits;
@@ -29,7 +36,10 @@ impl Subscription {
     async fn checkpoints(
         &self,
         ctx: &Context<'_>,
-    ) -> Result<impl futures::Stream<Item = Result<Checkpoint, RpcError>>, RpcError> {
+    ) -> Result<
+        impl futures::Stream<Item = Result<Edge<String, Checkpoint, EmptyFields>, RpcError>>,
+        RpcError,
+    > {
         let package_store = ctx.data::<Arc<StreamingPackageStore>>()?.clone();
         let limits: &Limits = ctx.data()?;
         let resolver_limits = limits.package_resolver();
@@ -39,16 +49,21 @@ impl Subscription {
             loop {
                 match receiver.recv().await {
                     Ok(processed) => {
+                        let sequence_number = processed.summary.sequence_number;
                         let scope = Scope::for_streamed_checkpoint(
                             package_store.clone(),
                             resolver_limits.clone(),
                             processed.clone(),
                         );
-                        yield Ok(Checkpoint {
-                            sequence_number: processed.summary.sequence_number,
-                            scope,
-                            streamed_data: Some(processed),
-                        });
+                        let cursor = CCheckpoint::new(sequence_number).encode_cursor();
+                        yield Ok(Edge::new(
+                            cursor,
+                            Checkpoint {
+                                sequence_number,
+                                scope,
+                                streamed_data: Some(processed),
+                            },
+                        ));
                     }
                     Err(e) => {
                         yield Err(broadcast_error(e));
@@ -70,7 +85,10 @@ impl Subscription {
         &self,
         ctx: &Context<'_>,
         filter: Option<TransactionFilter>,
-    ) -> Result<impl futures::Stream<Item = Result<Transaction, RpcError>>, RpcError> {
+    ) -> Result<
+        impl futures::Stream<Item = Result<Edge<String, Transaction, EmptyFields>, RpcError>>,
+        RpcError,
+    > {
         let package_store = ctx.data::<Arc<StreamingPackageStore>>()?.clone();
         let limits: &Limits = ctx.data()?;
         let resolver_limits = limits.package_resolver();
@@ -93,7 +111,9 @@ impl Subscription {
                             if !filter.matches(&tx.contents) {
                                 continue;
                             }
-                            yield Transaction::with_contents(scope.clone(), tx.contents.clone());
+                            let cursor = CTransaction::new(tx.tx_sequence_number).encode_cursor();
+                            yield Transaction::with_contents(scope.clone(), tx.contents.clone())
+                                .map(|transaction| Edge::new(cursor, transaction));
                         }
                     }
                     Err(e) => {
@@ -116,7 +136,10 @@ impl Subscription {
         &self,
         ctx: &Context<'_>,
         filter: Option<EventFilter>,
-    ) -> Result<impl futures::Stream<Item = Result<Event, RpcError>>, RpcError> {
+    ) -> Result<
+        impl futures::Stream<Item = Result<Edge<String, Event, EmptyFields>, RpcError>>,
+        RpcError,
+    > {
         let package_store = ctx.data::<Arc<StreamingPackageStore>>()?.clone();
         let limits: &Limits = ctx.data()?;
         let resolver_limits = limits.package_resolver();
@@ -143,16 +166,24 @@ impl Subscription {
                                 if !filter.matches(&native) {
                                     continue;
                                 }
-                                yield Ok(Event {
-                                    scope: scope.with_active_transaction_contents(
-                                        digest,
-                                        tx.contents.clone(),
-                                    ),
-                                    native,
-                                    transaction_digest: digest,
-                                    sequence_number: idx as u64,
-                                    timestamp_ms,
-                                });
+                                let cursor = CEvent::new(EventCursor {
+                                    tx_sequence_number: tx.tx_sequence_number,
+                                    ev_sequence_number: idx as u64,
+                                })
+                                .encode_cursor();
+                                yield Ok(Edge::new(
+                                    cursor,
+                                    Event {
+                                        scope: scope.with_active_transaction_contents(
+                                            digest,
+                                            tx.contents.clone(),
+                                        ),
+                                        native,
+                                        transaction_digest: digest,
+                                        sequence_number: idx as u64,
+                                        timestamp_ms,
+                                    },
+                                ));
                             }
                         }
                     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -69,7 +69,7 @@ struct CheckpointContents {
     streamed_data: Option<Arc<ProcessedCheckpoint>>,
 }
 
-pub(crate) type CCheckpoint = JsonCursor<u64>;
+pub type CCheckpoint = JsonCursor<u64>;
 
 /// Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
 #[Object]

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -42,14 +42,14 @@ pub(crate) mod filter;
 mod lookups;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Copy)]
-pub(crate) struct EventCursor {
+pub struct EventCursor {
     #[serde(rename = "t")]
     pub tx_sequence_number: u64,
     #[serde(rename = "e")]
     pub ev_sequence_number: u64,
 }
 
-pub(crate) type CEvent = JsonCursor<EventCursor>;
+pub type CEvent = JsonCursor<EventCursor>;
 
 #[derive(Clone)]
 pub(crate) struct Event {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -68,7 +68,7 @@ pub(crate) struct TransactionContents {
     pub(crate) contents: Option<Arc<NativeTransactionContents>>,
 }
 
-pub(crate) type CTransaction = JsonCursor<u64>;
+pub type CTransaction = JsonCursor<u64>;
 
 pub(crate) struct TransactionConnection {
     pub edges: Vec<Edge<String, Transaction, EmptyFields>>,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -80,6 +80,11 @@ const GRAPHQL_SUBSCRIPTIONS_PATH: &str = "/graphql/subscriptions";
 const HEALTH_PATH: &str = "/graphql/health";
 
 mod api;
+pub use crate::api::scalars::cursor::JsonCursor;
+pub use crate::api::types::checkpoint::CCheckpoint;
+pub use crate::api::types::event::CEvent;
+pub use crate::api::types::event::EventCursor;
+pub use crate::api::types::transaction::CTransaction;
 pub mod args;
 pub mod config;
 mod error;

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4137,7 +4137,7 @@ type Subscription {
 	
 	This subscription is not yet available for use.
 	"""
-	checkpoints: Checkpoint!
+	checkpoints: CheckpointEdge!
 	"""
 	Subscribe to events as they are emitted, with optional filtering.
 	
@@ -4147,7 +4147,7 @@ type Subscription {
 	
 	This subscription is not yet available for use.
 	"""
-	events(filter: EventFilter): Event!
+	events(filter: EventFilter): EventEdge!
 	"""
 	Subscribe to transactions as they are finalized, with optional filtering.
 	
@@ -4157,7 +4157,7 @@ type Subscription {
 	
 	This subscription is not yet available for use.
 	"""
-	transactions(filter: TransactionFilter): Transaction!
+	transactions(filter: TransactionFilter): TransactionEdge!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4133,7 +4133,7 @@ type Subscription {
 	
 	This subscription is not yet available for use.
 	"""
-	checkpoints: Checkpoint!
+	checkpoints: CheckpointEdge!
 	"""
 	Subscribe to events as they are emitted, with optional filtering.
 	
@@ -4143,7 +4143,7 @@ type Subscription {
 	
 	This subscription is not yet available for use.
 	"""
-	events(filter: EventFilter): Event!
+	events(filter: EventFilter): EventEdge!
 	"""
 	Subscribe to transactions as they are finalized, with optional filtering.
 	
@@ -4153,7 +4153,7 @@ type Subscription {
 	
 	This subscription is not yet available for use.
 	"""
-	transactions(filter: TransactionFilter): Transaction!
+	transactions(filter: TransactionFilter): TransactionEdge!
 }
 
 """


### PR DESCRIPTION
## Description 

- Expose cursor: String! on Checkpoint — encoded JsonCursor<u64> of the sequence number, matching the format Query.checkpoints pagination already uses.
- Clients (especially streaming subscribers) read this on each yielded checkpoint and pass it back as afterCursor to resume from this point.

## Test plan 

How did you test the new or updated feature?
- e2e + unit tests

---

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476
   - #26487
   - #26425
   - #26495
   - #26731

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Add cursor field to Checkpoint object
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
