### PR TITLE
Unify validity_check and validity_check_no_gas_check for dry_run

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2417,9 +2417,9 @@ impl AuthorityState {
             .into());
         }
 
-        // Compute input/receiving object kinds before mock gas injection so the mock
-        // gas reference is not included in input_object_kinds (it is added to
-        // input_objects directly after object loading).
+        // Full validity check including gas budget and price.
+        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
+
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
@@ -2444,9 +2444,6 @@ impl AuthorityState {
         } else {
             None
         };
-
-        // Full validity check including gas budget and price.
-        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
 
         let declared_withdrawals = self.pre_object_load_checks(
             &transaction,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2417,15 +2417,14 @@ impl AuthorityState {
             .into());
         }
 
-        // Cheap validity checks for a transaction, including input size limits.
-        transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
-
+        // Compute input/receiving object kinds before mock gas injection so the mock
+        // gas reference is not included in input_object_kinds (it is added to
+        // input_objects directly after object loading).
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
-        // Create and inject mock gas coin before pre_object_load_checks so that
-        // funds withdrawal processing sees non-empty payment and doesn't incorrectly
-        // create an address balance withdrawal for gas.
+        // Inject mock gas coin before validity_check so that the non-empty gas
+        // payment check passes for dry-run transactions submitted without gas.
         // Skip mock gas for gasless transactions — they don't use gas coins.
         let is_gasless = protocol_config.enable_gasless() && transaction.is_gasless_transaction();
         let mock_gas_object = if allow_mock_gas_coin && transaction.gas().is_empty() && !is_gasless
@@ -2444,6 +2443,10 @@ impl AuthorityState {
         } else {
             None
         };
+
+        // Full validity check including gas budget and price. Mock gas is already
+        // injected above so the non-empty payment check passes.
+        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
 
         let declared_withdrawals = self.pre_object_load_checks(
             &transaction,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2423,8 +2423,9 @@ impl AuthorityState {
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
-        // Inject mock gas coin before validity_check so that the non-empty gas
-        // payment check passes for dry-run transactions submitted without gas.
+        // Inject mock gas coin before pre_object_load_checks so that funds
+        // withdrawal processing sees non-empty payment and doesn't incorrectly
+        // create an address balance withdrawal for gas.
         // Skip mock gas for gasless transactions — they don't use gas coins.
         let is_gasless = protocol_config.enable_gasless() && transaction.is_gasless_transaction();
         let mock_gas_object = if allow_mock_gas_coin && transaction.gas().is_empty() && !is_gasless
@@ -2444,8 +2445,7 @@ impl AuthorityState {
             None
         };
 
-        // Full validity check including gas budget and price. Mock gas is already
-        // injected above so the non-empty payment check passes.
+        // Full validity check including gas budget and price.
         transaction.validity_check(&epoch_store.tx_validity_check_context())?;
 
         let declared_withdrawals = self.pre_object_load_checks(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2417,15 +2417,19 @@ impl AuthorityState {
             .into());
         }
 
-        // Full validity check including gas budget and price.
-        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
-
+        // Compute input/receiving object kinds before mock gas injection so the mock
+        // gas reference is not included in input_object_kinds (it is added to
+        // input_objects directly after object loading).
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
-        // Inject mock gas coin before pre_object_load_checks so that funds
-        // withdrawal processing sees non-empty payment and doesn't incorrectly
-        // create an address balance withdrawal for gas.
+        // Inject mock gas coin before validity_check so that on protocol versions
+        // where address-balance gas payments are not yet enabled, the non-empty
+        // payment check in validity_check passes for simulate/dev-inspect requests
+        // submitted without explicit gas.
+        // Also required before pre_object_load_checks so that funds-withdrawal
+        // processing sees non-empty payment and doesn't create an address-balance
+        // withdrawal for gas.
         // Skip mock gas for gasless transactions — they don't use gas coins.
         let is_gasless = protocol_config.enable_gasless() && transaction.is_gasless_transaction();
         let mock_gas_object = if allow_mock_gas_coin && transaction.gas().is_empty() && !is_gasless
@@ -2444,6 +2448,9 @@ impl AuthorityState {
         } else {
             None
         };
+
+        // Full validity check including gas budget and price.
+        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
 
         let declared_withdrawals = self.pre_object_load_checks(
             &transaction,

--- a/crates/sui-e2e-tests/tests/dry_run_tests.rs
+++ b/crates/sui-e2e-tests/tests/dry_run_tests.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// These tests use the JSON-RPC dry_run_transaction_block endpoint to verify
+// the behavior that external clients observe when submitting transactions with
+// invalid gas parameters.
+#![allow(deprecated)]
+
+use sui_macros::sim_test;
+use sui_protocol_config::ProtocolConfig;
+use sui_types::{
+    base_types::SuiAddress, programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::TransactionData,
+};
+use test_cluster::TestClusterBuilder;
+
+async fn build_transfer_sui_tx(
+    sender: SuiAddress,
+    gas_budget: u64,
+    gas_price: u64,
+) -> TransactionData {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.transfer_sui(SuiAddress::random_for_testing_only(), None);
+    let pt = builder.finish();
+    // Empty gas payment — dry_run injects a mock gas coin.
+    TransactionData::new_programmable(sender, vec![], pt, gas_budget, gas_price)
+}
+
+#[sim_test]
+async fn test_dry_run_gas_budget_too_low() {
+    let cluster = TestClusterBuilder::new().build().await;
+    let client = cluster.sui_client();
+    let sender = cluster.get_address_0();
+    let rgp = cluster.get_reference_gas_price().await;
+
+    let tx = build_transfer_sui_tx(sender, 0, rgp).await;
+    let err = client
+        .read_api()
+        .dry_run_transaction_block(tx)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("is lower than min:"),
+        "Expected GasBudgetTooLow error, got: {err}"
+    );
+}
+
+#[sim_test]
+async fn test_dry_run_gas_budget_too_high() {
+    let cluster = TestClusterBuilder::new().build().await;
+    let client = cluster.sui_client();
+    let sender = cluster.get_address_0();
+    let rgp = cluster.get_reference_gas_price().await;
+    let max_budget = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
+
+    let tx = build_transfer_sui_tx(sender, max_budget + 1, rgp).await;
+    let err = client
+        .read_api()
+        .dry_run_transaction_block(tx)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("is higher than max:"),
+        "Expected GasBudgetTooHigh error, got: {err}"
+    );
+}
+
+#[sim_test]
+async fn test_dry_run_gas_price_too_low() {
+    let cluster = TestClusterBuilder::new().build().await;
+    let client = cluster.sui_client();
+    let sender = cluster.get_address_0();
+    let max_budget = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
+    let rgp = cluster.get_reference_gas_price().await;
+
+    // Use rgp - 1, which is below RGP but above 0 so the transaction is not
+    // treated as a gasless transaction (which requires price == 0).
+    let tx = build_transfer_sui_tx(sender, max_budget, rgp - 1).await;
+    let err = client
+        .read_api()
+        .dry_run_transaction_block(tx)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("under reference gas price (RGP)"),
+        "Expected GasPriceUnderRGP error, got: {err}"
+    );
+}
+
+#[sim_test]
+async fn test_dry_run_gas_price_too_high() {
+    let cluster = TestClusterBuilder::new().build().await;
+    let client = cluster.sui_client();
+    let sender = cluster.get_address_0();
+    let config = ProtocolConfig::get_for_max_version_UNSAFE();
+    let max_gas_price = config.max_gas_price();
+    let max_budget = config.max_tx_gas();
+
+    // max_gas_price satisfies the too-high condition (price >= max_gas_price).
+    let tx = build_transfer_sui_tx(sender, max_budget, max_gas_price).await;
+    let err = client
+        .read_api()
+        .dry_run_transaction_block(tx)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("Gas price cannot exceed"),
+        "Expected GasPriceTooHigh error, got: {err}"
+    );
+}

