### PR TITLE
[traffic_controller] Avoid cloning PolicyConfig on every check

### DIFF
--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -342,7 +342,7 @@ impl TrafficController {
 
     /// Handle check with dry-run mode considered
     pub async fn check(&self, client: &Option<IpAddr>, proxied_client: &Option<IpAddr>) -> bool {
-        let policy_config = { self.policy_config.read().await.clone() };
+        let dry_run = self.policy_config.read().await.dry_run;
 
         let allowed = match &self.acl {
             Acl::Allowlist(allowlist) => client.is_none() || allowlist.contains(&client.unwrap()),
@@ -352,7 +352,7 @@ impl TrafficController {
             }
         };
 
-        match (allowed, policy_config.dry_run) {
+        match (allowed, dry_run) {
             // request allowed
             (true, _) => true,
             // request blocked while in dry-run mode


### PR DESCRIPTION
## Summary
`TrafficController::check` runs on the inbound-request critical path (every validator RPC goes through the traffic check). It clones the entire `PolicyConfig` — including its `allow_list: Option<Vec<String>>` and the `PolicyType` threshold configs — solely to read the single `dry_run: bool`. This reads the bool directly under the read lock instead, dropping a per-request heap clone and shortening the lock hold to a single field read.

Behavior is unchanged: `dry_run` is the only field of the cloned config that `check` used; the allow/block decision reads `self.acl`, not the config.

```diff
-        let policy_config = { self.policy_config.read().await.clone() };
+        let dry_run = self.policy_config.read().await.dry_run;

         let allowed = match &self.acl {
             ...
         };

-        match (allowed, policy_config.dry_run) {
+        match (allowed, dry_run) {
```

## Test plan
- `cargo nextest run -p sui-core traffic` — pass
- `cargo xclippy` clean
- `cargo fmt --all -- --check` clean
