### PR TITLE
[sui-benchmark] Fix flaky cancellation_count threshold in test_composite_workload

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1698,7 +1698,12 @@ mod test {
             assert!(metrics_sum.success_count > 150);
             assert!(metrics_sum.permanent_failure_count > 50);
         }
-        assert!(metrics_sum.cancellation_count > 100);
+        // Congestion-induced cancellations vary seed-to-seed in a narrow band that
+        // can dip just below 100 (observed ~98-121 over a 200-seed sweep), making a
+        // `> 100` bar flake ~3% of the time. A `> 50` bar still asserts that
+        // shared-object congestion control actually kicked in, with comfortable
+        // margin below the observed floor.
+        assert!(metrics_sum.cancellation_count > 50);
 
         if address_aliases_enabled {
             let alias_add_stats = metrics


### PR DESCRIPTION
## Summary

`test_composite_workload` (sui-benchmark simtest) asserts `metrics_sum.cancellation_count > 100`. This is a brittle threshold and flakes on unrelated PRs.

The number of congestion-induced cancellations (transactions cancelled by shared-object congestion control) varies seed-to-seed in a narrow band that straddles 100. Because the CI simtest seed is derived from the commit hash, any commit can land on a sub-101 seed and fail — with no relation to the change under test.

## Evidence

A local 200-seed sweep with `scripts/simtest/seed-search.py`:
- **6/200 (~3%) failed**, every failure on this exact assertion (`cancellation_count > 100`).
- The 6 failing seeds had `cancellation_count` = **84, 97, 98, 100, 100, 100** (min **84**); passing seeds measured 109–121. So the metric's natural range (~84–121) straddles the `> 100` bar.
- Every other assertion in the test (signed_and_sent > 500, success > 200, permanent_failure > 100, insufficient_funds > 2, accumulator deletions > 0) passed by a wide margin; only this threshold is brittle.

The threshold sits right inside the metric's natural variance, so it is inherently ~3% flaky regardless of the code under test.

## Fix

Lower the bar to `> 50`. That still verifies that shared-object congestion control actually engaged — the point of the assertion — while leaving comfortable margin (~34) below the observed floor of 84, eliminating the flake.

## Test plan

- [x] 200-seed `seed-search.py` sweep used to characterize the flake; all 6 failing seeds' counts measured (min 84), confirming `> 50` clears them with margin
- [ ] CI
