### PR TITLE
ci: restrict heavy CI token permissions

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -18,6 +18,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to the heavy PR CI workflows that use sccache:
  - `rust.yml`
  - `external.yml`
  - `bridge.yml`
- Leave the existing sccache AWS secret behavior unchanged.
- Do not add `id-token: write`; this keeps the OIDC migration as a separate, explicit follow-up.

## Why

These workflows run pull request code and only need repository read access for checkout/local actions. Explicit read-only `GITHUB_TOKEN` permissions reduce the blast radius from the repo default write token while preserving current CI behavior.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/rust.yml .github/workflows/external.yml .github/workflows/bridge.yml`
- `actionlint` was not installed in the local environment, so I used YAML parsing plus diff review for this narrow workflow-only change.