### PR TITLE
[cli]: add more specific jsonrpc error code for external signers ledger fallback

### DIFF
--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -27,9 +27,12 @@ use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{PublicKey, Signature, SuiKeyPair, SuiSignature, SuiSignatureInner};
 use tokio::process::Command;
 
-// TODO create specific error code or some metadata method to improve on this.
-/// Ledgers do not support key generation, so we use the JSON RPC method not found error code to identify when create is not supported by the signer.
+// TODO: Remove this legacy Ledger fallback after supported ledger-signer versions return
+// CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE for create_key.
+/// Legacy Ledger signers returned method-not-found when asked to create keys.
 const JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE: i32 = -32601;
+/// Signers return this when asked to create a key, so generate can fall back to indexing an existing key.
+const CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE: i32 = -32013;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExternalExecError {
@@ -453,10 +456,11 @@ impl AccountKeystore for External {
                 let create_not_supported = matches!(
                     &create_error,
                     ExternalExecError::JsonRpc(JsonRpcError::RemoteError(error))
-                        if error.code == JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE
+                        if error.code == CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE
+                            || error.code == JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE
                 );
 
-                // return here if we failed to create a key for a reason other than the method not being found, otherwise attempt to fallback to adding an existing key.
+                // Ledger signers cannot generate keys, so fall back to adding an existing key.
                 if !create_not_supported {
                     return Err(anyhow!(
                         "Failed to create a new key on the external signer: {create_error}"
@@ -751,7 +755,11 @@ impl AccountKeystore for External {
 
 #[cfg(test)]
 mod tests {
-    use super::{External, ExternalExecError, MockCommandRunner, StdCommandRunner, StoredKey};
+    use super::{
+        External, ExternalExecError, JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE,
+        CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE, MockCommandRunner, StdCommandRunner,
+        StoredKey,
+    };
     use crate::external::ProvisionMode;
     use crate::key_identity::KeyIdentity;
     use crate::keystore::{ALIASES_FILE_EXTENSION, AccountKeystore, GenerateOptions, GeneratedKey};
@@ -780,6 +788,8 @@ mod tests {
     const PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE: i32 = -32012;
     const PROVISION_MODE_NOT_SUPPORTED_MESSAGE: &str =
         "Provision mode is not supported by yubikey-signer";
+    const CREATE_KEY_UNSUPPORTED_USE_EXISTING_MESSAGE: &str =
+        "create_key is not supported; use an existing key";
 
     fn unsupported_action_error(method: &str) -> ExternalExecError {
         RemoteError {
@@ -1052,11 +1062,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_generate_fallback_add_first_unindexed_key() {
+        assert_generate_fallback_add_first_unindexed_key(
+            CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE,
+            CREATE_KEY_UNSUPPORTED_USE_EXISTING_MESSAGE,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_generate_fallback_add_first_unindexed_key_legacy_method_not_found() {
+        assert_generate_fallback_add_first_unindexed_key(
+            JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE,
+            "Unsupported action create_key",
+        )
+        .await;
+    }
+
+    async fn assert_generate_fallback_add_first_unindexed_key(
+        create_key_error_code: i32,
+        create_key_error_message: &'static str,
+    ) {
         let mut mock = MockCommandRunner::new();
         let key_id = "key-123";
         mock.expect_run().returning(move |_, method, params| {
             if method == "create_key" && params == JsonValue::Null {
-                return Err(unsupported_action_error("create_key"));
+                return Err(RemoteError {
+                    code: create_key_error_code,
+                    message: create_key_error_message.to_string(),
+                    data: None,
+                }
+                .into());
             }
             if method == "keys" && params == json![null] {
                 return Ok(json!({

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -453,7 +453,7 @@ impl AccountKeystore for External {
                 })
                 .map_err(|e| anyhow!("Failed to parse key response from external signer: {}", e))?,
             Err(create_error) => {
-                let create_not_supported = matches!(
+                let should_use_existing_key = matches!(
                     &create_error,
                     ExternalExecError::JsonRpc(JsonRpcError::RemoteError(error))
                         if error.code == CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE
@@ -461,7 +461,7 @@ impl AccountKeystore for External {
                 );
 
                 // Ledger signers cannot generate keys, so fall back to adding an existing key.
-                if !create_not_supported {
+                if !should_use_existing_key {
                     return Err(anyhow!(
                         "Failed to create a new key on the external signer: {create_error}"
                     ));

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -756,9 +756,8 @@ impl AccountKeystore for External {
 #[cfg(test)]
 mod tests {
     use super::{
-        External, ExternalExecError, JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE,
-        CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE, MockCommandRunner, StdCommandRunner,
-        StoredKey,
+        CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE, External, ExternalExecError,
+        JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE, MockCommandRunner, StdCommandRunner, StoredKey,
     };
     use crate::external::ProvisionMode;
     use crate::key_identity::KeyIdentity;


### PR DESCRIPTION
## Description 

Add a separate error code `CREATE_KEY_UNSUPPORTED_USE_EXISTING_ERROR_CODE = -32013` out of the JSON RPC "server error" range to specify when a device cannot generate keys and should use an existing key. This is common for devices like ledger where key generation is done at device setup and keys are derived from a path (slip 10). Previously this was using a more generic code which may be confused in the future.

## Test plan 

unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
