### PR TITLE
ci: stop warming macOS sccache daily

### DIFF
--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -29,8 +29,6 @@ jobs:
             ubuntu-ghcloud,
             ubuntu-arm64,
             windows-ghcloud,
-            macos-latest-large,
-            macos-latest-xlarge,
           ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -48,37 +46,11 @@ jobs:
           echo "PG_DATABASE_URL=postgres://postgres:root@localhost/" >> $GITHUB_ENV
           echo "PG_EXAMPLE_DATABASE_URL=postgres://postgres:root@localhost/diesel_example" >> $GITHUB_ENV
 
-      - name: Install postgres (MacOS arm64)
-        if: ${{ matrix.os == 'macos-latest-xlarge' }}
-        shell: bash
-        env:
-          PQ_LIB_DIR: "$(brew --prefix libpq)/lib"
-          LIBRARY_PATH: "/opt/homebrew/lib:$LIBRARY_PATH"
-          PKG_CONFIG_PATH: "/opt/homebrew/lib/pkgconfig:$PKG_CONFIG_PATH"
-          PATH: "/opt/homebrew/bin:$PATH"
-        run: |
-          brew install postgresql
-
       - name: Install postgres (Ubuntu arm64)
         if: ${{ matrix.os == 'ubuntu-arm64' }}
         shell: bash
         run: |
           sudo apt update && sudo apt install -y libpq-dev
-
-      - name: Remove unused apps (MacOS)
-        if: ${{ startsWith(matrix.os, 'macos-') }}
-        continue-on-error: true
-        shell: bash
-        run: |
-          # Both hosted macOS runners (x86_64 and arm64) ship with little free disk relative to
-          # our build footprint, and the headroom shifts whenever GitHub bumps the runner image.
-          # The df -h before/after leaves proof when the runner dies silently mid-job.
-          df -h /
-          sudo rm -rf /Applications/Xcode*.app
-          sudo rm -rf ~/Library/Developer/Xcode/DerivedData
-          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
-          sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/*
-          df -h /
 
       - uses: ./.github/actions/setup-sccache
         with:
@@ -192,7 +164,7 @@ jobs:
           echo "| Platform | Objects | Size | Job Status |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
 
-          for os in ubuntu-ghcloud ubuntu-arm64 windows-ghcloud macos-latest-large macos-latest-xlarge; do
+          for os in ubuntu-ghcloud ubuntu-arm64 windows-ghcloud; do
             stats=$(aws s3 ls "s3://mystenlabs-sccache/${os}/" --summarize --recursive 2>&1 | tail -2)
             objects=$(echo "$stats" | grep 'Total Objects' | awk '{print $3}')
             bytes=$(echo "$stats" | grep 'Total Size' | awk '{print $3}')


### PR DESCRIPTION
## Description

Stop daily macOS sccache warmups in `.github/workflows/sccache-warmup.yml`.

This removes `macos-latest-large` and `macos-latest-xlarge` from the warmup matrix, drops the now-unreachable macOS-only setup/cleanup steps, and keeps the cache summary scoped to the remaining Linux/Windows prefixes.

Rationale: the macOS cache is only consumed by release builds, and those builds skip compilation when the release archive already exists. Running daily macOS warmups spends premium minutes against an infrequent, often no-op consumer, while the x86_64 macOS warmer has been slow and flaky.

## Test plan

- Parsed the updated workflow with Ruby's YAML parser.
- Compared the PR branch against `main`; only `.github/workflows/sccache-warmup.yml` changed.