### PR TITLE
Gate address-balance gas-smash fix on assigned accumulator version

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -158,7 +158,7 @@ impl EpochState {
                 self.execution_metrics.clone(),
                 false, // enable_expensive_checks
                 // TODO: Integrate with early execution error
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &self.epoch_start_state.epoch(),
                 self.epoch_start_state.epoch_start_timestamp_ms(),
                 checked_input_objects,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1998,9 +1998,10 @@ impl AuthorityState {
             self.config.certificate_deny_config.certificate_deny_set(),
             &execution_env.funds_withdraw_status,
         );
+        let accumulator_version = execution_env.assigned_versions.accumulator_version;
         let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
+            Some(error) => ExecutionOrEarlyError::failed(error, accumulator_version),
+            None => ExecutionOrEarlyError::ok(accumulator_version),
         };
 
         // Skip on early error: the tx will fail anyway and rewriting may fail if the accumulator
@@ -2503,9 +2504,11 @@ impl AuthorityState {
             self.config.certificate_deny_config.certificate_deny_set(),
             &FundsWithdrawStatus::MaybeSufficient,
         );
+        // Simulation/dev-inspect path (not committed): the assigned accumulator version is not
+        // available here, so the gas-smash gate is left inactive (None).
         let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
+            Some(error) => ExecutionOrEarlyError::failed(error, None),
+            None => ExecutionOrEarlyError::ok(None),
         };
 
         let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
