### PR TITLE
debug(settlement): diagnose accumulator underflow on settlement failure

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -177,6 +177,7 @@ impl ConsensusHandlerInitializer {
         let settlement_scheduler = SettlementScheduler::new(
             self.state.execution_scheduler().as_ref().clone(),
             self.state.get_transaction_cache_reader().clone(),
+            self.state.get_account_funds_read().clone(),
             self.state.metrics.clone(),
         );
         ConsensusHandler::new(
@@ -3669,6 +3670,7 @@ mod tests {
         let settlement_scheduler = SettlementScheduler::new(
             state.execution_scheduler().as_ref().clone(),
             state.get_transaction_cache_reader().clone(),
+            state.get_account_funds_read().clone(),
             state.metrics.clone(),
         );
         let mut consensus_handler = ConsensusHandler::new(
@@ -3934,6 +3936,7 @@ mod tests {
         let settlement_scheduler = SettlementScheduler::new(
             state.execution_scheduler().as_ref().clone(),
             state.get_transaction_cache_reader().clone(),
+            state.get_account_funds_read().clone(),
             state.metrics.clone(),
         );
         let mut handler = ConsensusHandler::new(
@@ -4060,6 +4063,7 @@ mod tests {
         let settlement_scheduler = SettlementScheduler::new(
             state.execution_scheduler().as_ref().clone(),
             state.get_transaction_cache_reader().clone(),
+            state.get_account_funds_read().clone(),
             state.metrics.clone(),
         );
         let mut handler = ConsensusHandler::new(

--- a/crates/sui-core/src/execution_scheduler/settlement_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/settlement_scheduler.rs
@@ -3,7 +3,7 @@
 
 use crate::authority::AuthorityMetrics;
 use crate::{
-    accumulators::{self, AccumulatorSettlementTxBuilder},
+    accumulators::{self, AccumulatorSettlementTxBuilder, funds_read::AccountFundsRead},
     authority::{
         ExecutionEnv,
         authority_per_epoch_store::AuthorityPerEpochStore,
@@ -16,11 +16,14 @@ use crate::{
     execution_scheduler::funds_withdraw_scheduler::FundsSettlement,
 };
 use futures::stream::{FuturesUnordered, StreamExt};
+use mysten_common::ZipDebugEqIteratorExt;
 use mysten_metrics::{monitored_mpsc, spawn_monitored_task};
 use parking_lot::Mutex;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use sui_types::{
     SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+    accumulator_root::AccumulatorObjId,
     base_types::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI},
     executable_transaction::VerifiedExecutableTransaction,
@@ -63,6 +66,7 @@ impl SettlementQueueSender {
 pub(crate) struct SettlementScheduler {
     execution_scheduler: ExecutionScheduler,
     transaction_cache_read: Arc<dyn TransactionCacheRead>,
+    account_funds_read: Arc<dyn AccountFundsRead>,
     settlement_queue_sender: Arc<Mutex<Option<SettlementQueueSender>>>,
     metrics: Arc<AuthorityMetrics>,
 }
@@ -71,11 +75,13 @@ impl SettlementScheduler {
     pub(crate) fn new(
         execution_scheduler: ExecutionScheduler,
         transaction_cache_read: Arc<dyn TransactionCacheRead>,
+        account_funds_read: Arc<dyn AccountFundsRead>,
         metrics: Arc<AuthorityMetrics>,
     ) -> Self {
         Self {
             execution_scheduler,
             transaction_cache_read,
+            account_funds_read,
             settlement_queue_sender: Arc::new(Mutex::new(None)),
             metrics,
         }
@@ -377,6 +383,10 @@ impl SettlementScheduler {
 
         let mut next_accumulator_version = None;
         for fx in all_settlement_effects.iter() {
+            if fx.status().is_err() {
+                self.log_underflowing_accounts(fx, &funds_changes);
+                self.dump_batch_transactions(&sorted_effects);
+            }
             assert!(
                 fx.status().is_ok(),
                 "settlement transaction cannot fail (digest: {:?}) {:#?}",
@@ -408,6 +418,63 @@ impl SettlementScheduler {
         debug!(?settlement_key, "early settlement: completed");
 
         settlement_tx_count
+    }
+
+    /// Settlement transactions are constructed to never fail, so a failure trips the assert above
+    /// and is node-fatal. The common cause is an accumulator account being withdrawn below zero.
+    /// Because a Move abort clears the effects (the failed tx's mutated set is empty), we can't
+    /// recover the offending account from `fx`; instead we re-check every account in this
+    /// checkpoint's `funds_changes` against its current balance, and log any whose projected
+    /// balance (`current balance + net funds change`) is negative.
+    fn log_underflowing_accounts(
+        &self,
+        fx: &TransactionEffects,
+        funds_changes: &BTreeMap<AccumulatorObjId, i128>,
+    ) {
+        error!(
+            digest = ?fx.transaction_digest(),
+            status = ?fx.status(),
+            "settlement transaction failed; checking for underflowing accumulator accounts"
+        );
+        for (account_id, funds_change) in funds_changes {
+            let (balance, root_version) = self
+                .account_funds_read
+                .get_latest_account_amount(account_id);
+            let projected = balance as i128 + funds_change;
+            if projected < 0 {
+                error!(
+                    ?account_id,
+                    balance,
+                    ?root_version,
+                    funds_change,
+                    shortfall = -projected,
+                    "accumulator account would underflow during settlement"
+                );
+            }
+        }
+    }
+
+    /// Dumps every input transaction in the settlement batch together with its accumulator
+    /// events. Called only on the (node-fatal) settlement-failure path to capture the
+    /// deposits/withdraws that fed into the failed settlement. `accumulator_events()`
+    /// recomputes from the effects' object changes, so it is unaffected by the builder having
+    /// already drained the cached events.
+    fn dump_batch_transactions(&self, sorted_effects: &[TransactionEffects]) {
+        let digests: Vec<_> = sorted_effects
+            .iter()
+            .map(|fx| *fx.transaction_digest())
+            .collect();
+        let txns = self
+            .transaction_cache_read
+            .multi_get_transaction_blocks(&digests);
+        for (fx, tx) in sorted_effects.iter().zip_debug_eq(txns) {
+            error!(
+                digest = ?fx.transaction_digest(),
+                accumulator_events = ?fx.accumulator_events(),
+                transaction = ?tx,
+                "settlement input transaction"
+            );
+        }
     }
 
     fn extract_consensus_commit_prologue_digest(


### PR DESCRIPTION
## Problem

Settlement transactions are constructed to never fail, so a failure trips the `fx.status().is_ok()` assert in `construct_and_execute_settlement` and is node-fatal. The common cause is an accumulator account being withdrawn below zero (the `value + merge - split` underflow in `accumulator.move`).

But a Move abort **clears the effects** (the failed tx's `mutated()` is empty), so the bare assert dump cannot tell you *which* account underflowed or *which* user transaction over-withdrew.

## Change

Add two diagnostics that run only on the (node-fatal) settlement-failure path, immediately before the assert panics:

- **`log_underflowing_accounts`** — for every account in this checkpoint's `funds_changes`, compare its current balance against the net change (`merge - split`) and log any whose projected balance (`balance + funds_change`) is negative, including the `shortfall`. This required threading `Arc<dyn AccountFundsRead>` into `SettlementScheduler` (+ its 4 `new` call sites in `consensus_handler.rs`, 3 of which are tests).
- **`dump_batch_transactions`** — dump every input transaction in the settlement batch (`sorted_effects`) together with its accumulator events, so the deposits/withdraws that fed the failed settlement can be traced to the originating user txns. Uses `accumulator_events()` (recomputed from effects) because the builder has already drained the cached events via `take_accumulator_events`.

## Notes

- Uses `error!` (not `debug!`) since this runs one line before a node-fatal panic and must be captured regardless of `RUST_LOG`.
- Because the abort clears effects, we cannot recover the failed tx's account set from `fx`; checking the whole-checkpoint `funds_changes` is the only surviving source. Non-underflowing accounts project ≥ 0 and stay silent.
- Pure diagnostics — no behavior change on the success path.

## Test plan

- [x] `cargo check -p sui-core`
- [x] `cargo fmt -p sui-core -- --check`
- [x] `cargo xclippy` (in `crates/sui-core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)