### PR TITLE
[tidehunter] Call Bytes::into_owned on multi_get results

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -259,15 +259,14 @@ impl Database {
                 .map(|r| Ok(r.map(GetResult::InMemory)))
                 .collect(),
             #[cfg(tidehunter)]
-            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => {
-                let res = keys.into_iter().map(|k| {
+            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => keys
+                .into_iter()
+                .map(|k| {
                     db.get(*ks, &transform_th_key(k.as_ref(), prefix))
                         .map_err(typed_store_error_from_th_error)
-                });
-                res.into_iter()
-                    .map(|r| r.map(|item| item.map(GetResult::TideHunter)))
-                    .collect()
-            }
+                        .map(|item| item.map(|bytes| GetResult::TideHunter(bytes.into_owned())))
+                })
+                .collect(),
             _ => unreachable!("typed store invariant violation"),
         }
     }


### PR DESCRIPTION
## Summary
- In `Database::multi_get`, the tidehunter branch now calls `Bytes::into_owned()` on each returned value before wrapping it in `GetResult::TideHunter`, matching the behavior callers expect when they hold onto results.
- `Bytes::into_owned` copies out of mmap-backed segments and trims sub-slices of large backing allocations, so we avoid pinning mapped files or keeping a large micro-cell read buffer alive past the call.

## Test plan
- [x] `USE_TIDEHUNTER=1 cargo check -p typed-store --features typed-store/tidehunter`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)