### PR TITLE
fix: Plausible custom events silently dropped

### DIFF
--- a/docs/site/src/components/AgentPrompt/index.tsx
+++ b/docs/site/src/components/AgentPrompt/index.tsx
@@ -42,7 +42,7 @@ const AGENTS: Agent[] = [
 
 function track(event: string, props: Record<string, string>) {
   if (typeof window !== "undefined") {
-    (window as any).__plausible_instance__?.track(event, { props });
+    (window as any).__plausible_track__?.(event, { props });
   }
 }
 

--- a/docs/site/src/pages/skills.js
+++ b/docs/site/src/pages/skills.js
@@ -27,7 +27,7 @@ function CopyCommand({ command }) {
           // is attached as a custom property so individual install commands
           // can be told apart if more copy buttons are added later.
           if (typeof window !== "undefined") {
-            window.__plausible_instance__?.track(
+            window.__plausible_track__?.(
               "Skills: copy install command",
               { props: { command } },
             );

--- a/docs/site/src/shared/plugins/plausible/client/index.ts
+++ b/docs/site/src/shared/plugins/plausible/client/index.ts
@@ -56,6 +56,7 @@ export async function onRouteDidUpdate({ location }: { location: Location }) {
         apiHost: opts.apiHost,
         hashMode: !!opts.hashMode,
         trackLocalhost: !!opts.trackLocalhost,
+        autoCapturePageviews: false,
       });
       if (instance) {
         (window as any).__plausible_instance__ = instance;
@@ -67,7 +68,8 @@ export async function onRouteDidUpdate({ location }: { location: Location }) {
     }
   }
 
-  // Resolve a working track function, supporting both APIs
+  // Resolve a working track function, supporting both APIs, and expose it
+  // globally so components like AgentPrompt can fire custom events.
   const track: any =
     (window as any).__plausible_instance__?.track || (mod as any).track;
 
@@ -79,6 +81,8 @@ export async function onRouteDidUpdate({ location }: { location: Location }) {
     );
     return;
   }
+
+  (window as any).__plausible_track__ = track;
 
   // Pageview on each SPA route change
   track("pageview", {


### PR DESCRIPTION
## Summary
- The Plausible tracker library (v0.4.4) exports named `init`/`track` functions where `init()` returns `void`, so `window.__plausible_instance__` was never set — components calling `__plausible_instance__?.track()` silently no-oped
- The library's `autoCapturePageviews` defaults to `true`, firing its own pageview and engagement events on top of what `onRouteDidUpdate` already sends — this flood of duplicate events triggered Plausible's rate limiter (`x-plausible-dropped: 1`), dropping all events including custom ones
- Stores the resolved `track` function as `window.__plausible_track__` and updates AgentPrompt and Skills page to use it
- Disables `autoCapturePageviews` since `onRouteDidUpdate` already handles pageview tracking

## Test plan
- [ ] Deploy preview and open browser DevTools Network tab
- [ ] Navigate between pages — confirm single pageview events without `x-plausible-dropped` header
- [ ] On a page with `<AgentPrompt>`, click "Copy prompt" — confirm `Docs: copy agent prompt` event fires without `x-plausible-dropped`
- [ ] Click "Open in agent" and select an agent — confirm `Docs: open agent prompt` event fires
- [ ] On /skills, click "Copy" — confirm `Skills: copy install command` event fires
- [ ] Verify all events appear in the Plausible dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)