### PR TITLE
fix(move-compiler): handle generic key+store type param in nested match fringe (ICE)

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -53,6 +53,14 @@ enum MatchTree {
         arms: BTreeMap<VariantName, (Vec<(Field, Var, Type)>, Box<MatchTree>)>,
         default: Box<MatchTree>,
     },
+    // A generic type parameter (e.g., `T: key + store`) in fringe position has no
+    // inspectable structure. The only valid patterns against it are wildcards/binders,
+    // so we bind the value and recurse on the remaining fringe.
+    TypeParamBind {
+        subject: FringeEntry,
+        subject_binders: Vec<(Mutability, Var)>,
+        next: Box<MatchTree>,
+    },
 }
 
 pub(super) fn compile_match(
@@ -212,6 +220,17 @@ fn build_match_tree(
                 datatype_name,
             )
         }
+    } else if is_type_param(&subject.ty.value) {
+        // A generic type parameter (TypeInner::Param or Ref(_, Param)) has no
+        // inspectable structure. Any pattern on it must be a binder or wildcard.
+        // Specialize as default and recurse on the remaining fringe.
+        let (subject_binders, default_matrix) = matrix.specialize_default(context);
+        let next = build_match_tree(context, fringe, default_matrix);
+        MatchTree::TypeParamBind {
+            subject,
+            subject_binders,
+            next: Box::new(next),
+        }
     } else {
         ice_assert!(
             context.reporter,
@@ -220,6 +239,17 @@ fn build_match_tree(
             "Non-datatype and non-builtin type reached match compilation without a prior error"
         );
         MatchTree::Failure
+    }
+}
+
+// Returns true if `ty` is a generic type parameter, possibly behind an immutable reference.
+// Such types have no inspectable datatype structure and must be treated as opaque wildcards
+// during match compilation.
+fn is_type_param(ty: &N::Type_) -> bool {
+    match ty.inner() {
+        N::TypeInner::Param(_) => true,
+        N::TypeInner::Ref(_, inner) => matches!(inner.value.inner(), N::TypeInner::Param(_)),
+        _ => false,
     }
 }
 
@@ -506,6 +536,20 @@ fn match_tree_to_exp(
                 }
             };
             make_copy_bindings(context, bindings, unpack_exp)
