### PR TITLE
docs: add announcement banner for Sui Agent Skills page

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -357,6 +357,7 @@ const config = {
       "data-mcp-enabled": "true",
       "data-mcp-server-url": "https://sui.mcp.kapa.ai",
       "data-mcp-button-text": "Use Sui MCP Server",
+      "data-chat-disclaimer": "**New:** Install [Sui Agent Skills](https://docs.sui.io/skills) to supercharge your AI coding agent with Sui expertise.",
       async: true,
     },
   ],
@@ -381,6 +382,12 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      announcementBar: {
+        id: "skills_launch",
+        content:
+          'New: <a href="/skills">Sui Agent Skills</a> — drop pre-built skills into Claude Code, Cursor, Codex, and other AI coding agents.',
+        isCloseable: true,
+      },
       image: "img/sui-doc-og.png",
       mermaid: {
         theme: {


### PR DESCRIPTION
## Summary
- Adds a dismissible announcement bar at the top of every docs page advertising the new [Sui Agent Skills](/skills) page
- Uses Docusaurus's built-in `announcementBar` config — no custom components needed
- Banner is closeable and persists dismissal via `localStorage` (keyed by `skills_launch` ID)

## Test plan
- [ ] Verify the banner appears at the top of docs pages
- [ ] Click the link — confirms it navigates to `/skills`
- [ ] Dismiss the banner — confirm it stays dismissed on reload
- [ ] Verify banner styling looks correct in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)