### PR TITLE
[move-core-types] Abstract underlying layout of type layouts

### DIFF
--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -72,14 +72,22 @@ pub(crate) type MoveTypeLayoutPool = [MoveTypeNode];
 /// false negatives. Compare by inflating to tree form or by comparing views.
 #[derive(Debug, Clone)]
 pub struct MoveTypeLayout {
-    pub(crate) pool: Arc<MoveTypeLayoutPool>,
-    pub(crate) root: LayoutRef,
+    pool: Arc<MoveTypeLayoutPool>,
+    root: LayoutRef,
 }
 
-/// A resolved view of an annotated layout node. Compound types contain
-/// owned layout types for direct navigation.
-#[derive(Debug, Clone)]
-pub enum MoveLayoutView {
+/// Borrowed compact annotated layout backed by an existing node pool.
+#[derive(Debug, Clone, Copy)]
+pub struct MoveTypeLayoutRef<'a> {
+    pool: &'a Arc<MoveTypeLayoutPool>,
+    root: LayoutRef,
+}
+
+// --- View types (all borrowed, Copy) ---
+
+/// A resolved view of an annotated layout node.
+#[derive(Debug, Clone, Copy)]
+pub enum MoveLayoutView<'a> {
     Bool,
     U8,
     U16,
@@ -89,58 +97,55 @@ pub enum MoveLayoutView {
     U256,
     Address,
     Signer,
-    Vector(Box<MoveTypeLayout>),
-    Struct(Box<MoveStructLayout>),
-    Enum(Box<MoveEnumLayout>),
+    Vector(MoveTypeLayoutRef<'a>),
+    Struct(MoveStructLayout<'a>),
+    Enum(MoveEnumLayout<'a>),
 }
 
 /// A compressed layout that is known to be a struct or enum (not a primitive
 /// or vector). This mirrors the tree-based [`crate::annotated_value::MoveDatatypeLayout`].
-#[derive(Debug, Clone)]
-pub(crate) enum MoveDatatypeLayout_ {
-    Struct(Box<MoveStructLayout>),
-    Enum(Box<MoveEnumLayout>),
-}
-
-/// Datatype layout with a reference to the original layout for inflation and conversion.
-#[derive(Debug, Clone)]
-pub struct MoveDatatypeLayout {
-    self_layout: MoveTypeLayout,
-    inner: MoveDatatypeLayout_,
+#[derive(Debug, Clone, Copy)]
+pub enum MoveDatatypeLayout<'a> {
+    Struct(MoveStructLayout<'a>),
+    Enum(MoveEnumLayout<'a>),
 }
 
 /// The enum layout with type tag and named variants, as a view into a shared pool.
-#[derive(Debug, Clone)]
-pub struct MoveEnumLayout {
-    type_: StructTag,
-    pub(crate) variants: Box<[VariantLayout]>,
+#[derive(Debug, Clone, Copy)]
+pub struct MoveEnumLayout<'a> {
+    type_: &'a StructTag,
+    variants: &'a [AnnotatedVariantEntry],
+    pool: &'a Arc<MoveTypeLayoutPool>,
 }
 
 /// The struct layout with type tag and named fields, as a view into a shared pool.
-#[derive(Debug, Clone)]
-pub struct MoveStructLayout {
-    type_: StructTag,
-    pub(crate) fields: MoveFieldsLayout,
+#[derive(Debug, Clone, Copy)]
+pub struct MoveStructLayout<'a> {
+    type_: &'a StructTag,
+    fields: MoveFieldsLayout<'a>,
 }
 
 /// The result of looking up a variant in an annotated enum layout.
-#[derive(Debug, Clone)]
-pub enum VariantLayout {
+#[derive(Debug, Clone, Copy)]
+pub enum VariantLayout<'a> {
     /// The variant's field layout is known.
     Known {
-        name: Identifier,
+        name: &'a Identifier,
         tag: VariantTag,
-        fields: MoveFieldsLayout,
+        fields: MoveFieldsLayout<'a>,
     },
     /// The variant exists but its field layout is not available.
-    Unknown { name: Identifier, tag: VariantTag },
+    Unknown {
+        name: &'a Identifier,
+        tag: VariantTag,
+    },
 }
 
 /// The field layout of a struct or enum variant, as a view into a shared pool.
-#[derive(Debug, Clone)]
-pub struct MoveFieldsLayout {
-    pool: Arc<MoveTypeLayoutPool>,
-    fields: Box<[AnnotatedFieldEntry]>,
+#[derive(Debug, Clone, Copy)]
+pub struct MoveFieldsLayout<'a> {
+    pool: &'a Arc<MoveTypeLayoutPool>,
+    fields: &'a [AnnotatedFieldEntry],
 }
 
 // --- Builder type ---
@@ -160,7 +165,7 @@ pub struct MoveTypeLayoutBuilder {
 impl MoveTypeLayout {
     /// Number of compound nodes in the table (excludes inline leaf types).
     pub fn node_count(&self) -> usize {
-        self.pool.len()
+        self.as_ref().node_count()
     }
 
     fn leaf(ty: LeafType) -> Self {
@@ -198,23 +203,31 @@ impl MoveTypeLayout {
         Self::leaf(LeafType::Signer)
     }
 
-    /// Create a resolved view for navigating this layout.
-    pub fn as_view(&self) -> MoveLayoutView {
-        resolve_ref(&self.pool, self.root)
+    /// Borrow this layout without cloning the pool.
+    pub fn as_ref(&self) -> MoveTypeLayoutRef<'_> {
+        MoveTypeLayoutRef {
+            pool: &self.pool,
+            root: self.root,
+        }
     }
 
-    /// Inflate back into a tree-based [`MoveTypeLayout`].
+    /// Create a resolved view for navigating this layout.
+    pub fn as_view(&self) -> MoveLayoutView<'_> {
+        self.as_ref().as_view()
+    }
+
+    /// Inflate back into a tree-based [`AV::MoveTypeLayout`].
     pub fn inflate(&self) -> AResult<AV::MoveTypeLayout> {
-        self.as_view().inflate()
+        self.as_ref().inflate()
     }
 }
 
 impl fmt::Display for MoveTypeLayout {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{:#}", self.as_view())
+            write!(f, "{:#}", self.as_ref())
         } else {
-            write!(f, "{}", self.as_view())
+            write!(f, "{}", self.as_ref())
         }
     }
 }
@@ -228,9 +241,53 @@ impl TryFrom<&AV::MoveTypeLayout> for MoveTypeLayout {
     }
 }
 
+// --- MoveTypeLayoutRef (borrowed root) ---
+
+impl<'a> MoveTypeLayoutRef<'a> {
+    /// Clone the underlying `Arc` to produce an owned layout. Cheap — only a
+    /// refcount bump.
+    pub fn to_owned(self) -> MoveTypeLayout {
+        MoveTypeLayout {
+            pool: self.pool.clone(),
+            root: self.root,
+        }
+    }
+
+    /// Number of compound nodes in the table (excludes inline leaf types).
+    pub fn node_count(self) -> usize {
+        self.pool.len()
+    }
+
+    /// Create a resolved view for navigating this layout.
+    pub fn as_view(self) -> MoveLayoutView<'a> {
+        resolve_ref(self.pool, self.root)
+    }
+
+    /// Inflate back into a tree-based [`AV::MoveTypeLayout`].
+    pub fn inflate(self) -> AResult<AV::MoveTypeLayout> {
+        self.as_view().inflate()
+    }
+}
+
+impl<'a> From<&'a MoveTypeLayout> for MoveTypeLayoutRef<'a> {
+    fn from(layout: &'a MoveTypeLayout) -> Self {
+        layout.as_ref()
+    }
+}
+
+impl fmt::Display for MoveTypeLayoutRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{:#}", self.as_view())
+        } else {
+            write!(f, "{}", self.as_view())
+        }
+    }
+}
+
 // --- MoveLayoutView ---
 
