### PR TITLE
fix: expose Plausible track function so custom events fire

### DIFF
--- a/docs/site/src/components/AgentPrompt/index.tsx
+++ b/docs/site/src/components/AgentPrompt/index.tsx
@@ -42,7 +42,7 @@ const AGENTS: Agent[] = [
 
 function track(event: string, props: Record<string, string>) {
   if (typeof window !== "undefined") {
-    (window as any).__plausible_instance__?.track(event, { props });
+    (window as any).__plausible_track__?.(event, { props });
   }
 }
 

--- a/docs/site/src/pages/skills.js
+++ b/docs/site/src/pages/skills.js
@@ -27,7 +27,7 @@ function CopyCommand({ command }) {
           // is attached as a custom property so individual install commands
           // can be told apart if more copy buttons are added later.
           if (typeof window !== "undefined") {
-            window.__plausible_instance__?.track(
+            window.__plausible_track__?.(
               "Skills: copy install command",
               { props: { command } },
             );

--- a/docs/site/src/shared/plugins/plausible/client/index.ts
+++ b/docs/site/src/shared/plugins/plausible/client/index.ts
@@ -67,7 +67,8 @@ export async function onRouteDidUpdate({ location }: { location: Location }) {
     }
   }
 
-  // Resolve a working track function, supporting both APIs
+  // Resolve a working track function, supporting both APIs, and expose it
+  // globally so components like AgentPrompt can fire custom events.
   const track: any =
     (window as any).__plausible_instance__?.track || (mod as any).track;
 
@@ -79,6 +80,8 @@ export async function onRouteDidUpdate({ location }: { location: Location }) {
     );
     return;
   }
+
+  (window as any).__plausible_track__ = track;
 
   // Pageview on each SPA route change
   track("pageview", {


### PR DESCRIPTION
## Summary
- The Plausible tracker library (v0.4.4) exports named `init`/`track` functions where `init()` returns `void`, so `window.__plausible_instance__` was never set
- Components calling `__plausible_instance__?.track()` (AgentPrompt and Skills page) silently no-oped — custom events were never sent to Plausible
- Stores the resolved `track` function as `window.__plausible_track__` and updates all consumers to use it

## Test plan
- [ ] Deploy to preview and open a page with an `<AgentPrompt>` component
- [ ] Click "Copy prompt" and "Open in agent" — verify events appear in Plausible under "Docs: copy agent prompt" and "Docs: open agent prompt"
- [ ] Visit /skills and click "Copy" — verify "Skills: copy install command" event fires
- [ ] Confirm pageview tracking still works (unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)