### PR TITLE
feat(accumulator): add create_for_testing for AccumulatorRoot

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/accumulator.move
+++ b/crates/sui-framework/packages/sui-framework/sources/accumulator.move
@@ -21,6 +21,11 @@ fun create(ctx: &TxContext) {
     })
 }
 
+#[test_only]
+public fun create_for_testing(ctx: &TxContext) {
+    create(ctx);
+}
+
 public(package) fun root_id(accumulator_root: &AccumulatorRoot): &UID {
     &accumulator_root.id
 }


### PR DESCRIPTION
Adds a `#[test_only]` `create_for_testing` function to the `sui::accumulator` module, mirroring the equivalent function in `sui::random`. This allows test code to create an `AccumulatorRoot` object without going through the system-address-gated `create` function.