### PR TITLE
[Block Streaming] consensus sync full nodes to verify local checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14858,6 +14858,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "clap",
+ "consensus-config",
  "coset",
  "fastcrypto",
  "fastcrypto-zkp",

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2156,6 +2156,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_network_with_observer_node() {
         use consensus_config::{NetworkPublicKey, ObserverParameters, PeerRecord};
+        use sui_benchmark::workloads::composite::*;
         use sui_types::crypto::KeypairTraits;
 
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
@@ -2258,26 +2259,44 @@ mod test {
         // Let the Observer node stabilize
         tokio::time::sleep(Duration::from_secs(5)).await;
 
-        info!("Running network for a period to verify Observer node doesn't crash");
+        info!("Running object-funds workload to verify Observer node doesn't crash");
 
-        // Let the network run for a while to ensure the Observer node is stable
-        // Submit a few transactions to generate some network activity
-        let sender = test_cluster.get_address_0();
-        let rgp = test_cluster.get_reference_gas_price().await;
-
-        for i in 0..5 {
-            info!("Submitting transaction {}", i);
-            // Fund an address to generate some transaction activity
-            let _ = test_cluster
-                .fund_address_and_return_gas(rgp, None, sender)
-                .await;
-            tokio::time::sleep(Duration::from_secs(2)).await;
+        let composite_metrics = Arc::new(Mutex::new(CompositionMetrics::new()));
+        let composite_config = CompositeWorkloadConfig {
+            num_shared_counters: 1,
+            address_balance_amount: 1000,
+            address_balance_gas_probability: 0.0,
+            mixed_gas_payment_probability: 0.0,
+            conflicting_transaction_probability: 0.0,
+            alias_tx_probability: 0.0,
+            metrics: Some(composite_metrics.clone()),
+            ..Default::default()
         }
+        .with_probability(ObjectBalanceDeposit::NAME, 0.1)
+        .with_probability(ObjectBalanceWithdraw::NAME, 0.3)
+        .with_probability(ObjectBalanceOverdraw::NAME, 1.0)
+        .with_probability(AccumulatorBalanceRead::NAME, 0.2);
 
-        info!("Waiting for the network to advance...");
+        let test_cluster = Arc::new(test_cluster);
+        let mut simulated_load_config = SimulatedLoadConfig::composite_only(composite_config);
+        simulated_load_config.randomized_transaction_weight = 0;
+        test_simulated_load_with_test_config(
+            test_cluster.clone(),
+            20,
+            simulated_load_config,
+            Some(30),
+            Some(10),
+            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
+            false,
+        )
+        .await;
 
-        // Let the network run longer so it produces a meaningful number of checkpoints.
-        tokio::time::sleep(Duration::from_secs(40)).await;
+        let metrics_sum = composite_metrics.lock().unwrap().sum_all();
+        info!("observer object-funds workload metrics: {metrics_sum:#?}");
+        assert!(
+            metrics_sum.insufficient_funds_count > 0,
+            "observer workload must exercise object-funds insufficient execution"
+        );
 
         // Snapshot the latest checkpoint that the network has executed, as observed by the
         // cluster's regular fullnode (which catches up via checkpoint sync). The Observer

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2276,10 +2276,69 @@ mod test {
 
         info!("Waiting for the network to advance...");
 
-        // Let the network run longer to verify Observer stability
+        // Let the network run longer so it produces a meaningful number of checkpoints.
         tokio::time::sleep(Duration::from_secs(40)).await;
 
-        // Check that the Observer node is still running and has the correct role
+        // Snapshot the latest checkpoint that the network has executed, as observed by the
+        // cluster's regular fullnode (which catches up via checkpoint sync). The Observer
+        // node instead catches up by streaming consensus blocks and finalizing checkpoints
+        // locally, so reaching this same sequence number proves block streaming keeps the
+        // Observer up to date with the rest of the network.
+        let target_checkpoint = test_cluster.fullnode_handle.sui_node.with(|node| {
+            node.state()
+                .get_checkpoint_store()
+                .get_highest_executed_checkpoint_seq_number()
+                .expect("checkpoint store read failed")
+                .expect("fullnode should have executed checkpoints")
+        });
+        assert!(
+            target_checkpoint > 0,
+            "network should have produced checkpoints for the catch-up check to be meaningful"
+        );
+
+        info!(
+            "Waiting for Observer node to catch up to checkpoint {} via block streaming",
+            target_checkpoint
+        );
+
+        // Poll the Observer's checkpoint store until it has finalized at least the target
+        // checkpoint. The Observer streams blocks continuously, so it should reach this
+        // snapshot quickly; failing within the timeout means block streaming did not keep
+        // the Observer caught up to the latest checkpoint.
+        let catch_up_timeout = Duration::from_secs(60);
+        let read_observer_checkpoint = || {
+            observer_state
+                .get_checkpoint_store()
+                .get_highest_executed_checkpoint_seq_number()
+                .expect("checkpoint store read failed")
+        };
+        let observer_checkpoint = tokio::time::timeout(catch_up_timeout, async {
+            loop {
+                if let Some(seq) = read_observer_checkpoint()
+                    && seq >= target_checkpoint
+                {
+                    return seq;
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "Observer node failed to catch up to checkpoint {} via block streaming within \
+                 {:?}; highest finalized checkpoint was {:?}",
+                target_checkpoint,
+                catch_up_timeout,
+                read_observer_checkpoint(),
+            )
+        });
+
+        info!(
+            "Observer node caught up to checkpoint {} (target {}) via block streaming",
+            observer_checkpoint, target_checkpoint
+        );
+
+        // The Observer must still be running with the Observer role after catching up.
         let final_node_role = observer_state.epoch_store_for_testing().node_role();
         info!(
             "Observer node final check - node_role: {:?}, runs_consensus: {}",
@@ -2287,7 +2346,7 @@ mod test {
             final_node_role.runs_consensus()
         );
 
-        info!("Observer node test completed successfully - node ran without crashing");
+        info!("Observer node test completed successfully - caught up via block streaming");
     }
 
     /// Finds the most recent protocol version that uses an older execution version

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3675,7 +3675,7 @@ impl AuthorityState {
 
     async fn init_object_funds_checker(&self) {
         let epoch_store = self.epoch_store.load();
-        if self.is_validator(&epoch_store)
+        if self.node_role(&epoch_store).runs_consensus()
             && epoch_store.protocol_config().enable_object_funds_withdraw()
         {
             if self.object_funds_checker.load().is_none() {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -26,6 +26,7 @@ pub struct CheckpointExecutorMetrics {
     // TODO: delete once users are migrated to non-Mysten histogram.
     pub last_executed_checkpoint_age_ms: MystenHistogram,
     pub checkpoint_executor_validator_path: IntGauge,
+    pub checkpoint_executor_validator_sync_fallback_path: IntGauge,
 
     pub stage_wait_duration_ns: IntCounterVec,
     pub stage_active_duration_ns: IntCounterVec,
@@ -118,6 +119,12 @@ impl CheckpointExecutorMetrics {
             checkpoint_executor_validator_path: register_int_gauge_with_registry!(
                 "checkpoint_executor_validator_path",
                 "Number of checkpoints executed using the validator path",
+                registry
+            )
+            .unwrap(),
+            checkpoint_executor_validator_sync_fallback_path: register_int_gauge_with_registry!(
+                "checkpoint_executor_validator_sync_fallback_path",
+                "Number of checkpoints executed using the validator fallback path to synced checkpoints",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -561,69 +561,47 @@ impl CheckpointExecutor {
                 .unwrap()
         };
 
-        // Observer full nodes - that sync state via consensus as well - can verify checkpoints locally as they execute transactions
-        // out of the consensus commit path. This will require some special handling here to match the behaviour when checkpoints
-        // get executed out of the sync path:
-        // 1. populate the full checkpoint data (transactions)
-        // 2. Commit the index batches
-        // 3. Update the congestion tracker
+        // Observer fullnodes have already executed these transactions through consensus,
+        // but still need the fullnode side effects that the synced path normally performs.
         if self.epoch_store.node_role().is_fullnode() {
             pipeline_handle
                 .skip_to(PipelineStage::FinalizeTransactions)
                 .await;
 
-            let (mut state, tx_data) =
+            let (state, tx_data) =
                 self.load_checkpoint_transactions(checkpoint, Some(state_hasher));
 
-            self.commit_post_processing_index_batches(&state.data.tx_digests)
+            return self
+                .finalize_executed_checkpoint_transactions(state, &tx_data, pipeline_handle)
                 .await;
+        }
 
-            // Records the transaction-to-checkpoint mapping and, crucially, notifies subscribers
-            // waiting on executed transactions from a verified checkpoint. This is more important for the
-            // full nodes syncing via consensus as existing components might already waiting for the signal.
-            self.insert_finalized_transactions(&state.data.tx_digests, sequence_number);
+        let checkpoint_contents = self
+            .checkpoint_store
+            .get_checkpoint_contents(&checkpoint.content_digest)
+            .expect("db error")
+            .expect("checkpoint contents not found");
 
-            finish_stage!(pipeline_handle, FinalizeTransactions);
+        let (tx_digests, fx_digests): (Vec<_>, Vec<_>) = checkpoint_contents
+            .iter()
+            .map(|digests| (digests.transaction, digests.effects))
+            .unzip();
 
-            self.state.congestion_tracker.process_checkpoint_effects(
-                &*self.transaction_cache_reader,
-                &state.data.checkpoint,
-                &tx_data.effects,
-            );
+        pipeline_handle
+            .skip_to(PipelineStage::FinalizeTransactions)
+            .await;
 
-            state.full_data = self.process_checkpoint_data(&state.data, &tx_data);
+        self.insert_finalized_transactions(&tx_digests, sequence_number);
 
-            finish_stage!(pipeline_handle, ProcessCheckpointData);
+        pipeline_handle.skip_to(PipelineStage::BuildDbBatch).await;
 
-            return state;
-        } else {
-            let checkpoint_contents = self
-                .checkpoint_store
-                .get_checkpoint_contents(&checkpoint.content_digest)
-                .expect("db error")
-                .expect("checkpoint contents not found");
-
-            let (tx_digests, fx_digests): (Vec<_>, Vec<_>) = checkpoint_contents
-                .iter()
-                .map(|digests| (digests.transaction, digests.effects))
-                .unzip();
-
-            pipeline_handle
-                .skip_to(PipelineStage::FinalizeTransactions)
-                .await;
-
-            self.insert_finalized_transactions(&tx_digests, sequence_number);
-
-            pipeline_handle.skip_to(PipelineStage::BuildDbBatch).await;
-
-            let ckpt_data = CheckpointExecutionData {
-                checkpoint,
-                checkpoint_contents,
-                tx_digests,
-                fx_digests,
-            };
-            return CheckpointExecutionState::new_with_global_state_hasher(ckpt_data, state_hasher);
+        let ckpt_data = CheckpointExecutionData {
+            checkpoint,
+            checkpoint_contents,
+            tx_digests,
+            fx_digests,
         };
+        CheckpointExecutionState::new_with_global_state_hasher(ckpt_data, state_hasher)
     }
 
     #[instrument(level = "info", skip_all)]

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -561,10 +561,6 @@ impl CheckpointExecutor {
                 .unwrap()
         };
 
-        pipeline_handle
-            .skip_to(PipelineStage::FinalizeTransactions)
-            .await;
-
         // Observer full nodes - that sync state via consensus as well - can verify checkpoints locally as they execute transactions
         // out of the consensus commit path. This will require some special handling here to match the behaviour when checkpoints
         // get executed out of the sync path:
@@ -572,6 +568,10 @@ impl CheckpointExecutor {
         // 2. Commit the index batches
         // 3. Update the congestion tracker
         if self.epoch_store.node_role().is_fullnode() {
+            pipeline_handle
+                .skip_to(PipelineStage::FinalizeTransactions)
+                .await;
+
             let (mut state, tx_data) =
                 self.load_checkpoint_transactions(checkpoint, Some(state_hasher));
 
@@ -607,6 +607,10 @@ impl CheckpointExecutor {
                 .iter()
                 .map(|digests| (digests.transaction, digests.effects))
                 .unzip();
+
+            pipeline_handle
+                .skip_to(PipelineStage::FinalizeTransactions)
+                .await;
 
             self.insert_finalized_transactions(&tx_digests, sequence_number);
 

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -383,7 +383,10 @@ impl CheckpointExecutor {
             mysten_metrics::monitored_scope("CheckpointExecutor::parallel_step");
 
         // Note: only `execute_transactions_from_synced_checkpoint` has end-of-epoch logic.
-        let ckpt_state = if self.state.is_fullnode(&self.epoch_store)
+        // For nodes that are not running consensus (Full nodes with checkpoint state sync only), always
+        // execute transactions via synced checkpoints. The rest of nodes should attempt only to verify the locally
+        // build checkpoints as those should (potentially) be already executed.
+        let ckpt_state = if !self.epoch_store.node_role().runs_consensus()
             || checkpoint.is_last_checkpoint_of_epoch()
         {
             self.execute_transactions_from_synced_checkpoint(checkpoint, &mut pipeline_handle)
@@ -510,6 +513,9 @@ impl CheckpointExecutor {
 
     // On validators, checkpoints have often already been constructed locally, in which
     // case we can skip many steps of the checkpoint execution process.
+    // If the node is a validator, then the checkpoint execution state will not contain the full data.
+    // If the node is a full node that has consensus state sync enabled, then the full data will be populated as they are required
+    // by downstream components.
     #[instrument(level = "info", skip_all)]
     async fn verify_locally_built_checkpoint(
         &self,
@@ -555,36 +561,65 @@ impl CheckpointExecutor {
                 .unwrap()
         };
 
-        let checkpoint_contents = self
-            .checkpoint_store
-            .get_checkpoint_contents(&checkpoint.content_digest)
-            .expect("db error")
-            .expect("checkpoint contents not found");
-
-        let (tx_digests, fx_digests): (Vec<_>, Vec<_>) = checkpoint_contents
-            .iter()
-            .map(|digests| (digests.transaction, digests.effects))
-            .unzip();
-
         pipeline_handle
             .skip_to(PipelineStage::FinalizeTransactions)
             .await;
 
-        // Currently this code only runs on validators, where this method call does nothing.
-        // But in the future, fullnodes may follow the mysticeti dag and build their own checkpoints.
-        self.insert_finalized_transactions(&tx_digests, sequence_number);
+        // Observer full nodes - that sync state via consensus as well - can verify checkpoints locally as they execute transactions
+        // out of the consensus commit path. This will require some special handling here to match the behaviour when checkpoints
+        // get executed out of the sync path:
+        // 1. populate the full checkpoint data (transactions)
+        // 2. Commit the index batches
+        // 3. Update the congestion tracker
+        if self.epoch_store.node_role().is_fullnode() {
+            let (mut state, tx_data) =
+                self.load_checkpoint_transactions(checkpoint, Some(state_hasher));
 
-        pipeline_handle.skip_to(PipelineStage::BuildDbBatch).await;
+            self.commit_post_processing_index_batches(&state.data.tx_digests)
+                .await;
 
-        CheckpointExecutionState::new_with_global_state_hasher(
-            CheckpointExecutionData {
+            // Records the transaction-to-checkpoint mapping and, crucially, notifies subscribers
+            // waiting on executed transactions from a verified checkpoint. This is more important for the
+            // full nodes syncing via consensus as existing components might already waiting for the signal.
+            self.insert_finalized_transactions(&state.data.tx_digests, sequence_number);
+
+            finish_stage!(pipeline_handle, FinalizeTransactions);
+
+            self.state.congestion_tracker.process_checkpoint_effects(
+                &*self.transaction_cache_reader,
+                &state.data.checkpoint,
+                &tx_data.effects,
+            );
+
+            state.full_data = self.process_checkpoint_data(&state.data, &tx_data);
+
+            finish_stage!(pipeline_handle, ProcessCheckpointData);
+
+            return state;
+        } else {
+            let checkpoint_contents = self
+                .checkpoint_store
+                .get_checkpoint_contents(&checkpoint.content_digest)
+                .expect("db error")
+                .expect("checkpoint contents not found");
+
+            let (tx_digests, fx_digests): (Vec<_>, Vec<_>) = checkpoint_contents
+                .iter()
+                .map(|digests| (digests.transaction, digests.effects))
+                .unzip();
+
+            self.insert_finalized_transactions(&tx_digests, sequence_number);
+
+            pipeline_handle.skip_to(PipelineStage::BuildDbBatch).await;
+
+            let ckpt_data = CheckpointExecutionData {
                 checkpoint,
                 checkpoint_contents,
                 tx_digests,
                 fx_digests,
-            },
-            state_hasher,
-        )
+            };
+            return CheckpointExecutionState::new_with_global_state_hasher(ckpt_data, state_hasher);
+        };
     }
 
     #[instrument(level = "info", skip_all)]
@@ -597,7 +632,7 @@ impl CheckpointExecutor {
         let (mut ckpt_state, tx_data, unexecuted_tx_digests) = {
             let _scope =
                 mysten_metrics::monitored_scope("CheckpointExecutor::execute_transactions");
-            let (ckpt_state, tx_data) = self.load_checkpoint_transactions(checkpoint);
+            let (ckpt_state, tx_data) = self.load_checkpoint_transactions(checkpoint, None);
             let unexecuted_tx_digests = self.schedule_transaction_execution(&ckpt_state, &tx_data);
             (ckpt_state, tx_data, unexecuted_tx_digests)
         };
@@ -619,32 +654,8 @@ impl CheckpointExecutor {
             self.execute_change_epoch_tx(&tx_data).await;
         }
 
-        // Collect index batches from post-processing and commit atomically.
-        // This must happen AFTER execute_change_epoch_tx (so that all transactions
-        // including the end-of-epoch tx have completed post-processing) and BEFORE
-        // insert_finalized_transactions (so that index data is available when
-        // transactions_executed_in_checkpoint_notify fires).
-        {
-            let mut raw_batches = Vec::new();
-            let mut cache_updates = Vec::new();
-            for tx_digest in &ckpt_state.data.tx_digests {
-                if let Some((raw_batch, cu)) = self.state.await_post_processing(tx_digest).await {
-                    raw_batches.push(raw_batch);
-                    cache_updates.push(cu);
-                }
-            }
-            if !raw_batches.is_empty()
-                && let Some(indexes) = &self.state.indexes
-            {
-                let mut db_batch = indexes.new_db_batch();
-                db_batch
-                    .concat(raw_batches)
-                    .expect("failed to build index batch");
-                indexes
-                    .commit_index_batch(db_batch, cache_updates)
-                    .expect("failed to commit index batch");
-            }
-        }
+        self.commit_post_processing_index_batches(&ckpt_state.data.tx_digests)
+            .await;
 
         let _scope = mysten_metrics::monitored_scope("CheckpointExecutor::finalize_checkpoint");
 
@@ -674,6 +685,32 @@ impl CheckpointExecutor {
         finish_stage!(pipeline_handle, ProcessCheckpointData);
 
         ckpt_state
+    }
+
+    // Collect index batches from post-processing and commit atomically.
+    // This must happen AFTER all transactions have completed execution and BEFORE
+    // insert_finalized_transactions (so that index data is available when
+    // transactions_executed_in_checkpoint_notify fires).
+    async fn commit_post_processing_index_batches(&self, tx_digests: &[TransactionDigest]) {
+        let mut raw_batches = Vec::new();
+        let mut cache_updates = Vec::new();
+        for tx_digest in tx_digests {
+            if let Some((raw_batch, cu)) = self.state.await_post_processing(tx_digest).await {
+                raw_batches.push(raw_batch);
+                cache_updates.push(cu);
+            }
+        }
+        if !raw_batches.is_empty()
+            && let Some(indexes) = &self.state.indexes
+        {
+            let mut db_batch = indexes.new_db_batch();
+            db_batch
+                .concat(raw_batches)
+                .expect("failed to build index batch");
+            indexes
+                .commit_index_batch(db_batch, cache_updates)
+                .expect("failed to commit index batch");
+        }
     }
 
     fn checkpoint_data_enabled(&self) -> bool {
@@ -736,10 +773,13 @@ impl CheckpointExecutor {
     }
 
     // Load all required transaction and effects data for the checkpoint.
+    // When `state_hasher` is provided the returned `CheckpointExecutionState`
+    // carries the hasher (used by the verify-locally-built-checkpoint path).
     #[instrument(level = "info", skip_all)]
     fn load_checkpoint_transactions(
         &self,
         checkpoint: VerifiedCheckpoint,
+        state_hasher: Option<GlobalStateHash>,
     ) -> (CheckpointExecutionState, CheckpointTransactionData) {
         let seq = checkpoint.sequence_number;
         let epoch = checkpoint.epoch;
@@ -749,6 +789,11 @@ impl CheckpointExecutor {
             .get_checkpoint_contents(&checkpoint.content_digest)
             .expect("db error")
             .expect("checkpoint contents not found");
+
+        let make_state = |data| match state_hasher {
+            Some(hasher) => CheckpointExecutionState::new_with_global_state_hasher(data, hasher),
+            None => CheckpointExecutionState::new(data),
+        };
 
         // attempt to load full checkpoint contents in bulk
         // Tolerate db error in case of data corruption.
@@ -791,7 +836,7 @@ impl CheckpointExecutor {
                 .multi_get_executed_effects_digests(&tx_digests);
 
             (
-                CheckpointExecutionState::new(CheckpointExecutionData {
+                make_state(CheckpointExecutionData {
                     checkpoint,
                     checkpoint_contents,
                     tx_digests,
@@ -839,7 +884,7 @@ impl CheckpointExecutor {
                 .multi_get_executed_effects_digests(&tx_digests);
 
             (
-                CheckpointExecutionState::new(CheckpointExecutionData {
+                make_state(CheckpointExecutionData {
                     checkpoint,
                     checkpoint_contents,
                     tx_digests,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -22,11 +22,14 @@ use futures::StreamExt;
 use mysten_common::{ZipDebugEqIteratorExt, debug_fatal, fatal, izip_debug_eq};
 use parking_lot::Mutex;
 use std::{sync::Arc, time::Instant};
-use sui_types::SUI_ACCUMULATOR_ROOT_OBJECT_ID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::crypto::RandomnessRound;
 use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber};
 use sui_types::transaction::{TransactionDataAPI, TransactionKind};
+use sui_types::{
+    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+    node_role::{FullNodeSyncMode, NodeRole},
+};
 
 use sui_config::node::{CheckpointExecutorConfig, RunWithRange};
 use sui_macros::fail_point;
@@ -535,6 +538,9 @@ impl CheckpointExecutor {
 
         let Some(locally_built_checkpoint) = locally_built_checkpoint else {
             // fall back to tx-by-tx execution path if we are catching up.
+            self.metrics
+                .checkpoint_executor_validator_sync_fallback_path
+                .inc();
             return self
                 .execute_transactions_from_synced_checkpoint(checkpoint, pipeline_handle)
                 .await;
@@ -563,7 +569,10 @@ impl CheckpointExecutor {
 
         // Observer fullnodes have already executed these transactions through consensus,
         // but still need the fullnode side effects that the synced path normally performs.
-        if self.epoch_store.node_role().is_fullnode() {
+        if matches!(
+            self.epoch_store.node_role(),
+            NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
+        ) {
             pipeline_handle
                 .skip_to(PipelineStage::FinalizeTransactions)
                 .await;

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -790,7 +790,7 @@ impl CheckpointExecutor {
             .expect("db error")
             .expect("checkpoint contents not found");
 
-        let make_state = |data| match state_hasher {
+        let checkpoint_state = |data| match state_hasher {
             Some(hasher) => CheckpointExecutionState::new_with_global_state_hasher(data, hasher),
             None => CheckpointExecutionState::new(data),
         };
@@ -836,7 +836,7 @@ impl CheckpointExecutor {
                 .multi_get_executed_effects_digests(&tx_digests);
 
             (
-                make_state(CheckpointExecutionData {
+                checkpoint_state(CheckpointExecutionData {
                     checkpoint,
                     checkpoint_contents,
                     tx_digests,
@@ -884,7 +884,7 @@ impl CheckpointExecutor {
                 .multi_get_executed_effects_digests(&tx_digests);
 
             (
-                make_state(CheckpointExecutionData {
+                checkpoint_state(CheckpointExecutionData {
                     checkpoint,
                     checkpoint_contents,
                     tx_digests,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -632,8 +632,7 @@ impl CheckpointExecutor {
         checkpoint: VerifiedCheckpoint,
         pipeline_handle: &mut PipelineHandle,
     ) -> CheckpointExecutionState {
-        let sequence_number = checkpoint.sequence_number;
-        let (mut ckpt_state, tx_data, unexecuted_tx_digests) = {
+        let (ckpt_state, tx_data, unexecuted_tx_digests) = {
             let _scope =
                 mysten_metrics::monitored_scope("CheckpointExecutor::execute_transactions");
             let (ckpt_state, tx_data) = self.load_checkpoint_transactions(checkpoint, None);
@@ -658,6 +657,18 @@ impl CheckpointExecutor {
             self.execute_change_epoch_tx(&tx_data).await;
         }
 
+        self.finalize_executed_checkpoint_transactions(ckpt_state, &tx_data, pipeline_handle)
+            .await
+    }
+
+    async fn finalize_executed_checkpoint_transactions(
+        &self,
+        mut ckpt_state: CheckpointExecutionState,
+        tx_data: &CheckpointTransactionData,
+        pipeline_handle: &mut PipelineHandle,
+    ) -> CheckpointExecutionState {
+        let sequence_number = ckpt_state.data.checkpoint.sequence_number;
+
         self.commit_post_processing_index_batches(&ckpt_state.data.tx_digests)
             .await;
 
@@ -676,15 +687,17 @@ impl CheckpointExecutor {
         // The early versions of the hasher (prior to effectsv2) rely on db
         // state, so we must wait until all transactions have been executed
         // before accumulating the checkpoint.
-        ckpt_state.state_hasher = Some(
-            self.global_state_hasher
-                .accumulate_checkpoint(&tx_data.effects, sequence_number, &self.epoch_store)
-                .expect("epoch cannot have ended"),
-        );
+        if ckpt_state.state_hasher.is_none() {
+            ckpt_state.state_hasher = Some(
+                self.global_state_hasher
+                    .accumulate_checkpoint(&tx_data.effects, sequence_number, &self.epoch_store)
+                    .expect("epoch cannot have ended"),
+            );
+        }
 
         finish_stage!(pipeline_handle, FinalizeTransactions);
 
-        ckpt_state.full_data = self.process_checkpoint_data(&ckpt_state.data, &tx_data);
+        ckpt_state.full_data = self.process_checkpoint_data(&ckpt_state.data, tx_data);
 
         finish_stage!(pipeline_handle, ProcessCheckpointData);
 

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -37,22 +37,38 @@ pub trait CertifiedCheckpointOutput: Sync + Send + 'static {
 }
 
 pub struct SubmitCheckpointToConsensus<T> {
-    pub sender: T,
-    pub signer: StableSyncAuthoritySigner,
-    pub authority: AuthorityName,
-    pub next_reconfiguration_timestamp_ms: u64,
+    sender: T,
+    signer: StableSyncAuthoritySigner,
+    authority: AuthorityName,
+    next_reconfiguration_timestamp_ms: u64,
+    log_checkpoint_output: LogCheckpointOutput,
+}
+
+impl<T> SubmitCheckpointToConsensus<T> {
+    pub fn new(
+        sender: T,
+        signer: StableSyncAuthoritySigner,
+        authority: AuthorityName,
+        next_reconfiguration_timestamp_ms: u64,
+        metrics: Arc<CheckpointMetrics>,
+    ) -> Self {
+        Self {
+            sender,
+            signer,
+            authority,
+            next_reconfiguration_timestamp_ms,
+            log_checkpoint_output: LogCheckpointOutput::new(metrics),
+        }
+    }
+}
+
+pub struct LogCheckpointOutput {
     pub metrics: Arc<CheckpointMetrics>,
 }
 
-pub struct LogCheckpointOutput;
-
 impl LogCheckpointOutput {
-    pub fn boxed() -> Box<dyn CheckpointOutput> {
-        Box::new(Self)
-    }
-
-    pub fn boxed_certified() -> Box<dyn CertifiedCheckpointOutput> {
-        Box::new(Self)
+    pub fn new(metrics: Arc<CheckpointMetrics>) -> Self {
+        Self { metrics }
     }
 }
 
@@ -68,26 +84,12 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
         epoch_store: &Arc<AuthorityPerEpochStore>,
         checkpoint_store: &Arc<CheckpointStore>,
     ) -> SuiResult {
-        LogCheckpointOutput
+        self.log_checkpoint_output
             .checkpoint_created(summary, contents, epoch_store, checkpoint_store)
             .await?;
 
         let checkpoint_timestamp = summary.timestamp_ms;
         let checkpoint_seq = summary.sequence_number;
-        self.metrics.checkpoint_creation_latency.observe(
-            summary
-                .timestamp()
-                .elapsed()
-                .unwrap_or_default()
-                .as_secs_f64(),
-        );
-        self.metrics.checkpoint_creation_latency_ms.observe(
-            summary
-                .timestamp()
-                .elapsed()
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
 
         let highest_verified_checkpoint = checkpoint_store
             .get_highest_verified_checkpoint()?
@@ -116,14 +118,16 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
             let transaction = ConsensusTransaction::new_checkpoint_signature_message_v2(message);
             self.sender
                 .submit_to_consensus(&[transaction], epoch_store)?;
-            self.metrics
+            self.log_checkpoint_output
+                .metrics
                 .last_sent_checkpoint_signature
                 .set(checkpoint_seq as i64);
         } else {
             debug!(
                 "Checkpoint at sequence {checkpoint_seq} is already certified, skipping signature submission to consensus",
             );
-            self.metrics
+            self.log_checkpoint_output
+                .metrics
                 .last_skipped_checkpoint_signature_submission
                 .set(checkpoint_seq as i64);
         }
@@ -151,6 +155,21 @@ impl CheckpointOutput for LogCheckpointOutput {
         _epoch_store: &Arc<AuthorityPerEpochStore>,
         _checkpoint_store: &Arc<CheckpointStore>,
     ) -> SuiResult {
+        self.metrics.checkpoint_creation_latency.observe(
+            summary
+                .timestamp()
+                .elapsed()
+                .unwrap_or_default()
+                .as_secs_f64(),
+        );
+        self.metrics.checkpoint_creation_latency_ms.observe(
+            summary
+                .timestamp()
+                .elapsed()
+                .unwrap_or_default()
+                .as_millis() as u64,
+        );
+
         trace!(
             "Including following transactions in checkpoint {}: {:?}",
             summary.sequence_number, contents

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -49,7 +49,6 @@ use sui_types::{
         ConsensusPosition, ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
         ExecutionTimeObservation,
     },
-    node_role::NodeRole,
     sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
     transaction::{
         InputObjectKind, SenderSignedData, TransactionDataAPI, TransactionKey, VerifiedTransaction,
@@ -3015,7 +3014,6 @@ impl MysticetiConsensusHandler {
         mut consensus_handler: ConsensusHandler<CheckpointService>,
         mut commit_receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
-        node_role: NodeRole,
     ) -> Self {
         debug!(
             last_processed_commit_at_startup,
@@ -3026,12 +3024,7 @@ impl MysticetiConsensusHandler {
             // TODO: pause when execution is overloaded, so consensus can detect the backpressure.
             while let Some(consensus_commit) = commit_receiver.recv().await {
                 let commit_index = consensus_commit.commit_ref.index;
-                if !node_role.process_consensus_commits() {
-                    debug!(
-                        commit_index,
-                        "Observer skipping consensus commit processing"
-                    );
-                } else if commit_index <= last_processed_commit_at_startup {
+                if commit_index <= last_processed_commit_at_startup {
                     consensus_handler.handle_prior_consensus_commit(consensus_commit);
                 } else {
                     consensus_handler

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -301,15 +301,12 @@ impl ConsensusManager {
             CommitConsumerArgs::new(replay_after_commit_index, last_processed_commit_index);
         let monitor = commit_consumer.monitor();
 
-        let node_role = epoch_store.node_role();
-
         // Spin up the new Mysticeti consensus handler to listen for committed sub dags, before starting authority.
         let handler = MysticetiConsensusHandler::new(
             last_processed_commit_index,
             consensus_handler,
             commit_receiver,
             monitor.clone(),
-            node_role,
         );
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -174,8 +174,8 @@ impl ExecutionScheduler {
         scheduler_type: FundsWithdrawSchedulerType,
         address_funds_scheduler_metrics: &Arc<AddressFundsSchedulerMetrics>,
     ) -> Option<FundsWithdrawScheduler> {
-        let withdraw_scheduler_enabled = epoch_store.node_role().process_consensus_commits()
-            && epoch_store.accumulators_enabled();
+        let withdraw_scheduler_enabled =
+            epoch_store.node_role().runs_consensus() && epoch_store.accumulators_enabled();
         if !withdraw_scheduler_enabled {
             return None;
         }

--- a/crates/sui-e2e-tests/Cargo.toml
+++ b/crates/sui-e2e-tests/Cargo.toml
@@ -66,6 +66,7 @@ sui-keys.workspace = true
 sui-light-client.workspace = true
 sui-rpc-api.workspace = true
 sui-rpc.workspace = true
+consensus-config.workspace = true
 shared-crypto.workspace = true
 sui-sdk-types.workspace = true
 tonic.workspace = true

--- a/crates/sui-e2e-tests/tests/observer_checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/observer_checkpoint_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use consensus_config::{NetworkPublicKey, ObserverParameters, PeerRecord};
 use sui_macros::sim_test;
@@ -107,43 +107,62 @@ async fn test_observer_uses_verify_checkpoint_path() {
         tx_digests.push(digest);
     }
 
-    // Wait for the observer to execute some checkpoints.
-    tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
-
     let checkpoint_store = observer_state.get_checkpoint_store();
-    let highest_executed = checkpoint_store
-        .get_highest_executed_checkpoint_seq_number()
-        .expect("db error")
-        .expect("observer should have executed at least one checkpoint");
 
-    info!("Observer highest executed checkpoint: {}", highest_executed);
+    let checkpoint_seqs = tokio::time::timeout(Duration::from_secs(30), async {
+        let checkpoint_seqs = observer_state
+            .epoch_store_for_testing()
+            .transactions_executed_in_checkpoint_notify(tx_digests.clone())
+            .await
+            .expect("observer should finalize submitted transactions");
+        let max_checkpoint_seq = checkpoint_seqs
+            .iter()
+            .copied()
+            .max()
+            .expect("submitted transactions should have checkpoints");
+        checkpoint_store
+            .notify_read_executed_checkpoint(max_checkpoint_seq)
+            .await;
+        checkpoint_seqs
+    })
+    .await
+    .expect("timed out waiting for observer to execute submitted transactions in checkpoints");
+
+    let checkpoint_seq_set = checkpoint_seqs.iter().copied().collect::<BTreeSet<_>>();
+    let max_checkpoint_seq = *checkpoint_seq_set
+        .iter()
+        .next_back()
+        .expect("submitted transactions should have checkpoints");
+
+    info!(
+        "Observer executed submitted transactions in checkpoints {:?}",
+        checkpoint_seq_set
+    );
     assert!(
-        highest_executed > 0,
-        "Observer should have executed checkpoints"
+        max_checkpoint_seq > 0,
+        "Observer should execute submitted transactions after the genesis checkpoint"
     );
 
-    // Verify that the observer built at least some checkpoints locally.
+    // Verify that the observer built the transaction checkpoints locally.
     // Locally computed checkpoints are produced by the checkpoint builder when the
     // node processes consensus commits. Their presence proves the observer entered
     // verify_locally_built_checkpoint (which looks them up) rather than always
     // falling back to the synced execution path.
-    let locally_built_count = (1..=highest_executed)
+    let missing_local_checkpoints = checkpoint_seq_set
+        .iter()
+        .copied()
         .filter(|seq| {
             checkpoint_store
                 .get_locally_computed_checkpoint(*seq)
                 .expect("db error")
-                .is_some()
+                .is_none()
         })
-        .count();
+        .collect::<Vec<_>>();
 
-    info!(
-        "Observer locally built {} out of {} executed checkpoints",
-        locally_built_count, highest_executed
-    );
     assert!(
-        locally_built_count > 0,
-        "Observer should have built at least some checkpoints locally, \
-         proving it uses the verify path"
+        missing_local_checkpoints.is_empty(),
+        "Observer should have locally built every checkpoint containing submitted transactions, missing {:?}",
+        missing_local_checkpoints,
     );
 
     // Verify that the RPC index is being populated on the observer.
@@ -161,8 +180,9 @@ async fn test_observer_uses_verify_checkpoint_path() {
 
     info!("Observer highest indexed checkpoint: {}", highest_indexed);
     assert!(
-        highest_indexed > 0,
-        "Observer RPC index should have indexed at least one checkpoint"
+        highest_indexed >= max_checkpoint_seq,
+        "Observer RPC index should have indexed through checkpoint {}",
+        max_checkpoint_seq
     );
 
     // Verify the legacy IndexStore post-processing pipeline works.
@@ -173,24 +193,24 @@ async fn test_observer_uses_verify_checkpoint_path() {
         .indexes
         .as_ref()
         .expect("observer should have an IndexStore");
-    let indexed_count = tx_digests
+    let missing_indexed_txs = tx_digests
         .iter()
+        .copied()
         .filter(|digest| {
             index_store
                 .get_transaction_seq(digest)
                 .expect("db error")
-                .is_some()
+                .is_none()
         })
-        .count();
+        .collect::<Vec<_>>();
 
     info!(
-        "Observer IndexStore indexed {} out of {} submitted transactions",
-        indexed_count,
-        tx_digests.len()
+        "Observer IndexStore indexed {} submitted transactions",
+        tx_digests.len() - missing_indexed_txs.len(),
     );
     assert!(
-        indexed_count > 0,
-        "Observer IndexStore should have indexed at least some transactions, \
-         proving commit_post_processing_index_batches works"
+        missing_indexed_txs.is_empty(),
+        "Observer IndexStore should have indexed every submitted transaction, missing {:?}",
+        missing_indexed_txs,
     );
 }

--- a/crates/sui-e2e-tests/tests/observer_checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/observer_checkpoint_tests.rs
@@ -1,0 +1,196 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use consensus_config::{NetworkPublicKey, ObserverParameters, PeerRecord};
+use sui_macros::sim_test;
+use sui_types::crypto::KeypairTraits;
+use sui_types::node_role::FullNodeSyncMode;
+use test_cluster::TestClusterBuilder;
+use tracing::info;
+
+/// Helper to build observer peers from a test cluster's validator nodes.
+fn build_observer_peers(test_cluster: &test_cluster::TestCluster) -> Vec<PeerRecord> {
+    test_cluster
+        .swarm
+        .validator_nodes()
+        .filter_map(|v| {
+            let config = v.config();
+            let consensus_config = config.consensus_config.as_ref()?;
+            let observer_port = consensus_config
+                .parameters
+                .as_ref()
+                .and_then(|p| p.observer.server_port)?;
+
+            let network_public_key =
+                NetworkPublicKey::new(config.network_key_pair().public().clone());
+
+            let host = config
+                .network_address
+                .to_socket_addr()
+                .unwrap()
+                .ip()
+                .to_string();
+
+            let address: sui_types::multiaddr::Multiaddr =
+                format!("/ip4/{}/udp/{}/http", host, observer_port)
+                    .parse()
+                    .unwrap();
+
+            Some(PeerRecord {
+                public_key: network_public_key,
+                address,
+            })
+        })
+        .take(1)
+        .collect()
+}
+
+/// Verifies that an observer full node takes the verify-locally-built-checkpoint
+/// path in the checkpoint executor. The observer processes consensus commits
+/// (executes transactions + builds checkpoints locally), so the checkpoint executor
+/// should find locally computed checkpoints and verify them rather than re-executing
+/// transactions from synced checkpoints.
+#[sim_test]
+async fn test_observer_uses_verify_checkpoint_path() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(4)
+        .with_validator_observer_config(Arc::new(|_idx| Some(ObserverParameters::default())))
+        .build()
+        .await;
+
+    let observer_peers = build_observer_peers(&test_cluster);
+    assert!(
+        !observer_peers.is_empty(),
+        "need at least one observer peer"
+    );
+
+    let observer_config = test_cluster
+        .fullnode_config_builder()
+        .with_observer_config(ObserverParameters {
+            peers: observer_peers,
+            ..Default::default()
+        })
+        .build(&mut rand::rngs::OsRng, test_cluster.swarm.config());
+
+    let observer_handle = test_cluster
+        .start_fullnode_from_config(observer_config)
+        .await;
+    let observer_state = observer_handle.sui_node.state();
+
+    // Confirm the observer has the correct role.
+    let node_role = observer_state.epoch_store_for_testing().node_role();
+    assert!(node_role.is_fullnode());
+    assert!(node_role.runs_consensus());
+    assert_eq!(
+        node_role,
+        sui_types::node_role::NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
+    );
+
+    // Submit transactions, capturing their digests.
+    let sender = test_cluster.get_address_0();
+    let mut tx_digests = Vec::new();
+    for _ in 0..5 {
+        let (digest, _effects) = test_cluster
+            .sign_and_execute_transaction_directly(
+                &test_cluster
+                    .test_transaction_builder_with_sender(sender)
+                    .await
+                    .transfer_sui(None, sender)
+                    .build(),
+            )
+            .await
+            .unwrap();
+        tx_digests.push(digest);
+    }
+
+    // Wait for the observer to execute some checkpoints.
+    tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+
+    let checkpoint_store = observer_state.get_checkpoint_store();
+    let highest_executed = checkpoint_store
+        .get_highest_executed_checkpoint_seq_number()
+        .expect("db error")
+        .expect("observer should have executed at least one checkpoint");
+
+    info!("Observer highest executed checkpoint: {}", highest_executed);
+    assert!(
+        highest_executed > 0,
+        "Observer should have executed checkpoints"
+    );
+
+    // Verify that the observer built at least some checkpoints locally.
+    // Locally computed checkpoints are produced by the checkpoint builder when the
+    // node processes consensus commits. Their presence proves the observer entered
+    // verify_locally_built_checkpoint (which looks them up) rather than always
+    // falling back to the synced execution path.
+    let locally_built_count = (1..=highest_executed)
+        .filter(|seq| {
+            checkpoint_store
+                .get_locally_computed_checkpoint(*seq)
+                .expect("db error")
+                .is_some()
+        })
+        .count();
+
+    info!(
+        "Observer locally built {} out of {} executed checkpoints",
+        locally_built_count, highest_executed
+    );
+    assert!(
+        locally_built_count > 0,
+        "Observer should have built at least some checkpoints locally, \
+         proving it uses the verify path"
+    );
+
+    // Verify that the RPC index is being populated on the observer.
+    // The verify path calls process_checkpoint_data which feeds index_checkpoint,
+    // and the pipeline then commits the index updates. A non-zero highest indexed
+    // checkpoint proves the indexing pipeline is working end-to-end.
+    let rpc_index = observer_state
+        .rpc_index
+        .as_ref()
+        .expect("observer should have an rpc_index");
+    let highest_indexed = rpc_index
+        .get_highest_indexed_checkpoint_seq_number()
+        .expect("db error")
+        .unwrap_or(0);
+
+    info!("Observer highest indexed checkpoint: {}", highest_indexed);
+    assert!(
+        highest_indexed > 0,
+        "Observer RPC index should have indexed at least one checkpoint"
+    );
+
+    // Verify the legacy IndexStore post-processing pipeline works.
+    // commit_post_processing_index_batches collects per-transaction index data
+    // (built during execution) and commits it at checkpoint boundaries. If this
+    // works, submitted transactions will have a sequence number in the index.
+    let index_store = observer_state
+        .indexes
+        .as_ref()
+        .expect("observer should have an IndexStore");
+    let indexed_count = tx_digests
+        .iter()
+        .filter(|digest| {
+            index_store
+                .get_transaction_seq(digest)
+                .expect("db error")
+                .is_some()
+        })
+        .count();
+
+    info!(
+        "Observer IndexStore indexed {} out of {} submitted transactions",
+        indexed_count,
+        tx_digests.len()
+    );
+    assert!(
+        indexed_count > 0,
+        "Observer IndexStore should have indexed at least some transactions, \
+         proving commit_post_processing_index_batches works"
+    );
+}

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1604,17 +1604,17 @@ impl SuiNode {
         );
 
         let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.is_validator() {
-            Box::new(SubmitCheckpointToConsensus {
-                sender: consensus_adapter,
-                signer: state.secret.clone(),
-                authority: config.protocol_public_key(),
-                next_reconfiguration_timestamp_ms: epoch_start_timestamp_ms
+            Box::new(SubmitCheckpointToConsensus::new(
+                consensus_adapter,
+                state.secret.clone(),
+                config.protocol_public_key(),
+                epoch_start_timestamp_ms
                     .checked_add(epoch_duration_ms)
                     .expect("Overflow calculating next_reconfiguration_timestamp_ms"),
-                metrics: checkpoint_metrics.clone(),
-            })
+                checkpoint_metrics.clone(),
+            ))
         } else {
-            LogCheckpointOutput::boxed()
+            Box::new(LogCheckpointOutput::new(checkpoint_metrics.clone()))
         };
 
         let certified_checkpoint_output = SendCheckpointToStateSync::new(state_sync_handle);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -672,7 +672,7 @@ impl SuiNode {
         );
 
         let index_store =
-            if node_role.should_enable_index_processing() && config.enable_index_processing {
+            if node_role.is_fullnode() && config.enable_index_processing {
                 info!("creating jsonrpc index store");
                 Some(Arc::new(IndexStore::new(
                     config.db_path().join("indexes"),
@@ -692,7 +692,7 @@ impl SuiNode {
         // mutually exclusive index backends; selecting the experimental
         // store skips building the old index and serves the index read
         // paths from the embedded store instead.
-        let (rpc_index, mut embedded_rpc_store) = if node_role.should_enable_index_processing()
+        let (rpc_index, mut embedded_rpc_store) = if node_role.is_fullnode()
             && config.rpc().is_some_and(|rpc| rpc.enable_indexing())
         {
             if config
@@ -2659,7 +2659,7 @@ async fn build_http_servers(
     Option<tokio::sync::broadcast::Sender<Arc<Checkpoint>>>,
 )> {
     // Validators do not expose these APIs
-    if !node_role.should_run_rpc_servers() {
+    if !node_role.is_fullnode() {
         return Ok((HttpServers::default(), None));
     }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -671,20 +671,19 @@ impl SuiNode {
             checkpoint_store.clone(),
         );
 
-        let index_store =
-            if node_role.is_fullnode() && config.enable_index_processing {
-                info!("creating jsonrpc index store");
-                Some(Arc::new(IndexStore::new(
-                    config.db_path().join("indexes"),
-                    &prometheus_registry,
-                    epoch_store
-                        .protocol_config()
-                        .max_move_identifier_len_as_option(),
-                    config.remove_deprecated_tables,
-                )))
-            } else {
-                None
-            };
+        let index_store = if node_role.is_fullnode() && config.enable_index_processing {
+            info!("creating jsonrpc index store");
+            Some(Arc::new(IndexStore::new(
+                config.db_path().join("indexes"),
+                &prometheus_registry,
+                epoch_store
+                    .protocol_config()
+                    .max_move_identifier_len_as_option(),
+                config.remove_deprecated_tables,
+            )))
+        } else {
+            None
+        };
 
         let chain_identifier = epoch_store.get_chain_identifier();
 
@@ -692,49 +691,48 @@ impl SuiNode {
         // mutually exclusive index backends; selecting the experimental
         // store skips building the old index and serves the index read
         // paths from the embedded store instead.
-        let (rpc_index, mut embedded_rpc_store) = if node_role.is_fullnode()
-            && config.rpc().is_some_and(|rpc| rpc.enable_indexing())
-        {
-            if config
-                .rpc()
-                .is_some_and(|rpc| rpc.use_experimental_rpc_store())
-            {
-                info!("creating embedded rpc-store");
-                // The tip indexer pulls checkpoints from the node's local
-                // checkpoint / perpetual stores via a dedicated read handle.
-                let ingestion_source = RocksDbStore::new(
-                    cache_traits.clone(),
-                    committee_store.clone(),
-                    checkpoint_store.clone(),
-                );
-                let embedded_rpc_store = EmbeddedRpcStore::bootstrap(
-                    &config,
-                    &store,
-                    &checkpoint_store,
-                    ingestion_source,
-                    chain_identifier,
-                    &prometheus_registry,
-                )
-                .await?;
-                (None, Some(embedded_rpc_store))
-            } else {
-                info!("creating rpc index store");
-                let rpc_index = Arc::new(
-                    RpcIndexStore::new(
-                        &config.db_path(),
+        let (rpc_index, mut embedded_rpc_store) =
+            if node_role.is_fullnode() && config.rpc().is_some_and(|rpc| rpc.enable_indexing()) {
+                if config
+                    .rpc()
+                    .is_some_and(|rpc| rpc.use_experimental_rpc_store())
+                {
+                    info!("creating embedded rpc-store");
+                    // The tip indexer pulls checkpoints from the node's local
+                    // checkpoint / perpetual stores via a dedicated read handle.
+                    let ingestion_source = RocksDbStore::new(
+                        cache_traits.clone(),
+                        committee_store.clone(),
+                        checkpoint_store.clone(),
+                    );
+                    let embedded_rpc_store = EmbeddedRpcStore::bootstrap(
+                        &config,
                         &store,
                         &checkpoint_store,
-                        &epoch_store,
-                        &cache_traits.backing_package_store,
-                        config.rpc().cloned().unwrap_or_default(),
+                        ingestion_source,
+                        chain_identifier,
+                        &prometheus_registry,
                     )
-                    .await,
-                );
-                (Some(rpc_index), None)
-            }
-        } else {
-            (None, None)
-        };
+                    .await?;
+                    (None, Some(embedded_rpc_store))
+                } else {
+                    info!("creating rpc index store");
+                    let rpc_index = Arc::new(
+                        RpcIndexStore::new(
+                            &config.db_path(),
+                            &store,
+                            &checkpoint_store,
+                            &epoch_store,
+                            &cache_traits.backing_package_store,
+                            config.rpc().cloned().unwrap_or_default(),
+                        )
+                        .await,
+                    );
+                    (Some(rpc_index), None)
+                }
+            } else {
+                (None, None)
+            };
 
         info!("creating archive reader");
         // Create network

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -619,7 +619,7 @@ impl Swarm {
     pub fn fullnodes(&self) -> impl Iterator<Item = &Node> {
         self.nodes
             .values()
-            .filter(|node| node.config().consensus_config.is_none())
+            .filter(|node| node.config().intended_node_role().is_fullnode())
     }
 
     pub async fn spawn_new_node(&mut self, config: NodeConfig) -> SuiNodeHandle {

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -77,7 +77,10 @@ impl NodeRole {
     /// transactions, create checkpoints, etc.). Observers stream blocks but
     /// rely on state-sync for execution, so they skip commit processing.
     pub fn process_consensus_commits(&self) -> bool {
-        matches!(self, Self::Validator)
+        matches!(
+            self,
+            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
+        )
     }
 
     /// Whether this node should expose HTTP/RPC servers (JSON-RPC, REST).

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -62,31 +62,6 @@ impl NodeRole {
             Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
         )
     }
-
-    // --- Temporary feature flags ---
-    // The flags below are temporary and may not match the eventual conditions to enable each feature.
-    // They will be removed and the callsites will resolve to one of the three conditions above
-    // once observer mode is fully implemented.
-
-    /// Whether this node should create index stores for JSON-RPC and REST API.
-    pub fn should_enable_index_processing(&self) -> bool {
-        matches!(self, Self::FullNode(_))
-    }
-
-    /// Whether this node should process consensus commit output (execute
-    /// transactions, create checkpoints, etc.). Observers stream blocks but
-    /// rely on state-sync for execution, so they skip commit processing.
-    pub fn process_consensus_commits(&self) -> bool {
-        matches!(
-            self,
-            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
-        )
-    }
-
-    /// Whether this node should expose HTTP/RPC servers (JSON-RPC, REST).
-    pub fn should_run_rpc_servers(&self) -> bool {
-        matches!(self, Self::FullNode(_))
-    }
 }
 
 impl std::fmt::Display for NodeRole {
@@ -109,26 +84,20 @@ mod tests {
     fn test_validator_role() {
         let role = NodeRole::Validator;
         assert!(role.runs_consensus());
-        assert!(!role.should_enable_index_processing());
-        assert!(!role.should_run_rpc_servers());
-        assert!(role.process_consensus_commits());
+        assert!(role.is_validator());
     }
 
     #[test]
     fn test_consensus_observer_role() {
         let role = NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver);
         assert!(role.runs_consensus());
-        assert!(role.should_enable_index_processing());
-        assert!(role.should_run_rpc_servers());
-        assert!(!role.process_consensus_commits());
+        assert!(role.is_fullnode());
     }
 
     #[test]
     fn test_fullnode_state_sync_role() {
         let role = NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly);
         assert!(!role.runs_consensus());
-        assert!(role.should_enable_index_processing());
-        assert!(role.should_run_rpc_servers());
-        assert!(!role.process_consensus_commits());
+        assert!(role.is_fullnode());
     }
 }


### PR DESCRIPTION
## Description 

Currently full nodes by default are executing transactions from synced (verified) checkpoints exclusively https://github.com/MystenLabs/sui/blob/027024d7f6a91a4cf5701b7e2f17d837cd6d09c3/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs#L384

For full nodes that have block streaming enabled (consensus sync) we should attempt to use the code path that validators follow and verify locally (verified) built checkpoints instead.

This PR is:
* allowing the consensus sync full nodes (that ones that run consensus) to attempt verify locally built checkpoints
* matching the existing logic that populates that legacy json indexes and the rpc indexes
* populating the full data to the checkpoint state (so the subscribers can successfully receive them)

## Test plan 

CI/Simtests/PT

**Note:** building an Antithesis setup to use an consensus sync full node instead of a state sync only. Will let it run for a few hours to confirm the behaviour.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
