### PR TITLE
[move][move-decompiler] Strip redundant `freeze` wrappers [7/8]

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
@@ -34,26 +34,23 @@ impl Refine for DedupeFreeze {
         else {
             return false;
         };
-        if args.len() != 1 {
-            return false;
-        }
-        match &args[0] {
-            // `freeze(freeze(e))` -> `freeze(e)`: drop the outer, keep the inner.
-            Exp::Data {
+        let strip = match args.as_slice() {
+            // `freeze(freeze(e))` → `freeze(e)`: drop the outer, keep the inner `Data`.
+            [Exp::Data {
                 op: DataOp::FreezeRef,
                 args: inner,
-            } if inner.len() == 1 => {
-                let inner = args.pop().unwrap();
-                *exp = inner;
-                true
-            }
-            // `freeze(&e)` -> `&e`: the immutable borrow already produces `&T`.
-            Exp::Borrow(false, _) => {
-                let inner = args.pop().unwrap();
-                *exp = inner;
-                true
-            }
+            }] if inner.len() == 1 => true,
+            // `freeze(&e)` → `&e`: the immutable borrow already produces `&T`.
+            [Exp::Borrow(false, _)] => true,
             _ => false,
+        };
+        if !strip {
+            return false;
         }
+        let Some(inner) = args.pop() else {
+            unreachable!()
+        };
+        *exp = inner;
+        true
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
@@ -34,23 +34,27 @@ impl Refine for DedupeFreeze {
         else {
             return false;
         };
-        let strip = match args.as_slice() {
-            // `freeze(freeze(e))` → `freeze(e)`: drop the outer, keep the inner `Data`.
-            [Exp::Data {
-                op: DataOp::FreezeRef,
-                args: inner,
-            }] if inner.len() == 1 => true,
-            // `freeze(&e)` → `&e`: the immutable borrow already produces `&T`.
-            [Exp::Borrow(false, _)] => true,
-            _ => false,
-        };
-        if !strip {
+        let [inner] = args.as_slice() else {
             return false;
-        }
-        let Some(inner) = args.pop() else {
-            unreachable!()
         };
-        *exp = inner;
-        true
+        match inner {
+            // `freeze(freeze(e))` → `freeze(e)`. After the inner the value is already `&T`,
+            // so the outer is a no-op. Drop the outer, keep the inner `Data { FreezeRef }`.
+            Exp::Data {
+                op: DataOp::FreezeRef,
+                ..
+            } => {
+                *exp = args.pop().expect("checked above");
+                true
+            }
+            // `freeze(&e)` → `&e`. The immutable borrow already produces `&T`, so the
+            // outer freeze is a no-op. We do *not* match `Borrow(true, _)` — freezing a
+            // `&mut T` is a real downgrade we must keep.
+            Exp::Borrow(false, _) => {
+                *exp = args.pop().expect("checked above");
+                true
+            }
+            _ => false,
+        }
     }
 }

--- a/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
@@ -58,3 +58,60 @@ impl Refine for DedupeFreeze {
         }
     }
 }
