### PR TITLE
Gate IFFW gas-smash short-circuit on mainnet settlement version

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -158,7 +158,7 @@ impl EpochState {
                 self.execution_metrics.clone(),
                 false, // enable_expensive_checks
                 // TODO: Integrate with early execution error
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &self.epoch_start_state.epoch(),
                 self.epoch_start_state.epoch_start_timestamp_ms(),
                 checked_input_objects,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -70,6 +70,7 @@ use std::{
 use sui_config::NodeConfig;
 use sui_config::node::{AuthorityOverloadConfig, StateDebugDumpConfig};
 use sui_execution::Executor;
+use sui_protocol_config::Chain;
 use sui_protocol_config::PerObjectCongestionControlMode;
 use sui_types::accumulator_root::AccumulatorObjId;
 use sui_types::crypto::RandomnessRound;
@@ -1999,9 +2000,17 @@ impl AuthorityState {
             self.config.certificate_deny_config.certificate_deny_set(),
             &execution_env.funds_withdraw_status,
         );
+        // Mainnet-only: feed the accumulator (settlement) version so the address-balance gas-smash
+        // short-circuit activates at its rollout version and replays bit-for-bit. Other chains pass
+        // `None`, where the short-circuit applies unconditionally.
+        let accumulator_version = if self.chain_identifier.chain() == Chain::Mainnet {
+            execution_env.assigned_versions.accumulator_version
+        } else {
+            None
+        };
         let execution_params = match early_execution_error {
-            None => ExecutionOrEarlyError::Ok(()),
-            Some(errors) => ExecutionOrEarlyError::Err(errors),
+            None => ExecutionOrEarlyError::ok(accumulator_version),
+            Some(errors) => ExecutionOrEarlyError::failed(errors, accumulator_version),
         };
 
         // Skip on early error: the tx will fail anyway and rewriting may fail if the accumulator
@@ -2504,9 +2513,11 @@ impl AuthorityState {
             self.config.certificate_deny_config.certificate_deny_set(),
             &FundsWithdrawStatus::MaybeSufficient,
         );
+        // Dev-inspect/simulation path (not committed): no assigned accumulator version here, so the
+        // IFFW short-circuit applies unconditionally (`None`), matching non-mainnet execution.
         let execution_params = match early_execution_error {
-            None => ExecutionOrEarlyError::Ok(()),
-            Some(errors) => ExecutionOrEarlyError::Err(errors),
+            None => ExecutionOrEarlyError::ok(None),
+            Some(errors) => ExecutionOrEarlyError::failed(errors, None),
         };
 
         let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
@@ -2562,9 +2573,10 @@ impl AuthorityState {
                     protocol_config,
                     self.metrics.execution_metrics.clone(),
                     false,
-                    ExecutionOrEarlyError::Err(NonEmpty::new(
-                        ExecutionErrorKind::InsufficientFundsForWithdraw,
-                    )),
+                    ExecutionOrEarlyError::failed(
+                        NonEmpty::new(ExecutionErrorKind::InsufficientFundsForWithdraw),
+                        None,
+                    ),
                     &epoch_id,
                     epoch_timestamp_ms,
                     cloned_input_objects,

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -925,7 +925,7 @@ fn create_genesis_transaction(
                 protocol_config,
                 metrics,
                 expensive_checks,
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &epoch_data.epoch_id(),
                 epoch_data.epoch_start_timestamp(),
                 input_objects,

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -126,8 +126,8 @@ pub fn execute_transaction_to_effects(
         &FundsWithdrawStatus::MaybeSufficient,
     );
     let execution_params = match early_execution_error {
-        None => ExecutionOrEarlyError::Ok(()),
-        Some(errors) => ExecutionOrEarlyError::Err(errors),
+        None => ExecutionOrEarlyError::ok(None),
+        Some(errors) => ExecutionOrEarlyError::failed(errors, None),
     };
     let (inner_store, gas_status, effects, _execution_timing, result) = executor
         .executor

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -789,8 +789,8 @@ impl LocalExec {
             &FundsWithdrawStatus::MaybeSufficient,
         );
         let execution_params = match early_execution_error {
-            None => ExecutionOrEarlyError::Ok(()),
-            Some(errors) => ExecutionOrEarlyError::Err(errors),
+            None => ExecutionOrEarlyError::ok(None),
+            Some(errors) => ExecutionOrEarlyError::failed(errors, None),
         };
         let (inner_store, gas_status, effects, _timings, result) = executor
             .execute_transaction_to_effects_and_execution_error(
@@ -867,8 +867,8 @@ impl LocalExec {
             &FundsWithdrawStatus::MaybeSufficient,
         );
         let execution_params = match early_execution_error {
-            None => ExecutionOrEarlyError::Ok(()),
-            Some(errors) => ExecutionOrEarlyError::Err(errors),
+            None => ExecutionOrEarlyError::ok(None),
+            Some(errors) => ExecutionOrEarlyError::failed(errors, None),
         };
         if let ProgrammableTransaction(pt) = transaction_kind {
             trace!(
@@ -985,8 +985,8 @@ impl LocalExec {
             &FundsWithdrawStatus::MaybeSufficient,
         );
         let execution_params = match early_execution_error {
-            None => ExecutionOrEarlyError::Ok(()),
-            Some(errors) => ExecutionOrEarlyError::Err(errors),
+            None => ExecutionOrEarlyError::ok(None),
+            Some(errors) => ExecutionOrEarlyError::failed(errors, None),
         };
         let (_, _, effects, _timings, exec_res) = executor
             .execute_transaction_to_effects_and_execution_error(

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -215,7 +215,7 @@ impl SingleValidator {
                 self.epoch_store.protocol_config(),
                 self.get_validator().metrics.execution_metrics.clone(),
                 false,
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &self.epoch_store.epoch(),
                 0,
                 input_objects,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -711,7 +711,7 @@ mod test {
                 &protocol_config,
                 metrics,
                 expensive_checks,
-                ExecutionOrEarlyError::Ok(()),
+                ExecutionOrEarlyError::ok(None),
                 &epoch.epoch_id(),
                 epoch.epoch_start_timestamp(),
                 input_objects,

--- a/crates/sui-types/src/execution_params.rs
+++ b/crates/sui-types/src/execution_params.rs
@@ -12,7 +12,56 @@ use crate::{
     execution_status::ExecutionErrorKind, transaction::CheckedInputObjects,
 };
 
-pub type ExecutionOrEarlyError = Result<(), NonEmpty<ExecutionErrorKind>>;
+/// Execution inputs computed before running a transaction: whether to fail it early (and with
+/// which errors), plus context for gas charging. An execution input only - never serialized into
+/// `TransactionEffects`, so adding fields here does not change effects or their digests.
+#[derive(Debug, Clone)]
+pub struct ExecutionOrEarlyError {
+    early_errors: Option<NonEmpty<ExecutionErrorKind>>,
+    /// Accumulator (settlement) root version assigned to this transaction. Gates the mainnet
+    /// address-balance gas-smash short-circuit. Populated only for mainnet committed execution;
+    /// `None` elsewhere, leaving that gate inert.
+    accumulator_version: Option<SequenceNumber>,
+}
+
+impl ExecutionOrEarlyError {
+    /// Execute the transaction normally (no predetermined early error).
+    pub fn ok(accumulator_version: Option<SequenceNumber>) -> Self {
+        Self {
+            early_errors: None,
+            accumulator_version,
+        }
+    }
+
+    /// Skip execution and fail the transaction with `errors`.
+    pub fn failed(
+        errors: NonEmpty<ExecutionErrorKind>,
+        accumulator_version: Option<SequenceNumber>,
+    ) -> Self {
+        Self {
+            early_errors: Some(errors),
+            accumulator_version,
+        }
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.early_errors.is_none()
+    }
+
+    /// The predetermined early errors, if any.
+    pub fn early_errors(&self) -> Option<&NonEmpty<ExecutionErrorKind>> {
+        self.early_errors.as_ref()
+    }
+
+    /// Consume self, returning the predetermined early errors, if any.
+    pub fn into_early_errors(self) -> Option<NonEmpty<ExecutionErrorKind>> {
+        self.early_errors
+    }
+
+    pub fn accumulator_version(&self) -> Option<SequenceNumber> {
+        self.accumulator_version
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FundsWithdrawStatus {

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -88,6 +88,52 @@ mod checked {
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     };
 
+    /// Mainnet settlement version at/above which an `InsufficientFundsForWithdraw` transaction
+    /// short-circuits execution entirely (zero-gas effects, mutable-input version bumps only),
+    /// superseding the address-balance gas-payment pruning hotfix. A compiled constant, not a
+    /// protocol flag, because it must take effect mid-epoch during recovery when the network cannot
+    /// reconfigure. Only consulted when an accumulator version is assigned (mainnet committed
+    /// execution); everywhere else the short-circuit applies unconditionally (see
+    /// `should_short_circuit_insufficient_funds`).
+    ///
+    /// Value is the mainnet accumulator root version immediately before the failed settlement.
+    const ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION: SequenceNumber =
+        SequenceNumber::from_u64(693531086);
+
+    fn has_insufficient_funds_for_withdraw(execution_params: &ExecutionOrEarlyError) -> bool {
+        execution_params.early_errors().is_some_and(|errors| {
+            errors
+                .iter()
+                .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw))
+        })
+    }
+
+    /// Whether the *head* early error is `InsufficientFundsForWithdraw`. Used to gate the first
+    /// address-balance gas-payment pruning hotfix: the head error is the one surfaced as the
+    /// failure status, so keying off it (rather than any occurrence) keeps the pruning bit-for-bit
+    /// with the original single-error hotfix.
+    fn head_error_is_insufficient_funds_for_withdraw(
+        execution_params: &ExecutionOrEarlyError,
+    ) -> bool {
+        execution_params.early_errors().is_some_and(|errors| {
+            matches!(
+                errors.head,
+                ExecutionErrorKind::InsufficientFundsForWithdraw
+            )
+        })
+    }
+
+    /// Whether to short-circuit an IFFW transaction. When an accumulator version is assigned
+    /// (mainnet committed execution) it gates on the settlement-version rollout point; otherwise
+    /// (every other chain and non-committed paths, where no accumulator version is assigned) the
+    /// short-circuit applies unconditionally.
+    fn should_short_circuit_insufficient_funds(execution_params: &ExecutionOrEarlyError) -> bool {
+        has_insufficient_funds_for_withdraw(execution_params)
+            && execution_params
+                .accumulator_version()
+                .is_none_or(|v| v >= ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION)
+    }
+
     fn payment_kind(
         gas_data: &GasData,
         transaction_kind: &TransactionKind,
@@ -217,17 +263,13 @@ mod checked {
             *epoch_id,
         );
 
-        let has_iffw_err = |params: &ExecutionOrEarlyError| match params {
-            Err(errors) => errors
-                .iter()
-                .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw)),
-            Ok(()) => false,
-        };
-
         // Short-circuit on InsufficientFundsForWithdraw: the transaction is guaranteed to fail
         // and has nothing to execute, so skip the executor pipeline. Bump versions of mutable
-        // inputs (so locks advance) and emit effects with a zero gas cost summary.
-        if has_iffw_err(&execution_params) {
+        // inputs (so locks advance) and emit effects with a zero gas cost summary. On mainnet
+        // committed execution this is gated on the settlement-version rollout point (below it we
+        // fall through to the address-balance gas-payment pruning hotfix instead); everywhere else
+        // it applies unconditionally.
+        if should_short_circuit_insufficient_funds(&execution_params) {
             temporary_store.ensure_active_inputs_mutated();
             transaction_dependencies.remove(&TransactionDigest::genesis_marker());
 
@@ -276,8 +318,10 @@ mod checked {
         // payment except the smash target (index 0). This is the single place we apply that
         // filter: by mutating `gas_data.payment` here, `payment_kind` and
         // `compute_input_reservations` below see an already-pruned list and need no special
-        // handling. Coin entries (real `ObjectRef`s) are always kept.
-        if has_iffw_err(&execution_params)
+        // handling. Coin entries (real `ObjectRef`s) are always kept. Unconditional (not
+        // settlement-version gated): the gas-underflow hotfix already rolled out on all chains.
+        // Keys off the head error only, to stay bit-for-bit with the first single-error hotfix.
+        if head_error_is_insufficient_funds_for_withdraw(&execution_params)
             && gas_data.payment.len() > 1
             && ParsedDigest::try_from(gas_data.payment[0].2).is_err()
         {
@@ -558,12 +602,12 @@ mod checked {
                     let mut execution_result: ResultWithTimings<
                         Mode::ExecutionResults,
                         Mode::Error,
-                    > = match execution_params {
-                        ExecutionOrEarlyError::Err(early_execution_errors) => Err((
+                    > = match execution_params.into_early_errors() {
+                        Some(early_execution_errors) => Err((
                             ExecutionError::from_kind(early_execution_errors.head).into(),
                             vec![],
                         )),
-                        ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                        None => execution_loop::<Mode>(
                             store,
                             temporary_store,
                             transaction_kind,
@@ -1783,5 +1827,80 @@ mod checked {
             )
             .expect("Unable to generate address_alias_state_create transaction!");
         builder
+    }
+
+    #[cfg(test)]
+    mod address_balance_smash_short_circuit_tests {
+        use super::{
+            ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION,
+            should_short_circuit_insufficient_funds,
+        };
+        use nonempty::NonEmpty;
+        use sui_types::base_types::SequenceNumber;
+        use sui_types::execution_params::ExecutionOrEarlyError;
+        use sui_types::execution_status::ExecutionErrorKind;
+
+        fn iffw(accumulator_version: Option<SequenceNumber>) -> ExecutionOrEarlyError {
+            ExecutionOrEarlyError::failed(
+                NonEmpty::new(ExecutionErrorKind::InsufficientFundsForWithdraw),
+                accumulator_version,
+            )
+        }
+
+        fn version(n: u64) -> Option<SequenceNumber> {
+            Some(SequenceNumber::from_u64(n))
+        }
+
+        #[test]
+        fn short_circuits_at_or_above_activation_version() {
+            let activation = ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION.value();
+            assert!(should_short_circuit_insufficient_funds(&iffw(version(
+                activation
+            ))));
+            if let Some(next) = activation.checked_add(1) {
+                assert!(should_short_circuit_insufficient_funds(&iffw(version(
+                    next
+                ))));
+            }
+        }
+
+        #[test]
+        fn preserves_hotfix_behavior_below_activation_version() {
+            let below = ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION.value() - 1;
+            assert!(!should_short_circuit_insufficient_funds(&iffw(version(
+                below
+            ))));
+        }
+
+        #[test]
+        fn short_circuits_without_accumulator_version() {
+            // Every non-mainnet / non-committed path passes `None`: short-circuit unconditionally.
+            assert!(should_short_circuit_insufficient_funds(&iffw(None)));
+        }
+
+        #[test]
+        fn requires_insufficient_funds_error() {
+            // Only IFFW transactions short-circuit, regardless of accumulator version.
+            assert!(!should_short_circuit_insufficient_funds(
+                &ExecutionOrEarlyError::ok(version(
+                    ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION.value()
+                ))
+            ));
+            assert!(!should_short_circuit_insufficient_funds(
+                &ExecutionOrEarlyError::ok(None)
+            ));
+            assert!(!should_short_circuit_insufficient_funds(
+                &ExecutionOrEarlyError::failed(
+                    NonEmpty::new(ExecutionErrorKind::CertificateDenied),
+                    version(ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION.value()),
+                )
+            ));
+            assert!(!should_short_circuit_insufficient_funds(
+                &ExecutionOrEarlyError::failed(
+                    NonEmpty::new(ExecutionErrorKind::CertificateDenied),
+                    None,
+                )
+            ));
+        }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -96,9 +96,9 @@ mod checked {
     /// execution); everywhere else the short-circuit applies unconditionally (see
     /// `should_short_circuit_insufficient_funds`).
     ///
-    /// Value is the mainnet accumulator root version immediately before the failed settlement.
+    /// Value is the mainnet accumulator root version where the new binary was activated on the network.
     const ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION: SequenceNumber =
-        SequenceNumber::from_u64(693531086);
+        SequenceNumber::from_u64(693531074);
 
     fn has_insufficient_funds_for_withdraw(execution_params: &ExecutionOrEarlyError) -> bool {
         execution_params.early_errors().is_some_and(|errors| {

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -241,11 +241,11 @@ mod checked {
         // we must still ensure an effect is committed and all objects versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
         let mut result = result.and_then(|()| {
-            let mut execution_result = match execution_params {
-                ExecutionOrEarlyError::Err(early_execution_errors) => {
+            let mut execution_result = match execution_params.into_early_errors() {
+                Some(early_execution_errors) => {
                     Err(ExecutionError::new(early_execution_errors.head, None))
                 }
-                ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                None => execution_loop::<Mode>(
                     temporary_store,
                     transaction_kind,
                     tx_ctx,

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -259,11 +259,11 @@ mod checked {
         // we must still ensure an effect is committed and all objects versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
         let mut result = result.and_then(|()| {
-            let mut execution_result = match execution_params {
-                ExecutionOrEarlyError::Err(early_execution_errors) => {
+            let mut execution_result = match execution_params.into_early_errors() {
+                Some(early_execution_errors) => {
                     Err(ExecutionError::new(early_execution_errors.head, None))
                 }
-                ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                None => execution_loop::<Mode>(
                     temporary_store,
                     transaction_kind,
                     tx_ctx,

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -279,11 +279,11 @@ mod checked {
         // we must still ensure an effect is committed and all objects versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
         let mut result = result.and_then(|()| {
-            let mut execution_result = match execution_params {
-                ExecutionOrEarlyError::Err(early_execution_errors) => {
+            let mut execution_result = match execution_params.into_early_errors() {
+                Some(early_execution_errors) => {
                     Err(ExecutionError::new(early_execution_errors.head, None))
                 }
-                ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                None => execution_loop::<Mode>(
                     temporary_store,
                     transaction_kind,
                     tx_ctx,

--- a/sui-execution/v3/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_engine.rs
@@ -356,12 +356,12 @@ mod checked {
                     let mut execution_result: ResultWithTimings<
                         Mode::ExecutionResults,
                         ExecutionError,
-                    > = match execution_params {
-                        ExecutionOrEarlyError::Err(early_execution_errors) => Err((
+                    > = match execution_params.into_early_errors() {
+                        Some(early_execution_errors) => Err((
                             ExecutionError::new(early_execution_errors.head, None),
                             vec![],
                         )),
-                        ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                        None => execution_loop::<Mode>(
                             store,
                             temporary_store,
                             transaction_kind,


### PR DESCRIPTION
## Summary

Stacked on Tim's branch (`tzakian/bump-on-iffw`); the diff here is gating-only.

Gates the new `InsufficientFundsForWithdraw` (IFFW) **short-circuit** behavior on the mainnet accumulator (settlement) root version so it can roll out mid-epoch and replay bit-for-bit. The pre-existing address-balance gas-payment **pruning hotfix** stays unconditional.

## Gating

Activation is keyed off the transaction's assigned accumulator (settlement) version, populated **only for mainnet committed execution** (`None` on every other chain and on non-committed paths: dev-inspect, simulation, genesis, replay tools).

```
short-circuit = IFFW && (accumulator_version is None || accumulator_version >= 693531086)
```

- **No accumulator version assigned (`None`):** short-circuit unconditionally. This covers every non-mainnet chain (testnet/devnet/fresh networks) and all non-committed paths.
- **Mainnet committed (`Some(v)`):** short-circuit iff `v >= 693531086`, otherwise fall through to the address-balance gas-payment pruning hotfix.

`693531086` is the mainnet accumulator root version immediately before the failed settlement. A transaction's assigned `accumulator_version` is the version it reads/settles against, so the failing IFFW transaction and everything after it carry `>= 693531086`. A compiled constant, not a protocol flag, because it had to take effect mid-epoch during recovery when the network cannot reconfigure.

Behavior by mainnet committed settlement version `v`:

| `v` | behavior |
| --- | --- |
| `v < 693531086` | address-balance gas-payment pruning hotfix (charges gas on the smashed coin) |
| `v >= 693531086` | short-circuit: skip the executor, bump mutable-input versions, emit zero-gas effects |

## Changes

- `ExecutionOrEarlyError` becomes a struct carrying `early_errors: Option<NonEmpty<ExecutionErrorKind>>` plus `accumulator_version: Option<SequenceNumber>`. It is an execution input only, never serialized into `TransactionEffects`, so the added field does not change effects or their digests.
- `authority.rs` feeds the accumulator version into committed execution only when the chain is Mainnet; all other construction sites pass `None`.
- The latest adapter gates the short-circuit on `should_short_circuit_insufficient_funds`; the payment pruning keeps using a plain IFFW check.
- v0-v3 adapters updated mechanically for the struct API.

## Test plan

- [x] `cargo check` / `xclippy` clean across touched crates
- [x] `address_balance_smash_short_circuit_tests`: fires at/above the activation version, preserves the hotfix path below it, fires unconditionally when no accumulator version is assigned, and stays inert for non-IFFW early errors
- [ ] CI (incl. simtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)