### PR TITLE
[cherry-pick][cli] Fix tree shake alg by using the pkg id instead of pkg display name

### DIFF
--- a/crates/sui-core/src/unit_tests/auth_unit_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/auth_unit_test_utils.rs
@@ -3,7 +3,7 @@
 
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
-use sui_move_build::{BuildConfig, CompiledPackage};
+use sui_move_build::{BuildConfig, CompiledPackage, PublishedDependency};
 use sui_types::crypto::Signature;
 use sui_types::move_package::UpgradePolicy;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -38,14 +38,30 @@ pub fn build_test_modules_with_dep_addr(
         dep_id_mapping.len(),
         package.dependency_ids.unpublished.len()
     );
-    for unpublished_dep in &package.dependency_ids.unpublished {
-        let published_id = dep_id_mapping.get(unpublished_dep).unwrap();
+    let unpublished_deps = package
+        .dependency_ids
+        .unpublished
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
+    for unpublished_dep in unpublished_deps {
+        let published_id = dep_id_mapping
+            .get(&unpublished_dep.id)
+            .or_else(|| dep_id_mapping.get(&unpublished_dep.name))
+            .unwrap();
         // Make sure we aren't overriding a package
         assert!(
             package
                 .dependency_ids
                 .published
-                .insert(*unpublished_dep, *published_id)
+                .insert(
+                    unpublished_dep.id,
+                    PublishedDependency::new(
+                        unpublished_dep.id,
+                        unpublished_dep.name,
+                        *published_id,
+                    ),
+                )
                 .is_none()
         )
     }

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -139,7 +139,12 @@ pub fn build_upgrade_test_modules_with_dep_addr(
     (
         package.get_package_digest(with_unpublished_deps).to_vec(),
         package.get_package_bytes(with_unpublished_deps),
-        package.dependency_ids.published.values().cloned().collect(),
+        package
+            .dependency_ids
+            .published
+            .values()
+            .map(|dep| dep.published_at)
+            .collect(),
     )
 }
 

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -363,7 +363,11 @@ impl CompiledPackage {
     /// Return the set of Object IDs corresponding to this package's transitive dependencies'
     /// storage package IDs (where to load those packages on-chain).
     pub fn get_dependency_storage_package_ids(&self) -> Vec<ObjectID> {
-        self.dependency_ids.published.values().cloned().collect()
+        self.dependency_ids
+            .published
+            .values()
+            .map(|dep| dep.published_at)
+            .collect()
     }
 
     /// Return a digest of the bytecode modules in this package.
@@ -564,7 +568,11 @@ impl CompiledPackage {
     }
 
     pub fn get_published_dependencies_ids(&self) -> Vec<ObjectID> {
-        self.dependency_ids.published.values().cloned().collect()
+        self.dependency_ids
+            .published
+            .values()
+            .map(|dep| dep.published_at)
+            .collect()
     }
 }
 
@@ -588,21 +596,84 @@ pub enum PublishedAtError {
 
 #[derive(Debug, Clone)]
 pub struct PackageDependencies {
-    /// Set of published dependencies (name and address).
-    pub published: BTreeMap<Symbol, ObjectID>,
-    /// Set of unpublished dependencies (name and address).
-    pub unpublished: BTreeSet<Symbol>,
+    /// Set of published dependencies keyed by package graph ID.
+    pub published: BTreeMap<Symbol, PublishedDependency>,
+    /// Set of unpublished dependencies by package graph ID.
+    pub unpublished: BTreeMap<Symbol, UnpublishedDependency>,
     /// Set of dependencies with invalid `published-at` addresses.
-    pub invalid: BTreeMap<Symbol, String>,
-    /// Set of dependencies that have conflicting `published-at` addresses. The key refers to
-    /// the package, and the tuple refers to the address in the (Move.lock, Move.toml) respectively.
-    pub conflicting: BTreeMap<Symbol, (ObjectID, ObjectID)>,
+    pub invalid: BTreeMap<Symbol, InvalidDependency>,
+    /// Set of dependencies that have conflicting `published-at` addresses.
+    pub conflicting: BTreeMap<Symbol, ConflictingDependency>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PublishedDependency {
+    /// Unique package graph ID used by the compiler and build artifacts.
+    ///
+    /// This may differ from `name` when multiple packages have the same declared package name,
+    /// for example `foo` and `foo_1`.
+    pub id: Symbol,
+    /// Human-readable package name declared by the package.
+    pub name: Symbol,
+    pub published_at: ObjectID,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnpublishedDependency {
+    /// Unique package graph ID used by the compiler and build artifacts.
+    ///
+    /// This may differ from `name` when multiple packages have the same declared package name,
+    /// for example `foo` and `foo_1`.
+    pub id: Symbol,
+    /// Human-readable package name declared by the package.
+    pub name: Symbol,
+}
+
+#[derive(Debug, Clone)]
+pub struct InvalidDependency {
+    /// Unique package graph ID used by the compiler and build artifacts.
+    ///
+    /// This may differ from `name` when multiple packages have the same declared package name,
+    /// for example `foo` and `foo_1`.
+    pub id: Symbol,
+    /// Human-readable package name declared by the package.
+    pub name: Symbol,
+    pub published_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConflictingDependency {
+    /// Unique package graph ID used by the compiler and build artifacts.
+    ///
+    /// This may differ from `name` when multiple packages have the same declared package name,
+    /// for example `foo` and `foo_1`.
+    pub id: Symbol,
+    /// Human-readable package name declared by the package.
+    pub name: Symbol,
+    pub lock_file_address: ObjectID,
+    pub manifest_address: ObjectID,
+}
+
+impl PublishedDependency {
+    pub fn new(id: Symbol, name: Symbol, published_at: ObjectID) -> Self {
+        Self {
+            id,
+            name,
+            published_at,
+        }
+    }
+}
+
+impl UnpublishedDependency {
+    pub fn new(id: Symbol, name: Symbol) -> Self {
+        Self { id, name }
+    }
 }
 
 impl PackageDependencies {
     pub fn new<F: MoveFlavor>(root_pkg: &RootPackage<F>) -> anyhow::Result<Self> {
         let mut published = BTreeMap::new();
-        let mut unpublished = BTreeSet::new();
+        let mut unpublished = BTreeMap::new();
 
         let packages = root_pkg.packages();
 
@@ -610,13 +681,21 @@ impl PackageDependencies {
             if p.is_root() {
                 continue;
             }
+            // The compiler uses package graph IDs as package names, including suffixes for
+            // duplicate declared names, so dependency IDs must use that same key space.
+            let id: Symbol = p.id().as_str().into();
+            let name: Symbol = p.display_name().into();
             if let Some(addresses) = p.published() {
                 published.insert(
-                    p.display_name().into(),
-                    ObjectID::from_address(addresses.published_at.0),
+                    id,
+                    PublishedDependency::new(
+                        id,
+                        name,
+                        ObjectID::from_address(addresses.published_at.0),
+                    ),
                 );
             } else {
-                unpublished.insert(p.display_name().into());
+                unpublished.insert(id, UnpublishedDependency::new(id, name));
             }
         }
 

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -3081,8 +3081,8 @@ mod tests {
                     .dependency_ids
                     .published
                     .values()
-                    .map(|dep_id| {
-                        let storage_id = AccountAddress::from(*dep_id);
+                    .map(|dep| {
+                        let storage_id = AccountAddress::from(dep.published_at);
                         let runtime_id = package_runtime_id(
                             &packages_by_storage_id
                                 .get(&storage_id)

--- a/crates/sui-single-node-benchmark/src/tx_generator/package_publish_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/package_publish_tx_generator.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
-use sui_move_build::{BuildConfig, CompiledPackage};
+use sui_move_build::{BuildConfig, CompiledPackage, PublishedDependency};
 use sui_test_transaction_builder::{PublishData, TestTransactionBuilder};
 use sui_types::transaction::{DEFAULT_VALIDATOR_GAS_PRICE, Transaction};
 use tracing::info;
@@ -80,7 +80,12 @@ impl PackagePublishTxGenerator {
         );
 
         let target_path = dir.join(path);
-        let published_deps = dep_map.clone();
+        let published_deps = dep_map
+            .iter()
+            .map(|(name, published_at)| {
+                (*name, PublishedDependency::new(*name, *name, *published_at))
+            })
+            .collect();
 
         let mut compiled_package = BuildConfig::new_for_testing_replace_addresses(
             dep_map.into_iter().map(|(k, v)| (k.to_string(), v)),

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -446,5 +446,9 @@ fn substitute_root_address(
 
 /// The on-chain addresses for a source package's dependencies
 fn dependency_addresses(package: &CompiledPackage) -> impl Iterator<Item = AccountAddress> + '_ {
-    package.dependency_ids.published.values().map(|id| **id)
+    package
+        .dependency_ids
+        .published
+        .values()
+        .map(|dep| AccountAddress::from(dep.published_at))
 }

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -863,7 +863,12 @@ async fn upgrade_package(
     let with_unpublished_deps = false;
     let package_bytes = package.get_package_bytes(with_unpublished_deps);
     let package_digest = package.get_package_digest(with_unpublished_deps).to_vec();
-    let package_deps = package.dependency_ids.published.into_values().collect();
+    let package_deps = package
+        .dependency_ids
+        .published
+        .into_values()
+        .map(|dep| dep.published_at)
+        .collect();
 
     upgrade_package_with_wallet(
         context,

--- a/crates/sui-surfer/src/surfer_state.rs
+++ b/crates/sui-surfer/src/surfer_state.rs
@@ -346,7 +346,12 @@ impl SurferState {
             self.address,
             self.gas_object,
             modules,
-            package.dependency_ids.published.values().cloned().collect(),
+            package
+                .dependency_ids
+                .published
+                .values()
+                .map(|dep| dep.published_at)
+                .collect(),
             TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
             rgp,
         );

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2115,8 +2115,8 @@ pub(crate) fn check_for_unpublished_deps(
         ",
             package_dependencies
                 .unpublished
-                .into_iter()
-                .map(|n| n.to_string())
+                .values()
+                .map(|dep| dep.name.to_string())
                 .collect::<Vec<_>>()
                 .join(", ")
         );
@@ -3693,6 +3693,7 @@ pub(crate) async fn pkg_tree_shake(
             // println!("{}", pkgs_to_keep.contains(pkg_name));
             pkgs_to_keep.contains(pkg_name)
         })
+        .map(|(pkg_name, dep)| (pkg_name, dep.published_at))
         .collect();
 
     info!("Pkgs to keep {pkgs_to_keep:#?}");

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -1030,7 +1030,7 @@ impl<'a> PTBBuilder<'a> {
                         .dependency_ids
                         .published
                         .values()
-                        .cloned()
+                        .map(|dep| dep.published_at)
                         .collect::<Vec<_>>(),
                     compiled_modules,
                 );

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -4287,6 +4287,67 @@ async fn test_tree_shaking_package_with_direct_dependency() -> Result<(), anyhow
 }
 
 #[sim_test]
+async fn test_tree_shaking_package_with_duplicate_dependency_names() -> Result<(), anyhow::Error> {
+    let mut test = TreeShakingTest::new().await?;
+
+    // Publish two packages with the same declared package name. The package system disambiguates
+    // them with package graph IDs like `a` and `a_1`; tree shaking needs to use that same key space.
+    let (package_a_id, _) = test.test_publish_package("A", false).await?;
+    let (package_a_alt_id, _) = test.test_publish_package("A_ALT", false).await?;
+
+    // `DuplicateDirect` declares both packages and references both. Tree shaking needs to keep
+    // both package graph IDs, even though both packages have the same declared package name.
+    let (package_duplicate_id, _) = test.test_publish_package("DuplicateDirect", false).await?;
+    let linkage_table = test.fetch_linkage_table(package_duplicate_id).await;
+
+    assert!(
+        linkage_table.contains_key(&package_a_id),
+        "Package DuplicateDirect should depend on A"
+    );
+    assert!(
+        linkage_table.contains_key(&package_a_alt_id),
+        "Package DuplicateDirect should depend on A_ALT"
+    );
+    assert_eq!(
+        linkage_table.len(),
+        2,
+        "Package DuplicateDirect should have exactly two dependencies"
+    );
+
+    Ok(())
+}
+
+#[sim_test]
+async fn test_tree_shaking_package_with_duplicate_dependency_names_drops_unused()
+-> Result<(), anyhow::Error> {
+    let mut test = TreeShakingTest::new().await?;
+
+    // Publish two packages with the same declared package name. `DuplicateSingle` declares both
+    // dependencies but references only A, so A_ALT must be dropped after tree shaking.
+    let (package_a_id, _) = test.test_publish_package("A", false).await?;
+    let (package_a_alt_id, _) = test.test_publish_package("A_ALT", false).await?;
+
+    let (package_duplicate_id, _) = test.test_publish_package("DuplicateSingle", false).await?;
+    let linkage_table = test.fetch_linkage_table(package_duplicate_id).await;
+
+    assert!(
+        linkage_table.contains_key(&package_a_id),
+        "Package DuplicateSingle should depend on A"
+    );
+    assert!(
+        !linkage_table.contains_key(&package_a_alt_id),
+        "Package DuplicateSingle should tree shake the unused A_ALT dependency"
+    );
+    assert_eq!(
+        linkage_table.len(),
+        1,
+        "Package DuplicateSingle should have exactly one dependency"
+    );
+
+    Ok(())
+}
+
+#[sim_test]
 async fn test_tree_shaking_package_with_unused_dependency() -> Result<(), anyhow::Error> {
     let mut test = TreeShakingTest::new().await?;
 

--- a/crates/sui/tests/data/tree_shaking/A_ALT/Move.toml
+++ b/crates/sui/tests/data/tree_shaking/A_ALT/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "a"
+edition = "2024"
+implicit-dependencies = false
+
+[dependencies]
+sui = { local = "../../system-packages/sui-framework" }
+std = { local = "../../system-packages/move-stdlib" }

--- a/crates/sui/tests/data/tree_shaking/A_ALT/sources/alt.move
+++ b/crates/sui/tests/data/tree_shaking/A_ALT/sources/alt.move
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module a::alt {
+    public fun alt() {
+        let x = 1;
+        let y = x + 1;
+        y;
+    }
+}

--- a/crates/sui/tests/data/tree_shaking/DuplicateDirect/Move.toml
+++ b/crates/sui/tests/data/tree_shaking/DuplicateDirect/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "duplicate_direct"
+edition = "2024"
+implicit-dependencies = false
+
+[dependencies]
+a0 = { local = "../A", rename-from = "a" }
+a1 = { local = "../A_ALT", rename-from = "a" }

--- a/crates/sui/tests/data/tree_shaking/DuplicateDirect/sources/duplicate_direct.move
+++ b/crates/sui/tests/data/tree_shaking/DuplicateDirect/sources/duplicate_direct.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module duplicate_direct::duplicate_direct {
+    public fun use_both() {
+        a0::a::a();
+        a1::alt::alt();
+    }
+}

--- a/crates/sui/tests/data/tree_shaking/DuplicateSingle/Move.toml
+++ b/crates/sui/tests/data/tree_shaking/DuplicateSingle/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "duplicate_single"
+edition = "2024"
+implicit-dependencies = false
+
+[dependencies]
+a0 = { local = "../A", rename-from = "a" }
+a1 = { local = "../A_ALT", rename-from = "a" }

--- a/crates/sui/tests/data/tree_shaking/DuplicateSingle/sources/duplicate_single.move
+++ b/crates/sui/tests/data/tree_shaking/DuplicateSingle/sources/duplicate_single.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module duplicate_single::duplicate_single {
+    public fun use_a() {
+        a0::a::a();
+    }
+}

--- a/crates/sui/tests/data/tree_shaking/README.md
+++ b/crates/sui/tests/data/tree_shaking/README.md
@@ -15,6 +15,8 @@ Tests projects are established as following
     - linkage table should be empty
 - A_v2 is a package upgrade of A (now at version 2).
     - linkage table should be empty
+- A_ALT is another package with declared package name a.
+    - linkage table should be empty
 - B_A is a normal package that depends on A, and source code references A.
     - linkage table should contain package A's ID
 - B_A1 is a package that depends on A, but source code does not reference any code from A.
@@ -44,3 +46,7 @@ Tests projects are established as following
     - linkage table should contain package K's ID
 - M has a code dependency on L_depends_on K package, and a dependency on K_v2 but no code references K_v2
     - linkage table should contain package K's ID and L's ID
+- DuplicateDirect depends on A and A_ALT, and references both packages.
+    - linkage table should contain both A's ID and A_ALT's ID
+- DuplicateSingle depends on A and A_ALT, but only references A.
+    - linkage table should contain A's ID and not A_ALT's ID


### PR DESCRIPTION
## Description 

This PR fixes the tree shake algorithm by using the pkg id instead of pkg display name. As the build system disambiguates same package names by adding suffixes, the tree shake algorithm did not account for this and thus dropped packages that were required to be in the dependency list.

## Test plan 

New tests + existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: