### PR TITLE
[tidehunter] Enable objects compactor on full nodes when num_epochs_to_retain=0

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -938,18 +938,24 @@ impl AuthorityStorePruner {
         registry: &Registry,
         pruner_watermarks: Arc<PrunerWatermarks>, // used by tidehunter relocation filters
     ) -> Self {
-        // On tidehunter validators the per-keyspace `objects_compactor`
+        // On tidehunter, the per-keyspace `objects_compactor`
         // (see `AuthorityPerpetualTables::open`) already retains only the latest
         // version per ObjectID during compaction, so running the object pruner
-        // would duplicate that work. Force-disable it regardless of the configured
-        // value.
+        // would duplicate that work. The compactor is enabled for validators
+        // and for any node configured with `num_epochs_to_retain = 0` — keep
+        // this predicate in sync with the one in `sui-node/src/lib.rs`.
+        // Force-disable the pruner whenever the compactor is active.
         #[cfg(tidehunter)]
-        if is_validator && pruning_config.num_epochs_to_retain != u64::MAX {
-            info!(
-                "Tidehunter validator: disabling object pruner (was num_epochs_to_retain={}). The objects compactor performs equivalent compaction.",
-                pruning_config.num_epochs_to_retain
-            );
-            pruning_config.num_epochs_to_retain = u64::MAX;
+        {
+            let objects_compactor_enabled =
+                is_validator || pruning_config.num_epochs_to_retain == 0;
+            if objects_compactor_enabled && pruning_config.num_epochs_to_retain != u64::MAX {
+                info!(
+                    "Tidehunter: disabling object pruner (was num_epochs_to_retain={}). The objects compactor performs equivalent compaction.",
+                    pruning_config.num_epochs_to_retain
+                );
+                pruning_config.num_epochs_to_retain = u64::MAX;
+            }
         }
 
         if pruning_config.num_epochs_to_retain > 0 && pruning_config.num_epochs_to_retain < u64::MAX

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -36,7 +36,10 @@ const ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE: &str = "EFFECTS_BLOCK_CACHE_MB";
 pub struct AuthorityPerpetualTablesOptions {
     /// Whether to enable write stalling on all column families.
     pub enable_write_stall: bool,
-    pub is_validator: bool,
+    /// On tidehunter, attach the per-keyspace objects compactor that retains
+    /// only the latest version per ObjectID. Mutually exclusive with the
+    /// object pruner — see `AuthorityStorePruner::new`.
+    pub enable_objects_compactor: bool,
 }
 
 impl AuthorityPerpetualTablesOptions {
@@ -236,7 +239,7 @@ impl AuthorityPerpetualTables {
         let mut objects_config = KeySpaceConfig::new()
             .with_max_dirty_keys(4 * default_max_dirty_keys())
             .with_value_cache_size(value_cache_size);
-        if matches!(db_options_override, Some(options) if options.is_validator) {
+        if matches!(db_options_override, Some(options) if options.enable_objects_compactor) {
             objects_config = objects_config.with_compactor(Box::new(objects_compactor));
         }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -515,9 +515,17 @@ impl SuiNode {
         let enable_write_stall = config
             .enable_db_write_stall
             .unwrap_or(node_role.runs_consensus());
+        // The tidehunter objects compactor retains only the latest version per
+        // ObjectID and is mutually exclusive with the object pruner. Enable it
+        // for validators (which always disable the pruner), and also for any
+        // node configured with `num_epochs_to_retain = 0` — that aggressive
+        // setting is what the compactor replaces. The pruner is force-disabled
+        // in `AuthorityStorePruner::new` whenever this is true.
+        let enable_objects_compactor = node_role.is_validator()
+            || config.authority_store_pruning_config.num_epochs_to_retain == 0;
         let perpetual_tables_options = AuthorityPerpetualTablesOptions {
             enable_write_stall,
-            is_validator: node_role.is_validator(),
+            enable_objects_compactor,
         };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
             &config.db_store_path(),


### PR DESCRIPTION
## Summary

Previously the tidehunter per-keyspace objects compactor was attached only on validators, so full nodes fell back to the aggressive object pruner (`num_epochs_to_retain = 0`), which does not perform well under tidehunter.

This change ties the compactor to the same config setting it replaces:

- On tidehunter, attach the objects compactor whenever the node is a validator **or** is configured with `num_epochs_to_retain = 0`.
- Whenever the compactor is enabled, force-disable the object pruner (set `num_epochs_to_retain = u64::MAX`).
- Other values of `num_epochs_to_retain` preserve existing behavior: no compactor, pruner runs per config with the existing warnings.
- Renames `AuthorityPerpetualTablesOptions::is_validator` → `enable_objects_compactor` to reflect what the field actually controls.

The compactor predicate is computed once at the call site in `sui-node/src/lib.rs` and mirrored in `AuthorityStorePruner::new` so the two stay in sync.

## Test plan

- [ ] `cargo check -p sui-core -p sui-node` (RocksDB build) — verified locally
- [ ] `USE_TIDEHUNTER=1 cargo check -p sui-core -p sui-node --features typed-store/tidehunter` — verified locally
- [ ] `cargo xclippy` on changed crates
- [ ] Deploy to private-testnet with `build_with_tidehunter=true` and verify a full node configured with `num_epochs_to_retain = 0` attaches the compactor and does not run the pruner

🤖 Generated with [Claude Code](https://claude.com/claude-code)