+        }
+        MatchTree::TypeParamBind {
+            subject,
+            subject_binders,
+            next,
+        } => {
+            // Bind any binder-pattern variables to the opaque type-parameter subject,
+            // then continue with the remaining match tree.
+            let bindings = subject_binders
+                .into_iter()
+                .map(|(_mut, binder)| (binder, (Mutability::Imm, subject.clone())))
+                .collect();
+            let next_exp = match_tree_to_exp(context, init_subject, *next);
+            make_copy_bindings(context, bindings, next_exp)
         }
         MatchTree::LiteralSwitch {
             subject,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/match_generic_key_type_param.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/match_generic_key_type_param.move
@@ -1,0 +1,31 @@
+// Regression test: deep nested match over a struct field whose type is a generic
+// type parameter constrained to `key + store` must compile without an ICE.
+// Previously, `TypeInner::Param` (or `Ref(false, Param)`) in fringe position fell
+// through to the `ice_assert!` catch-all in `build_match_tree`, causing a compiler
+// panic. After the fix, such types are treated as opaque wildcards.
+module 0x2::M {
+    public enum State has store, drop {
+        Idle,
+        Active { value: u64 },
+    }
+
+    public struct Inner<T: key + store> has store {
+        asset: T,
+        state: State,
+    }
+
+    public enum Outer<T: key + store> has store {
+        Variant { inner: Inner<T> },
+    }
+
+    public fun extract_value<T: key + store>(outer: Outer<T>): u64 {
+        match (outer) {
+            Outer::Variant {
+                inner: Inner { asset: _asset, state: State::Active { value } },
+            } => value,
+            Outer::Variant {
+                inner: Inner { asset: _asset, state: State::Idle },
+            } => 0,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/match_generic_key_type_param.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/match_generic_key_type_param.move
@@ -18,14 +18,15 @@ module 0x2::M {
         Variant { inner: Inner<T> },
     }
 
-    public fun extract_value<T: key + store>(outer: Outer<T>): u64 {
+    // The function returns the asset so the non-drop T is not silently discarded.
+    public fun extract_value<T: key + store>(outer: Outer<T>): (u64, T) {
         match (outer) {
             Outer::Variant {
-                inner: Inner { asset: _asset, state: State::Active { value } },
-            } => value,
+                inner: Inner { asset, state: State::Active { value } },
+            } => (value, asset),
             Outer::Variant {
-                inner: Inner { asset: _asset, state: State::Idle },
-            } => 0,
+                inner: Inner { asset, state: State::Idle },
+            } => (0, asset),
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/match_generic_key_type_param.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/match_generic_key_type_param.snap
@@ -1,0 +1,7 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---


### PR DESCRIPTION
## Problem

`sui move build` crashes with an internal compiler panic when a match arm contains a deeply nested pattern where a struct field has type `T: key + store` — a raw generic type parameter, not a concrete named wrapper type.

```
thread 'main' panicked at
external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs:
called `Option::unwrap()` on a `None` value
```

In the current `main` the panic was softened to an `ice_assert!` diagnostic (from #25475), but the ICE still fires and compilation fails.

## Root Cause

`build_match_tree` dispatches on the fringe subject type:

1. Builtin type → `compile_match_literal`  
2. Concrete type with type-args → `compile_match_struct` / `compile_variant_switch`  
3. Anything else → `ice_assert!` + `MatchTree::Failure`

A generic type parameter (`TypeInner::Param`) — or an immutable reference to one (`TypeInner::Ref(false, Param)`) as produced by the fringe binder machinery — is **not** a builtin and has **no** type arguments. It falls through to (3).

The concrete trigger: `Outer<T: key+store>` wraps `Inner<T>` which has field `asset: T`. The fringe entry for `asset` is `Ref(false, Param(T))`. `type_arguments()` recurses through `Ref` → `Param` → returns `None` → falls to `ice_assert!`.

The same nesting depth with a concrete wrapper type (e.g. `Wrapper<T: store>`) compiles correctly because its fringe entry is `Ref(false, Apply(Wrapper, [T]))` and `type_arguments()` returns `Some([T])`.

## Fix

Add `MatchTree::TypeParamBind` and an `is_type_param` guard before the `ice_assert!` catch-all. A generic type parameter in fringe position has no inspectable structure — any pattern on it must be a binder or wildcard — so we specialize as default and recurse on the remaining fringe.

Changes:
- `MatchTree::TypeParamBind { subject, subject_binders, next }` — new variant
- `is_type_param(ty)` — helper that matches `Param` and `Ref(_, Param)` 
- Guard in `build_match_tree` between the existing `else if type_arguments()` and `else ice_assert!` branches
- New arm in `match_tree_to_exp` that binds pattern variables and continues

The `ice_assert!` catch-all is preserved unchanged for genuinely unreachable cases (e.g. `TypeInner::Anything` from `abort` expressions, which #25475 correctly handles as `MatchTree::Failure`).

## Reproducer

```move
public enum State has store, drop { Idle, Active { value: u64 } }

public struct Inner<T: key + store> has store {
    asset: T,      // ← raw generic type parameter, not a wrapper
    state: State,
}

public enum Outer<T: key + store> has store {
    Variant { inner: Inner<T> },
}

// Returns (value, asset) so the non-drop T is not silently discarded.
// The nested arm pattern on `asset: T` is what triggered the ICE.
public fun extract_value<T: key + store>(outer: Outer<T>): (u64, T) {
    match (outer) {
        Outer::Variant {
            inner: Inner { asset, state: State::Active { value } },
        } => (value, asset),
        Outer::Variant {
            inner: Inner { asset, state: State::Idle },
        } => (0, asset),
    }
}
```

A self-contained reproduction is available on branch `sui-move-2024-bug-panic-proof` of [0xkurious/usufruct-protocol](https://github.com/0xkurious/usufruct-protocol) — `cd usufruct && sui move build` triggers the ICE immediately.

## Relation to #25475

| Case | Type in fringe | Pre-#25475 | Post-#25475 | This PR |
|---|---|---|---|---|
| `abort` as match subject | `TypeInner::Anything` | hard panic | `MatchTree::Failure` ✓ | unchanged |
| `T: key+store` field | `TypeInner::Ref(false, Param)` | hard panic | `ice_assert!` fires ✗ | `TypeParamBind` ✓ |

## Testing

Added `tests/move_2024/hlir/match_generic_key_type_param.move` with the reproducer above. The snap file expects no diagnostics (clean compilation).

- `cargo check -p move-compiler` — passes
- `cargo test -p move-compiler --test move_check_testsuite -- hlir` — **22/22 pass**