@@ -2561,7 +2564,10 @@ impl AuthorityState {
                     protocol_config,
                     self.metrics.execution_metrics.clone(),
                     false,
-                    ExecutionOrEarlyError::Err(ExecutionErrorKind::InsufficientFundsForWithdraw),
+                    ExecutionOrEarlyError::failed(
+                        ExecutionErrorKind::InsufficientFundsForWithdraw,
+                        None,
+                    ),
                     &epoch_id,
                     epoch_timestamp_ms,
                     cloned_input_objects,

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1368,6 +1368,104 @@ async fn test_mix_coin_reservations_real_coins_and_shared_object() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
+/// Regression test: gas smashing must not underflow the address balance when a
+/// transaction fails with InsufficientFundsForWithdraw.
+///
+/// TX1 drains the AB to 0.  TX2 has gas_data.payment =
+/// [real_coin_a, real_coin_b, coin_reservation]: two real coins and a coin
+/// reservation.  After TX1 depletes the AB, the fund-checker fires IFFW for TX2.
+///
+/// With the fix, smashing is skipped entirely for IFFW transactions that have any
+/// address-balance payment.  This means:
+///   - No AB AccumulatorEvent is emitted (no underflow at settlement).
+///   - The two real coins are not merged: real_coin_b is not deleted and both coins
+///     keep their original balances (0 gas charged).
+///   - SUI conservation holds because no coin is mutated or deleted.
+#[sim_test]
+async fn test_gas_smash_no_ab_underflow_on_iffw() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+
+    // Fund the AB; both per-tx reservations must be ≤ this to pass signing validation.
+    let initial_ab = 20_000_000u64;
+    test_env.fund_one_address_balance(sender, initial_ab).await;
+
+    // Refresh gas list after funding (funding consumes one coin).
+    let mut all_gas = test_env.get_gas_for_sender(sender);
+    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
+
+    // TX1: withdraw all AB (pays gas from a real coin so the full initial_ab is freed).
+    let gas_for_tx1 = all_gas.remove(0);
+    let dummy = SuiAddress::random_for_testing_only();
+    let tx1 = test_env
+        .tx_builder_with_gas(sender, gas_for_tx1)
+        .transfer_sui_to_address_balance(
+            FundSource::address_fund_with_reservation(initial_ab),
+            vec![(initial_ab, dummy)],
+        )
+        .build();
+
+    // TX2: gas_data.payment = [real_coin_a, real_coin_b, coin_reservation].
+    // Using two real coins deliberately exercises the case where smashing would normally
+    // delete real_coin_b — the fix must leave it intact.
+    // Reservation = initial_ab / 2 passes per-tx signing validation (≤ initial_ab) but
+    // exceeds the post-TX1 balance of 0, triggering IFFW.
+    let real_coin_a = all_gas.remove(0);
+    let real_coin_b = all_gas.remove(0);
+    let reservation = initial_ab / 2;
+    let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
+    let tx2 = test_env
+        .tx_builder_with_gas_objects(sender, vec![real_coin_a, real_coin_b, fake_coin])
+        .build();
+
+    let tx1_digest = tx1.digest();
+    let tx2_digest = tx2.digest();
+
+    let mut effects = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[tx1, tx2])
+        .await
+        .unwrap();
+
+    let tx2_effects = effects.pop().unwrap().1;
+    let tx1_effects = effects.pop().unwrap().1;
+
+    assert!(
+        tx1_effects.status().is_ok(),
+        "TX1 should succeed: {:?}",
+        tx1_effects.status()
+    );
+    let status_str = format!("{:?}", tx2_effects.status());
+    assert!(
+        status_str.contains("InsufficientFundsForWithdraw"),
+        "TX2 should fail with InsufficientFundsForWithdraw, got: {status_str}"
+    );
+
+    // Wait for settlement.  Without the fix the settlement transaction aborts trying
+    // to split `reservation` from a 0-balance AB, crashing the node.
+    test_env
+        .cluster
+        .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
+        .await;
+
+    // AB must not have been touched by the failed TX2.
+    let final_ab = test_env.get_sui_balance_ab(sender);
+    assert_eq!(final_ab, 0, "AB should stay 0; got {final_ab}");
+
+    test_env.cluster.trigger_reconfiguration().await;
+}
+
 fn build_fake_coin_reservation_pt(
     chain_id: sui_types::digests::ChainIdentifier,
 ) -> TransactionKind {

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -925,7 +925,7 @@ fn create_genesis_transaction(
                 protocol_config,
                 metrics,
                 expensive_checks,
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &epoch_data.epoch_id(),
                 epoch_data.epoch_start_timestamp(),
                 input_objects,

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -126,8 +126,8 @@ pub fn execute_transaction_to_effects(
         &FundsWithdrawStatus::MaybeSufficient,
     );
     let execution_params = match early_execution_error {
-        Some(error) => ExecutionOrEarlyError::Err(error),
-        None => ExecutionOrEarlyError::Ok(()),
+        Some(error) => ExecutionOrEarlyError::failed(error, None),
+        None => ExecutionOrEarlyError::ok(None),
     };
     let (inner_store, gas_status, effects, _execution_timing, result) = executor
         .executor

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -789,8 +789,8 @@ impl LocalExec {
             &FundsWithdrawStatus::MaybeSufficient,
         );
         let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
+            Some(error) => ExecutionOrEarlyError::failed(error, None),
+            None => ExecutionOrEarlyError::ok(None),
         };
         let (inner_store, gas_status, effects, _timings, result) = executor
             .execute_transaction_to_effects_and_execution_error(
@@ -867,8 +867,8 @@ impl LocalExec {
             &FundsWithdrawStatus::MaybeSufficient,
         );
         let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
+            Some(error) => ExecutionOrEarlyError::failed(error, None),
+            None => ExecutionOrEarlyError::ok(None),
         };
         if let ProgrammableTransaction(pt) = transaction_kind {
             trace!(
@@ -985,8 +985,8 @@ impl LocalExec {
             &FundsWithdrawStatus::MaybeSufficient,
         );
         let execution_params = match early_execution_error {
-            Some(error) => ExecutionOrEarlyError::Err(error),
-            None => ExecutionOrEarlyError::Ok(()),
+            Some(error) => ExecutionOrEarlyError::failed(error, None),
+            None => ExecutionOrEarlyError::ok(None),
         };
         let (_, _, effects, _timings, exec_res) = executor
             .execute_transaction_to_effects_and_execution_error(

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -215,7 +215,7 @@ impl SingleValidator {
                 self.epoch_store.protocol_config(),
                 self.get_validator().metrics.execution_metrics.clone(),
                 false,
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &self.epoch_store.epoch(),
                 0,
                 input_objects,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -711,7 +711,7 @@ mod test {
                 &protocol_config,
                 metrics,
                 expensive_checks,
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &epoch.epoch_id(),
                 epoch.epoch_start_timestamp(),
                 input_objects,

--- a/crates/sui-types/src/execution_params.rs
+++ b/crates/sui-types/src/execution_params.rs
@@ -11,7 +11,62 @@ use crate::{
     execution_status::ExecutionErrorKind, transaction::CheckedInputObjects,
 };
 
-pub type ExecutionOrEarlyError = Result<(), ExecutionErrorKind>;
+/// Execution inputs computed before running a transaction: whether to fail it early (and with
+/// which error), plus deterministic context needed during gas charging.
+///
+/// This is an execution *input* only and is never serialized into `TransactionEffects`. Unlike
+/// `ExecutionErrorKind` / `ExecutionFailureStatus`, adding fields here does not change effects or
+/// their digests — which is why the assigned accumulator version is carried here rather than
+/// embedded in the error kind.
+#[derive(Debug, Clone)]
+pub struct ExecutionOrEarlyError {
+    early_error: Option<ExecutionErrorKind>,
+    /// Accumulator root version assigned to this transaction. Present whenever the transaction
+    /// reads address balances (always so for `InsufficientFundsForWithdraw`). Used to
+    /// deterministically gate gas-charging behavior within an epoch without changing effects.
+    accumulator_version: Option<SequenceNumber>,
+}
+
+impl ExecutionOrEarlyError {
+    /// Execute the transaction normally (no predetermined early error).
+    pub fn ok(accumulator_version: Option<SequenceNumber>) -> Self {
+        Self {
+            early_error: None,
+            accumulator_version,
+        }
+    }
+
+    /// Skip execution and fail the transaction with `error`.
+    pub fn failed(error: ExecutionErrorKind, accumulator_version: Option<SequenceNumber>) -> Self {
+        Self {
+            early_error: Some(error),
+            accumulator_version,
+        }
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.early_error.is_none()
+    }
+
+    pub fn is_err(&self) -> bool {
+        self.early_error.is_some()
+    }
+
+    /// The predetermined early error, if any.
+    pub fn early_error(&self) -> Option<&ExecutionErrorKind> {
+        self.early_error.as_ref()
+    }
+
+    /// Consume self, returning the predetermined early error, if any.
+    pub fn into_early_error(self) -> Option<ExecutionErrorKind> {
+        self.early_error
+    }
+
+    /// Accumulator root version assigned to this transaction, if any.
+    pub fn accumulator_version(&self) -> Option<SequenceNumber> {
+        self.accumulator_version
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FundsWithdrawStatus {

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -177,7 +177,7 @@ mod checked {
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
         input_objects: CheckedInputObjects,
-        gas_data: GasData,
+        mut gas_data: GasData,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         rewritten_inputs: Option<Vec<bool>>,
@@ -227,6 +227,22 @@ mod checked {
         };
         let gas_price = gas_status.gas_price();
         let rgp = gas_status.reference_gas_price();
+
+        // On an early `InsufficientFundsForWithdraw` abort we drop every address-balance
+        // payment except the smash target (index 0). This is the single place we apply that
+        // filter: by mutating `gas_data.payment` here, `payment_kind` and
+        // `compute_input_reservations` below see an already-pruned list and need no special
+        // handling. Coin entries (real `ObjectRef`s) are always kept.
+        if matches!(
+            execution_params,
+            Err(ExecutionErrorKind::InsufficientFundsForWithdraw)
+        ) && gas_data.payment.len() > 1
+            && ParsedDigest::try_from(gas_data.payment[0].2).is_err()
+        {
+            gas_data
+                .payment
+                .retain(|entry| ParsedDigest::try_from(entry.2).is_err());
+        }
 
         let mut gas_charger = GasCharger::new(
             transaction_digest,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -88,6 +88,98 @@ mod checked {
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     };
 
+    /// Accumulator root version at which the address-balance gas-smash fix begins to apply.
+    ///
+    /// A transaction cancelled with `InsufficientFundsForWithdraw` must not withdraw from an
+    /// address balance while smashing gas (doing so causes a later settlement underflow). The fix
+    /// in `GasCharger::new` suppresses that withdrawal, but applying it unconditionally would
+    /// change the effects of transactions that were already certified with the old behavior and
+    /// fork replay. We therefore gate it on the transaction's assigned accumulator root version:
+    /// transactions reading a version below this keep the original behavior (so certified history
+    /// replays bit-for-bit), and the fix applies at/above it.
+    ///
+    /// This is a compiled constant (not a protocol-config flag) on purpose: it must take effect
+    /// mid-epoch during incident recovery, when the network cannot reconfigure. Set it to the
+    /// accumulator root version of the first checkpoint re-executed during recovery. Keep it a
+    /// `const` so it is trivial to adjust.
+    const ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION: SequenceNumber =
+        SequenceNumber::from_u64(692949576);
+
+    /// Whether to suppress the address-balance leg of gas smashing for this transaction.
+    ///
+    /// True only for transactions cancelled with `InsufficientFundsForWithdraw` whose assigned
+    /// accumulator version is at or above [`ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION`].
+    /// Gating on the version keeps already-certified transactions (below the activation version)
+    /// replaying with the original behavior; see that constant's documentation.
+    fn should_filter_address_balance_gas_smash(execution_params: &ExecutionOrEarlyError) -> bool {
+        matches!(
+            execution_params.early_error(),
+            Some(ExecutionErrorKind::InsufficientFundsForWithdraw)
+        ) && execution_params
+            .accumulator_version()
+            .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION)
+    }
+
+    #[cfg(test)]
+    mod address_balance_smash_gate_tests {
+        use super::{
+            ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION,
+            should_filter_address_balance_gas_smash,
+        };
+        use sui_types::base_types::SequenceNumber;
+        use sui_types::execution_params::ExecutionOrEarlyError;
+        use sui_types::execution_status::ExecutionErrorKind;
+
+        fn version(n: u64) -> Option<SequenceNumber> {
+            Some(SequenceNumber::from_u64(n))
+        }
+
+        #[test]
+        fn applies_at_or_above_activation_version() {
+            let activation = ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION.value();
+            for v in [activation, activation + 1] {
+                assert!(should_filter_address_balance_gas_smash(
+                    &ExecutionOrEarlyError::failed(
+                        ExecutionErrorKind::InsufficientFundsForWithdraw,
+                        version(v),
+                    )
+                ));
+            }
+        }
+
+        #[test]
+        fn preserves_old_behavior_below_activation_version() {
+            let below = ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION.value() - 1;
+            assert!(!should_filter_address_balance_gas_smash(
+                &ExecutionOrEarlyError::failed(
+                    ExecutionErrorKind::InsufficientFundsForWithdraw,
+                    version(below),
+                )
+            ));
+        }
+
+        #[test]
+        fn only_applies_to_insufficient_funds_cancellations() {
+            let above = version(ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION.value() + 1);
+
+            // Successful execution is never affected.
+            assert!(!should_filter_address_balance_gas_smash(
+                &ExecutionOrEarlyError::ok(above)
+            ));
+            // A different early-error reason is never affected.
+            assert!(!should_filter_address_balance_gas_smash(
+                &ExecutionOrEarlyError::failed(ExecutionErrorKind::CertificateDenied, above)
+            ));
+            // Insufficient funds but no assigned accumulator version: leave unchanged.
+            assert!(!should_filter_address_balance_gas_smash(
+                &ExecutionOrEarlyError::failed(
+                    ExecutionErrorKind::InsufficientFundsForWithdraw,
+                    None,
+                )
+            ));
+        }
+    }
+
     fn payment_kind(
         gas_data: &GasData,
         transaction_kind: &TransactionKind,
@@ -233,10 +325,13 @@ mod checked {
         // filter: by mutating `gas_data.payment` here, `payment_kind` and
         // `compute_input_reservations` below see an already-pruned list and need no special
         // handling. Coin entries (real `ObjectRef`s) are always kept.
-        if matches!(
-            execution_params,
-            Err(ExecutionErrorKind::InsufficientFundsForWithdraw)
-        ) && gas_data.payment.len() > 1
+        //
+        // Gated on the transaction's assigned accumulator version (see
+        // `should_filter_address_balance_gas_smash`) so that already-certified transactions —
+        // reading a version below the activation version — replay bit-for-bit with the original
+        // behavior; the prune applies only at/above it.
+        if should_filter_address_balance_gas_smash(&execution_params)
+            && gas_data.payment.len() > 1
             && ParsedDigest::try_from(gas_data.payment[0].2).is_err()
         {
             gas_data
@@ -516,12 +611,12 @@ mod checked {
                     let mut execution_result: ResultWithTimings<
                         Mode::ExecutionResults,
                         Mode::Error,
-                    > = match execution_params {
-                        ExecutionOrEarlyError::Err(early_execution_error) => Err((
+                    > = match execution_params.into_early_error() {
+                        Some(early_execution_error) => Err((
                             ExecutionError::new(early_execution_error, None).into(),
                             vec![],
                         )),
-                        ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                        None => execution_loop::<Mode>(
                             store,
                             temporary_store,
                             transaction_kind,

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -241,11 +241,11 @@ mod checked {
         // we must still ensure an effect is committed and all objects versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
         let mut result = result.and_then(|()| {
-            let mut execution_result = match execution_params {
-                ExecutionOrEarlyError::Err(early_execution_error) => {
+            let mut execution_result = match execution_params.into_early_error() {
+                Some(early_execution_error) => {
                     Err(ExecutionError::new(early_execution_error, None))
                 }
-                ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                None => execution_loop::<Mode>(
                     temporary_store,
                     transaction_kind,
                     tx_ctx,

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -259,11 +259,11 @@ mod checked {
         // we must still ensure an effect is committed and all objects versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
         let mut result = result.and_then(|()| {
-            let mut execution_result = match execution_params {
-                ExecutionOrEarlyError::Err(early_execution_error) => {
+            let mut execution_result = match execution_params.into_early_error() {
+                Some(early_execution_error) => {
                     Err(ExecutionError::new(early_execution_error, None))
                 }
-                ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                None => execution_loop::<Mode>(
                     temporary_store,
                     transaction_kind,
                     tx_ctx,

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -279,11 +279,11 @@ mod checked {
         // we must still ensure an effect is committed and all objects versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
         let mut result = result.and_then(|()| {
-            let mut execution_result = match execution_params {
-                ExecutionOrEarlyError::Err(early_execution_error) => {
+            let mut execution_result = match execution_params.into_early_error() {
+                Some(early_execution_error) => {
                     Err(ExecutionError::new(early_execution_error, None))
                 }
-                ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                None => execution_loop::<Mode>(
                     temporary_store,
                     transaction_kind,
                     tx_ctx,

--- a/sui-execution/v3/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_engine.rs
@@ -356,11 +356,11 @@ mod checked {
                     let mut execution_result: ResultWithTimings<
                         Mode::ExecutionResults,
                         ExecutionError,
-                    > = match execution_params {
-                        ExecutionOrEarlyError::Err(early_execution_error) => {
+                    > = match execution_params.into_early_error() {
+                        Some(early_execution_error) => {
                             Err((ExecutionError::new(early_execution_error, None), vec![]))
                         }
-                        ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                        None => execution_loop::<Mode>(
                             store,
                             temporary_store,
                             transaction_kind,


### PR DESCRIPTION
Stacked on top of #26816 (base branch `mlogan-fix-gas-underflow`).

## Why

#26816 stops a transaction cancelled with `InsufficientFundsForWithdraw` from withdrawing from an address balance while smashing gas (which otherwise causes a settlement underflow / node panic). But that change alters execution output for the affected transactions, applied **unconditionally**. Transactions of this shape that were already certified with the old behavior (e.g. the withdrawal succeeded because the account had enough for the gas portion) would now replay to different effects → **replay fork**.

A `protocol_config` flag can't gate it here: protocol versions only activate at an **epoch boundary**, and the network is halted and cannot reconfigure.

## What

Gate the fix on a value that is **deterministic across validators, monotonic within an epoch, and available at execution time**: the **accumulator root version assigned to the transaction**.

- Below `ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION` → original (pre-fix) smashing, so already-certified history replays bit-for-bit.
- At/above it → the fix applies.

The activation version is a compiled `const` (currently `692949576`) — **not** a protocol-config flag — so it takes effect the moment every node runs the patched binary, no reconfiguration needed, and is trivial to adjust during recovery.

### Plumbing (no serialized-effects change, no trait-signature change)

The version reaches gas charging through the existing `execution_params` argument. `ExecutionOrEarlyError` is turned from a `Result<(), ExecutionErrorKind>` alias into a small **struct** carrying both the early error and the assigned accumulator version. This type is an execution **input** and is never serialized into `TransactionEffects`, so adding a field does not change effects/digests. Crucially the version is **not** added to `ExecutionErrorKind` / `ExecutionFailureStatus` (which *is* serialized).

- Committed path (`authority.rs`) supplies `assigned_versions.accumulator_version`.
- Simulation/dev-inspect, replay, genesis, benchmark, and swarm-config paths pass `None` (gate inactive — best-effort, documented).
- v0–v3 adapters adapt mechanically to the struct (behavior-preserving; they never read the version).

The gate decision is extracted into `should_filter_address_balance_gas_smash` and unit-tested at the activation boundary (needed because the high `const` makes the fix path unreachable in from-genesis tests).

## Operator notes / caveats
- **Set the const** to the accumulator root version of the first checkpoint re-executed during recovery (read it off a halted validator). It must be identical in every validator binary.
- This is a binary-level (un-versioned) change: it does **not** fork the resuming validator set (they continue from committed state and never re-derive certified history), but from-genesis replay of the affected range remains a discontinuity — handle via post-fix snapshots. The version gate makes that discontinuity start exactly at the activation version.
- The fix only engages on re-execution — a node that reuses already-persisted (buggy) effects must discard them (revert to the last certified checkpoint and re-execute).

## Test plan
- [x] `cargo check` across all touched crates (sui-types, sui-execution v0–v3 + latest, sui-core, simulacrum, genesis-builder, single-node-benchmark, swarm-config, replay, replay-2)
- [ ] `cargo nextest -p sui-adapter-latest address_balance_smash_gate` (build verifying in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)