### PR TITLE
Use serde_with::Bytes in Signature::Deserialize

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -43,7 +43,7 @@ use roaring::RoaringBitmap;
 use schemars::JsonSchema;
 use serde::ser::Serializer;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_with::{Bytes, serde_as};
+use serde_with::{Bytes, DeserializeAs, serde_as};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -751,8 +751,7 @@ impl<'de> Deserialize<'de> for Signature {
             let s = String::deserialize(deserializer)?;
             Base64::decode(&s).map_err(|e| Error::custom(e.to_string()))?
         } else {
-            let data: Vec<u8> = Vec::deserialize(deserializer)?;
-            data
+            Bytes::deserialize_as(deserializer)?
         };
 
         Self::from_bytes(&bytes).map_err(|e| Error::custom(e.to_string()))


### PR DESCRIPTION
The `Signature::Serialize` impl uses `serialize_bytes`, but `Signature::Deserialize` goes through `Vec::deserialize` (the `deserialize_seq` path). Switch to `serde_with::Bytes::deserialize_as` so both sides go through the "byte blob" serde path. Wire format is unchanged for BCS, bincode, and JSON.