+
+// No `.move` test exercises this: Move source has no syntactic `freeze`, and the structurer
+// only emits single, load-bearing `FreezeRef`s (the `&mut T -> &T` at call args), never the
+// nested / freeze-of-`&` shapes this pass targets. These unit tests build the AST directly so
+// the refinement still has positive coverage.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn var(n: &str) -> Exp {
+        Exp::Variable(n.to_string())
+    }
+
+    fn freeze(e: Exp) -> Exp {
+        Exp::Data {
+            op: DataOp::FreezeRef,
+            args: vec![e],
+        }
+    }
+
+    #[test]
+    fn collapses_nested_freeze() {
+        // freeze(freeze(x)) -> freeze(x)
+        let mut e = freeze(freeze(var("x")));
+        assert!(refine(&mut e));
+        let Exp::Data {
+            op: DataOp::FreezeRef,
+            args,
+        } = &e
+        else {
+            panic!("expected a single freeze, got {e:?}");
+        };
+        assert!(matches!(args.as_slice(), [Exp::Variable(n)] if n == "x"));
+    }
+
+    #[test]
+    fn collapses_freeze_of_immutable_borrow() {
+        // freeze(&x) -> &x
+        let mut e = freeze(Exp::Borrow(false, Box::new(var("x"))));
+        assert!(refine(&mut e));
+        assert!(matches!(&e, Exp::Borrow(false, _)));
+    }
+
+    #[test]
+    fn keeps_freeze_of_mut_borrow() {
+        // freeze(&mut x) is a real downgrade — leave it alone.
+        let mut e = freeze(Exp::Borrow(true, Box::new(var("x"))));
+        assert!(!refine(&mut e));
+        assert!(matches!(
+            &e,
+            Exp::Data {
+                op: DataOp::FreezeRef,
+                ..
+            }
+        ));
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/dedupe_freeze.rs
@@ -1,0 +1,59 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Strip redundant `freeze` wrappings:
+//!
+//! - `freeze(freeze(e))` -> `freeze(e)`. Move's `freeze` is `&mut T -> &T`; applying it
+//!   twice has the same observable result as once (after the inner the type is already
+//!   `&T`, and the outer would no-op).
+//! - `freeze(&e)` -> `&e`. An immutable `Borrow(false, _)` is already `&T`, so wrapping
+//!   it in `freeze` is a no-op. Note we *don't* strip `freeze(&mut e)` — that one
+//!   genuinely downgrades `&mut e` to `&e`.
+//!
+//! Both shapes survive the structurer in cases where the bytecode emitted a `FreezeRef`
+//! that the source didn't (or used to chain through reference-shape transformations).
+//! Snapshot impact is modest, but the visible noise of `freeze(freeze(...))` and
+//! `freeze(&l0)` is easy to read past at a glance.
+
+use move_stackless_bytecode_2::ast::DataOp;
+
+use crate::{ast::Exp, refinement::Refine};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    DedupeFreeze.refine(exp)
+}
+
+struct DedupeFreeze;
+
+impl Refine for DedupeFreeze {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        let Exp::Data {
+            op: DataOp::FreezeRef,
+            args,
+        } = exp
+        else {
+            return false;
+        };
+        if args.len() != 1 {
+            return false;
+        }
+        match &args[0] {
+            // `freeze(freeze(e))` -> `freeze(e)`: drop the outer, keep the inner.
+            Exp::Data {
+                op: DataOp::FreezeRef,
+                args: inner,
+            } if inner.len() == 1 => {
+                let inner = args.pop().unwrap();
+                *exp = inner;
+                true
+            }
+            // `freeze(&e)` -> `&e`: the immutable borrow already produces `&T`.
+            Exp::Borrow(false, _) => {
+                let inner = args.pop().unwrap();
+                *exp = inner;
+                true
+            }
+            _ => false,
+        }
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -6,6 +6,7 @@ use crate::ast::Exp;
 mod bool_if_simplify;
 mod collapse_let_usage;
 mod collect_uses;
+mod dedupe_freeze;
 mod flatten_seq;
 mod fuse_let;
 mod hoist_arm_assignments;
@@ -51,6 +52,7 @@ const REFINEMENTS: &[Refinement] = &[
     remove_trailing_continue::refine,
     remove_trailing_return::refine,
     simplify_borrow_deref::refine,
+    dedupe_freeze::refine,
     simplify_zero_compare::refine,
     negate_comparison::refine,
     simplify_if::refine,


### PR DESCRIPTION
## Description

Add a refinement that strips redundant `freeze` wrappers — `freeze(freeze(e))` and `freeze(&e)` — that the structurer can leave behind.

## Test plan

Snapshot updates with new refinements.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user
might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
