### PR TITLE
gas_charger: clamp gas_budget to smashed total to prevent deduct_gas underflow on IFFW filter

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -34,12 +34,15 @@ use sui_protocol_config::{
     Chain, ExecutionTimeEstimateParams, PerObjectCongestionControlMode, ProtocolConfig,
     ProtocolVersion,
 };
-use sui_types::effects::TransactionEffects;
+use sui_types::accumulator_root::AccumulatorValue;
+use sui_types::balance::Balance;
+use sui_types::coin_reservation::ParsedObjectRefWithdrawal;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::epoch_data::EpochData;
 use sui_types::error::UserInputError;
 use sui_types::execution::SharedInput;
 use sui_types::execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus};
-use sui_types::gas_coin::GasCoin;
+use sui_types::gas_coin::{GAS, GasCoin};
 use sui_types::messages_consensus::{
     AuthorityCapabilitiesV2, ConsensusDeterminedVersionAssignments,
 };
@@ -58,7 +61,7 @@ use sui_types::{
     crypto::{AccountKeyPair, AuthorityKeyPair},
     crypto::{Signature, get_key_pair},
     object::{GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION, Owner},
-    transaction::PlainTransactionWithClaims,
+    transaction::{PlainTransactionWithClaims, TransactionDataAPI},
 };
 use sui_types::{SUI_CLOCK_OBJECT_SHARED_VERSION, digests::Digest};
 use sui_types::{dynamic_field::DynamicFieldType, messages_consensus::ConsensusTransaction};
@@ -6520,6 +6523,104 @@ async fn test_insufficient_balance_for_withdraw_early_error() {
     } else {
         panic!("Expected execution status to be Failure");
     }
+}
+
+#[tokio::test]
+async fn test_insufficient_balance_for_withdraw_does_not_emit_gas_smash_events() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+
+    let state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+    let epoch_store = state.load_epoch_store_one_call_per_task();
+    let chain_identifier = epoch_store.get_chain_identifier();
+    let sui_accumulator_id =
+        AccumulatorValue::get_field_id(sender, &Balance::type_tag(GAS::type_tag())).unwrap();
+    let gas_reservation_ref =
+        ParsedObjectRefWithdrawal::new(*sui_accumulator_id.inner(), epoch_store.epoch(), 500)
+            .encode(OBJECT_START_VERSION, chain_identifier);
+
+    let mut tx_data = TestTransactionBuilder::new(sender, gas_object_ref, 1000)
+        .transfer_sui(None, sender)
+        .build();
+    tx_data.gas_data_mut().payment.push(gas_reservation_ref);
+
+    let certificate = VerifiedExecutableTransaction::new_for_testing(tx_data, &sender_key);
+    let mut execution_env = ExecutionEnv::new();
+    execution_env.funds_withdraw_status = FundsWithdrawStatus::Insufficient;
+
+    let (effects, execution_error) = state
+        .try_execute_immediately(&certificate, execution_env, &epoch_store)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        execution_error.unwrap().kind(),
+        &ExecutionErrorKind::InsufficientFundsForWithdraw
+    );
+    assert!(effects.status().is_err());
+    assert!(
+        effects.accumulator_events().is_empty(),
+        "insufficient withdraw failed effects must not contain gas-smash accumulator events"
+    );
+}
+
+/// Regression test: with a gas payment of [tiny real coin, large AB reservation] and an
+/// `InsufficientFundsForWithdraw` early error, the AB-filter in `execute_transaction_to_effects`
+/// drops the AB entry from `gas_data.payment`. The remaining coin alone is smaller than the
+/// signed `gas_budget`, so without clamping `gas_status.gas_budget` to the post-filter smashed
+/// total, `bucketize_computation` produces a `computation_cost` exceeding the coin's balance and
+/// `deduct_gas`'s `assert!(balance >= charge)` (gas.rs:282) fires, panicking the validator.
+#[tokio::test]
+async fn test_insufficient_balance_for_withdraw_with_small_coin_does_not_panic() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let small_coin_value = 100u64;
+    let gas_object = Object::new_gas_with_balance_and_owner_for_testing(small_coin_value, sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+
+    let state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+    let epoch_store = state.load_epoch_store_one_call_per_task();
+    let chain_identifier = epoch_store.get_chain_identifier();
+    let sui_accumulator_id =
+        AccumulatorValue::get_field_id(sender, &Balance::type_tag(GAS::type_tag())).unwrap();
+    // Large enough reservation that the signed budget can exceed the real coin's value.
+    let large_reservation = 10_000_000u64;
+    let gas_reservation_ref = ParsedObjectRefWithdrawal::new(
+        *sui_accumulator_id.inner(),
+        epoch_store.epoch(),
+        large_reservation,
+    )
+    .encode(OBJECT_START_VERSION, chain_identifier);
+
+    // Budget exceeds the real coin's value but is covered by coin + reservation.
+    let gas_price = 1000u64;
+    let gas_budget = 2_000_000u64;
+    let mut tx_data = TestTransactionBuilder::new(sender, gas_object_ref, gas_price)
+        .with_gas_budget(gas_budget)
+        .transfer_sui(None, sender)
+        .build();
+    tx_data.gas_data_mut().payment.push(gas_reservation_ref);
+
+    let certificate = VerifiedExecutableTransaction::new_for_testing(tx_data, &sender_key);
+    let mut execution_env = ExecutionEnv::new();
+    execution_env.funds_withdraw_status = FundsWithdrawStatus::Insufficient;
+
+    let (effects, execution_error) = state
+        .try_execute_immediately(&certificate, execution_env, &epoch_store)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        execution_error.unwrap().kind(),
+        &ExecutionErrorKind::InsufficientFundsForWithdraw,
+    );
+    assert!(effects.status().is_err());
 }
 
 #[tokio::test]

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -128,6 +128,12 @@ pub mod checked {
                 Self::V2(status) => status.gas_price(),
             }
         }