--- a/crates/sui-e2e-tests/tests/dry_run_tests.rs
+++ b/crates/sui-e2e-tests/tests/dry_run_tests.rs
@@ -28,7 +28,10 @@ async fn build_transfer_sui_tx(
 
 #[sim_test]
 async fn test_dry_run_gas_budget_too_low() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let client = cluster.sui_client();
     let sender = cluster.get_address_0();
     let rgp = cluster.get_reference_gas_price().await;
@@ -48,7 +51,10 @@ async fn test_dry_run_gas_budget_too_low() {
 
 #[sim_test]
 async fn test_dry_run_gas_budget_too_high() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let client = cluster.sui_client();
     let sender = cluster.get_address_0();
     let rgp = cluster.get_reference_gas_price().await;
@@ -69,7 +75,10 @@ async fn test_dry_run_gas_budget_too_high() {
 
 #[sim_test]
 async fn test_dry_run_gas_price_too_low() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let client = cluster.sui_client();
     let sender = cluster.get_address_0();
     let max_budget = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
@@ -92,7 +101,10 @@ async fn test_dry_run_gas_price_too_low() {
 
 #[sim_test]
 async fn test_dry_run_gas_price_too_high() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let client = cluster.sui_client();
     let sender = cluster.get_address_0();
     let config = ProtocolConfig::get_for_max_version_UNSAFE();

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3448,7 +3448,20 @@ impl TransactionDataAPI for TransactionDataV1 {
             }
         }
 
-        self.validity_check_no_gas_check(config)?;
+        self.kind().validity_check(config)?;
+
+        if config.enable_gasless() && self.is_gasless_transaction() {
+            let TransactionKind::ProgrammableTransaction(pt) = &self.kind else {
+                debug_fatal!("gasless transaction is not a ProgrammableTransaction");
+                return Err(UserInputError::Unsupported(
+                    "Gasless transactions must be programmable transactions".to_string(),
+                )
+                .into());
+            };
+            pt.validate_gasless_transaction(config)?;
+        }
+
+        self.check_sponsorship()?;
         Ok(())
     }
 
@@ -3526,22 +3539,6 @@ impl TransactionDataAPI for TransactionDataV1 {
 }
 
 impl TransactionDataV1 {
-    fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult {
-        self.kind().validity_check(config)?;
-
-        if config.enable_gasless() && self.is_gasless_transaction() {
-            let TransactionKind::ProgrammableTransaction(pt) = &self.kind else {
-                debug_fatal!("gasless transaction is not a ProgrammableTransaction");
-                return Err(UserInputError::Unsupported(
-                    "Gasless transactions must be programmable transactions".to_string(),
-                ));
-            };
-            pt.validate_gasless_transaction(config)?;
-        }
-
-        self.check_sponsorship()
-    }
-
     fn accumulate_funds_withdrawals(
         &self,
         chain_identifier: ChainIdentifier,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2920,8 +2920,6 @@ pub trait TransactionDataAPI {
 
     fn validity_check(&self, context: &TxValidityCheckContext<'_>) -> SuiResult;
 
-    fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult;
-
     /// Check if the transaction is compliant with sponsorship.
     fn check_sponsorship(&self) -> UserInputResult;
 
@@ -3454,24 +3452,6 @@ impl TransactionDataAPI for TransactionDataV1 {
         Ok(())
     }
 
-    // Keep all the logic for validity here, we need this for dry run where the gas
-    // may not be provided and created "on the fly"
-    fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult {
-        self.kind().validity_check(config)?;
-
-        if config.enable_gasless() && self.is_gasless_transaction() {
-            let TransactionKind::ProgrammableTransaction(pt) = &self.kind else {
-                debug_fatal!("gasless transaction is not a ProgrammableTransaction");
-                return Err(UserInputError::Unsupported(
-                    "Gasless transactions must be programmable transactions".to_string(),
-                ));
-            };
-            pt.validate_gasless_transaction(config)?;
-        }
-
-        self.check_sponsorship()
-    }
-
     /// Check if the transaction is sponsored (namely gas owner != sender)
     fn is_sponsored_tx(&self) -> bool {
         self.gas_owner() != self.sender
@@ -3546,6 +3526,22 @@ impl TransactionDataAPI for TransactionDataV1 {
 }
 
 impl TransactionDataV1 {
+    fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult {
+        self.kind().validity_check(config)?;
+
+        if config.enable_gasless() && self.is_gasless_transaction() {
+            let TransactionKind::ProgrammableTransaction(pt) = &self.kind else {
+                debug_fatal!("gasless transaction is not a ProgrammableTransaction");
+                return Err(UserInputError::Unsupported(
+                    "Gasless transactions must be programmable transactions".to_string(),
+                ));
+            };
+            pt.validate_gasless_transaction(config)?;
+        }
+
+        self.check_sponsorship()
+    }
+
     fn accumulate_funds_withdrawals(
         &self,
         chain_identifier: ChainIdentifier,


### PR DESCRIPTION
## Summary

`TransactionDataAPI` previously exposed two validity-check methods:
- `validity_check` — full check including gas budget, price, and payment object requirements
- `validity_check_no_gas_check` — subset used by dry-run because gas payment could be empty

The split existed because dry-run was designed to accept transactions with no gas payment and inject a mock gas coin at runtime. However, empty `gas_data.payment` is now a first-class representation for address-balance gas transactions, not just a dry-run artefact. The old justification no longer applies.

### Changes

**`sui-types`** — `validity_check_no_gas_check` is removed from the `TransactionDataAPI` trait. It becomes a private method on `TransactionDataV1`, still called internally by `validity_check` as its final step.

**`sui-core`** — `simulate_transaction` (the shared path for dry-run and dev-inspect) is updated:
1. Input/receiving object kinds are computed before mock gas injection so the mock coin reference is not included in `input_object_kinds` (it continues to be added directly to `input_objects` after object loading).
2. The mock gas coin is injected as before—now before the validity check rather than after it.
3. `validity_check_no_gas_check` is replaced with `validity_check` using the epoch store's full context, so gas budget and price are validated on the same path as normal transaction submission.

**`sui-e2e-tests`** — Four new regression tests call `dry_run_transaction_block` via JSON-RPC and assert the current error behavior for invalid gas parameters (budget too low/high, price too low/high), ensuring future refactors don't silently change what clients observe.

## Test plan

- [ ] `cargo nextest run -p sui-e2e-tests --test dry_run_tests`
- [ ] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-core -p sui-types --lib`