### PR TITLE
Assert settlement effects success in checkpoint builder to avoid race with persistence

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2052,6 +2052,20 @@ impl CheckpointBuilder {
         )
         .await;
 
+        // Assert success here, in the builder task, before these effects are included in
+        // the checkpoint. The settlement scheduler also asserts this, but it runs in a
+        // separate task, so its assertion does not order against checkpoint persistence -
+        // checking it here is what prevents a checkpoint from being built over the effects
+        // of a failed settlement transaction.
+        for fx in settlement_effects.iter().chain(barrier_effects.iter()) {
+            assert!(
+                fx.status().is_ok(),
+                "settlement transaction cannot fail (digest: {:?}) {:#?}",
+                fx.transaction_digest(),
+                fx
+            );
+        }
+
         settlement_effects
             .into_iter()
             .chain(barrier_effects)


### PR DESCRIPTION
## Problem

There was a race between settlement transaction execution and checkpoint building. The settlement scheduler executes the accumulator settlement + barrier transactions and asserts they did not fail (`assert!(fx.status().is_ok())`), but that assertion runs in a *separate task* from the checkpoint builder. The checkpoint builder independently reads the same effects from the cache (woken by `write_transaction_outputs` at execution-commit time, before any assertion) and could build/persist a checkpoint over the effects of a failed settlement transaction — the scheduler's assertion would only panic afterward, too late to prevent the durable artifact.

## Fix

Assert settlement and barrier effects are successful **in the checkpoint builder's own task** (`CheckpointBuilder::resolve_settlement_effects`), right after they are read and before they are included in the checkpoint. Because this runs in the same task as checkpoint persistence, it orders before it. A failed settlement now makes the builder abort rather than persist a checkpoint. This mirrors why the v1 path (which asserts inline in the builder) never had this race.

The settlement scheduler keeps its own assertion, since it needs `next_accumulator_version` regardless.

## Testing

- `cargo check -p sui-core` and `cargo xclippy -D warnings` clean.
- Settlement e2e simtests pass: `test_multiple_settlement_txns`, `test_deposit_and_withdraw`, `test_deposits`, `test_withdraw_insufficient_balance`, `test_accumulators_root_created`, `test_deposit_and_withdraw_with_larger_reservation`.