### PR TITLE
ci: enable sccache in bridge.yml (clippy + test jobs)

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -82,6 +82,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+      - uses: ./.github/actions/setup-sccache
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
       - name: cargo clippy
         run: cargo xclippy -D warnings
@@ -103,6 +108,11 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: ./.github/actions/setup-sccache
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master


### PR DESCRIPTION
## Summary

`bridge.yml` is the biggest **pre-land CI sccache coverage gap** — its Rust jobs `clippy` (`cargo xclippy`) and `test` (`cargo nextest`), both on `ubuntu-ghcloud`, never invoked `setup-sccache`, so they compile cold every run. This adds the repo's `./.github/actions/setup-sccache` composite to both, matching `rust.yml`.

**Impact:** `bridge.yml` is ~3.4k runner-min/week (~2.2k `test`, ~984 `clippy`). It compiles the `sui-bridge` / `sui-bridge-indexer` packages from the shared workspace, so it benefits from the warm `ubuntu-ghcloud` S3 cache that `sccache-warmup.yml` already populates daily.

## Change

- `clippy` and `test` jobs: add `./.github/actions/setup-sccache` after checkout with `key-prefix: ubuntu-ghcloud` (same prefix as `rust.yml` + the warmup), passing `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`.
- `rustfmt` (fmt-only) and `bridge-evm` (Solidity/Foundry) are unchanged — they don't compile Rust, so sccache wouldn't help.

The composite action is the repo's single source of truth for the Rust CI build env (mold + sccache S3), and it **gracefully degrades on fork PRs** (no AWS secrets → sccache disabled, build still runs).

## Test plan

- [ ] `clippy` and `test` jobs run green with sccache enabled
- [ ] sccache stats appear in their logs (Compile requests / Cache hits)
- [ ] Hit rate improves on a second run against the warm `ubuntu-ghcloud` cache
- [ ] No change to build output or test results

## Not in this PR (follow-ups from the coverage review)

- **Permissions hardening**: set `permissions: contents: read` by default on the heavy CI workflows (repo default is `write`), elevate only jobs that need it; consider short-lived OIDC creds scoped to the sccache bucket instead of static `AWS_ACCESS_KEY_ID`.
- **Per-job observability**: add a post-step emitting `sccache --show-stats` (hits/misses/errors) into the job summary so each heavy job's cache effectiveness is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)