### PR TITLE
Deduplicate bitmap scans

### DIFF
--- a/crates/sui-inverted-index/src/bitmap_query/iter.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/iter.rs
@@ -25,18 +25,20 @@ use roaring::RoaringBitmap;
 
 use super::BitmapBucketIteratorSource;
 use super::BitmapQuery;
-use super::BucketItem;
+use super::DedupedQuery;
 use super::LeafHead;
 use super::MultiError;
 use super::ScanDirection;
-use super::TermSpec;
 use super::Watermarked;
 use super::WatermarkedBucket;
 use super::bound_in_direction;
 use super::bucket_edges;
+use super::build_term_specs;
+use super::count_on_floor_refs;
 use super::eval_term_at_bucket;
 use super::frontier_advanced;
-use super::split_term_literals;
+use super::recompute_unreferenced;
+use super::take_snapshot_bitmap;
 
 /// Evaluate a DNF `BitmapQuery` as an ordered iterator of marked bucket bitmaps.
 /// Output emits `Watermarked::Item((bucket_id, bitmap))` interleaved with
@@ -51,36 +53,22 @@ pub fn eval_bitmap_query_bucket_iter<'a, S>(
 where
     S: BitmapBucketIteratorSource<'a>,
 {
-    // One peekable leaf per literal; terms reference them by index. Each leaf
-    // iterator borrows the backend's `'a` store, not `source`, so the thin
-    // `source` handle is dropped once the leaves are built.
-    let mut leaves: Vec<IterPeekable<S::Iter>> = Vec::new();
-    let mut terms: Vec<TermSpec> = Vec::new();
-    for term in query.terms {
-        let (includes, excludes) = split_term_literals(term);
-        let mut include_idx = Vec::with_capacity(includes.len());
-        for key in includes {
-            include_idx.push(leaves.len());
-            leaves.push(
-                source
-                    .scan_bucket_iter(key, range.clone(), direction)
-                    .peekable(),
-            );
-        }
-        let mut exclude_idx = Vec::with_capacity(excludes.len());
-        for key in excludes {
-            exclude_idx.push(leaves.len());
-            leaves.push(
-                source
-                    .scan_bucket_iter(key, range.clone(), direction)
-                    .peekable(),
-            );
-        }
-        terms.push(TermSpec {
-            includes: include_idx,
-            excludes: exclude_idx,
-            dead: false,
-        });
+    // One peekable leaf per *unique* dimension key — terms reference them by
+    // index. Identical keys across literals share a single backend scan; see
+    // [`build_term_specs`]. Each leaf iterator borrows the backend's `'a`
+    // store, not `source`, so the thin `source` handle is dropped once the
+    // leaves are built.
+    let DedupedQuery {
+        keys: unique_keys,
+        mut terms,
+    } = build_term_specs(query.terms);
+    let mut leaves: Vec<IterPeekable<S::Iter>> = Vec::with_capacity(unique_keys.len());
+    for key in unique_keys {
+        leaves.push(
+            source
+                .scan_bucket_iter(key, range.clone(), direction)
+                .peekable(),
+        );
     }
 
     let leaf_count = leaves.len();
@@ -94,8 +82,9 @@ where
     } else {
         range.end
     };
-    // `gone[i]`: leaf retired (its term died or it is a spent exclude).
-    let mut gone = vec![false; leaf_count];
+    // `unreferenced[i]`: leaf is retired — either no satisfiable term still
+    // points at it, or its bucket stream is at EOF (a spent exclude).
+    let mut unreferenced = vec![false; leaf_count];
     // `front[i]`: clamped position each leaf has provably scanned to. Bounds the
     // resume cursor when a leaf errors before it can advance.
     let mut front = vec![request_floor; leaf_count];
@@ -116,7 +105,7 @@ where
             // position it has now scanned to.
             let mut class: Vec<Option<LeafHead>> = (0..leaf_count).map(|_| None).collect();
             for i in 0..leaf_count {
-                if gone[i] {
+                if unreferenced[i] {
                     continue;
                 }
                 match leaves[i].peek() {
@@ -135,38 +124,29 @@ where
                 }
             }
 
-            // An include at EOF kills its term (the intersection is permanently
-            // empty); drop all of that term's leaves so they stop being polled.
+            // An include at EOF makes its term unsatisfiable (the intersection
+            // is permanently empty). With dedup, an EOF'd leaf may be an
+            // include for several terms; all of them become unsatisfiable.
             for term in terms.iter_mut() {
-                if !term.dead
+                if !term.unsatisfiable
                     && term
                         .includes
                         .iter()
                         .any(|&i| matches!(class[i], Some(LeafHead::Eof)))
                 {
-                    term.dead = true;
+                    term.unsatisfiable = true;
                 }
             }
-            for term in &terms {
-                if term.dead {
-                    for &i in term.includes.iter().chain(term.excludes.iter()) {
-                        gone[i] = true;
-                    }
-                } else {
-                    // A spent exclude just stops contributing subtractions.
-                    for &i in &term.excludes {
-                        if matches!(class[i], Some(LeafHead::Eof)) {
-                            gone[i] = true;
-                        }
-                    }
-                }
-            }
+            // Recompute leaf liveness from current term state. A leaf may be
+            // shared across terms (include for one, exclude for another), so it
+            // can only be retired when no satisfiable term still references it.
+            recompute_unreferenced(&terms, &class, &mut unreferenced);
 
             // Consume any budget-error frame so the error surfaces (after the
             // floor watermark below).
             let mut errors: Vec<anyhow::Error> = Vec::new();
             for i in 0..leaf_count {
-                if !gone[i] && matches!(class[i], Some(LeafHead::Error)) {
+                if !unreferenced[i] && matches!(class[i], Some(LeafHead::Error)) {
                     match leaves[i].next() {
                         Some(Err(e)) => errors.push(e),
                         _ => unreachable!("peek classified Error"),
@@ -174,7 +154,7 @@ where
                 }
             }
 
-            let active: Vec<usize> = (0..leaf_count).filter(|&i| !gone[i]).collect();
+            let active: Vec<usize> = (0..leaf_count).filter(|&i| !unreferenced[i]).collect();
             if active.is_empty() {
                 // Every term retired naturally: cap the scan at the range
                 // terminus so the client learns it covered the whole range.
@@ -219,27 +199,46 @@ where
                 .expect("active leaves carry buckets when there is no error");
             let (_pre, post) = bucket_edges(floor_bucket, bucket_size, &range, direction);
 
+            // Snapshot the bitmaps of leaves sitting on `floor_bucket` —
+            // each unique leaf consumed exactly once — then distribute to
+            // every referencing term. See [`build_term_specs`] for why
+            // dedup matters: a leaf shared across terms can only be
+            // pulled once before its iterator moves on.
+            let mut snapshot: Vec<Option<RoaringBitmap>> = (0..leaf_count).map(|_| None).collect();
+            let mut on_floor = vec![false; leaf_count];
+            for i in 0..leaf_count {
+                if !unreferenced[i]
+                    && matches!(class[i], Some(LeafHead::Bucket(b)) if b == floor_bucket)
+                {
+                    on_floor[i] = true;
+                    front[i] = post;
+                    snapshot[i] = match leaves[i].next() {
+                        Some(Ok((_, bitmap))) => Some(bitmap),
+                        _ => None,
+                    };
+                }
+            }
+            let mut remaining_refs = count_on_floor_refs(&terms, &on_floor);
+
             let mut result: Option<RoaringBitmap> = None;
             for term in &terms {
-                if term.dead {
+                if term.unsatisfiable {
                     continue;
                 }
-                let includes = take_term_side(
-                    &term.includes,
-                    floor_bucket,
-                    post,
-                    &class,
-                    &mut front,
-                    &mut leaves,
-                );
-                let excludes = take_term_side(
-                    &term.excludes,
-                    floor_bucket,
-                    post,
-                    &class,
-                    &mut front,
-                    &mut leaves,
-                );
+                let includes: Vec<Option<RoaringBitmap>> = term
+                    .includes
+                    .iter()
+                    .map(|&i| {
+                        take_snapshot_bitmap(&mut snapshot, &mut remaining_refs, &on_floor, i)
+                    })
+                    .collect();
+                let excludes: Vec<Option<RoaringBitmap>> = term
+                    .excludes
+                    .iter()
+                    .map(|&i| {
+                        take_snapshot_bitmap(&mut snapshot, &mut remaining_refs, &on_floor, i)
+                    })
+                    .collect();
                 if let Some(bitmap) = eval_term_at_bucket(includes, excludes) {
                     result = Some(match result {
                         None => bitmap,
@@ -257,36 +256,6 @@ where
             }
         }
     })
-}
-
-/// Gather one term side's bitmaps at `floor_bucket`, consuming the leaves that
-/// sit there (and advancing their `front` to the bucket's trailing edge) and
-/// recording `None` for leaves that sit on a later bucket.
-fn take_term_side<I>(
-    indices: &[usize],
-    floor_bucket: u64,
-    post: u64,
-    class: &[Option<LeafHead>],
-    front: &mut [u64],
-    leaves: &mut [IterPeekable<I>],
-) -> Vec<Option<RoaringBitmap>>
-where
-    I: Iterator<Item = BucketItem>,
-{
-    indices
-        .iter()
-        .map(|&i| {
-            if matches!(class[i], Some(LeafHead::Bucket(b)) if b == floor_bucket) {
-                front[i] = post;
-                match leaves[i].next() {
-                    Some(Ok((_, bitmap))) => Some(bitmap),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -346,6 +315,44 @@ mod tests {
         let out = items_only(&collect_marked(out));
 
         assert_eq!(out, vec![(0, vec![2]), (1, vec![5])]);
+    }
+
+    /// Two terms share the same include `a`. The iter evaluator must collapse
+    /// them to a single backend scan and distribute its per-bucket bitmap to
+    /// both terms. Mirrors the stream-side
+    /// `shared_include_across_terms_scans_dimension_once` test so the dedup
+    /// invariant is exercised on both evaluators.
+    #[test]
+    fn shared_include_across_terms_scans_dimension_once() {
+        use crate::bitmap_query::test_utils::CountingBucketSource;
+
+        let source = CountingBucketSource::new(BTreeMap::from([
+            (test_key(b"a"), vec![(0, vec![1, 2, 3])]),
+            (test_key(b"b"), vec![(0, vec![1])]),
+            (test_key(b"c"), vec![(0, vec![2])]),
+        ]));
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), include(b"b")]).unwrap(),
+            BitmapTerm::new(vec![include(b"a"), include(b"c")]).unwrap(),
+        ])
+        .unwrap();
+
+        let out = items_only(&collect_marked(
+            eval_bitmap_query_bucket_iter(
+                source.clone(),
+                query,
+                0..200_000,
+                BUCKET_SIZE,
+                ScanDirection::Ascending,
+            )
+            .collect(),
+        ));
+
+        // Bucket 0: term1 = a∩b = {1}; term2 = a∩c = {2}; union = {1, 2}.
+        assert_eq!(out, vec![(0, vec![1, 2])]);
+        assert_eq!(source.scan_count(&test_key(b"a")), 1);
+        assert_eq!(source.scan_count(&test_key(b"b")), 1);
+        assert_eq!(source.scan_count(&test_key(b"c")), 1);
     }
 
     /// The iterator evaluator must produce the exact same `Watermarked` sequence

--- a/crates/sui-inverted-index/src/bitmap_query/mod.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/mod.rs
@@ -25,6 +25,8 @@
 //! source is sparse, ordered by the requested scan direction, and stores bitmap
 //! positions relative to that bucket.
 
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ops::Range;
 
 use anyhow::Result;
@@ -257,6 +259,12 @@ impl BitmapLiteral {
     pub fn exclude(dimension_key: Vec<u8>) -> Result<Self> {
         Ok(Self::Exclude(BitmapKey::new(dimension_key)?))
     }
+
+    pub(crate) fn key_bytes(&self) -> &[u8] {
+        match self {
+            BitmapLiteral::Include(k) | BitmapLiteral::Exclude(k) => k.as_bytes(),
+        }
+    }
 }
 
 impl BitmapQuery {
@@ -275,11 +283,17 @@ impl BitmapQuery {
         })
     }
 
-    /// Total leaf literal count across every term. The per-request
-    /// budget must be at least this many so every leaf can emit its
-    /// first watermark.
-    pub fn leaf_count(&self) -> usize {
-        self.terms.iter().map(|t| t.literals.len()).sum()
+    /// Count of distinct dimension-key leaves the query will scan. Identical
+    /// keys across literals (whether within a term or across terms) collapse
+    /// to one leaf at evaluation time, so the per-request budget floor —
+    /// "every leaf can emit its first watermark" — applies to this
+    /// deduplicated count, not the raw literal total.
+    pub fn unique_leaf_count(&self) -> usize {
+        self.terms
+            .iter()
+            .flat_map(|t| t.literals.iter().map(|l| l.key_bytes()))
+            .collect::<HashSet<_>>()
+            .len()
     }
 }
 
@@ -295,16 +309,50 @@ impl BitmapTerm {
     }
 }
 
-fn split_term_literals(term: BitmapTerm) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
-    let mut include = Vec::new();
-    let mut exclude = Vec::new();
-    for literal in term.literals {
-        match literal {
-            BitmapLiteral::Include(key) => include.push(key.into_inner()),
-            BitmapLiteral::Exclude(key) => exclude.push(key.into_inner()),
+/// Deduplicated leaf list + per-term references over those leaves, ready for
+/// the evaluator. `keys[i]` is the dimension-key bytes for leaf `i`; each
+/// [`TermSpec`] references leaves by that index.
+pub(crate) struct DedupedQuery {
+    pub(crate) keys: Vec<Vec<u8>>,
+    pub(crate) terms: Vec<TermSpec>,
+}
+
+/// Deduplicate literals across the whole query and translate each term's
+/// includes/excludes into indices over the shared leaf list.
+///
+/// Dedup is keyed on encoded dimension-key bytes, so the same key appearing
+/// in multiple terms (e.g. `(sender=A AND module=X) OR (sender=A AND
+/// type=Y)`) maps to a single backend scan instead of two duplicate scans.
+pub(crate) fn build_term_specs(terms: Vec<BitmapTerm>) -> DedupedQuery {
+    let mut key_to_idx: HashMap<Vec<u8>, usize> = HashMap::new();
+    let mut keys: Vec<Vec<u8>> = Vec::new();
+    let mut specs: Vec<TermSpec> = Vec::with_capacity(terms.len());
+    for term in terms {
+        let mut include_idx = Vec::with_capacity(term.literals.len());
+        let mut exclude_idx = Vec::with_capacity(term.literals.len());
+        for literal in term.literals {
+            let (push_target, key) = match literal {
+                BitmapLiteral::Include(k) => (&mut include_idx, k.into_inner()),
+                BitmapLiteral::Exclude(k) => (&mut exclude_idx, k.into_inner()),
+            };
+            let idx = match key_to_idx.get(&key) {
+                Some(&i) => i,
+                None => {
+                    let i = keys.len();
+                    key_to_idx.insert(key.clone(), i);
+                    keys.push(key);
+                    i
+                }
+            };
+            push_target.push(idx);
         }
+        specs.push(TermSpec {
+            includes: include_idx,
+            excludes: exclude_idx,
+            unsatisfiable: false,
+        });
     }
-    (include, exclude)
+    DedupedQuery { keys, terms: specs }
 }
 
 /// The less-advanced of two frontier positions in scan direction: the min
@@ -350,6 +398,79 @@ pub(crate) fn bucket_edges(
     }
 }
 
+/// Pull the snapshotted bitmap for leaf `i` to give to one referencing term
+/// this round. Returns `None` if the leaf isn't on the floor bucket (so the
+/// term short-circuits). When `remaining_refs[i] > 1`, the bitmap is cloned so
+/// other referencing terms still see it; the last reference takes by value to
+/// avoid an unnecessary copy in the common single-reference case.
+pub(crate) fn take_snapshot_bitmap(
+    snapshot: &mut [Option<RoaringBitmap>],
+    remaining_refs: &mut [usize],
+    on_floor: &[bool],
+    i: usize,
+) -> Option<RoaringBitmap> {
+    if !on_floor[i] {
+        return None;
+    }
+    if remaining_refs[i] > 1 {
+        remaining_refs[i] -= 1;
+        snapshot[i].clone()
+    } else {
+        remaining_refs[i] = remaining_refs[i].saturating_sub(1);
+        snapshot[i].take()
+    }
+}
+
+/// Per-round refcount: how many satisfiable term-side slots reference each
+/// on-floor leaf. Drives [`take_snapshot_bitmap`]'s take-vs-clone decision so
+/// the last referencing slot reclaims the bitmap by value.
+pub(crate) fn count_on_floor_refs(terms: &[TermSpec], on_floor: &[bool]) -> Vec<usize> {
+    let mut refs = vec![0usize; on_floor.len()];
+    for term in terms {
+        if term.unsatisfiable {
+            continue;
+        }
+        for &i in term.includes.iter().chain(term.excludes.iter()) {
+            if on_floor[i] {
+                refs[i] += 1;
+            }
+        }
+    }
+    refs
+}
+
+/// Recompute leaf liveness from current term state. A leaf becomes
+/// `unreferenced` when no satisfiable term still points at it, or when its
+/// head is at EOF (the bucket stream is permanently exhausted; any further
+/// peek would be wasted work, and any include-referencing term will be marked
+/// `unsatisfiable` separately).
+///
+/// `unreferenced` is monotonic — entries only transition false → true — so
+/// this is safe to invoke each round; previously-retired leaves stay retired.
+pub(crate) fn recompute_unreferenced(
+    terms: &[TermSpec],
+    class: &[Option<LeafHead>],
+    unreferenced: &mut [bool],
+) {
+    let leaf_count = unreferenced.len();
+    let mut referenced = vec![false; leaf_count];
+    for term in terms {
+        if term.unsatisfiable {
+            continue;
+        }
+        for &i in term.includes.iter().chain(term.excludes.iter()) {
+            if !unreferenced[i] && !matches!(class[i], Some(LeafHead::Eof)) {
+                referenced[i] = true;
+            }
+        }
+    }
+    for i in 0..leaf_count {
+        if !referenced[i] {
+            unreferenced[i] = true;
+        }
+    }
+}
+
 /// Evaluate one DNF term at a single bucket from the per-leaf bitmaps present
 /// there: intersect the includes (any absent include ⇒ empty term), then
 /// subtract the union of the present excludes (`a AND NOT b`). Returns the
@@ -381,9 +502,9 @@ pub(crate) fn eval_term_at_bucket(
 pub(crate) struct TermSpec {
     pub(crate) includes: Vec<usize>,
     pub(crate) excludes: Vec<usize>,
-    /// Set once any include leaf hits EOF: the intersection can never match
-    /// again, so the whole term is retired and its leaves dropped.
-    pub(crate) dead: bool,
+    /// Set once any include leaf hits EOF: the term's intersection is
+    /// permanently empty (it can never match again). Latched.
+    pub(crate) unsatisfiable: bool,
 }
 
 /// A leaf's head this round, from a non-consuming peek.
@@ -394,21 +515,23 @@ pub(crate) enum LeafHead {
 }
 
 #[cfg(test)]
-mod test_utils {
+pub(crate) mod test_utils {
     use std::collections::BTreeMap;
+    use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::Mutex;
 
     use futures::StreamExt;
     use futures::stream;
 
     use super::*;
 
-    pub(super) const BUCKET_SIZE: u64 = 100_000;
-    pub(super) type TestBuckets = BTreeMap<Vec<u8>, Vec<(u64, Vec<u32>)>>;
+    pub(crate) const BUCKET_SIZE: u64 = 100_000;
+    pub(crate) type TestBuckets = BTreeMap<Vec<u8>, Vec<(u64, Vec<u32>)>>;
 
     #[derive(Clone)]
-    pub(super) struct TestBucketSource {
-        pub(super) buckets: Arc<TestBuckets>,
+    pub(crate) struct TestBucketSource {
+        pub(crate) buckets: Arc<TestBuckets>,
     }
 
     impl BitmapBucketSource for TestBucketSource {
@@ -436,7 +559,7 @@ mod test_utils {
     }
 
     impl TestBucketSource {
-        pub(super) fn bucket_items(
+        pub(crate) fn bucket_items(
             &self,
             dimension_key: &[u8],
             direction: ScanDirection,
@@ -452,7 +575,7 @@ mod test_utils {
         }
     }
 
-    pub(super) fn make_bitmap(bits: &[u32]) -> RoaringBitmap {
+    pub(crate) fn make_bitmap(bits: &[u32]) -> RoaringBitmap {
         let mut bm = RoaringBitmap::new();
         for &b in bits {
             bm.insert(b);
@@ -460,15 +583,89 @@ mod test_utils {
         bm
     }
 
-    pub(super) fn test_key(value: &[u8]) -> Vec<u8> {
+    pub(crate) fn test_key(value: &[u8]) -> Vec<u8> {
         crate::dimensions::encode_dimension_key(crate::dimensions::IndexDimension::Sender, value)
     }
 
-    pub(super) fn include(value: &[u8]) -> BitmapLiteral {
+    pub(crate) fn include(value: &[u8]) -> BitmapLiteral {
         BitmapLiteral::include(test_key(value)).unwrap()
     }
 
-    pub(super) fn exclude(value: &[u8]) -> BitmapLiteral {
+    /// A `TestBucketSource` that records how many times `scan_bucket_*` is
+    /// invoked per dimension key. Used to verify the evaluator deduplicates
+    /// leaves across terms (a key referenced from multiple terms should be
+    /// scanned exactly once).
+    #[derive(Clone)]
+    pub(crate) struct CountingBucketSource {
+        pub(crate) buckets: Arc<TestBuckets>,
+        scan_counts: Arc<Mutex<HashMap<Vec<u8>, usize>>>,
+    }
+
+    impl CountingBucketSource {
+        pub(crate) fn new(buckets: TestBuckets) -> Self {
+            Self {
+                buckets: Arc::new(buckets),
+                scan_counts: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        pub(crate) fn scan_count(&self, key: &[u8]) -> usize {
+            self.scan_counts
+                .lock()
+                .unwrap()
+                .get(key)
+                .copied()
+                .unwrap_or(0)
+        }
+
+        fn record(&self, key: &[u8]) {
+            *self
+                .scan_counts
+                .lock()
+                .unwrap()
+                .entry(key.to_vec())
+                .or_insert(0) += 1;
+        }
+
+        fn bucket_items(&self, dimension_key: &[u8], direction: ScanDirection) -> Vec<BucketItem> {
+            let mut buckets = self.buckets.get(dimension_key).cloned().unwrap_or_default();
+            if matches!(direction, ScanDirection::Descending) {
+                buckets.reverse();
+            }
+            buckets
+                .into_iter()
+                .map(|(bucket_id, bits)| Ok((bucket_id, make_bitmap(&bits))))
+                .collect()
+        }
+    }
+
+    impl BitmapBucketSource for CountingBucketSource {
+        fn scan_bucket_stream(
+            &self,
+            dimension_key: Vec<u8>,
+            _range: Range<u64>,
+            direction: ScanDirection,
+        ) -> BucketStream {
+            self.record(&dimension_key);
+            stream::iter(self.bucket_items(&dimension_key, direction)).boxed()
+        }
+    }
+
+    impl<'a> BitmapBucketIteratorSource<'a> for CountingBucketSource {
+        type Iter = std::vec::IntoIter<BucketItem>;
+
+        fn scan_bucket_iter(
+            &self,
+            dimension_key: Vec<u8>,
+            _range: Range<u64>,
+            direction: ScanDirection,
+        ) -> Self::Iter {
+            self.record(&dimension_key);
+            self.bucket_items(&dimension_key, direction).into_iter()
+        }
+    }
+
+    pub(crate) fn exclude(value: &[u8]) -> BitmapLiteral {
         BitmapLiteral::exclude(test_key(value)).unwrap()
     }
 }
@@ -476,6 +673,7 @@ mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::test_utils::exclude;
+    use super::test_utils::include;
     use super::*;
 
     #[test]
@@ -488,5 +686,37 @@ mod tests {
         );
         assert!(BitmapLiteral::include(vec![0xff, 0x00]).is_err());
         assert!(BitmapTerm::new(vec![exclude(b"neg")]).is_err());
+    }
+
+    #[test]
+    fn unique_leaf_count_counts_distinct_keys_across_terms() {
+        // Two terms both include `a` and `b`; only `c` is unique to term 1
+        // and `d` to term 2. The raw literal count is 6, but only 4 unique
+        // dimension keys are scanned at eval time.
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), include(b"b"), include(b"c")]).unwrap(),
+            BitmapTerm::new(vec![include(b"a"), include(b"b"), include(b"d")]).unwrap(),
+        ])
+        .unwrap();
+        assert_eq!(query.unique_leaf_count(), 4);
+    }
+
+    #[test]
+    fn build_term_specs_collapses_duplicate_keys_to_one_leaf() {
+        // Same key used as include in one term and exclude in another should
+        // share a single leaf slot, with each term referring to it by the
+        // same index.
+        let terms = vec![
+            BitmapTerm::new(vec![include(b"a"), include(b"b")]).unwrap(),
+            BitmapTerm::new(vec![include(b"b"), exclude(b"a")]).unwrap(),
+        ];
+        let DedupedQuery { keys, terms: specs } = build_term_specs(terms);
+        assert_eq!(keys.len(), 2, "only `a` and `b` are unique");
+        // Term 0: include a (slot 0), include b (slot 1).
+        assert_eq!(specs[0].includes, vec![0, 1]);
+        assert!(specs[0].excludes.is_empty());
+        // Term 1: include b (slot 1), exclude a (slot 0) — same slots as term 0.
+        assert_eq!(specs[1].includes, vec![1]);
+        assert_eq!(specs[1].excludes, vec![0]);
     }
 }

--- a/crates/sui-inverted-index/src/bitmap_query/stream.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/stream.rs
@@ -32,17 +32,20 @@ use super::BitmapQuery;
 use super::BitmapScanLimitExceeded;
 use super::BucketItem;
 use super::BucketStream;
+use super::DedupedQuery;
 use super::LeafHead;
 use super::MultiError;
 use super::ScanDirection;
-use super::TermSpec;
 use super::Watermarked;
 use super::WatermarkedBucketStream;
 use super::bound_in_direction;
 use super::bucket_edges;
+use super::build_term_specs;
+use super::count_on_floor_refs;
 use super::eval_term_at_bucket;
 use super::frontier_advanced;
-use super::split_term_literals;
+use super::recompute_unreferenced;
+use super::take_snapshot_bitmap;
 
 /// Per-request bucket-scan accounting, delivered via the `on_metrics`
 /// callback passed to `eval_bitmap_query_stream`. Fires once when the
@@ -54,7 +57,7 @@ pub struct BitmapScanMetrics {
     /// Buckets actually evaluated (charged against the per-request
     /// budget). At exhaustion each leaf may have fetched one extra
     /// bucket that was discarded rather than evaluated, so observed
-    /// backend reads can exceed this by up to `BitmapQuery::leaf_count()`.
+    /// backend reads can exceed this by up to `BitmapQuery::unique_leaf_count()`.
     pub buckets_evaluated: u64,
 }
 
@@ -86,12 +89,12 @@ impl BitmapScanBudget {
 
     /// Charge a leaf's mandatory first bucket: decrements the shared pool
     /// when it can, but ALWAYS succeeds. The runtime guards `budget >=
-    /// leaf_count`, but a *shared* atomic with concurrent leaves gives no
-    /// ordering guarantee — a sparse term can drain the pool before a
-    /// slower sibling leaf charges its first bucket, leaving that leaf
-    /// unable to report its first position (a cursorless `SCAN_LIMIT`).
-    /// Reserving the first bucket per leaf makes the `leaf_count` floor's
-    /// promise — "every leaf reaches its first bucket" — actually hold.
+    /// unique_leaf_count`, but a *shared* atomic with concurrent leaves
+    /// gives no ordering guarantee — a sparse term can drain the pool
+    /// before a slower sibling leaf charges its first bucket, leaving that
+    /// leaf unable to report its first position (a cursorless `SCAN_LIMIT`).
+    /// Reserving the first bucket per leaf makes the `unique_leaf_count`
+    /// floor's promise — "every leaf reaches its first bucket" — hold.
     /// Charging-when-possible keeps `buckets_evaluated` accurate in the
     /// common `budget >> leaves` case; it only undercounts a first bucket
     /// taken after the pool was already exhausted by other leaves.
@@ -149,7 +152,7 @@ where
     S: BitmapBucketSource,
     F: FnOnce(BitmapScanMetrics) + Send + 'static,
 {
-    let leaves = query.leaf_count();
+    let leaves = query.unique_leaf_count();
     if (budget as usize) < leaves {
         // Misconfig guard: short-circuit before any scan setup. No
         // `on_metrics` here — there's no scan to account for, and the
@@ -229,37 +232,23 @@ pub(crate) fn eval_bitmap_query_bucket_stream<S>(
 where
     S: BitmapBucketSource,
 {
-    // One peekable leaf per literal; terms reference them by index. Budgeted
-    // bucket streams are `'static`, so `source` is only borrowed while building.
-    let mut leaves: Vec<Peekable<BucketStream>> = Vec::new();
-    let mut terms: Vec<TermSpec> = Vec::new();
-    for term in query.terms {
-        let (includes, excludes) = split_term_literals(term);
-        let mut include_idx = Vec::with_capacity(includes.len());
-        for key in includes {
-            include_idx.push(leaves.len());
-            let raw = source.scan_bucket_stream(key, range.clone(), direction);
-            leaves.push(
-                budgeted_bucket_stream(raw, budget.clone())
-                    .boxed()
-                    .peekable(),
-            );
-        }
-        let mut exclude_idx = Vec::with_capacity(excludes.len());
-        for key in excludes {
-            exclude_idx.push(leaves.len());
-            let raw = source.scan_bucket_stream(key, range.clone(), direction);
-            leaves.push(
-                budgeted_bucket_stream(raw, budget.clone())
-                    .boxed()
-                    .peekable(),
-            );
-        }
-        terms.push(TermSpec {
-            includes: include_idx,
-            excludes: exclude_idx,
-            dead: false,
-        });
+    // One peekable leaf per *unique* dimension key — terms reference them by
+    // index. Identical keys across literals share a single backend scan, so
+    // `(sender=A AND module=X) OR (sender=A AND type=Y)` reads `sender=A`
+    // once. Budgeted bucket streams are `'static`, so `source` is only
+    // borrowed while building.
+    let DedupedQuery {
+        keys: unique_keys,
+        mut terms,
+    } = build_term_specs(query.terms);
+    let mut leaves: Vec<Peekable<BucketStream>> = Vec::with_capacity(unique_keys.len());
+    for key in unique_keys {
+        let raw = source.scan_bucket_stream(key, range.clone(), direction);
+        leaves.push(
+            budgeted_bucket_stream(raw, budget.clone())
+                .boxed()
+                .peekable(),
+        );
     }
 
     let leaf_count = leaves.len();
@@ -275,8 +264,9 @@ where
     };
 
     async_stream::try_stream! {
-        // `gone[i]`: leaf retired (its term died or it is a spent exclude).
-        let mut gone = vec![false; leaf_count];
+        // `unreferenced[i]`: leaf is retired — either no satisfiable term still
+        // points at it, or its bucket stream is at EOF (a spent exclude).
+        let mut unreferenced = vec![false; leaf_count];
         // `front[i]`: clamped position each leaf has provably scanned to. Bounds
         // the resume cursor when a leaf errors before it can advance.
         let mut front = vec![request_floor; leaf_count];
@@ -287,7 +277,7 @@ where
             // parallelism), recording each head and the position it scanned to.
             let mut peeks = Vec::new();
             for (i, leaf) in leaves.iter_mut().enumerate() {
-                if !gone[i] {
+                if !unreferenced[i] {
                     peeks.push(peek_leaf(
                         Pin::new(leaf),
                         i,
@@ -307,38 +297,30 @@ where
                 class[i] = Some(head);
             }
 
-            // An include at EOF kills its term (the intersection is permanently
-            // empty); drop all of that term's leaves so they stop being polled.
+            // An include at EOF makes its term unsatisfiable (the intersection
+            // is permanently empty). With dedup, an EOF'd leaf may be an
+            // include for several terms; all of them become unsatisfiable.
             for term in terms.iter_mut() {
-                if !term.dead
+                if !term.unsatisfiable
                     && term
                         .includes
                         .iter()
                         .any(|&i| matches!(class[i], Some(LeafHead::Eof)))
                 {
-                    term.dead = true;
+                    term.unsatisfiable = true;
                 }
             }
-            for term in &terms {
-                if term.dead {
-                    for &i in term.includes.iter().chain(term.excludes.iter()) {
-                        gone[i] = true;
-                    }
-                } else {
-                    // A spent exclude just stops contributing subtractions.
-                    for &i in &term.excludes {
-                        if matches!(class[i], Some(LeafHead::Eof)) {
-                            gone[i] = true;
-                        }
-                    }
-                }
-            }
+            // Recompute leaf liveness from current term state. A leaf may be
+            // shared across terms (include for one, exclude for another), so it
+            // can only be retired when no satisfiable term still references
+            // it — or when its head is at EOF.
+            recompute_unreferenced(&terms, &class, &mut unreferenced);
 
             // Consume any budget-error frame so the error surfaces (after the
             // floor watermark below).
             let mut errors: Vec<anyhow::Error> = Vec::new();
             for i in 0..leaf_count {
-                if !gone[i] && matches!(class[i], Some(LeafHead::Error)) {
+                if !unreferenced[i] && matches!(class[i], Some(LeafHead::Error)) {
                     match Pin::new(&mut leaves[i]).next().await {
                         Some(Err(e)) => errors.push(e),
                         _ => unreachable!("peek classified Error"),
@@ -346,7 +328,7 @@ where
                 }
             }
 
-            let active: Vec<usize> = (0..leaf_count).filter(|&i| !gone[i]).collect();
+            let active: Vec<usize> = (0..leaf_count).filter(|&i| !unreferenced[i]).collect();
             if active.is_empty() {
                 // Every term retired naturally: cap at the range terminus so the
                 // client learns the scan covered the whole range.
@@ -388,34 +370,49 @@ where
                 .expect("active leaves carry buckets when there is no error");
             let (_pre, post) = bucket_edges(floor_bucket, bucket_size, &range, direction);
 
-            // Take the bitmaps of a term side that sit on `floor_bucket`,
-            // consuming those leaves (and advancing their `front` past the
-            // bucket); leaves on a later bucket contribute `None`.
-            macro_rules! take_side {
-                ($side:expr) => {{
-                    let mut out = Vec::with_capacity($side.len());
-                    for &i in $side {
-                        if matches!(class[i], Some(LeafHead::Bucket(b)) if b == floor_bucket) {
-                            front[i] = post;
-                            out.push(match Pin::new(&mut leaves[i]).next().await {
-                                Some(Ok((_, bitmap))) => Some(bitmap),
-                                _ => None,
-                            });
-                        } else {
-                            out.push(None);
-                        }
-                    }
-                    out
-                }};
+            // Snapshot the bitmaps of leaves sitting on `floor_bucket` —
+            // each unique leaf consumed exactly once, regardless of how many
+            // terms reference it — then distribute. Without dedup, a leaf
+            // shared across multiple terms would otherwise be polled once per
+            // term, each call advancing past the bucket so siblings see
+            // nothing. The single-consume + distribute keeps storage reads
+            // proportional to unique keys, not literal occurrences.
+            let mut snapshot: Vec<Option<RoaringBitmap>> =
+                (0..leaf_count).map(|_| None).collect();
+            let mut on_floor = vec![false; leaf_count];
+            for i in 0..leaf_count {
+                if !unreferenced[i]
+                    && matches!(class[i], Some(LeafHead::Bucket(b)) if b == floor_bucket)
+                {
+                    on_floor[i] = true;
+                    front[i] = post;
+                    snapshot[i] = match Pin::new(&mut leaves[i]).next().await {
+                        Some(Ok((_, bitmap))) => Some(bitmap),
+                        _ => None,
+                    };
+                }
             }
+            let mut remaining_refs = count_on_floor_refs(&terms, &on_floor);
 
             let mut result: Option<RoaringBitmap> = None;
             for term in &terms {
-                if term.dead {
+                if term.unsatisfiable {
                     continue;
                 }
-                let includes = take_side!(&term.includes);
-                let excludes = take_side!(&term.excludes);
+                let includes: Vec<Option<RoaringBitmap>> = term
+                    .includes
+                    .iter()
+                    .map(|&i| {
+                        take_snapshot_bitmap(&mut snapshot, &mut remaining_refs, &on_floor, i)
+                    })
+                    .collect();
+                let excludes: Vec<Option<RoaringBitmap>> = term
+                    .excludes
+                    .iter()
+                    .map(|&i| {
+                        take_snapshot_bitmap(&mut snapshot, &mut remaining_refs, &on_floor, i)
+                    })
+                    .collect();
                 if let Some(bitmap) = eval_term_at_bucket(includes, excludes) {
                     result = Some(match result {
                         None => bitmap,
@@ -673,7 +670,7 @@ mod tests {
 
     /// Tightest-budget starvation. `term1 = (a AND b)` is disjoint (matches
     /// nothing) and `term2 = c`'s only data sits far ahead of the request floor.
-    /// With `budget == leaf_count`, round 1 still fetches every leaf's first
+    /// With `budget == unique_leaf_count`, round 1 still fetches every leaf's first
     /// bucket, so the driver derives a real floor watermark before the budget
     /// exhausts advancing `a`. The scan therefore ends with that forward-progress
     /// watermark ahead of `SCAN_LIMIT` — never a cursorless error that would
@@ -702,7 +699,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Budget == leaf_count: the runtime floor, the tightest starvation.
+        // Budget == unique_leaf_count: the runtime floor, the tightest starvation.
         let stream = eval_bitmap_query_stream(
             source,
             query,
@@ -834,6 +831,81 @@ mod tests {
         );
         assert!(BitmapLiteral::include(vec![0xff, 0x00]).is_err());
         assert!(BitmapTerm::new(vec![exclude(b"neg")]).is_err());
+    }
+
+    /// Two terms share the same include literal `a`. Dedup must collapse them
+    /// to a single backend scan of `a` and distribute its per-bucket bitmap to
+    /// both terms — otherwise term 2 would see `a` already consumed by term 1
+    /// at the floor bucket and silently drop matches.
+    #[tokio::test]
+    async fn shared_include_across_terms_scans_dimension_once() {
+        use crate::bitmap_query::test_utils::CountingBucketSource;
+
+        let source = CountingBucketSource::new(BTreeMap::from([
+            (test_key(b"a"), vec![(0, vec![1, 2, 3])]),
+            (test_key(b"b"), vec![(0, vec![1])]),
+            (test_key(b"c"), vec![(0, vec![2])]),
+        ]));
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a"), include(b"b")]).unwrap(),
+            BitmapTerm::new(vec![include(b"a"), include(b"c")]).unwrap(),
+        ])
+        .unwrap();
+
+        let stream = eval_bitmap_query_stream(
+            source.clone(),
+            query,
+            0..200_000,
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            u64::MAX,
+            |_| {},
+        );
+        let (items, _watermarks) = drain_marked(stream).await.unwrap();
+
+        // Term 1: a ∩ b = {1}; term 2: a ∩ c = {2}; OR = {1, 2}. If `a` were
+        // not distributed to term 2, term 2 would be empty and items = [1].
+        assert_eq!(items, vec![1, 2]);
+        // The dedup property: `a` was scanned exactly once.
+        assert_eq!(source.scan_count(&test_key(b"a")), 1);
+        assert_eq!(source.scan_count(&test_key(b"b")), 1);
+        assert_eq!(source.scan_count(&test_key(b"c")), 1);
+    }
+
+    /// Same key appearing as include in one term and exclude in another:
+    /// dedup still collapses to one leaf, and snapshot-distribute clones so
+    /// both polarities see the bitmap.
+    #[tokio::test]
+    async fn shared_key_across_include_and_exclude_terms_scans_once() {
+        use crate::bitmap_query::test_utils::CountingBucketSource;
+
+        let source = CountingBucketSource::new(BTreeMap::from([
+            (test_key(b"a"), vec![(0, vec![1, 2])]),
+            (test_key(b"b"), vec![(0, vec![1, 2, 3])]),
+        ]));
+        // term 1: b AND NOT a -> {3}
+        // term 2: b AND a     -> {1, 2}
+        // OR -> {1, 2, 3}
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"b"), exclude(b"a")]).unwrap(),
+            BitmapTerm::new(vec![include(b"b"), include(b"a")]).unwrap(),
+        ])
+        .unwrap();
+
+        let stream = eval_bitmap_query_stream(
+            source.clone(),
+            query,
+            0..100_000,
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            u64::MAX,
+            |_| {},
+        );
+        let (items, _watermarks) = drain_marked(stream).await.unwrap();
+
+        assert_eq!(items, vec![1, 2, 3]);
+        assert_eq!(source.scan_count(&test_key(b"a")), 1);
+        assert_eq!(source.scan_count(&test_key(b"b")), 1);
     }
 
     #[tokio::test]
@@ -1000,7 +1072,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scan_budget_below_leaf_count_yields_misconfig_error() {
+    async fn scan_budget_below_unique_leaf_count_yields_misconfig_error() {
         // Defensive runtime guard: a per-request budget smaller than the
         // query's leaf count would produce a cursorless SCAN_LIMIT
         // (merged watermarks stay None until every child reports). The
@@ -1117,7 +1189,7 @@ mod tests {
 
         // Budget = leaf count gives every leaf one bucket fetch (the
         // minimum the runtime guard allows; see
-        // `scan_budget_below_leaf_count_yields_misconfig_error`). Once
+        // `scan_budget_below_unique_leaf_count_yields_misconfig_error`). Once
         // the budget exhausts mid-scan, ScanLimitExceeded propagates
         // without the driver mistaking the exclude leaf's error for a
         // natural EOF.

--- a/crates/sui-kv-rpc/src/operation.rs
+++ b/crates/sui-kv-rpc/src/operation.rs
@@ -89,7 +89,7 @@ impl QueryContext {
     /// `BitmapScanBudget` internally and reports the resulting
     /// `BitmapScanMetrics` via the `on_metrics` callback. The budget caps
     /// evaluated buckets, not backend reads — see
-    /// `eval_bitmap_query_stream` for the (≤ leaf_count) slop at
+    /// `eval_bitmap_query_stream` for the (≤ unique_leaf_count) slop at
     /// exhaustion.
     pub(crate) fn scan_budget(&self, spec: BitmapIndexSpec) -> u64 {
         match spec.table_name {


### PR DESCRIPTION
## Description

This dedupes db scans when a query has repeated keys. This is useful generally, but I am tackling it now before changing how negation works (which will require every negated event literal to bitwise-and with the 'Extant' bitmap).
