### PR TITLE
[consensus] Avoid per-block Vec allocation in block sync ancestor collection

### DIFF
--- a/consensus/core/src/block_sync_service.rs
+++ b/consensus/core/src/block_sync_service.rs
@@ -120,7 +120,7 @@ impl BlockSyncService {
                 // fetch_after_rounds will only be used to filter out already accepted blocks.
                 let missing_ancestors = blocks
                     .iter()
-                    .flat_map(|block| block.ancestors().to_vec())
+                    .flat_map(|block| block.ancestors().iter().copied())
                     .filter(|block_ref| fetch_after_rounds[block_ref.author] < block_ref.round)
                     .collect::<BTreeSet<_>>()
                     .into_iter()


### PR DESCRIPTION
## Summary
`BlockSyncService::fetch_blocks` gathers the missing ancestors of the requested blocks with `block.ancestors().to_vec()` inside a `flat_map`, allocating a throwaway `Vec<BlockRef>` for every block in the response only to immediately consume it. `BlockRef` is `Copy` and `ancestors()` returns `&[BlockRef]`, so the slice can be iterated with `.iter().copied()` instead, dropping one heap allocation per block.

The change is behavior-preserving: the downstream `.filter(...)` and `.collect::<BTreeSet<_>>()` receive `BlockRef` by value either way.

This path runs on the live block-sync serving side (`fetch_missing_ancestors = true`), driven by the synchronizer's live loop, and is exercised whenever a peer validator requests missing ancestors.

```diff
                 let missing_ancestors = blocks
                     .iter()
-                    .flat_map(|block| block.ancestors().to_vec())
+                    .flat_map(|block| block.ancestors().iter().copied())
                     .filter(|block_ref| fetch_after_rounds[block_ref.author] < block_ref.round)
                     .collect::<BTreeSet<_>>()
                     .into_iter()
                     .collect::<Vec<_>>();
```

## Test plan
- `cargo nextest run -p consensus-core fetch_blocks` — 5/5 pass (`test_handle_fetch_blocks`, `successful_fetch_blocks_from_peer`, `synchronizer_periodic_task_fetch_blocks`, `saturate_fetch_blocks_from_peer`, `test_max_fetch_blocks_response_bytes_uses_response_mode_limit`)
- `cargo xclippy` clean
- `cargo fmt --all -- --check` clean
