### PR TITLE
[consensus] clean up stale allow(dead_code) and allow(unused) attributes

### DIFF
--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -422,38 +422,11 @@ mod base_committer_builder {
     pub(crate) struct BaseCommitterBuilder {
         context: Arc<Context>,
         dag_state: Arc<RwLock<DagState>>,
-        wave_length: u32,
-        leader_offset: u32,
-        round_offset: u32,
     }
 
     impl BaseCommitterBuilder {
         pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
-            Self {
-                context,
-                dag_state,
-                wave_length: DEFAULT_WAVE_LENGTH,
-                leader_offset: 0,
-                round_offset: 0,
-            }
-        }
-
-        #[allow(unused)]
-        pub(crate) fn with_wave_length(mut self, wave_length: u32) -> Self {
-            self.wave_length = wave_length;
-            self
-        }
-
-        #[allow(unused)]
-        pub(crate) fn with_leader_offset(mut self, leader_offset: u32) -> Self {
-            self.leader_offset = leader_offset;
-            self
-        }
-
-        #[allow(unused)]
-        pub(crate) fn with_round_offset(mut self, round_offset: u32) -> Self {
-            self.round_offset = round_offset;
-            self
+            Self { context, dag_state }
         }
 
         pub(crate) fn build(self) -> BaseCommitter {

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -204,7 +204,6 @@ pub(crate) struct BlockV2 {
     misbehavior_reports: Vec<MisbehaviorReport>,
 }
 
-#[allow(unused)]
 impl BlockV2 {
     pub(crate) fn new(
         epoch: Epoch,
@@ -309,7 +308,7 @@ pub(crate) struct BlockV3 {
     misbehavior_reports: Vec<MisbehaviorReport>,
 }
 
-#[allow(unused)]
+#[allow(dead_code)]
 impl BlockV3 {
     pub(crate) fn new(
         epoch: Epoch,

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -244,7 +244,7 @@ impl LeaderSwapTable {
         context: Arc<Context>,
         // Ignore linter warning in simtests.
         // TODO: maybe override protocol configs in tests for swap_stake_threshold, and call new().
-        #[allow(unused_variables)] swap_stake_threshold: u64,
+        #[cfg_attr(msim, allow(unused_variables))] swap_stake_threshold: u64,
         commit_index: CommitIndex,
         reputation_scores: ReputationScores,
     ) -> Self {

--- a/consensus/core/src/network/metrics_layer.rs
+++ b/consensus/core/src/network/metrics_layer.rs
@@ -67,7 +67,7 @@ impl MetricsCallbackMaker {
 
         MetricsResponseCallback {
             metrics: self.metrics.clone(),
-            timer,
+            _timer: timer,
             route,
             excessive_message_size: self.excessive_message_size,
         }
@@ -77,8 +77,7 @@ impl MetricsCallbackMaker {
 pub(crate) struct MetricsResponseCallback {
     metrics: Arc<NetworkRouteMetrics>,
     // The timer is held on to and "observed" once dropped
-    #[allow(unused)]
-    timer: HistogramTimer,
+    _timer: HistogramTimer,
     route: String,
     excessive_message_size: usize,
 }

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -50,7 +50,6 @@ pub enum PeerId {
     /// A validator node identified by its authority index.
     Validator(AuthorityIndex),
     /// An observer node identified by its network public key.
-    #[allow(dead_code)]
     Observer(Box<NodeId>),
 }
 
@@ -246,7 +245,6 @@ pub(crate) type ObserverBlockStream = Pin<Box<dyn Stream<Item = Vec<Bytes>> + Se
 /// Unlike ValidatorNetworkService which uses AuthorityIndex, this uses NodeId (NetworkPublicKey)
 /// to identify peers since observers are not part of the committee.
 #[async_trait]
-#[allow(dead_code)]
 pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
     /// Handles a block received from a peer subscription. Used by ObserverSubscriber to process
     /// blocks streamed from validators or other observers.
@@ -262,7 +260,6 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<ObserverBlockStream>;
 
     /// Handles the request to fetch blocks by references from an observer peer.
-    #[allow(unused)]
     async fn handle_fetch_blocks(
         &self,
         peer: NodeId,
@@ -272,7 +269,6 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to fetch commits by index range from an observer peer.
-    #[allow(unused)]
     /// Returns serialized commits and certifier blocks.
     async fn handle_fetch_commits(
         &self,
@@ -285,7 +281,6 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
 /// Unlike ValidatorNetworkClient which uses AuthorityIndex, this uses PeerId to identify peers
 /// since the observer server can serve both validators and observer nodes.
 #[async_trait]
-#[allow(dead_code)]
 pub(crate) trait ObserverNetworkClient: Send + Sync + Sized + 'static {
     /// Initiates block streaming with a peer (validator or observer).
     /// Returns a stream of blocks with the highest commit index.
@@ -331,7 +326,6 @@ pub(crate) trait NetworkManager: Send + Sync {
     fn validator_client(&self) -> Arc<Self::ValidatorClient>;
 
     /// Returns the observer network client.
-    #[allow(dead_code)]
     fn observer_client(&self) -> Arc<Self::ObserverClient>;
 
     /// Starts the validator network server with the provided service.

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -86,7 +86,6 @@ pub(crate) struct FetchCommitsResponse {
 /// Information about an observer peer connection, set in request extensions by the server.
 #[derive(Clone, Debug)]
 pub(crate) struct ObserverPeerInfo {
-    #[allow(unused)]
     pub(crate) public_key: NetworkPublicKey,
 }
 
@@ -219,7 +218,6 @@ impl TonicObserverClient {
         }
     }
 
-    #[allow(unused)]
     async fn get_client(
         &self,
         peer: PeerId,

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -758,7 +758,6 @@ pub(crate) struct TonicManager {
     network_keypair: NetworkKeyPair,
     own_address: SocketAddr,
     validator_client: Arc<TonicValidatorClient>,
-    #[allow(dead_code)]
     observer_client: Arc<TonicObserverClient>,
     server: Option<ServerHandle>,
     observer_server: Option<ServerHandle>,

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -29,7 +29,6 @@ use crate::{
 /// ObserverSubscriber manages block stream subscriptions to peers (validators or other observers),
 /// taking care of retrying when subscription streams break. Blocks returned from peers are sent
 /// to the observer service for processing. The `ObserverSubscriber` can only subscribe to one peer at a time.
-#[allow(unused)]
 pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetworkService> {
     context: Arc<Context>,
     network_client: Arc<C>,
@@ -38,7 +37,6 @@ pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetwor
     subscription: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
-#[allow(unused)]
 impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, S> {
     pub(crate) fn new(
         context: Arc<Context>,

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -22,7 +22,6 @@ pub(crate) enum PeerService {
     /// The validator consensus service for validator-to-validator communication
     Validator,
     /// The observer service for streaming blocks and serving observer requests
-    #[allow(dead_code)]
     Observer,
 }
 
@@ -84,7 +83,6 @@ impl PeersPool {
 
     /// Registers a validator as known in the pool with its supported services.
     /// Note: this method will override the peer if it already exists in the pool.
-    #[allow(dead_code)]
     pub(crate) fn register_validator(
         &self,
         authority_index: AuthorityIndex,
@@ -115,7 +113,6 @@ impl PeersPool {
     /// Registers an observer as known in the pool.
     /// Note that we do not allow observers to register with supported services other than Observer. This is done for safety
     /// as only validators are supposed to support both the Validator and Observer services.
-    #[allow(dead_code)]
     pub(crate) fn register_observer(&self, node_id: NodeId) {
         let mut peers = self.registered_peers.write();
         peers.insert(
@@ -127,7 +124,7 @@ impl PeersPool {
     }
 
     /// Removes a peer from the pool
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn remove_peer(&self, peer: &PeerId) {
         let mut peers = self.registered_peers.write();
         peers.remove(peer);
@@ -176,7 +173,6 @@ impl PeersPool {
     }
 
     /// Gets all known peers that are compatible with the current node.
-    #[allow(dead_code)]
     pub(crate) fn get_known_peers(&self) -> Vec<PeerId> {
         let compatible_services = self.get_compatible_services();
         self.get_known_peers_for_services(&compatible_services)
@@ -188,7 +184,6 @@ impl PeersPool {
     ///
     /// Note: This method does NOT check node compatibility. If you want to ensure
     /// only compatible peers are returned, use `get_known_peers()`
-    #[allow(dead_code)]
     pub(crate) fn get_known_peers_for_services(
         &self,
         filter_services: &[PeerService],
@@ -220,7 +215,6 @@ impl PeersPool {
     /// Gets the compatible services based on the current node type
     /// - If we're a Validator node: can talk to both Validator and Observer services
     /// - If we're an Observer node: can only talk to Observer services
-    #[allow(dead_code)]
     fn get_compatible_services(&self) -> Vec<PeerService> {
         if self.context.is_validator() {
             vec![PeerService::Validator, PeerService::Observer]

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -428,7 +428,6 @@ pub struct LayerBuilder<'a> {
     blocks: Vec<VerifiedBlock>,
 }
 
-#[allow(unused)]
 impl<'a> LayerBuilder<'a> {
     fn new(dag_builder: &'a mut DagBuilder, start_round: Round) -> Self {
         assert!(start_round > 0, "genesis round is created by default");
@@ -642,7 +641,7 @@ impl<'a> LayerBuilder<'a> {
         round: Round,
     ) -> Vec<(AuthorityIndex, Vec<BlockRef>)> {
         let quorum_threshold = self.dag_builder.context.committee.quorum_threshold() as usize;
-        let mut authorities: Vec<AuthorityIndex> = self
+        let authorities: Vec<AuthorityIndex> = self
             .dag_builder
             .context
             .committee
@@ -707,7 +706,7 @@ impl<'a> LayerBuilder<'a> {
     fn configure_no_leader_links(
         &mut self,
         authorities: Vec<AuthorityIndex>,
-        round: Round,
+        _round: Round,
     ) -> Vec<(AuthorityIndex, Vec<BlockRef>)> {
         let mut missing_leaders = Vec::new();
         let mut specified_leader_offsets = self

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -52,7 +52,6 @@ pub(crate) struct TransactionConsumer {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[allow(unused)]
 pub enum BlockStatus {
     /// The block has been sequenced as part of a committed sub dag. That means that any transaction that has been included in the block
     /// has been committed as well.

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -182,12 +182,6 @@ pub(crate) mod universal_committer_builder {
             }
         }
 
-        #[allow(unused)]
-        pub(crate) fn with_wave_length(mut self, wave_length: Round) -> Self {
-            self.wave_length = wave_length;
-            self
-        }
-
         pub(crate) fn with_number_of_leaders(mut self, number_of_leaders: usize) -> Self {
             self.number_of_leaders = number_of_leaders;
             self


### PR DESCRIPTION


## Description 

Most of the allow attributes in consensus/core were stale: the annotated items were already used in production. Remove those. For genuinely test-only items (PeersPool::remove_peer), gate with cfg(test). Delete the unused BaseCommitter/UniversalCommitter builder methods plus the now-vestigial fields. Narrow leader_schedule's allow(unused_variables) to msim only since the parameter is only shadowed under that cfg. Rename the RAII histogram timer field on MetricsResponseCallback to _timer instead of suppressing the lint.

Retain allow(dead_code) on the v3 prep code (BlockV3 constructors, Proposer::set_next_commit_leader_schedule, ProposalLeaderWaiter:: update_v3_schedule) that will be wired up by the FlexCommitter follow-up.

## Test plan 

CI
