### PR TITLE
docs: fix redirect for /standards/deepbookv3

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -16,6 +16,11 @@
       "permanent": true
     },
     {
+      "source": "/standards/deepbookv3",
+      "destination": "/onchain-finance/deepbookv3/deepbook",
+      "permanent": true
+    },
+    {
       "source": "/standards/deepbookv3/:path*",
       "destination": "/onchain-finance/deepbookv3/:path*",
       "permanent": true


### PR DESCRIPTION
## Summary
- Add exact redirect for `/standards/deepbookv3` → `/onchain-finance/deepbookv3/deepbook`
- The existing wildcard redirect (`/standards/deepbookv3/:path*`) does not match the exact path `/standards/deepbookv3`, so links like `https://docs.sui.io/standards/deepbookv3#deepbook-tokenomics` were broken

## Test plan
- [ ] Verify `/standards/deepbookv3` redirects to `/onchain-finance/deepbookv3/deepbook`
- [ ] Verify `/standards/deepbookv3#deepbook-tokenomics` resolves to `/onchain-finance/deepbookv3/deepbook#deepbook-tokenomics`
- [ ] Verify existing wildcard redirects (e.g. `/standards/deepbookv3/design`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)