### PR TITLE
[release/v1.73.0] Cherry-pick tidehunter pruner fix + update to 2e0cd56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,12 +2846,6 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-
-[[package]]
-name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
@@ -3001,15 +2995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bloom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
-dependencies = [
- "bit-vec 0.4.4",
 ]
 
 [[package]]
@@ -5483,6 +5468,19 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.2",
  "libm",
+ "rand 0.9.0",
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
  "rand 0.9.0",
  "siphasher 1.0.1",
 ]
@@ -8406,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2e0cd5669b1b6776e204e9ad0385189a65a62236#2e0cd5669b1b6776e204e9ad0385189a65a62236"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -11582,7 +11580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
- "fastbloom",
+ "fastbloom 0.14.1",
  "getrandom 0.3.2",
  "lru-slab",
  "rand 0.9.0",
@@ -17981,7 +17979,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2e0cd5669b1b6776e204e9ad0385189a65a62236#2e0cd5669b1b6776e204e9ad0385189a65a62236"
 dependencies = [
  "anyhow",
  "clap",
@@ -17990,19 +17988,20 @@ dependencies = [
  "rhai",
  "rustyline",
  "tidehunter",
+ "tikv-jemallocator",
 ]
 
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2e0cd5669b1b6776e204e9ad0385189a65a62236#2e0cd5669b1b6776e204e9ad0385189a65a62236"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",
  "blake2",
- "bloom",
  "bytes",
  "crc32fast",
+ "fastbloom 0.17.0",
  "libc",
  "lru 0.12.5",
  "lz4_flex",

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -439,6 +439,7 @@ impl AuthorityStorePruner {
                 checkpoint_store,
                 num_epochs_to_retain,
                 pruner_watermarks,
+                false,
             )?;
         }
         Ok(())
@@ -665,6 +666,7 @@ impl AuthorityStorePruner {
         checkpoint_store: &Arc<CheckpointStore>,
         num_epochs_to_retain: u64,
         pruning_watermark: &Arc<PrunerWatermarks>,
+        objects_compactor_active: bool,
     ) -> anyhow::Result<bool> {
         use std::sync::atomic::Ordering;
         let objects_pruning_checkpoint_id = perpetual_db
@@ -687,7 +689,13 @@ impl AuthorityStorePruner {
         let checkpoint_id =
             checkpoint_store.get_epoch_last_checkpoint_seq_number(target_epoch_id)?;
 
-        let new_watermark = min(target_epoch_id + 1, objects_pruning_epoch_id);
+        // The objects compactor handles object retention continuously without advancing
+        // `highest_pruned_checkpoint`, so capping on it would freeze the watermark at 0.
+        let new_watermark = if objects_compactor_active {
+            target_epoch_id + 1
+        } else {
+            min(target_epoch_id + 1, objects_pruning_epoch_id)
+        };
         if current_watermark == new_watermark {
             return Ok(false);
         }
@@ -696,7 +704,11 @@ impl AuthorityStorePruner {
             .epoch_id
             .store(new_watermark, Ordering::Relaxed);
         if let Some(checkpoint_id) = checkpoint_id {
-            let watermark = min(checkpoint_id, objects_pruning_checkpoint_id);
+            let watermark = if objects_compactor_active {
+                checkpoint_id
+            } else {
+                min(checkpoint_id, objects_pruning_checkpoint_id)
+            };
             info!("relocation: setting checkpoint watermark to {}", watermark);
             pruning_watermark
                 .checkpoint_id
@@ -711,12 +723,14 @@ impl AuthorityStorePruner {
         checkpoint_store: &Arc<CheckpointStore>,
         num_epochs_to_retain: u64,
         pruning_watermark: Arc<PrunerWatermarks>,
+        objects_compactor_active: bool,
     ) -> anyhow::Result<()> {
         let watermark_updated = Self::update_pruning_watermarks(
             perpetual_db,
             checkpoint_store,
             num_epochs_to_retain,
             &pruning_watermark,
+            objects_compactor_active,
         )?;
         if !watermark_updated {
             info!("skip relocation. Watermark hasn't changed");
@@ -859,7 +873,7 @@ impl AuthorityStorePruner {
                                 }
                             },
                             _ = checkpoints_prune_interval.tick() => {
-                                if let Err(err) = Self::prune_th(&perpetual_db, &checkpoint_store, num_epochs_to_retain, pruner_watermarks.clone()) {
+                                if let Err(err) = Self::prune_th(&perpetual_db, &checkpoint_store, num_epochs_to_retain, pruner_watermarks.clone(), !prune_objects) {
                                     error!("Failed to prune checkpoints: {:?}", err);
                                 }
                             },

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -52,7 +52,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "14b04e9d8130c20fdc03a629c02fe50f628cb789", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "2e0cd5669b1b6776e204e9ad0385189a65a62236", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "14b04e9d8130c20fdc03a629c02fe50f628cb789", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "2e0cd5669b1b6776e204e9ad0385189a65a62236", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -136,6 +136,7 @@ fn thdb_config(metric_conf: &MetricConf) -> Config {
         commit_pool_size,
         num_flusher_threads,
         batch_codec,
+        relocation_max_reclaim_pct: 100,
         ..Config::default()
     };
 


### PR DESCRIPTION
Cherry-picks two tidehunter commits from `main` onto `releases/sui-v1.73.0-release`:

- `78aea9a321` — fix(tidehunter pruner): uncap checkpoint watermark when objects compactor is active (#26779)
- `c0c9b9f18f` — [chore] Update tidehunter to 2e0cd56 and set relocation_max_reclaim_pct=100 (#26785)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
