### PR TITLE
ci(release): fix update-homebrew-formula gating on release events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,10 +249,10 @@ jobs:
     name: Bump sui formula on Homebrew/homebrew-core
     needs: release-build
     # releasing sui cli on testnet releases because it lags `main` less than mainnet, but is more likely to be stable than devnet
-    if: ${{ contains( inputs.sui_tag, 'testnet') || contains( github.ref_name, 'testnet') }}
+    if: ${{ contains( github.event.inputs.sui_tag, 'testnet') || contains( github.ref_name, 'testnet') }}
     uses: ./.github/workflows/homebrew-bump.yml
     with:
-      sui_tag: ${{ inputs.sui_tag || github.ref_name }}
+      sui_tag: ${{ github.event.inputs.sui_tag || github.ref_name }}
     secrets:
       HOMEBREW_GH_FORMULA_BUMP: ${{ secrets.HOMEBREW_GH_FORMULA_BUMP }}
 


### PR DESCRIPTION
## Summary

The `update-homebrew-formula` reusable-workflow call introduced in #26713 references `inputs.sui_tag` in its `if:` and `with:` expressions. Per [GitHub docs](https://docs.github.com/en/actions/learn-github-actions/contexts#inputs-context), the `inputs` context is **only available** on `workflow_dispatch` or `workflow_call` triggers. release.yml also runs on `release: types: created`, where `inputs` is absent — that breaks the expression evaluation, the job silently fails to schedule, and the run is marked `failure` even though every visible job succeeded.

Observed on **testnet-v1.73.0** ([run 26470764158](https://github.com/MystenLabs/sui/actions/runs/26470764158)): no `update-homebrew-formula` job, no `Run brew bump-formula-pr for sui` job, no homebrew-core PR — Homebrew formula stayed on the prior version, requiring a manual `gh workflow run homebrew-bump.yml` dispatch.

The same release.yml file already has the correct pattern at line 17 for `env.TAG_NAME`:
```yaml
TAG_NAME: "${{ github.event.inputs.sui_tag || github.ref_name }}"
```
which works on both `release` and `workflow_dispatch` triggers.

## Change

Two surgical edits to the `update-homebrew-formula` block:
- `if:` — `inputs.sui_tag` → `github.event.inputs.sui_tag`
- `with: sui_tag:` — `inputs.sui_tag` → `github.event.inputs.sui_tag`

No behavior change on `workflow_dispatch` (both forms resolve to the same value); fixes silent failure on `release` event.

## Test plan

- The next testnet release will exercise this — the run should now include `update-homebrew-formula` → `Run brew bump-formula-pr for sui` in its jobs list, and the run-level conclusion should be `success`.
- Workflow_dispatch path (release captain manual fallback) already verified working via [run 26471260940](https://github.com/MystenLabs/sui/actions/runs/26471260940) (the manual bump for testnet-v1.73.0 dispatched just before this PR).
- Devnet/mainnet releases continue to skip the job cleanly via the `contains(..., 'testnet')` gate (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)