### PR TITLE
sui-replay-2: add --skip-artifacts flag

### DIFF
--- a/crates/sui-replay-2/src/artifacts/manager.rs
+++ b/crates/sui-replay-2/src/artifacts/manager.rs
@@ -48,6 +48,11 @@ pub enum EncodingType {
 pub struct ArtifactManager<'a> {
     pub base_path: &'a Path,
     pub overrides_allowed: bool,
+    /// When true, all write operations (`serialize_artifact`, `serialize_move_trace`,
+    /// `try_remove_artifact`) become no-ops and the base directory is not created.
+    /// Reads still work if the base directory already exists. Used for performance
+    /// profiling where artifact serialization would otherwise dominate the trace.
+    pub skip_writes: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,15 +75,28 @@ impl EncodingType {
 impl<'b> ArtifactManager<'b> {
     /// Creates a new `ArtifactManager` with the given base path and whether overrides are allowed.
     pub fn new(base_path: &'b Path, overrides_allowed: bool) -> Result<Self> {
-        std::fs::create_dir_all(base_path).map_err(|e| {
-            anyhow!(
-                "Failed to create base path for replay artifacts at {}: {e}",
-                base_path.display()
-            )
-        })?;
+        Self::new_with_options(base_path, overrides_allowed, false)
+    }
+
+    /// Creates a new `ArtifactManager` and allows opting out of writes. When `skip_writes` is
+    /// true the base directory is not created and all serialize/remove operations are no-ops.
+    pub fn new_with_options(
+        base_path: &'b Path,
+        overrides_allowed: bool,
+        skip_writes: bool,
+    ) -> Result<Self> {
+        if !skip_writes {
+            std::fs::create_dir_all(base_path).map_err(|e| {
+                anyhow!(
+                    "Failed to create base path for replay artifacts at {}: {e}",
+                    base_path.display()
+                )
+            })?;
+        }
         Ok(ArtifactManager {
             base_path,
             overrides_allowed,
+            skip_writes,
         })
     }
 
@@ -245,6 +263,10 @@ impl ArtifactMember<'_, '_> {
             return None;
         }
 
+        if self.manager.skip_writes {
+            return Some(Ok(()));
+        }
+
         if !self.manager.overrides_allowed && self.artifact_path.exists() {
             return Some(Err(anyhow!(
                 "Trace file already exists at {}",
@@ -265,6 +287,10 @@ impl ArtifactMember<'_, '_> {
     pub fn serialize_artifact(&self, data: &impl serde::Serialize) -> Option<Result<()>> {
         if self.artifact_type == Artifact::Trace {
             return None;
+        }
+
+        if self.manager.skip_writes {
+            return Some(Ok(()));
         }
 
         if !self.manager.overrides_allowed && self.artifact_path.exists() {
@@ -311,6 +337,9 @@ impl ArtifactMember<'_, '_> {
     }
 
     pub fn try_remove_artifact(&self) -> Result<()> {
+        if self.manager.skip_writes {
+            return Ok(());
+        }
         if self.manager.overrides_allowed
             && let Err(e) = std::fs::remove_file(&self.artifact_path)
             && e.kind() != std::io::ErrorKind::NotFound

--- a/crates/sui-replay-2/src/lib.rs
+++ b/crates/sui-replay-2/src/lib.rs
@@ -152,6 +152,12 @@ pub struct ReplayConfigStable {
     /// should be overwritten or an error raised if they already exist.
     #[arg(long = "overwrite", num_args = 0, default_missing_value = "true")]
     pub overwrite: Option<bool>,
+
+    /// Skip writing replay artifacts (transaction data, effects, gas report, cache summary,
+    /// move call info, trace) to disk. Useful for performance profiling where artifact
+    /// serialization would otherwise dominate the trace.
+    #[arg(long = "skip-artifacts", num_args = 0, default_missing_value = "true")]
+    pub skip_artifacts: Option<bool>,
 }
 
 /// Arguments for replay used for internal processing
@@ -165,6 +171,7 @@ pub struct ReplayConfigStableInternal {
     pub output_dir: Option<PathBuf>,
     pub show_effects: bool,
     pub overwrite: bool,
+    pub skip_artifacts: bool,
 }
 
 impl Default for ReplayConfigStableInternal {
@@ -181,6 +188,7 @@ impl Default for ReplayConfigStableInternal {
             output_dir: None,
             show_effects: true,
             overwrite: false,
+            skip_artifacts: false,
         }
     }
 }
@@ -318,6 +326,11 @@ pub fn merge_configs(
             .overwrite
             .or(file_config.overwrite)
             .unwrap_or(default_config.overwrite),
+
+        skip_artifacts: cli_config
+            .skip_artifacts
+            .or(file_config.skip_artifacts)
+            .unwrap_or(default_config.skip_artifacts),
     }
 }
 
@@ -334,6 +347,7 @@ pub async fn handle_replay_config(
         output_dir,
         show_effects: _, // used in the caller
         overwrite: overwrite_existing,
+        skip_artifacts,
     } = &stable_config;
     let mut terminate_early = *terminate_early;
 
@@ -404,6 +418,7 @@ pub async fn handle_replay_config(
                 terminate_early,
                 *track_time,
                 *cache_executor,
+                *skip_artifacts,
             )
             .await?;
         }
@@ -424,6 +439,7 @@ pub async fn handle_replay_config(
                 terminate_early,
                 *track_time,
                 *cache_executor,
+                *skip_artifacts,
             )
             .await?;
         }
@@ -441,6 +457,7 @@ pub async fn handle_replay_config(
                 terminate_early,
                 *track_time,
                 *cache_executor,
+                *skip_artifacts,
             )
             .await?;
         }
@@ -460,6 +477,7 @@ pub async fn handle_replay_config(
                 terminate_early,
                 *track_time,
                 *cache_executor,
+                *skip_artifacts,
             )
             .await?;
         }
@@ -482,6 +500,7 @@ pub async fn handle_replay_config(
                 terminate_early,
                 *track_time,
                 *cache_executor,
+                *skip_artifacts,
             )
             .await?;
         }
@@ -501,6 +520,7 @@ async fn run_replay<S>(
     terminate_early: bool,
     track_time: bool,
     cache_executor: bool,
+    skip_artifacts: bool,
 ) -> Result<()>
 where
     S: ReadDataStore + StoreSummary + SetupStore,
@@ -521,7 +541,8 @@ where
 
     for tx_digest in digests {
         let tx_dir = output_root_dir.join(tx_digest);
-        let artifact_manager = ArtifactManager::new(&tx_dir, overwrite_existing)?;
+        let artifact_manager =
+            ArtifactManager::new_with_options(&tx_dir, overwrite_existing, skip_artifacts)?;
         let span = info_span!("replay", tx_digest = %tx_digest);
 
         tx_spinner.set_message(format!("Executing transaction {}", tx_digest));

--- a/crates/sui-replay-2/src/main.rs
+++ b/crates/sui-replay-2/src/main.rs
@@ -80,7 +80,9 @@ async fn main() -> Result<()> {
     let output_root =
         handle_replay_config(&stable_config, &config.replay_experimental, VERSION).await?;
 
-    if let Some(digest) = &stable_config.digest {
+    if let Some(digest) = &stable_config.digest
+        && !stable_config.skip_artifacts
+    {
         print_effects_or_fork(
             digest,
             &output_root,


### PR DESCRIPTION
Make every per-tx artifact write a no-op when `--skip-artifacts` is passed: the `.replay/<digest>/` directory is not created, JSON / zstd serialization is short-circuited, and `print_effects_or_fork` (which reads artifacts back from disk) is skipped in `main.rs`.

When profiling the replay loop with samply, artifact serialization otherwise dominates the CPU trace (~50% of samples in `libsystem_kernel::write`) and drowns out the Move-VM work we actually want to study. The flag's behavior is already documented in the sui-replay skill (see SKILL.md) and is required by the samply recipe there.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

👀

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
