### PR TITLE
[sui-surfer] exercise recently shipped Move and transaction features

### DIFF
--- a/crates/sui-surfer/src/surf_strategy.rs
+++ b/crates/sui-surfer/src/surf_strategy.rs
@@ -4,16 +4,33 @@
 use std::time::Duration;
 
 use move_binary_format::normalized;
+use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::StructTag;
-use rand::{Rng, seq::SliceRandom};
+use rand::{Rng, RngCore, rngs::StdRng, seq::SliceRandom};
 use sui_types::{
-    base_types::ObjectRef,
+    SUI_FRAMEWORK_ADDRESS,
+    base_types::{ObjectID, ObjectRef, SuiAddress},
     transaction::{CallArg, ObjectArg, SharedObjectMutability},
 };
 use tokio::time::Instant;
 use tracing::debug;
 
 use crate::surfer_state::{EntryFunction, SurferState};
+
+type Datatype = normalized::Datatype<normalized::ArcIdentifier>;
+
+/// If `dt` is a `sui::transfer::Receiving<T>`, returns the inner type `T`.
+fn receiving_inner_type(dt: &Datatype) -> Option<&Type> {
+    if dt.module.address == SUI_FRAMEWORK_ADDRESS
+        && dt.module.name.as_ident_str() == IdentStr::new("transfer").unwrap()
+        && dt.name.as_ident_str() == IdentStr::new("Receiving").unwrap()
+        && dt.type_arguments.len() == 1
+    {
+        Some(&dt.type_arguments[0])
+    } else {
+        None
+    }
+}
 
 enum InputObjectPassKind {
     Value,
@@ -22,6 +39,57 @@ enum InputObjectPassKind {
 }
 
 type Type = normalized::Type<normalized::ArcIdentifier>;
+
+/// Upper bound on the length of randomly generated `vector<T>` pure arguments.
+/// Kept small so transactions stay cheap while still exercising non-empty vectors.
+const MAX_VECTOR_LEN: usize = 16;
+
+/// BCS-encode a randomly generated value for a "pure" (non-object) Move type.
+/// Returns `None` for types that cannot be passed as a `CallArg::Pure` (objects,
+/// type parameters, signer, references). Vectors of pure element types are
+/// supported recursively.
+fn random_pure_arg_bytes(rng: &mut StdRng, ty: &Type) -> Option<Vec<u8>> {
+    Some(match ty {
+        Type::Bool => vec![u8::from(rng.r#gen::<bool>())],
+        Type::U8 => vec![rng.r#gen::<u8>()],
+        Type::U16 => rng.r#gen::<u16>().to_le_bytes().to_vec(),
+        Type::U32 => rng.r#gen::<u32>().to_le_bytes().to_vec(),
+        Type::U64 => rng.r#gen::<u64>().to_le_bytes().to_vec(),
+        Type::U128 => rng.r#gen::<u128>().to_le_bytes().to_vec(),
+        // BCS encodes u256 and address as 32 little-endian bytes; any 32 bytes is valid.
+        Type::U256 | Type::Address => {
+            let mut bytes = [0u8; 32];
+            rng.fill_bytes(&mut bytes);
+            bytes.to_vec()
+        }
+        Type::Vector(inner) => {
+            let len = rng.gen_range(0..MAX_VECTOR_LEN);
+            let mut out = uleb128_encode(len);
+            for _ in 0..len {
+                out.extend(random_pure_arg_bytes(rng, inner)?);
+            }
+            out
+        }
+        _ => return None,
+    })
+}
+
+/// ULEB128 encoding used by BCS for sequence length prefixes.
+fn uleb128_encode(mut value: usize) -> Vec<u8> {
+    let mut out = vec![];
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+    out
+}
 
 #[derive(Clone, Default)]
 pub struct SurfStrategy {
@@ -65,6 +133,11 @@ impl SurfStrategy {
     ) -> Option<Vec<CallArg>> {
         let mut args = vec![];
         let mut chosen_owned_objects = vec![];
+        // Object ids chosen so far, used to coordinate `Receiving<T>` arguments
+        // with the parent object they were transferred to.
+        let mut chosen_object_ids: Vec<ObjectID> = vec![];
+        // Receivable objects taken from inventory, to restore if assembly fails.
+        let mut chosen_received: Vec<(SuiAddress, StructTag, ObjectRef)> = vec![];
         let mut failed = false;
         for param in params {
             let arg = match param {
@@ -78,14 +151,31 @@ impl SurfStrategy {
                     bcs::to_bytes(&state.cluster.get_addresses().choose(&mut state.rng)).unwrap(),
                 ),
                 ty @ Type::Datatype(_) => {
-                    match Self::choose_object_call_arg(
-                        state,
-                        InputObjectPassKind::Value,
-                        ty,
-                        &mut chosen_owned_objects,
-                    )
-                    .await
-                    {
+                    // A `Receiving<T>` argument is handled specially: it references a
+                    // child object transferred to one of the parent objects already
+                    // chosen for this call.
+                    let receiving = match &ty {
+                        Type::Datatype(dt) => receiving_inner_type(dt).cloned(),
+                        _ => None,
+                    };
+                    let chosen = if let Some(inner) = receiving {
+                        Self::choose_receiving_arg(
+                            state,
+                            &inner,
+                            &chosen_object_ids,
+                            &mut chosen_received,
+                        )
+                        .await
+                    } else {
+                        Self::choose_object_call_arg(
+                            state,
+                            InputObjectPassKind::Value,
+                            ty,
+                            &mut chosen_owned_objects,
+                        )
+                        .await
+                    };
+                    match chosen {
                         Some(arg) => arg,
                         None => {
                             failed = true;
@@ -109,11 +199,24 @@ impl SurfStrategy {
                         }
                     }
                 }
-                Type::U256 | Type::Signer | Type::Vector(_) | Type::TypeParameter(_) => {
+                ref t @ (Type::U256 | Type::Vector(_)) => {
+                    match random_pure_arg_bytes(&mut state.rng, t) {
+                        Some(bytes) => CallArg::Pure(bytes),
+                        None => {
+                            // e.g. vector<Object>, which can't be a pure argument.
+                            failed = true;
+                            break;
+                        }
+                    }
+                }
+                Type::Signer | Type::TypeParameter(_) => {
                     failed = true;
                     break;
                 }
             };
+            if let CallArg::Object(obj_arg) = &arg {
+                chosen_object_ids.push(obj_arg.id());
+            }
             args.push(arg);
         }
         if failed {
@@ -124,10 +227,39 @@ impl SurfStrategy {
                     .unwrap()
                     .insert(obj_ref);
             }
+            for (parent, struct_tag, obj_ref) in chosen_received {
+                state
+                    .return_receivable_object(parent, struct_tag, obj_ref)
+                    .await;
+            }
             None
         } else {
             Some(args)
         }
+    }
+
+    /// Choose a `Receiving<T>` argument: find a child object of type `T` that was
+    /// transferred to one of the already-chosen parent objects' addresses.
+    async fn choose_receiving_arg(
+        state: &mut SurferState,
+        inner: &Type,
+        chosen_object_ids: &[ObjectID],
+        chosen_received: &mut Vec<(SuiAddress, StructTag, ObjectRef)>,
+    ) -> Option<CallArg> {
+        let pool = state.pool.read().await;
+        let type_tag = match inner {
+            Type::Datatype(dt) => dt.to_struct_tag(&*pool),
+            _ => return None,
+        };
+        drop(pool);
+        for parent_id in chosen_object_ids {
+            let parent_addr = SuiAddress::from(*parent_id);
+            if let Some(obj_ref) = state.take_receivable_object(&parent_addr, &type_tag).await {
+                chosen_received.push((parent_addr, type_tag.clone(), obj_ref));
+                return Some(CallArg::Object(ObjectArg::Receiving(obj_ref)));
+            }
+        }
+        None
     }
 
     async fn choose_object_call_arg(
@@ -146,16 +278,28 @@ impl SurfStrategy {
         drop(pool);
         let owned = state.matching_owned_objects_count(&type_tag);
         let shared = state.matching_shared_objects_count(&type_tag).await;
+        let party = state.matching_party_objects_count(&type_tag);
         let immutable = state.matching_immutable_objects_count(&type_tag).await;
 
+        // Shared and party objects can be consumed by-value (e.g. shared object
+        // deletion / party transfer) as well as passed by reference. Immutable
+        // objects are only valid as immutable references.
         let total_matching_count = match kind {
-            InputObjectPassKind::Value => owned,
-            InputObjectPassKind::MutRef => owned + shared,
-            InputObjectPassKind::ByRef => owned + shared + immutable,
+            InputObjectPassKind::Value | InputObjectPassKind::MutRef => owned + shared + party,
+            InputObjectPassKind::ByRef => owned + shared + party + immutable,
         };
         if total_matching_count == 0 {
             return None;
         }
+        let mutable = matches!(
+            kind,
+            InputObjectPassKind::MutRef | InputObjectPassKind::Value
+        );
+        let consensus_mutability = if mutable {
+            SharedObjectMutability::Mutable
+        } else {
+            SharedObjectMutability::Immutable
+        };
         let mut n = state.rng.gen_range(0..total_matching_count);
         if n < owned {
             let obj_ref = state.choose_nth_owned_object(&type_tag, n);
@@ -168,14 +312,21 @@ impl SurfStrategy {
             return Some(CallArg::Object(ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
-                mutability: if matches!(kind, InputObjectPassKind::MutRef) {
-                    SharedObjectMutability::Mutable
-                } else {
-                    SharedObjectMutability::Immutable
-                },
+                mutability: consensus_mutability,
             }));
         }
         n -= shared;
+        if n < party {
+            // Party objects are referenced like shared objects, using their current
+            // consensus start version as the initial shared version.
+            let (id, initial_shared_version) = state.choose_nth_party_object(&type_tag, n);
+            return Some(CallArg::Object(ObjectArg::SharedObject {
+                id,
+                initial_shared_version,
+                mutability: consensus_mutability,
+            }));
+        }
+        n -= party;
         let obj_ref = state.choose_nth_immutable_object(&type_tag, n).await;
         Some(CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref)))
     }

--- a/crates/sui-surfer/src/surfer_state.rs
+++ b/crates/sui-surfer/src/surfer_state.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use move_binary_format::file_format::Visibility;
 use move_binary_format::normalized;
 use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::StructTag;
 use mysten_common::fatal;
+use rand::Rng;
 use rand::rngs::StdRng;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -14,9 +15,12 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_move_build::BuildConfig;
 use sui_protocol_config::{Chain, ProtocolConfig};
-use sui_types::base_types::{ConsensusObjectSequenceKey, ObjectID, ObjectRef, SuiAddress};
+use sui_types::base_types::{
+    ConsensusObjectSequenceKey, ObjectID, ObjectRef, SequenceNumber, SuiAddress,
+};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::object::{Object, Owner};
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::storage::WriteKind;
 use sui_types::transaction::{CallArg, ObjectArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH, TransactionData};
 use sui_types::{Identifier, SUI_FRAMEWORK_ADDRESS};
@@ -24,7 +28,29 @@ use test_cluster::TestCluster;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 
+/// How a transaction's gas is paid. The surfer randomizes this to exercise the
+/// different gas-payment code paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GasMode {
+    /// Pay with the account's gas coin (the common case).
+    Normal,
+    /// Pay gas from the sender's address balance (accumulator).
+    AddressBalance,
+    /// Free-tier transaction: address-balance gas with price 0.
+    Gasless,
+}
+
+/// Max number of times to retry submitting a transaction before giving up. Some
+/// gas modes (e.g. address-balance with no funded balance) or stale consensus
+/// inputs can fail deterministically; capping avoids spinning forever.
+const MAX_TX_SUBMIT_ATTEMPTS: usize = 10;
+
 type Type = normalized::Type<normalized::ArcIdentifier>;
+
+/// Gas budget for publishing the building-block packages. These packages have
+/// grown to many modules, so the budget must be well above the per-move-call
+/// publish unit. Kept below the protocol `max_tx_gas` (10 SUI).
+const GAS_BUDGET_FOR_PUBLISH: u64 = 5_000_000_000;
 
 #[derive(Debug, Clone)]
 pub struct EntryFunction {
@@ -40,14 +66,26 @@ pub struct SurfStatistics {
     pub num_failed_transactions: u64,
     pub num_owned_obj_transactions: u64,
     pub num_shared_obj_transactions: u64,
+    /// Transactions that paid gas from the sender's address balance.
+    pub num_address_balance_gas_transactions: u64,
+    /// Free-tier (price 0) gasless transactions.
+    pub num_gasless_transactions: u64,
+    /// Transactions that received an object (`ObjectArg::Receiving`).
+    pub num_receiving_transactions: u64,
+    /// Transactions that used at least one party (consensus-address-owned) input.
+    pub num_party_object_transactions: u64,
     pub unique_move_functions_called: HashSet<(ObjectID, String, String)>,
 }
 
 impl SurfStatistics {
+    #[allow(clippy::too_many_arguments)]
     pub fn record_transaction(
         &mut self,
         has_shared_object: bool,
         tx_succeeded: bool,
+        gas_mode: GasMode,
+        uses_receiving: bool,
+        uses_party: bool,
         package: ObjectID,
         module: String,
         function: String,
@@ -62,6 +100,17 @@ impl SurfStatistics {
         } else {
             self.num_owned_obj_transactions += 1;
         }
+        match gas_mode {
+            GasMode::Normal => (),
+            GasMode::AddressBalance => self.num_address_balance_gas_transactions += 1,
+            GasMode::Gasless => self.num_gasless_transactions += 1,
+        }
+        if uses_receiving {
+            self.num_receiving_transactions += 1;
+        }
+        if uses_party {
+            self.num_party_object_transactions += 1;
+        }
         self.unique_move_functions_called
             .insert((package, module, function));
     }
@@ -73,6 +122,11 @@ impl SurfStatistics {
             result.num_failed_transactions += stat.num_failed_transactions;
             result.num_owned_obj_transactions += stat.num_owned_obj_transactions;
             result.num_shared_obj_transactions += stat.num_shared_obj_transactions;
+            result.num_address_balance_gas_transactions +=
+                stat.num_address_balance_gas_transactions;
+            result.num_gasless_transactions += stat.num_gasless_transactions;
+            result.num_receiving_transactions += stat.num_receiving_transactions;
+            result.num_party_object_transactions += stat.num_party_object_transactions;
             result
                 .unique_move_functions_called
                 .extend(stat.unique_move_functions_called);
@@ -92,6 +146,13 @@ impl SurfStatistics {
             self.num_owned_obj_transactions, self.num_shared_obj_transactions
         );
         info!(
+            "Feature usage: {} address-balance-gas, {} gasless, {} receiving, {} party-object",
+            self.num_address_balance_gas_transactions,
+            self.num_gasless_transactions,
+            self.num_receiving_transactions,
+            self.num_party_object_transactions,
+        );
+        info!(
             "Unique move functions called: {}",
             self.unique_move_functions_called.len()
         );
@@ -106,6 +167,18 @@ pub type ImmObjects = Arc<RwLock<HashMap<StructTag, Vec<ObjectRef>>>>;
 /// (object ID, initial shared version).
 pub type SharedObjects = Arc<RwLock<HashMap<StructTag, Vec<ConsensusObjectSequenceKey>>>>;
 
+/// Objects transferred to another object's address, keyed by that address (the
+/// parent object's id reinterpreted as an address). These can be received via
+/// `ObjectArg::Receiving` when the parent is also an input. Shared across surfer
+/// tasks so any account controlling the parent can receive them.
+pub type ReceivableObjects =
+    Arc<RwLock<HashMap<SuiAddress, HashMap<StructTag, IndexSet<ObjectRef>>>>>;
+
+/// Party objects (`ConsensusAddressOwner`) owned by this account, keyed by type,
+/// mapping object id to its current consensus start version (which changes each
+/// time the object is transferred).
+pub type PartyObjects = HashMap<StructTag, IndexMap<ObjectID, SequenceNumber>>;
+
 pub struct SurferState {
     pub pool: Arc<RwLock<normalized::ArcPool>>,
     pub id: usize,
@@ -117,7 +190,13 @@ pub struct SurferState {
     pub owned_objects: OwnedObjects,
     pub immutable_objects: ImmObjects,
     pub shared_objects: SharedObjects,
+    pub receivable_objects: ReceivableObjects,
+    pub party_objects: PartyObjects,
     pub entry_functions: Arc<RwLock<Vec<EntryFunction>>>,
+
+    /// Monotonic nonce providing replay protection for address-balance / gasless
+    /// transactions (which carry no gas object to make them unique).
+    pub withdraw_nonce: u32,
 
     pub stats: SurfStatistics,
 }
@@ -132,6 +211,7 @@ impl SurferState {
         owned_objects: OwnedObjects,
         immutable_objects: ImmObjects,
         shared_objects: SharedObjects,
+        receivable_objects: ReceivableObjects,
         entry_functions: Arc<RwLock<Vec<EntryFunction>>>,
     ) -> Self {
         Self {
@@ -144,7 +224,10 @@ impl SurferState {
             owned_objects,
             immutable_objects,
             shared_objects,
+            receivable_objects,
+            party_objects: HashMap::new(),
             entry_functions,
+            withdraw_nonce: 0,
             stats: Default::default(),
         }
     }
@@ -161,19 +244,63 @@ impl SurferState {
         let use_shared_object = args
             .iter()
             .any(|arg| matches!(arg, CallArg::Object(ObjectArg::SharedObject { .. })));
-        let tx_data = TransactionData::new_move_call(
-            self.address,
-            package,
-            Identifier::new(module.as_str()).unwrap(),
-            Identifier::new(function.as_str()).unwrap(),
-            vec![],
-            self.gas_object,
-            args,
-            TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
-            rgp,
-        )
-        .unwrap();
+        let uses_receiving = args
+            .iter()
+            .any(|arg| matches!(arg, CallArg::Object(ObjectArg::Receiving(_))));
+        // Party objects are passed as shared-object inputs; detect whether any of
+        // the chosen inputs is one of our tracked party objects.
+        let uses_party = args.iter().any(|arg| {
+            matches!(arg, CallArg::Object(ObjectArg::SharedObject { id, .. }) if self.is_party_object(id))
+        });
+
+        // Build a single-command programmable transaction (exercises the PTB path,
+        // and is required for the address-balance / gasless gas modes).
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            if builder
+                .move_call(
+                    package,
+                    Identifier::new(module.as_str()).unwrap(),
+                    Identifier::new(function.as_str()).unwrap(),
+                    vec![],
+                    args,
+                )
+                .is_err()
+            {
+                debug!("Failed to build move call for {module}::{function}");
+                return;
+            }
+            builder.finish()
+        };
+
+        let budget = TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp;
+        let gas_mode = self.choose_gas_mode();
+        let tx_data = match gas_mode {
+            GasMode::Normal => TransactionData::new_programmable(
+                self.address,
+                vec![self.gas_object],
+                pt,
+                budget,
+                rgp,
+            ),
+            GasMode::AddressBalance | GasMode::Gasless => {
+                let price = if gas_mode == GasMode::Gasless { 0 } else { rgp };
+                let nonce = self.next_withdraw_nonce();
+                let epoch = self.current_epoch().await;
+                TransactionData::new_programmable_with_address_balance_gas(
+                    self.address,
+                    pt,
+                    budget,
+                    price,
+                    self.cluster.get_chain_identifier(),
+                    epoch,
+                    nonce,
+                )
+            }
+        };
+
         let tx = self.cluster.wallet.sign_transaction(&tx_data).await;
+        let mut attempts = 0;
         let response = loop {
             debug!("Executing transaction {:?}", tx.digest());
             match self
@@ -182,28 +309,51 @@ impl SurferState {
                 .execute_transaction_may_fail(tx.clone())
                 .await
             {
-                Ok(effects) => break effects,
+                Ok(response) => break Some(response),
                 Err(e) => {
+                    attempts += 1;
+                    if attempts >= MAX_TX_SUBMIT_ATTEMPTS {
+                        error!(
+                            "Giving up on transaction {:?} after {attempts} attempts: {e:?}",
+                            tx.digest()
+                        );
+                        break None;
+                    }
                     error!("Error executing transaction {:?}: {e:?}", tx.digest());
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 }
             }
         };
-        debug!(
-            "Successfully executed transaction {:?} with response {:?}",
-            tx, response
-        );
+        let Some(response) = response else {
+            // Could not get the transaction accepted (e.g. a gas mode whose
+            // preconditions aren't met). Record it as failed and move on.
+            self.stats.record_transaction(
+                use_shared_object,
+                false,
+                gas_mode,
+                uses_receiving,
+                uses_party,
+                package,
+                module,
+                function,
+            );
+            return;
+        };
         let effects = response.effects;
         info!(
-            "[{:?}] Calling Move function {:?}::{:?} returned {:?}",
+            "[{:?}] Calling Move function {:?}::{:?} (gas: {:?}) returned {:?}",
             self.address,
             module,
             function,
+            gas_mode,
             effects.status()
         );
         self.stats.record_transaction(
             use_shared_object,
             effects.status().is_ok(),
+            gas_mode,
+            uses_receiving,
+            uses_party,
             package,
             module,
             function,
@@ -211,8 +361,42 @@ impl SurferState {
         self.process_tx_effects(&effects).await;
     }
 
+    fn choose_gas_mode(&mut self) -> GasMode {
+        // Mostly normal gas; occasionally exercise the address-balance and gasless
+        // (free-tier) gas paths.
+        match self.rng.gen_range(0u8..100) {
+            0..=4 => GasMode::Gasless,
+            5..=9 => GasMode::AddressBalance,
+            _ => GasMode::Normal,
+        }
+    }
+
+    fn next_withdraw_nonce(&mut self) -> u32 {
+        let nonce = self.withdraw_nonce;
+        self.withdraw_nonce += 1;
+        nonce
+    }
+
+    async fn current_epoch(&self) -> u64 {
+        self.cluster
+            .fullnode_handle
+            .sui_node
+            .with(|node| node.state().current_epoch_for_testing())
+    }
+
+    fn is_party_object(&self, id: &ObjectID) -> bool {
+        self.party_objects.values().any(|ids| ids.contains_key(id))
+    }
+
     #[tracing::instrument(skip_all, fields(surfer_id = self.id))]
     async fn process_tx_effects(&mut self, effects: &TransactionEffects) {
+        // Drop any deleted/wrapped objects from our inventories first, so we don't
+        // later submit transactions referencing stale objects (which the validators
+        // would reject, forcing wasteful retries).
+        for (obj_ref, _kind) in effects.all_removed_objects() {
+            self.forget_object(&obj_ref.0).await;
+        }
+
         for (obj_ref, owner, write_kind) in effects.all_changed_objects() {
             if matches!(owner, Owner::ObjectOwner(_)) {
                 // For object owned objects, we don't need to do anything.
@@ -220,12 +404,13 @@ impl SurferState {
                 // races and the child object may no longer exist.
                 continue;
             }
-            // let obj_ref = owned_ref.reference.to_object_ref();
-            let object = self
+            let Some(object) = self
                 .cluster
                 .get_object_from_fullnode_store(&obj_ref.0)
                 .await
-                .unwrap();
+            else {
+                continue;
+            };
             if object.is_package() {
                 self.discover_entry_functions(object).await;
                 continue;
@@ -246,16 +431,23 @@ impl SurferState {
                             .entry(struct_tag)
                             .or_default()
                             .insert(obj_ref);
+                    } else {
+                        // Transferred to some other address. If that address turns out
+                        // to be a parent object (transfer-to-object), this becomes
+                        // receivable via `transfer::receive`.
+                        self.receivable_objects
+                            .write()
+                            .await
+                            .entry(address)
+                            .or_default()
+                            .entry(struct_tag)
+                            .or_default()
+                            .insert(obj_ref);
                     }
                 }
                 Owner::ObjectOwner(_) => (),
                 Owner::Shared {
                     initial_shared_version,
-                }
-                // TODO: Implement full support for ConsensusAddressOwner objects in sui-surfer.
-                | Owner::ConsensusAddressOwner {
-                    start_version: initial_shared_version,
-                    ..
                 } => {
                     if write_kind != WriteKind::Mutate {
                         self.shared_objects
@@ -268,10 +460,50 @@ impl SurferState {
                     // We do not need to insert it if it's a Mutate, because it means
                     // we should already have it in the inventory.
                 }
+                Owner::ConsensusAddressOwner {
+                    start_version,
+                    owner: party_owner,
+                } => {
+                    // Party object. Only the owning account can use it as a consensus
+                    // input. Like shared objects, the *input* version is the initial
+                    // consensus version and stays constant across later mutations /
+                    // re-transfers, so only record it when the object first becomes a
+                    // party object (not on Mutate).
+                    if party_owner == self.address && write_kind != WriteKind::Mutate {
+                        self.party_objects
+                            .entry(struct_tag)
+                            .or_default()
+                            .entry(obj_ref.0)
+                            .or_insert(start_version);
+                    }
+                }
             }
             if obj_ref.0 == self.gas_object.0 {
                 self.gas_object = obj_ref;
             }
+        }
+    }
+
+    /// Remove all references to an object (by id) from every inventory. Used when
+    /// an object is deleted or wrapped.
+    async fn forget_object(&mut self, id: &ObjectID) {
+        for set in self.owned_objects.values_mut() {
+            set.retain(|r| &r.0 != id);
+        }
+        for ids in self.party_objects.values_mut() {
+            ids.shift_remove(id);
+        }
+        {
+            let mut receivable = self.receivable_objects.write().await;
+            for tags in receivable.values_mut() {
+                for set in tags.values_mut() {
+                    set.retain(|r| &r.0 != id);
+                }
+            }
+        }
+        let mut shared = self.shared_objects.write().await;
+        for refs in shared.values_mut() {
+            refs.retain(|(oid, _)| oid != id);
         }
     }
 
@@ -343,7 +575,9 @@ impl SurferState {
             self.gas_object,
             modules,
             package.dependency_ids.published.values().cloned().collect(),
-            TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
+            // The building-block packages can be large (many modules), so use a
+            // generous budget rather than the small per-call publish unit.
+            GAS_BUDGET_FOR_PUBLISH,
             rgp,
         );
         let tx = self.cluster.wallet.sign_transaction(&tx_data).await;
@@ -373,6 +607,13 @@ impl SurferState {
                 }
             }
         };
+        if !response.effects.status().is_ok() {
+            fatal!(
+                "Failed to publish package {:?}: {:?}",
+                path,
+                response.effects.status()
+            );
+        }
         info!("Successfully published package in {:?}", path);
         self.process_tx_effects(&response.effects).await;
     }
@@ -420,6 +661,59 @@ impl SurferState {
         n: usize,
     ) -> ConsensusObjectSequenceKey {
         self.shared_objects.read().await.get(type_tag).unwrap()[n]
+    }
+
+    pub fn matching_party_objects_count(&self, type_tag: &StructTag) -> usize {
+        self.party_objects
+            .get(type_tag)
+            .map(|objects| objects.len())
+            .unwrap_or(0)
+    }
+
+    pub fn choose_nth_party_object(
+        &self,
+        type_tag: &StructTag,
+        n: usize,
+    ) -> ConsensusObjectSequenceKey {
+        let (id, version) = self
+            .party_objects
+            .get(type_tag)
+            .unwrap()
+            .get_index(n)
+            .unwrap();
+        (*id, *version)
+    }
+
+    /// Take (remove) a receivable child object of the given type that was
+    /// transferred to `parent`'s address. Returns `None` if there is none.
+    pub async fn take_receivable_object(
+        &self,
+        parent: &SuiAddress,
+        type_tag: &StructTag,
+    ) -> Option<ObjectRef> {
+        let mut receivable = self.receivable_objects.write().await;
+        let set = receivable.get_mut(parent)?.get_mut(type_tag)?;
+        let obj_ref = set.iter().next().copied()?;
+        set.swap_remove(&obj_ref);
+        Some(obj_ref)
+    }
+
+    /// Put back a receivable child object that was taken but not used (because the
+    /// surrounding transaction could not be assembled).
+    pub async fn return_receivable_object(
+        &self,
+        parent: SuiAddress,
+        type_tag: StructTag,
+        obj_ref: ObjectRef,
+    ) {
+        self.receivable_objects
+            .write()
+            .await
+            .entry(parent)
+            .or_default()
+            .entry(type_tag)
+            .or_default()
+            .insert(obj_ref);
     }
 }
 

--- a/crates/sui-surfer/src/surfer_task.rs
+++ b/crates/sui-surfer/src/surfer_task.rs
@@ -14,7 +14,9 @@ use tokio::sync::{RwLock, watch};
 
 use crate::{
     surf_strategy::SurfStrategy,
-    surfer_state::{ImmObjects, OwnedObjects, SharedObjects, SurfStatistics, SurferState},
+    surfer_state::{
+        ImmObjects, OwnedObjects, ReceivableObjects, SharedObjects, SurfStatistics, SurferState,
+    },
 };
 
 pub struct SurferTask {
@@ -34,6 +36,7 @@ impl SurferTask {
         let mut rng = StdRng::seed_from_u64(seed);
         let immutable_objects: ImmObjects = Arc::new(RwLock::new(HashMap::new()));
         let shared_objects: SharedObjects = Arc::new(RwLock::new(HashMap::new()));
+        let receivable_objects: ReceivableObjects = Arc::new(RwLock::new(HashMap::new()));
 
         let mut accounts: HashMap<SuiAddress, (Option<ObjectRef>, OwnedObjects)> = cluster
             .get_addresses()
@@ -94,6 +97,17 @@ impl SurferTask {
                                             .or_default()
                                             .insert(obj_ref);
                                     }
+                                } else {
+                                    // Owned by a non-account address (e.g. an object's
+                                    // address): potentially receivable via Receiving.
+                                    receivable_objects
+                                        .write()
+                                        .await
+                                        .entry(address)
+                                        .or_default()
+                                        .entry(struct_tag)
+                                        .or_default()
+                                        .insert(obj_ref);
                                 }
                             }
                             Owner::ObjectOwner(_) => (),
@@ -119,6 +133,7 @@ impl SurferTask {
                     owned_objects,
                     immutable_objects.clone(),
                     shared_objects.clone(),
+                    receivable_objects.clone(),
                     entry_functions.clone(),
                 );
                 SurferTask {
@@ -133,6 +148,17 @@ impl SurferTask {
     pub async fn surf(mut self) -> SurfStatistics {
         loop {
             let entry_functions = self.state.entry_functions.read().await.clone();
+
+            // No callable functions discovered yet (e.g. packages still being
+            // published). Yield instead of spinning in a tight loop, which would
+            // otherwise starve the runtime (and trip the simulator's deadlock
+            // detector).
+            if entry_functions.is_empty() {
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => continue,
+                    _ = self.exit_rcv.changed() => return self.state.stats,
+                }
+            }
 
             tokio::select! {
                 _ = self.surf_strategy

--- a/crates/sui-surfer/tests/move_building_blocks/sources/address_balance.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/address_balance.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Deposits SUI into the sender's address balance (accumulator), which is the
+/// precondition for address-balance gas payments and gasless transactions.
+module move_building_blocks::address_balance {
+    use sui::coin::{Self, Coin};
+    use sui::sui::SUI;
+
+    public fun deposit_sui(coin: Coin<SUI>, ctx: &TxContext) {
+        let balance = coin.into_balance();
+        balance.send_funds(ctx.sender());
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/borrows.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/borrows.move
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises the `borrow` hot-potato API (Referent / Borrow). The full
+/// borrow/put_back cycle is performed inside a single call.
+module move_building_blocks::borrows {
+    use sui::borrow::{Self, Referent};
+
+    public struct Asset has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public struct Vault has key, store {
+        id: UID,
+        referent: Referent<Asset>,
+    }
+
+    public fun create_vault(value: u64, ctx: &mut TxContext) {
+        let asset = Asset { id: object::new(ctx), value };
+        let referent = borrow::new(asset, ctx);
+        transfer::share_object(Vault { id: object::new(ctx), referent });
+    }
+
+    public fun borrow_and_return(vault: &mut Vault, new_value: u64) {
+        let (mut asset, borrow) = borrow::borrow(&mut vault.referent);
+        asset.value = new_value;
+        borrow::put_back(&mut vault.referent, asset, borrow);
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/clocks.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/clocks.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Reads the shared `Clock` (0x6) so transactions take it as an immutable shared
+/// input.
+module move_building_blocks::clocks {
+    use sui::clock::{Self, Clock};
+
+    public struct TimeStamped has key, store {
+        id: UID,
+        ts: u64,
+    }
+
+    public fun stamp(clock: &Clock, ctx: &mut TxContext) {
+        let stamped = TimeStamped { id: object::new(ctx), ts: clock.timestamp_ms() };
+        transfer::transfer(stamped, ctx.sender());
+    }
+
+    public fun update_stamp(stamped: &mut TimeStamped, clock: &Clock) {
+        stamped.ts = clock::timestamp_ms(clock);
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/coins.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/coins.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Defines its own coin type and exposes monomorphic entry functions for
+/// mint/burn/split/merge so the surfer exercises the `coin`/`balance` machinery
+/// (which is otherwise only reachable via generic framework calls).
+module move_building_blocks::coins {
+    use sui::coin::{Self, Coin, TreasuryCap};
+
+    /// One-time witness for the coin type.
+    public struct COINS has drop {}
+
+    /// Shared holder for the treasury cap so any account can mint.
+    public struct Treasury has key {
+        id: UID,
+        cap: TreasuryCap<COINS>,
+    }
+
+    fun init(witness: COINS, ctx: &mut TxContext) {
+        let (treasury_cap, metadata) = coin::create_currency(
+            witness,
+            9,
+            b"SURF",
+            b"Surfer Coin",
+            b"Coin minted by sui-surfer building blocks",
+            option::none(),
+            ctx,
+        );
+        transfer::public_freeze_object(metadata);
+        transfer::share_object(Treasury { id: object::new(ctx), cap: treasury_cap });
+    }
+
+    public fun mint(treasury: &mut Treasury, amount: u64, ctx: &mut TxContext) {
+        let coin = coin::mint(&mut treasury.cap, amount % 1_000_000, ctx);
+        transfer::public_transfer(coin, ctx.sender());
+    }
+
+    public fun burn(treasury: &mut Treasury, coin: Coin<COINS>) {
+        let _ = coin::burn(&mut treasury.cap, coin);
+    }
+
+    public fun split(coin: &mut Coin<COINS>, amount: u64, ctx: &mut TxContext) {
+        let value = coin.value();
+        if (value > 1) {
+            let split_amount = 1 + (amount % (value - 1));
+            let new_coin = coin.split(split_amount, ctx);
+            transfer::public_transfer(new_coin, ctx.sender());
+        }
+    }
+
+    public fun merge(coin: &mut Coin<COINS>, other: Coin<COINS>) {
+        coin.join(other);
+    }
+
+    public fun zero_and_destroy(ctx: &mut TxContext) {
+        let coin = coin::zero<COINS>(ctx);
+        coin.destroy_zero();
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/collections.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/collections.move
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises the framework collection types via a single shared object holding
+/// one of each. Monomorphic (concrete key/value types) so the surfer can call
+/// the entry functions without type arguments.
+module move_building_blocks::collections {
+    use sui::bag::{Self, Bag};
+    use sui::linked_table::{Self, LinkedTable};
+    use sui::table_vec::{Self, TableVec};
+    use sui::vec_map::{Self, VecMap};
+    use sui::vec_set::{Self, VecSet};
+
+    public struct Collections has key, store {
+        id: UID,
+        map: VecMap<u64, u64>,
+        set: VecSet<u64>,
+        bag: Bag,
+        tvec: TableVec<u64>,
+        ltable: LinkedTable<u64, u64>,
+    }
+
+    public fun create(ctx: &mut TxContext) {
+        let collections = Collections {
+            id: object::new(ctx),
+            map: vec_map::empty(),
+            set: vec_set::empty(),
+            bag: bag::new(ctx),
+            tvec: table_vec::empty(ctx),
+            ltable: linked_table::new(ctx),
+        };
+        transfer::share_object(collections);
+    }
+
+    public fun map_insert(c: &mut Collections, key: u64, value: u64) {
+        if (!c.map.contains(&key)) {
+            c.map.insert(key, value);
+        }
+    }
+
+    public fun map_remove(c: &mut Collections, key: u64) {
+        if (c.map.contains(&key)) {
+            let (_, _) = c.map.remove(&key);
+        }
+    }
+
+    public fun set_insert(c: &mut Collections, key: u64) {
+        if (!c.set.contains(&key)) {
+            c.set.insert(key);
+        }
+    }
+
+    public fun set_remove(c: &mut Collections, key: u64) {
+        if (c.set.contains(&key)) {
+            c.set.remove(&key);
+        }
+    }
+
+    public fun bag_add(c: &mut Collections, key: u64, value: u64) {
+        if (!c.bag.contains(key)) {
+            c.bag.add(key, value);
+        }
+    }
+
+    public fun bag_remove(c: &mut Collections, key: u64) {
+        if (c.bag.contains(key)) {
+            let _: u64 = c.bag.remove(key);
+        }
+    }
+
+    public fun tvec_push(c: &mut Collections, value: u64) {
+        c.tvec.push_back(value);
+    }
+
+    public fun tvec_pop(c: &mut Collections) {
+        if (!c.tvec.is_empty()) {
+            let _ = c.tvec.pop_back();
+        }
+    }
+
+    public fun ltable_push(c: &mut Collections, key: u64, value: u64) {
+        if (!c.ltable.contains(key)) {
+            c.ltable.push_back(key, value);
+        }
+    }
+
+    public fun ltable_pop(c: &mut Collections) {
+        if (!c.ltable.is_empty()) {
+            let (_, _) = c.ltable.pop_front();
+        }
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/crypto.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/crypto.move
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Wraps the cryptographic native functions in monomorphic entry functions so the
+/// surfer can fuzz them with random byte vectors. Failures (aborts / `false`
+/// results) are expected and intentionally exercise the natives' error paths.
+module move_building_blocks::crypto {
+    use sui::bls12381;
+    use sui::ecdsa_k1;
+    use sui::ecdsa_r1;
+    use sui::ecvrf;
+    use sui::ed25519;
+    use sui::hash;
+    use sui::hmac;
+    use sui::poseidon;
+    use std::hash as std_hash;
+
+    public fun do_blake2b256(data: vector<u8>) {
+        let _ = hash::blake2b256(&data);
+    }
+
+    public fun do_keccak256(data: vector<u8>) {
+        let _ = hash::keccak256(&data);
+    }
+
+    public fun do_sha2_256(data: vector<u8>) {
+        let _ = std_hash::sha2_256(data);
+    }
+
+    public fun do_sha3_256(data: vector<u8>) {
+        let _ = std_hash::sha3_256(data);
+    }
+
+    public fun do_hmac_sha3_256(key: vector<u8>, msg: vector<u8>) {
+        let _ = hmac::hmac_sha3_256(&key, &msg);
+    }
+
+    public fun do_ed25519_verify(signature: vector<u8>, public_key: vector<u8>, msg: vector<u8>) {
+        let _ = ed25519::ed25519_verify(&signature, &public_key, &msg);
+    }
+
+    public fun do_secp256k1_verify(
+        signature: vector<u8>,
+        public_key: vector<u8>,
+        msg: vector<u8>,
+        hash_kind: u8,
+    ) {
+        let _ = ecdsa_k1::secp256k1_verify(&signature, &public_key, &msg, hash_kind);
+    }
+
+    public fun do_secp256r1_verify(
+        signature: vector<u8>,
+        public_key: vector<u8>,
+        msg: vector<u8>,
+        hash_kind: u8,
+    ) {
+        let _ = ecdsa_r1::secp256r1_verify(&signature, &public_key, &msg, hash_kind);
+    }
+
+    public fun do_ecvrf_verify(
+        hash_bytes: vector<u8>,
+        alpha_string: vector<u8>,
+        public_key: vector<u8>,
+        proof: vector<u8>,
+    ) {
+        let _ = ecvrf::ecvrf_verify(&hash_bytes, &alpha_string, &public_key, &proof);
+    }
+
+    public fun do_bls12381_min_sig_verify(
+        signature: vector<u8>,
+        public_key: vector<u8>,
+        msg: vector<u8>,
+    ) {
+        let _ = bls12381::bls12381_min_sig_verify(&signature, &public_key, &msg);
+    }
+
+    public fun do_bls12381_min_pk_verify(
+        signature: vector<u8>,
+        public_key: vector<u8>,
+        msg: vector<u8>,
+    ) {
+        let _ = bls12381::bls12381_min_pk_verify(&signature, &public_key, &msg);
+    }
+
+    public fun do_poseidon_bn254(data: vector<u256>) {
+        // poseidon_bn254 aborts on empty input, so only call it with a payload.
+        if (!data.is_empty()) {
+            let _ = poseidon::poseidon_bn254(&data);
+        }
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/derived_objects.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/derived_objects.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises derived objects (`derived_object::claim` / `exists` /
+/// `derive_address`).
+module move_building_blocks::derived_objects {
+    use sui::derived_object;
+
+    public struct Registry has key, store {
+        id: UID,
+    }
+
+    public struct Derived has key, store {
+        id: UID,
+        key: u64,
+    }
+
+    public fun create_registry(ctx: &mut TxContext) {
+        transfer::share_object(Registry { id: object::new(ctx) });
+    }
+
+    public fun claim(registry: &mut Registry, key: u64, ctx: &mut TxContext) {
+        if (!derived_object::exists(&registry.id, key)) {
+            let uid = derived_object::claim(&mut registry.id, key);
+            transfer::transfer(Derived { id: uid, key }, ctx.sender());
+        }
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/dynamic_fields.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/dynamic_fields.move
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises dynamic fields and dynamic object fields directly (the existing
+/// `objects`/`limits` modules only touch them indirectly via `Table`).
+module move_building_blocks::dynamic_fields {
+    use sui::dynamic_field;
+    use sui::dynamic_object_field;
+
+    public struct Holder has key, store {
+        id: UID,
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun create_holder(ctx: &mut TxContext) {
+        transfer::share_object(Holder { id: object::new(ctx) });
+    }
+
+    public fun df_add(holder: &mut Holder, name: u64, value: u64) {
+        if (!dynamic_field::exists_(&holder.id, name)) {
+            dynamic_field::add(&mut holder.id, name, value);
+        }
+    }
+
+    public fun df_set(holder: &mut Holder, name: u64, value: u64) {
+        if (dynamic_field::exists_with_type<u64, u64>(&holder.id, name)) {
+            let stored = dynamic_field::borrow_mut<u64, u64>(&mut holder.id, name);
+            *stored = value;
+        }
+    }
+
+    public fun df_remove(holder: &mut Holder, name: u64) {
+        if (dynamic_field::exists_with_type<u64, u64>(&holder.id, name)) {
+            let _: u64 = dynamic_field::remove(&mut holder.id, name);
+        }
+    }
+
+    public fun dof_add(holder: &mut Holder, name: u64, value: u64, ctx: &mut TxContext) {
+        if (!dynamic_object_field::exists_(&holder.id, name)) {
+            dynamic_object_field::add(&mut holder.id, name, Child { id: object::new(ctx), value });
+        }
+    }
+
+    public fun dof_remove(holder: &mut Holder, name: u64) {
+        if (dynamic_object_field::exists_with_type<u64, Child>(&holder.id, name)) {
+            let Child { id, value: _ } = dynamic_object_field::remove<u64, Child>(&mut holder.id, name);
+            object::delete(id);
+        }
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/events.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/events.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises regular and authenticated (light-client verifiable) event emission.
+module move_building_blocks::events {
+    use sui::event;
+
+    public struct SimpleEvent has copy, drop {
+        value: u64,
+        who: address,
+    }
+
+    public struct DataEvent has copy, drop {
+        data: vector<u8>,
+    }
+
+    public fun emit_simple(value: u64, who: address) {
+        event::emit(SimpleEvent { value, who });
+    }
+
+    public fun emit_data(data: vector<u8>) {
+        event::emit(DataEvent { data });
+    }
+
+    /// Authenticated event streams (`enable_authenticated_event_streams`).
+    public fun emit_authenticated_simple(value: u64, who: address) {
+        event::emit_authenticated(SimpleEvent { value, who });
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/language_features.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/language_features.move
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises Move 2024 language features (enums, `match`, macros, positional
+/// structs) so the corresponding bytecode (e.g. `variant_nodes`) is executed.
+module move_building_blocks::language_features {
+    public enum Shape has store, drop, copy {
+        Circle(u64),
+        Rectangle(u64, u64),
+        Empty,
+    }
+
+    /// Positional struct.
+    public struct Pair(u64, u64) has store, drop, copy;
+
+    public struct ShapeHolder has key, store {
+        id: UID,
+        shape: Shape,
+        bounds: Pair,
+        area: u64,
+    }
+
+    macro fun square($x: u64): u64 {
+        $x * $x
+    }
+
+    public fun create(kind: u8, a: u64, b: u64, ctx: &mut TxContext) {
+        // Bound inputs so area computations cannot overflow u64.
+        let a = a % 100_000;
+        let b = b % 100_000;
+        let shape = make_shape(kind, a, b);
+        let computed_area = area(&shape);
+        let holder = ShapeHolder {
+            id: object::new(ctx),
+            shape,
+            bounds: Pair(a, b),
+            area: computed_area,
+        };
+        transfer::share_object(holder);
+    }
+
+    public fun update(holder: &mut ShapeHolder, kind: u8, a: u64, b: u64) {
+        let a = a % 100_000;
+        let b = b % 100_000;
+        let shape = make_shape(kind, a, b);
+        holder.area = area(&shape);
+        holder.shape = shape;
+        holder.bounds = Pair(a, b);
+    }
+
+    fun make_shape(kind: u8, a: u64, b: u64): Shape {
+        match (kind % 3) {
+            0 => Shape::Circle(a),
+            1 => Shape::Rectangle(a, b),
+            _ => Shape::Empty,
+        }
+    }
+
+    fun area(shape: &Shape): u64 {
+        match (shape) {
+            Shape::Circle(r) => square!(*r),
+            Shape::Rectangle(w, h) => *w * *h,
+            Shape::Empty => 0,
+        }
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/party_objects.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/party_objects.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises party objects (`ConsensusAddressOwner`) via `party_transfer` /
+/// `public_party_transfer`. Objects are transferred to the sender as a single
+/// owner party so the sender can later mutate, re-party, or delete them.
+module move_building_blocks::party_objects {
+    use sui::party;
+
+    public struct PartyObject has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun create_to_sender(value: u64, ctx: &mut TxContext) {
+        let obj = PartyObject { id: object::new(ctx), value };
+        transfer::public_party_transfer(obj, party::single_owner(ctx.sender()));
+    }
+
+    public fun mutate(obj: &mut PartyObject, value: u64) {
+        obj.value = value;
+    }
+
+    /// Re-transfer the existing party object to the sender as a party object. The
+    /// input consensus version stays constant across re-transfers.
+    public fun reparty(obj: PartyObject, ctx: &TxContext) {
+        transfer::public_party_transfer(obj, party::single_owner(ctx.sender()));
+    }
+
+    public fun delete(obj: PartyObject) {
+        let PartyObject { id, value: _ } = obj;
+        object::delete(id);
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/receiving.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/receiving.move
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises object receiving (`transfer::receive` / `public_receive` and
+/// `ObjectArg::Receiving`). A single shared `Parent` is created at publish time;
+/// items are transferred to its address and later received back. Using one shared
+/// parent ensures the surfer reliably pairs a "send" with a later "receive".
+module move_building_blocks::receiving {
+    use sui::transfer::Receiving;
+
+    public struct Parent has key {
+        id: UID,
+        sent: u64,
+        received: u64,
+    }
+
+    public struct Item has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    fun init(ctx: &mut TxContext) {
+        let mut parent = Parent {
+            id: object::new(ctx),
+            sent: 0,
+            received: 0,
+        };
+        // Seed some items already owned by the parent so the surfer can exercise
+        // `receive` without first having to land a `send` transaction.
+        let parent_address = parent.id.uid_to_address();
+        let mut i = 0;
+        while (i < 8) {
+            transfer::transfer(Item { id: object::new(ctx), value: i }, parent_address);
+            i = i + 1;
+        };
+        parent.sent = 8;
+        transfer::share_object(parent);
+    }
+
+    /// Transfer a freshly created item to the parent object's address so it can
+    /// later be received.
+    public fun send_item_to_parent(parent: &mut Parent, value: u64, ctx: &mut TxContext) {
+        let item = Item { id: object::new(ctx), value };
+        transfer::transfer(item, parent.id.uid_to_address());
+        parent.sent = parent.sent + 1;
+    }
+
+    /// Receive an item using the restricted (`receive`) variant and forward it to
+    /// the sender.
+    public fun receive_item(parent: &mut Parent, item: Receiving<Item>, ctx: &mut TxContext) {
+        let received = transfer::receive(&mut parent.id, item);
+        parent.received = parent.received + 1;
+        transfer::transfer(received, ctx.sender());
+    }
+
+    /// Receive an item using the public (`public_receive`) variant and delete it.
+    public fun receive_and_delete(parent: &mut Parent, item: Receiving<Item>) {
+        let Item { id, value: _ } = transfer::public_receive(&mut parent.id, item);
+        parent.received = parent.received + 1;
+        object::delete(id);
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/regulated_coin.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/regulated_coin.move
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises regulated coins and the deny list v2 (`create_regulated_currency_v2`,
+/// `deny_list_v2_add` / `_remove` / `_enable_global_pause`). The shared `DenyList`
+/// (0x403) is taken as a mutable input.
+module move_building_blocks::regulated_coin {
+    use sui::coin::{Self, TreasuryCap, DenyCapV2};
+    use sui::deny_list::DenyList;
+
+    public struct REGULATED_COIN has drop {}
+
+    public struct Caps has key {
+        id: UID,
+        treasury: TreasuryCap<REGULATED_COIN>,
+        deny: DenyCapV2<REGULATED_COIN>,
+    }
+
+    fun init(witness: REGULATED_COIN, ctx: &mut TxContext) {
+        let (treasury, deny, metadata) = coin::create_regulated_currency_v2(
+            witness,
+            6,
+            b"RSURF",
+            b"Regulated Surf",
+            b"Regulated coin minted by sui-surfer building blocks",
+            option::none(),
+            true,
+            ctx,
+        );
+        transfer::public_freeze_object(metadata);
+        transfer::share_object(Caps { id: object::new(ctx), treasury, deny });
+    }
+
+    public fun mint(caps: &mut Caps, amount: u64, ctx: &mut TxContext) {
+        let coin = coin::mint(&mut caps.treasury, amount % 100_000, ctx);
+        transfer::public_transfer(coin, ctx.sender());
+    }
+
+    public fun deny_add(deny_list: &mut DenyList, caps: &mut Caps, addr: address, ctx: &mut TxContext) {
+        if (!coin::deny_list_v2_contains_next_epoch<REGULATED_COIN>(deny_list, addr)) {
+            coin::deny_list_v2_add(deny_list, &mut caps.deny, addr, ctx);
+        }
+    }
+
+    public fun deny_remove(deny_list: &mut DenyList, caps: &mut Caps, addr: address, ctx: &mut TxContext) {
+        if (coin::deny_list_v2_contains_next_epoch<REGULATED_COIN>(deny_list, addr)) {
+            coin::deny_list_v2_remove(deny_list, &mut caps.deny, addr, ctx);
+        }
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/shared_deletion.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/shared_deletion.move
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises shared object deletion (`shared_object_deletion`). The surfer can
+/// pass the shared object by value to `delete`, which consensus must order and
+/// the execution layer must allow.
+module move_building_blocks::shared_deletion {
+    public struct Deletable has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun create(value: u64, ctx: &mut TxContext) {
+        transfer::share_object(Deletable { id: object::new(ctx), value });
+    }
+
+    public fun mutate(obj: &mut Deletable, value: u64) {
+        obj.value = value;
+    }
+
+    public fun delete(obj: Deletable) {
+        let Deletable { id, value: _ } = obj;
+        object::delete(id);
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/transfer_variants.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/transfer_variants.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises the `public_*` transfer variants (the existing `objects` module
+/// only uses the non-public `transfer`/`share_object`/`freeze_object`).
+module move_building_blocks::transfer_variants {
+    public struct Widget has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun create_owned(value: u64, ctx: &mut TxContext) {
+        transfer::public_transfer(Widget { id: object::new(ctx), value }, ctx.sender());
+    }
+
+    public fun create_shared(value: u64, ctx: &mut TxContext) {
+        transfer::public_share_object(Widget { id: object::new(ctx), value });
+    }
+
+    public fun create_frozen(value: u64, ctx: &mut TxContext) {
+        transfer::public_freeze_object(Widget { id: object::new(ctx), value });
+    }
+
+    public fun transfer_to(widget: Widget, recipient: address) {
+        transfer::public_transfer(widget, recipient);
+    }
+
+    public fun freeze_widget(widget: Widget) {
+        transfer::public_freeze_object(widget);
+    }
+}

--- a/crates/sui-surfer/tests/move_building_blocks/sources/versions.move
+++ b/crates/sui-surfer/tests/move_building_blocks/sources/versions.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exercises the `versioned` wrapper, including the remove/upgrade flow.
+module move_building_blocks::versions {
+    use sui::versioned::{Self, Versioned};
+
+    public struct Inner has store {
+        value: u64,
+    }
+
+    public struct InnerV2 has store {
+        value: u64,
+        extra: u64,
+    }
+
+    public struct Wrapper has key, store {
+        id: UID,
+        versioned: Versioned,
+    }
+
+    public fun create(value: u64, ctx: &mut TxContext) {
+        let versioned = versioned::create(1, Inner { value }, ctx);
+        transfer::share_object(Wrapper { id: object::new(ctx), versioned });
+    }
+
+    public fun upgrade(wrapper: &mut Wrapper, value: u64) {
+        if (versioned::version(&wrapper.versioned) == 1) {
+            let (Inner { value: old }, cap) =
+                versioned::remove_value_for_upgrade<Inner>(&mut wrapper.versioned);
+            versioned::upgrade(
+                &mut wrapper.versioned,
+                2,
+                InnerV2 { value: old + (value % 1_000), extra: value % 1_000 },
+                cap,
+            );
+        }
+    }
+}

--- a/crates/sui-surfer/tests/smoke_tests.rs
+++ b/crates/sui-surfer/tests/smoke_tests.rs
@@ -12,6 +12,25 @@ async fn smoke_test() {
     path.extend(["tests", "move_building_blocks"]);
     let results =
         sui_surfer::run(Duration::from_secs(30), Duration::from_secs(15), vec![path]).await;
+    results.print_stats();
     assert!(results.num_successful_transactions > 0);
-    assert!(!results.unique_move_functions_called.is_empty());
+    // The building-block package exposes many modules (objects, collections,
+    // crypto, dynamic fields, coins, events, receiving, party, etc.). Make sure a
+    // broad set of them is actually exercised, not just a couple.
+    assert!(
+        results.unique_move_functions_called.len() >= 30,
+        "expected the surfer to exercise many functions, only saw {}",
+        results.unique_move_functions_called.len()
+    );
+    // Make sure the newer transaction/object features are reachable: gasless and
+    // address-balance gas, object receiving, and party (consensus-address-owned)
+    // objects. At least one of these should fire in a run of this length.
+    let advanced_feature_txns = results.num_gasless_transactions
+        + results.num_address_balance_gas_transactions
+        + results.num_receiving_transactions
+        + results.num_party_object_transactions;
+    assert!(
+        advanced_feature_txns > 0,
+        "expected the surfer to exercise gasless / address-balance / receiving / party features"
+    );
 }


### PR DESCRIPTION
## Why

sui-surfer's fuzzing "building blocks" had not been updated in a long time, so most Move and transaction features shipped over the past year were never exercised — gasless and address-balance gas, party (consensus-address-owned) objects, object receiving, dynamic object fields, the crypto natives, regulated coins / deny list, derived objects, enums/macros, authenticated event streams, and more. This catches the surfer up so it actually fuzzes those paths.

## What

**Engine (`src/`)**
- Generate `vector<T>` and `u256` pure arguments (unlocks the crypto natives and bulk ops).
- Object **receiving**: detect `Receiving<T>` params and build `ObjectArg::Receiving`, coordinated with the parent object; track receivable children in a shared map.
- **Party objects**: track consensus-address-owned objects per account and pass them as consensus inputs (constant initial version).
- Randomize the **gas mode** per transaction (normal / address-balance / gasless) on a one-command PTB; allow shared/party objects to be consumed by value (shared-object deletion).
- Robustness: prune deleted/wrapped objects from inventory, cap submission retries, raise the publish gas budget, assert publish success, and stop `surf()` from busy-looping when no functions are discovered (this previously surfaced as a simulator "deadlock"). Added per-feature stats.

**New building-block modules** (`tests/move_building_blocks/sources/`): crypto, events (incl. authenticated streams), collections, dynamic_fields, coins, regulated_coin, clocks, language_features (enums/match/macros/positional structs), shared_deletion, receiving, party_objects, derived_objects, address_balance, borrows, versions, transfer_variants.

## Coverage

The smoke test now exercises ~80 unique Move functions (was ~10) and reliably fires the gasless, address-balance-gas, receiving, and party-object paths; assertions were tightened accordingly.

## Not in scope

Auth/signature-level features (address aliases, zklogin, passkey) are not move-call-level. Larger subsystems (coin_registry, display_registry, closed-loop token, kiosk/transfer_policy, config, group_ops/vdf/nitro_attestation) are left as straightforward follow-up modules.

## Future work: coverage guarantee

Today coverage is observed (the run prints ~80 of ~84 discovered functions called) but not guaranteed — the surfer is random and time-bounded, so a scenario missed this run isn't forced to run next time. A scenario is missed for one of two reasons: it was never selected (random shuffle + run ends mid-pass), or it was selected but its args/preconditions weren't satisfiable.

A coverage floor could be added (warn-only) by:
- Biasing scheduling toward not-yet-covered functions (using the shared called-set) instead of a uniform shuffle, so the run converges on full coverage.
- Running until `called == discovered` (with a max-time fallback) instead of a fixed duration.
- Logging the uncovered `module::function` list + called/discovered ratio at the end of each run.
- Per-building-block discipline: make each function's preconditions seedable/creatable by the surfer (as `receiving::init` seeds items so `receive` is reachable from the first attempt), so "reachable" is actually true; whatever still can't be reached then surfaces as the real, reviewable gap.

The fully-deterministic alternative (an explicit per-function scenario+setup list) was considered but rejected for now since it loses auto-discovery of newly added building blocks.