+
+        pub fn reduce_gas_budget(&mut self, new_budget: u64) {
+            match self {
+                Self::V2(status) => status.reduce_gas_budget(new_budget),
+            }
+        }
     }
 
     /// Summary of the charges in a transaction.

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -254,6 +254,18 @@ mod checked {
             }
         }
 
+        /// Lower the `gas_budget` if `new_budget` is smaller. Never raises it. Used after gas
+        /// smashing when a filter has dropped some payment sources (e.g. an address-balance
+        /// reservation that can't be honored on an `InsufficientFundsForWithdraw` abort): the
+        /// budget the user signed for assumed those sources contribute, so we cap it at what the
+        /// remaining payment can actually pay to keep `bucketize_computation` and the storage
+        /// charge path from producing a `net_change` larger than the smash_target coin can cover.
+        pub(crate) fn reduce_gas_budget(&mut self, new_budget: u64) {
+            if new_budget < self.gas_budget {
+                self.gas_budget = new_budget;
+            }
+        }
+
         pub(crate) fn new_with_budget(
             gas_budget: u64,
             gas_price: u64,

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -124,7 +124,7 @@ pub mod checked {
         pub fn new(
             tx_digest: TransactionDigest,
             payment_kind: PaymentKind,
-            gas_status: SuiGasStatus,
+            mut gas_status: SuiGasStatus,
             temporary_store: &mut TemporaryStore<'_>,
             protocol_config: &ProtocolConfig,
         ) -> Self {
@@ -145,6 +145,18 @@ pub mod checked {
                     PaymentMetadata::Smash(metadata)
                 }
             };
+            // Cap the gas budget at the actually-smashable amount. Normally signing-time
+            // `check_gas_balance` guarantees `total_smashed >= gas_budget`, but on an early
+            // `InsufficientFundsForWithdraw` the caller may have dropped address-balance
+            // payments from `gas_data.payment` first; in that case the smash_target coin(s)
+            // alone might not cover the signed budget, and `bucketize_computation` /
+            // `deduct_gas` would otherwise compute a charge larger than the coin can pay,
+            // panicking in `deduct_gas`'s `balance - charge` step.
+            if let PaymentMetadata::Smash(metadata) = &payment
+                && metadata.total_smashed < gas_status.gas_budget()
+            {
+                gas_status.reduce_gas_budget(metadata.total_smashed);
+            }
             Self {
                 tx_digest,
                 gas_model_version,


### PR DESCRIPTION
## Summary

When the AB-filter in `execute_transaction_to_effects` drops address-balance entries from `gas_data.payment` on an `InsufficientFundsForWithdraw` early abort, the remaining real coin(s) can be smaller than the signed `gas_budget`.
## Release notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): emergency hardening of the IFFW + address-balance gas-payment path. Prevents a `deduct_gas` underflow panic in a corner case the #26816 filter does not cover.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: