### PR TITLE
[1.73] Backport DKG failure recovery fixes

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -608,6 +608,7 @@ pub struct AuthorityEpochTables {
     /// Records the final output of DKG after completion, including the public VSS key and
     /// any local private shares.
     pub(crate) dkg_output: DBMap<u64, dkg_v1::Output<PkG, EncG>>,
+    pub(crate) dkg_output_v2: DBMap<u64, Option<dkg_v1::Output<PkG, EncG>>>,
     /// Holds the value of the next RandomnessRound to be generated.
     pub(crate) randomness_next_round: DBMap<u64, RandomnessRound>,
     /// Holds the value of the highest completed RandomnessRound (as reported to RandomnessReporter).
@@ -866,6 +867,10 @@ impl AuthorityEpochTables {
             ),
             (
                 "dkg_output".to_string(),
+                ThConfig::new(8, 1, KeyType::uniform(1)),
+            ),
+            (
+                "dkg_output_v2".to_string(),
                 ThConfig::new(8, 1, KeyType::uniform(1)),
             ),
             (

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -78,7 +78,7 @@ pub(crate) struct ConsensusCommitOutput {
     dkg_confirmations: BTreeMap<PartyId, VersionedDkgConfirmation>,
     dkg_processed_messages: BTreeMap<PartyId, VersionedProcessedMessage>,
     dkg_used_message: Option<VersionedUsedProcessedMessages>,
-    dkg_output: Option<dkg_v1::Output<PkG, EncG>>,
+    dkg_output: Option<Option<dkg_v1::Output<PkG, EncG>>>,
 
     // jwk state
     pending_jwks: BTreeSet<(AuthorityName, JwkId, JWK)>,
@@ -257,7 +257,7 @@ impl ConsensusCommitOutput {
         self.dkg_used_message = Some(used_messages);
     }
 
-    pub fn set_dkg_output(&mut self, output: dkg_v1::Output<PkG, EncG>) {
+    pub fn set_dkg_output(&mut self, output: Option<dkg_v1::Output<PkG, EncG>>) {
         self.dkg_output = Some(output);
     }
 
@@ -386,7 +386,7 @@ impl ConsensusCommitOutput {
                 .map(|used_msgs| (SINGLETON_KEY, used_msgs)),
         )?;
         if let Some(output) = self.dkg_output {
-            batch.insert_batch(&tables.dkg_output, [(SINGLETON_KEY, output)])?;
+            batch.insert_batch(&tables.dkg_output_v2, [(SINGLETON_KEY, output)])?;
         }
 
         batch.insert_batch(

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -27,7 +27,7 @@ use parking_lot::RwLockWriteGuard;
 use serde::{Deserialize, Serialize};
 use sui_config::node::CongestionLogConfig;
 use sui_macros::{fail_point, fail_point_arg, fail_point_if};
-use sui_protocol_config::{PerObjectCongestionControlMode, ProtocolConfig};
+use sui_protocol_config::{Chain, PerObjectCongestionControlMode, ProtocolConfig};
 use sui_types::{
     SUI_RANDOMNESS_STATE_OBJECT_ID,
     authenticator_state::ActiveJwk,
@@ -2448,7 +2448,17 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             randomness_dkg_confirmations,
         );
 
-        if randomness_dkg_updates || randomness_dkg_confirmation_updates {
+        // On mainnet from epoch 1143 onward, always advance the DKG state machine until
+        // it is resolved, regardless of whether new messages/confirmations were processed
+        // this commit.
+        let always_advance_dkg_to_resolution = self.epoch_store.get_chain() == Chain::Mainnet
+            && self.epoch_store.epoch() >= 1143
+            && randomness_manager.dkg_status() == DkgStatus::Pending;
+
+        if randomness_dkg_updates
+            || randomness_dkg_confirmation_updates
+            || always_advance_dkg_to_resolution
+        {
             randomness_manager
                 .advance_dkg(&mut state.output, commit_info.round)
                 .await

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -303,61 +303,85 @@ impl RandomnessManager {
             next_randomness_round: RandomnessRound(0),
             highest_completed_round: Arc::new(Mutex::new(highest_completed_round)),
         };
-        let dkg_output = tables
-            .dkg_output
+        let dkg_output = match tables
+            .dkg_output_v2
             .get(&SINGLETON_KEY)
-            .expect("typed_store should not fail");
-        if let Some(dkg_output) = dkg_output {
-            info!(
-                "random beacon: loaded existing DKG output for epoch {}",
-                committee.epoch()
-            );
-            epoch_store
-                .metrics
-                .epoch_random_beacon_dkg_num_shares
-                .set(dkg_output.shares.as_ref().map_or(0, |shares| shares.len()) as i64);
-            rm.dkg_output
-                .set(Some(dkg_output.clone()))
-                .expect("setting new OnceCell should succeed");
-            network_handle.update_epoch(
-                committee.epoch(),
-                rm.authority_info.clone(),
-                dkg_output,
-                rm.party.t(),
-                highest_completed_round,
-            );
-        } else {
-            info!(
-                "random beacon: no existing DKG output found for epoch {}",
-                committee.epoch()
-            );
-
-            // Load intermediate data.
-            assert!(
-                epoch_store.protocol_config().dkg_version() > 0,
-                "BUG: DKG version 0 is deprecated"
-            );
-            rm.processed_messages.extend(
-                tables
-                    .dkg_processed_messages_v2
-                    .safe_iter()
-                    .map(|result| result.expect("typed_store should not fail")),
-            );
-            if let Some(used_messages) = tables
-                .dkg_used_messages_v2
+            .expect("typed_store should not fail")
+        {
+            Some(dkg_output) => Some(dkg_output),
+            None => tables
+                .dkg_output
                 .get(&SINGLETON_KEY)
                 .expect("typed_store should not fail")
-            {
-                rm.used_messages
-                    .set(used_messages.clone())
+                .map(Some),
+        };
+        match dkg_output {
+            Some(Some(dkg_output)) => {
+                info!(
+                    "random beacon: loaded existing DKG output for epoch {}",
+                    committee.epoch()
+                );
+                epoch_store
+                    .metrics
+                    .epoch_random_beacon_dkg_num_shares
+                    .set(dkg_output.shares.as_ref().map_or(0, |shares| shares.len()) as i64);
+                rm.dkg_output
+                    .set(Some(dkg_output.clone()))
+                    .expect("setting new OnceCell should succeed");
+                network_handle.update_epoch(
+                    committee.epoch(),
+                    rm.authority_info.clone(),
+                    dkg_output,
+                    rm.party.t(),
+                    highest_completed_round,
+                );
+            }
+            Some(None) => {
+                // DKG previously completed as a failure (recorded only in `dkg_output_v2`).
+                // Restore that terminal state so DKG isn't re-run and randomness stays disabled
+                // for the epoch.
+                error!(
+                    "random beacon: loaded failed DKG for epoch {}. Randomness disabled for this epoch. All randomness-using transactions will fail.",
+                    committee.epoch()
+                );
+                epoch_store.metrics.epoch_random_beacon_dkg_failed.set(1);
+                rm.dkg_output
+                    .set(None)
                     .expect("setting new OnceCell should succeed");
             }
-            rm.confirmations.extend(
-                tables
-                    .dkg_confirmations_v2
-                    .safe_iter()
-                    .map(|result| result.expect("typed_store should not fail")),
-            );
+            None => {
+                info!(
+                    "random beacon: no existing DKG output found for epoch {}",
+                    committee.epoch()
+                );
+
+                // Load intermediate data.
+                assert!(
+                    epoch_store.protocol_config().dkg_version() > 0,
+                    "BUG: DKG version 0 is deprecated"
+                );
+                rm.processed_messages.extend(
+                    tables
+                        .dkg_processed_messages_v2
+                        .safe_iter()
+                        .map(|result| result.expect("typed_store should not fail")),
+                );
+                if let Some(used_messages) = tables
+                    .dkg_used_messages_v2
+                    .get(&SINGLETON_KEY)
+                    .expect("typed_store should not fail")
+                {
+                    rm.used_messages
+                        .set(used_messages.clone())
+                        .expect("setting new OnceCell should succeed");
+                }
+                rm.confirmations.extend(
+                    tables
+                        .dkg_confirmations_v2
+                        .safe_iter()
+                        .map(|result| result.expect("typed_store should not fail")),
+                );
+            }
         }
 
         // Resume randomness generation from where we left off.
@@ -555,7 +579,7 @@ impl RandomnessManager {
                         self.party.t(),
                         None,
                     );
-                    consensus_output.set_dkg_output(output);
+                    consensus_output.set_dkg_output(Some(output));
                 }
                 Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
                 Err(e) => error!("random beacon: error while processing DKG Confirmations: {e:?}"),
@@ -577,6 +601,7 @@ impl RandomnessManager {
             self.dkg_output
                 .set(None)
                 .expect("checked above that `dkg_output` is uninitialized");
+            consensus_output.set_dkg_output(None);
         }
 
         Ok(())
@@ -1092,6 +1117,30 @@ mod tests {
         // Verify DKG failed.
         for randomness_manager in &randomness_managers {
             assert_eq!(DkgStatus::Failed, randomness_manager.dkg_status());
+        }
+
+        // Verify the failure is durably loaded on restart: a RandomnessManager reconstructed
+        // from the same epoch store must report DKG as failed (not pending), exercising the
+        // `dkg_output_v2` failure-load path in `try_new`.
+        for (i, validator) in network_config.validator_configs.iter().enumerate() {
+            let consensus_adapter = Arc::new(ConsensusAdapter::new(
+                Arc::new(MockConsensusClient::new()),
+                CheckpointStore::new_for_tests(),
+                epoch_stores[i].name,
+                100_000,
+                100_000,
+                ConsensusAdapterMetrics::new_test(),
+                Arc::new(tokio::sync::Notify::new()),
+            ));
+            let recovered_randomness_manager = RandomnessManager::try_new(
+                Arc::downgrade(&epoch_stores[i]),
+                Box::new(consensus_adapter),
+                sui_network::randomness::Handle::new_stub(),
+                validator.protocol_key_pair(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(DkgStatus::Failed, recovered_randomness_manager.dkg_status());
         }
     }
 }


### PR DESCRIPTION
## Summary
- backport DKG failure persistence via `dkg_output_v2`
- keep mainnet DKG advancing to terminal success/failure from epoch 1143 onward
- restore terminal failed DKG state on restart and cover it in the expiration test

## Original commits
- 42c601e574b6b0e977a479b8978cc394f43c8c26 persist dkg failure
- 5445323ef25a8b4d66a8420230abcf8294db9665 always advance dkg state machine
- d10b7db79a6634acbc483ad8633a7d27fe3bc7c8 Add dkg_output_v2 tidehunter config and DKG-failure restart test

## Test plan
- `cargo fmt --all -- --check`
- `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-core test_dkg_expiration_v1`
- `cargo xclippy` from `crates/sui-core`