### PR TITLE
cli: `sui start` improvements

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1021,10 +1021,10 @@ async fn start(
         sui_config_path
     };
 
-    // the indexer requires to set the fullnode's data ingestion directory
+    // the indexer and consistent store require the fullnode's data ingestion directory
     // note that this overrides the default configuration that is set when running the genesis
     // command, which sets data_ingestion_dir to None.
-    if with_indexer.is_some() && data_ingestion_dir.is_none() {
+    if (with_indexer.is_some() || with_consistent_store.is_some()) && data_ingestion_dir.is_none() {
         data_ingestion_dir = Some(mysten_common::tempdir()?.keep())
     }
 
@@ -1051,8 +1051,6 @@ async fn start(
 
     let mut swarm = swarm_builder.build();
     swarm.launch().await?;
-    // Let nodes connect to one another
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
     info!("Cluster started");
 
     let fullnode_rpc_url = socket_addr_to_url(fullnode_rpc_address)?


### PR DESCRIPTION
## Description

`sui start` currently includes a 2s delay after the swarm has started for the nodes to connect to each other, but in practice it takes much less time than this and the other services that are spun up are resilient to the nodes they talk to not being available immediately.

This change removes the 2s delay. It also fixes an issue where `sui start --with-consistent-store` would fail because of a lack of data ingestion directory.

## Test plan

Manually tested the following scenarios, 5 successful repetitions each:

- sui start without the 2s delay:
  - Ran `sui start --force-regenesis --fullnode-rpc-port <port> --quiet` 5 times.
  - Polled gRPC `GetServiceInfo`
  - Polled JSON-RPC `sui_getChainIdentifier`
- indexer startup:
  - Ran `sui start --force-regenesis --fullnode-rpc-port <port> --with-indexer --quiet` 5 times.
  - Polled gRPC `GetServiceInfo`
  - Polled JSON-RPC `sui_getChainIdentifier`
- GraphQL startup:
  - Ran `sui start --force-regenesis --fullnode-rpc-port <port> --with-consistent-store=127.0.0.1:<port> --with-graphql=127.0.0.1:<port> --quiet` 5 times.
  - Polled gRPC `GetServiceInfo`
  - Polled JSON-RPC `sui_getChainIdentifier`
  - Polled GraphQL `{ chainIdentifier }`
- faucet startup:
  - Ran `sui start --force-regenesis --fullnode-rpc-port <port> --with-faucet=127.0.0.1:<port> --quiet` 3 times.
  - Polled gRPC `GetServiceInfo`
  - Polled JSON-RPC `sui_getChainIdentifier`
  - Polled faucet /v1/status.
- --with-consistent-store bug fix:
  - Ran `sui start --force-regenesis --fullnode-rpc-port <port> --with-consistent-store=127.0.0.1:<port> --quiet` 5 times.
  - Polled gRPC `GetServiceInfo`
  - Polled JSON-RPC `sui_getChainIdentifier`
  - Polled consistent-store TCP listener.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
