### PR TITLE
[move-compiler][lint] Unused return value

### DIFF
--- a/crates/sui-framework/docs/sui/sui.md
+++ b/crates/sui-framework/docs/sui/sui.md
@@ -160,7 +160,7 @@ This should be called only once during genesis creation.
     <a href="../sui/transfer.md#sui_transfer_public_freeze_object">transfer::public_freeze_object</a>(metadata);
     <b>let</b> <b>mut</b> supply = treasury.treasury_into_supply();
     <b>let</b> total_sui = supply.increase_supply(<a href="../sui/sui.md#sui_sui_TOTAL_SUPPLY_MIST">TOTAL_SUPPLY_MIST</a>);
-    supply.destroy_supply();
+    <b>let</b> _ = supply.destroy_supply();
     total_sui
 }
 </code></pre>

--- a/crates/sui-framework/packages/sui-framework/sources/sui.move
+++ b/crates/sui-framework/packages/sui-framework/sources/sui.move
@@ -47,7 +47,7 @@ fun new(ctx: &mut TxContext): Balance<SUI> {
     transfer::public_freeze_object(metadata);
     let mut supply = treasury.treasury_into_supply();
     let total_sui = supply.increase_supply(TOTAL_SUPPLY_MIST);
-    supply.destroy_supply();
+    let _ = supply.destroy_supply();
     total_sui
 }
 

