### PR TITLE
fix(simulate): accept explicit gas_price=0 for gasless-eligible transactions

### DIFF
--- a/crates/sui-e2e-tests/tests/grpc_simulate_gasless_tests.rs
+++ b/crates/sui-e2e-tests/tests/grpc_simulate_gasless_tests.rs
@@ -211,6 +211,68 @@ async fn simulate_respects_explicit_price_over_gasless() {
     assert!(returned.effects().status().success());
 }
 
+/// Explicitly setting gas_price=0 on a gasless-eligible tx must be accepted: the API should
+/// treat `price=0` the same as an unset price for purposes of gasless candidacy.
+#[sim_test]
+async fn simulate_explicit_gas_price_zero_accepted_for_gasless_eligible_tx() {
+    let mut test_env = setup_gasless_env().await;
+    let sender = test_env.get_sender(1);
+    let recipient = test_env.get_sender(2);
+    let (coin_type, coin_refs) =
+        setup_mintable_coin_env(&mut test_env, 0, &[(5_000, sender)]).await;
+    let tx = build_coin_send_funds_tx(sender, coin_refs[0], coin_type, recipient);
+
+    let response = connect(&test_env)
+        .await
+        .simulate_transaction(
+            SimulateTransactionRequest::new(to_unresolved_proto(tx, Some(0)))
+                .with_do_gas_selection(true),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let returned = response.transaction();
+    let gas_payment = returned.transaction().gas_payment();
+    assert_eq!(gas_payment.price, Some(0));
+    assert_eq!(gas_payment.budget, Some(0));
+    assert!(gas_payment.objects.is_empty());
+    assert!(returned.effects().status().success());
+}
+
+/// A fully-formed BCS gasless transaction (price=0, budget=0, no payment objects) must be
+/// accepted when do_gas_selection=true. The BCS path bypasses is_gasless_candidate to avoid
+/// second-guessing an explicit caller choice, but a BCS transaction already in gasless shape
+/// should be simulated as-is rather than being routed through the priced flow (which would
+/// fail because gas_price=0 < RGP).
+#[sim_test]
+async fn simulate_bcs_gasless_transaction_accepted() {
+    let mut test_env = setup_gasless_env().await;
+    let sender = test_env.get_sender(1);
+    let recipient = test_env.get_sender(2);
+    let (coin_type, coin_refs) =
+        setup_mintable_coin_env(&mut test_env, 0, &[(5_000, sender)]).await;
+    // wrap_tx already produces price=0, budget=0, payment=[] — a valid gasless shape.
+    // The Coin<T> input provides address-owned replay protection, so no ValidDuring needed.
+    let tx = build_coin_send_funds_tx(sender, coin_refs[0], coin_type, recipient);
+
+    let response = connect(&test_env)
+        .await
+        .simulate_transaction(
+            SimulateTransactionRequest::new(Transaction::from(tx)).with_do_gas_selection(true),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let returned = response.transaction();
+    let gas_payment = returned.transaction().gas_payment();
+    assert_eq!(gas_payment.price, Some(0));
+    assert_eq!(gas_payment.budget, Some(0));
+    assert!(gas_payment.objects.is_empty());
+    assert!(returned.effects().status().success());
+}
+
 /// A tx whose `Coin<T>` input is a type *not* on the gasless allowlist must not be classified
 /// as gasless-eligible: `is_gasless_candidate` should reject it via `check_gasless_object_inputs`,
 /// and the simulate flow should fall through to the priced flow rather than returning

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -103,8 +103,15 @@ pub fn simulate_transaction(
 
     let perform_gas_selection = request.do_gas_selection() && checks.enabled();
     let simulation_result = 'simulate: {
-        if perform_gas_selection {
-            // If the caller didn't set a price and the tx passes the cheap structural +
+        // BCS transactions that are already in gasless shape (price=0, no payment) are simulated
+        // as-is — the caller pre-built the transaction, so gas selection is not needed and the
+        // priced flow must be skipped (it would fail with GasPriceUnderRGP for price=0).
+        let skip_gas_selection_for_bcs_gasless = perform_gas_selection
+            && request.transaction().bcs_opt().is_some()
+            && transaction.is_gasless_transaction();
+
+        if perform_gas_selection && !skip_gas_selection_for_bcs_gasless {
+            // If the caller didn't set a non-zero price and the tx passes the cheap structural +
             // object-input gasless checks, try a gasless simulate first. Post-execution gasless
             // requirements (all input Coins consumed, minimum transfer amounts) can only be
             // verified by running the tx. If that fails, we discard the gasless variant and
@@ -658,9 +665,10 @@ fn select_gas(
 
 /// Returns true if the simulate request is eligible for auto gas_price=0 handling.
 ///
-/// Requires: gasless enabled by protocol, caller did not set price or gas payment objects, tx is a
-/// PTB that passes the structural gasless checks, and all loaded Move object inputs pass the
-/// runtime gasless input check (`Coin<T>` with `T` allowlisted, AddressOwner/ConsensusAddressOwner).
+/// Requires: gasless enabled by protocol, caller did not set price (or set it to 0) and did not
+/// set gas payment objects, tx is a PTB that passes the structural gasless checks, and all loaded
+/// Move object inputs pass the runtime gasless input check (`Coin<T>` with `T` allowlisted,
+/// AddressOwner/ConsensusAddressOwner).
 fn is_gasless_candidate(
     request: &SimulateTransactionRequest,
     transaction: &sui_types::transaction::TransactionData,
@@ -675,7 +683,14 @@ fn is_gasless_candidate(
     if request.transaction().bcs_opt().is_some() {
         return Ok(false);
     }
-    if request.transaction().gas_payment().price.is_some() {
+    // An explicit non-zero price opts out of gasless. price=0 is treated the same as unset: the
+    // caller is either asserting gasless intent or echoing the suggestion from a prior simulate.
+    if request
+        .transaction()
+        .gas_payment()
+        .price
+        .is_some_and(|p| p != 0)
+    {
         return Ok(false);
     }
     if !request.transaction().gas_payment().objects.is_empty() {


### PR DESCRIPTION
## Summary

The gRPC \`SimulateTransaction\` API had two related bugs where valid gasless transactions were incorrectly routed to the priced flow, which then failed with \`GasPriceUnderRGP\` (gas_price=0 < RGP):

1. **Explicit price=0 (unresolved/proto path):** \`is_gasless_candidate\` checked \`price.is_some()\`, treating \`Some(0)\` the same as any other explicit non-zero price. Callers echoing back the \`gas_price=0\` suggestion from a prior simulate response were rejected.

   Fix: change to \`price.is_some_and(|p| p != 0)\` — explicit \`price=0\` is treated as equivalent to unset.

2. **Pre-built BCS gasless transaction:** A fully-formed BCS transaction with \`price=0, budget=0, payment=[]\` is already in gasless shape, but the BCS path always bypasses \`is_gasless_candidate\` (to avoid second-guessing the caller's explicit choices) and fell into the priced flow unconditionally.

   Fix: skip gas selection entirely when a BCS transaction is already in gasless shape (\`is_gasless_transaction()\` returns true), letting it fall through to direct simulation.

## Test plan

- \`simulate_explicit_gas_price_zero_accepted_for_gasless_eligible_tx\`: verifies the unresolved-path fix (fails before, passes after)
- \`simulate_bcs_gasless_transaction_accepted\`: verifies the BCS path fix (fails before, passes after)
- All existing gasless simulate tests pass unchanged (explicit non-zero price still opts out of gasless as before)

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] gRPC: \`SimulateTransaction\` now accepts \`gas_price=0\` for gasless-tier-eligible transactions (both via the unresolved proto path and as pre-built BCS transactions) instead of returning an error.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: