### PR TITLE
fix: skip all smashing and gas charging on InsufficientFundsForWithdraw

### DIFF
--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1686,6 +1686,154 @@ async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
+/// Regression test: same shape as test_gas_smash_no_ab_underflow_on_iffw, but the
+/// two real coins each hold only 1 MIST. Total real-coin gas after smashing is 2
+/// MIST — far below the gas budget. With AB entries dropped on IFFW the gas
+/// charger falls back to charging the real coins, and `deduct_gas` asserts
+/// balance >= charge. If gas charging is not also skipped for this case the
+/// node panics during settlement.
+#[sim_test]
+async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+
+    // AB must be large enough that the per-tx signing validation accepts
+    // TX2's reservation (≤ AB) and total gas balance (real coins + reservation)
+    // covers the default gas budget (≈ 5_000_000_000 MIST).
+    let initial_ab = 10_000_000_000u64;
+    test_env.fund_one_address_balance(sender, initial_ab).await;
+
+    let all_gas = test_env.get_gas_for_sender(sender);
+    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
+
+    // Pre-step: split two 1-MIST coins off a normal gas coin and transfer them
+    // back to sender. These tiny coins will be TX2's real-coin gas payments.
+    let splitter_gas = all_gas[0];
+    let mut split_builder = ProgrammableTransactionBuilder::new();
+    let one_a = split_builder.pure(1u64).unwrap();
+    let one_b = split_builder.pure(1u64).unwrap();
+    let split_result =
+        split_builder.command(Command::SplitCoins(Argument::GasCoin, vec![one_a, one_b]));
+    let Argument::Result(split_idx) = split_result else {
+        panic!("SplitCoins should return Argument::Result");
+    };
+    let recipient_arg = split_builder.pure(sender).unwrap();
+    split_builder.command(Command::TransferObjects(
+        vec![
+            Argument::NestedResult(split_idx, 0),
+            Argument::NestedResult(split_idx, 1),
+        ],
+        recipient_arg,
+    ));
+    let split_pt = split_builder.finish();
+    let split_tx = TransactionData::new_programmable(
+        sender,
+        vec![splitter_gas],
+        split_pt,
+        test_env.rgp * 5_000_000,
+        test_env.rgp,
+    );
+    let (_, split_effects) = test_env.exec_tx_directly(split_tx).await.unwrap();
+    assert!(
+        split_effects.status().is_ok(),
+        "tiny-coin split failed: {:?}",
+        split_effects.status()
+    );
+    let tiny_coins: Vec<_> = split_effects
+        .created()
+        .into_iter()
+        .filter(
+            |(_, owner)| matches!(owner, sui_types::object::Owner::AddressOwner(a) if *a == sender),
+        )
+        .map(|(obj_ref, _)| obj_ref)
+        .collect();
+    assert_eq!(
+        tiny_coins.len(),
+        2,
+        "expected exactly two created tiny coins"
+    );
+    let tiny_coin_a = tiny_coins[0];
+    let tiny_coin_b = tiny_coins[1];
+    assert_eq!(test_env.get_coin_balance(tiny_coin_a.0).await, 1);
+    assert_eq!(test_env.get_coin_balance(tiny_coin_b.0).await, 1);
+
+    // Refresh gas list; splitter_gas was mutated and tiny coins are now also in
+    // the wallet's gas-object list. Pick a separate coin to pay for TX1.
+    let all_gas = test_env.get_gas_for_sender(sender);
+    let gas_for_tx1 = *all_gas
+        .iter()
+        .find(|g| g.0 != splitter_gas.0 && g.0 != tiny_coin_a.0 && g.0 != tiny_coin_b.0)
+        .expect("need a non-tiny coin to pay TX1's gas");
+
+    // TX1: drain the AB to 0 (gas comes from a real coin, so the full
+    // initial_ab transfers out).
+    let dummy = SuiAddress::random_for_testing_only();
+    let tx1 = test_env
+        .tx_builder_with_gas(sender, gas_for_tx1)
+        .transfer_sui_to_address_balance(
+            FundSource::address_fund_with_reservation(initial_ab),
+            vec![(initial_ab, dummy)],
+        )
+        .build();
+
+    // TX2: gas_data.payment = [tiny_coin_a (1 MIST), tiny_coin_b (1 MIST),
+    // coin_reservation]. After TX1 drains the AB the reservation withdraw
+    // fails with IFFW.  reservation = initial_ab / 2 passes the per-tx signing
+    // check (≤ initial_ab) and reservation + 2 MIST > default budget.
+    let reservation = initial_ab / 2;
+    let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
+    let tx2 = test_env
+        .tx_builder_with_gas_objects(sender, vec![tiny_coin_a, tiny_coin_b, fake_coin])
+        .build();
+
+    let tx1_digest = tx1.digest();
+    let tx2_digest = tx2.digest();
+
+    let mut effects = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[tx1, tx2])
+        .await
+        .unwrap();
+
+    let tx2_effects = effects.pop().unwrap().1;
+    let tx1_effects = effects.pop().unwrap().1;
+
+    assert!(
+        tx1_effects.status().is_ok(),
+        "TX1 should succeed: {:?}",
+        tx1_effects.status()
+    );
+    let status_str = format!("{:?}", tx2_effects.status());
+    assert!(
+        status_str.contains("InsufficientFundsForWithdraw"),
+        "TX2 should fail with InsufficientFundsForWithdraw, got: {status_str}"
+    );
+
+    // Settlement must complete. Without an additional fix, gas charging tries
+    // to deduct gas from a 2-MIST coin and panics in deduct_gas's
+    // `balance >= charge` assertion, crashing the node.
+    test_env
+        .cluster
+        .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
+        .await;
+
+    let final_ab = test_env.get_sui_balance_ab(sender);
+    assert_eq!(final_ab, 0, "AB should stay 0; got {final_ab}");
+
+    test_env.cluster.trigger_reconfiguration().await;
+}
+
 fn build_fake_coin_reservation_pt(
     chain_id: sui_types::digests::ChainIdentifier,
 ) -> TransactionKind {

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1368,6 +1368,100 @@ async fn test_mix_coin_reservations_real_coins_and_shared_object() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
+/// Regression test: gas smashing must not underflow the address balance when a
+/// transaction fails with InsufficientFundsForWithdraw.
+///
+/// TX1 drains the AB to 0.  TX2 has gas_data.payment = [real_coin, coin_reservation];
+/// the coin_reservation creates an AddressBalance entry in smashed_payments.  After
+/// TX1 depletes the AB, the fund-checker fires IFFW for TX2.  Without the fix,
+/// smash_gas emits a negative AB AccumulatorEvent anyway, underflowing the AB at
+/// settlement time and causing a node panic.
+#[sim_test]
+async fn test_gas_smash_no_ab_underflow_on_iffw() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+
+    // Fund the AB with a known amount; both per-tx reservations must be ≤ this for
+    // the bundle to pass signing-time validation.
+    let initial_ab = 20_000_000u64;
+    test_env.fund_one_address_balance(sender, initial_ab).await;
+
+    // Refresh gas list after funding (funding consumes one coin).
+    let mut all_gas = test_env.get_gas_for_sender(sender);
+    assert!(all_gas.len() >= 2, "need ≥2 gas coins");
+
+    // TX1: withdraw all AB (pays gas from a real coin so the full initial_ab is freed).
+    let gas_for_tx1 = all_gas.remove(0);
+    let dummy = SuiAddress::random_for_testing_only();
+    let tx1 = test_env
+        .tx_builder_with_gas(sender, gas_for_tx1)
+        .transfer_sui_to_address_balance(
+            FundSource::address_fund_with_reservation(initial_ab),
+            vec![(initial_ab, dummy)],
+        )
+        .build();
+
+    // TX2: gas_data.payment = [real_coin, coin_reservation].
+    // Reservation = initial_ab / 2 so it passes per-tx signing validation (≤ initial_ab)
+    // but exceeds the post-TX1 AB balance of 0, triggering IFFW.
+    let gas_for_tx2 = all_gas.remove(0);
+    let reservation = initial_ab / 2;
+    let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
+    let tx2 = test_env
+        .tx_builder_with_gas_objects(sender, vec![gas_for_tx2, fake_coin])
+        .build();
+
+    let tx1_digest = tx1.digest();
+    let tx2_digest = tx2.digest();
+
+    let mut effects = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[tx1, tx2])
+        .await
+        .unwrap();
+
+    let tx2_effects = effects.pop().unwrap().1;
+    let tx1_effects = effects.pop().unwrap().1;
+
+    assert!(
+        tx1_effects.status().is_ok(),
+        "TX1 should succeed: {:?}",
+        tx1_effects.status()
+    );
+    let status_str = format!("{:?}", tx2_effects.status());
+    assert!(
+        status_str.contains("InsufficientFundsForWithdraw"),
+        "TX2 should fail with InsufficientFundsForWithdraw, got: {status_str}"
+    );
+
+    // Wait for settlement.  Without the fix the settlement transaction aborts trying
+    // to split `reservation` from a 0-balance AB, crashing the node.
+    test_env
+        .cluster
+        .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
+        .await;
+
+    // TX2's failed smash must not have emitted a withdrawal event: the AB stays at 0.
+    let final_ab = test_env.get_sui_balance_ab(sender);
+    assert_eq!(
+        final_ab, 0,
+        "AB should stay 0; bug would underflow it to {final_ab}"
+    );
+
+    test_env.cluster.trigger_reconfiguration().await;
+}
+
 fn build_fake_coin_reservation_pt(
     chain_id: sui_types::digests::ChainIdentifier,
 ) -> TransactionKind {

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1686,174 +1686,20 @@ async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
-/// Regression test: same shape as test_gas_smash_no_ab_underflow_on_iffw, but the
-/// two real coins each hold only 1 MIST. Total real-coin gas after smashing is 2
-/// MIST — far below the gas budget. With AB entries dropped on IFFW the gas
-/// charger falls back to charging the real coins, and `deduct_gas` asserts
-/// balance >= charge. If gas charging is not also skipped for this case the
-/// node panics during settlement.
-#[sim_test]
-async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
-    if has_mainnet_protocol_config_override() {
-        return;
-    }
-
-    let mut test_env = TestEnvBuilder::new()
-        .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_coin_reservation_for_testing();
-            cfg
-        }))
-        .build()
-        .await;
-
-    let sender = test_env.get_sender(0);
-
-    // AB must be large enough that the per-tx signing validation accepts
-    // TX2's reservation (≤ AB) and total gas balance (real coins + reservation)
-    // covers the default gas budget (≈ 5_000_000_000 MIST).
-    let initial_ab = 10_000_000_000u64;
-    test_env.fund_one_address_balance(sender, initial_ab).await;
-
-    let all_gas = test_env.get_gas_for_sender(sender);
-    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
-
-    // Pre-step: split two 1-MIST coins off a normal gas coin and transfer them
-    // back to sender. These tiny coins will be TX2's real-coin gas payments.
-    let splitter_gas = all_gas[0];
-    let mut split_builder = ProgrammableTransactionBuilder::new();
-    let one_a = split_builder.pure(1u64).unwrap();
-    let one_b = split_builder.pure(1u64).unwrap();
-    let split_result =
-        split_builder.command(Command::SplitCoins(Argument::GasCoin, vec![one_a, one_b]));
-    let Argument::Result(split_idx) = split_result else {
-        panic!("SplitCoins should return Argument::Result");
-    };
-    let recipient_arg = split_builder.pure(sender).unwrap();
-    split_builder.command(Command::TransferObjects(
-        vec![
-            Argument::NestedResult(split_idx, 0),
-            Argument::NestedResult(split_idx, 1),
-        ],
-        recipient_arg,
-    ));
-    let split_pt = split_builder.finish();
-    let split_tx = TransactionData::new_programmable(
-        sender,
-        vec![splitter_gas],
-        split_pt,
-        test_env.rgp * 5_000_000,
-        test_env.rgp,
-    );
-    let (_, split_effects) = test_env.exec_tx_directly(split_tx).await.unwrap();
-    assert!(
-        split_effects.status().is_ok(),
-        "tiny-coin split failed: {:?}",
-        split_effects.status()
-    );
-    let tiny_coins: Vec<_> = split_effects
-        .created()
-        .into_iter()
-        .filter(
-            |(_, owner)| matches!(owner, sui_types::object::Owner::AddressOwner(a) if *a == sender),
-        )
-        .map(|(obj_ref, _)| obj_ref)
-        .collect();
-    assert_eq!(
-        tiny_coins.len(),
-        2,
-        "expected exactly two created tiny coins"
-    );
-    let tiny_coin_a = tiny_coins[0];
-    let tiny_coin_b = tiny_coins[1];
-    assert_eq!(test_env.get_coin_balance(tiny_coin_a.0).await, 1);
-    assert_eq!(test_env.get_coin_balance(tiny_coin_b.0).await, 1);
-
-    // Refresh gas list; splitter_gas was mutated and tiny coins are now also in
-    // the wallet's gas-object list. Pick a separate coin to pay for TX1.
-    let all_gas = test_env.get_gas_for_sender(sender);
-    let gas_for_tx1 = *all_gas
-        .iter()
-        .find(|g| g.0 != splitter_gas.0 && g.0 != tiny_coin_a.0 && g.0 != tiny_coin_b.0)
-        .expect("need a non-tiny coin to pay TX1's gas");
-
-    // TX1: drain the AB to 0 (gas comes from a real coin, so the full
-    // initial_ab transfers out).
-    let dummy = SuiAddress::random_for_testing_only();
-    let tx1 = test_env
-        .tx_builder_with_gas(sender, gas_for_tx1)
-        .transfer_sui_to_address_balance(
-            FundSource::address_fund_with_reservation(initial_ab),
-            vec![(initial_ab, dummy)],
-        )
-        .build();
-
-    // TX2: gas_data.payment = [tiny_coin_a (1 MIST), tiny_coin_b (1 MIST),
-    // coin_reservation]. After TX1 drains the AB the reservation withdraw
-    // fails with IFFW.  reservation = initial_ab / 2 passes the per-tx signing
-    // check (≤ initial_ab) and reservation + 2 MIST > default budget.
-    let reservation = initial_ab / 2;
-    let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
-    let tx2 = test_env
-        .tx_builder_with_gas_objects(sender, vec![tiny_coin_a, tiny_coin_b, fake_coin])
-        .build();
-
-    let tx1_digest = tx1.digest();
-    let tx2_digest = tx2.digest();
-
-    let mut effects = test_env
-        .cluster
-        .sign_and_execute_txns_in_soft_bundle(&[tx1, tx2])
-        .await
-        .unwrap();
-
-    let tx2_effects = effects.pop().unwrap().1;
-    let tx1_effects = effects.pop().unwrap().1;
-
-    assert!(
-        tx1_effects.status().is_ok(),
-        "TX1 should succeed: {:?}",
-        tx1_effects.status()
-    );
-    let status_str = format!("{:?}", tx2_effects.status());
-    assert!(
-        status_str.contains("InsufficientFundsForWithdraw"),
-        "TX2 should fail with InsufficientFundsForWithdraw, got: {status_str}"
-    );
-
-    // Settlement must complete. Without an additional fix, gas charging tries
-    // to deduct gas from a 2-MIST coin and panics in deduct_gas's
-    // `balance >= charge` assertion, crashing the node.
-    test_env
-        .cluster
-        .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
-        .await;
-
-    let final_ab = test_env.get_sui_balance_ab(sender);
-    assert_eq!(final_ab, 0, "AB should stay 0; got {final_ab}");
-
-    test_env.cluster.trigger_reconfiguration().await;
-}
-
 /// Regression test: AB-as-smash-target on IFFW with non-genesis coins.
 ///
 /// TX2 has gas_data.payment = [coin_reservation, real_coin_a, real_coin_b].
-/// Because the first entry is the reservation, the AB is the smash target and
-/// the per-payment fix in execution_engine does NOT strip AB entries (smashing
-/// proceeds normally). After TX1 drains the AB, TX2 still fails with IFFW
-/// during execution.
+/// The coin_reservation is first, so the AB is the smash target.
+/// After TX1 drains the AB, TX2 fails with IFFW.
 ///
 /// `real_coin_a` and `real_coin_b` are split off a genesis gas coin so they
-/// carry a non-zero `storage_rebate`. With genesis coins (rebate = 0) the
-/// AB-IFFW early-return appears to "just work"; with non-genesis coins the
-/// deleted-coin rebates must be accounted for somewhere in the gas summary,
-/// or the conservation check fails and the recovery path takes over.
+/// carry a non-zero `storage_rebate`, which exercises the conservation check
+/// more thoroughly.
 ///
-/// Expected outcome:
-///   - TX1 succeeds, AB drained to 0.
-///   - TX2 fails with InsufficientFundsForWithdraw.
-///   - Real coins are deleted; their balances land in the AB via the deposit
-///     event from smashing.
-///   - Settlement completes (no underflow / no panic).
+/// With the skip-all fix, smashing is entirely skipped for IFFW transactions
+/// that involve any AB payment. The real coins are NOT deleted; they retain
+/// their original balances. The AB stays at 0 and settlement completes without
+/// any panic.
 #[sim_test]
 async fn test_gas_smash_ab_target_iffw() {
     if has_mainnet_protocol_config_override() {
@@ -1984,41 +1830,32 @@ async fn test_gas_smash_ab_target_iffw() {
         .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
         .await;
 
-    // The real coins should both be deleted by gas smashing.
-    let deleted_ids: std::collections::HashSet<_> = tx2_effects
-        .deleted()
-        .into_iter()
-        .map(|(id, _, _)| id)
-        .collect();
+    // Smashing is skipped entirely for IFFW: no coins are deleted.
     assert!(
-        deleted_ids.contains(&real_coin_a.0),
-        "real_coin_a should be deleted, deleted={deleted_ids:?}"
-    );
-    assert!(
-        deleted_ids.contains(&real_coin_b.0),
-        "real_coin_b should be deleted, deleted={deleted_ids:?}"
+        tx2_effects.deleted().is_empty(),
+        "no coins should be deleted when smashing is skipped: {:?}",
+        tx2_effects.deleted()
     );
 
-    // The deleted coins' storage_rebate must be accounted for in the gas summary
-    // (sender_rebate + non_refundable == total input rebate), otherwise the
-    // simple-conservation check would have failed and triggered the recovery
-    // panic.
+    // Gas summary is zero: no computation or storage charges.
     let cost = tx2_effects.gas_cost_summary();
-    assert_eq!(cost.storage_cost, 0, "no writes, so no storage cost");
-    assert!(
-        cost.storage_rebate + cost.non_refundable_storage_fee > 0,
-        "input coin rebates must appear in the gas summary; got {cost:?}",
+    assert_eq!(cost.gas_used(), 0, "IFFW should charge 0 gas; got {cost:?}");
+
+    // Both real coins retain their original balances.
+    assert_eq!(
+        test_env.get_coin_balance(real_coin_a.0).await,
+        real_coin_a_balance,
+        "real_coin_a balance must be unchanged"
+    );
+    assert_eq!(
+        test_env.get_coin_balance(real_coin_b.0).await,
+        real_coin_b_balance,
+        "real_coin_b balance must be unchanged"
     );
 
-    // Final AB = smash deposit (a + b) + any refund from sender_rebate exceeding
-    // the capped computation cost. Refund can be 0 if computation_cost ≥
-    // sender_rebate; either way the AB never goes below the deposit.
+    // AB stays at 0 — no deposit from smashing since smashing was skipped.
     let final_ab = test_env.get_sui_balance_ab(sender);
-    assert!(
-        final_ab >= real_coin_a_balance + real_coin_b_balance,
-        "AB should hold at least the smashed real-coin balances; got {final_ab}, expected ≥ {}",
-        real_coin_a_balance + real_coin_b_balance,
-    );
+    assert_eq!(final_ab, 0, "AB should stay 0; got {final_ab}");
 
     test_env.cluster.trigger_reconfiguration().await;
 }

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1834,7 +1834,7 @@ async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
-/// Regression test: AB-as-smash-target on IFFW.
+/// Regression test: AB-as-smash-target on IFFW with non-genesis coins.
 ///
 /// TX2 has gas_data.payment = [coin_reservation, real_coin_a, real_coin_b].
 /// Because the first entry is the reservation, the AB is the smash target and
@@ -1842,17 +1842,17 @@ async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
 /// proceeds normally). After TX1 drains the AB, TX2 still fails with IFFW
 /// during execution.
 ///
-/// During smashing the real coins are deleted and a single positive
-/// AccumulatorEvent of `total_smashed - reservation` (= sum of real coin
-/// balances) is emitted against the AB. There is no withdrawal event for the
-/// reservation itself — that would only happen in `charge_gas`, and the
-/// existing AB-IFFW early-return skips it.
+/// `real_coin_a` and `real_coin_b` are split off a genesis gas coin so they
+/// carry a non-zero `storage_rebate`. With genesis coins (rebate = 0) the
+/// AB-IFFW early-return appears to "just work"; with non-genesis coins the
+/// deleted-coin rebates must be accounted for somewhere in the gas summary,
+/// or the conservation check fails and the recovery path takes over.
 ///
 /// Expected outcome:
 ///   - TX1 succeeds, AB drained to 0.
-///   - TX2 fails with InsufficientFundsForWithdraw and is not charged.
+///   - TX2 fails with InsufficientFundsForWithdraw.
 ///   - Real coins are deleted; their balances land in the AB via the deposit
-///     event (so final AB = sum of real coin balances).
+///     event from smashing.
 ///   - Settlement completes (no underflow / no panic).
 #[sim_test]
 async fn test_gas_smash_ab_target_iffw() {
@@ -1870,14 +1870,75 @@ async fn test_gas_smash_ab_target_iffw() {
 
     let sender = test_env.get_sender(0);
 
-    let initial_ab = 20_000_000u64;
+    // initial_ab must cover the reservation (≤ AB at signing time), and the
+    // reservation alone needs to be ≥ default gas budget (5_000_000_000) so
+    // signing-time gas-balance validation passes.
+    let initial_ab = 10_000_000_000u64;
     test_env.fund_one_address_balance(sender, initial_ab).await;
 
-    let mut all_gas = test_env.get_gas_for_sender(sender);
-    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
+    let all_gas = test_env.get_gas_for_sender(sender);
+    assert!(all_gas.len() >= 2, "need ≥2 gas coins");
+
+    // Pre-step: split two coins off a genesis gas coin so they have non-zero
+    // `storage_rebate` (genesis-allocated coins have `storage_rebate = 0` and
+    // would hide rebate-accounting bugs).  Split coins are sized large enough
+    // that any incidental gas charge won't take them below zero.
+    let splitter_gas = all_gas[0];
+    let split_amount = 1_000_000_000u64;
+    let mut split_builder = ProgrammableTransactionBuilder::new();
+    let amt_a = split_builder.pure(split_amount).unwrap();
+    let amt_b = split_builder.pure(split_amount).unwrap();
+    let split_result =
+        split_builder.command(Command::SplitCoins(Argument::GasCoin, vec![amt_a, amt_b]));
+    let Argument::Result(split_idx) = split_result else {
+        panic!("SplitCoins should return Argument::Result");
+    };
+    let recipient_arg = split_builder.pure(sender).unwrap();
+    split_builder.command(Command::TransferObjects(
+        vec![
+            Argument::NestedResult(split_idx, 0),
+            Argument::NestedResult(split_idx, 1),
+        ],
+        recipient_arg,
+    ));
+    let split_pt = split_builder.finish();
+    let split_tx = TransactionData::new_programmable(
+        sender,
+        vec![splitter_gas],
+        split_pt,
+        test_env.rgp * 5_000_000,
+        test_env.rgp,
+    );
+    let (_, split_effects) = test_env.exec_tx_directly(split_tx).await.unwrap();
+    assert!(
+        split_effects.status().is_ok(),
+        "coin split failed: {:?}",
+        split_effects.status()
+    );
+    let split_coins: Vec<_> = split_effects
+        .created()
+        .into_iter()
+        .filter(
+            |(_, owner)| matches!(owner, sui_types::object::Owner::AddressOwner(a) if *a == sender),
+        )
+        .map(|(obj_ref, _)| obj_ref)
+        .collect();
+    assert_eq!(split_coins.len(), 2, "expected exactly two split coins");
+    let real_coin_a = split_coins[0];
+    let real_coin_b = split_coins[1];
+    let real_coin_a_balance = test_env.get_coin_balance(real_coin_a.0).await;
+    let real_coin_b_balance = test_env.get_coin_balance(real_coin_b.0).await;
+    assert_eq!(real_coin_a_balance, split_amount);
+    assert_eq!(real_coin_b_balance, split_amount);
+
+    // Re-fetch the wallet's gas list; the splitter coin's version changed.
+    let all_gas = test_env.get_gas_for_sender(sender);
+    let gas_for_tx1 = *all_gas
+        .iter()
+        .find(|g| g.0 != splitter_gas.0 && g.0 != real_coin_a.0 && g.0 != real_coin_b.0)
+        .expect("need a non-split coin to pay TX1's gas");
 
     // TX1: drain the AB to 0 (gas comes from a real coin).
-    let gas_for_tx1 = all_gas.remove(0);
     let dummy = SuiAddress::random_for_testing_only();
     let tx1 = test_env
         .tx_builder_with_gas(sender, gas_for_tx1)
@@ -1889,10 +1950,6 @@ async fn test_gas_smash_ab_target_iffw() {
 
     // TX2: gas_data.payment = [coin_reservation, real_coin_a, real_coin_b].
     // Reservation first → AB is the smash target; real coins are smashed into it.
-    let real_coin_a = all_gas.remove(0);
-    let real_coin_b = all_gas.remove(0);
-    let real_coin_a_balance = test_env.get_coin_balance(real_coin_a.0).await;
-    let real_coin_b_balance = test_env.get_coin_balance(real_coin_b.0).await;
     let reservation = initial_ab / 2;
     let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
     let tx2 = test_env
@@ -1942,14 +1999,25 @@ async fn test_gas_smash_ab_target_iffw() {
         "real_coin_b should be deleted, deleted={deleted_ids:?}"
     );
 
-    // Final AB receives the deposit event for (total_smashed - reservation), which
-    // equals the sum of the real coin balances. No actual reservation withdrawal
-    // happens because charge_gas early-returns on AB-IFFW.
+    // The deleted coins' storage_rebate must be accounted for in the gas summary
+    // (sender_rebate + non_refundable == total input rebate), otherwise the
+    // simple-conservation check would have failed and triggered the recovery
+    // panic.
+    let cost = tx2_effects.gas_cost_summary();
+    assert_eq!(cost.storage_cost, 0, "no writes, so no storage cost");
+    assert!(
+        cost.storage_rebate + cost.non_refundable_storage_fee > 0,
+        "input coin rebates must appear in the gas summary; got {cost:?}",
+    );
+
+    // Final AB = smash deposit (a + b) + any refund from sender_rebate exceeding
+    // the capped computation cost. Refund can be 0 if computation_cost ≥
+    // sender_rebate; either way the AB never goes below the deposit.
     let final_ab = test_env.get_sui_balance_ab(sender);
-    assert_eq!(
-        final_ab,
+    assert!(
+        final_ab >= real_coin_a_balance + real_coin_b_balance,
+        "AB should hold at least the smashed real-coin balances; got {final_ab}, expected ≥ {}",
         real_coin_a_balance + real_coin_b_balance,
-        "AB should hold the smashed real-coin balances; got {final_ab}",
     );
 
     test_env.cluster.trigger_reconfiguration().await;

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1371,11 +1371,16 @@ async fn test_mix_coin_reservations_real_coins_and_shared_object() {
 /// Regression test: gas smashing must not underflow the address balance when a
 /// transaction fails with InsufficientFundsForWithdraw.
 ///
-/// TX1 drains the AB to 0.  TX2 has gas_data.payment = [real_coin, coin_reservation];
-/// the coin_reservation creates an AddressBalance entry in smashed_payments.  After
-/// TX1 depletes the AB, the fund-checker fires IFFW for TX2.  Without the fix,
-/// smash_gas emits a negative AB AccumulatorEvent anyway, underflowing the AB at
-/// settlement time and causing a node panic.
+/// TX1 drains the AB to 0.  TX2 has gas_data.payment =
+/// [real_coin_a, real_coin_b, coin_reservation]: two real coins and a coin
+/// reservation.  After TX1 depletes the AB, the fund-checker fires IFFW for TX2.
+///
+/// With the fix, smashing is skipped entirely for IFFW transactions that have any
+/// address-balance payment.  This means:
+///   - No AB AccumulatorEvent is emitted (no underflow at settlement).
+///   - The two real coins are not merged: real_coin_b is not deleted and both coins
+///     keep their original balances (0 gas charged).
+///   - SUI conservation holds because no coin is mutated or deleted.
 #[sim_test]
 async fn test_gas_smash_no_ab_underflow_on_iffw() {
     if has_mainnet_protocol_config_override() {
@@ -1392,14 +1397,13 @@ async fn test_gas_smash_no_ab_underflow_on_iffw() {
 
     let sender = test_env.get_sender(0);
 
-    // Fund the AB with a known amount; both per-tx reservations must be ≤ this for
-    // the bundle to pass signing-time validation.
+    // Fund the AB; both per-tx reservations must be ≤ this to pass signing validation.
     let initial_ab = 20_000_000u64;
     test_env.fund_one_address_balance(sender, initial_ab).await;
 
     // Refresh gas list after funding (funding consumes one coin).
     let mut all_gas = test_env.get_gas_for_sender(sender);
-    assert!(all_gas.len() >= 2, "need ≥2 gas coins");
+    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
 
     // TX1: withdraw all AB (pays gas from a real coin so the full initial_ab is freed).
     let gas_for_tx1 = all_gas.remove(0);
@@ -1412,14 +1416,19 @@ async fn test_gas_smash_no_ab_underflow_on_iffw() {
         )
         .build();
 
-    // TX2: gas_data.payment = [real_coin, coin_reservation].
-    // Reservation = initial_ab / 2 so it passes per-tx signing validation (≤ initial_ab)
-    // but exceeds the post-TX1 AB balance of 0, triggering IFFW.
-    let gas_for_tx2 = all_gas.remove(0);
+    // TX2: gas_data.payment = [real_coin_a, real_coin_b, coin_reservation].
+    // Using two real coins deliberately exercises the case where smashing would normally
+    // delete real_coin_b — the fix must leave it intact.
+    // Reservation = initial_ab / 2 passes per-tx signing validation (≤ initial_ab) but
+    // exceeds the post-TX1 balance of 0, triggering IFFW.
+    let real_coin_a = all_gas.remove(0);
+    let real_coin_b = all_gas.remove(0);
+    let real_coin_a_balance = test_env.get_coin_balance(real_coin_a.0).await;
+    let real_coin_b_balance = test_env.get_coin_balance(real_coin_b.0).await;
     let reservation = initial_ab / 2;
     let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
     let tx2 = test_env
-        .tx_builder_with_gas_objects(sender, vec![gas_for_tx2, fake_coin])
+        .tx_builder_with_gas_objects(sender, vec![real_coin_a, real_coin_b, fake_coin])
         .build();
 
     let tx1_digest = tx1.digest();
@@ -1452,11 +1461,26 @@ async fn test_gas_smash_no_ab_underflow_on_iffw() {
         .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
         .await;
 
-    // TX2's failed smash must not have emitted a withdrawal event: the AB stays at 0.
+    // AB must not have been touched by the failed TX2.
     let final_ab = test_env.get_sui_balance_ab(sender);
+    assert_eq!(final_ab, 0, "AB should stay 0; got {final_ab}");
+
+    // Because smashing is skipped for IFFW, real_coin_b must not have been deleted
+    // and both coins keep their full original balances (0 gas charged).
+    assert!(
+        tx2_effects.deleted().is_empty(),
+        "no coins should be deleted when smashing is skipped: {:?}",
+        tx2_effects.deleted()
+    );
     assert_eq!(
-        final_ab, 0,
-        "AB should stay 0; bug would underflow it to {final_ab}"
+        test_env.get_coin_balance(real_coin_a.0).await,
+        real_coin_a_balance,
+        "real_coin_a balance must be unchanged"
+    );
+    assert_eq!(
+        test_env.get_coin_balance(real_coin_b.0).await,
+        real_coin_b_balance,
+        "real_coin_b balance must be unchanged"
     );
 
     test_env.cluster.trigger_reconfiguration().await;

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1538,6 +1538,154 @@ async fn test_gas_smash_no_ab_underflow_on_iffw() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
+/// Regression test: same shape as test_gas_smash_no_ab_underflow_on_iffw, but the
+/// two real coins each hold only 1 MIST. Total real-coin gas after smashing is 2
+/// MIST — far below the gas budget. With AB entries dropped on IFFW the gas
+/// charger falls back to charging the real coins, and `deduct_gas` asserts
+/// balance >= charge. If gas charging is not also skipped for this case the
+/// node panics during settlement.
+#[sim_test]
+async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+
+    // AB must be large enough that the per-tx signing validation accepts
+    // TX2's reservation (≤ AB) and total gas balance (real coins + reservation)
+    // covers the default gas budget (≈ 5_000_000_000 MIST).
+    let initial_ab = 10_000_000_000u64;
+    test_env.fund_one_address_balance(sender, initial_ab).await;
+
+    let all_gas = test_env.get_gas_for_sender(sender);
+    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
+
+    // Pre-step: split two 1-MIST coins off a normal gas coin and transfer them
+    // back to sender. These tiny coins will be TX2's real-coin gas payments.
+    let splitter_gas = all_gas[0];
+    let mut split_builder = ProgrammableTransactionBuilder::new();
+    let one_a = split_builder.pure(1u64).unwrap();
+    let one_b = split_builder.pure(1u64).unwrap();
+    let split_result =
+        split_builder.command(Command::SplitCoins(Argument::GasCoin, vec![one_a, one_b]));
+    let Argument::Result(split_idx) = split_result else {
+        panic!("SplitCoins should return Argument::Result");
+    };
+    let recipient_arg = split_builder.pure(sender).unwrap();
+    split_builder.command(Command::TransferObjects(
+        vec![
+            Argument::NestedResult(split_idx, 0),
+            Argument::NestedResult(split_idx, 1),
+        ],
+        recipient_arg,
+    ));
+    let split_pt = split_builder.finish();
+    let split_tx = TransactionData::new_programmable(
+        sender,
+        vec![splitter_gas],
+        split_pt,
+        test_env.rgp * 5_000_000,
+        test_env.rgp,
+    );
+    let (_, split_effects) = test_env.exec_tx_directly(split_tx).await.unwrap();
+    assert!(
+        split_effects.status().is_ok(),
+        "tiny-coin split failed: {:?}",
+        split_effects.status()
+    );
+    let tiny_coins: Vec<_> = split_effects
+        .created()
+        .into_iter()
+        .filter(
+            |(_, owner)| matches!(owner, sui_types::object::Owner::AddressOwner(a) if *a == sender),
+        )
+        .map(|(obj_ref, _)| obj_ref)
+        .collect();
+    assert_eq!(
+        tiny_coins.len(),
+        2,
+        "expected exactly two created tiny coins"
+    );
+    let tiny_coin_a = tiny_coins[0];
+    let tiny_coin_b = tiny_coins[1];
+    assert_eq!(test_env.get_coin_balance(tiny_coin_a.0).await, 1);
+    assert_eq!(test_env.get_coin_balance(tiny_coin_b.0).await, 1);
+
+    // Refresh gas list; splitter_gas was mutated and tiny coins are now also in
+    // the wallet's gas-object list. Pick a separate coin to pay for TX1.
+    let all_gas = test_env.get_gas_for_sender(sender);
+    let gas_for_tx1 = *all_gas
+        .iter()
+        .find(|g| g.0 != splitter_gas.0 && g.0 != tiny_coin_a.0 && g.0 != tiny_coin_b.0)
+        .expect("need a non-tiny coin to pay TX1's gas");
+
+    // TX1: drain the AB to 0 (gas comes from a real coin, so the full
+    // initial_ab transfers out).
+    let dummy = SuiAddress::random_for_testing_only();
+    let tx1 = test_env
+        .tx_builder_with_gas(sender, gas_for_tx1)
+        .transfer_sui_to_address_balance(
+            FundSource::address_fund_with_reservation(initial_ab),
+            vec![(initial_ab, dummy)],
+        )
+        .build();
+
+    // TX2: gas_data.payment = [tiny_coin_a (1 MIST), tiny_coin_b (1 MIST),
+    // coin_reservation]. After TX1 drains the AB the reservation withdraw
+    // fails with IFFW.  reservation = initial_ab / 2 passes the per-tx signing
+    // check (≤ initial_ab) and reservation + 2 MIST > default budget.
+    let reservation = initial_ab / 2;
+    let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
+    let tx2 = test_env
+        .tx_builder_with_gas_objects(sender, vec![tiny_coin_a, tiny_coin_b, fake_coin])
+        .build();
+
+    let tx1_digest = tx1.digest();
+    let tx2_digest = tx2.digest();
+
+    let mut effects = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[tx1, tx2])
+        .await
+        .unwrap();
+
+    let tx2_effects = effects.pop().unwrap().1;
+    let tx1_effects = effects.pop().unwrap().1;
+
+    assert!(
+        tx1_effects.status().is_ok(),
+        "TX1 should succeed: {:?}",
+        tx1_effects.status()
+    );
+    let status_str = format!("{:?}", tx2_effects.status());
+    assert!(
+        status_str.contains("InsufficientFundsForWithdraw"),
+        "TX2 should fail with InsufficientFundsForWithdraw, got: {status_str}"
+    );
+
+    // Settlement must complete. Without an additional fix, gas charging tries
+    // to deduct gas from a 2-MIST coin and panics in deduct_gas's
+    // `balance >= charge` assertion, crashing the node.
+    test_env
+        .cluster
+        .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
+        .await;
+
+    let final_ab = test_env.get_sui_balance_ab(sender);
+    assert_eq!(final_ab, 0, "AB should stay 0; got {final_ab}");
+
+    test_env.cluster.trigger_reconfiguration().await;
+}
+
 fn build_fake_coin_reservation_pt(
     chain_id: sui_types::digests::ChainIdentifier,
 ) -> TransactionKind {

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1415,15 +1415,15 @@ async fn test_mix_coin_reservations_real_coins_and_shared_object() {
 /// transaction fails with InsufficientFundsForWithdraw.
 ///
 /// TX1 drains the AB to 0.  TX2 has gas_data.payment =
-/// [real_coin_a, real_coin_b, coin_reservation]: two real coins and a coin
-/// reservation.  After TX1 depletes the AB, the fund-checker fires IFFW for TX2.
+/// [real_coin_a, real_coin_b, coin_reservation] and an extra owned-object input
+/// (a coin transferred in the PTB).  After TX1 depletes the AB, IFFW fires for TX2.
 ///
-/// With the fix, smashing is skipped entirely for IFFW transactions that have any
-/// address-balance payment.  This means:
+/// With the fix, smashing is skipped entirely for IFFW.  This verifies:
 ///   - No AB AccumulatorEvent is emitted (no underflow at settlement).
-///   - The two real coins are not merged: real_coin_b is not deleted and both coins
-///     keep their original balances (0 gas charged).
-///   - SUI conservation holds because no coin is mutated or deleted.
+///   - The two gas coins are not merged; both keep their original balances (0 gas).
+///   - The extra PTB input gets its version bumped but is NOT storage-charged —
+///     collect_storage_and_rebate is skipped, so its storage_rebate is unchanged.
+///     SUI conservation must still hold.
 #[sim_test]
 async fn test_gas_smash_no_ab_underflow_on_iffw() {
     if has_mainnet_protocol_config_override() {
@@ -1446,7 +1446,7 @@ async fn test_gas_smash_no_ab_underflow_on_iffw() {
 
     // Refresh gas list after funding (funding consumes one coin).
     let mut all_gas = test_env.get_gas_for_sender(sender);
-    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
+    assert!(all_gas.len() >= 4, "need ≥4 gas coins");
 
     // TX1: withdraw all AB (pays gas from a real coin so the full initial_ab is freed).
     let gas_for_tx1 = all_gas.remove(0);
@@ -1459,19 +1459,21 @@ async fn test_gas_smash_no_ab_underflow_on_iffw() {
         )
         .build();
 
-    // TX2: gas_data.payment = [real_coin_a, real_coin_b, coin_reservation].
-    // Using two real coins deliberately exercises the case where smashing would normally
-    // delete real_coin_b — the fix must leave it intact.
-    // Reservation = initial_ab / 2 passes per-tx signing validation (≤ initial_ab) but
-    // exceeds the post-TX1 balance of 0, triggering IFFW.
+    // TX2: gas_data.payment = [real_coin_a, real_coin_b, coin_reservation] plus an
+    // extra owned-object input (input_coin) that the PTB transfers to sender.
+    // input_coin gets its version bumped by ensure_active_inputs_mutated but
+    // collect_storage_and_rebate is skipped — its storage_rebate must stay unchanged.
     let real_coin_a = all_gas.remove(0);
     let real_coin_b = all_gas.remove(0);
+    let input_coin = all_gas.remove(0);
     let real_coin_a_balance = test_env.get_coin_balance(real_coin_a.0).await;
     let real_coin_b_balance = test_env.get_coin_balance(real_coin_b.0).await;
+    let input_coin_balance = test_env.get_coin_balance(input_coin.0).await;
     let reservation = initial_ab / 2;
     let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
     let tx2 = test_env
         .tx_builder_with_gas_objects(sender, vec![real_coin_a, real_coin_b, fake_coin])
+        .transfer(FullObjectRef::from_fastpath_ref(input_coin), sender)
         .build();
 
     let tx1_digest = tx1.digest();
@@ -1524,6 +1526,13 @@ async fn test_gas_smash_no_ab_underflow_on_iffw() {
         test_env.get_coin_balance(real_coin_b.0).await,
         real_coin_b_balance,
         "real_coin_b balance must be unchanged"
+    );
+    // input_coin had its version bumped (it's an owned PTB input) but collect_storage_and_rebate
+    // was skipped, so its storage_rebate was not updated.  Conservation must still hold.
+    assert_eq!(
+        test_env.get_coin_balance(input_coin.0).await,
+        input_coin_balance,
+        "input_coin balance must be unchanged (version bumped, not storage-charged)"
     );
 
     test_env.cluster.trigger_reconfiguration().await;

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -915,6 +915,49 @@ async fn test_gas_smash_from_fake_coin() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
+/// Regression test: smashing two real gas coins must conserve SUI and produce the
+/// correct final balance. One coin is deleted (smashed into the other) so this
+/// exercises the deleted-input path of collect_storage_and_rebate, which is now
+/// placed after the IFFW early-return check.
+#[sim_test]
+async fn test_gas_smash_two_real_coins() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new().build().await;
+
+    let (sender, mut all_gas) = test_env.get_sender_and_all_gas(0);
+    assert!(all_gas.len() >= 2, "need ≥2 gas coins");
+
+    let coin1 = all_gas.remove(0);
+    let coin2 = all_gas.remove(0);
+    let coin1_balance = test_env.get_coin_balance(coin1.0).await;
+    let coin2_balance = test_env.get_coin_balance(coin2.0).await;
+
+    let tx = test_env
+        .tx_builder_with_gas_objects(sender, vec![coin1, coin2])
+        .build();
+    let (_, effects) = test_env.exec_tx_directly(tx).await.unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "Transaction failed: {:?}",
+        effects.status()
+    );
+
+    let gas_used = effects.gas_cost_summary().gas_used();
+
+    // coin2 is deleted (smashed into coin1)
+    assert_eq!(effects.deleted().len(), 1);
+    assert_eq!(effects.deleted()[0].0, coin2.0);
+
+    // coin1 holds the combined balance minus gas
+    let final_balance = test_env.get_coin_balance(coin1.0).await;
+    assert_eq!(final_balance, coin1_balance + coin2_balance - gas_used);
+
+    test_env.cluster.trigger_reconfiguration().await;
+}
+
 #[sim_test]
 async fn test_gas_coin_not_owned_by_gas_owner() {
     if has_mainnet_protocol_config_override() {

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1834,6 +1834,127 @@ async fn test_gas_smash_no_underflow_on_iffw_tiny_real_coins() {
     test_env.cluster.trigger_reconfiguration().await;
 }
 
+/// Regression test: AB-as-smash-target on IFFW.
+///
+/// TX2 has gas_data.payment = [coin_reservation, real_coin_a, real_coin_b].
+/// Because the first entry is the reservation, the AB is the smash target and
+/// the per-payment fix in execution_engine does NOT strip AB entries (smashing
+/// proceeds normally). After TX1 drains the AB, TX2 still fails with IFFW
+/// during execution.
+///
+/// During smashing the real coins are deleted and a single positive
+/// AccumulatorEvent of `total_smashed - reservation` (= sum of real coin
+/// balances) is emitted against the AB. There is no withdrawal event for the
+/// reservation itself — that would only happen in `charge_gas`, and the
+/// existing AB-IFFW early-return skips it.
+///
+/// Expected outcome:
+///   - TX1 succeeds, AB drained to 0.
+///   - TX2 fails with InsufficientFundsForWithdraw and is not charged.
+///   - Real coins are deleted; their balances land in the AB via the deposit
+///     event (so final AB = sum of real coin balances).
+///   - Settlement completes (no underflow / no panic).
+#[sim_test]
+async fn test_gas_smash_ab_target_iffw() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+
+    let initial_ab = 20_000_000u64;
+    test_env.fund_one_address_balance(sender, initial_ab).await;
+
+    let mut all_gas = test_env.get_gas_for_sender(sender);
+    assert!(all_gas.len() >= 3, "need ≥3 gas coins");
+
+    // TX1: drain the AB to 0 (gas comes from a real coin).
+    let gas_for_tx1 = all_gas.remove(0);
+    let dummy = SuiAddress::random_for_testing_only();
+    let tx1 = test_env
+        .tx_builder_with_gas(sender, gas_for_tx1)
+        .transfer_sui_to_address_balance(
+            FundSource::address_fund_with_reservation(initial_ab),
+            vec![(initial_ab, dummy)],
+        )
+        .build();
+
+    // TX2: gas_data.payment = [coin_reservation, real_coin_a, real_coin_b].
+    // Reservation first → AB is the smash target; real coins are smashed into it.
+    let real_coin_a = all_gas.remove(0);
+    let real_coin_b = all_gas.remove(0);
+    let real_coin_a_balance = test_env.get_coin_balance(real_coin_a.0).await;
+    let real_coin_b_balance = test_env.get_coin_balance(real_coin_b.0).await;
+    let reservation = initial_ab / 2;
+    let fake_coin = test_env.encode_coin_reservation(sender, 0, reservation);
+    let tx2 = test_env
+        .tx_builder_with_gas_objects(sender, vec![fake_coin, real_coin_a, real_coin_b])
+        .build();
+
+    let tx1_digest = tx1.digest();
+    let tx2_digest = tx2.digest();
+
+    let mut effects = test_env
+        .cluster
+        .sign_and_execute_txns_in_soft_bundle(&[tx1, tx2])
+        .await
+        .unwrap();
+
+    let tx2_effects = effects.pop().unwrap().1;
+    let tx1_effects = effects.pop().unwrap().1;
+
+    assert!(
+        tx1_effects.status().is_ok(),
+        "TX1 should succeed: {:?}",
+        tx1_effects.status()
+    );
+    let status_str = format!("{:?}", tx2_effects.status());
+    assert!(
+        status_str.contains("InsufficientFundsForWithdraw"),
+        "TX2 should fail with InsufficientFundsForWithdraw, got: {status_str}"
+    );
+
+    test_env
+        .cluster
+        .wait_for_tx_settlement(&[tx1_digest, tx2_digest])
+        .await;
+
+    // The real coins should both be deleted by gas smashing.
+    let deleted_ids: std::collections::HashSet<_> = tx2_effects
+        .deleted()
+        .into_iter()
+        .map(|(id, _, _)| id)
+        .collect();
+    assert!(
+        deleted_ids.contains(&real_coin_a.0),
+        "real_coin_a should be deleted, deleted={deleted_ids:?}"
+    );
+    assert!(
+        deleted_ids.contains(&real_coin_b.0),
+        "real_coin_b should be deleted, deleted={deleted_ids:?}"
+    );
+
+    // Final AB receives the deposit event for (total_smashed - reservation), which
+    // equals the sum of the real coin balances. No actual reservation withdrawal
+    // happens because charge_gas early-returns on AB-IFFW.
+    let final_ab = test_env.get_sui_balance_ab(sender);
+    assert_eq!(
+        final_ab,
+        real_coin_a_balance + real_coin_b_balance,
+        "AB should hold the smashed real-coin balances; got {final_ab}",
+    );
+
+    test_env.cluster.trigger_reconfiguration().await;
+}
+
 fn build_fake_coin_reservation_pt(
     chain_id: sui_types::digests::ChainIdentifier,
 ) -> TransactionKind {

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -232,6 +232,10 @@ mod checked {
             transaction_digest,
             payment_kind(&gas_data, &transaction_kind, protocol_config),
             gas_status,
+            matches!(
+                execution_params,
+                Err(ExecutionErrorKind::InsufficientFundsForWithdraw)
+            ),
             &mut temporary_store,
             protocol_config,
         );

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -405,6 +405,21 @@ pub mod checked {
             // object model to prevent replay), then return a zero gas summary.  This leaves
             // every object exactly as it was — no value changes, no storage_rebate changes,
             // no accumulator events — which makes SUI conservation trivially true.
+            //
+            // Why it is safe to skip collect_storage_and_rebate:
+            // collect_storage_and_rebate stamps a new storage_rebate onto every object in
+            // written_objects based on its current size and the network storage price.  If we
+            // then return a zero GasCostSummary the per-transaction SUI conservation check
+            // (check_sui_conserved_expensive) would observe a mismatch: the output objects
+            // carry a different storage_rebate than the input objects, but the gas summary
+            // accounts for none of it.  That discrepancy would trigger the conservation
+            // invariant violation and panic the node.
+            //
+            // We avoid this entirely because smashing was also skipped: no coins were merged,
+            // no coins were deleted, and ensure_active_inputs_mutated writes every gas object
+            // back with its *original* storage_rebate unchanged.  The output storage_rebate
+            // equals the input storage_rebate for every object, so the conservation check sees
+            // a zero net delta — consistent with the zero gas summary.
             if execution_result
                 .as_ref()
                 .err()

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -399,6 +399,28 @@ pub mod checked {
             debug_assert!(self.gas_status.storage_rebate() == 0);
             debug_assert!(self.gas_status.storage_gas_units() == 0);
 
+            // Fast path for InsufficientFundsForWithdraw: the transaction was doomed before
+            // execution started and smashing was already skipped in GasCharger::new.  We do
+            // nothing here except ensure active inputs are version-bumped (required by Sui's
+            // object model to prevent replay), then return a zero gas summary.  This leaves
+            // every object exactly as it was — no value changes, no storage_rebate changes,
+            // no accumulator events — which makes SUI conservation trivially true.
+            if execution_result
+                .as_ref()
+                .err()
+                .map(|err| {
+                    matches!(
+                        err.kind(),
+                        sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
+                    )
+                })
+                .unwrap_or(false)
+                && self.has_address_balance_payment()
+            {
+                temporary_store.ensure_active_inputs_mutated();
+                return GasCostSummary::default();
+            }
+
             if !matches!(&self.payment, PaymentMetadata::Unmetered) {
                 // bucketize computation cost
                 let is_move_abort = execution_result
@@ -425,32 +447,7 @@ pub mod checked {
             }
 
             temporary_store.ensure_active_inputs_mutated();
-
-            // Determine ahead of time whether the IFFW zero-gas path will fire.  We check this
-            // before collect_storage_and_rebate because:
-            //   - Unmetered transactions (advance epoch, system txs) MUST run
-            //     collect_storage_and_rebate so that newly-created system objects receive proper
-            //     storage_rebate values and the SUI conservation check passes.
-            //   - IFFW transactions MUST NOT run collect_storage_and_rebate: smashing was skipped
-            //     entirely, so the gas coin retains its original storage_rebate; stamping a new
-            //     rebate and then returning a zero gas summary would leave that delta unaccounted
-            //     for and violate conservation.
-            let is_iffw_zero_gas = execution_result
-                .as_ref()
-                .err()
-                .map(|err| {
-                    matches!(
-                        err.kind(),
-                        sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
-                    )
-                })
-                .unwrap_or(false)
-                && self.has_address_balance_payment();
-
-            // compute and collect storage charges — skipped only for the IFFW zero-gas path
-            if !is_iffw_zero_gas {
-                temporary_store.collect_storage_and_rebate(self);
-            }
+            temporary_store.collect_storage_and_rebate(self);
 
             if matches!(&self.payment, PaymentMetadata::Unmetered) {
                 return GasCostSummary::default();
@@ -459,12 +456,6 @@ pub mod checked {
             if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
                 #[skip_checked_arithmetic]
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
-            }
-
-            if is_iffw_zero_gas {
-                // If we don't have enough balance to withdraw, don't charge for gas.
-                // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
-                return GasCostSummary::default();
             }
 
             self.compute_storage_and_rebate(temporary_store, execution_result);

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -141,35 +141,42 @@ pub mod checked {
                 PaymentKind_::Smash(mut payment_methods) => {
                     let (_, smash_target) = payment_methods.shift_remove_index(0).unwrap();
 
-                    // When the transaction is doomed due to insufficient funds, filter out
-                    // address balance payments from secondary payments to avoid underflowing
-                    // the AB during smashing.
-                    let had_ab_payments_filtered = is_early_error
-                        && payment_methods
-                            .values()
-                            .any(|p| matches!(p, PaymentMethod::AddressBalance(_, _)));
-                    let payment_methods = if is_early_error {
-                        payment_methods
-                            .into_iter()
-                            .filter_map(|(index, payment)| match &payment {
-                                PaymentMethod::AddressBalance(_, _) => None,
-                                PaymentMethod::Coin(_) => Some((index, payment)),
-                            })
-                            .collect()
+                    // When the transaction is doomed due to InsufficientFundsForWithdraw, skip
+                    // smashing entirely.  Any AddressBalance entries in the payment list cannot
+                    // be debited (the AB is empty), and merging real coins at this point would
+                    // delete them before we have a chance to charge gas — breaking SUI
+                    // conservation when we later return a zero gas summary.  By skipping
+                    // smashing we leave all gas coins untouched; `had_ab_payments_filtered`
+                    // records that AB entries were present so the IFFW zero-gas early return
+                    // still fires correctly.
+                    let had_ab_payments = is_early_error
+                        && (matches!(smash_target, PaymentMethod::AddressBalance(_, _))
+                            || payment_methods
+                                .values()
+                                .any(|p| matches!(p, PaymentMethod::AddressBalance(_, _))));
+                    if had_ab_payments {
+                        let metadata = SmashMetadata {
+                            total_smashed: 0,
+                            gas_charge_location: smash_target.location(),
+                            smash_target,
+                            smashed_payments: IndexMap::new(),
+                            had_ab_payments_filtered: true,
+                        };
+                        // Intentionally skip metadata.smash_gas: no coins are merged and no
+                        // AccumulatorEvents are emitted.
+                        PaymentMetadata::Smash(metadata)
                     } else {
-                        payment_methods
-                    };
-
-                    let mut metadata = SmashMetadata {
-                        // dummy value set below in smash_gas
-                        total_smashed: 0,
-                        gas_charge_location: smash_target.location(),
-                        smash_target,
-                        smashed_payments: payment_methods,
-                        had_ab_payments_filtered,
-                    };
-                    metadata.smash_gas(&tx_digest, temporary_store);
-                    PaymentMetadata::Smash(metadata)
+                        let mut metadata = SmashMetadata {
+                            // dummy value set below in smash_gas
+                            total_smashed: 0,
+                            gas_charge_location: smash_target.location(),
+                            smash_target,
+                            smashed_payments: payment_methods,
+                            had_ab_payments_filtered: false,
+                        };
+                        metadata.smash_gas(&tx_digest, temporary_store);
+                        PaymentMetadata::Smash(metadata)
+                    }
                 }
             };
             Self {
@@ -417,8 +424,9 @@ pub mod checked {
                 }
             }
 
-            // Increment versions for all input objects that were touched.
+            // compute and collect storage charges
             temporary_store.ensure_active_inputs_mutated();
+            temporary_store.collect_storage_and_rebate(self);
 
             if matches!(&self.payment, PaymentMetadata::Unmetered) {
                 return GasCostSummary::default();
@@ -429,10 +437,6 @@ pub mod checked {
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
             }
 
-            // Early return for InsufficientFundsForWithdraw must happen BEFORE
-            // collect_storage_and_rebate.  If we collected first, the gas coin's
-            // storage_rebate would be stamped with a new value but never paid for in the
-            // gas summary, causing a SUI conservation violation.
             if execution_result
                 .as_ref()
                 .err()
@@ -445,12 +449,11 @@ pub mod checked {
                 .unwrap_or(false)
                 && self.has_address_balance_payment() {
                     // If we don't have enough balance to withdraw, don't charge for gas.
+                    // Smashing was skipped at construction time so no coins were merged and the
+                    // gas summary is trivially zero.
                     // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
                     return GasCostSummary::default();
             }
-
-            // compute and collect storage charges
-            temporary_store.collect_storage_and_rebate(self);
 
             self.compute_storage_and_rebate(temporary_store, execution_result);
 

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -426,22 +426,16 @@ pub mod checked {
 
             temporary_store.ensure_active_inputs_mutated();
 
-            if matches!(&self.payment, PaymentMetadata::Unmetered) {
-                return GasCostSummary::default();
-            }
-            let gas_payment_location = self.gas_payment_location();
-            if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
-                #[skip_checked_arithmetic]
-                trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
-            }
-
-            // This early return must come BEFORE collect_storage_and_rebate.  Smashing was
-            // skipped entirely for IFFW transactions (no coins merged, no events emitted), so
-            // the gas coin retains its original value and storage_rebate.  If we called
-            // collect_storage_and_rebate first it would stamp a new storage_rebate on the
-            // (unmodified) gas coin; then returning a zero gas summary would leave that rebate
-            // unaccounted for, violating SUI conservation.
-            if execution_result
+            // Determine ahead of time whether the IFFW zero-gas path will fire.  We check this
+            // before collect_storage_and_rebate because:
+            //   - Unmetered transactions (advance epoch, system txs) MUST run
+            //     collect_storage_and_rebate so that newly-created system objects receive proper
+            //     storage_rebate values and the SUI conservation check passes.
+            //   - IFFW transactions MUST NOT run collect_storage_and_rebate: smashing was skipped
+            //     entirely, so the gas coin retains its original storage_rebate; stamping a new
+            //     rebate and then returning a zero gas summary would leave that delta unaccounted
+            //     for and violate conservation.
+            let is_iffw_zero_gas = execution_result
                 .as_ref()
                 .err()
                 .map(|err| {
@@ -451,15 +445,27 @@ pub mod checked {
                     )
                 })
                 .unwrap_or(false)
-                && self.has_address_balance_payment()
-            {
+                && self.has_address_balance_payment();
+
+            // compute and collect storage charges — skipped only for the IFFW zero-gas path
+            if !is_iffw_zero_gas {
+                temporary_store.collect_storage_and_rebate(self);
+            }
+
+            if matches!(&self.payment, PaymentMetadata::Unmetered) {
+                return GasCostSummary::default();
+            }
+            let gas_payment_location = self.gas_payment_location();
+            if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
+                #[skip_checked_arithmetic]
+                trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+            }
+
+            if is_iffw_zero_gas {
                 // If we don't have enough balance to withdraw, don't charge for gas.
                 // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
                 return GasCostSummary::default();
             }
-
-            // compute and collect storage charges
-            temporary_store.collect_storage_and_rebate(self);
 
             self.compute_storage_and_rebate(temporary_store, execution_result);
 

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -72,6 +72,11 @@ pub mod checked {
         /// The original payment methods to be smashed into the `smash_target`. It does not include
         /// the `smash_target` itself. Keyed by location to guarantee uniqueness.
         smashed_payments: IndexMap<PaymentLocation, PaymentMethod>,
+        /// True when address-balance entries were present in the original payment list but were
+        /// filtered out because the transaction has an early InsufficientFundsForWithdraw error.
+        /// Preserved so that `has_address_balance_payment` can still return the correct answer
+        /// after the filter has been applied.
+        had_ab_payments_filtered: bool,
     }
 
     /// Public wrapper that describes how gas will be paid before smashing occurs.
@@ -139,6 +144,10 @@ pub mod checked {
                     // When the transaction is doomed due to insufficient funds, filter out
                     // address balance payments from secondary payments to avoid underflowing
                     // the AB during smashing.
+                    let had_ab_payments_filtered = is_early_error
+                        && payment_methods
+                            .values()
+                            .any(|p| matches!(p, PaymentMethod::AddressBalance(_, _)));
                     let payment_methods = if is_early_error {
                         payment_methods
                             .into_iter()
@@ -157,6 +166,7 @@ pub mod checked {
                         gas_charge_location: smash_target.location(),
                         smash_target,
                         smashed_payments: payment_methods,
+                        had_ab_payments_filtered,
                     };
                     metadata.smash_gas(&tx_digest, temporary_store);
                     PaymentMetadata::Smash(metadata)
@@ -229,9 +239,12 @@ pub mod checked {
         pub(crate) fn has_address_balance_payment(&self) -> bool {
             match &self.payment {
                 PaymentMetadata::Unmetered | PaymentMetadata::Gasless => false,
-                PaymentMetadata::Smash(metadata) => metadata
-                    .payment_methods()
-                    .any(|payment| matches!(payment, PaymentMethod::AddressBalance(_, _))),
+                PaymentMetadata::Smash(metadata) => {
+                    metadata.had_ab_payments_filtered
+                        || metadata
+                            .payment_methods()
+                            .any(|payment| matches!(payment, PaymentMethod::AddressBalance(_, _)))
+                }
             }
         }
 
@@ -404,9 +417,8 @@ pub mod checked {
                 }
             }
 
-            // compute and collect storage charges
+            // Increment versions for all input objects that were touched.
             temporary_store.ensure_active_inputs_mutated();
-            temporary_store.collect_storage_and_rebate(self);
 
             if matches!(&self.payment, PaymentMetadata::Unmetered) {
                 return GasCostSummary::default();
@@ -417,6 +429,10 @@ pub mod checked {
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
             }
 
+            // Early return for InsufficientFundsForWithdraw must happen BEFORE
+            // collect_storage_and_rebate.  If we collected first, the gas coin's
+            // storage_rebate would be stamped with a new value but never paid for in the
+            // gas summary, causing a SUI conservation violation.
             if execution_result
                 .as_ref()
                 .err()
@@ -428,10 +444,13 @@ pub mod checked {
                 })
                 .unwrap_or(false)
                 && self.has_address_balance_payment() {
-                    // If we don't have enough balance to withdraw, don't charge for gas
+                    // If we don't have enough balance to withdraw, don't charge for gas.
                     // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
                     return GasCostSummary::default();
             }
+
+            // compute and collect storage charges
+            temporary_store.collect_storage_and_rebate(self);
 
             self.compute_storage_and_rebate(temporary_store, execution_result);
 

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -424,9 +424,7 @@ pub mod checked {
                 }
             }
 
-            // compute and collect storage charges
             temporary_store.ensure_active_inputs_mutated();
-            temporary_store.collect_storage_and_rebate(self);
 
             if matches!(&self.payment, PaymentMetadata::Unmetered) {
                 return GasCostSummary::default();
@@ -437,6 +435,12 @@ pub mod checked {
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
             }
 
+            // This early return must come BEFORE collect_storage_and_rebate.  Smashing was
+            // skipped entirely for IFFW transactions (no coins merged, no events emitted), so
+            // the gas coin retains its original value and storage_rebate.  If we called
+            // collect_storage_and_rebate first it would stamp a new storage_rebate on the
+            // (unmodified) gas coin; then returning a zero gas summary would leave that rebate
+            // unaccounted for, violating SUI conservation.
             if execution_result
                 .as_ref()
                 .err()
@@ -447,13 +451,15 @@ pub mod checked {
                     )
                 })
                 .unwrap_or(false)
-                && self.has_address_balance_payment() {
-                    // If we don't have enough balance to withdraw, don't charge for gas.
-                    // Smashing was skipped at construction time so no coins were merged and the
-                    // gas summary is trivially zero.
-                    // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
-                    return GasCostSummary::default();
+                && self.has_address_balance_payment()
+            {
+                // If we don't have enough balance to withdraw, don't charge for gas.
+                // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
+                return GasCostSummary::default();
             }
+
+            // compute and collect storage charges
+            temporary_store.collect_storage_and_rebate(self);
 
             self.compute_storage_and_rebate(temporary_store, execution_result);
 

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -402,24 +402,14 @@ pub mod checked {
             // Fast path for InsufficientFundsForWithdraw: the transaction was doomed before
             // execution started and smashing was already skipped in GasCharger::new.  We do
             // nothing here except ensure active inputs are version-bumped (required by Sui's
-            // object model to prevent replay), then return a zero gas summary.  This leaves
-            // every object exactly as it was — no value changes, no storage_rebate changes,
-            // no accumulator events — which makes SUI conservation trivially true.
+            // object model to prevent replay), then return a zero gas summary.
             //
-            // Why it is safe to skip collect_storage_and_rebate:
-            // collect_storage_and_rebate stamps a new storage_rebate onto every object in
-            // written_objects based on its current size and the network storage price.  If we
-            // then return a zero GasCostSummary the per-transaction SUI conservation check
-            // (check_sui_conserved_expensive) would observe a mismatch: the output objects
-            // carry a different storage_rebate than the input objects, but the gas summary
-            // accounts for none of it.  That discrepancy would trigger the conservation
-            // invariant violation and panic the node.
-            //
-            // We avoid this entirely because smashing was also skipped: no coins were merged,
-            // no coins were deleted, and ensure_active_inputs_mutated writes every gas object
-            // back with its *original* storage_rebate unchanged.  The output storage_rebate
-            // equals the input storage_rebate for every object, so the conservation check sees
-            // a zero net delta — consistent with the zero gas summary.
+            // collect_storage_and_rebate is intentionally skipped: it would stamp new
+            // storage_rebate values onto the gas objects, but returning a zero gas summary
+            // afterward would leave those deltas unaccounted for in the SUI conservation check.
+            // Because smashing was also skipped, ensure_active_inputs_mutated writes every gas
+            // object back with its original storage_rebate, so input == output everywhere and
+            // the zero gas summary is consistent.
             if execution_result
                 .as_ref()
                 .err()

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -125,6 +125,7 @@ pub mod checked {
             tx_digest: TransactionDigest,
             payment_kind: PaymentKind,
             gas_status: SuiGasStatus,
+            is_early_error: bool,
             temporary_store: &mut TemporaryStore<'_>,
             protocol_config: &ProtocolConfig,
         ) -> Self {
@@ -134,6 +135,22 @@ pub mod checked {
                 PaymentKind_::Gasless => PaymentMetadata::Gasless,
                 PaymentKind_::Smash(mut payment_methods) => {
                     let (_, smash_target) = payment_methods.shift_remove_index(0).unwrap();
+
+                    // When the transaction is doomed due to insufficient funds, filter out
+                    // address balance payments from secondary payments to avoid underflowing
+                    // the AB during smashing.
+                    let payment_methods = if is_early_error {
+                        payment_methods
+                            .into_iter()
+                            .filter_map(|(index, payment)| match &payment {
+                                PaymentMethod::AddressBalance(_, _) => None,
+                                PaymentMethod::Coin(_) => Some((index, payment)),
+                            })
+                            .collect()
+                    } else {
+                        payment_methods
+                    };
+
                     let mut metadata = SmashMetadata {
                         // dummy value set below in smash_gas
                         total_smashed: 0,
@@ -206,6 +223,15 @@ pub mod checked {
             match &self.payment {
                 PaymentMetadata::Unmetered | PaymentMetadata::Gasless => None,
                 PaymentMetadata::Smash(metadata) => Some(metadata.gas_charge_location),
+            }
+        }
+
+        pub(crate) fn has_address_balance_payment(&self) -> bool {
+            match &self.payment {
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => false,
+                PaymentMetadata::Smash(metadata) => metadata
+                    .payment_methods()
+                    .any(|payment| matches!(payment, PaymentMethod::AddressBalance(_, _))),
             }
         }
 
@@ -401,7 +427,7 @@ pub mod checked {
                     )
                 })
                 .unwrap_or(false)
-                && matches!(gas_payment_location, Some(PaymentLocation::AddressBalance(_))) {
+                && self.has_address_balance_payment() {
                     // If we don't have enough balance to withdraw, don't charge for gas
                     // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
                     return GasCostSummary::default();


### PR DESCRIPTION
## Problem

When a transaction fails with `InsufficientFundsForWithdraw` (the address balance does not have sufficient funds to cover its reservations), gas smashing was still executing unconditionally. This caused two distinct crashes depending on the payment structure:

1. **Accumulator underflow at settlement**: For `gas_data.payment = [real_coin, coin_reservation]`, smashing emitted a negative `AccumulatorEvent` against the address balance. Since the AB was empty, the settlement transaction's `accumulator::update_u128` Move call aborted with an arithmetic underflow, crashing the node.

2. **SUI conservation panic**: For `gas_data.payment = [coin_reservation]` (pure AB payment), the existing zero-gas early return fired *after* `collect_storage_and_rebate` had already stamped a new `storage_rebate` on the gas coin. Returning a zero gas summary left that delta unaccounted for, triggering the conservation invariant check.

3. **`deduct_gas` assertion panic**: With tiny real coins (e.g. 1 MIST each), if gas charging fell through to the real coin, `deduct_gas` asserted `balance >= charge` and panicked.

## Fix

Two changes work together:

**`GasCharger::new`**: When `is_early_error` is `InsufficientFundsForWithdraw` and any address-balance payment is present, skip `smash_gas` entirely. No coins are merged, no `AccumulatorEvent`s are emitted, and `had_ab_payments_filtered` is set so `has_address_balance_payment()` returns the correct answer after filtering.

**`charge_gas`**: Detect the IFFW + AB condition at the very top of the function, before bucketization, before reset, before everything. If matched, call only `ensure_active_inputs_mutated` (required by Sui's object model to version-bump gas objects and prevent replay) and return a zero gas summary immediately. This leaves every object exactly as it was loaded — no value changes, no `storage_rebate` changes, no events. SUI conservation is trivially true.

## Tests

Three new simtests in `address_balance_compatibility_tests.rs`:

- `test_gas_smash_no_ab_underflow_on_iffw`: the core regression — two real coins plus a coin reservation as gas, AB drained to zero by a preceding transaction in a soft bundle, IFFW fires, settlement must complete without panicking and the AB must stay at zero.
- `test_gas_smash_no_underflow_on_iffw_tiny_real_coins`: same scenario but the real coins hold 1 MIST each (far below any gas budget), confirming `deduct_gas` is never reached.
- `test_gas_smash_two_real_coins`: non-IFFW smash of two real coins verifies the happy path still conserves SUI and correctly merges the coins.

The soft-bundle setup is required because per-transaction signing validation would reject a coin reservation whose amount exceeds the current AB balance; the bundle lets TX1 drain the AB while TX2 is still accepted at signing time, making TX2 receive IFFW at execution time.