### PR TITLE
fix(tidehunter pruner): uncap checkpoint watermark when objects compactor is active

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -439,6 +439,7 @@ impl AuthorityStorePruner {
                 checkpoint_store,
                 num_epochs_to_retain,
                 pruner_watermarks,
+                false,
             )?;
         }
         Ok(())
@@ -665,6 +666,7 @@ impl AuthorityStorePruner {
         checkpoint_store: &Arc<CheckpointStore>,
         num_epochs_to_retain: u64,
         pruning_watermark: &Arc<PrunerWatermarks>,
+        objects_compactor_active: bool,
     ) -> anyhow::Result<bool> {
         use std::sync::atomic::Ordering;
         let objects_pruning_checkpoint_id = perpetual_db
@@ -687,7 +689,13 @@ impl AuthorityStorePruner {
         let checkpoint_id =
             checkpoint_store.get_epoch_last_checkpoint_seq_number(target_epoch_id)?;
 
-        let new_watermark = min(target_epoch_id + 1, objects_pruning_epoch_id);
+        // The objects compactor handles object retention continuously without advancing
+        // `highest_pruned_checkpoint`, so capping on it would freeze the watermark at 0.
+        let new_watermark = if objects_compactor_active {
+            target_epoch_id + 1
+        } else {
+            min(target_epoch_id + 1, objects_pruning_epoch_id)
+        };
         if current_watermark == new_watermark {
             return Ok(false);
         }
@@ -696,7 +704,11 @@ impl AuthorityStorePruner {
             .epoch_id
             .store(new_watermark, Ordering::Relaxed);
         if let Some(checkpoint_id) = checkpoint_id {
-            let watermark = min(checkpoint_id, objects_pruning_checkpoint_id);
+            let watermark = if objects_compactor_active {
+                checkpoint_id
+            } else {
+                min(checkpoint_id, objects_pruning_checkpoint_id)
+            };
             info!("relocation: setting checkpoint watermark to {}", watermark);
             pruning_watermark
                 .checkpoint_id
@@ -711,12 +723,14 @@ impl AuthorityStorePruner {
         checkpoint_store: &Arc<CheckpointStore>,
         num_epochs_to_retain: u64,
         pruning_watermark: Arc<PrunerWatermarks>,
+        objects_compactor_active: bool,
     ) -> anyhow::Result<()> {
         let watermark_updated = Self::update_pruning_watermarks(
             perpetual_db,
             checkpoint_store,
             num_epochs_to_retain,
             &pruning_watermark,
+            objects_compactor_active,
         )?;
         if !watermark_updated {
             info!("skip relocation. Watermark hasn't changed");
@@ -859,7 +873,7 @@ impl AuthorityStorePruner {
                                 }
                             },
                             _ = checkpoints_prune_interval.tick() => {
-                                if let Err(err) = Self::prune_th(&perpetual_db, &checkpoint_store, num_epochs_to_retain, pruner_watermarks.clone()) {
+                                if let Err(err) = Self::prune_th(&perpetual_db, &checkpoint_store, num_epochs_to_retain, pruner_watermarks.clone(), !prune_objects) {
                                     error!("Failed to prune checkpoints: {:?}", err);
                                 }
                             },


### PR DESCRIPTION
## Summary

### Root cause

1. On validators, the per-keyspace **objects compactor** is the active object-retention strategy and the object pruner is force-disabled (`authority_store_pruner.rs:948-959`, setting `num_epochs_to_retain = u64::MAX`).
2. `set_highest_pruned_checkpoint` is only written from inside the object pruner (lines 214, 255). With the object pruner disabled, `highest_pruned_checkpoint` stays at 0 forever.
3. `update_pruning_watermarks` capped the new watermark at `min(target_epoch_id + 1, objects_pruning_epoch_id)` — which collapses to `min(target, 0) = 0`.
4. `prune_th` sees the watermark hasn't changed, short-circuits, and never calls `start_relocation()`. TideHunter's relocation filters keep everything live; WAL fragments are never reclaimed.

### Fix

Thread an `objects_compactor_active` flag through `prune_th` → `update_pruning_watermarks`. When set, skip both the epoch- and checkpoint-watermark caps: the compactor handles object retention continuously, so there is nothing to wait on. The non-TideHunter caller (`prune_checkpoints_for_eligible_epochs`) passes `false`, preserving existing behavior.

## Test plan
- [ ] CI green
- [ ] Deploy to a TideHunter validator and confirm `relocation: setting epoch watermark to N` appears (instead of `skip relocation. Watermark hasn't changed`)
- [ ] Verify WAL fragment count decreases for old epochs over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)