--- a/crates/sui/tests/shell_tests/rename_same_package_and_module/use_math/sources/math.move
+++ b/crates/sui/tests/shell_tests/rename_same_package_and_module/use_math/sources/math.move
@@ -4,6 +4,6 @@
 module use_math::both;
 
 public fun foo() {
-  math_a::math::a();
-  math_b::math::a();
+  let _ = math_a::math::a();
+  let _ = math_b::math::a();
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
@@ -20,6 +20,12 @@ pub trait AbstractDomain: Clone + Sized {
 pub trait TransferFunctions {
     type State: AbstractDomain;
 
+    /// Called before any commands in the block are executed, with the block's pre-state.
+    fn start_block(&mut self, _label: Label, _pre: &Self::State) {}
+
+    /// Called after all commands in the block have been executed, with the block's post-state.
+    fn finish_block(&mut self, _label: Label, _post: &Self::State) {}
+
     /// Execute local@instr found at index local@index in the current basic block from pre-state
     /// local@pre.
     /// Should return an AnalysisError if executing the instruction is unsuccessful, and () if
@@ -39,16 +45,37 @@ pub trait TransferFunctions {
     ) -> Diagnostics;
 }
 
+/// The pre- and post-states of a block, as observed at the fixpoint of the analysis. The
+/// post-state is `None` if the block was never processed (e.g. unreachable).
+pub struct BlockStates<State> {
+    pub pre: State,
+    pub post: Option<State>,
+}
+
 pub fn analyze_function<C: CFG, TF: TransferFunctions>(
     transfer_functions: &mut TF,
     cfg: &C,
     initial_state: TF::State,
 ) -> (BTreeMap<Label, TF::State>, Diagnostics) {
+    let (states, diags) = analyze_function_with_post_states(transfer_functions, cfg, initial_state);
+    let pre_states = states
+        .into_iter()
+        .map(|(lbl, BlockStates { pre, .. })| (lbl, pre))
+        .collect();
+    (pre_states, diags)
+}
+
+/// Like [`analyze_function`] but exposes both the pre- and post-state of every block.
+pub fn analyze_function_with_post_states<C: CFG, TF: TransferFunctions>(
+    transfer_functions: &mut TF,
+    cfg: &C,
+    initial_state: TF::State,
+) -> (BTreeMap<Label, BlockStates<TF::State>>, Diagnostics) {
     fn collect_states_and_diagnostics<State>(
         map: BTreeMap<Label, absint::BlockInvariant<(State, Option<Rc<Diagnostics>>)>>,
-    ) -> (BTreeMap<Label, State>, Diagnostics) {
+    ) -> (BTreeMap<Label, BlockStates<State>>, Diagnostics) {
         let mut diags = Diagnostics::new();
-        let final_states = map
+        let states = map
             .into_iter()
             .map(|(lbl, inv)| {
                 let absint::BlockInvariant {
@@ -56,14 +83,20 @@ pub fn analyze_function<C: CFG, TF: TransferFunctions>(
                     post,
                 } = inv;
                 debug_assert!(_pre_diags.is_none());
-                // can be None for empty blocks
-                if let absint::BlockPostCondition::Processed((_, Some(rc_diags))) = post {
-                    diags.extend(Rc::into_inner(rc_diags).unwrap());
-                }
-                (lbl, pre)
+                // `post` is `Unprocessed` for empty / unreachable blocks.
+                let post = match post {
+                    absint::BlockPostCondition::Processed((post, post_diags)) => {
+                        if let Some(rc_diags) = post_diags {
+                            diags.extend(Rc::into_inner(rc_diags).unwrap());
+                        }
+                        Some(post)
+                    }
+                    absint::BlockPostCondition::Unprocessed => None,
+                };
+                (lbl, BlockStates { pre, post })
             })
             .collect();
-        (final_states, diags)
+        (states, diags)
     }
 
     let mut interpreter = AbstractInterpreter { transfer_functions };
@@ -104,20 +137,25 @@ impl<TF: TransferFunctions> absint::AbstractInterpreter for AbstractInterpreter<
 
     fn visit_block_pre_execution(
         &mut self,
-        _block_id: Self::BlockId,
+        block_id: Self::BlockId,
         invariant: &mut absint::BlockInvariant<(TF::State, Option<Rc<Diagnostics>>)>,
     ) -> Result<(), Self::Error> {
         // each block needs its own unique Diagnostics, so set to None to be then initialized
         // in the `execute`
         invariant.pre.1 = None;
+        self.transfer_functions
+            .start_block(block_id, &invariant.pre.0);
         Ok(())
     }
 
     fn visit_block_post_execution(
         &mut self,
-        _block_id: Self::BlockId,
-        _invariant: &mut absint::BlockInvariant<Self::State>,
+        block_id: Self::BlockId,
+        invariant: &mut absint::BlockInvariant<Self::State>,
     ) -> Result<(), Self::Error> {
+        if let absint::BlockPostCondition::Processed((post, _)) = &invariant.post {
+            self.transfer_functions.finish_block(block_id, post);
+        }
         Ok(())
     }
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -7,7 +7,7 @@ use crate::{
     PreCompiledProgramInfo,
     cfgir::{
         CFGContext,
-        absint::{AbstractDomain, JoinResult, TransferFunctions, analyze_function},
+        absint::{AbstractDomain, JoinResult, TransferFunctions},
         ast as G,
         cfg::ImmForwardCFG,
     },
@@ -546,8 +546,9 @@ pub trait SimpleAbsIntConstructor: Sized {
         let Some(mut ai) = Self::new(context, cfg, &mut init_state) else {
             return Diagnostics::new();
         };
-        let (final_state, ds) = analyze_function(&mut ai, cfg, init_state);
-        ai.finish(final_state, ds)
+        let (final_states, ds) =
+            crate::cfgir::absint::analyze_function_with_post_states(&mut ai, cfg, init_state);
+        ai.finish(final_states, ds)
     }
 }
 
@@ -556,21 +557,36 @@ pub trait SimpleAbsInt: Sized {
     /// The execution context local to a command
     type ExecutionContext: SimpleExecutionContext;
 
-    /// A hook for an additional processing after visiting all codes. The `final_states` are the
-    /// pre-states for each block (keyed by the label for the block). The `diags` are collected from
+    /// A hook for an additional processing after visiting all codes. The `final_states` give the
+    /// pre- and post-states for each block (keyed by the label for the block); the post-state is
+    /// `None` if the block was never processed (e.g. unreachable). The `diags` are collected from
     /// all code visited.
     fn finish(
         &mut self,
-        final_states: BTreeMap<Label, Self::State>,
+        final_states: BTreeMap<Label, crate::cfgir::absint::BlockStates<Self::State>>,
         diags: Diagnostics,
     ) -> Diagnostics;
 
-    /// A hook for any pre-processing at the start of a command
-    fn start_command(&self, pre: &mut Self::State) -> Self::ExecutionContext;
+    /// Called once at the start of each block, with the block's pre-state.
+    fn start_block(&mut self, _label: Label, _pre: &Self::State) {}
 
-    /// A hook for any post-processing after a command has been visited
+    /// Called once at the end of each processed block, with the block's post-state.
+    fn finish_block(&mut self, _label: Label, _post: &Self::State) {}
+
+    /// A hook for any pre-processing at the start of a command, with the enclosing block's
+    /// label and the command's index in that block.
+    fn start_command(
+        &self,
+        label: Label,
+        idx: usize,
+        pre: &mut Self::State,
+    ) -> Self::ExecutionContext;
+
+    /// A hook for any post-processing after a command has been visited.
     fn finish_command(
         &self,
+        label: Label,
+        idx: usize,
         context: Self::ExecutionContext,
         state: &mut Self::State,
     ) -> Diagnostics;
@@ -809,16 +825,24 @@ pub fn default_values<V: Clone + Default>(c: usize) -> Vec<V> {
 impl<V: SimpleAbsInt> TransferFunctions for V {
     type State = V::State;
 
+    fn start_block(&mut self, label: Label, pre: &Self::State) {
+        SimpleAbsInt::start_block(self, label, pre)
+    }
+
+    fn finish_block(&mut self, label: Label, post: &Self::State) {
+        SimpleAbsInt::finish_block(self, label, post)
+    }
+
     fn execute(
         &mut self,
         pre: &mut Self::State,
-        _lbl: Label,
-        _idx: usize,
+        lbl: Label,
+        idx: usize,
         cmd: &Command,
     ) -> Diagnostics {
-        let mut context = self.start_command(pre);
+        let mut context = self.start_command(lbl, idx, pre);
         self.command(&mut context, pre, cmd);
-        self.finish_command(context, pre)
+        self.finish_command(lbl, idx, context, pre)
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{any::Any, collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use crate::{
     PreCompiledProgramInfo,
@@ -25,7 +25,7 @@ use move_proc_macros::growing_stack;
 pub type AbsIntVisitorObj = Box<dyn AbstractInterpreterVisitor>;
 pub type CFGIRVisitorObj = Box<dyn CFGIRVisitor>;
 
-pub trait CFGIRVisitor: Send + Sync {
+pub trait CFGIRVisitor: Send + Sync + Any {
     fn visit(
         &self,
         env: &CompilationEnv,
@@ -41,7 +41,7 @@ pub trait CFGIRVisitor: Send + Sync {
     }
 }
 
-pub trait AbstractInterpreterVisitor: Send + Sync {
+pub trait AbstractInterpreterVisitor: Send + Sync + Any {
     fn verify(&self, context: &CFGContext, cfg: &ImmForwardCFG) -> Diagnostics;
 
     fn visitor(self) -> Visitor
@@ -331,7 +331,7 @@ impl<V: CFGIRVisitor + 'static> From<V> for CFGIRVisitorObj {
     }
 }
 
-impl<V: CFGIRVisitorConstructor + Send + Sync> CFGIRVisitor for V {
+impl<V: CFGIRVisitorConstructor + Send + Sync + 'static> CFGIRVisitor for V {
     fn visit(
         &self,
         env: &CompilationEnv,
@@ -852,7 +852,7 @@ impl<V: AbstractInterpreterVisitor + 'static> From<V> for AbsIntVisitorObj {
     }
 }
 
-impl<V: SimpleAbsIntConstructor + Send + Sync> AbstractInterpreterVisitor for V {
+impl<V: SimpleAbsIntConstructor + Send + Sync + 'static> AbstractInterpreterVisitor for V {
     fn verify(&self, context: &CFGContext, cfg: &ImmForwardCFG) -> Diagnostics {
         <Self as SimpleAbsIntConstructor>::verify(context, cfg)
     }

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -30,6 +30,7 @@ use crate::{
     typing::{self, visitor::TypingVisitorObj},
     unit_test,
 };
+use indexmap::IndexMap;
 use move_command_line_common::files::{
     DEBUG_INFO_EXTENSION, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, extension_equals,
     find_filenames_and_keep_specified,
@@ -38,6 +39,7 @@ use move_core_types::language_storage::ModuleId as CompiledModuleId;
 use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use std::{
+    any::{Any, TypeId},
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     io::{Read, Write},
@@ -62,7 +64,7 @@ pub struct Compiler {
     pre_compiled_lib: Option<Arc<PreCompiledProgramInfo>>,
     compiled_module_named_address_mapping: BTreeMap<CompiledModuleId, String>,
     flags: Flags,
-    visitors: Vec<Visitor>,
+    visitors: IndexMap<TypeId, Visitor>,
     warning_filter: Option<FilterScope>,
     known_warning_filters: Vec<(
         /* Prefix */ Option<Symbol>,
@@ -203,7 +205,7 @@ impl Compiler {
             pre_compiled_lib: None,
             compiled_module_named_address_mapping: BTreeMap::new(),
             flags: Flags::empty(),
-            visitors: vec![],
+            visitors: IndexMap::new(),
             warning_filter: None,
             known_warning_filters: vec![],
             package_configs,
@@ -275,12 +277,17 @@ impl Compiler {
     }
 
     pub fn add_visitor(mut self, pass: impl Into<Visitor>) -> Self {
-        self.visitors.push(pass.into());
+        let visitor = pass.into();
+        // De-dup by concrete visitor type. First occurrence wins.
+        self.visitors.entry(visitor.type_id()).or_insert(visitor);
         self
     }
 
     pub fn add_visitors(mut self, passes: impl IntoIterator<Item = Visitor>) -> Self {
-        self.visitors.extend(passes);
+        for visitor in passes {
+            // De-dup by concrete visitor type. First occurrence wins.
+            self.visitors.entry(visitor.type_id()).or_insert(visitor);
+        }
         self
     }
 
@@ -395,7 +402,7 @@ impl Compiler {
         )?;
         let mut compilation_env = CompilationEnv::new(
             flags,
-            visitors,
+            visitors.into_values().collect(),
             save_hooks,
             warning_filter,
             package_configs,
@@ -1216,4 +1223,15 @@ fn run(
         }
     }
     rec(compilation_env, pre_compiled_lib, cur, until)
+}
+
+impl Visitor {
+    /// Returns the `TypeId` of the underlying visitor
+    fn type_id(&self) -> TypeId {
+        match self {
+            Visitor::TypingVisitor(v) => Any::type_id(&**v),
+            Visitor::CFGIRVisitor(v) => Any::type_id(&**v),
+            Visitor::AbsIntVisitor(v) => Any::type_id(&**v),
+        }
+    }
 }

--- a/external-crates/move/crates/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/ast.rs
@@ -9,8 +9,8 @@ use crate::{
     },
     naming::ast::{BuiltinTypeName, BuiltinTypeName_, DatatypeTypeParameter, TParam},
     parser::ast::{
-        self as P, BinOp, ConstantName, DatatypeName, ENTRY_MODIFIER, Field, FunctionName,
-        TargetKind, UnaryOp, VariantName,
+        self as P, Ability_, BinOp, ConstantName, DatatypeName, ENTRY_MODIFIER, Field,
+        FunctionName, TargetKind, UnaryOp, VariantName,
     },
     shared::{
         Name, NumericalAddress, TName, ast_debug::*, program_info::TypingProgramInfo,
@@ -661,6 +661,15 @@ impl BaseType_ {
         }
     }
 
+    pub fn has_ability_(&self, ability: Ability_) -> bool {
+        match self {
+            BaseType_::Apply(abilities, _, _) | BaseType_::Param(TParam { abilities, .. }) => {
+                abilities.has_ability_(ability)
+            }
+            BaseType_::Unreachable | BaseType_::UnresolvedError => true,
+        }
+    }
+
     pub fn bool(loc: Loc) -> BaseType {
         Self::builtin(loc, BuiltinTypeName_::Bool, vec![])
     }
@@ -757,6 +766,13 @@ impl SingleType_ {
         match self {
             SingleType_::Ref(_, _) => AbilitySet::references(loc),
             SingleType_::Base(b) => b.value.abilities(loc),
+        }
+    }
+
+    pub fn has_ability_(&self, ability: Ability_) -> bool {
+        match self {
+            SingleType_::Ref(_, _) => AbilitySet::REFERENCES.contains(&ability),
+            SingleType_::Base(b) => b.value.has_ability_(ability),
         }
     }
 

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -4,7 +4,7 @@
 use move_symbol_pool::Symbol;
 
 use crate::{
-    cfgir::visitor::CFGIRVisitor,
+    cfgir::visitor::{AbstractInterpreterVisitor, CFGIRVisitor},
     command_line::compiler::Visitor,
     diagnostics::{
         codes::{DiagnosticInfo, DiagnosticsID, Severity, custom},
@@ -25,6 +25,7 @@ pub mod unnecessary_conditional;
 pub mod unnecessary_unit;
 pub mod unnecessary_while_loop;
 pub mod unneeded_return;
+pub mod unused_return_value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LintLevel {
@@ -176,6 +177,12 @@ lints!(
         "combinable_comparisons",
         "comparison operations condition can be simplified"
     ),
+    (
+        UnusedReturnValue,
+        LinterDiagnosticCategory::Suspicious,
+        "unused_return_value",
+        "return value of a non-mutating call is discarded"
+    ),
 );
 
 pub const ALLOW_ATTR_CATEGORY: &str = "lint";
@@ -220,6 +227,7 @@ pub fn linter_visitors(level: LintLevel) -> Vec<Visitor> {
                 unnecessary_unit::UnnecessaryUnit.visitor(),
                 equal_operands::EqualOperands.visitor(),
                 combinable_comparisons::CombinableComparisons.visitor(),
+                unused_return_value::UnusedReturnValue.visitor(),
             ]
         }
     }

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -1,0 +1,316 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Flags discarded return values of calls with no `&mut` arg (Sui: ignoring `(&mut) TxContext`).
+//! `IgnoreAndPop` of a `Fresh` value warns immediately; otherwise a `Bound` value alive in a
+//! return block's post-state on every return path warns once per originating call.
+
+use crate::{
+    cfgir::{
+        CFGContext,
+        absint::{BlockStates, JoinResult},
+        cfg::{CFG, ImmForwardCFG},
+        visitor::{
+            LocalState, SimpleAbsInt, SimpleAbsIntConstructor, SimpleDomain, SimpleExecutionContext,
+        },
+    },
+    diag,
+    diagnostics::{Diagnostic, Diagnostics},
+    editions::Flavor,
+    hlir::ast::{
+        BaseType_, Command, Command_, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_,
+        Type, Type_, Var,
+    },
+    linters::StyleCodes,
+    parser::ast::Ability_,
+    sui_mode::{SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME},
+};
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub struct UnusedReturnValue;
+
+pub struct UnusedReturnValueAI {
+    is_sui: bool,
+    return_blocks: BTreeSet<Label>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ValueId {
+    block: Label,
+    cmd_idx: usize,
+    var: Symbol,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum Value {
+    /// Pure-call result not yet bound to a named local.
+    Fresh(Loc),
+    /// Bound to one or more named locals; `id -> originating call loc`. Joins union the maps.
+    Bound(BTreeMap<ValueId, Loc>),
+    #[default]
+    Other,
+}
+
+#[derive(Clone, Debug)]
+pub struct State {
+    locals: BTreeMap<Var, LocalState<Value>>,
+}
+
+pub struct ExecutionContext {
+    diags: Diagnostics,
+    location: (Label, usize),
+}
+
+impl SimpleAbsIntConstructor for UnusedReturnValue {
+    type AI<'a> = UnusedReturnValueAI;
+
+    fn new<'a>(
+        context: &'a CFGContext<'a>,
+        cfg: &ImmForwardCFG,
+        _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,
+    ) -> Option<Self::AI<'a>> {
+        if context.attributes.is_test_or_test_only()
+            || context
+                .info
+                .module(&context.module)
+                .attributes
+                .is_test_or_test_only()
+        {
+            return None;
+        }
+        let is_sui = context.env.package_config(context.package).flavor == Flavor::Sui;
+        let return_blocks = cfg
+            .block_labels()
+            .filter(|lbl| {
+                matches!(
+                    cfg.commands(*lbl).last(),
+                    Some((_, sp!(_, Command_::Return { .. })))
+                )
+            })
+            .collect();
+        Some(UnusedReturnValueAI {
+            is_sui,
+            return_blocks,
+        })
+    }
+}
+
+impl SimpleAbsInt for UnusedReturnValueAI {
+    type State = State;
+    type ExecutionContext = ExecutionContext;
+
+    fn finish(
+        &mut self,
+        final_states: BTreeMap<Label, BlockStates<State>>,
+        mut diags: Diagnostics,
+    ) -> Diagnostics {
+        if self.return_blocks.is_empty() {
+            return diags;
+        }
+        let per_return: Vec<BTreeMap<ValueId, Loc>> = self
+            .return_blocks
+            .iter()
+            .filter_map(|lbl| {
+                let post = final_states.get(lbl)?.post.as_ref()?;
+                let mut m = BTreeMap::new();
+                for ls in post.locals.values() {
+                    if let LocalState::Available(_, v) = ls {
+                        let ids = match v {
+                            Value::Bound(ids) => ids,
+                            Value::Fresh(_) => {
+                                debug_assert!(false, "should never store a fresh value in a local");
+                                continue;
+                            }
+                            Value::Other => continue,
+                        };
+                        m.extend(ids);
+                    }
+                }
+                if m.is_empty() { None } else { Some(m) }
+            })
+            .collect();
+        if per_return.is_empty() {
+            return diags;
+        }
+        // intersect the unused from each return block
+        let mut iter = per_return.into_iter();
+        let mut unused = iter.next().unwrap();
+        for m in iter {
+            unused.retain(|id, _| m.contains_key(id));
+        }
+
+        // report an error for each unused value
+        for (_id, loc) in unused {
+            diags.add(unused_return_value_warning(loc));
+        }
+        diags
+    }
+
+    fn start_command(&self, label: Label, idx: usize, _: &mut State) -> ExecutionContext {
+        ExecutionContext {
+            diags: Diagnostics::new(),
+            location: (label, idx),
+        }
+    }
+
+    fn finish_command(
+        &self,
+        _label: Label,
+        _idx: usize,
+        context: ExecutionContext,
+        _state: &mut State,
+    ) -> Diagnostics {
+        let ExecutionContext { diags, .. } = context;
+        diags
+    }
+
+    fn command_custom(
+        &self,
+        context: &mut ExecutionContext,
+        state: &mut State,
+        cmd: &Command,
+    ) -> bool {
+        let Command_::IgnoreAndPop { exp, .. } = &cmd.value else {
+            return false;
+        };
+        let values = self.exp(context, state, exp);
+        for v in values {
+            if let Value::Fresh(call_loc) = v {
+                context.add_diag(unused_return_value_warning(call_loc));
+            }
+        }
+        true
+    }
+
+    fn call_custom(
+        &self,
+        _context: &mut ExecutionContext,
+        _state: &mut State,
+        loc: &Loc,
+        return_ty: &Type,
+        f: &ModuleCall,
+        _args: Vec<Value>,
+    ) -> Option<Vec<Value>> {
+        let is_pure = call_is_pure(self.is_sui, f);
+        // Non-drop slots are forced to be used by the type system, no need to track them.
+        let mk_value = |st: &SingleType| {
+            if is_pure && st.value.has_ability_(Ability_::Drop) {
+                Value::Fresh(*loc)
+            } else {
+                Value::Other
+            }
+        };
+        Some(match &return_ty.value {
+            Type_::Unit => vec![],
+            Type_::Single(st) => vec![mk_value(st)],
+            Type_::Multiple(sts) => sts.iter().map(mk_value).collect(),
+        })
+    }
+
+    fn lvalue_custom(
+        &self,
+        context: &mut ExecutionContext,
+        state: &mut State,
+        l: &LValue,
+        value: &Value,
+    ) -> bool {
+        let sp!(loc, l_) = l;
+        let LValue_::Var { var, .. } = l_ else {
+            return false;
+        };
+        let new_value = match value {
+            // Leading-underscore locals are conventionally intentionally/potentially unused
+            Value::Fresh(_) | Value::Bound(_) if var.starts_with_underscore() => Value::Other,
+            Value::Fresh(call_loc) => {
+                let (block, cmd_idx) = context.location;
+                let id = ValueId {
+                    block,
+                    cmd_idx,
+                    var: var.0.value,
+                };
+                Value::Bound(BTreeMap::from([(id, *call_loc)]))
+            }
+            Value::Bound(_) | Value::Other => value.clone(),
+        };
+        state
+            .locals_mut()
+            .insert(*var, LocalState::Available(*loc, new_value));
+        true
+    }
+}
+
+impl SimpleDomain for State {
+    type Value = Value;
+
+    fn new(_context: &CFGContext, locals: BTreeMap<Var, LocalState<Value>>) -> Self {
+        State { locals }
+    }
+
+    fn locals_mut(&mut self) -> &mut BTreeMap<Var, LocalState<Value>> {
+        &mut self.locals
+    }
+
+    fn locals(&self) -> &BTreeMap<Var, LocalState<Value>> {
+        &self.locals
+    }
+
+    fn join_value(v1: &Value, v2: &Value) -> Value {
+        match (v1, v2) {
+            (Value::Bound(m1), Value::Bound(m2)) => {
+                let mut m = m1.clone();
+                for (id, loc) in m2 {
+                    m.insert(*id, *loc);
+                }
+                Value::Bound(m)
+            }
+            // One side lost tracking - drop. `MaybeUnavailable` from the framework's
+            // `LocalState` join still hides consumed-on-one-branch values from `finish`.
+            _ => Value::Other,
+        }
+    }
+
+    fn join_impl(&mut self, _: &Self, _: &mut JoinResult) {}
+}
+
+impl SimpleExecutionContext for ExecutionContext {
+    fn add_diag(&mut self, diag: Diagnostic) {
+        self.diags.add(diag)
+    }
+}
+
+/// No `&mut` arg (Sui: ignoring `(&mut) TxContext`).
+fn call_is_pure(is_sui: bool, f: &ModuleCall) -> bool {
+    !f.arguments
+        .iter()
+        .any(|arg| is_mutating_ref_arg(is_sui, &arg.ty))
+}
+
+fn is_mutating_ref_arg(is_sui: bool, ty: &Type) -> bool {
+    let Type_::Single(sp!(_, st_)) = &ty.value else {
+        return false;
+    };
+    let SingleType_::Ref(true, bt) = st_ else {
+        return false;
+    };
+    if is_sui
+        && let BaseType_::Apply(_, sp!(_, tn), _) = &bt.value
+        && tn.is(
+            &SUI_ADDR_VALUE,
+            TX_CONTEXT_MODULE_NAME,
+            TX_CONTEXT_TYPE_NAME,
+        )
+    {
+        return false;
+    }
+    true
+}
+
+fn unused_return_value_warning(call_loc: Loc) -> Diagnostic {
+    let msg = "Unused return value. This function takes no '&mut' arguments, \
+               so its result is the only observable effect of the call";
+    let mut d = diag!(StyleCodes::UnusedReturnValue.diag_info(), (call_loc, msg));
+    d.add_note("Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.");
+    d
+}

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -19,8 +19,8 @@ use crate::{
     editions::Flavor,
     hlir::{
         ast::{
-            BaseType_, Command, Command_, Exp, LValue, LValue_, Label, ModuleCall, SingleType,
-            SingleType_, Type, Type_, UnannotatedExp_, Var,
+            Command, Command_, Exp, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_,
+            Type, Type_, UnannotatedExp_, Var,
         },
         translate::{DisplayVar, display_var},
     },
@@ -40,12 +40,21 @@ pub struct UnusedReturnValueAI {
 /// Function unique index derived from the block label + command index within the block
 pub type CommandIndex = (Label, usize);
 
+/// Information about a tracked pure call
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CallSite {
+    /// The location
+    loc: Loc,
+    /// In Sui mode, was an &mut TxContext present but excluded
+    tx_context_exempted: bool,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum Value {
     /// Pure-call result not yet bound to a named local.
-    Fresh(Loc),
-    /// Bound to one or more named locals; `id -> originating call loc`. Joins union the maps.
-    Bound(BTreeMap<CommandIndex, Loc>),
+    Fresh(CallSite),
+    /// Bound to one or more temporary locals; `index -> originating call loc`
+    Bound(BTreeMap<CommandIndex, CallSite>),
     #[default]
     Other,
 }
@@ -126,8 +135,8 @@ impl SimpleAbsInt for UnusedReturnValueAI {
         let mut sites = BTreeMap::new();
         for v in values {
             match v {
-                Value::Fresh(call_loc) => {
-                    sites.insert(context.current_command, call_loc);
+                Value::Fresh(call_site) => {
+                    sites.insert(context.current_command, call_site);
                 }
                 Value::Bound(v_sites) => {
                     sites.extend(v_sites);
@@ -135,8 +144,8 @@ impl SimpleAbsInt for UnusedReturnValueAI {
                 Value::Other => (),
             }
         }
-        for loc in sites.into_values() {
-            context.add_diag(unused_return_value_warning(loc));
+        for call_site in sites.into_values() {
+            context.add_diag(unused_return_value_warning(call_site));
         }
         false
     }
@@ -171,14 +180,22 @@ impl SimpleAbsInt for UnusedReturnValueAI {
         f: &ModuleCall,
         _args: Vec<Value>,
     ) -> Option<Vec<Value>> {
-        let is_pure = call_is_pure(self.is_sui, f);
-        // Non-drop slots are forced to be used by the type system, no need to track them.
+        let purity = call_purity(self.is_sui, f);
         let mk_value = |st: &SingleType| {
-            if is_pure && st.value.has_ability_(Ability_::Drop) {
-                Value::Fresh(*loc)
-            } else {
-                Value::Other
-            }
+            let tx_context_exempted = match purity {
+                Purity::Mutable => return Value::Other,
+                // Non-drop slots are forced to be used by the type system, no need to track them.
+                Purity::Pure { .. } if !st.value.has_ability_(Ability_::Drop) => {
+                    return Value::Other;
+                }
+                Purity::Pure {
+                    tx_context_exempted,
+                } => *&tx_context_exempted,
+            };
+            Value::Fresh(CallSite {
+                loc: *loc,
+                tx_context_exempted,
+            })
         };
         Some(match &return_ty.value {
             Type_::Unit => vec![],
@@ -204,8 +221,8 @@ impl SimpleAbsInt for UnusedReturnValueAI {
             // compiler generated temporaries.
             // The compiler already generates warnings for unused locals.
             _ if matches!(display_var, DisplayVar::Orig(_)) => Value::Other,
-            Value::Fresh(call_loc) => {
-                Value::Bound(BTreeMap::from([(context.current_command, *call_loc)]))
+            Value::Fresh(call_site) => {
+                Value::Bound(BTreeMap::from([(context.current_command, *call_site)]))
             }
             Value::Bound(_) | Value::Other => value.clone(),
         };
@@ -258,37 +275,56 @@ impl SimpleExecutionContext for ExecutionContext {
     }
 }
 
-/// No `&mut` arg (Sui: ignoring `(&mut) TxContext`).
-fn call_is_pure(is_sui: bool, f: &ModuleCall) -> bool {
-    !f.arguments
-        .iter()
-        .any(|arg| is_mutating_ref_arg(is_sui, &arg.ty))
+/// Whether a call should be treated as "pure" for the purposes of this lint.
+enum Purity {
+    /// No `&mut` arguments
+    Pure {
+        /// In Sui flavor, was there an excluded `&mut TxContext`
+        tx_context_exempted: bool,
+    },
+    /// At least one `&mut` argument
+    Mutable,
 }
 
-fn is_mutating_ref_arg(is_sui: bool, ty: &Type) -> bool {
-    let Type_::Single(sp!(_, st_)) = &ty.value else {
-        return false;
-    };
-    let SingleType_::Ref(true, bt) = st_ else {
-        return false;
-    };
-    if is_sui
-        && let BaseType_::Apply(_, sp!(_, tn), _) = &bt.value
-        && tn.is(
-            &SUI_ADDR_VALUE,
-            TX_CONTEXT_MODULE_NAME,
-            TX_CONTEXT_TYPE_NAME,
-        )
-    {
-        return false;
+fn call_purity(is_sui: bool, f: &ModuleCall) -> Purity {
+    let mut tx_context_exempted = false;
+    for arg in &f.arguments {
+        let Type_::Single(sp!(_, SingleType_::Ref(true, bt))) = &arg.ty.value else {
+            continue;
+        };
+        let is_tx_context = is_sui
+            && bt
+                .value
+                .is_apply(
+                    &SUI_ADDR_VALUE,
+                    TX_CONTEXT_MODULE_NAME,
+                    TX_CONTEXT_TYPE_NAME,
+                )
+                .is_some();
+        if !is_tx_context {
+            return Purity::Mutable;
+        }
+        tx_context_exempted = true;
     }
-    true
+    Purity::Pure {
+        tx_context_exempted,
+    }
 }
 
-fn unused_return_value_warning(call_loc: Loc) -> Diagnostic {
+fn unused_return_value_warning(call_site: CallSite) -> Diagnostic {
+    let CallSite {
+        loc,
+        tx_context_exempted,
+    } = call_site;
     let msg = "Unused return value. This function takes no '&mut' arguments, \
                so its result is the only observable effect of the call";
-    let mut d = diag!(StyleCodes::UnusedReturnValue.diag_info(), (call_loc, msg));
+    let mut d = diag!(StyleCodes::UnusedReturnValue.diag_info(), (loc, msg));
+    if tx_context_exempted {
+        d.add_note(
+            "This function takes a '&mut TxContext' argument, but 'TxContext' is not counted \
+             as a mutable reference input for this lint.",
+        );
+    }
     d.add_note("Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.");
     d
 }

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -31,18 +31,18 @@ use crate::{
 use move_ir_types::location::*;
 use std::collections::BTreeMap;
 
-pub struct UnusedReturnValue;
+pub(crate) struct UnusedReturnValue;
 
-pub struct UnusedReturnValueAI {
+pub(crate) struct UnusedReturnValueAI {
     is_sui: bool,
 }
 
 /// Function unique index derived from the block label + command index within the block
-pub type CommandIndex = (Label, usize);
+pub(crate) type CommandIndex = (Label, usize);
 
 /// Information about a tracked pure call
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CallSite {
+pub(crate) struct CallSite {
     /// The location
     loc: Loc,
     /// In Sui mode, was an &mut TxContext present but excluded
@@ -50,7 +50,7 @@ pub struct CallSite {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub enum Value {
+pub(crate) enum Value {
     /// Pure-call result not yet bound to a named local.
     Fresh(CallSite),
     /// Bound to one or more temporary locals; `index -> originating call loc`
@@ -60,11 +60,11 @@ pub enum Value {
 }
 
 #[derive(Clone, Debug)]
-pub struct State {
+pub(crate) struct State {
     locals: BTreeMap<Var, LocalState<Value>>,
 }
 
-pub struct ExecutionContext {
+pub(crate) struct ExecutionContext {
     diags: Diagnostics,
     current_command: (Label, usize),
 }
@@ -156,14 +156,13 @@ impl SimpleAbsInt for UnusedReturnValueAI {
         state: &mut State,
         e: &Exp,
     ) -> Option<Vec<Value>> {
-        // If the local is copied or borrowed, this will not free the value, but does mean that
-        // the value is now "used". We can update the value as being used to prevent any
-        // erroneous error reporting... though this likely will never happen
+        // Copying or borrowing the local does not free the tracked value, but it does count as a
+        // use, so we stop tracking it (mark it `Other`) to avoid a spurious unused-value warning.
         let var = match &e.exp.value {
             UnannotatedExp_::Copy { var, .. } | UnannotatedExp_::BorrowLocal(_, var) => var,
             _ => return None,
         };
-        if state.locals().get(var).is_some() {
+        if state.locals().contains_key(var) {
             state
                 .locals_mut()
                 .insert(*var, LocalState::Available(e.exp.loc, Value::Other));
@@ -321,8 +320,7 @@ fn unused_return_value_warning(call_site: CallSite) -> Diagnostic {
     let mut d = diag!(StyleCodes::UnusedReturnValue.diag_info(), (loc, msg));
     if tx_context_exempted {
         d.add_note(
-            "This function takes a '&mut TxContext' argument, but 'TxContext' is not counted \
-             as a mutable reference input for this lint.",
+            "'TxContext' is not considered a mutable reference input for the purposes of this lint.",
         );
     }
     d.add_note("Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.");

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -190,7 +190,7 @@ impl SimpleAbsInt for UnusedReturnValueAI {
                 }
                 Purity::Pure {
                     tx_context_exempted,
-                } => *&tx_context_exempted,
+                } => tx_context_exempted,
             };
             Value::Fresh(CallSite {
                 loc: *loc,

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -9,7 +9,7 @@ use crate::{
     cfgir::{
         CFGContext,
         absint::{BlockStates, JoinResult},
-        cfg::{CFG, ImmForwardCFG},
+        cfg::ImmForwardCFG,
         visitor::{
             LocalState, SimpleAbsInt, SimpleAbsIntConstructor, SimpleDomain, SimpleExecutionContext,
         },
@@ -19,8 +19,8 @@ use crate::{
     editions::Flavor,
     hlir::{
         ast::{
-            BaseType_, Command, Command_, LValue, LValue_, Label, ModuleCall, SingleType,
-            SingleType_, Type, Type_, Var,
+            BaseType_, Command, Command_, Exp, LValue, LValue_, Label, ModuleCall, SingleType,
+            SingleType_, Type, Type_, UnannotatedExp_, Var,
         },
         translate::{DisplayVar, display_var},
     },
@@ -29,29 +29,23 @@ use crate::{
     sui_mode::{SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME},
 };
 use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 pub struct UnusedReturnValue;
 
 pub struct UnusedReturnValueAI {
     is_sui: bool,
-    return_blocks: BTreeSet<Label>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ValueId {
-    block: Label,
-    cmd_idx: usize,
-    var: Symbol,
-}
+/// Function unique index derived from the block label + command index within the block
+pub type CommandIndex = (Label, usize);
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum Value {
     /// Pure-call result not yet bound to a named local.
     Fresh(Loc),
     /// Bound to one or more named locals; `id -> originating call loc`. Joins union the maps.
-    Bound(BTreeMap<ValueId, Loc>),
+    Bound(BTreeMap<CommandIndex, Loc>),
     #[default]
     Other,
 }
@@ -63,7 +57,7 @@ pub struct State {
 
 pub struct ExecutionContext {
     diags: Diagnostics,
-    location: (Label, usize),
+    current_command: (Label, usize),
 }
 
 impl SimpleAbsIntConstructor for UnusedReturnValue {
@@ -71,7 +65,7 @@ impl SimpleAbsIntConstructor for UnusedReturnValue {
 
     fn new<'a>(
         context: &'a CFGContext<'a>,
-        cfg: &ImmForwardCFG,
+        _cfg: &ImmForwardCFG,
         _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,
     ) -> Option<Self::AI<'a>> {
         if context.attributes.is_test_or_test_only()
@@ -84,19 +78,7 @@ impl SimpleAbsIntConstructor for UnusedReturnValue {
             return None;
         }
         let is_sui = context.env.package_config(context.package).flavor == Flavor::Sui;
-        let return_blocks = cfg
-            .block_labels()
-            .filter(|lbl| {
-                matches!(
-                    cfg.commands(*lbl).last(),
-                    Some((_, sp!(_, Command_::Return { .. })))
-                )
-            })
-            .collect();
-        Some(UnusedReturnValueAI {
-            is_sui,
-            return_blocks,
-        })
+        Some(UnusedReturnValueAI { is_sui })
     }
 }
 
@@ -106,55 +88,16 @@ impl SimpleAbsInt for UnusedReturnValueAI {
 
     fn finish(
         &mut self,
-        final_states: BTreeMap<Label, BlockStates<State>>,
-        mut diags: Diagnostics,
+        _final_states: BTreeMap<Label, BlockStates<State>>,
+        diags: Diagnostics,
     ) -> Diagnostics {
-        if self.return_blocks.is_empty() {
-            return diags;
-        }
-        let per_return: Vec<BTreeMap<ValueId, Loc>> = self
-            .return_blocks
-            .iter()
-            .filter_map(|lbl| {
-                let post = final_states.get(lbl)?.post.as_ref()?;
-                let mut m = BTreeMap::new();
-                for ls in post.locals.values() {
-                    if let LocalState::Available(_, v) = ls {
-                        let ids = match v {
-                            Value::Bound(ids) => ids,
-                            Value::Fresh(_) => {
-                                debug_assert!(false, "should never store a fresh value in a local");
-                                continue;
-                            }
-                            Value::Other => continue,
-                        };
-                        m.extend(ids);
-                    }
-                }
-                if m.is_empty() { None } else { Some(m) }
-            })
-            .collect();
-        if per_return.is_empty() {
-            return diags;
-        }
-        // intersect the unused from each return block
-        let mut iter = per_return.into_iter();
-        let mut unused = iter.next().unwrap();
-        for m in iter {
-            unused.retain(|id, _| m.contains_key(id));
-        }
-
-        // report an error for each unused value
-        for (_id, loc) in unused {
-            diags.add(unused_return_value_warning(loc));
-        }
         diags
     }
 
     fn start_command(&self, label: Label, idx: usize, _: &mut State) -> ExecutionContext {
         ExecutionContext {
             diags: Diagnostics::new(),
-            location: (label, idx),
+            current_command: (label, idx),
         }
     }
 
@@ -178,13 +121,45 @@ impl SimpleAbsInt for UnusedReturnValueAI {
         let Command_::IgnoreAndPop { exp, .. } = &cmd.value else {
             return false;
         };
+        // Report any popped, unused value. Collecting based on call sites
         let values = self.exp(context, state, exp);
+        let mut sites = BTreeMap::new();
         for v in values {
-            if let Value::Fresh(call_loc) = v {
-                context.add_diag(unused_return_value_warning(call_loc));
+            match v {
+                Value::Fresh(call_loc) => {
+                    sites.insert(context.current_command, call_loc);
+                }
+                Value::Bound(v_sites) => {
+                    sites.extend(v_sites);
+                }
+                Value::Other => (),
             }
         }
-        true
+        for loc in sites.into_values() {
+            context.add_diag(unused_return_value_warning(loc));
+        }
+        false
+    }
+
+    fn exp_custom(
+        &self,
+        _context: &mut ExecutionContext,
+        state: &mut State,
+        e: &Exp,
+    ) -> Option<Vec<Value>> {
+        // If the local is copied or borrowed, this will not free the value, but does mean that
+        // the value is now "used". We can update the value as being used to prevent any
+        // erroneous error reporting... though this likely will never happen
+        let var = match &e.exp.value {
+            UnannotatedExp_::Copy { var, .. } | UnannotatedExp_::BorrowLocal(_, var) => var,
+            _ => return None,
+        };
+        if state.locals().get(var).is_some() {
+            state
+                .locals_mut()
+                .insert(*var, LocalState::Available(e.exp.loc, Value::Other));
+        }
+        None
     }
 
     fn call_custom(
@@ -230,13 +205,7 @@ impl SimpleAbsInt for UnusedReturnValueAI {
             // The compiler already generates warnings for unused locals.
             _ if matches!(display_var, DisplayVar::Orig(_)) => Value::Other,
             Value::Fresh(call_loc) => {
-                let (block, cmd_idx) = context.location;
-                let id = ValueId {
-                    block,
-                    cmd_idx,
-                    var: var.0.value,
-                };
-                Value::Bound(BTreeMap::from([(id, *call_loc)]))
+                Value::Bound(BTreeMap::from([(context.current_command, *call_loc)]))
             }
             Value::Bound(_) | Value::Other => value.clone(),
         };
@@ -264,16 +233,19 @@ impl SimpleDomain for State {
 
     fn join_value(v1: &Value, v2: &Value) -> Value {
         match (v1, v2) {
+            (Value::Fresh(_), v) | (v, Value::Fresh(_)) => {
+                debug_assert!(
+                    false,
+                    "A fresh value should never reach the end of the block"
+                );
+                v.clone()
+            }
+            (Value::Other, v) | (v, Value::Other) => v.clone(),
             (Value::Bound(m1), Value::Bound(m2)) => {
                 let mut m = m1.clone();
-                for (id, loc) in m2 {
-                    m.insert(*id, *loc);
-                }
+                m.extend(m2);
                 Value::Bound(m)
             }
-            // One side lost tracking - drop. `MaybeUnavailable` from the framework's
-            // `LocalState` join still hides consumed-on-one-branch values from `finish`.
-            _ => Value::Other,
         }
     }
 

--- a/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/unused_return_value.rs
@@ -17,9 +17,12 @@ use crate::{
     diag,
     diagnostics::{Diagnostic, Diagnostics},
     editions::Flavor,
-    hlir::ast::{
-        BaseType_, Command, Command_, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_,
-        Type, Type_, Var,
+    hlir::{
+        ast::{
+            BaseType_, Command, Command_, LValue, LValue_, Label, ModuleCall, SingleType,
+            SingleType_, Type, Type_, Var,
+        },
+        translate::{DisplayVar, display_var},
     },
     linters::StyleCodes,
     parser::ast::Ability_,
@@ -220,9 +223,12 @@ impl SimpleAbsInt for UnusedReturnValueAI {
         let LValue_::Var { var, .. } = l_ else {
             return false;
         };
+        let display_var = display_var(var.0.value);
         let new_value = match value {
-            // Leading-underscore locals are conventionally intentionally/potentially unused
-            Value::Fresh(_) | Value::Bound(_) if var.starts_with_underscore() => Value::Other,
+            // If bound to a user-named local, stop tracking. We only want to track through
+            // compiler generated temporaries.
+            // The compiler already generates warnings for unused locals.
+            _ if matches!(display_var, DisplayVar::Orig(_)) => Value::Other,
             Value::Fresh(call_loc) => {
                 let (block, cmd_idx) = context.location;
                 let id = ValueId {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/id_leak.rs
@@ -172,17 +172,27 @@ impl SimpleAbsInt for IDLeakVerifierAI<'_> {
     type State = State;
     type ExecutionContext = ExecutionContext;
 
-    fn finish(&mut self, _final_states: BTreeMap<Label, State>, diags: Diagnostics) -> Diagnostics {
+    fn finish(
+        &mut self,
+        _final_states: BTreeMap<Label, crate::cfgir::absint::BlockStates<State>>,
+        diags: Diagnostics,
+    ) -> Diagnostics {
         diags
     }
 
-    fn start_command(&self, _: &mut State) -> ExecutionContext {
+    fn start_command(&self, _label: Label, _idx: usize, _: &mut State) -> ExecutionContext {
         ExecutionContext {
             diags: Diagnostics::new(),
         }
     }
 
-    fn finish_command(&self, context: ExecutionContext, _state: &mut State) -> Diagnostics {
+    fn finish_command(
+        &self,
+        _label: Label,
+        _idx: usize,
+        context: ExecutionContext,
+        _state: &mut State,
+    ) -> Diagnostics {
         let ExecutionContext { diags } = context;
         diags
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -122,17 +122,27 @@ impl SimpleAbsInt for CustomStateChangeVerifierAI {
     type State = State;
     type ExecutionContext = ExecutionContext;
 
-    fn finish(&mut self, _final_states: BTreeMap<Label, State>, diags: Diagnostics) -> Diagnostics {
+    fn finish(
+        &mut self,
+        _final_states: BTreeMap<Label, crate::cfgir::absint::BlockStates<State>>,
+        diags: Diagnostics,
+    ) -> Diagnostics {
         diags
     }
 
-    fn start_command(&self, _: &mut State) -> ExecutionContext {
+    fn start_command(&self, _label: Label, _idx: usize, _: &mut State) -> ExecutionContext {
         ExecutionContext {
             diags: Diagnostics::new(),
         }
     }
 
-    fn finish_command(&self, context: ExecutionContext, _state: &mut State) -> Diagnostics {
+    fn finish_command(
+        &self,
+        _label: Label,
+        _idx: usize,
+        context: ExecutionContext,
+        _state: &mut State,
+    ) -> Diagnostics {
         let ExecutionContext { diags } = context;
         diags
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -204,23 +204,38 @@ pub fn known_filters() -> (Option<Symbol>, Vec<(FilterName, Vec<DiagnosticsID>)>
     (Some(ALLOW_ATTR_CATEGORY.into()), filters)
 }
 
+/// Sui-mode lints that run unconditionally at `LintLevel::Default` and `LintLevel::All`.
+/// Kept as a helper so the `All` arm doesn't double-register lints that live in the core
+/// linter list (which is also added at `All`).
+fn sui_only_default_visitors() -> Vec<Visitor> {
+    vec![
+        share_owned::ShareOwnedVerifier.visitor(),
+        self_transfer::SelfTransferVerifier.visitor(),
+        custom_state_change::CustomStateChangeVerifier.visitor(),
+        coin_field::CoinFieldVisitor.visitor(),
+        freeze_wrapped::FreezeWrappedVisitor.visitor(),
+        collection_equality::CollectionEqualityVisitor.visitor(),
+        public_random::PublicRandomVisitor.visitor(),
+        missing_key::MissingKeyVisitor.visitor(),
+        unnecessary_public_entry::UnnecessaryPublicEntry.visitor(),
+        uncallable_function::UncallableFunction.visitor(),
+    ]
+}
+
 pub fn linter_visitors(level: LintLevel) -> Vec<Visitor> {
     match level {
         LintLevel::None => vec![],
-        LintLevel::Default => vec![
-            share_owned::ShareOwnedVerifier.visitor(),
-            self_transfer::SelfTransferVerifier.visitor(),
-            custom_state_change::CustomStateChangeVerifier.visitor(),
-            coin_field::CoinFieldVisitor.visitor(),
-            freeze_wrapped::FreezeWrappedVisitor.visitor(),
-            collection_equality::CollectionEqualityVisitor.visitor(),
-            public_random::PublicRandomVisitor.visitor(),
-            missing_key::MissingKeyVisitor.visitor(),
-            unnecessary_public_entry::UnnecessaryPublicEntry.visitor(),
-            uncallable_function::UncallableFunction.visitor(),
-        ],
+        LintLevel::Default => {
+            let mut visitors = sui_only_default_visitors();
+            // The core linter registers `unused_return_value` at `LintLevel::All`. To make it
+            // on-by-default in Sui packages, register it here too.
+            visitors.push(crate::linters::unused_return_value::UnusedReturnValue.visitor());
+            visitors
+        }
         LintLevel::All => {
-            let mut visitors = linter_visitors(LintLevel::Default);
+            // Note: `unused_return_value` is not in this list — the core linter list registers
+            // it at `All`, so adding it here would cause duplicate diagnostics in Sui+--lint.
+            let mut visitors = sui_only_default_visitors();
             visitors.extend([
                 freezing_capability::WarnFreezeCapability.visitor(),
                 public_mut_tx_context::PreferMutableTxContext.visitor(),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -204,38 +204,25 @@ pub fn known_filters() -> (Option<Symbol>, Vec<(FilterName, Vec<DiagnosticsID>)>
     (Some(ALLOW_ATTR_CATEGORY.into()), filters)
 }
 
-/// Sui-mode lints that run unconditionally at `LintLevel::Default` and `LintLevel::All`.
-/// Kept as a helper so the `All` arm doesn't double-register lints that live in the core
-/// linter list (which is also added at `All`).
-fn sui_only_default_visitors() -> Vec<Visitor> {
-    vec![
-        share_owned::ShareOwnedVerifier.visitor(),
-        self_transfer::SelfTransferVerifier.visitor(),
-        custom_state_change::CustomStateChangeVerifier.visitor(),
-        coin_field::CoinFieldVisitor.visitor(),
-        freeze_wrapped::FreezeWrappedVisitor.visitor(),
-        collection_equality::CollectionEqualityVisitor.visitor(),
-        public_random::PublicRandomVisitor.visitor(),
-        missing_key::MissingKeyVisitor.visitor(),
-        unnecessary_public_entry::UnnecessaryPublicEntry.visitor(),
-        uncallable_function::UncallableFunction.visitor(),
-    ]
-}
-
 pub fn linter_visitors(level: LintLevel) -> Vec<Visitor> {
     match level {
         LintLevel::None => vec![],
-        LintLevel::Default => {
-            let mut visitors = sui_only_default_visitors();
-            // The core linter registers `unused_return_value` at `LintLevel::All`. To make it
-            // on-by-default in Sui packages, register it here too.
-            visitors.push(crate::linters::unused_return_value::UnusedReturnValue.visitor());
-            visitors
-        }
+        LintLevel::Default => vec![
+            share_owned::ShareOwnedVerifier.visitor(),
+            self_transfer::SelfTransferVerifier.visitor(),
+            custom_state_change::CustomStateChangeVerifier.visitor(),
+            coin_field::CoinFieldVisitor.visitor(),
+            freeze_wrapped::FreezeWrappedVisitor.visitor(),
+            collection_equality::CollectionEqualityVisitor.visitor(),
+            public_random::PublicRandomVisitor.visitor(),
+            missing_key::MissingKeyVisitor.visitor(),
+            unnecessary_public_entry::UnnecessaryPublicEntry.visitor(),
+            uncallable_function::UncallableFunction.visitor(),
+            // This is not on by default outside of Sui mode
+            crate::linters::unused_return_value::UnusedReturnValue.visitor(),
+        ],
         LintLevel::All => {
-            // Note: `unused_return_value` is not in this list — the core linter list registers
-            // it at `All`, so adding it here would cause duplicate diagnostics in Sui+--lint.
-            let mut visitors = sui_only_default_visitors();
+            let mut visitors = linter_visitors(LintLevel::Default);
             visitors.extend([
                 freezing_capability::WarnFreezeCapability.visitor(),
                 public_mut_tx_context::PreferMutableTxContext.visitor(),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -122,17 +122,27 @@ impl SimpleAbsInt for SelfTransferVerifierAI {
     type State = State;
     type ExecutionContext = ExecutionContext;
 
-    fn finish(&mut self, _final_states: BTreeMap<Label, State>, diags: Diagnostics) -> Diagnostics {
+    fn finish(
+        &mut self,
+        _final_states: BTreeMap<Label, crate::cfgir::absint::BlockStates<State>>,
+        diags: Diagnostics,
+    ) -> Diagnostics {
         diags
     }
 
-    fn start_command(&self, _: &mut State) -> ExecutionContext {
+    fn start_command(&self, _label: Label, _idx: usize, _: &mut State) -> ExecutionContext {
         ExecutionContext {
             diags: Diagnostics::new(),
         }
     }
 
-    fn finish_command(&self, context: ExecutionContext, _state: &mut State) -> Diagnostics {
+    fn finish_command(
+        &self,
+        _label: Label,
+        _idx: usize,
+        context: ExecutionContext,
+        _state: &mut State,
+    ) -> Diagnostics {
         let ExecutionContext { diags } = context;
         diags
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -124,17 +124,27 @@ impl SimpleAbsInt for ShareOwnedVerifierAI<'_> {
     type State = State;
     type ExecutionContext = ExecutionContext;
 
-    fn finish(&mut self, _final_states: BTreeMap<Label, State>, diags: Diagnostics) -> Diagnostics {
+    fn finish(
+        &mut self,
+        _final_states: BTreeMap<Label, crate::cfgir::absint::BlockStates<State>>,
+        diags: Diagnostics,
+    ) -> Diagnostics {
         diags
     }
 
-    fn start_command(&self, _: &mut State) -> ExecutionContext {
+    fn start_command(&self, _label: Label, _idx: usize, _: &mut State) -> ExecutionContext {
         ExecutionContext {
             diags: Diagnostics::new(),
         }
     }
 
-    fn finish_command(&self, context: ExecutionContext, _state: &mut State) -> Diagnostics {
+    fn finish_command(
+        &self,
+        _label: Label,
+        _idx: usize,
+        context: ExecutionContext,
+        _state: &mut State,
+    ) -> Diagnostics {
         let ExecutionContext { diags } = context;
         diags
     }

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 
 use crate::{
     command_line::compiler::Visitor,
@@ -17,7 +17,7 @@ use move_proc_macros::growing_stack;
 
 pub type TypingVisitorObj = Box<dyn TypingVisitor>;
 
-pub trait TypingVisitor: Send + Sync {
+pub trait TypingVisitor: Send + Sync + Any {
     fn visit(&self, env: &CompilationEnv, program: &T::Program);
 
     fn visitor(self) -> Visitor
@@ -569,7 +569,7 @@ impl<V: TypingVisitor + 'static> From<V> for TypingVisitorObj {
     }
 }
 
-impl<V: TypingVisitorConstructor + Send + Sync> TypingVisitor for V {
+impl<V: TypingVisitorConstructor + Send + Sync + 'static> TypingVisitor for V {
     fn visit(&self, env: &CompilationEnv, program: &T::Program) {
         Self::visit(env, program)
     }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.move
@@ -1,0 +1,19 @@
+// Cases where the lint *should* warn but does not, by design of the analysis.
+module 0x42::m;
+
+fun pure(x: u64): u64 { x + 1 }
+
+// Operators discard their operands' tracking. The arithmetic itself has no effect, but the
+// statement-discard is not flagged because the framework's default `BinopExp` evaluation
+// returns a plain default value rather than propagating `Fresh`.
+fun binop_discard() {
+    (pure(1) + pure(2)); // no warn, but both calls are effectively unused
+}
+
+// Reassignment to the same local overwrites the prior `Bound` value; the previous call's
+// tracking is lost, so its discard is silently dropped.
+fun overwrite() {
+    let mut x = pure(1); // no warn: x is later overwritten before being used
+    x = pure(2);
+    let _ = x;
+}

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.move
@@ -1,19 +1,8 @@
-// Cases where the lint *should* warn but does not, by design of the analysis.
+// Cases where the lint *could* warn but does not, by design of the analysis.
 module 0x42::m;
 
 fun pure(x: u64): u64 { x + 1 }
 
-// Operators discard their operands' tracking. The arithmetic itself has no effect, but the
-// statement-discard is not flagged because the framework's default `BinopExp` evaluation
-// returns a plain default value rather than propagating `Fresh`.
-fun binop_discard() {
-    (pure(1) + pure(2)); // no warn, but both calls are effectively unused
-}
-
-// Reassignment to the same local overwrites the prior `Bound` value; the previous call's
-// tracking is lost, so its discard is silently dropped.
-fun overwrite() {
-    let mut x = pure(1); // no warn: x is later overwritten before being used
-    x = pure(2);
-    let _ = x;
+fun t() {
+    pure(1) + 1; // no warning, even though the value is not "used"
 }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.snap
@@ -5,10 +5,4 @@ info:
   edition: 2024.alpha
   lint: true
 ---
-warning[W09003]: unused assignment
-   ┌─ tests/linter/move_2024/false_negative_unused_return_value.move:16:9
-   │
-16 │     let mut x = pure(1); // no warn: x is later overwritten before being used
-   │         ^^^^^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
-   │
-   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/false_negative_unused_return_value.snap
@@ -1,0 +1,14 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: true
+---
+warning[W09003]: unused assignment
+   ┌─ tests/linter/move_2024/false_negative_unused_return_value.move:16:9
+   │
+16 │     let mut x = pure(1); // no warn: x is later overwritten before being used
+   │         ^^^^^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/suppress_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/suppress_unused_return_value.move
@@ -1,0 +1,13 @@
+// module-level suppression
+#[allow(lint(unused_return_value))]
+module 0x42::m {
+    fun pure(x: u64): u64 { x + 1 }
+    fun t() { pure(1); }
+}
+
+// function-level suppression
+module 0x42::n {
+    fun pure(x: u64): u64 { x + 1 }
+    #[allow(lint(unused_return_value))]
+    fun t() { pure(1); }
+}

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/suppress_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/suppress_unused_return_value.move
@@ -2,12 +2,14 @@
 #[allow(lint(unused_return_value))]
 module 0x42::m {
     fun pure(x: u64): u64 { x + 1 }
+
     fun t() { pure(1); }
 }
 
 // function-level suppression
 module 0x42::n {
     fun pure(x: u64): u64 { x + 1 }
+
     #[allow(lint(unused_return_value))]
     fun t() { pure(1); }
 }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/suppress_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/suppress_unused_return_value.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: true
+---
+

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_negative_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_negative_unused_return_value.move
@@ -1,64 +1,40 @@
 module 0x42::m;
 
 fun pure(x: u64): u64 { x + 1 }
-fun mutating(x: &mut u64): u64 { *x = *x + 1; *x }
+
+fun imm(_: &u64) {}
+
+fun mutating(_: &mut u64): u64 { 0 }
 
 // explicit `let _` discard is fine
-fun explicit_ignore() {
+fun t(b: bool): u64 {
     let _ = pure(1);
-}
-
-// underscore-prefixed binding is conventionally unused; no warn
-fun underscore_var() {
     let _x = pure(1);
+
+    // used in return
+    if (b) return pure(1);
+
+    // has mut input
+    mutating(&mut 0);
+
+    // Used in expr
+    let _ = pure(pure(1));
+    imm(&pure(1));
+    let _ = mutating(&mut pure(1));
+    let _ = pure(if (b) pure(0) else pure(1));
+    0
 }
 
-// result used as the function's return value
-fun returned(): u64 {
-    pure(1)
-}
-
-// result used by another call (Move consumes it)
-fun used_by_call(): u64 {
+#[allow(unused_variable)]
+fun t_unused_variable() {
+    // Triggers unused variable, not the lint
     let x = pure(1);
-    pure(x)
 }
 
-// call has a `&mut` arg: the call may have side effects, do not warn
-fun mut_arg_no_warn() {
-    let mut y = 0;
-    mutating(&mut y);
-}
-
-// used on every return path: no warn
-fun used_on_every_path(b: bool): u64 {
-    let x = pure(1);
-    if (b) {
-        return pure(x)
-    };
-    pure(x)
-}
-
-// used in some path and unused in another: do not warn (MaybeUnavailable at join)
-fun maybe_used(b: bool) {
-    let x = pure(1);
-    if (b) {
-        let _ = pure(x);
-    };
-}
-
-// shadowing: each x has its own scope; the inner x is used
-fun shadow(): u64 {
-    let x = pure(1);
+#[allow(unused_assignment)]
+fun t_unused_assignment() {
+    // Triggers unused assignment, not the lint
+    let mut x = pure(1);
+    x = pure(2);
     let _ = x;
-    {
-        let x = pure(2);
-        x
-    }
-}
-
-// reference returns are tracked but consuming them by another call counts as use
-fun ref_return(): u64 {
-    let r = &10u64;
-    *r
 }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_negative_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_negative_unused_return_value.move
@@ -1,0 +1,64 @@
+module 0x42::m;
+
+fun pure(x: u64): u64 { x + 1 }
+fun mutating(x: &mut u64): u64 { *x = *x + 1; *x }
+
+// explicit `let _` discard is fine
+fun explicit_ignore() {
+    let _ = pure(1);
+}
+
+// underscore-prefixed binding is conventionally unused; no warn
+fun underscore_var() {
+    let _x = pure(1);
+}
+
+// result used as the function's return value
+fun returned(): u64 {
+    pure(1)
+}
+
+// result used by another call (Move consumes it)
+fun used_by_call(): u64 {
+    let x = pure(1);
+    pure(x)
+}
+
+// call has a `&mut` arg: the call may have side effects, do not warn
+fun mut_arg_no_warn() {
+    let mut y = 0;
+    mutating(&mut y);
+}
+
+// used on every return path: no warn
+fun used_on_every_path(b: bool): u64 {
+    let x = pure(1);
+    if (b) {
+        return pure(x)
+    };
+    pure(x)
+}
+
+// used in some path and unused in another: do not warn (MaybeUnavailable at join)
+fun maybe_used(b: bool) {
+    let x = pure(1);
+    if (b) {
+        let _ = pure(x);
+    };
+}
+
+// shadowing: each x has its own scope; the inner x is used
+fun shadow(): u64 {
+    let x = pure(1);
+    let _ = x;
+    {
+        let x = pure(2);
+        x
+    }
+}
+
+// reference returns are tracked but consuming them by another call counts as use
+fun ref_return(): u64 {
+    let r = &10u64;
+    *r
+}

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_negative_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_negative_unused_return_value.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: true
+---
+

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.move
@@ -1,0 +1,89 @@
+module 0x42::m;
+
+public enum E has drop { A, B }
+
+fun pure(x: u64): u64 { x + 1 }
+fun pure2(x: u64): u64 { x + 2 }
+
+public macro fun apply<$T>($body: || -> $T): $T { $body() }
+
+// direct statement-discard
+fun direct() {
+    pure(1); // warn
+}
+
+// bound to a local that is never used
+#[allow(unused_variable)]
+fun bound_unused(): u64 {
+    let x = pure(1); // warn
+    0
+}
+
+// if/else as a discarded statement -- both arms are pure calls
+fun if_else_statement(b: bool) {
+    if (b) pure(1) else pure(2); // warn x2
+}
+
+// if/else nested in a let-bound unused var
+#[allow(unused_variable)]
+fun if_else_bound_unused(b: bool): u64 {
+    let x = if (b) pure(1) else pure(2); // warn x2 (one per branch)
+    0
+}
+
+// match as a discarded statement
+fun match_statement(e: E) {
+    match (e) {
+        E::A => pure(1), // warn
+        E::B => pure(2), // warn
+    };
+}
+
+// match nested in a let-bound unused var
+#[allow(unused_variable)]
+fun match_bound_unused(e: E): u64 {
+    let x = match (e) {
+        E::A => pure(1), // warn
+        E::B => pure(2), // warn
+    };
+    0
+}
+
+// loop with break that yields a pure call's value, statement-discarded
+fun loop_break_statement(b: bool) {
+    loop {
+        if (b) break pure(1); // warn
+    };
+}
+
+// named block whose value comes from a labeled break, statement-discarded
+fun named_block_statement(b: bool) {
+    'l: {
+        if (b) {
+            return 'l pure(1) // warn
+        };
+        pure2(2) // warn (tail of the labeled block)
+    };
+}
+
+// two different pure calls, only one used: warn for the unused one only
+#[allow(unused_variable)]
+fun two_pures_one_used(): u64 {
+    let x = pure(1);
+    let y = pure2(2); // warn (y is never read)
+    x
+}
+
+// macro call statement-discarded; inlines to a discarded `pure(1)`
+fun macro_direct() {
+    apply!(|| pure(1)); // warn
+}
+
+// named labeled break from inside a macro's lambda; the enclosing 'l block is discarded
+#[allow(dead_code)]
+fun macro_named_break() {
+    'l: {
+        apply!(|| return 'l pure(1)); // warn
+        0 // unreachable tail to give 'l a non-trivial body
+    };
+}

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.move
@@ -1,57 +1,51 @@
 module 0x42::m;
 
-public enum E has drop { A, B }
+public enum E has drop {
+    A,
+    B,
+}
 
 fun pure(x: u64): u64 { x + 1 }
+
 fun pure2(x: &u64): (u64, &u64) { (*x + 2, x) }
 
 public macro fun apply<$T>($body: || -> $T): $T { $body() }
 
 // direct statement-discard
-fun direct() {
+#[allow(dead_code)]
+fun direct(b: bool, e: &E) {
     pure(1); // warn
-}
-
-// if/else as a discarded statement -- both arms are pure calls
-fun if_else_statement(b: bool) {
+    pure2(&0); // warn once, even though two values are ignored
     if (b) pure(1) else pure(2); // warn x2
-}
-
-// match as a discarded statement
-fun match_statement(e: E) {
     match (e) {
         E::A => pure(1), // warn
         E::B => pure(2), // warn
     };
-}
-
-// loop with break that yields a pure call's value, statement-discarded
-fun loop_break_statement(b: bool) {
     loop {
         if (b) break pure(1); // warn
     };
-}
-
-// named block whose value comes from a labeled break, statement-discarded
-fun named_block_statement(b: bool) {
     'l: {
         if (b) {
             return 'l pure(1) // warn
         };
         pure(2) // warn
     };
-}
-
-// macro call statement-discarded; inlines to a discarded `pure(1)`
-fun macro_direct() {
     apply!(|| pure(1)); // warn
-}
-
-// named labeled break from inside a macro's lambda; the enclosing 'l block is discarded
-#[allow(dead_code)]
-fun macro_named_break() {
     'l: {
         apply!(|| return 'l pure(1)); // warn
         0 // unreachable
     };
+    pure2(&pure(0)); // warn for the outer pure2
+}
+
+#[allow(dead_code)]
+fun after_branch(cond: bool) {
+    if (cond) return;
+    pure(1); // warn
+    apply!(|| pure(2)); // warn
+    'l: {
+        apply!(|| return 'l pure(1)); // warn
+        0 // unreachable
+    };
+    if (cond) { if (cond) pure(1) else pure(2) } else { 0 }; // warn
 }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.move
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.move
@@ -3,7 +3,7 @@ module 0x42::m;
 public enum E has drop { A, B }
 
 fun pure(x: u64): u64 { x + 1 }
-fun pure2(x: u64): u64 { x + 2 }
+fun pure2(x: &u64): (u64, &u64) { (*x + 2, x) }
 
 public macro fun apply<$T>($body: || -> $T): $T { $body() }
 
@@ -12,23 +12,9 @@ fun direct() {
     pure(1); // warn
 }
 
-// bound to a local that is never used
-#[allow(unused_variable)]
-fun bound_unused(): u64 {
-    let x = pure(1); // warn
-    0
-}
-
 // if/else as a discarded statement -- both arms are pure calls
 fun if_else_statement(b: bool) {
     if (b) pure(1) else pure(2); // warn x2
-}
-
-// if/else nested in a let-bound unused var
-#[allow(unused_variable)]
-fun if_else_bound_unused(b: bool): u64 {
-    let x = if (b) pure(1) else pure(2); // warn x2 (one per branch)
-    0
 }
 
 // match as a discarded statement
@@ -37,16 +23,6 @@ fun match_statement(e: E) {
         E::A => pure(1), // warn
         E::B => pure(2), // warn
     };
-}
-
-// match nested in a let-bound unused var
-#[allow(unused_variable)]
-fun match_bound_unused(e: E): u64 {
-    let x = match (e) {
-        E::A => pure(1), // warn
-        E::B => pure(2), // warn
-    };
-    0
 }
 
 // loop with break that yields a pure call's value, statement-discarded
@@ -62,16 +38,8 @@ fun named_block_statement(b: bool) {
         if (b) {
             return 'l pure(1) // warn
         };
-        pure2(2) // warn (tail of the labeled block)
+        pure(2) // warn
     };
-}
-
-// two different pure calls, only one used: warn for the unused one only
-#[allow(unused_variable)]
-fun two_pures_one_used(): u64 {
-    let x = pure(1);
-    let y = pure2(2); // warn (y is never read)
-    x
 }
 
 // macro call statement-discarded; inlines to a discarded `pure(1)`
@@ -84,6 +52,6 @@ fun macro_direct() {
 fun macro_named_break() {
     'l: {
         apply!(|| return 'l pure(1)); // warn
-        0 // unreachable tail to give 'l a non-trivial body
+        0 // unreachable
     };
 }

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
@@ -1,0 +1,150 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: true
+---
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:12:5
+   │
+12 │     pure(1); // warn
+   │     ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:18:13
+   │
+18 │     let x = pure(1); // warn
+   │             ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:24:12
+   │
+24 │     if (b) pure(1) else pure(2); // warn x2
+   │            ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:24:25
+   │
+24 │     if (b) pure(1) else pure(2); // warn x2
+   │                         ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:30:20
+   │
+30 │     let x = if (b) pure(1) else pure(2); // warn x2 (one per branch)
+   │                    ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:30:33
+   │
+30 │     let x = if (b) pure(1) else pure(2); // warn x2 (one per branch)
+   │                                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:37:17
+   │
+37 │         E::A => pure(1), // warn
+   │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:38:17
+   │
+38 │         E::B => pure(2), // warn
+   │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:46:17
+   │
+46 │         E::A => pure(1), // warn
+   │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:47:17
+   │
+47 │         E::B => pure(2), // warn
+   │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:55:22
+   │
+55 │         if (b) break pure(1); // warn
+   │                      ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:63:23
+   │
+63 │             return 'l pure(1) // warn
+   │                       ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:65:9
+   │
+65 │         pure2(2) // warn (tail of the labeled block)
+   │         ^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:73:13
+   │
+73 │     let y = pure2(2); // warn (y is never read)
+   │             ^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:79:15
+   │
+79 │     apply!(|| pure(1)); // warn
+   │               ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:86:29
+   │
+86 │         apply!(|| return 'l pure(1)); // warn
+   │                             ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
@@ -6,46 +6,154 @@ info:
   lint: true
 ---
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:12:5
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:17:5
    │
-12 │     pure(1); // warn
+17 │     pure(1); // warn
    │     ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:17:12
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:18:5
    │
-17 │     if (b) pure(1) else pure(2); // warn x2
+18 │     pure2(&0); // warn once, even though two values are ignored
+   │     ^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:19:12
+   │
+19 │     if (b) pure(1) else pure(2); // warn x2
    │            ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:17:25
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:19:25
    │
-17 │     if (b) pure(1) else pure(2); // warn x2
+19 │     if (b) pure(1) else pure(2); // warn x2
    │                         ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:23:17
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:21:17
    │
-23 │         E::A => pure(1), // warn
+21 │         E::A => pure(1), // warn
    │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:24:17
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:22:17
    │
-24 │         E::B => pure(2), // warn
+22 │         E::B => pure(2), // warn
    │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:25:22
+   │
+25 │         if (b) break pure(1); // warn
+   │                      ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:29:23
+   │
+29 │             return 'l pure(1) // warn
+   │                       ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:31:9
+   │
+31 │         pure(2) // warn
+   │         ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:33:15
+   │
+33 │     apply!(|| pure(1)); // warn
+   │               ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:35:29
+   │
+35 │         apply!(|| return 'l pure(1)); // warn
+   │                             ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:38:5
+   │
+38 │     pure2(&pure(0)); // warn for the outer pure2
+   │     ^^^^^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:44:5
+   │
+44 │     pure(1); // warn
+   │     ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:45:15
+   │
+45 │     apply!(|| pure(2)); // warn
+   │               ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:47:29
+   │
+47 │         apply!(|| return 'l pure(1)); // warn
+   │                             ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:50:27
+   │
+50 │     if (cond) { if (cond) pure(1) else pure(2) } else { 0 }; // warn
+   │                           ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:50:40
+   │
+50 │     if (cond) { if (cond) pure(1) else pure(2) } else { 0 }; // warn
+   │                                        ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
@@ -15,136 +15,37 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:18:13
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:17:12
    │
-18 │     let x = pure(1); // warn
-   │             ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:24:12
-   │
-24 │     if (b) pure(1) else pure(2); // warn x2
+17 │     if (b) pure(1) else pure(2); // warn x2
    │            ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:24:25
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:17:25
    │
-24 │     if (b) pure(1) else pure(2); // warn x2
+17 │     if (b) pure(1) else pure(2); // warn x2
    │                         ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:30:20
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:23:17
    │
-30 │     let x = if (b) pure(1) else pure(2); // warn x2 (one per branch)
-   │                    ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:30:33
-   │
-30 │     let x = if (b) pure(1) else pure(2); // warn x2 (one per branch)
-   │                                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:37:17
-   │
-37 │         E::A => pure(1), // warn
+23 │         E::A => pure(1), // warn
    │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:38:17
+   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:24:17
    │
-38 │         E::B => pure(2), // warn
+24 │         E::B => pure(2), // warn
    │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:46:17
-   │
-46 │         E::A => pure(1), // warn
-   │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:47:17
-   │
-47 │         E::B => pure(2), // warn
-   │                 ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:55:22
-   │
-55 │         if (b) break pure(1); // warn
-   │                      ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:63:23
-   │
-63 │             return 'l pure(1) // warn
-   │                       ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:65:9
-   │
-65 │         pure2(2) // warn (tail of the labeled block)
-   │         ^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:73:13
-   │
-73 │     let y = pure2(2); // warn (y is never read)
-   │             ^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:79:15
-   │
-79 │     apply!(|| pure(1)); // warn
-   │               ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:86:29
-   │
-86 │         apply!(|| return 'l pure(1)); // warn
-   │                             ^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/linter/suppress_unnecessary_unit.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/suppress_unnecessary_unit.snap
@@ -5,4 +5,11 @@ info:
   edition: legacy
   lint: true
 ---
-
+warning[Lint W02013]: return value of a non-mutating call is discarded
+  ┌─ tests/linter/suppress_unnecessary_unit.move:7:27
+  │
+7 │         if (!x) () else { test_empty_else(x); };
+  │                           ^^^^^^^^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+  │
+  = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+  = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.move
@@ -1,31 +1,13 @@
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
 
-// In Sui mode, `&mut TxContext` and `&TxContext` are exempt from counting as mutating
-// parameters for this lint. Functions whose only references are TxContexts are treated
-// as pure: discarding their result warns.
+// TxContext is not considered a "mutating" input for the unused return value lint
 
 module a::tests {
     use sui::tx_context::TxContext;
 
-    fun new_id(_ctx: &mut TxContext): u64 { 0 }
-    fun read_only(_ctx: &TxContext): u64 { 0 }
-    fun really_mutating(x: &mut u64): u64 { *x = *x + 1; *x }
+    fun mut_ctx(_ctx: &mut TxContext): u64 { 0 }
 
-    // `&mut TxContext` exempt: warn on discard
-    fun mut_tx_ctx(ctx: &mut TxContext) {
-        new_id(ctx); // warn
-    }
-
-    // `&TxContext` exempt: warn on discard
-    fun immut_tx_ctx(ctx: &TxContext) {
-        read_only(ctx); // warn
-    }
-
-    // genuinely mutating: do not warn
-    fun mut_other() {
-        let y = 0;
-        really_mutating(&mut y);
+    fun t(ctx: &mut TxContext) {
+        mut_ctx(ctx);
     }
 }
 

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// In Sui mode, `&mut TxContext` and `&TxContext` are exempt from counting as mutating
+// parameters for this lint. Functions whose only references are TxContexts are treated
+// as pure: discarding their result warns.
+
+module a::tests {
+    use sui::tx_context::TxContext;
+
+    fun new_id(_ctx: &mut TxContext): u64 { 0 }
+    fun read_only(_ctx: &TxContext): u64 { 0 }
+    fun really_mutating(x: &mut u64): u64 { *x = *x + 1; *x }
+
+    // `&mut TxContext` exempt: warn on discard
+    fun mut_tx_ctx(ctx: &mut TxContext) {
+        new_id(ctx); // warn
+    }
+
+    // `&TxContext` exempt: warn on discard
+    fun immut_tx_ctx(ctx: &TxContext) {
+        read_only(ctx); // warn
+    }
+
+    // genuinely mutating: do not warn
+    fun mut_other() {
+        let y = 0;
+        really_mutating(&mut y);
+    }
+}
+
+module sui::tx_context {
+    struct TxContext has drop {}
+}

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
@@ -1,0 +1,24 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: sui
+  edition: legacy
+  lint: true
+---
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/sui_mode/linter/unused_return_value_tx_context.move:17:9
+   │
+17 │         new_id(ctx); // warn
+   │         ^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[Lint W02013]: return value of a non-mutating call is discarded
+   ┌─ tests/sui_mode/linter/unused_return_value_tx_context.move:22:9
+   │
+22 │         read_only(ctx); // warn
+   │         ^^^^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+   │
+   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
+   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
@@ -11,5 +11,6 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
 10 │         mut_ctx(ctx);
    │         ^^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
+   = This function takes a '&mut TxContext' argument, but 'TxContext' is not counted as a mutable reference input for this lint.
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
@@ -6,19 +6,10 @@ info:
   lint: true
 ---
 warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/sui_mode/linter/unused_return_value_tx_context.move:17:9
+   ┌─ tests/sui_mode/linter/unused_return_value_tx_context.move:10:9
    │
-17 │         new_id(ctx); // warn
-   │         ^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
-   │
-   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
-   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[Lint W02013]: return value of a non-mutating call is discarded
-   ┌─ tests/sui_mode/linter/unused_return_value_tx_context.move:22:9
-   │
-22 │         read_only(ctx); // warn
-   │         ^^^^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
+10 │         mut_ctx(ctx);
+   │         ^^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
@@ -11,6 +11,6 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
 10 │         mut_ctx(ctx);
    │         ^^^^^^^^^^^^ Unused return value. This function takes no '&mut' arguments, so its result is the only observable effect of the call
    │
-   = This function takes a '&mut TxContext' argument, but 'TxContext' is not counted as a mutable reference input for this lint.
+   = 'TxContext' is not considered a mutable reference input for the purposes of this lint.
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')


### PR DESCRIPTION
## Description 

- Added a lint for unused return values in cases where there is no &mut input and the return value _has_ `drop`
- For Sui, `&mut TxContext` is not considered a mutable input

## Test plan 

- New tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
