### PR TITLE
[indexer-alt-framework] feature-gate diesel deps behind postgres

### DIFF
--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -14,9 +14,9 @@ backoff.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["env"] }
-diesel = { workspace = true, features = ["chrono"] }
-diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
-diesel_migrations.workspace = true
+diesel = { workspace = true, features = ["chrono"], optional = true }
+diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"], optional = true }
+diesel_migrations = { workspace = true, optional = true }
 futures.workspace = true
 http.workspace = true
 mysten-network.workspace = true
@@ -52,7 +52,6 @@ sui-pg-db = { workspace = true, optional = true }
 [dev-dependencies]
 telemetry-subscribers.workspace = true
 wiremock.workspace = true
-sui-pg-db.workspace = true
 dashmap.workspace = true
 
 sui-indexer-alt-framework-store-traits = { workspace = true, features = ["testing"] }
@@ -61,4 +60,9 @@ sui-synthetic-ingestion.workspace = true
 [features]
 default = ["cluster"]
 cluster = ["dep:tracing-subscriber", "postgres"]
-postgres = ["dep:sui-pg-db"]
+postgres = [
+    "dep:sui-pg-db",
+    "dep:diesel",
+    "dep:diesel-async",
+    "dep:diesel_migrations",
+]

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
@@ -260,11 +260,11 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
-    use sui_pg_db::Connection;
-    use sui_pg_db::Db;
     use tokio::sync::mpsc;
 
     use crate::metrics::tests::test_metrics;
+    use crate::mocks::store::FallibleMockConnection;
+    use crate::mocks::store::FallibleMockStore;
     use crate::pipeline::Processor;
     use crate::pipeline::concurrent::BatchStatus;
     use crate::types::full_checkpoint_content::Checkpoint;
@@ -291,7 +291,7 @@ mod tests {
 
     #[async_trait]
     impl Handler for TestHandler {
-        type Store = Db;
+        type Store = FallibleMockStore;
         type Batch = Vec<Entry>;
 
         const MIN_EAGER_ROWS: usize = 10;
@@ -317,7 +317,7 @@ mod tests {
         async fn commit<'a>(
             &self,
             _batch: &Self::Batch,
-            _conn: &mut Connection<'a>,
+            _conn: &mut FallibleMockConnection<'a>,
         ) -> anyhow::Result<usize> {
             tokio::time::sleep(Duration::from_millis(1000)).await;
             Ok(0)

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -104,8 +104,8 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
+    use sui_field_count::FieldCount;
     use sui_indexer_alt_framework_store_traits::testing::mock_store::MockWatermark;
-    use sui_pg_db::FieldCount;
     use sui_types::full_checkpoint_content::Checkpoint;
     use tokio::time::Duration;
 


### PR DESCRIPTION
`diesel`, `diesel-async`, and `diesel_migrations` were unconditional dependencies even though the only code touching them is the opinionated Postgres backend (`postgres/` module and `cluster.rs`, both already gated behind features). Downstream consumers that turn off default features were still paying for three Diesel crates on the compile path.

Made all three crates `optional = true` and added them to the existing `postgres` feature. The feature graph stays the same: `default = ["cluster"]`, `cluster = ["dep:tracing-subscriber", "postgres"]`, and `postgres` now pulls in
`sui-pg-db` + the three `diesel*` crates together.

Two test modules previously reached into `sui_pg_db` types without the `postgres` feature being active:

- `pipeline/concurrent/collector.rs` used `sui_pg_db::{Connection, Db}` as the `Self::Store` / `Self::Connection<'a>` type tags on a test `Handler`. The test never touched a database; switch the tags to the in-tree `FallibleMockStore` / `FallibleMockConnection`.
- `pipeline/concurrent/reader_watermark.rs` used `sui_pg_db::FieldCount` for a `#[derive(FieldCount)]` attribute. `FieldCount` is re-exported from `sui-field-count` (which the framework already depends on), so the import switches to `sui_field_count::FieldCount`.

With those two test changes, `sui-pg-db` is no longer needed unconditionally in dev-dependencies; the dev-dep declaration is dropped. The remaining test usage (cluster.rs, postgres/handler.rs) travels through the optional main dep that the `postgres` feature turns on.

Tested: `cargo check`/`nextest` clean under each of `--no-default-features`, `--no-default-features --features postgres`, and default features. Default features yields 152 tests; `--no-default-features` yields 146 (the 6 extras are the cluster/postgres-gated modules).

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