-impl MoveLayoutView {
+impl<'a> MoveLayoutView<'a> {
     /// Reconstruct the equivalent tree-based layout. Returns an error
     /// if any enum variant has an unknown layout.
     pub fn inflate(&self) -> AResult<AV::MoveTypeLayout> {
@@ -263,18 +320,17 @@ impl MoveLayoutView {
             MoveLayoutView::Enum(ev) => {
                 let variants = ev
                     .variants()
-                    .iter()
-                    .map(|vl| match vl.fields() {
-                        Some(fields) => {
+                    .map(|vl| match vl {
+                        VariantLayout::Known { name, tag, fields } => {
                             let field_layouts = fields
                                 .fields()
-                                .map(|(name, layout)| {
-                                    Ok(AV::MoveFieldLayout::new(name.clone(), layout.inflate()?))
+                                .map(|(n, layout)| {
+                                    Ok(AV::MoveFieldLayout::new(n.clone(), layout.inflate()?))
                                 })
                                 .collect::<AResult<_>>()?;
-                            Ok(((vl.name().clone(), vl.tag()), field_layouts))
+                            Ok(((name.clone(), tag), field_layouts))
                         }
-                        None => {
+                        VariantLayout::Unknown { .. } => {
                             anyhow::bail!("cannot inflate enum with unknown variant layout")
                         }
                     })
@@ -312,8 +368,8 @@ impl MoveLayoutView {
     }
 }
 
-impl From<MoveLayoutView> for TypeTag {
-    fn from(view: MoveLayoutView) -> TypeTag {
+impl From<MoveLayoutView<'_>> for TypeTag {
+    fn from(view: MoveLayoutView<'_>) -> TypeTag {
         match view {
             MoveLayoutView::Bool => TypeTag::Bool,
             MoveLayoutView::U8 => TypeTag::U8,
@@ -331,7 +387,7 @@ impl From<MoveLayoutView> for TypeTag {
     }
 }
 
-impl fmt::Display for MoveLayoutView {
+impl fmt::Display for MoveLayoutView<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MoveLayoutView::Bool => write!(f, "bool"),
@@ -343,8 +399,8 @@ impl fmt::Display for MoveLayoutView {
             MoveLayoutView::U256 => write!(f, "u256"),
             MoveLayoutView::Address => write!(f, "address"),
             MoveLayoutView::Signer => write!(f, "signer"),
-            MoveLayoutView::Vector(vv) if f.alternate() => write!(f, "vector<{:#}>", vv),
-            MoveLayoutView::Vector(vv) => write!(f, "vector<{}>", vv),
+            MoveLayoutView::Vector(vv) if f.alternate() => write!(f, "vector<{vv:#}>"),
+            MoveLayoutView::Vector(vv) => write!(f, "vector<{vv}>"),
             MoveLayoutView::Struct(sv) if f.alternate() => write!(f, "{sv:#}"),
             MoveLayoutView::Struct(sv) => write!(f, "{sv}"),
             MoveLayoutView::Enum(ev) if f.alternate() => write!(f, "{ev:#}"),
@@ -355,45 +411,24 @@ impl fmt::Display for MoveLayoutView {
 
 // --- MoveDatatypeLayout ---
 
-impl MoveDatatypeLayout {
-    /// Wrap a `MoveTypeLayout` that is known to be a struct or enum.
+impl<'a> MoveDatatypeLayout<'a> {
+    /// Wrap a borrowed layout that is known to be a struct or enum.
     /// Returns `None` if the layout is a primitive or vector.
-    pub fn new(layout: MoveTypeLayout) -> Option<Self> {
+    pub fn new(layout: MoveTypeLayoutRef<'a>) -> Option<Self> {
         match layout.as_view() {
-            MoveLayoutView::Struct(struct_layout) => Some(MoveDatatypeLayout {
-                self_layout: layout,
-                inner: MoveDatatypeLayout_::Struct(struct_layout),
-            }),
-            MoveLayoutView::Enum(enum_layout) => Some(MoveDatatypeLayout {
-                self_layout: layout,
-                inner: MoveDatatypeLayout_::Enum(enum_layout),
-            }),
+            MoveLayoutView::Struct(s) => Some(MoveDatatypeLayout::Struct(s)),
+            MoveLayoutView::Enum(e) => Some(MoveDatatypeLayout::Enum(e)),
             _ => None,
         }
     }
 
-    /// Convert into the underlying `MoveTypeLayout`.
-    pub fn into_layout(self) -> MoveTypeLayout {
-        self.self_layout
-    }
-
-    /// Borrow the underlying `MoveTypeLayout`.
-    pub fn as_layout(&self) -> &MoveTypeLayout {
-        &self.self_layout
-    }
-
-    /// Create a view for navigating this layout.
-    pub fn as_view(&self) -> MoveLayoutView {
-        self.self_layout.as_view()
-    }
-
     /// Inflate back into a tree-based [`AV::MoveDatatypeLayout`].
-    pub fn inflate(&self) -> AResult<crate::annotated_value::MoveDatatypeLayout> {
-        match &self.inner {
-            MoveDatatypeLayout_::Struct(move_struct_layout) => Ok(AV::MoveDatatypeLayout::Struct(
-                Box::new(AV::MoveStructLayout {
-                    type_: move_struct_layout.type_.clone(),
-                    fields: move_struct_layout
+    pub fn inflate(self) -> AResult<AV::MoveDatatypeLayout> {
+        match self {
+            MoveDatatypeLayout::Struct(sv) => Ok(AV::MoveDatatypeLayout::Struct(Box::new(
+                AV::MoveStructLayout {
+                    type_: sv.type_().clone(),
+                    fields: sv
                         .fields()
                         .map(|(name, layout)| {
                             Ok(AV::MoveFieldLayout {
@@ -402,24 +437,23 @@ impl MoveDatatypeLayout {
                             })
                         })
                         .collect::<AResult<_>>()?,
-                }),
-            )),
-            MoveDatatypeLayout_::Enum(move_enum_layout) => {
-                let variants = move_enum_layout
+                },
+            ))),
+            MoveDatatypeLayout::Enum(ev) => {
+                let variants = ev
                     .variants()
-                    .iter()
                     .map(|vl| match vl {
                         VariantLayout::Known { name, tag, fields } => {
                             let field_layouts = fields
                                 .fields()
-                                .map(|(name, layout)| {
+                                .map(|(n, layout)| {
                                     Ok(AV::MoveFieldLayout {
-                                        name: name.clone(),
+                                        name: n.clone(),
                                         layout: layout.inflate()?,
                                     })
                                 })
                                 .collect::<AResult<_>>()?;
-                            Ok(((name.clone(), *tag), field_layouts))
+                            Ok(((name.clone(), tag), field_layouts))
                         }
                         VariantLayout::Unknown { name, tag } => anyhow::bail!(
                             "cannot inflate enum with unknown variant layout: {} (tag {})",
@@ -429,7 +463,7 @@ impl MoveDatatypeLayout {
                     })
                     .collect::<AResult<_>>()?;
                 Ok(AV::MoveDatatypeLayout::Enum(Box::new(AV::MoveEnumLayout {
-                    type_: move_enum_layout.type_.clone(),
+                    type_: ev.type_().clone(),
                     variants,
                 })))
             }
@@ -439,19 +473,19 @@ impl MoveDatatypeLayout {
 
 // --- MoveFieldsLayout ---
 
-impl MoveFieldsLayout {
+impl<'a> MoveFieldsLayout<'a> {
     /// Number of fields.
-    pub fn field_count(&self) -> usize {
+    pub fn field_count(self) -> usize {
         self.fields.len()
     }
 
     /// Access a field by index, returning `(name, layout)`.
-    pub fn field(&self, i: usize) -> Option<(&Identifier, MoveTypeLayout)> {
+    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a>)> {
         self.fields.get(i).map(|entry| {
             (
                 &entry.name,
-                MoveTypeLayout {
-                    pool: self.pool.clone(),
+                MoveTypeLayoutRef {
+                    pool: self.pool,
                     root: entry.layout,
                 },
             )
@@ -459,24 +493,24 @@ impl MoveFieldsLayout {
     }
 
     /// Look up a field by name, returning its layout.
-    pub fn field_by_name(&self, name: &str) -> Option<MoveTypeLayout> {
+    pub fn field_by_name(self, name: &str) -> Option<MoveTypeLayoutRef<'a>> {
         self.fields
             .iter()
             .find(|entry| entry.name.as_str() == name)
-            .map(|entry| MoveTypeLayout {
-                pool: self.pool.clone(),
+            .map(|entry| MoveTypeLayoutRef {
+                pool: self.pool,
                 root: entry.layout,
             })
     }
 
     /// Iterate over all fields as `(name, layout)` pairs.
-    pub fn fields(&self) -> impl ExactSizeIterator<Item = (&Identifier, MoveTypeLayout)> {
-        let pool = &self.pool;
+    pub fn fields(self) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a>)> {
+        let pool = self.pool;
         self.fields.iter().map(move |entry| {
             (
                 &entry.name,
-                MoveTypeLayout {
-                    pool: pool.clone(),
+                MoveTypeLayoutRef {
+                    pool,
                     root: entry.layout,
                 },
             )
@@ -486,39 +520,39 @@ impl MoveFieldsLayout {
 
 // --- MoveStructLayout ---
 
-impl MoveStructLayout {
+impl<'a> MoveStructLayout<'a> {
     /// The struct's type tag.
-    pub fn type_(&self) -> &StructTag {
-        &self.type_
+    pub fn type_(self) -> &'a StructTag {
+        self.type_
     }
 
     /// Check whether this struct's type tag matches the given [`TypeTag`].
-    pub fn is_type_tag(&self, t: &TypeTag) -> bool {
-        matches!(t, TypeTag::Struct(s) if &**s == self.type_())
+    pub fn is_type_tag(self, t: &TypeTag) -> bool {
+        matches!(t, TypeTag::Struct(s) if &**s == self.type_)
     }
 
     /// Access the fields layout.
-    pub fn fields_layout(&self) -> &MoveFieldsLayout {
-        &self.fields
+    pub fn fields_layout(self) -> MoveFieldsLayout<'a> {
+        self.fields
     }
 
     /// Number of fields.
-    pub fn field_count(&self) -> usize {
+    pub fn field_count(self) -> usize {
         self.fields.field_count()
     }
 
     /// Access a field by index, returning `(name, layout)`.
-    pub fn field(&self, i: usize) -> Option<(&Identifier, MoveTypeLayout)> {
+    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a>)> {
         self.fields.field(i)
     }
 
     /// Iterate over all fields as `(name, layout)` pairs.
-    pub fn fields(&self) -> impl ExactSizeIterator<Item = (&Identifier, MoveTypeLayout)> {
+    pub fn fields(self) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a>)> {
         self.fields.fields()
     }
 }
 
-impl fmt::Display for MoveStructLayout {
+impl fmt::Display for MoveStructLayout<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {{ ", self.type_)?;
         for (i, (name, layout)) in self.fields().enumerate() {
@@ -537,9 +571,9 @@ impl fmt::Display for MoveStructLayout {
 
 // --- VariantLayout ---
 
-impl VariantLayout {
+impl<'a> VariantLayout<'a> {
     /// The variant's name.
-    pub fn name(&self) -> &Identifier {
+    pub fn name(self) -> &'a Identifier {
         match self {
             VariantLayout::Known { name, .. } => name,
             VariantLayout::Unknown { name, .. } => name,
@@ -547,15 +581,15 @@ impl VariantLayout {
     }
 
     /// The variant's tag.
-    pub fn tag(&self) -> VariantTag {
+    pub fn tag(self) -> VariantTag {
         match self {
-            VariantLayout::Known { tag, .. } => *tag,
-            VariantLayout::Unknown { tag, .. } => *tag,
+            VariantLayout::Known { tag, .. } => tag,
+            VariantLayout::Unknown { tag, .. } => tag,
         }
     }
 
     /// The variant's fields, or `None` if the layout is unknown.
-    pub fn fields(&self) -> Option<&MoveFieldsLayout> {
+    pub fn fields(self) -> Option<MoveFieldsLayout<'a>> {
         match self {
             VariantLayout::Known { fields, .. } => Some(fields),
             VariantLayout::Unknown { .. } => None,
@@ -565,42 +599,63 @@ impl VariantLayout {
 
 // --- MoveEnumLayout ---
 
-impl MoveEnumLayout {
+impl<'a> MoveEnumLayout<'a> {
     /// The enum's type tag.
-    pub fn type_(&self) -> &StructTag {
-        &self.type_
+    pub fn type_(self) -> &'a StructTag {
+        self.type_
     }
 
     /// Check whether this enum's type tag matches the given [`TypeTag`].
-    pub fn is_type_tag(&self, t: &TypeTag) -> bool {
-        matches!(t, TypeTag::Struct(s) if **s == *self.type_())
+    pub fn is_type_tag(self, t: &TypeTag) -> bool {
+        matches!(t, TypeTag::Struct(s) if **s == *self.type_)
     }
 
     /// Number of variants.
-    pub fn variant_count(&self) -> usize {
+    pub fn variant_count(self) -> usize {
         self.variants.len()
     }
 
     /// Access a variant by position index.
-    pub fn variant(&self, i: usize) -> Option<&VariantLayout> {
-        self.variants.get(i)
+    pub fn variant(self, i: usize) -> Option<VariantLayout<'a>> {
+        self.variants.get(i).map(|v| variant_view(self.pool, v))
     }
 
     /// Find a variant by its tag value.
-    pub fn variant_by_tag(&self, tag: VariantTag) -> Option<&VariantLayout> {
-        self.variants.iter().find(|vl| vl.tag() == tag)
+    pub fn variant_by_tag(self, tag: VariantTag) -> Option<VariantLayout<'a>> {
+        self.variants
+            .iter()
+            .find(|v| v.tag == tag)
+            .map(|v| variant_view(self.pool, v))
     }
 
     /// Iterate over all variants.
-    pub fn variants(&self) -> &[VariantLayout] {
-        &self.variants
+    pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a>> {
+        let pool = self.pool;
+        self.variants.iter().map(move |v| variant_view(pool, v))
     }
 }
 
-impl fmt::Display for MoveEnumLayout {
+fn variant_view<'a>(
+    pool: &'a Arc<MoveTypeLayoutPool>,
+    v: &'a AnnotatedVariantEntry,
+) -> VariantLayout<'a> {
+    match &v.fields {
+        Some(fields) => VariantLayout::Known {
+            name: &v.name,
+            tag: v.tag,
+            fields: MoveFieldsLayout { pool, fields },
+        },
+        None => VariantLayout::Unknown {
+            name: &v.name,
+            tag: v.tag,
+        },
+    }
+}
+
+impl fmt::Display for MoveEnumLayout<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {{ ", self.type_)?;
-        for (i, vl) in self.variants().iter().enumerate() {
+        for (i, vl) in self.variants().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }
@@ -800,7 +855,7 @@ impl Default for MoveTypeLayoutBuilder {
 // Free functions
 // =============================================================================
 
-fn leaf_to_layout_view(leaf: LeafType) -> MoveLayoutView {
+fn leaf_to_layout_view<'a>(leaf: LeafType) -> MoveLayoutView<'a> {
     match leaf {
         LeafType::Bool => MoveLayoutView::Bool,
         LeafType::U8 => MoveLayoutView::U8,
@@ -817,42 +872,25 @@ fn leaf_to_layout_view(leaf: LeafType) -> MoveLayoutView {
 /// Resolve a [`LayoutRef`] against the pool into a [`MoveLayoutView`].
 ///
 /// Panics if the reference points to an out-of-bounds table index.
-fn resolve_ref(pool: &Arc<MoveTypeLayoutPool>, r: LayoutRef) -> MoveLayoutView {
+fn resolve_ref<'a>(pool: &'a Arc<MoveTypeLayoutPool>, r: LayoutRef) -> MoveLayoutView<'a> {
     match r.resolve() {
         ResolvedRef::Leaf(leaf) => leaf_to_layout_view(leaf),
         ResolvedRef::Index(idx) => match &pool[idx] {
-            MoveTypeNode::Vector(inner) => MoveLayoutView::Vector(Box::new(MoveTypeLayout {
-                pool: pool.clone(),
-                root: *inner,
-            })),
-            MoveTypeNode::Struct(s) => MoveLayoutView::Struct(Box::new(MoveStructLayout {
-                type_: s.type_.clone(),
+            MoveTypeNode::Vector(inner) => {
+                MoveLayoutView::Vector(MoveTypeLayoutRef { pool, root: *inner })
+            }
+            MoveTypeNode::Struct(s) => MoveLayoutView::Struct(MoveStructLayout {
+                type_: &s.type_,
                 fields: MoveFieldsLayout {
-                    pool: pool.clone(),
-                    fields: s.fields.clone(),
+                    pool,
+                    fields: &s.fields,
                 },
-            })),
-            MoveTypeNode::Enum(e) => MoveLayoutView::Enum(Box::new(MoveEnumLayout {
-                type_: e.type_.clone(),
-                variants: e
-                    .variants
-                    .iter()
-                    .map(|entry| match &entry.fields {
-                        Some(fields) => VariantLayout::Known {
-                            name: entry.name.clone(),
-                            tag: entry.tag,
-                            fields: MoveFieldsLayout {
-                                pool: pool.clone(),
-                                fields: fields.clone(),
-                            },
-                        },
-                        None => VariantLayout::Unknown {
-                            name: entry.name.clone(),
-                            tag: entry.tag,
-                        },
-                    })
-                    .collect(),
-            })),
+            }),
+            MoveTypeNode::Enum(e) => MoveLayoutView::Enum(MoveEnumLayout {
+                type_: &e.type_,
+                variants: &e.variants,
+                pool,
+            }),
         },
     }
 }

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -3,91 +3,76 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::annotated_value as AV;
-pub use crate::compressed::LayoutHandle;
-use crate::compressed::{LayoutRef, LeafType, ResolvedRef, VariantTag};
+use crate::compressed::VariantTag;
+use crate::compressed::backend::DefaultAnnotated;
+use crate::compressed::backend::annotated_nodes::{AnnotatedFieldEntry, AnnotatedVariantEntry};
 use crate::identifier::Identifier;
 use crate::language_storage::{StructTag, TypeTag};
 use anyhow::Result as AResult;
-use indexmap::IndexSet;
 use std::fmt;
-use std::sync::Arc;
 
-static EMPTY_POOL: std::sync::LazyLock<Arc<MoveTypeLayoutPool>> =
-    std::sync::LazyLock::new(|| Arc::from(Vec::<MoveTypeNode>::new()));
+/// The default compressed-annotated layout builder. Alias so most users can just write
+/// `MoveTypeLayoutBuilder::new()`.
+///
+/// To use a different backend, name its concrete builder type directly (e.g.
+/// `AnnotatedBoxPoolBuilder`) — call sites are otherwise identical.
+pub use crate::compressed::backend::DefaultAnnotatedBuilder as MoveTypeLayoutBuilder;
 
-// --- Node types ---
+// =============================================================================
+// Trait: TypeLayout
+// =============================================================================
 
-/// A named field entry: field name paired with its layout reference.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct AnnotatedFieldEntry {
-    pub name: Identifier,
-    pub layout: LayoutRef,
+/// A backing store for compressed annotated layouts. Implementors decide how
+/// roots are encoded and where node data lives.
+///
+/// This trait is **per-flavor** rather than shared with the runtime flavor;
+/// see the doc comment on `runtime::TypeLayout` for the GAT/HRTB rationale.
+pub trait TypeLayout: Sized {
+    /// Cheap-to-`Clone` reference into the backend's storage. Typically `Copy`
+    /// (e.g. a packed index) but not required to be — Arc-handle backends use
+    /// a `Clone`-only `Root` carrying a refcounted pointer.
+    type Root: Clone + fmt::Debug;
+
+    /// Resolve a root to its resolved view at that node. `r` is borrowed so
+    /// the returned view can borrow into data the `Root` keeps alive (e.g.
+    /// an `Arc<TreeNode>` inside the root).
+    fn realize_view<'a>(&'a self, r: &'a Self::Root) -> MoveLayoutView<'a, Self>;
+
+    /// Number of compound nodes accessible through this backend.
+    fn node_count(&self) -> usize;
 }
 
-/// A single variant entry in an enum node.
-/// `None` fields means the variant exists but its field layout is unknown.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct AnnotatedVariantEntry {
-    pub name: Identifier,
-    pub tag: VariantTag,
-    pub fields: Option<Box<[AnnotatedFieldEntry]>>,
-}
+// =============================================================================
+// Owned and borrowed layout types
+// =============================================================================
 
-/// Annotated struct layout node with type tag and named fields inline.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct MoveStructNode {
-    pub(crate) type_: StructTag,
-    pub(crate) fields: Box<[AnnotatedFieldEntry]>,
-}
-
-/// Annotated enum layout node with type tag and named variants inline.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct MoveEnumNode {
-    pub(crate) type_: StructTag,
-    pub(crate) variants: Box<[AnnotatedVariantEntry]>,
-}
-
-/// A compound layout node in the annotated compressed node table.
-/// Leaf types (primitives) are encoded inline in [`LayoutRef`] and never
-/// appear in the table.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum MoveTypeNode {
-    Vector(LayoutRef),
-    Struct(MoveStructNode),
-    Enum(MoveEnumNode),
-}
-
-/// The shared node table backing a [`MoveTypeLayout`].
-pub(crate) type MoveTypeLayoutPool = [MoveTypeNode];
-
-// --- Owned layout types ---
-
-/// A deduplicated, flat representation of an annotated [`AV::MoveTypeLayout`] tree.
-/// Names and type tags are stored inline in nodes. Cloning is cheap — the
-/// node table is shared via `Arc`.
+/// A deduplicated, flat representation of an annotated [`AV::MoveTypeLayout`]
+/// tree, generic over the backend `T`.
 ///
 /// NOTE: `Eq`/`PartialEq`/`Hash` are intentionally not derived. Two layouts
 /// representing the same type may have different pool orderings (node
 /// permutations), so structural equality on the raw fields would produce
 /// false negatives. Compare by inflating to tree form or by comparing views.
 #[derive(Debug, Clone)]
-pub struct MoveTypeLayout {
-    pool: Arc<MoveTypeLayoutPool>,
-    root: LayoutRef,
+pub struct MoveTypeLayout<T: TypeLayout = DefaultAnnotated> {
+    pool: T,
+    root: T::Root,
 }
 
-/// Borrowed compact annotated layout backed by an existing node pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveTypeLayoutRef<'a> {
-    pool: &'a Arc<MoveTypeLayoutPool>,
-    root: LayoutRef,
+/// Borrowed view onto a [`MoveTypeLayout`] without cloning the pool.
+#[derive(Debug)]
+pub struct MoveTypeLayoutRef<'a, T: TypeLayout = DefaultAnnotated> {
+    pub(crate) pool: &'a T,
+    pub(crate) root: &'a T::Root,
 }
 
-// --- View types (all borrowed, Copy) ---
+// =============================================================================
+// View types (all borrowed, Copy)
+// =============================================================================
 
 /// A resolved view of an annotated layout node.
-#[derive(Debug, Clone, Copy)]
-pub enum MoveLayoutView<'a> {
+#[derive(Debug)]
+pub enum MoveLayoutView<'a, T: TypeLayout = DefaultAnnotated> {
     Bool,
     U8,
     U16,
@@ -97,42 +82,42 @@ pub enum MoveLayoutView<'a> {
     U256,
     Address,
     Signer,
-    Vector(MoveTypeLayoutRef<'a>),
-    Struct(MoveStructLayout<'a>),
-    Enum(MoveEnumLayout<'a>),
+    Vector(MoveTypeLayoutRef<'a, T>),
+    Struct(MoveStructLayout<'a, T>),
+    Enum(MoveEnumLayout<'a, T>),
 }
 
 /// A compressed layout that is known to be a struct or enum (not a primitive
 /// or vector). This mirrors the tree-based [`crate::annotated_value::MoveDatatypeLayout`].
-#[derive(Debug, Clone, Copy)]
-pub enum MoveDatatypeLayout<'a> {
-    Struct(MoveStructLayout<'a>),
-    Enum(MoveEnumLayout<'a>),
+#[derive(Debug)]
+pub enum MoveDatatypeLayout<'a, T: TypeLayout = DefaultAnnotated> {
+    Struct(MoveStructLayout<'a, T>),
+    Enum(MoveEnumLayout<'a, T>),
 }
 
 /// The enum layout with type tag and named variants, as a view into a shared pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveEnumLayout<'a> {
-    type_: &'a StructTag,
-    variants: &'a [AnnotatedVariantEntry],
-    pool: &'a Arc<MoveTypeLayoutPool>,
+#[derive(Debug)]
+pub struct MoveEnumLayout<'a, T: TypeLayout = DefaultAnnotated> {
+    pub(crate) type_: &'a StructTag,
+    pub(crate) variants: &'a [AnnotatedVariantEntry<T::Root>],
+    pub(crate) pool: &'a T,
 }
 
 /// The struct layout with type tag and named fields, as a view into a shared pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveStructLayout<'a> {
-    type_: &'a StructTag,
-    fields: MoveFieldsLayout<'a>,
+#[derive(Debug)]
+pub struct MoveStructLayout<'a, T: TypeLayout = DefaultAnnotated> {
+    pub(crate) type_: &'a StructTag,
+    pub(crate) fields: MoveFieldsLayout<'a, T>,
 }
 
 /// The result of looking up a variant in an annotated enum layout.
-#[derive(Debug, Clone, Copy)]
-pub enum VariantLayout<'a> {
+#[derive(Debug)]
+pub enum VariantLayout<'a, T: TypeLayout = DefaultAnnotated> {
     /// The variant's field layout is known.
     Known {
         name: &'a Identifier,
         tag: VariantTag,
-        fields: MoveFieldsLayout<'a>,
+        fields: MoveFieldsLayout<'a, T>,
     },
     /// The variant exists but its field layout is not available.
     Unknown {
@@ -142,18 +127,134 @@ pub enum VariantLayout<'a> {
 }
 
 /// The field layout of a struct or enum variant, as a view into a shared pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveFieldsLayout<'a> {
-    pool: &'a Arc<MoveTypeLayoutPool>,
-    fields: &'a [AnnotatedFieldEntry],
+#[derive(Debug)]
+pub struct MoveFieldsLayout<'a, T: TypeLayout = DefaultAnnotated> {
+    pub(crate) pool: &'a T,
+    pub(crate) fields: &'a [AnnotatedFieldEntry<T::Root>],
 }
 
-// --- Builder type ---
+// `#[derive(Copy, Clone)]` would over-constrain to `T: Copy`; these are all
+// `&'a T` plus Copy fields, so they're unconditionally Copy.
+macro_rules! impl_copy_clone {
+    ($($t:ident),* $(,)?) => { $(
+        impl<T: TypeLayout> Clone for $t<'_, T> { fn clone(&self) -> Self { *self } }
+        impl<T: TypeLayout> Copy for $t<'_, T> {}
+    )* };
+}
+impl_copy_clone!(
+    MoveTypeLayoutRef,
+    MoveLayoutView,
+    MoveDatatypeLayout,
+    MoveEnumLayout,
+    MoveStructLayout,
+    VariantLayout,
+    MoveFieldsLayout,
+);
 
-/// Incrementally builds an annotated [`MoveTypeLayout`] with automatic
-/// deduplication of nodes.
-pub struct MoveTypeLayoutBuilder {
-    nodes: IndexSet<MoveTypeNode>,
+// =============================================================================
+// Builder trait + generic builder
+// =============================================================================
+
+/// Backend-write-side abstraction for the annotated flavor. Mirrors
+/// [`crate::compressed::runtime::BackendBuilder`] but with annotated-specific
+/// signatures for `struct_layout`/`enum_layout` (carry type tags + names).
+///
+/// `intern_tree` and `build` are provided as default methods so callers can drive
+/// any backend builder directly without an extra wrapper.
+pub trait BackendBuilder: Sized {
+    /// Cheap-to-`Clone` reference into the backend's storage (matches
+    /// `<Self::Output as TypeLayout>::Root`).
+    type Root: Clone + fmt::Debug;
+    /// The TypeLayout backend produced by `finalize`.
+    type Output: TypeLayout<Root = Self::Root>;
+    /// Errors raised by compound constructors (e.g. capacity-limit failures).
+    type Error;
+
+    fn bool(&mut self) -> Self::Root;
+    fn u8(&mut self) -> Self::Root;
+    fn u16(&mut self) -> Self::Root;
+    fn u32(&mut self) -> Self::Root;
+    fn u64(&mut self) -> Self::Root;
+    fn u128(&mut self) -> Self::Root;
+    fn u256(&mut self) -> Self::Root;
+    fn address(&mut self) -> Self::Root;
+    fn signer(&mut self) -> Self::Root;
+
+    fn vector(&mut self, element: Self::Root) -> Result<Self::Root, Self::Error>;
+
+    fn struct_layout(
+        &mut self,
+        type_tag: &StructTag,
+        fields: &[(&Identifier, Self::Root)],
+    ) -> Result<Self::Root, Self::Error>;
+
+    fn enum_layout(
+        &mut self,
+        type_tag: &StructTag,
+        variants: &[(
+            &Identifier,
+            VariantTag,
+            Option<&[(&Identifier, Self::Root)]>,
+        )],
+    ) -> Result<Self::Root, Self::Error>;
+
+    fn finalize(self, root: Self::Root) -> Self::Output;
+
+    /// Recursively intern a tree-based annotated layout. Tree-based enum
+    /// layouts always have known variants, so all variants are wrapped in `Some`.
+    fn intern_tree(&mut self, layout: &AV::MoveTypeLayout) -> Result<Self::Root, Self::Error> {
+        Ok(match layout {
+            AV::MoveTypeLayout::Bool => self.bool(),
+            AV::MoveTypeLayout::U8 => self.u8(),
+            AV::MoveTypeLayout::U16 => self.u16(),
+            AV::MoveTypeLayout::U32 => self.u32(),
+            AV::MoveTypeLayout::U64 => self.u64(),
+            AV::MoveTypeLayout::U128 => self.u128(),
+            AV::MoveTypeLayout::U256 => self.u256(),
+            AV::MoveTypeLayout::Address => self.address(),
+            AV::MoveTypeLayout::Signer => self.signer(),
+            AV::MoveTypeLayout::Vector(inner) => {
+                let inner_h = self.intern_tree(inner)?;
+                self.vector(inner_h)?
+            }
+            AV::MoveTypeLayout::Struct(s) => {
+                let fields = s
+                    .fields
+                    .iter()
+                    .map(|f| Ok((&f.name, self.intern_tree(&f.layout)?)))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.struct_layout(&s.type_, &fields)?
+            }
+            AV::MoveTypeLayout::Enum(e) => {
+                let variants = e
+                    .variants
+                    .iter()
+                    .map(|((variant_name, tag), field_layouts)| {
+                        let fields: Vec<(&Identifier, Self::Root)> = field_layouts
+                            .iter()
+                            .map(|f| Ok((&f.name, self.intern_tree(&f.layout)?)))
+                            .collect::<Result<_, _>>()?;
+                        Ok((variant_name, *tag, fields))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let variant_refs: Vec<(
+                    &Identifier,
+                    VariantTag,
+                    Option<&[(&Identifier, Self::Root)]>,
+                )> = variants
+                    .iter()
+                    .map(|(vn, tag, fields)| (*vn, *tag, Some(fields.as_slice())))
+                    .collect();
+                self.enum_layout(&e.type_, &variant_refs)?
+            }
+        })
+    }
+
+    /// Finalize the builder and wrap the result in a [`MoveTypeLayout`].
+    fn build(self, root: Self::Root) -> MoveTypeLayout<Self::Output> {
+        let pool = self.finalize(root.clone());
+        MoveTypeLayout::from_parts(pool, root)
+    }
 }
 
 // =============================================================================
@@ -162,57 +263,28 @@ pub struct MoveTypeLayoutBuilder {
 
 // --- MoveTypeLayout ---
 
-impl MoveTypeLayout {
-    /// Number of compound nodes in the table (excludes inline leaf types).
+impl<T: TypeLayout> MoveTypeLayout<T> {
+    /// Construct a layout from its raw parts. Used by backends to build their
+    /// concrete instantiations from a finalized pool + root.
+    pub fn from_parts(pool: T, root: T::Root) -> Self {
+        MoveTypeLayout { pool, root }
+    }
+
+    /// Number of compound nodes accessible through the backend.
     pub fn node_count(&self) -> usize {
-        self.as_ref().node_count()
-    }
-
-    fn leaf(ty: LeafType) -> Self {
-        MoveTypeLayout {
-            pool: EMPTY_POOL.clone(),
-            root: LayoutRef::leaf(ty),
-        }
-    }
-
-    pub fn bool() -> Self {
-        Self::leaf(LeafType::Bool)
-    }
-    pub fn u8() -> Self {
-        Self::leaf(LeafType::U8)
-    }
-    pub fn u16() -> Self {
-        Self::leaf(LeafType::U16)
-    }
-    pub fn u32() -> Self {
-        Self::leaf(LeafType::U32)
-    }
-    pub fn u64() -> Self {
-        Self::leaf(LeafType::U64)
-    }
-    pub fn u128() -> Self {
-        Self::leaf(LeafType::U128)
-    }
-    pub fn u256() -> Self {
-        Self::leaf(LeafType::U256)
-    }
-    pub fn address() -> Self {
-        Self::leaf(LeafType::Address)
-    }
-    pub fn signer() -> Self {
-        Self::leaf(LeafType::Signer)
+        self.pool.node_count()
     }
 
     /// Borrow this layout without cloning the pool.
-    pub fn as_ref(&self) -> MoveTypeLayoutRef<'_> {
+    pub fn as_ref(&self) -> MoveTypeLayoutRef<'_, T> {
         MoveTypeLayoutRef {
             pool: &self.pool,
-            root: self.root,
+            root: &self.root,
         }
     }
 
     /// Create a resolved view for navigating this layout.
-    pub fn as_view(&self) -> MoveLayoutView<'_> {
+    pub fn as_view(&self) -> MoveLayoutView<'_, T> {
         self.as_ref().as_view()
     }
 
@@ -222,7 +294,7 @@ impl MoveTypeLayout {
     }
 }
 
-impl fmt::Display for MoveTypeLayout {
+impl<T: TypeLayout> fmt::Display for MoveTypeLayout<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             write!(f, "{:#}", self.as_ref())
@@ -232,35 +304,34 @@ impl fmt::Display for MoveTypeLayout {
     }
 }
 
-impl TryFrom<&AV::MoveTypeLayout> for MoveTypeLayout {
-    type Error = anyhow::Error;
-    fn try_from(layout: &AV::MoveTypeLayout) -> Result<Self, Self::Error> {
-        let mut b = MoveTypeLayoutBuilder::new();
-        let root = b.from_tree(layout)?;
-        Ok(b.build(root))
+// --- MoveTypeLayoutRef ---
+
+impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
+    /// Construct a borrowed layout from a pool reference and a root reference.
+    pub fn new(pool: &'a T, root: &'a T::Root) -> Self {
+        MoveTypeLayoutRef { pool, root }
     }
-}
 
-// --- MoveTypeLayoutRef (borrowed root) ---
-
-impl<'a> MoveTypeLayoutRef<'a> {
-    /// Clone the underlying `Arc` to produce an owned layout. Cheap — only a
-    /// refcount bump.
-    pub fn to_owned(self) -> MoveTypeLayout {
+    /// Clone the backend to produce an owned layout (cheap when the backend's
+    /// `Clone` impl is itself cheap, e.g. an `Arc` refcount bump).
+    pub fn to_owned(self) -> MoveTypeLayout<T>
+    where
+        T: Clone,
+    {
         MoveTypeLayout {
             pool: self.pool.clone(),
-            root: self.root,
+            root: self.root.clone(),
         }
     }
 
-    /// Number of compound nodes in the table (excludes inline leaf types).
+    /// Number of compound nodes accessible through the backend.
     pub fn node_count(self) -> usize {
-        self.pool.len()
+        self.pool.node_count()
     }
 
     /// Create a resolved view for navigating this layout.
-    pub fn as_view(self) -> MoveLayoutView<'a> {
-        resolve_ref(self.pool, self.root)
+    pub fn as_view(self) -> MoveLayoutView<'a, T> {
+        self.pool.realize_view(self.root)
     }
 
     /// Inflate back into a tree-based [`AV::MoveTypeLayout`].
@@ -269,13 +340,13 @@ impl<'a> MoveTypeLayoutRef<'a> {
     }
 }
 
-impl<'a> From<&'a MoveTypeLayout> for MoveTypeLayoutRef<'a> {
-    fn from(layout: &'a MoveTypeLayout) -> Self {
+impl<'a, T: TypeLayout> From<&'a MoveTypeLayout<T>> for MoveTypeLayoutRef<'a, T> {
+    fn from(layout: &'a MoveTypeLayout<T>) -> Self {
         layout.as_ref()
     }
 }
 
-impl fmt::Display for MoveTypeLayoutRef<'_> {
+impl<T: TypeLayout> fmt::Display for MoveTypeLayoutRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             write!(f, "{:#}", self.as_view())
@@ -287,7 +358,7 @@ impl fmt::Display for MoveTypeLayoutRef<'_> {
 
 // --- MoveLayoutView ---
 
-impl<'a> MoveLayoutView<'a> {
+impl<T: TypeLayout> MoveLayoutView<'_, T> {
     /// Reconstruct the equivalent tree-based layout. Returns an error
     /// if any enum variant has an unknown layout.
     pub fn inflate(&self) -> AResult<AV::MoveTypeLayout> {
@@ -368,8 +439,8 @@ impl<'a> MoveLayoutView<'a> {
     }
 }
 
-impl From<MoveLayoutView<'_>> for TypeTag {
-    fn from(view: MoveLayoutView<'_>) -> TypeTag {
+impl<T: TypeLayout> From<MoveLayoutView<'_, T>> for TypeTag {
+    fn from(view: MoveLayoutView<'_, T>) -> TypeTag {
         match view {
             MoveLayoutView::Bool => TypeTag::Bool,
             MoveLayoutView::U8 => TypeTag::U8,
@@ -387,7 +458,7 @@ impl From<MoveLayoutView<'_>> for TypeTag {
     }
 }
 
-impl fmt::Display for MoveLayoutView<'_> {
+impl<T: TypeLayout> fmt::Display for MoveLayoutView<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MoveLayoutView::Bool => write!(f, "bool"),
@@ -411,10 +482,10 @@ impl fmt::Display for MoveLayoutView<'_> {
 
 // --- MoveDatatypeLayout ---
 
-impl<'a> MoveDatatypeLayout<'a> {
+impl<'a, T: TypeLayout> MoveDatatypeLayout<'a, T> {
     /// Wrap a borrowed layout that is known to be a struct or enum.
     /// Returns `None` if the layout is a primitive or vector.
-    pub fn new(layout: MoveTypeLayoutRef<'a>) -> Option<Self> {
+    pub fn new(layout: MoveTypeLayoutRef<'a, T>) -> Option<Self> {
         match layout.as_view() {
             MoveLayoutView::Struct(s) => Some(MoveDatatypeLayout::Struct(s)),
             MoveLayoutView::Enum(e) => Some(MoveDatatypeLayout::Enum(e)),
@@ -473,45 +544,47 @@ impl<'a> MoveDatatypeLayout<'a> {
 
 // --- MoveFieldsLayout ---
 
-impl<'a> MoveFieldsLayout<'a> {
+impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
     /// Number of fields.
     pub fn field_count(self) -> usize {
         self.fields.len()
     }
 
     /// Access a field by index, returning `(name, layout)`.
-    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a>)> {
+    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         self.fields.get(i).map(|entry| {
             (
                 &entry.name,
                 MoveTypeLayoutRef {
                     pool: self.pool,
-                    root: entry.layout,
+                    root: &entry.layout,
                 },
             )
         })
     }
 
     /// Look up a field by name, returning its layout.
-    pub fn field_by_name(self, name: &str) -> Option<MoveTypeLayoutRef<'a>> {
+    pub fn field_by_name(self, name: &str) -> Option<MoveTypeLayoutRef<'a, T>> {
         self.fields
             .iter()
             .find(|entry| entry.name.as_str() == name)
             .map(|entry| MoveTypeLayoutRef {
                 pool: self.pool,
-                root: entry.layout,
+                root: &entry.layout,
             })
     }
 
     /// Iterate over all fields as `(name, layout)` pairs.
-    pub fn fields(self) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a>)> {
+    pub fn fields(
+        self,
+    ) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         let pool = self.pool;
         self.fields.iter().map(move |entry| {
             (
                 &entry.name,
                 MoveTypeLayoutRef {
                     pool,
-                    root: entry.layout,
+                    root: &entry.layout,
                 },
             )
         })
@@ -520,7 +593,7 @@ impl<'a> MoveFieldsLayout<'a> {
 
 // --- MoveStructLayout ---
 
-impl<'a> MoveStructLayout<'a> {
+impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
     /// The struct's type tag.
     pub fn type_(self) -> &'a StructTag {
         self.type_
@@ -532,7 +605,7 @@ impl<'a> MoveStructLayout<'a> {
     }
 
     /// Access the fields layout.
-    pub fn fields_layout(self) -> MoveFieldsLayout<'a> {
+    pub fn fields_layout(self) -> MoveFieldsLayout<'a, T> {
         self.fields
     }
 
@@ -542,17 +615,19 @@ impl<'a> MoveStructLayout<'a> {
     }
 
     /// Access a field by index, returning `(name, layout)`.
-    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a>)> {
+    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         self.fields.field(i)
     }
 
     /// Iterate over all fields as `(name, layout)` pairs.
-    pub fn fields(self) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a>)> {
+    pub fn fields(
+        self,
+    ) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         self.fields.fields()
     }
 }
 
-impl fmt::Display for MoveStructLayout<'_> {
+impl<T: TypeLayout> fmt::Display for MoveStructLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {{ ", self.type_)?;
         for (i, (name, layout)) in self.fields().enumerate() {
@@ -571,7 +646,7 @@ impl fmt::Display for MoveStructLayout<'_> {
 
 // --- VariantLayout ---
 
-impl<'a> VariantLayout<'a> {
+impl<'a, T: TypeLayout> VariantLayout<'a, T> {
     /// The variant's name.
     pub fn name(self) -> &'a Identifier {
         match self {
@@ -589,7 +664,7 @@ impl<'a> VariantLayout<'a> {
     }
 
     /// The variant's fields, or `None` if the layout is unknown.
-    pub fn fields(self) -> Option<MoveFieldsLayout<'a>> {
+    pub fn fields(self) -> Option<MoveFieldsLayout<'a, T>> {
         match self {
             VariantLayout::Known { fields, .. } => Some(fields),
             VariantLayout::Unknown { .. } => None,
@@ -599,7 +674,7 @@ impl<'a> VariantLayout<'a> {
 
 // --- MoveEnumLayout ---
 
-impl<'a> MoveEnumLayout<'a> {
+impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
     /// The enum's type tag.
     pub fn type_(self) -> &'a StructTag {
         self.type_
@@ -616,12 +691,12 @@ impl<'a> MoveEnumLayout<'a> {
     }
 
     /// Access a variant by position index.
-    pub fn variant(self, i: usize) -> Option<VariantLayout<'a>> {
+    pub fn variant(self, i: usize) -> Option<VariantLayout<'a, T>> {
         self.variants.get(i).map(|v| variant_view(self.pool, v))
     }
 
     /// Find a variant by its tag value.
-    pub fn variant_by_tag(self, tag: VariantTag) -> Option<VariantLayout<'a>> {
+    pub fn variant_by_tag(self, tag: VariantTag) -> Option<VariantLayout<'a, T>> {
         self.variants
             .iter()
             .find(|v| v.tag == tag)
@@ -629,16 +704,16 @@ impl<'a> MoveEnumLayout<'a> {
     }
 
     /// Iterate over all variants.
-    pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a>> {
+    pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a, T>> {
         let pool = self.pool;
         self.variants.iter().map(move |v| variant_view(pool, v))
     }
 }
 
-fn variant_view<'a>(
-    pool: &'a Arc<MoveTypeLayoutPool>,
-    v: &'a AnnotatedVariantEntry,
-) -> VariantLayout<'a> {
+fn variant_view<'a, T: TypeLayout>(
+    pool: &'a T,
+    v: &'a AnnotatedVariantEntry<T::Root>,
+) -> VariantLayout<'a, T> {
     match &v.fields {
         Some(fields) => VariantLayout::Known {
             name: &v.name,
@@ -652,7 +727,7 @@ fn variant_view<'a>(
     }
 }
 
-impl fmt::Display for MoveEnumLayout<'_> {
+impl<T: TypeLayout> fmt::Display for MoveEnumLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {{ ", self.type_)?;
         for (i, vl) in self.variants().enumerate() {
@@ -678,219 +753,5 @@ impl fmt::Display for MoveEnumLayout<'_> {
             write!(f, ")")?;
         }
         write!(f, " }}")
-    }
-}
-
-// --- MoveTypeLayoutBuilder ---
-
-impl MoveTypeLayoutBuilder {
-    pub fn new() -> Self {
-        Self {
-            nodes: IndexSet::new(),
-        }
-    }
-
-    fn add_node(&mut self, node: MoveTypeNode) -> AResult<LayoutHandle> {
-        let (idx, _) = self.nodes.insert_full(node);
-        Ok(LayoutHandle(LayoutRef::index(idx)?))
-    }
-
-    pub fn bool(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::Bool))
-    }
-    pub fn u8(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U8))
-    }
-    pub fn u16(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U16))
-    }
-    pub fn u32(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U32))
-    }
-    pub fn u64(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U64))
-    }
-    pub fn u128(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U128))
-    }
-    pub fn u256(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U256))
-    }
-    pub fn address(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::Address))
-    }
-    pub fn signer(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::Signer))
-    }
-
-    pub fn vector(&mut self, element: LayoutHandle) -> AResult<LayoutHandle> {
-        self.add_node(MoveTypeNode::Vector(element.0))
-    }
-
-    /// Build a struct layout node.
-    /// `fields` is a list of (field_name, field_layout) pairs.
-    pub fn struct_layout(
-        &mut self,
-        type_tag: &StructTag,
-        fields: &[(&Identifier, LayoutHandle)],
-    ) -> AResult<LayoutHandle> {
-        let fields: Box<[AnnotatedFieldEntry]> = fields
-            .iter()
-            .map(|(name, h)| AnnotatedFieldEntry {
-                name: (*name).clone(),
-                layout: h.0,
-            })
-            .collect();
-        self.add_node(MoveTypeNode::Struct(MoveStructNode {
-            type_: type_tag.clone(),
-            fields,
-        }))
-    }
-
-    /// Build an enum layout node.
-    /// Each variant is `(variant_name, tag, fields)` where fields is
-    /// `None` for unknown layout or `Some(&[(field_name, layout)])` for known.
-    pub fn enum_layout(
-        &mut self,
-        type_tag: &StructTag,
-        variants: &[(
-            &Identifier,
-            VariantTag,
-            Option<&[(&Identifier, LayoutHandle)]>,
-        )],
-    ) -> AResult<LayoutHandle> {
-        let variant_entries: Box<[AnnotatedVariantEntry]> = variants
-            .iter()
-            .map(|(vn, tag, fields)| {
-                let field_entries = fields.map(|fields| {
-                    fields
-                        .iter()
-                        .map(|(fn_name, h)| AnnotatedFieldEntry {
-                            name: (*fn_name).clone(),
-                            layout: h.0,
-                        })
-                        .collect()
-                });
-                AnnotatedVariantEntry {
-                    name: (*vn).clone(),
-                    tag: *tag,
-                    fields: field_entries,
-                }
-            })
-            .collect();
-        self.add_node(MoveTypeNode::Enum(MoveEnumNode {
-            type_: type_tag.clone(),
-            variants: variant_entries,
-        }))
-    }
-
-    /// Recursively intern a tree-based annotated layout.
-    /// Tree-based enum layouts always have known variants, so all variants
-    /// are wrapped in `Some`.
-    pub fn from_tree(&mut self, layout: &AV::MoveTypeLayout) -> AResult<LayoutHandle> {
-        Ok(match layout {
-            AV::MoveTypeLayout::Bool => self.bool(),
-            AV::MoveTypeLayout::U8 => self.u8(),
-            AV::MoveTypeLayout::U16 => self.u16(),
-            AV::MoveTypeLayout::U32 => self.u32(),
-            AV::MoveTypeLayout::U64 => self.u64(),
-            AV::MoveTypeLayout::U128 => self.u128(),
-            AV::MoveTypeLayout::U256 => self.u256(),
-            AV::MoveTypeLayout::Address => self.address(),
-            AV::MoveTypeLayout::Signer => self.signer(),
-            AV::MoveTypeLayout::Vector(inner) => {
-                let inner_h = self.from_tree(inner)?;
-                self.vector(inner_h)?
-            }
-            AV::MoveTypeLayout::Struct(s) => {
-                let fields = s
-                    .fields
-                    .iter()
-                    .map(|f| Ok((&f.name, self.from_tree(&f.layout)?)))
-                    .collect::<AResult<Vec<_>>>()?;
-                self.struct_layout(&s.type_, &fields)?
-            }
-            AV::MoveTypeLayout::Enum(e) => {
-                let variants = e
-                    .variants
-                    .iter()
-                    .map(|((variant_name, tag), field_layouts)| {
-                        let fields: Vec<(&Identifier, LayoutHandle)> = field_layouts
-                            .iter()
-                            .map(|f| Ok((&f.name, self.from_tree(&f.layout)?)))
-                            .collect::<AResult<_>>()?;
-                        Ok((variant_name, *tag, fields))
-                    })
-                    .collect::<AResult<Vec<_>>>()?;
-                let variant_refs: Vec<(
-                    &Identifier,
-                    VariantTag,
-                    Option<&[(&Identifier, LayoutHandle)]>,
-                )> = variants
-                    .iter()
-                    .map(|(vn, tag, fields)| (*vn, *tag, Some(fields.as_slice())))
-                    .collect();
-                self.enum_layout(&e.type_, &variant_refs)?
-            }
-        })
-    }
-
-    /// Finalize the builder into an immutable [`MoveTypeLayout`].
-    pub fn build(self, root: LayoutHandle) -> MoveTypeLayout {
-        let nodes: Vec<MoveTypeNode> = self.nodes.into_iter().collect();
-        MoveTypeLayout {
-            pool: Arc::from(nodes),
-            root: root.0,
-        }
-    }
-}
-
-impl Default for MoveTypeLayoutBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// =============================================================================
-// Free functions
-// =============================================================================
-
-fn leaf_to_layout_view<'a>(leaf: LeafType) -> MoveLayoutView<'a> {
-    match leaf {
-        LeafType::Bool => MoveLayoutView::Bool,
-        LeafType::U8 => MoveLayoutView::U8,
-        LeafType::U16 => MoveLayoutView::U16,
-        LeafType::U32 => MoveLayoutView::U32,
-        LeafType::U64 => MoveLayoutView::U64,
-        LeafType::U128 => MoveLayoutView::U128,
-        LeafType::U256 => MoveLayoutView::U256,
-        LeafType::Address => MoveLayoutView::Address,
-        LeafType::Signer => MoveLayoutView::Signer,
-    }
-}
-
-/// Resolve a [`LayoutRef`] against the pool into a [`MoveLayoutView`].
-///
-/// Panics if the reference points to an out-of-bounds table index.
-fn resolve_ref<'a>(pool: &'a Arc<MoveTypeLayoutPool>, r: LayoutRef) -> MoveLayoutView<'a> {
-    match r.resolve() {
-        ResolvedRef::Leaf(leaf) => leaf_to_layout_view(leaf),
-        ResolvedRef::Index(idx) => match &pool[idx] {
-            MoveTypeNode::Vector(inner) => {
-                MoveLayoutView::Vector(MoveTypeLayoutRef { pool, root: *inner })
-            }
-            MoveTypeNode::Struct(s) => MoveLayoutView::Struct(MoveStructLayout {
-                type_: &s.type_,
-                fields: MoveFieldsLayout {
-                    pool,
-                    fields: &s.fields,
-                },
-            }),
-            MoveTypeNode::Enum(e) => MoveLayoutView::Enum(MoveEnumLayout {
-                type_: &e.type_,
-                variants: &e.variants,
-                pool,
-            }),
-        },
     }
 }

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -276,6 +276,7 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     }
 
     /// Borrow this layout without cloning the pool.
+    #[inline]
     pub fn as_ref(&self) -> MoveTypeLayoutRef<'_, T> {
         MoveTypeLayoutRef {
             pool: &self.pool,
@@ -284,6 +285,7 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     }
 
     /// Create a resolved view for navigating this layout.
+    #[inline]
     pub fn as_view(&self) -> MoveLayoutView<'_, T> {
         self.as_ref().as_view()
     }
@@ -308,6 +310,7 @@ impl<T: TypeLayout> fmt::Display for MoveTypeLayout<T> {
 
 impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
     /// Construct a borrowed layout from a pool reference and a root reference.
+    #[inline]
     pub fn new(pool: &'a T, root: &'a T::Root) -> Self {
         MoveTypeLayoutRef { pool, root }
     }
@@ -330,6 +333,7 @@ impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
     }
 
     /// Create a resolved view for navigating this layout.
+    #[inline]
     pub fn as_view(self) -> MoveLayoutView<'a, T> {
         self.pool.realize_view(self.root)
     }
@@ -415,6 +419,7 @@ impl<T: TypeLayout> MoveLayoutView<'_, T> {
     }
 
     /// Check whether this layout matches the given [`TypeTag`].
+    #[inline]
     pub fn is_type_tag(&self, t: &TypeTag) -> bool {
         match self {
             MoveLayoutView::Bool => *t == TypeTag::Bool,
@@ -485,6 +490,7 @@ impl<T: TypeLayout> fmt::Display for MoveLayoutView<'_, T> {
 impl<'a, T: TypeLayout> MoveDatatypeLayout<'a, T> {
     /// Wrap a borrowed layout that is known to be a struct or enum.
     /// Returns `None` if the layout is a primitive or vector.
+    #[inline]
     pub fn new(layout: MoveTypeLayoutRef<'a, T>) -> Option<Self> {
         match layout.as_view() {
             MoveLayoutView::Struct(s) => Some(MoveDatatypeLayout::Struct(s)),
@@ -546,11 +552,13 @@ impl<'a, T: TypeLayout> MoveDatatypeLayout<'a, T> {
 
 impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
     /// Number of fields.
+    #[inline]
     pub fn field_count(self) -> usize {
         self.fields.len()
     }
 
     /// Access a field by index, returning `(name, layout)`.
+    #[inline]
     pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         self.fields.get(i).map(|entry| {
             (
@@ -564,6 +572,7 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
     }
 
     /// Look up a field by name, returning its layout.
+    #[inline]
     pub fn field_by_name(self, name: &str) -> Option<MoveTypeLayoutRef<'a, T>> {
         self.fields
             .iter()
@@ -575,6 +584,7 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
     }
 
     /// Iterate over all fields as `(name, layout)` pairs.
+    #[inline]
     pub fn fields(
         self,
     ) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
@@ -595,31 +605,37 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
 
 impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
     /// The struct's type tag.
+    #[inline]
     pub fn type_(self) -> &'a StructTag {
         self.type_
     }
 
     /// Check whether this struct's type tag matches the given [`TypeTag`].
+    #[inline]
     pub fn is_type_tag(self, t: &TypeTag) -> bool {
         matches!(t, TypeTag::Struct(s) if &**s == self.type_)
     }
 
     /// Access the fields layout.
+    #[inline]
     pub fn fields_layout(self) -> MoveFieldsLayout<'a, T> {
         self.fields
     }
 
     /// Number of fields.
+    #[inline]
     pub fn field_count(self) -> usize {
         self.fields.field_count()
     }
 
     /// Access a field by index, returning `(name, layout)`.
+    #[inline]
     pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         self.fields.field(i)
     }
 
     /// Iterate over all fields as `(name, layout)` pairs.
+    #[inline]
     pub fn fields(
         self,
     ) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
@@ -648,6 +664,7 @@ impl<T: TypeLayout> fmt::Display for MoveStructLayout<'_, T> {
 
 impl<'a, T: TypeLayout> VariantLayout<'a, T> {
     /// The variant's name.
+    #[inline]
     pub fn name(self) -> &'a Identifier {
         match self {
             VariantLayout::Known { name, .. } => name,
@@ -656,6 +673,7 @@ impl<'a, T: TypeLayout> VariantLayout<'a, T> {
     }
 
     /// The variant's tag.
+    #[inline]
     pub fn tag(self) -> VariantTag {
         match self {
             VariantLayout::Known { tag, .. } => tag,
@@ -664,6 +682,7 @@ impl<'a, T: TypeLayout> VariantLayout<'a, T> {
     }
 
     /// The variant's fields, or `None` if the layout is unknown.
+    #[inline]
     pub fn fields(self) -> Option<MoveFieldsLayout<'a, T>> {
         match self {
             VariantLayout::Known { fields, .. } => Some(fields),
@@ -676,26 +695,31 @@ impl<'a, T: TypeLayout> VariantLayout<'a, T> {
 
 impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
     /// The enum's type tag.
+    #[inline]
     pub fn type_(self) -> &'a StructTag {
         self.type_
     }
 
     /// Check whether this enum's type tag matches the given [`TypeTag`].
+    #[inline]
     pub fn is_type_tag(self, t: &TypeTag) -> bool {
         matches!(t, TypeTag::Struct(s) if **s == *self.type_)
     }
 
     /// Number of variants.
+    #[inline]
     pub fn variant_count(self) -> usize {
         self.variants.len()
     }
 
     /// Access a variant by position index.
+    #[inline]
     pub fn variant(self, i: usize) -> Option<VariantLayout<'a, T>> {
         self.variants.get(i).map(|v| variant_view(self.pool, v))
     }
 
     /// Find a variant by its tag value.
+    #[inline]
     pub fn variant_by_tag(self, tag: VariantTag) -> Option<VariantLayout<'a, T>> {
         self.variants
             .iter()
@@ -704,12 +728,14 @@ impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
     }
 
     /// Iterate over all variants.
+    #[inline]
     pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a, T>> {
         let pool = self.pool;
         self.variants.iter().map(move |v| variant_view(pool, v))
     }
 }
 
+#[inline]
 fn variant_view<'a, T: TypeLayout>(
     pool: &'a T,
     v: &'a AnnotatedVariantEntry<T::Root>,

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/mod.rs
@@ -4,4 +4,8 @@
 mod layout;
 mod serde_impl;
 
-pub use layout::*;
+pub use layout::{
+    BackendBuilder, MoveDatatypeLayout, MoveEnumLayout, MoveFieldsLayout, MoveLayoutView,
+    MoveStructLayout, MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef, TypeLayout,
+    VariantLayout,
+};

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/serde_impl.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/serde_impl.rs
@@ -22,6 +22,17 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
         self,
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
+        self.as_ref().deserialize(deserializer)
+    }
+}
+
+impl<'a, 'd> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a> {
+    type Value = AnnValue;
+
+    fn deserialize<D: serde::de::Deserializer<'d>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
         match self.as_view() {
             MoveLayoutView::Bool => bool::deserialize(deserializer).map(AnnValue::Bool),
             MoveLayoutView::U8 => u8::deserialize(deserializer).map(AnnValue::U8),
@@ -39,7 +50,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
             MoveLayoutView::Struct(sv) => {
                 let fields = deserializer.deserialize_tuple(
                     sv.field_count(),
-                    CompressedStructFieldVisitor(&sv.fields),
+                    CompressedStructFieldVisitor(sv.fields_layout()),
                 )?;
                 Ok(AnnValue::Struct(AnnStruct {
                     type_: sv.type_().clone(),
@@ -48,7 +59,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
             }
             MoveLayoutView::Enum(ev) => {
                 let (variant_name, tag, fields) =
-                    deserializer.deserialize_tuple(2, CompressedEnumFieldVisitor(&ev))?;
+                    deserializer.deserialize_tuple(2, CompressedEnumFieldVisitor(ev))?;
                 Ok(AnnValue::Variant(AnnVariant {
                     type_: ev.type_().clone(),
                     variant_name,
@@ -57,15 +68,15 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
                 }))
             }
             MoveLayoutView::Vector(vv) => Ok(AnnValue::Vector(
-                deserializer.deserialize_seq(CompressedVectorVisitor(&vv))?,
+                deserializer.deserialize_seq(CompressedVectorVisitor(vv))?,
             )),
         }
     }
 }
 
-struct CompressedVectorVisitor<'a>(&'a MoveTypeLayout);
+struct CompressedVectorVisitor<'a>(MoveTypeLayoutRef<'a>);
 
-impl<'d> serde::de::Visitor<'d> for CompressedVectorVisitor<'_> {
+impl<'a, 'd> serde::de::Visitor<'d> for CompressedVectorVisitor<'a> {
     type Value = Vec<AnnValue>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -84,9 +95,9 @@ impl<'d> serde::de::Visitor<'d> for CompressedVectorVisitor<'_> {
     }
 }
 
-struct CompressedStructFieldVisitor<'a>(&'a MoveFieldsLayout);
+struct CompressedStructFieldVisitor<'a>(MoveFieldsLayout<'a>);
 
-impl<'d> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'_> {
+impl<'a, 'd> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a> {
     type Value = Vec<(Identifier, AnnValue)>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -99,7 +110,7 @@ impl<'d> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'_> {
     {
         let mut vals = Vec::new();
         for (i, (name, field_layout)) in self.0.fields().enumerate() {
-            match seq.next_element_seed(&field_layout)? {
+            match seq.next_element_seed(field_layout)? {
                 Some(val) => vals.push((name.clone(), val)),
                 None => return Err(A::Error::invalid_length(i, &self)),
             }
@@ -108,9 +119,9 @@ impl<'d> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'_> {
     }
 }
 
-struct CompressedEnumFieldVisitor<'a>(&'a MoveEnumLayout);
+struct CompressedEnumFieldVisitor<'a>(MoveEnumLayout<'a>);
 
-impl<'d> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'_> {
+impl<'a, 'd> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a> {
     type Value = (Identifier, VariantTag, Vec<(Identifier, AnnValue)>);
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -149,9 +160,9 @@ impl<'d> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'_> {
     }
 }
 
-struct CompressedVariantFieldSeed<'a>(&'a MoveFieldsLayout);
+struct CompressedVariantFieldSeed<'a>(MoveFieldsLayout<'a>);
 
-impl<'d> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'_> {
+impl<'a, 'd> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'a> {
     type Value = Vec<(Identifier, AnnValue)>;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/serde_impl.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/serde_impl.rs
@@ -12,10 +12,10 @@ use crate::{VARIANT_TAG_MAX_VALUE, account_address::AccountAddress, u256};
 use serde::{Deserialize, de::Error as _};
 
 // -------------------------------------------------------------------------
-// Deserialization — DeserializeSeed for &MoveTypeLayout
+// Deserialization — DeserializeSeed for MoveTypeLayoutRef / &MoveTypeLayout
 // -------------------------------------------------------------------------
 
-impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
+impl<'d, T: TypeLayout> serde::de::DeserializeSeed<'d> for &MoveTypeLayout<T> {
     type Value = AnnValue;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(
@@ -26,7 +26,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
     }
 }
 
-impl<'a, 'd> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a, T> {
     type Value = AnnValue;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(
@@ -74,9 +74,9 @@ impl<'a, 'd> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a> {
     }
 }
 
-struct CompressedVectorVisitor<'a>(MoveTypeLayoutRef<'a>);
+struct CompressedVectorVisitor<'a, T: TypeLayout>(MoveTypeLayoutRef<'a, T>);
 
-impl<'a, 'd> serde::de::Visitor<'d> for CompressedVectorVisitor<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedVectorVisitor<'a, T> {
     type Value = Vec<AnnValue>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -95,9 +95,9 @@ impl<'a, 'd> serde::de::Visitor<'d> for CompressedVectorVisitor<'a> {
     }
 }
 
-struct CompressedStructFieldVisitor<'a>(MoveFieldsLayout<'a>);
+struct CompressedStructFieldVisitor<'a, T: TypeLayout>(MoveFieldsLayout<'a, T>);
 
-impl<'a, 'd> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a, T> {
     type Value = Vec<(Identifier, AnnValue)>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -119,9 +119,9 @@ impl<'a, 'd> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a> {
     }
 }
 
-struct CompressedEnumFieldVisitor<'a>(MoveEnumLayout<'a>);
+struct CompressedEnumFieldVisitor<'a, T: TypeLayout>(MoveEnumLayout<'a, T>);
 
-impl<'a, 'd> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a, T> {
     type Value = (Identifier, VariantTag, Vec<(Identifier, AnnValue)>);
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -160,9 +160,9 @@ impl<'a, 'd> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a> {
     }
 }
 
-struct CompressedVariantFieldSeed<'a>(MoveFieldsLayout<'a>);
+struct CompressedVariantFieldSeed<'a, T: TypeLayout>(MoveFieldsLayout<'a, T>);
 
-impl<'a, 'd> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'a, T> {
     type Value = Vec<(Identifier, AnnValue)>;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/annotated_nodes.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/annotated_nodes.rs
@@ -121,6 +121,7 @@ pub type AnnotatedPoolBuilder = PoolBuilder<MoveTypeNode<LayoutRef>>;
 // =============================================================================
 
 /// Map a [`LeafType`] to the corresponding leaf variant of [`MoveLayoutView`].
+#[inline]
 pub(crate) fn leaf_view<'a, T: TypeLayout>(leaf: LeafType) -> MoveLayoutView<'a, T> {
     use MoveLayoutView as V;
     match leaf {
@@ -138,6 +139,7 @@ pub(crate) fn leaf_view<'a, T: TypeLayout>(leaf: LeafType) -> MoveLayoutView<'a,
 
 /// Build a `MoveLayoutView` from a node-table entry. Reusable across any
 /// backend whose `Root` matches the node's reference type.
+#[inline]
 pub(crate) fn build_view_from_node<'a, T: TypeLayout>(
     pool: &'a T,
     node: &'a MoveTypeNode<T::Root>,

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/annotated_nodes.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/annotated_nodes.rs
@@ -1,0 +1,160 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Annotated-flavor node-table representation. Holds the node data types, the
+//! [`AnnotatedPoolBuilder`] alias, and the helpers that translate stored
+//! nodes into an annotated `MoveLayoutView`.
+
+use super::encoding::{LayoutRef, LeafType, PoolBuilder};
+use crate::compressed::VariantTag;
+use crate::compressed::annotated::{
+    MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout, MoveTypeLayoutRef,
+    TypeLayout,
+};
+use crate::identifier::Identifier;
+use crate::language_storage::StructTag;
+
+// =============================================================================
+// Node types
+// =============================================================================
+
+/// A named field entry: field name paired with its layout reference.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AnnotatedFieldEntry<R> {
+    pub name: Identifier,
+    pub layout: R,
+}
+
+/// A single variant entry in an enum node.
+/// `None` fields means the variant exists but its field layout is unknown.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AnnotatedVariantEntry<R> {
+    pub name: Identifier,
+    pub tag: VariantTag,
+    pub fields: Option<Box<[AnnotatedFieldEntry<R>]>>,
+}
+
+/// Annotated struct layout node with type tag and named fields inline.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MoveStructNode<R> {
+    pub(crate) type_: StructTag,
+    pub(crate) fields: Box<[AnnotatedFieldEntry<R>]>,
+}
+
+/// Annotated enum layout node with type tag and named variants inline.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MoveEnumNode<R> {
+    pub(crate) type_: StructTag,
+    pub(crate) variants: Box<[AnnotatedVariantEntry<R>]>,
+}
+
+/// A compound layout node generic over the reference type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MoveTypeNode<R> {
+    Vector(R),
+    Struct(MoveStructNode<R>),
+    Enum(MoveEnumNode<R>),
+}
+
+// =============================================================================
+// Constructors for node-table pools (LayoutRef-keyed)
+// =============================================================================
+
+impl MoveTypeNode<LayoutRef> {
+    /// Build a struct node from a type tag and a slice of `(name, layout-ref)`
+    /// pairs.
+    pub(crate) fn struct_node(type_tag: &StructTag, fields: &[(&Identifier, LayoutRef)]) -> Self {
+        let field_entries: Box<[AnnotatedFieldEntry<LayoutRef>]> = fields
+            .iter()
+            .map(|(name, h)| AnnotatedFieldEntry {
+                name: (*name).clone(),
+                layout: *h,
+            })
+            .collect();
+        MoveTypeNode::Struct(MoveStructNode {
+            type_: type_tag.clone(),
+            fields: field_entries,
+        })
+    }
+
+    /// Build an enum node from a type tag and a slice of variant descriptors.
+    pub(crate) fn enum_node(
+        type_tag: &StructTag,
+        variants: &[(&Identifier, VariantTag, Option<&[(&Identifier, LayoutRef)]>)],
+    ) -> Self {
+        let variant_entries: Box<[AnnotatedVariantEntry<LayoutRef>]> = variants
+            .iter()
+            .map(|(vn, tag, fields)| {
+                let field_entries = fields.map(|fields| {
+                    fields
+                        .iter()
+                        .map(|(fn_name, h)| AnnotatedFieldEntry {
+                            name: (*fn_name).clone(),
+                            layout: *h,
+                        })
+                        .collect()
+                });
+                AnnotatedVariantEntry {
+                    name: (*vn).clone(),
+                    tag: *tag,
+                    fields: field_entries,
+                }
+            })
+            .collect();
+        MoveTypeNode::Enum(MoveEnumNode {
+            type_: type_tag.clone(),
+            variants: variant_entries,
+        })
+    }
+}
+
+// =============================================================================
+// PoolBuilder alias
+// =============================================================================
+
+/// Annotated-flavor node-table builder.
+pub type AnnotatedPoolBuilder = PoolBuilder<MoveTypeNode<LayoutRef>>;
+
+// =============================================================================
+// View helpers
+// =============================================================================
+
+/// Map a [`LeafType`] to the corresponding leaf variant of [`MoveLayoutView`].
+pub(crate) fn leaf_view<'a, T: TypeLayout>(leaf: LeafType) -> MoveLayoutView<'a, T> {
+    use MoveLayoutView as V;
+    match leaf {
+        LeafType::Bool => V::Bool,
+        LeafType::U8 => V::U8,
+        LeafType::U16 => V::U16,
+        LeafType::U32 => V::U32,
+        LeafType::U64 => V::U64,
+        LeafType::U128 => V::U128,
+        LeafType::U256 => V::U256,
+        LeafType::Address => V::Address,
+        LeafType::Signer => V::Signer,
+    }
+}
+
+/// Build a `MoveLayoutView` from a node-table entry. Reusable across any
+/// backend whose `Root` matches the node's reference type.
+pub(crate) fn build_view_from_node<'a, T: TypeLayout>(
+    pool: &'a T,
+    node: &'a MoveTypeNode<T::Root>,
+) -> MoveLayoutView<'a, T> {
+    match node {
+        MoveTypeNode::Vector(inner) => MoveLayoutView::Vector(MoveTypeLayoutRef::new(pool, inner)),
+        MoveTypeNode::Struct(s) => MoveLayoutView::Struct(MoveStructLayout {
+            type_: &s.type_,
+            fields: MoveFieldsLayout {
+                pool,
+                fields: &s.fields,
+            },
+        }),
+        MoveTypeNode::Enum(e) => MoveLayoutView::Enum(MoveEnumLayout {
+            type_: &e.type_,
+            variants: &e.variants,
+            pool,
+        }),
+    }
+}

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/arc_pool.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/arc_pool.rs
@@ -64,6 +64,7 @@ pub type RuntimeArcPool = ArcPool<runtime_nodes::MoveTypeNode<LayoutRef>>;
 impl runtime::TypeLayout for RuntimeArcPool {
     type Root = LayoutRef;
 
+    #[inline]
     fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> runtime::MoveLayoutView<'a, Self> {
         match r.resolve() {
             ResolvedRef::Leaf(l) => runtime_nodes::leaf_view(l),
@@ -71,6 +72,7 @@ impl runtime::TypeLayout for RuntimeArcPool {
         }
     }
 
+    #[inline]
     fn node_count(&self) -> usize {
         self.nodes.len()
     }
@@ -79,6 +81,7 @@ impl runtime::TypeLayout for RuntimeArcPool {
 impl annotated::TypeLayout for AnnotatedArcPool {
     type Root = LayoutRef;
 
+    #[inline]
     fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> annotated::MoveLayoutView<'a, Self> {
         match r.resolve() {
             ResolvedRef::Leaf(l) => annotated_nodes::leaf_view(l),
@@ -86,6 +89,7 @@ impl annotated::TypeLayout for AnnotatedArcPool {
         }
     }
 
+    #[inline]
     fn node_count(&self) -> usize {
         self.nodes.len()
     }

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/arc_pool.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/arc_pool.rs
@@ -1,0 +1,300 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `Arc`-shared flat node table backend.
+//!
+//! Defines the `Arc<[Node]>` storage and per-flavor builder wrappers that
+//! produce it. Node data types and pool-builder aliases live in
+//! [`super::runtime_nodes`] / [`super::annotated_nodes`]; this module owns
+//! the storage type, the per-flavor `TypeLayout` impls, the `BackendBuilder`
+//! impls that finalize into an [`ArcPool`], and the convenience surface
+//! (`MoveTypeLayout::bool()`/…, `TryFrom<&tree>`, `MoveTypeLayoutBuilder::new`).
+
+use std::sync::Arc;
+
+use anyhow::Result as AResult;
+
+use crate::compressed::VariantTag;
+use crate::compressed::backend::annotated_nodes::{self, AnnotatedPoolBuilder};
+use crate::compressed::backend::encoding::{LayoutRef, LeafType, ResolvedRef};
+use crate::compressed::backend::runtime_nodes::{self, RuntimePoolBuilder};
+use crate::compressed::{annotated, runtime};
+use crate::identifier::Identifier;
+use crate::language_storage::StructTag;
+use crate::{annotated_value, runtime_value};
+
+// =============================================================================
+// ArcPool storage
+// =============================================================================
+
+/// `Arc`-shared flat node table. Cloning is a refcount bump.
+#[derive(Debug, Clone)]
+pub struct ArcPool<Node> {
+    pub(crate) nodes: Arc<[Node]>,
+}
+
+impl<Node> ArcPool<Node> {
+    pub(crate) fn from_vec(nodes: Vec<Node>) -> Self {
+        Self {
+            nodes: Arc::from(nodes),
+        }
+    }
+}
+
+impl<Node> Default for ArcPool<Node> {
+    fn default() -> Self {
+        Self::from_vec(Vec::new())
+    }
+}
+
+// =============================================================================
+// Concrete per-flavor aliases
+// =============================================================================
+
+/// Annotated-flavor [`ArcPool`] specialization.
+pub type AnnotatedArcPool = ArcPool<annotated_nodes::MoveTypeNode<LayoutRef>>;
+/// Runtime-flavor [`ArcPool`] specialization.
+pub type RuntimeArcPool = ArcPool<runtime_nodes::MoveTypeNode<LayoutRef>>;
+
+// =============================================================================
+// `TypeLayout` impls (per flavor)
+// =============================================================================
+
+impl runtime::TypeLayout for RuntimeArcPool {
+    type Root = LayoutRef;
+
+    fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> runtime::MoveLayoutView<'a, Self> {
+        match r.resolve() {
+            ResolvedRef::Leaf(l) => runtime_nodes::leaf_view(l),
+            ResolvedRef::Index(i) => runtime_nodes::build_view_from_node(self, &self.nodes[i]),
+        }
+    }
+
+    fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+impl annotated::TypeLayout for AnnotatedArcPool {
+    type Root = LayoutRef;
+
+    fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> annotated::MoveLayoutView<'a, Self> {
+        match r.resolve() {
+            ResolvedRef::Leaf(l) => annotated_nodes::leaf_view(l),
+            ResolvedRef::Index(i) => annotated_nodes::build_view_from_node(self, &self.nodes[i]),
+        }
+    }
+
+    fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+// =============================================================================
+// Per-pool builder wrappers + `BackendBuilder` impls
+// =============================================================================
+
+/// Runtime-flavor builder that finalizes into a [`RuntimeArcPool`].
+#[derive(Debug, Default)]
+pub struct RuntimeArcPoolBuilder(pub RuntimePoolBuilder);
+
+/// Annotated-flavor builder that finalizes into an [`AnnotatedArcPool`].
+#[derive(Debug, Default)]
+pub struct AnnotatedArcPoolBuilder(pub AnnotatedPoolBuilder);
+
+impl RuntimeArcPoolBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl AnnotatedArcPoolBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl runtime::BackendBuilder for RuntimeArcPoolBuilder {
+    type Root = LayoutRef;
+    type Output = RuntimeArcPool;
+    type Error = anyhow::Error;
+
+    fn bool(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Bool)
+    }
+    fn u8(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U8)
+    }
+    fn u16(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U16)
+    }
+    fn u32(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U32)
+    }
+    fn u64(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U64)
+    }
+    fn u128(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U128)
+    }
+    fn u256(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U256)
+    }
+    fn address(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Address)
+    }
+    fn signer(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Signer)
+    }
+    fn vector(&mut self, element: LayoutRef) -> AResult<LayoutRef> {
+        self.0.intern(runtime_nodes::MoveTypeNode::Vector(element))
+    }
+    fn struct_layout(&mut self, fields: &[LayoutRef]) -> AResult<LayoutRef> {
+        self.0
+            .intern(runtime_nodes::MoveTypeNode::struct_node(fields))
+    }
+    fn enum_layout(&mut self, variants: &[Option<&[LayoutRef]>]) -> AResult<LayoutRef> {
+        self.0
+            .intern(runtime_nodes::MoveTypeNode::enum_node(variants))
+    }
+    fn finalize(self, _root: LayoutRef) -> RuntimeArcPool {
+        ArcPool::from_vec(self.0.into_vec())
+    }
+}
+
+impl annotated::BackendBuilder for AnnotatedArcPoolBuilder {
+    type Root = LayoutRef;
+    type Output = AnnotatedArcPool;
+    type Error = anyhow::Error;
+
+    fn bool(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Bool)
+    }
+    fn u8(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U8)
+    }
+    fn u16(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U16)
+    }
+    fn u32(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U32)
+    }
+    fn u64(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U64)
+    }
+    fn u128(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U128)
+    }
+    fn u256(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U256)
+    }
+    fn address(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Address)
+    }
+    fn signer(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Signer)
+    }
+    fn vector(&mut self, element: LayoutRef) -> AResult<LayoutRef> {
+        self.0
+            .intern(annotated_nodes::MoveTypeNode::Vector(element))
+    }
+    fn struct_layout(
+        &mut self,
+        type_tag: &StructTag,
+        fields: &[(&Identifier, LayoutRef)],
+    ) -> AResult<LayoutRef> {
+        self.0
+            .intern(annotated_nodes::MoveTypeNode::struct_node(type_tag, fields))
+    }
+    fn enum_layout(
+        &mut self,
+        type_tag: &StructTag,
+        variants: &[(&Identifier, VariantTag, Option<&[(&Identifier, LayoutRef)]>)],
+    ) -> AResult<LayoutRef> {
+        self.0
+            .intern(annotated_nodes::MoveTypeNode::enum_node(type_tag, variants))
+    }
+    fn finalize(self, _root: LayoutRef) -> AnnotatedArcPool {
+        ArcPool::from_vec(self.0.into_vec())
+    }
+}
+
+// =============================================================================
+// Convenience surface (leaf constructors, TryFrom, builder new/Default)
+// =============================================================================
+//
+// These impls are concrete (not generic) so that callers can write
+// `RC::MoveTypeLayout::try_from(...)` or `RC::MoveTypeLayoutBuilder::new()`
+// without specifying a backend — the type-parameter default (`ArcPool`) makes
+// resolution unambiguous.
+
+impl runtime::MoveTypeLayout<RuntimeArcPool> {
+    fn leaf(ty: LeafType) -> Self {
+        runtime::MoveTypeLayout::from_parts(RuntimeArcPool::default(), LayoutRef::leaf(ty))
+    }
+}
+
+impl annotated::MoveTypeLayout<AnnotatedArcPool> {
+    fn leaf(ty: LeafType) -> Self {
+        annotated::MoveTypeLayout::from_parts(AnnotatedArcPool::default(), LayoutRef::leaf(ty))
+    }
+}
+
+// Per-flavor leaf-constructor convenience methods, generated identically for
+// both flavors. Both delegate to the private `Self::leaf(ty)` defined above.
+macro_rules! impl_leaf_ctors {
+    ($ty:ty) => {
+        impl $ty {
+            pub fn bool() -> Self {
+                Self::leaf(LeafType::Bool)
+            }
+            pub fn u8() -> Self {
+                Self::leaf(LeafType::U8)
+            }
+            pub fn u16() -> Self {
+                Self::leaf(LeafType::U16)
+            }
+            pub fn u32() -> Self {
+                Self::leaf(LeafType::U32)
+            }
+            pub fn u64() -> Self {
+                Self::leaf(LeafType::U64)
+            }
+            pub fn u128() -> Self {
+                Self::leaf(LeafType::U128)
+            }
+            pub fn u256() -> Self {
+                Self::leaf(LeafType::U256)
+            }
+            pub fn address() -> Self {
+                Self::leaf(LeafType::Address)
+            }
+            pub fn signer() -> Self {
+                Self::leaf(LeafType::Signer)
+            }
+        }
+    };
+}
+impl_leaf_ctors!(runtime::MoveTypeLayout<RuntimeArcPool>);
+impl_leaf_ctors!(annotated::MoveTypeLayout<AnnotatedArcPool>);
+
+impl TryFrom<&runtime_value::MoveTypeLayout> for runtime::MoveTypeLayout<RuntimeArcPool> {
+    type Error = anyhow::Error;
+    fn try_from(layout: &runtime_value::MoveTypeLayout) -> Result<Self, Self::Error> {
+        use runtime::BackendBuilder as _;
+        let mut b = RuntimeArcPoolBuilder::default();
+        let root = b.intern_tree(layout)?;
+        Ok(b.build(root))
+    }
+}
+
+impl TryFrom<&annotated_value::MoveTypeLayout> for annotated::MoveTypeLayout<AnnotatedArcPool> {
+    type Error = anyhow::Error;
+    fn try_from(layout: &annotated_value::MoveTypeLayout) -> Result<Self, Self::Error> {
+        use annotated::BackendBuilder as _;
+        let mut b = AnnotatedArcPoolBuilder::default();
+        let root = b.intern_tree(layout)?;
+        Ok(b.build(root))
+    }
+}

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/box_pool.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/box_pool.rs
@@ -73,6 +73,7 @@ pub type RuntimeBoxPool = BoxPool<runtime_nodes::MoveTypeNode<LayoutRef>>;
 impl runtime::TypeLayout for RuntimeBoxPool {
     type Root = LayoutRef;
 
+    #[inline]
     fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> runtime::MoveLayoutView<'a, Self> {
         match r.resolve() {
             ResolvedRef::Leaf(l) => runtime_nodes::leaf_view(l),
@@ -80,6 +81,7 @@ impl runtime::TypeLayout for RuntimeBoxPool {
         }
     }
 
+    #[inline]
     fn node_count(&self) -> usize {
         self.nodes.len()
     }
@@ -88,6 +90,7 @@ impl runtime::TypeLayout for RuntimeBoxPool {
 impl annotated::TypeLayout for AnnotatedBoxPool {
     type Root = LayoutRef;
 
+    #[inline]
     fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> annotated::MoveLayoutView<'a, Self> {
         match r.resolve() {
             ResolvedRef::Leaf(l) => annotated_nodes::leaf_view(l),
@@ -95,6 +98,7 @@ impl annotated::TypeLayout for AnnotatedBoxPool {
         }
     }
 
+    #[inline]
     fn node_count(&self) -> usize {
         self.nodes.len()
     }

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/box_pool.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/box_pool.rs
@@ -1,0 +1,218 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `Box`-owned flat node table backend.
+//!
+//! Same shape as [`super::arc_pool::ArcPool`] but uses `Box<[Node]>` (deep
+//! clones, no refcount). Node data types and pool-builder aliases live in
+//! [`super::runtime_nodes`] / [`super::annotated_nodes`]; this module owns
+//! the storage type, the per-flavor `TypeLayout` impls, and the
+//! `BackendBuilder` impls that finalize into a [`BoxPool`].
+//!
+//! `BoxPool` does **not** define the `MoveTypeLayout::bool()`/`TryFrom<&tree>`/
+//! `MoveTypeLayoutBuilder::new()` conveniences — those live on the default
+//! backend ([`super::arc_pool::ArcPool`]). Defining them for both pools would
+//! make calls that elide the backend type parameter ambiguous (default type
+//! parameters do not apply during trait-impl resolution). To build a layout
+//! into a `BoxPool`, use the generic builder directly:
+//!
+//! ```ignore
+//! let mut b = RC::MoveTypeLayoutBuilder(RuntimeBoxPoolBuilder::default());
+//! let root = b.intern_tree(&tree)?;
+//! let layout: RC::MoveTypeLayout<RuntimeBoxPool> = b.build(root);
+//! ```
+
+use anyhow::Result as AResult;
+
+use crate::compressed::VariantTag;
+use crate::compressed::backend::annotated_nodes::{self, AnnotatedPoolBuilder};
+use crate::compressed::backend::encoding::{LayoutRef, LeafType, ResolvedRef};
+use crate::compressed::backend::runtime_nodes::{self, RuntimePoolBuilder};
+use crate::compressed::{annotated, runtime};
+use crate::identifier::Identifier;
+use crate::language_storage::StructTag;
+
+// =============================================================================
+// BoxPool storage
+// =============================================================================
+
+/// `Box`-owned flat node table. Cloning deep-clones the slice (`Node: Clone`).
+#[derive(Debug, Clone)]
+pub struct BoxPool<Node> {
+    pub(crate) nodes: Box<[Node]>,
+}
+
+impl<Node> BoxPool<Node> {
+    pub(crate) fn from_vec(nodes: Vec<Node>) -> Self {
+        Self {
+            nodes: nodes.into_boxed_slice(),
+        }
+    }
+}
+
+impl<Node> Default for BoxPool<Node> {
+    fn default() -> Self {
+        Self::from_vec(Vec::new())
+    }
+}
+
+// =============================================================================
+// Concrete per-flavor aliases
+// =============================================================================
+
+/// Annotated-flavor [`BoxPool`] specialization.
+pub type AnnotatedBoxPool = BoxPool<annotated_nodes::MoveTypeNode<LayoutRef>>;
+/// Runtime-flavor [`BoxPool`] specialization.
+pub type RuntimeBoxPool = BoxPool<runtime_nodes::MoveTypeNode<LayoutRef>>;
+
+// =============================================================================
+// `TypeLayout` impls (per flavor)
+// =============================================================================
+
+impl runtime::TypeLayout for RuntimeBoxPool {
+    type Root = LayoutRef;
+
+    fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> runtime::MoveLayoutView<'a, Self> {
+        match r.resolve() {
+            ResolvedRef::Leaf(l) => runtime_nodes::leaf_view(l),
+            ResolvedRef::Index(i) => runtime_nodes::build_view_from_node(self, &self.nodes[i]),
+        }
+    }
+
+    fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+impl annotated::TypeLayout for AnnotatedBoxPool {
+    type Root = LayoutRef;
+
+    fn realize_view<'a>(&'a self, r: &'a LayoutRef) -> annotated::MoveLayoutView<'a, Self> {
+        match r.resolve() {
+            ResolvedRef::Leaf(l) => annotated_nodes::leaf_view(l),
+            ResolvedRef::Index(i) => annotated_nodes::build_view_from_node(self, &self.nodes[i]),
+        }
+    }
+
+    fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+// =============================================================================
+// Per-pool builder wrappers + `BackendBuilder` impls
+// =============================================================================
+
+/// Runtime-flavor builder that finalizes into a [`RuntimeBoxPool`].
+#[derive(Debug, Default)]
+pub struct RuntimeBoxPoolBuilder(pub RuntimePoolBuilder);
+
+/// Annotated-flavor builder that finalizes into an [`AnnotatedBoxPool`].
+#[derive(Debug, Default)]
+pub struct AnnotatedBoxPoolBuilder(pub AnnotatedPoolBuilder);
+
+impl runtime::BackendBuilder for RuntimeBoxPoolBuilder {
+    type Root = LayoutRef;
+    type Output = RuntimeBoxPool;
+    type Error = anyhow::Error;
+
+    fn bool(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Bool)
+    }
+    fn u8(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U8)
+    }
+    fn u16(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U16)
+    }
+    fn u32(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U32)
+    }
+    fn u64(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U64)
+    }
+    fn u128(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U128)
+    }
+    fn u256(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U256)
+    }
+    fn address(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Address)
+    }
+    fn signer(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Signer)
+    }
+    fn vector(&mut self, element: LayoutRef) -> AResult<LayoutRef> {
+        self.0.intern(runtime_nodes::MoveTypeNode::Vector(element))
+    }
+    fn struct_layout(&mut self, fields: &[LayoutRef]) -> AResult<LayoutRef> {
+        self.0
+            .intern(runtime_nodes::MoveTypeNode::struct_node(fields))
+    }
+    fn enum_layout(&mut self, variants: &[Option<&[LayoutRef]>]) -> AResult<LayoutRef> {
+        self.0
+            .intern(runtime_nodes::MoveTypeNode::enum_node(variants))
+    }
+    fn finalize(self, _root: LayoutRef) -> RuntimeBoxPool {
+        BoxPool::from_vec(self.0.into_vec())
+    }
+}
+
+impl annotated::BackendBuilder for AnnotatedBoxPoolBuilder {
+    type Root = LayoutRef;
+    type Output = AnnotatedBoxPool;
+    type Error = anyhow::Error;
+
+    fn bool(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Bool)
+    }
+    fn u8(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U8)
+    }
+    fn u16(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U16)
+    }
+    fn u32(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U32)
+    }
+    fn u64(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U64)
+    }
+    fn u128(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U128)
+    }
+    fn u256(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::U256)
+    }
+    fn address(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Address)
+    }
+    fn signer(&mut self) -> LayoutRef {
+        LayoutRef::leaf(LeafType::Signer)
+    }
+    fn vector(&mut self, element: LayoutRef) -> AResult<LayoutRef> {
+        self.0
+            .intern(annotated_nodes::MoveTypeNode::Vector(element))
+    }
+    fn struct_layout(
+        &mut self,
+        type_tag: &StructTag,
+        fields: &[(&Identifier, LayoutRef)],
+    ) -> AResult<LayoutRef> {
+        self.0
+            .intern(annotated_nodes::MoveTypeNode::struct_node(type_tag, fields))
+    }
+    fn enum_layout(
+        &mut self,
+        type_tag: &StructTag,
+        variants: &[(&Identifier, VariantTag, Option<&[(&Identifier, LayoutRef)]>)],
+    ) -> AResult<LayoutRef> {
+        self.0
+            .intern(annotated_nodes::MoveTypeNode::enum_node(type_tag, variants))
+    }
+    fn finalize(self, _root: LayoutRef) -> AnnotatedBoxPool {
+        BoxPool::from_vec(self.0.into_vec())
+    }
+}

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/encoding.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/encoding.rs
@@ -30,6 +30,7 @@ pub enum LeafType {
 }
 
 impl LeafType {
+    #[inline]
     pub(crate) fn from_u8(v: u8) -> Option<Self> {
         match v {
             0 => Some(Self::Bool),
@@ -78,6 +79,7 @@ pub(crate) enum ResolvedRef {
 }
 
 impl LayoutRef {
+    #[inline]
     pub(crate) const fn leaf(ty: LeafType) -> Self {
         LayoutRef(LEAF_TAG | ty as u16)
     }
@@ -89,6 +91,7 @@ impl LayoutRef {
         Ok(LayoutRef(idx as u16))
     }
 
+    #[inline]
     pub(crate) fn resolve(self) -> ResolvedRef {
         if self.0 & LEAF_TAG != 0 {
             let disc = (self.0 & LEAF_MASK) as u8;

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/encoding.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/encoding.rs
@@ -1,0 +1,137 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic encoding primitives shared by all node-table compressed-layout
+//! backends: the [`LayoutRef`] 16-bit packed encoding and the deduplicating
+//! [`PoolBuilder<Node>`] used during construction.
+
+use anyhow::Result as AResult;
+use indexmap::IndexSet;
+
+// =============================================================================
+// LeafType
+// =============================================================================
+
+/// Discriminant for primitive (leaf) Move types, encoded inline in a
+/// [`LayoutRef`] rather than stored in a node table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum LeafType {
+    Bool = 0,
+    U8 = 1,
+    U16 = 2,
+    U32 = 3,
+    U64 = 4,
+    U128 = 5,
+    U256 = 6,
+    Address = 7,
+    Signer = 8,
+}
+
+impl LeafType {
+    pub(crate) fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Bool),
+            1 => Some(Self::U8),
+            2 => Some(Self::U16),
+            3 => Some(Self::U32),
+            4 => Some(Self::U64),
+            5 => Some(Self::U128),
+            6 => Some(Self::U256),
+            7 => Some(Self::Address),
+            8 => Some(Self::Signer),
+            _ => None,
+        }
+    }
+}
+
+// =============================================================================
+// LayoutRef encoding: leaf-inline / pool-index (16 bits)
+// =============================================================================
+
+const LEAF_TAG: u16 = 0x8000;
+const LEAF_MASK: u16 = !LEAF_TAG;
+
+const _: () = {
+    assert!(
+        LEAF_TAG & LEAF_MASK == 0,
+        "leaf tag and mask must be disjoint"
+    );
+    assert!(LEAF_TAG == 0x8000, "leaf tag must be the high bit of a u16");
+    assert!(
+        LEAF_MASK == 0x7FFF,
+        "leaf mask must be the low 15 bits of a u16"
+    );
+};
+
+/// A compact reference to a layout node. Bit 15 distinguishes between:
+/// - **Leaf** (bit 15 set): the low bits encode a [`LeafType`] discriminant.
+/// - **Table index** (bit 15 clear): the low 15 bits index into the node table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LayoutRef(u16);
+
+/// The result of resolving a [`LayoutRef`].
+pub(crate) enum ResolvedRef {
+    Leaf(LeafType),
+    Index(usize),
+}
+
+impl LayoutRef {
+    pub(crate) const fn leaf(ty: LeafType) -> Self {
+        LayoutRef(LEAF_TAG | ty as u16)
+    }
+
+    pub(crate) fn index(idx: usize) -> AResult<Self> {
+        if idx > LEAF_MASK as usize {
+            anyhow::bail!("table index {idx} exceeds 15-bit maximum ({LEAF_MASK})");
+        }
+        Ok(LayoutRef(idx as u16))
+    }
+
+    pub(crate) fn resolve(self) -> ResolvedRef {
+        if self.0 & LEAF_TAG != 0 {
+            let disc = (self.0 & LEAF_MASK) as u8;
+            ResolvedRef::Leaf(
+                LeafType::from_u8(disc)
+                    .unwrap_or_else(|| panic!("invalid leaf discriminant: {disc}")),
+            )
+        } else {
+            ResolvedRef::Index(self.0 as usize)
+        }
+    }
+}
+
+// =============================================================================
+// PoolBuilder: in-progress, deduplicating node table
+// =============================================================================
+
+/// Deduplicating builder for a flat node table. Stores compound nodes in an
+/// [`IndexSet`] keyed by value; produces a `Vec<Node>` on finalize.
+#[derive(Debug)]
+pub struct PoolBuilder<Node: Eq + std::hash::Hash> {
+    nodes: IndexSet<Node>,
+}
+
+impl<Node: Eq + std::hash::Hash> Default for PoolBuilder<Node> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Node: Eq + std::hash::Hash> PoolBuilder<Node> {
+    pub fn new() -> Self {
+        Self {
+            nodes: IndexSet::new(),
+        }
+    }
+
+    pub(crate) fn intern(&mut self, n: Node) -> AResult<LayoutRef> {
+        let (idx, _) = self.nodes.insert_full(n);
+        LayoutRef::index(idx)
+    }
+
+    pub fn into_vec(self) -> Vec<Node> {
+        self.nodes.into_iter().collect()
+    }
+}

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/mod.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backing-store implementations for compressed layouts.
+//!
+//! Each storage submodule ([`arc_pool`], [`box_pool`]) provides a concrete way
+//! of holding layout node data and implements the per-flavor `TypeLayout`
+//! traits on its storage type. The infrastructure shared between node-table
+//! backends is split three ways:
+//!
+//! - [`encoding`] — flavor-agnostic primitives: `LayoutRef`, `LeafType`,
+//!   `PoolBuilder<Node>`.
+//! - [`runtime_nodes`] — runtime-flavor node types, pool-builder alias, and
+//!   view-construction helpers.
+//! - [`annotated_nodes`] — annotated-flavor equivalent.
+
+pub mod annotated_nodes;
+pub mod arc_pool;
+pub mod box_pool;
+pub mod encoding;
+pub mod runtime_nodes;
+
+pub use arc_pool::ArcPool;
+pub use box_pool::BoxPool;
+pub use encoding::{LayoutRef, LeafType};
+
+/// The default backend used by [`crate::compressed::annotated::MoveTypeLayout`]
+/// and related types when no explicit backend type parameter is supplied.
+pub type DefaultAnnotated = arc_pool::AnnotatedArcPool;
+
+/// The default backend used by [`crate::compressed::runtime::MoveTypeLayout`]
+/// and related types when no explicit backend type parameter is supplied.
+pub type DefaultRuntime = arc_pool::RuntimeArcPool;
+
+/// The default backend-builder used by
+/// [`crate::compressed::annotated::MoveTypeLayoutBuilder`].
+pub type DefaultAnnotatedBuilder = arc_pool::AnnotatedArcPoolBuilder;
+
+/// The default backend-builder used by
+/// [`crate::compressed::runtime::MoveTypeLayoutBuilder`].
+pub type DefaultRuntimeBuilder = arc_pool::RuntimeArcPoolBuilder;

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/runtime_nodes.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/runtime_nodes.rs
@@ -1,0 +1,110 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime-flavor node-table representation. Holds the node data types, the
+//! [`RuntimePoolBuilder`] alias, and the helpers that translate stored nodes
+//! into a runtime `MoveLayoutView`.
+
+use super::encoding::{LayoutRef, LeafType, PoolBuilder};
+use crate::compressed::runtime::{
+    MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout, MoveTypeLayoutRef,
+    TypeLayout,
+};
+
+// =============================================================================
+// Node types
+// =============================================================================
+
+/// Struct layout node: field types stored as references of type `R`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MoveStructNode<R> {
+    pub(crate) fields: Box<[R]>,
+}
+
+/// Enum layout node: each variant is either a known list of field
+/// references, or `None` if the variant exists but its field layout is
+/// not available.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MoveEnumNode<R> {
+    pub(crate) variants: Box<[Option<Box<[R]>>]>,
+}
+
+/// A compound layout node generic over the reference type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MoveTypeNode<R> {
+    Vector(R),
+    Struct(MoveStructNode<R>),
+    Enum(MoveEnumNode<R>),
+}
+
+// =============================================================================
+// Constructors for node-table pools (LayoutRef-keyed)
+// =============================================================================
+
+impl MoveTypeNode<LayoutRef> {
+    /// Build a struct node from a slice of field references.
+    pub(crate) fn struct_node(fields: &[LayoutRef]) -> Self {
+        MoveTypeNode::Struct(MoveStructNode {
+            fields: fields.iter().copied().collect(),
+        })
+    }
+
+    /// Build an enum node from a slice of optional variant field-reference lists.
+    pub(crate) fn enum_node(variants: &[Option<&[LayoutRef]>]) -> Self {
+        MoveTypeNode::Enum(MoveEnumNode {
+            variants: variants
+                .iter()
+                .map(|v| v.map(|fields| fields.iter().copied().collect()))
+                .collect(),
+        })
+    }
+}
+
+// =============================================================================
+// PoolBuilder alias
+// =============================================================================
+
+/// Runtime-flavor node-table builder.
+pub type RuntimePoolBuilder = PoolBuilder<MoveTypeNode<LayoutRef>>;
+
+// =============================================================================
+// View helpers
+// =============================================================================
+
+/// Map a [`LeafType`] to the corresponding leaf variant of [`MoveLayoutView`].
+pub(crate) fn leaf_view<'a, T: TypeLayout>(leaf: LeafType) -> MoveLayoutView<'a, T> {
+    use MoveLayoutView as V;
+    match leaf {
+        LeafType::Bool => V::Bool,
+        LeafType::U8 => V::U8,
+        LeafType::U16 => V::U16,
+        LeafType::U32 => V::U32,
+        LeafType::U64 => V::U64,
+        LeafType::U128 => V::U128,
+        LeafType::U256 => V::U256,
+        LeafType::Address => V::Address,
+        LeafType::Signer => V::Signer,
+    }
+}
+
+/// Build a `MoveLayoutView` from a node-table entry. Reusable across any
+/// backend whose `Root` matches the node's reference type.
+pub(crate) fn build_view_from_node<'a, T: TypeLayout>(
+    pool: &'a T,
+    node: &'a MoveTypeNode<T::Root>,
+) -> MoveLayoutView<'a, T> {
+    match node {
+        MoveTypeNode::Vector(inner) => MoveLayoutView::Vector(MoveTypeLayoutRef::new(pool, inner)),
+        MoveTypeNode::Struct(s) => MoveLayoutView::Struct(MoveStructLayout {
+            fields: MoveFieldsLayout {
+                pool,
+                fields: &s.fields,
+            },
+        }),
+        MoveTypeNode::Enum(e) => MoveLayoutView::Enum(MoveEnumLayout {
+            pool,
+            variants: &e.variants,
+        }),
+    }
+}

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/runtime_nodes.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/runtime_nodes.rs
@@ -73,6 +73,7 @@ pub type RuntimePoolBuilder = PoolBuilder<MoveTypeNode<LayoutRef>>;
 // =============================================================================
 
 /// Map a [`LeafType`] to the corresponding leaf variant of [`MoveLayoutView`].
+#[inline]
 pub(crate) fn leaf_view<'a, T: TypeLayout>(leaf: LeafType) -> MoveLayoutView<'a, T> {
     use MoveLayoutView as V;
     match leaf {
@@ -90,6 +91,7 @@ pub(crate) fn leaf_view<'a, T: TypeLayout>(leaf: LeafType) -> MoveLayoutView<'a,
 
 /// Build a `MoveLayoutView` from a node-table entry. Reusable across any
 /// backend whose `Root` matches the node's reference type.
+#[inline]
 pub(crate) fn build_view_from_node<'a, T: TypeLayout>(
     pool: &'a T,
     node: &'a MoveTypeNode<T::Root>,

--- a/external-crates/move/crates/move-core-types/src/compressed/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/mod.rs
@@ -3,113 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod annotated;
+pub mod backend;
 pub mod runtime;
 
 // =============================================================================
 // Shared types used by both runtime and annotated compressed layouts
 // =============================================================================
 
-const LEAF_TAG: u16 = 0x8000;
-const LEAF_MASK: u16 = !LEAF_TAG;
-
-const _: () = {
-    assert!(
-        LEAF_TAG & LEAF_MASK == 0,
-        "leaf tag and mask must be disjoint"
-    );
-    assert!(LEAF_TAG == 0x8000, "leaf tag must be the high bit of a u16");
-    assert!(
-        LEAF_MASK == 0x7FFF,
-        "leaf mask must be the low 15 bits of a u16"
-    );
-};
-
 /// Tag identifying an enum variant. This is a type alias for `u16` — the
 /// canonical `VariantTag` lives in `move-binary-format` but cannot be
 /// referenced from here (circular dependency), so we define a local alias.
 pub type VariantTag = u16;
-
-/// Discriminant for primitive (leaf) Move types, encoded inline in a
-/// [`LayoutRef`] rather than stored in the node table.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u8)]
-pub(crate) enum LeafType {
-    Bool = 0,
-    U8 = 1,
-    U16 = 2,
-    U32 = 3,
-    U64 = 4,
-    U128 = 5,
-    U256 = 6,
-    Address = 7,
-    Signer = 8,
-}
-
-/// A compact reference to a layout node. Bit 15 distinguishes between:
-/// - **Leaf** (bit 15 set): the low bits encode a [`LeafType`] discriminant.
-/// - **Table index** (bit 15 clear): the low 15 bits index into the node table.
-///
-/// This is an internal storage type. External callers interact with layouts
-/// through [`LayoutHandle`] (for building) and view types (for reading).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct LayoutRef(u16);
-
-/// The result of resolving a [`LayoutRef`].
-pub(crate) enum ResolvedRef {
-    Leaf(LeafType),
-    Index(usize),
-}
-
-/// An opaque handle to a layout node returned by the builder.
-///
-/// Handles are only useful for passing back into the same builder (to compose
-/// compound types) or to [`MoveTypeLayoutBuilder::build`] to designate the root.
-/// The internal representation is not exposed.
-#[derive(Debug, Clone, Copy)]
-pub struct LayoutHandle(pub(crate) LayoutRef);
-
-// =============================================================================
-// Implementations
-// =============================================================================
-
-impl LeafType {
-    pub(crate) fn from_u8(v: u8) -> Option<Self> {
-        match v {
-            0 => Some(Self::Bool),
-            1 => Some(Self::U8),
-            2 => Some(Self::U16),
-            3 => Some(Self::U32),
-            4 => Some(Self::U64),
-            5 => Some(Self::U128),
-            6 => Some(Self::U256),
-            7 => Some(Self::Address),
-            8 => Some(Self::Signer),
-            _ => None,
-        }
-    }
-}
-
-impl LayoutRef {
-    pub(crate) const fn leaf(ty: LeafType) -> Self {
-        LayoutRef(LEAF_TAG | ty as u16)
-    }
-
-    pub(crate) fn index(idx: usize) -> anyhow::Result<Self> {
-        if idx > LEAF_MASK as usize {
-            anyhow::bail!("table index {idx} exceeds 15-bit maximum ({LEAF_MASK})");
-        }
-        Ok(LayoutRef(idx as u16))
-    }
-
-    pub(crate) fn resolve(self) -> ResolvedRef {
-        if self.0 & LEAF_TAG != 0 {
-            let disc = (self.0 & LEAF_MASK) as u8;
-            ResolvedRef::Leaf(
-                LeafType::from_u8(disc)
-                    .unwrap_or_else(|| panic!("invalid leaf discriminant: {disc}")),
-            )
-        } else {
-            ResolvedRef::Index(self.0 as usize)
-        }
-    }
-}

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -2,78 +2,77 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compressed::{LayoutRef, LeafType, ResolvedRef};
+use crate::compressed::backend::DefaultRuntime;
 use crate::runtime_value as RV;
 use anyhow::Result as AResult;
-use indexmap::IndexSet;
 use std::fmt;
-use std::sync::Arc;
 
-pub use crate::compressed::LayoutHandle;
-
-static EMPTY_POOL: std::sync::LazyLock<Arc<MoveTypeLayoutPool>> =
-    std::sync::LazyLock::new(|| Arc::from(Vec::<MoveTypeNode>::new()));
+/// The default compressed-runtime layout builder. Alias so most users can just write
+/// `MoveTypeLayoutBuilder::new()`.
+///
+/// To use a different backend, name its concrete builder type directly (e.g.
+/// `RuntimeBoxPoolBuilder`) — call sites are otherwise identical.
+pub use crate::compressed::backend::DefaultRuntimeBuilder as MoveTypeLayoutBuilder;
 
 // =============================================================================
-// Type declarations
+// Trait: TypeLayout
 // =============================================================================
 
-// --- Node types (internal) ---
+/// A backing store for compressed runtime layouts. Implementors decide how
+/// roots are encoded and where node data lives.
+///
+/// This trait is **per-flavor** rather than shared with the annotated flavor
+/// because each flavor returns its own concrete `MoveLayoutView<'_, Self>`,
+/// and a shared trait with a GAT `type View<'a>` runs into the stable-Rust
+/// interaction between the GAT's implicit `Self: 'a` bound and HRTB use sites
+/// (e.g. `Display` on the owned `MoveTypeLayout<T>`), which forces
+/// `T: 'static` — too restrictive for backends that hold borrowed data.
+pub trait TypeLayout: Sized {
+    /// Cheap-to-`Clone` reference into the backend's storage. Typically `Copy`
+    /// (e.g. a packed index) but not required to be — Arc-handle backends use
+    /// a `Clone`-only `Root` carrying a refcounted pointer.
+    type Root: Clone + fmt::Debug;
 
-/// Struct layout node: field types stored as [`LayoutRef`]s.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct MoveStructNode {
-    pub(crate) fields: Box<[LayoutRef]>,
+    /// Resolve a root to its resolved view at that node. `r` is borrowed so
+    /// the returned view can borrow into data the `Root` keeps alive (e.g.
+    /// an `Arc<TreeNode>` inside the root).
+    fn realize_view<'a>(&'a self, r: &'a Self::Root) -> MoveLayoutView<'a, Self>;
+
+    /// Number of compound nodes accessible through this backend.
+    fn node_count(&self) -> usize;
 }
 
-/// Enum layout node: each variant is either a known list of field
-/// [`LayoutRef`]s, or `None` indicating the variant exists but its
-/// field layout is not available.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct MoveEnumNode {
-    pub(crate) variants: Box<[Option<Box<[LayoutRef]>>]>,
-}
+// =============================================================================
+// Owned and borrowed layout types
+// =============================================================================
 
-/// A compound layout node in the compressed node table.
-/// Leaf types (primitives) are encoded inline in [`LayoutRef`] and never
-/// appear in the table.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum MoveTypeNode {
-    Vector(LayoutRef),
-    Struct(MoveStructNode),
-    Enum(MoveEnumNode),
-}
-
-/// The shared node table backing a [`MoveTypeLayout`].
-pub(crate) type MoveTypeLayoutPool = [MoveTypeNode];
-
-// --- Owned layout types ---
-
-/// A deduplicated, flat representation of a [`RV::MoveTypeLayout`] tree.
-/// Cloning is cheap — the pool is shared via `Arc`.
+/// A deduplicated, flat representation of a [`RV::MoveTypeLayout`] tree,
+/// generic over the backend `T`.
 ///
 /// NOTE: `Eq`/`PartialEq`/`Hash` are intentionally not derived. Two layouts
 /// representing the same type may have different pool orderings (node
 /// permutations), so structural equality on the raw fields would produce
 /// false negatives. Compare by inflating to tree form or by comparing views.
 #[derive(Debug, Clone)]
-pub struct MoveTypeLayout {
-    pool: Arc<MoveTypeLayoutPool>,
-    root: LayoutRef,
+pub struct MoveTypeLayout<T: TypeLayout = DefaultRuntime> {
+    pool: T,
+    root: T::Root,
 }
 
-/// Borrowed compact runtime layout backed by an existing node pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveTypeLayoutRef<'a> {
-    pool: &'a Arc<MoveTypeLayoutPool>,
-    root: LayoutRef,
+/// Borrowed view onto a [`MoveTypeLayout`] without cloning the pool.
+#[derive(Debug)]
+pub struct MoveTypeLayoutRef<'a, T: TypeLayout = DefaultRuntime> {
+    pub(crate) pool: &'a T,
+    pub(crate) root: &'a T::Root,
 }
 
-// --- View types (all borrowed, Copy) ---
+// =============================================================================
+// View types (all borrowed, Copy)
+// =============================================================================
 
 /// A resolved view of a layout node.
-#[derive(Debug, Clone, Copy)]
-pub enum MoveLayoutView<'a> {
+#[derive(Debug)]
+pub enum MoveLayoutView<'a, T: TypeLayout = DefaultRuntime> {
     Bool,
     U8,
     U16,
@@ -83,51 +82,150 @@ pub enum MoveLayoutView<'a> {
     U256,
     Address,
     Signer,
-    Vector(MoveTypeLayoutRef<'a>),
-    Struct(MoveStructLayout<'a>),
-    Enum(MoveEnumLayout<'a>),
+    Vector(MoveTypeLayoutRef<'a, T>),
+    Struct(MoveStructLayout<'a, T>),
+    Enum(MoveEnumLayout<'a, T>),
 }
 
 /// The enum layout of an enum type, as a view into a shared pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveEnumLayout<'a> {
-    pool: &'a Arc<MoveTypeLayoutPool>,
-    variants: &'a [Option<Box<[LayoutRef]>>],
+#[derive(Debug)]
+pub struct MoveEnumLayout<'a, T: TypeLayout = DefaultRuntime> {
+    pub(crate) pool: &'a T,
+    pub(crate) variants: &'a [Option<Box<[T::Root]>>],
 }
 
 /// The struct layout of a struct type, as a view into a shared pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveStructLayout<'a>(pub MoveFieldsLayout<'a>);
+#[derive(Debug)]
+pub struct MoveStructLayout<'a, T: TypeLayout = DefaultRuntime> {
+    pub(crate) fields: MoveFieldsLayout<'a, T>,
+}
 
 /// The result of looking up a variant in an enum view.
-#[derive(Debug, Clone, Copy)]
-pub enum VariantLayout<'a> {
+#[derive(Debug)]
+pub enum VariantLayout<'a, T: TypeLayout = DefaultRuntime> {
     /// The variant's field layout is known.
-    Known(MoveFieldsLayout<'a>),
+    Known(MoveFieldsLayout<'a, T>),
     /// The variant exists but its field layout is not available.
     Unknown,
 }
 
 /// The field layout of a struct or enum variant, as a view into a shared pool.
-#[derive(Debug, Clone, Copy)]
-pub struct MoveFieldsLayout<'a> {
-    pool: &'a Arc<MoveTypeLayoutPool>,
-    fields: &'a [LayoutRef],
+#[derive(Debug)]
+pub struct MoveFieldsLayout<'a, T: TypeLayout = DefaultRuntime> {
+    pub(crate) pool: &'a T,
+    pub(crate) fields: &'a [T::Root],
 }
 
-// --- Builder type ---
+// `#[derive(Copy, Clone)]` would over-constrain to `T: Copy`; these are all
+// `&'a T` plus Copy fields, so they're unconditionally Copy.
+macro_rules! impl_copy_clone {
+    ($($t:ident),* $(,)?) => { $(
+        impl<T: TypeLayout> Clone for $t<'_, T> { fn clone(&self) -> Self { *self } }
+        impl<T: TypeLayout> Copy for $t<'_, T> {}
+    )* };
+}
+impl_copy_clone!(
+    MoveTypeLayoutRef,
+    MoveLayoutView,
+    MoveEnumLayout,
+    MoveStructLayout,
+    VariantLayout,
+    MoveFieldsLayout,
+);
 
-/// Incrementally builds a [`MoveTypeLayout`] with automatic deduplication.
-/// Leaf types are encoded inline in [`LayoutRef`] and never stored in the
-/// node table.
-pub struct MoveTypeLayoutBuilder {
-    nodes: IndexSet<MoveTypeNode>,
+// =============================================================================
+// Builder trait + generic builder
+// =============================================================================
+
+/// Backend-write-side abstraction: each method constructs a layout root for
+/// one Move type-constructor. Each concrete backend (see e.g.
+/// [`crate::compressed::backend::arc_pool`]) decides how to allocate, encode,
+/// or deduplicate the root and where to store any compound node data.
+///
+/// `intern_tree` and `build` are provided as default methods so callers can drive
+/// any backend builder directly without an extra wrapper.
+pub trait BackendBuilder: Sized {
+    /// Cheap-to-`Clone` reference into the backend's storage (matches
+    /// `<Self::Output as TypeLayout>::Root`).
+    type Root: Clone + fmt::Debug;
+    /// The TypeLayout backend produced by `finalize`.
+    type Output: TypeLayout<Root = Self::Root>;
+    /// Errors raised by compound constructors (e.g. capacity-limit failures).
+    type Error;
+
+    fn bool(&mut self) -> Self::Root;
+    fn u8(&mut self) -> Self::Root;
+    fn u16(&mut self) -> Self::Root;
+    fn u32(&mut self) -> Self::Root;
+    fn u64(&mut self) -> Self::Root;
+    fn u128(&mut self) -> Self::Root;
+    fn u256(&mut self) -> Self::Root;
+    fn address(&mut self) -> Self::Root;
+    fn signer(&mut self) -> Self::Root;
+
+    fn vector(&mut self, element: Self::Root) -> Result<Self::Root, Self::Error>;
+    fn struct_layout(&mut self, fields: &[Self::Root]) -> Result<Self::Root, Self::Error>;
+    fn enum_layout(
+        &mut self,
+        variants: &[Option<&[Self::Root]>],
+    ) -> Result<Self::Root, Self::Error>;
+
+    /// Finalize the builder into an immutable [`TypeLayout`] backend.
+    fn finalize(self, root: Self::Root) -> Self::Output;
+
+    /// Recursively intern a tree-based layout, deduplicating shared subtrees.
+    /// Tree-based enum layouts always have known variants, so all variants are
+    /// wrapped in `Some`.
+    fn intern_tree(&mut self, layout: &RV::MoveTypeLayout) -> Result<Self::Root, Self::Error> {
+        Ok(match layout {
+            RV::MoveTypeLayout::Bool => self.bool(),
+            RV::MoveTypeLayout::U8 => self.u8(),
+            RV::MoveTypeLayout::U16 => self.u16(),
+            RV::MoveTypeLayout::U32 => self.u32(),
+            RV::MoveTypeLayout::U64 => self.u64(),
+            RV::MoveTypeLayout::U128 => self.u128(),
+            RV::MoveTypeLayout::U256 => self.u256(),
+            RV::MoveTypeLayout::Address => self.address(),
+            RV::MoveTypeLayout::Signer => self.signer(),
+            RV::MoveTypeLayout::Vector(inner) => {
+                let inner_h = self.intern_tree(inner)?;
+                self.vector(inner_h)?
+            }
+            RV::MoveTypeLayout::Struct(s) => {
+                let fields = s
+                    .fields()
+                    .iter()
+                    .map(|f| self.intern_tree(f))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.struct_layout(&fields)?
+            }
+            RV::MoveTypeLayout::Enum(e) => {
+                let variant_handles =
+                    e.0.iter()
+                        .map(|v| {
+                            v.iter()
+                                .map(|f| self.intern_tree(f))
+                                .collect::<Result<Vec<_>, _>>()
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                let variant_refs: Vec<Option<&[Self::Root]>> =
+                    variant_handles.iter().map(|v| Some(v.as_slice())).collect();
+                self.enum_layout(&variant_refs)?
+            }
+        })
+    }
+
+    /// Finalize the builder and wrap the result in a [`MoveTypeLayout`].
+    fn build(self, root: Self::Root) -> MoveTypeLayout<Self::Output> {
+        let pool = self.finalize(root.clone());
+        MoveTypeLayout::from_parts(pool, root)
+    }
 }
 
-// --- Display helper ---
+// =============================================================================
+// Display helper
+// =============================================================================
 
-/// Helper type that uses `T`'s `Display` implementation as its own `Debug` implementation,
-/// to allow other `Display` implementations to take advantage of structured formatting helpers.
 struct DebugAsDisplay<'a, T>(&'a T);
 
 // =============================================================================
@@ -136,57 +234,30 @@ struct DebugAsDisplay<'a, T>(&'a T);
 
 // --- MoveTypeLayout ---
 
-impl MoveTypeLayout {
-    /// Number of compound nodes in the table (excludes inline leaf types).
+impl<T: TypeLayout> MoveTypeLayout<T> {
+    /// Construct a layout from its raw parts. Used by backends to build their
+    /// concrete instantiations from a finalized pool + root.
+    pub fn from_parts(pool: T, root: T::Root) -> Self {
+        MoveTypeLayout { pool, root }
+    }
+}
+
+impl<T: TypeLayout> MoveTypeLayout<T> {
+    /// Number of compound nodes accessible through the backend.
     pub fn node_count(&self) -> usize {
-        self.as_ref().node_count()
-    }
-
-    fn leaf(ty: LeafType) -> Self {
-        MoveTypeLayout {
-            pool: EMPTY_POOL.clone(),
-            root: LayoutRef::leaf(ty),
-        }
-    }
-
-    pub fn bool() -> Self {
-        Self::leaf(LeafType::Bool)
-    }
-    pub fn u8() -> Self {
-        Self::leaf(LeafType::U8)
-    }
-    pub fn u16() -> Self {
-        Self::leaf(LeafType::U16)
-    }
-    pub fn u32() -> Self {
-        Self::leaf(LeafType::U32)
-    }
-    pub fn u64() -> Self {
-        Self::leaf(LeafType::U64)
-    }
-    pub fn u128() -> Self {
-        Self::leaf(LeafType::U128)
-    }
-    pub fn u256() -> Self {
-        Self::leaf(LeafType::U256)
-    }
-    pub fn address() -> Self {
-        Self::leaf(LeafType::Address)
-    }
-    pub fn signer() -> Self {
-        Self::leaf(LeafType::Signer)
+        self.pool.node_count()
     }
 
     /// Borrow this layout without cloning the pool.
-    pub fn as_ref(&self) -> MoveTypeLayoutRef<'_> {
+    pub fn as_ref(&self) -> MoveTypeLayoutRef<'_, T> {
         MoveTypeLayoutRef {
             pool: &self.pool,
-            root: self.root,
+            root: &self.root,
         }
     }
 
     /// Create a resolved view for navigating this layout.
-    pub fn as_view(&self) -> MoveLayoutView<'_> {
+    pub fn as_view(&self) -> MoveLayoutView<'_, T> {
         self.as_ref().as_view()
     }
 
@@ -197,16 +268,7 @@ impl MoveTypeLayout {
     }
 }
 
-impl TryFrom<&RV::MoveTypeLayout> for MoveTypeLayout {
-    type Error = anyhow::Error;
-    fn try_from(layout: &RV::MoveTypeLayout) -> Result<Self, Self::Error> {
-        let mut b = MoveTypeLayoutBuilder::new();
-        let root = b.from_tree(layout)?;
-        Ok(b.build(root))
-    }
-}
-
-impl fmt::Display for MoveTypeLayout {
+impl<T: TypeLayout> fmt::Display for MoveTypeLayout<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             write!(f, "{:#}", self.as_ref())
@@ -216,26 +278,34 @@ impl fmt::Display for MoveTypeLayout {
     }
 }
 
-// --- MoveTypeLayoutRef (borrowed root) ---
+// --- MoveTypeLayoutRef ---
 
-impl<'a> MoveTypeLayoutRef<'a> {
-    /// Clone the underlying `Arc` to produce an owned layout. Cheap — only a
-    /// refcount bump.
-    pub fn to_owned(self) -> MoveTypeLayout {
+impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
+    /// Construct a borrowed layout from a pool reference and a root reference.
+    pub fn new(pool: &'a T, root: &'a T::Root) -> Self {
+        MoveTypeLayoutRef { pool, root }
+    }
+
+    /// Clone the backend to produce an owned layout (cheap when the backend's
+    /// `Clone` impl is itself cheap, e.g. an `Arc` refcount bump).
+    pub fn to_owned(self) -> MoveTypeLayout<T>
+    where
+        T: Clone,
+    {
         MoveTypeLayout {
             pool: self.pool.clone(),
-            root: self.root,
+            root: self.root.clone(),
         }
     }
 
-    /// Number of compound nodes in the table (excludes inline leaf types).
+    /// Number of compound nodes accessible through the backend.
     pub fn node_count(self) -> usize {
-        self.pool.len()
+        self.pool.node_count()
     }
 
     /// Create a resolved view for navigating this layout.
-    pub fn as_view(self) -> MoveLayoutView<'a> {
-        resolve_ref(self.pool, self.root)
+    pub fn as_view(self) -> MoveLayoutView<'a, T> {
+        self.pool.realize_view(self.root)
     }
 
     /// Reconstruct the equivalent tree-based layout. Returns an error
@@ -245,13 +315,13 @@ impl<'a> MoveTypeLayoutRef<'a> {
     }
 }
 
-impl<'a> From<&'a MoveTypeLayout> for MoveTypeLayoutRef<'a> {
-    fn from(layout: &'a MoveTypeLayout) -> Self {
+impl<'a, T: TypeLayout> From<&'a MoveTypeLayout<T>> for MoveTypeLayoutRef<'a, T> {
+    fn from(layout: &'a MoveTypeLayout<T>) -> Self {
         layout.as_ref()
     }
 }
 
-impl fmt::Display for MoveTypeLayoutRef<'_> {
+impl<T: TypeLayout> fmt::Display for MoveTypeLayoutRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             write!(f, "{:#}", self.as_view())
@@ -263,7 +333,7 @@ impl fmt::Display for MoveTypeLayoutRef<'_> {
 
 // --- MoveLayoutView ---
 
-impl<'a> MoveLayoutView<'a> {
+impl<T: TypeLayout> MoveLayoutView<'_, T> {
     /// Reconstruct the equivalent tree-based layout. Returns an error
     /// if any enum variant has an unknown layout.
     pub fn inflate(&self) -> AResult<RV::MoveTypeLayout> {
@@ -279,7 +349,11 @@ impl<'a> MoveLayoutView<'a> {
             MoveLayoutView::Signer => RV::MoveTypeLayout::Signer,
             MoveLayoutView::Vector(vv) => RV::MoveTypeLayout::Vector(Box::new(vv.inflate()?)),
             MoveLayoutView::Struct(sv) => {
-                let fields = sv.0.fields().map(|f| f.inflate()).collect::<AResult<_>>()?;
+                let fields = sv
+                    .fields
+                    .fields()
+                    .map(|f| f.inflate())
+                    .collect::<AResult<_>>()?;
                 RV::MoveTypeLayout::Struct(Box::new(RV::MoveStructLayout::new(fields)))
             }
             MoveLayoutView::Enum(ev) => {
@@ -300,7 +374,7 @@ impl<'a> MoveLayoutView<'a> {
     }
 }
 
-impl fmt::Display for MoveLayoutView<'_> {
+impl<T: TypeLayout> fmt::Display for MoveLayoutView<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MoveLayoutView::Bool => write!(f, "bool"),
@@ -324,55 +398,60 @@ impl fmt::Display for MoveLayoutView<'_> {
 
 // --- MoveFieldsLayout ---
 
-impl<'a> MoveFieldsLayout<'a> {
+impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
     /// Number of fields.
     pub fn field_count(self) -> usize {
         self.fields.len()
     }
 
     /// Access a field by index.
-    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a>> {
+    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a, T>> {
         self.fields.get(i).map(|f| MoveTypeLayoutRef {
             pool: self.pool,
-            root: *f,
+            root: f,
         })
     }
 
     /// Iterate over all fields as layouts.
-    pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a>> {
+    pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a, T>> {
         self.fields.iter().map(move |f| MoveTypeLayoutRef {
             pool: self.pool,
-            root: *f,
+            root: f,
         })
     }
 }
 
 // --- MoveStructLayout ---
 
-impl<'a> MoveStructLayout<'a> {
+impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
+    /// Access the fields layout.
+    pub fn fields_layout(self) -> MoveFieldsLayout<'a, T> {
+        self.fields
+    }
+
     /// Number of fields.
     pub fn field_count(self) -> usize {
-        self.0.field_count()
+        self.fields.field_count()
     }
 
     /// Access a field by index.
-    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a>> {
-        self.0.field(i)
+    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a, T>> {
+        self.fields.field(i)
     }
 
     /// Iterate over all fields as layouts.
-    pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a>> {
-        self.0.fields()
+    pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a, T>> {
+        self.fields.fields()
     }
 }
 
-impl fmt::Display for MoveStructLayout<'_> {
+impl<T: TypeLayout> fmt::Display for MoveStructLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "struct {}", self.0)
+        write!(f, "struct {}", self.fields)
     }
 }
 
-impl fmt::Display for MoveFieldsLayout<'_> {
+impl<T: TypeLayout> fmt::Display for MoveFieldsLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use DebugAsDisplay as DD;
 
@@ -382,7 +461,7 @@ impl fmt::Display for MoveFieldsLayout<'_> {
                 &i,
                 &DD(&MoveTypeLayoutRef {
                     pool: self.pool,
-                    root: *field,
+                    root: field,
                 }),
             );
         }
@@ -392,41 +471,35 @@ impl fmt::Display for MoveFieldsLayout<'_> {
 
 // --- MoveEnumLayout ---
 
-impl<'a> MoveEnumLayout<'a> {
+impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
     /// Number of variants.
     pub fn variant_count(self) -> usize {
         self.variants.len()
     }
 
     /// Access a variant by index.
-    pub fn variant(self, i: usize) -> Option<VariantLayout<'a>> {
-        self.variants.get(i).map(|v| self.make_variant(v))
+    pub fn variant(self, i: usize) -> Option<VariantLayout<'a, T>> {
+        self.variants.get(i).map(|v| make_variant(self.pool, v))
     }
 
     /// Iterate over all variants.
-    pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a>> {
+    pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a, T>> {
         let pool = self.pool;
-        self.variants
-            .iter()
-            .map(move |v| make_variant_for_pool(pool, v))
-    }
-
-    fn make_variant(self, v: &'a Option<Box<[LayoutRef]>>) -> VariantLayout<'a> {
-        make_variant_for_pool(self.pool, v)
+        self.variants.iter().map(move |v| make_variant(pool, v))
     }
 }
 
-fn make_variant_for_pool<'a>(
-    pool: &'a Arc<MoveTypeLayoutPool>,
-    v: &'a Option<Box<[LayoutRef]>>,
-) -> VariantLayout<'a> {
+fn make_variant<'a, T: TypeLayout>(
+    pool: &'a T,
+    v: &'a Option<Box<[T::Root]>>,
+) -> VariantLayout<'a, T> {
     match v {
         Some(fields) => VariantLayout::Known(MoveFieldsLayout { pool, fields }),
         None => VariantLayout::Unknown,
     }
 }
 
-impl fmt::Display for MoveEnumLayout<'_> {
+impl<T: TypeLayout> fmt::Display for MoveEnumLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "enum ")?;
         for (tag, vl) in self.variants().enumerate() {
@@ -454,164 +527,5 @@ impl<T: fmt::Display> fmt::Debug for DebugAsDisplay<'_, T> {
         } else {
             write!(f, "{}", self.0)
         }
-    }
-}
-
-// --- MoveTypeLayoutBuilder ---
-
-impl MoveTypeLayoutBuilder {
-    pub fn new() -> Self {
-        Self {
-            nodes: IndexSet::new(),
-        }
-    }
-
-    fn add_node(&mut self, node: MoveTypeNode) -> AResult<LayoutHandle> {
-        let (idx, _) = self.nodes.insert_full(node);
-        Ok(LayoutHandle(LayoutRef::index(idx)?))
-    }
-
-    pub fn bool(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::Bool))
-    }
-    pub fn u8(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U8))
-    }
-    pub fn u16(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U16))
-    }
-    pub fn u32(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U32))
-    }
-    pub fn u64(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U64))
-    }
-    pub fn u128(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U128))
-    }
-    pub fn u256(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::U256))
-    }
-    pub fn address(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::Address))
-    }
-    pub fn signer(&mut self) -> LayoutHandle {
-        LayoutHandle(LayoutRef::leaf(LeafType::Signer))
-    }
-
-    pub fn vector(&mut self, element: LayoutHandle) -> AResult<LayoutHandle> {
-        self.add_node(MoveTypeNode::Vector(element.0))
-    }
-
-    pub fn struct_layout(&mut self, fields: &[LayoutHandle]) -> AResult<LayoutHandle> {
-        let field_refs: Box<[LayoutRef]> = fields.iter().map(|h| h.0).collect();
-        self.add_node(MoveTypeNode::Struct(MoveStructNode { fields: field_refs }))
-    }
-
-    pub fn enum_layout(&mut self, variants: &[Option<&[LayoutHandle]>]) -> AResult<LayoutHandle> {
-        let variant_refs: Box<[Option<Box<[LayoutRef]>>]> = variants
-            .iter()
-            .map(|v| v.map(|fields| fields.iter().map(|h| h.0).collect()))
-            .collect();
-        self.add_node(MoveTypeNode::Enum(MoveEnumNode {
-            variants: variant_refs,
-        }))
-    }
-
-    /// Recursively intern a tree-based layout, deduplicating shared subtrees.
-    /// Tree-based enum layouts always have known variants, so all variants
-    /// are wrapped in `Some`.
-    pub fn from_tree(&mut self, layout: &RV::MoveTypeLayout) -> AResult<LayoutHandle> {
-        Ok(match layout {
-            RV::MoveTypeLayout::Bool => self.bool(),
-            RV::MoveTypeLayout::U8 => self.u8(),
-            RV::MoveTypeLayout::U16 => self.u16(),
-            RV::MoveTypeLayout::U32 => self.u32(),
-            RV::MoveTypeLayout::U64 => self.u64(),
-            RV::MoveTypeLayout::U128 => self.u128(),
-            RV::MoveTypeLayout::U256 => self.u256(),
-            RV::MoveTypeLayout::Address => self.address(),
-            RV::MoveTypeLayout::Signer => self.signer(),
-            RV::MoveTypeLayout::Vector(inner) => {
-                let inner_h = self.from_tree(inner)?;
-                self.vector(inner_h)?
-            }
-            RV::MoveTypeLayout::Struct(s) => {
-                let fields = s
-                    .fields()
-                    .iter()
-                    .map(|f| self.from_tree(f))
-                    .collect::<AResult<Vec<_>>>()?;
-                self.struct_layout(&fields)?
-            }
-            RV::MoveTypeLayout::Enum(e) => {
-                let variant_handles =
-                    e.0.iter()
-                        .map(|v| {
-                            v.iter()
-                                .map(|f| self.from_tree(f))
-                                .collect::<AResult<Vec<_>>>()
-                        })
-                        .collect::<AResult<Vec<_>>>()?;
-                let variant_refs: Vec<Option<&[LayoutHandle]>> =
-                    variant_handles.iter().map(|v| Some(v.as_slice())).collect();
-                self.enum_layout(&variant_refs)?
-            }
-        })
-    }
-
-    /// Finalize the builder into an immutable [`MoveTypeLayout`].
-    pub fn build(self, root: LayoutHandle) -> MoveTypeLayout {
-        let nodes: Vec<MoveTypeNode> = self.nodes.into_iter().collect();
-        MoveTypeLayout {
-            pool: Arc::from(nodes),
-            root: root.0,
-        }
-    }
-}
-
-impl Default for MoveTypeLayoutBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// =============================================================================
-// Free functions
-// =============================================================================
-
-fn leaf_to_layout_view<'a>(leaf: LeafType) -> MoveLayoutView<'a> {
-    match leaf {
-        LeafType::Bool => MoveLayoutView::Bool,
-        LeafType::U8 => MoveLayoutView::U8,
-        LeafType::U16 => MoveLayoutView::U16,
-        LeafType::U32 => MoveLayoutView::U32,
-        LeafType::U64 => MoveLayoutView::U64,
-        LeafType::U128 => MoveLayoutView::U128,
-        LeafType::U256 => MoveLayoutView::U256,
-        LeafType::Address => MoveLayoutView::Address,
-        LeafType::Signer => MoveLayoutView::Signer,
-    }
-}
-
-/// Resolve a [`LayoutRef`] against the pool into a [`MoveLayoutView`].
-///
-/// Panics if the reference points to an out-of-bounds table index.
-fn resolve_ref<'a>(pool: &'a Arc<MoveTypeLayoutPool>, r: LayoutRef) -> MoveLayoutView<'a> {
-    match r.resolve() {
-        ResolvedRef::Leaf(leaf) => leaf_to_layout_view(leaf),
-        ResolvedRef::Index(idx) => match &pool[idx] {
-            MoveTypeNode::Vector(inner) => {
-                MoveLayoutView::Vector(MoveTypeLayoutRef { pool, root: *inner })
-            }
-            MoveTypeNode::Struct(s) => MoveLayoutView::Struct(MoveStructLayout(MoveFieldsLayout {
-                pool,
-                fields: &s.fields,
-            })),
-            MoveTypeNode::Enum(e) => MoveLayoutView::Enum(MoveEnumLayout {
-                pool,
-                variants: &e.variants,
-            }),
-        },
     }
 }

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -44,7 +44,7 @@ pub(crate) enum MoveTypeNode {
     Enum(MoveEnumNode),
 }
 
-/// The backing store of compound layout nodes.
+/// The shared node table backing a [`MoveTypeLayout`].
 pub(crate) type MoveTypeLayoutPool = [MoveTypeNode];
 
 // --- Owned layout types ---
@@ -62,10 +62,18 @@ pub struct MoveTypeLayout {
     root: LayoutRef,
 }
 
-/// A resolved view of a layout node. Leaf types are unit variants;
-/// compound types contain owned layout types for direct navigation.
-#[derive(Debug, Clone)]
-pub enum MoveLayoutView {
+/// Borrowed compact runtime layout backed by an existing node pool.
+#[derive(Debug, Clone, Copy)]
+pub struct MoveTypeLayoutRef<'a> {
+    pool: &'a Arc<MoveTypeLayoutPool>,
+    root: LayoutRef,
+}
+
+// --- View types (all borrowed, Copy) ---
+
+/// A resolved view of a layout node.
+#[derive(Debug, Clone, Copy)]
+pub enum MoveLayoutView<'a> {
     Bool,
     U8,
     U16,
@@ -75,42 +83,36 @@ pub enum MoveLayoutView {
     U256,
     Address,
     Signer,
-    Vector(Box<MoveTypeLayout>),
-    Struct(Box<MoveStructLayout>),
-    Enum(Box<MoveEnumLayout>),
-}
-
-/// The layout of a Move datatype, which is either a struct or an enum.
-#[derive(Debug, Clone)]
-pub enum MoveDatatypeLayout {
-    Struct(Box<MoveStructLayout>),
-    Enum(Box<MoveEnumLayout>),
+    Vector(MoveTypeLayoutRef<'a>),
+    Struct(MoveStructLayout<'a>),
+    Enum(MoveEnumLayout<'a>),
 }
 
 /// The enum layout of an enum type, as a view into a shared pool.
-#[derive(Debug, Clone)]
-pub struct MoveEnumLayout {
-    pub(crate) variants: Box<[VariantLayout]>,
+#[derive(Debug, Clone, Copy)]
+pub struct MoveEnumLayout<'a> {
+    pool: &'a Arc<MoveTypeLayoutPool>,
+    variants: &'a [Option<Box<[LayoutRef]>>],
 }
 
 /// The struct layout of a struct type, as a view into a shared pool.
-#[derive(Debug, Clone)]
-pub struct MoveStructLayout(pub MoveFieldsLayout);
+#[derive(Debug, Clone, Copy)]
+pub struct MoveStructLayout<'a>(pub MoveFieldsLayout<'a>);
 
 /// The result of looking up a variant in an enum view.
-#[derive(Debug, Clone)]
-pub enum VariantLayout {
+#[derive(Debug, Clone, Copy)]
+pub enum VariantLayout<'a> {
     /// The variant's field layout is known.
-    Known(MoveFieldsLayout),
+    Known(MoveFieldsLayout<'a>),
     /// The variant exists but its field layout is not available.
     Unknown,
 }
 
 /// The field layout of a struct or enum variant, as a view into a shared pool.
-#[derive(Debug, Clone)]
-pub struct MoveFieldsLayout {
-    pool: Arc<MoveTypeLayoutPool>,
-    fields: Box<[LayoutRef]>,
+#[derive(Debug, Clone, Copy)]
+pub struct MoveFieldsLayout<'a> {
+    pool: &'a Arc<MoveTypeLayoutPool>,
+    fields: &'a [LayoutRef],
 }
 
 // --- Builder type ---
@@ -137,7 +139,7 @@ struct DebugAsDisplay<'a, T>(&'a T);
 impl MoveTypeLayout {
     /// Number of compound nodes in the table (excludes inline leaf types).
     pub fn node_count(&self) -> usize {
-        self.pool.len()
+        self.as_ref().node_count()
     }
 
     fn leaf(ty: LeafType) -> Self {
@@ -175,15 +177,23 @@ impl MoveTypeLayout {
         Self::leaf(LeafType::Signer)
     }
 
+    /// Borrow this layout without cloning the pool.
+    pub fn as_ref(&self) -> MoveTypeLayoutRef<'_> {
+        MoveTypeLayoutRef {
+            pool: &self.pool,
+            root: self.root,
+        }
+    }
+
     /// Create a resolved view for navigating this layout.
-    pub fn as_view(&self) -> MoveLayoutView {
-        resolve_ref(&self.pool, self.root)
+    pub fn as_view(&self) -> MoveLayoutView<'_> {
+        self.as_ref().as_view()
     }
 
     /// Reconstruct the equivalent tree-based layout. Returns an error
     /// if any enum variant has an unknown layout.
     pub fn inflate(&self) -> AResult<RV::MoveTypeLayout> {
-        self.as_view().inflate()
+        self.as_ref().inflate()
     }
 }
 
@@ -198,29 +208,62 @@ impl TryFrom<&RV::MoveTypeLayout> for MoveTypeLayout {
 
 impl fmt::Display for MoveTypeLayout {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.as_view() {
-            MoveLayoutView::Bool => write!(f, "bool"),
-            MoveLayoutView::U8 => write!(f, "u8"),
-            MoveLayoutView::U16 => write!(f, "u16"),
-            MoveLayoutView::U32 => write!(f, "u32"),
-            MoveLayoutView::U64 => write!(f, "u64"),
-            MoveLayoutView::U128 => write!(f, "u128"),
-            MoveLayoutView::U256 => write!(f, "u256"),
-            MoveLayoutView::Address => write!(f, "address"),
-            MoveLayoutView::Signer => write!(f, "signer"),
-            MoveLayoutView::Vector(vv) if f.alternate() => write!(f, "vector<{:#}>", vv),
-            MoveLayoutView::Vector(vv) => write!(f, "vector<{}>", vv),
-            MoveLayoutView::Struct(fv) if f.alternate() => write!(f, "{:#}", &*fv),
-            MoveLayoutView::Struct(fv) => write!(f, "{}", &*fv),
-            MoveLayoutView::Enum(ev) if f.alternate() => write!(f, "{ev:#}"),
-            MoveLayoutView::Enum(ev) => write!(f, "{ev}"),
+        if f.alternate() {
+            write!(f, "{:#}", self.as_ref())
+        } else {
+            write!(f, "{}", self.as_ref())
+        }
+    }
+}
+
+// --- MoveTypeLayoutRef (borrowed root) ---
+
+impl<'a> MoveTypeLayoutRef<'a> {
+    /// Clone the underlying `Arc` to produce an owned layout. Cheap — only a
+    /// refcount bump.
+    pub fn to_owned(self) -> MoveTypeLayout {
+        MoveTypeLayout {
+            pool: self.pool.clone(),
+            root: self.root,
+        }
+    }
+
+    /// Number of compound nodes in the table (excludes inline leaf types).
+    pub fn node_count(self) -> usize {
+        self.pool.len()
+    }
+
+    /// Create a resolved view for navigating this layout.
+    pub fn as_view(self) -> MoveLayoutView<'a> {
+        resolve_ref(self.pool, self.root)
+    }
+
+    /// Reconstruct the equivalent tree-based layout. Returns an error
+    /// if any enum variant has an unknown layout.
+    pub fn inflate(self) -> AResult<RV::MoveTypeLayout> {
+        self.as_view().inflate()
+    }
+}
+
+impl<'a> From<&'a MoveTypeLayout> for MoveTypeLayoutRef<'a> {
+    fn from(layout: &'a MoveTypeLayout) -> Self {
+        layout.as_ref()
+    }
+}
+
+impl fmt::Display for MoveTypeLayoutRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{:#}", self.as_view())
+        } else {
+            write!(f, "{}", self.as_view())
         }
     }
 }
 
 // --- MoveLayoutView ---
 
-impl MoveLayoutView {
+impl<'a> MoveLayoutView<'a> {
     /// Reconstruct the equivalent tree-based layout. Returns an error
     /// if any enum variant has an unknown layout.
     pub fn inflate(&self) -> AResult<RV::MoveTypeLayout> {
@@ -235,15 +278,14 @@ impl MoveLayoutView {
             MoveLayoutView::Address => RV::MoveTypeLayout::Address,
             MoveLayoutView::Signer => RV::MoveTypeLayout::Signer,
             MoveLayoutView::Vector(vv) => RV::MoveTypeLayout::Vector(Box::new(vv.inflate()?)),
-            MoveLayoutView::Struct(fv) => {
-                let fields = fv.0.fields().map(|f| f.inflate()).collect::<AResult<_>>()?;
+            MoveLayoutView::Struct(sv) => {
+                let fields = sv.0.fields().map(|f| f.inflate()).collect::<AResult<_>>()?;
                 RV::MoveTypeLayout::Struct(Box::new(RV::MoveStructLayout::new(fields)))
             }
             MoveLayoutView::Enum(ev) => {
                 let variants = ev
                     .variants()
-                    .iter()
-                    .map(|vfv| match vfv {
+                    .map(|vl| match vl {
                         VariantLayout::Known(fv) => {
                             fv.fields().map(|f| f.inflate()).collect::<AResult<_>>()
                         }
@@ -258,26 +300,48 @@ impl MoveLayoutView {
     }
 }
 
+impl fmt::Display for MoveLayoutView<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MoveLayoutView::Bool => write!(f, "bool"),
+            MoveLayoutView::U8 => write!(f, "u8"),
+            MoveLayoutView::U16 => write!(f, "u16"),
+            MoveLayoutView::U32 => write!(f, "u32"),
+            MoveLayoutView::U64 => write!(f, "u64"),
+            MoveLayoutView::U128 => write!(f, "u128"),
+            MoveLayoutView::U256 => write!(f, "u256"),
+            MoveLayoutView::Address => write!(f, "address"),
+            MoveLayoutView::Signer => write!(f, "signer"),
+            MoveLayoutView::Vector(vv) if f.alternate() => write!(f, "vector<{vv:#}>"),
+            MoveLayoutView::Vector(vv) => write!(f, "vector<{vv}>"),
+            MoveLayoutView::Struct(sv) if f.alternate() => write!(f, "{sv:#}"),
+            MoveLayoutView::Struct(sv) => write!(f, "{sv}"),
+            MoveLayoutView::Enum(ev) if f.alternate() => write!(f, "{ev:#}"),
+            MoveLayoutView::Enum(ev) => write!(f, "{ev}"),
+        }
+    }
+}
+
 // --- MoveFieldsLayout ---
 
-impl MoveFieldsLayout {
+impl<'a> MoveFieldsLayout<'a> {
     /// Number of fields.
-    pub fn field_count(&self) -> usize {
+    pub fn field_count(self) -> usize {
         self.fields.len()
     }
 
     /// Access a field by index.
-    pub fn field(&self, i: usize) -> Option<MoveTypeLayout> {
-        self.fields.get(i).map(|f| MoveTypeLayout {
-            pool: self.pool.clone(),
+    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a>> {
+        self.fields.get(i).map(|f| MoveTypeLayoutRef {
+            pool: self.pool,
             root: *f,
         })
     }
 
-    /// Iterate over all fields as layout views.
-    pub fn fields(&self) -> impl ExactSizeIterator<Item = MoveTypeLayout> {
-        self.fields.iter().map(move |f| MoveTypeLayout {
-            pool: self.pool.clone(),
+    /// Iterate over all fields as layouts.
+    pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a>> {
+        self.fields.iter().map(move |f| MoveTypeLayoutRef {
+            pool: self.pool,
             root: *f,
         })
     }
@@ -285,30 +349,30 @@ impl MoveFieldsLayout {
 
 // --- MoveStructLayout ---
 
-impl MoveStructLayout {
+impl<'a> MoveStructLayout<'a> {
     /// Number of fields.
-    pub fn field_count(&self) -> usize {
+    pub fn field_count(self) -> usize {
         self.0.field_count()
     }
 
     /// Access a field by index.
-    pub fn field(&self, i: usize) -> Option<MoveTypeLayout> {
+    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a>> {
         self.0.field(i)
     }
 
     /// Iterate over all fields as layouts.
-    pub fn fields(&self) -> impl ExactSizeIterator<Item = MoveTypeLayout> {
+    pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a>> {
         self.0.fields()
     }
 }
 
-impl fmt::Display for MoveStructLayout {
+impl fmt::Display for MoveStructLayout<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "struct {}", self.0)
     }
 }
 
-impl fmt::Display for MoveFieldsLayout {
+impl fmt::Display for MoveFieldsLayout<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use DebugAsDisplay as DD;
 
@@ -316,8 +380,8 @@ impl fmt::Display for MoveFieldsLayout {
         for (i, field) in self.fields.iter().enumerate() {
             map.entry(
                 &i,
-                &DD(&MoveTypeLayout {
-                    pool: self.pool.clone(),
+                &DD(&MoveTypeLayoutRef {
+                    pool: self.pool,
                     root: *field,
                 }),
             );
@@ -328,29 +392,46 @@ impl fmt::Display for MoveFieldsLayout {
 
 // --- MoveEnumLayout ---
 
-impl MoveEnumLayout {
+impl<'a> MoveEnumLayout<'a> {
     /// Number of variants.
-    pub fn variant_count(&self) -> usize {
+    pub fn variant_count(self) -> usize {
         self.variants.len()
     }
 
     /// Access a variant by index.
-    pub fn variant(&self, i: usize) -> Option<&VariantLayout> {
-        self.variants.get(i)
+    pub fn variant(self, i: usize) -> Option<VariantLayout<'a>> {
+        self.variants.get(i).map(|v| self.make_variant(v))
     }
 
     /// Iterate over all variants.
-    pub fn variants(&self) -> &[VariantLayout] {
-        &self.variants
+    pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a>> {
+        let pool = self.pool;
+        self.variants
+            .iter()
+            .map(move |v| make_variant_for_pool(pool, v))
+    }
+
+    fn make_variant(self, v: &'a Option<Box<[LayoutRef]>>) -> VariantLayout<'a> {
+        make_variant_for_pool(self.pool, v)
     }
 }
 
-impl fmt::Display for MoveEnumLayout {
+fn make_variant_for_pool<'a>(
+    pool: &'a Arc<MoveTypeLayoutPool>,
+    v: &'a Option<Box<[LayoutRef]>>,
+) -> VariantLayout<'a> {
+    match v {
+        Some(fields) => VariantLayout::Known(MoveFieldsLayout { pool, fields }),
+        None => VariantLayout::Unknown,
+    }
+}
+
+impl fmt::Display for MoveEnumLayout<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "enum ")?;
-        for (tag, vfv) in self.variants().iter().enumerate() {
+        for (tag, vl) in self.variants().enumerate() {
             write!(f, "variant_tag: {} {{ ", tag)?;
-            match vfv {
+            match vl {
                 VariantLayout::Known(fv) => {
                     for (i, field) in fv.fields().enumerate() {
                         write!(f, "{}: {}, ", i, field)?;
@@ -499,7 +580,7 @@ impl Default for MoveTypeLayoutBuilder {
 // Free functions
 // =============================================================================
 
-fn leaf_to_layout_view(leaf: LeafType) -> MoveLayoutView {
+fn leaf_to_layout_view<'a>(leaf: LeafType) -> MoveLayoutView<'a> {
     match leaf {
         LeafType::Bool => MoveLayoutView::Bool,
         LeafType::U8 => MoveLayoutView::U8,
@@ -516,36 +597,21 @@ fn leaf_to_layout_view(leaf: LeafType) -> MoveLayoutView {
 /// Resolve a [`LayoutRef`] against the pool into a [`MoveLayoutView`].
 ///
 /// Panics if the reference points to an out-of-bounds table index.
-fn resolve_ref(pool: &Arc<MoveTypeLayoutPool>, r: LayoutRef) -> MoveLayoutView {
+fn resolve_ref<'a>(pool: &'a Arc<MoveTypeLayoutPool>, r: LayoutRef) -> MoveLayoutView<'a> {
     match r.resolve() {
         ResolvedRef::Leaf(leaf) => leaf_to_layout_view(leaf),
         ResolvedRef::Index(idx) => match &pool[idx] {
-            MoveTypeNode::Vector(inner) => MoveLayoutView::Vector(Box::new(MoveTypeLayout {
-                pool: pool.clone(),
-                root: *inner,
-            })),
-            MoveTypeNode::Struct(s) => {
-                MoveLayoutView::Struct(Box::new(MoveStructLayout(MoveFieldsLayout {
-                    pool: pool.clone(),
-                    fields: s.fields.clone(),
-                })))
+            MoveTypeNode::Vector(inner) => {
+                MoveLayoutView::Vector(MoveTypeLayoutRef { pool, root: *inner })
             }
-            MoveTypeNode::Enum(e) => MoveLayoutView::Enum(Box::new(MoveEnumLayout {
-                variants: e
-                    .variants
-                    .iter()
-                    .map(|v| {
-                        v.as_ref().map(|fields| MoveFieldsLayout {
-                            pool: pool.clone(),
-                            fields: fields.clone(),
-                        })
-                    })
-                    .map(|v| match v {
-                        Some(fields) => VariantLayout::Known(fields),
-                        None => VariantLayout::Unknown,
-                    })
-                    .collect(),
+            MoveTypeNode::Struct(s) => MoveLayoutView::Struct(MoveStructLayout(MoveFieldsLayout {
+                pool,
+                fields: &s.fields,
             })),
+            MoveTypeNode::Enum(e) => MoveLayoutView::Enum(MoveEnumLayout {
+                pool,
+                variants: &e.variants,
+            }),
         },
     }
 }

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -249,6 +249,7 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     }
 
     /// Borrow this layout without cloning the pool.
+    #[inline]
     pub fn as_ref(&self) -> MoveTypeLayoutRef<'_, T> {
         MoveTypeLayoutRef {
             pool: &self.pool,
@@ -257,6 +258,7 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     }
 
     /// Create a resolved view for navigating this layout.
+    #[inline]
     pub fn as_view(&self) -> MoveLayoutView<'_, T> {
         self.as_ref().as_view()
     }
@@ -282,6 +284,7 @@ impl<T: TypeLayout> fmt::Display for MoveTypeLayout<T> {
 
 impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
     /// Construct a borrowed layout from a pool reference and a root reference.
+    #[inline]
     pub fn new(pool: &'a T, root: &'a T::Root) -> Self {
         MoveTypeLayoutRef { pool, root }
     }
@@ -304,6 +307,7 @@ impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
     }
 
     /// Create a resolved view for navigating this layout.
+    #[inline]
     pub fn as_view(self) -> MoveLayoutView<'a, T> {
         self.pool.realize_view(self.root)
     }
@@ -400,11 +404,13 @@ impl<T: TypeLayout> fmt::Display for MoveLayoutView<'_, T> {
 
 impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
     /// Number of fields.
+    #[inline]
     pub fn field_count(self) -> usize {
         self.fields.len()
     }
 
     /// Access a field by index.
+    #[inline]
     pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a, T>> {
         self.fields.get(i).map(|f| MoveTypeLayoutRef {
             pool: self.pool,
@@ -413,6 +419,7 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
     }
 
     /// Iterate over all fields as layouts.
+    #[inline]
     pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a, T>> {
         self.fields.iter().map(move |f| MoveTypeLayoutRef {
             pool: self.pool,
@@ -425,21 +432,25 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
 
 impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
     /// Access the fields layout.
+    #[inline]
     pub fn fields_layout(self) -> MoveFieldsLayout<'a, T> {
         self.fields
     }
 
     /// Number of fields.
+    #[inline]
     pub fn field_count(self) -> usize {
         self.fields.field_count()
     }
 
     /// Access a field by index.
+    #[inline]
     pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a, T>> {
         self.fields.field(i)
     }
 
     /// Iterate over all fields as layouts.
+    #[inline]
     pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a, T>> {
         self.fields.fields()
     }
@@ -473,22 +484,26 @@ impl<T: TypeLayout> fmt::Display for MoveFieldsLayout<'_, T> {
 
 impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
     /// Number of variants.
+    #[inline]
     pub fn variant_count(self) -> usize {
         self.variants.len()
     }
 
     /// Access a variant by index.
+    #[inline]
     pub fn variant(self, i: usize) -> Option<VariantLayout<'a, T>> {
         self.variants.get(i).map(|v| make_variant(self.pool, v))
     }
 
     /// Iterate over all variants.
+    #[inline]
     pub fn variants(self) -> impl ExactSizeIterator<Item = VariantLayout<'a, T>> {
         let pool = self.pool;
         self.variants.iter().map(move |v| make_variant(pool, v))
     }
 }
 
+#[inline]
 fn make_variant<'a, T: TypeLayout>(
     pool: &'a T,
     v: &'a Option<Box<[T::Root]>>,

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/mod.rs
@@ -4,4 +4,7 @@
 mod layout;
 mod serde_impl;
 
-pub use layout::*;
+pub use layout::{
+    BackendBuilder, MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout,
+    MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef, TypeLayout, VariantLayout,
+};

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/serde_impl.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/serde_impl.rs
@@ -18,6 +18,17 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
         self,
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
+        self.as_ref().deserialize(deserializer)
+    }
+}
+
+impl<'a, 'd> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a> {
+    type Value = MoveValue;
+
+    fn deserialize<D: serde::de::Deserializer<'d>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
         match self.as_view() {
             MoveLayoutView::Bool => bool::deserialize(deserializer).map(MoveValue::Bool),
             MoveLayoutView::U8 => u8::deserialize(deserializer).map(MoveValue::U8),
@@ -32,25 +43,25 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
             MoveLayoutView::Signer => {
                 AccountAddress::deserialize(deserializer).map(MoveValue::Signer)
             }
-            MoveLayoutView::Struct(fv) => {
+            MoveLayoutView::Struct(sv) => {
                 let fields = deserializer
-                    .deserialize_tuple(fv.field_count(), CompressedStructFieldVisitor(&fv.0))?;
+                    .deserialize_tuple(sv.field_count(), CompressedStructFieldVisitor(sv.0))?;
                 Ok(MoveValue::Struct(MoveStruct(fields)))
             }
             MoveLayoutView::Enum(ev) => {
-                let variant = deserializer.deserialize_tuple(2, CompressedEnumFieldVisitor(&ev))?;
+                let variant = deserializer.deserialize_tuple(2, CompressedEnumFieldVisitor(ev))?;
                 Ok(MoveValue::Variant(variant))
             }
             MoveLayoutView::Vector(vv) => Ok(MoveValue::Vector(
-                deserializer.deserialize_seq(CompressedVectorVisitor(&vv))?,
+                deserializer.deserialize_seq(CompressedVectorVisitor(vv))?,
             )),
         }
     }
 }
 
-struct CompressedVectorVisitor<'a>(&'a MoveTypeLayout);
+struct CompressedVectorVisitor<'a>(MoveTypeLayoutRef<'a>);
 
-impl<'d> serde::de::Visitor<'d> for CompressedVectorVisitor<'_> {
+impl<'a, 'd> serde::de::Visitor<'d> for CompressedVectorVisitor<'a> {
     type Value = Vec<MoveValue>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -69,9 +80,9 @@ impl<'d> serde::de::Visitor<'d> for CompressedVectorVisitor<'_> {
     }
 }
 
-struct CompressedStructFieldVisitor<'a>(&'a MoveFieldsLayout);
+struct CompressedStructFieldVisitor<'a>(MoveFieldsLayout<'a>);
 
-impl<'d> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'_> {
+impl<'a, 'd> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a> {
     type Value = Vec<MoveValue>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -84,7 +95,7 @@ impl<'d> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'_> {
     {
         let mut vals = Vec::new();
         for (i, field_view) in self.0.fields().enumerate() {
-            match seq.next_element_seed(&field_view)? {
+            match seq.next_element_seed(field_view)? {
                 Some(elem) => vals.push(elem),
                 None => return Err(A::Error::invalid_length(i, &self)),
             }
@@ -93,9 +104,9 @@ impl<'d> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'_> {
     }
 }
 
-struct CompressedEnumFieldVisitor<'a>(&'a MoveEnumLayout);
+struct CompressedEnumFieldVisitor<'a>(MoveEnumLayout<'a>);
 
-impl<'d> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'_> {
+impl<'a, 'd> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a> {
     type Value = MoveVariant;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -130,9 +141,9 @@ impl<'d> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'_> {
     }
 }
 
-struct CompressedVariantFieldSeed<'a>(&'a MoveFieldsLayout);
+struct CompressedVariantFieldSeed<'a>(MoveFieldsLayout<'a>);
 
-impl<'d> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'_> {
+impl<'a, 'd> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'a> {
     type Value = Vec<MoveValue>;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/serde_impl.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/serde_impl.rs
@@ -8,10 +8,10 @@ use crate::{VARIANT_TAG_MAX_VALUE, account_address::AccountAddress, u256};
 use serde::{Deserialize, de::Error as _};
 
 // -------------------------------------------------------------------------
-// Deserialization — DeserializeSeed for &MoveLayoutView
+// Deserialization — DeserializeSeed for MoveTypeLayoutRef / &MoveTypeLayout
 // -------------------------------------------------------------------------
 
-impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
+impl<'d, T: TypeLayout> serde::de::DeserializeSeed<'d> for &MoveTypeLayout<T> {
     type Value = MoveValue;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(
@@ -22,7 +22,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
     }
 }
 
-impl<'a, 'd> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a, T> {
     type Value = MoveValue;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(
@@ -45,7 +45,7 @@ impl<'a, 'd> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a> {
             }
             MoveLayoutView::Struct(sv) => {
                 let fields = deserializer
-                    .deserialize_tuple(sv.field_count(), CompressedStructFieldVisitor(sv.0))?;
+                    .deserialize_tuple(sv.field_count(), CompressedStructFieldVisitor(sv.fields))?;
                 Ok(MoveValue::Struct(MoveStruct(fields)))
             }
             MoveLayoutView::Enum(ev) => {
@@ -59,9 +59,9 @@ impl<'a, 'd> serde::de::DeserializeSeed<'d> for MoveTypeLayoutRef<'a> {
     }
 }
 
-struct CompressedVectorVisitor<'a>(MoveTypeLayoutRef<'a>);
+struct CompressedVectorVisitor<'a, T: TypeLayout>(MoveTypeLayoutRef<'a, T>);
 
-impl<'a, 'd> serde::de::Visitor<'d> for CompressedVectorVisitor<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedVectorVisitor<'a, T> {
     type Value = Vec<MoveValue>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -80,9 +80,9 @@ impl<'a, 'd> serde::de::Visitor<'d> for CompressedVectorVisitor<'a> {
     }
 }
 
-struct CompressedStructFieldVisitor<'a>(MoveFieldsLayout<'a>);
+struct CompressedStructFieldVisitor<'a, T: TypeLayout>(MoveFieldsLayout<'a, T>);
 
-impl<'a, 'd> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a, T> {
     type Value = Vec<MoveValue>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -104,9 +104,9 @@ impl<'a, 'd> serde::de::Visitor<'d> for CompressedStructFieldVisitor<'a> {
     }
 }
 
-struct CompressedEnumFieldVisitor<'a>(MoveEnumLayout<'a>);
+struct CompressedEnumFieldVisitor<'a, T: TypeLayout>(MoveEnumLayout<'a, T>);
 
-impl<'a, 'd> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a, T> {
     type Value = MoveVariant;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -141,9 +141,9 @@ impl<'a, 'd> serde::de::Visitor<'d> for CompressedEnumFieldVisitor<'a> {
     }
 }
 
-struct CompressedVariantFieldSeed<'a>(MoveFieldsLayout<'a>);
+struct CompressedVariantFieldSeed<'a, T: TypeLayout>(MoveFieldsLayout<'a, T>);
 
-impl<'a, 'd> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'a> {
+impl<'a, 'd, T: TypeLayout> serde::de::DeserializeSeed<'d> for CompressedVariantFieldSeed<'a, T> {
     type Value = Vec<MoveValue>;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(

--- a/external-crates/move/crates/move-core-types/src/unit_tests/compressed_layout_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/compressed_layout_test.rs
@@ -4,6 +4,8 @@
 use crate::{
     account_address::AccountAddress,
     annotated_value::{self as A, compressed_layouts as AC},
+    compressed::annotated::BackendBuilder as _,
+    compressed::runtime::BackendBuilder as _,
     ident_str,
     identifier::Identifier,
     language_storage::StructTag,
@@ -872,4 +874,68 @@ fn annotated_deser_parity_vector() {
         A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::Struct(Box::new(struct_layout))));
     let blob = bcs::to_bytes(&vec![(1u8,), (2u8,)]).unwrap();
     assert_annotated_deser_parity(&vec_struct_layout, &blob);
+}
+
+// =============================================================================
+// BoxPool backend: build/inflate/deserialize parity vs ArcPool
+// =============================================================================
+
+#[test]
+fn runtime_box_pool_build_inflate_deserialize() {
+    use crate::compressed::backend::box_pool::{RuntimeBoxPool, RuntimeBoxPoolBuilder};
+
+    // enum { V0(u64), V1(bool, u64) }
+    let layout = R::MoveTypeLayout::Enum(Box::new(R::MoveEnumLayout(Box::new(vec![
+        vec![R::MoveTypeLayout::U64],
+        vec![R::MoveTypeLayout::Bool, R::MoveTypeLayout::U64],
+    ]))));
+
+    // Build via the BoxPool builder directly.
+    let mut b = RuntimeBoxPoolBuilder::default();
+    let root = b.intern_tree(&layout).unwrap();
+    let box_layout: RC::MoveTypeLayout<RuntimeBoxPool> = b.build(root);
+
+    // Inflate parity with the original tree.
+    let inflated = box_layout.inflate().unwrap();
+    assert_eq!(format!("{inflated}"), format!("{layout}"));
+
+    // node_count agrees with the ArcPool roundtrip on the same layout.
+    let arc_layout = RC::MoveTypeLayout::try_from(&layout).unwrap();
+    assert_eq!(box_layout.node_count(), arc_layout.node_count());
+
+    // Deserialization parity: a BCS-encoded variant decodes to the same value
+    // through both backends.
+    let blob = bcs::to_bytes(&(1u8, (true, 7u64))).unwrap();
+    let v_box: R::MoveValue = bcs::from_bytes_seed(&box_layout, &blob).unwrap();
+    let v_arc: R::MoveValue = bcs::from_bytes_seed(&arc_layout, &blob).unwrap();
+    assert_eq!(v_box, v_arc);
+}
+
+#[test]
+fn annotated_box_pool_build_inflate_deserialize() {
+    use crate::compressed::backend::box_pool::{AnnotatedBoxPool, AnnotatedBoxPoolBuilder};
+
+    let struct_layout = A::MoveStructLayout {
+        type_: test_struct_tag("Item"),
+        fields: vec![
+            A::MoveFieldLayout::new(ident_str!("x").to_owned(), A::MoveTypeLayout::U8),
+            A::MoveFieldLayout::new(ident_str!("y").to_owned(), A::MoveTypeLayout::U64),
+        ],
+    };
+    let layout = A::MoveTypeLayout::Struct(Box::new(struct_layout));
+
+    let mut b = AnnotatedBoxPoolBuilder::default();
+    let root = b.intern_tree(&layout).unwrap();
+    let box_layout: AC::MoveTypeLayout<AnnotatedBoxPool> = b.build(root);
+
+    let inflated = box_layout.inflate().unwrap();
+    assert_eq!(format!("{inflated}"), format!("{layout}"));
+
+    let arc_layout = AC::MoveTypeLayout::try_from(&layout).unwrap();
+    assert_eq!(box_layout.node_count(), arc_layout.node_count());
+
+    let blob = bcs::to_bytes(&(9u8, 123u64)).unwrap();
+    let v_box: A::MoveValue = bcs::from_bytes_seed(&box_layout, &blob).unwrap();
+    let v_arc: A::MoveValue = bcs::from_bytes_seed(&arc_layout, &blob).unwrap();
+    assert_eq!(v_box, v_arc);
 }


### PR DESCRIPTION
## Description 

The key things are:
1. The core structure in terms of usage is the ref-based layout
2. After discussions with @cgswords the type layouts are now parametrized by the data "backend" (i.e., a specific representation of the data). The type layouts provide a uniform interface for building/inspecting/using these layouts. There is a default backend (Arc-based) but there is also a box-based backend (but we could likewise go for an Arc-tree, or arena-based ones if we wanted to). 


I'm not 100% happy with the organization of the `backend` dir so would love any suggestions there -- I've tried a bunch of different possible options and disliked them all :'(


## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
