### PR TITLE
Add dkg_output_v2 tidehunter config and DKG-failure restart test

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -863,6 +863,10 @@ impl AuthorityEpochTables {
                 ThConfig::new(8, 1, KeyType::uniform(1)),
             ),
             (
+                "dkg_output_v2".to_string(),
+                ThConfig::new(8, 1, KeyType::uniform(1)),
+            ),
+            (
                 "randomness_next_round".to_string(),
                 ThConfig::new(8, 1, KeyType::uniform(1)),
             ),

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -1118,5 +1118,29 @@ mod tests {
         for randomness_manager in &randomness_managers {
             assert_eq!(DkgStatus::Failed, randomness_manager.dkg_status());
         }
+
+        // Verify the failure is durably loaded on restart: a RandomnessManager reconstructed
+        // from the same epoch store must report DKG as failed (not pending), exercising the
+        // `dkg_output_v2` failure-load path in `try_new`.
+        for (i, validator) in network_config.validator_configs.iter().enumerate() {
+            let consensus_adapter = Arc::new(ConsensusAdapter::new(
+                Arc::new(MockConsensusClient::new()),
+                CheckpointStore::new_for_tests(),
+                epoch_stores[i].name,
+                100_000,
+                100_000,
+                ConsensusAdapterMetrics::new_test(),
+                Arc::new(tokio::sync::Notify::new()),
+            ));
+            let recovered_randomness_manager = RandomnessManager::try_new(
+                Arc::downgrade(&epoch_stores[i]),
+                Box::new(consensus_adapter),
+                sui_network::randomness::Handle::new_stub(),
+                validator.protocol_key_pair(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(DkgStatus::Failed, recovered_randomness_manager.dkg_status());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to "persist dkg failure" (commit `723d35ea42`, already on `mlogan-force-epoch-close`):

- **Tidehunter config**: register `dkg_output_v2` in the tidehunter keyspace configs so the table opens under `USE_TIDEHUNTER` (same singleton config as `dkg_output`: `ThConfig::new(8, 1, KeyType::uniform(1))`). Without this, the table is declared on the struct but has no tidehunter keyspace config, which fails at table-open time (not at compile time).
- **Test**: extend `test_dkg_expiration` to reconstruct a `RandomnessManager` via `try_new` from the same epoch stores after the DKG timeout is persisted, and assert it loads the failure as `DkgStatus::Failed`. This guards the `dkg_output_v2` failure-load path in `try_new` (previously a persisted failure could not be represented, so a restart would treat it as `Pending`).

## Test plan

- **RocksDB**: `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-core test_dkg` — `test_dkg_v1` ✅, `test_dkg_expiration_v1` ✅
- **Tidehunter**: `USE_TIDEHUNTER=1 cargo nextest run -p sui-core --features typed-store/tidehunter test_dkg` — both ✅ (confirms `dkg_output_v2` opens and round-trips at runtime)
- `cargo xclippy` clean; `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
