### PR TITLE
ci(sccache-warmup): broaden macOS disk cleanup to x86_64 runner

### DIFF
--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -65,12 +65,14 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y libpq-dev
 
-      - name: Remove unused apps (MacOS arm64)
-        if: ${{ matrix.os == 'macos-latest-xlarge' }}
+      - name: Remove unused apps (MacOS)
+        if: ${{ startsWith(matrix.os, 'macos-') }}
         continue-on-error: true
         shell: bash
         run: |
-          # MacOS arm64 runner only has 14GB avaialble, which is too small for our builds, so removing unused softwared.
+          # Both hosted macOS runners (x86_64 and arm64) ship with little free disk relative to
+          # our build footprint, and the headroom shifts whenever GitHub bumps the runner image.
+          # The df -h before/after leaves proof when the runner dies silently mid-job.
           df -h /
           sudo rm -rf /Applications/Xcode*.app
           sudo rm -rf ~/Library/Developer/Xcode/DerivedData


### PR DESCRIPTION
## Summary

`sccache-warmup.yml`'s `Remove unused apps` step was gated to `matrix.os == 'macos-latest-xlarge'` (arm64) only — so `macos-latest-large` (x86_64) ran with no disk cleanup. Starting with the GitHub runner image dated **2026-05-25**, the x86_64 macOS job has been dying silently between "Register cargo problem matcher" and the first cargo step. Every daily warmup run since May 25 has failed on `macos-latest-large` (only that platform); the other 4 platforms succeed, and there were **zero sui-side commits in the regression window**:

| Date | x86_64 macOS | other 4 |
|---|---|---|
| 2026-05-19 → 2026-05-24 | ✅ ✅ ✅ ✅ ✅ ✅ | ✅ |
| 2026-05-25 → 2026-05-28 | ❌ ❌ ❌ ❌ | ✅ |

The job dies between steps 8 and 9 — step 9 ("Build release binaries") never even starts; the runner just stops responding. That signature plus the image-version timing (runner image `20260525.0142.1` is dated May 25) points at the new image leaving too little disk headroom for the release build.

Today's failed run: https://github.com/MystenLabs/sui/actions/runs/26577619128

## Fix

- Widen the cleanup gate from `matrix.os == 'macos-latest-xlarge'` → `startsWith(matrix.os, 'macos-')` so both hosted macOS runners run the cleanup.
- Rename the step from "Remove unused apps (MacOS arm64)" → "Remove unused apps (MacOS)".
- Update the comment to reflect that disk pressure isn't arm64-specific (and explain why we keep the `df -h /` before/after instead of removing it).

The paths cleaned (`/Applications/Xcode*.app`, `~/Library/Developer/...`) exist on both architectures, so the same script works.

## Test plan

- [ ] The next scheduled warmup (daily 12:00 UTC) completes on `macos-latest-large` for the first time since 2026-05-24.
- [ ] The `df -h /` before/after output tells us how much headroom we recovered (and gives evidence for the next silent-death case).

## Out of scope

If disk cleanup alone isn't enough — i.e., the May-25 image is fundamentally too constrained for the release build — the follow-up is either pinning a specific image label (`macos-13-large` etc.) or dropping `macos-latest-large` from the warmup matrix entirely. The `df -h` output from the next run will tell us which path to take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)