### PR TITLE
Dump full transaction and effects data on checkpoint and transaction fork

### DIFF
--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -302,6 +302,8 @@ impl<'a> TestAuthorityBuilder<'a> {
             &authority_store,
             backpressure_manager.clone(),
         );
+        checkpoint_store
+            .set_transaction_cache_reader(cache_traits.transaction_cache_reader.clone());
 
         let chain_id = ChainIdentifier::from(*genesis.checkpoint().digest());
         let chain = match self.chain_override {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -531,6 +531,7 @@ impl CheckpointExecutor {
             &locally_built_checkpoint,
             &checkpoint,
             &self.checkpoint_store,
+            &*self.transaction_cache_reader,
         );
 
         // Checkpoint builder triggers accumulation of the checkpoint, so this is guaranteed to finish.
@@ -877,6 +878,8 @@ impl CheckpointExecutor {
                             tx_digest,
                             expected_fx_digest,
                             executed_fx_digest,
+                            txn,
+                            effects,
                             &*self.transaction_cache_reader,
                         );
                         None

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/utils.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/utils.rs
@@ -11,8 +11,12 @@ use std::time::Duration;
 use strum::VariantNames;
 use sui_types::{
     base_types::{TransactionDigest, TransactionEffectsDigest},
+    effects::TransactionEffects,
+    executable_transaction::VerifiedExecutableTransaction,
     message_envelope::Message,
-    messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary, VerifiedCheckpoint},
+    messages_checkpoint::{
+        CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, VerifiedCheckpoint,
+    },
 };
 use tokio::sync::watch;
 use tracing::{debug, error, instrument, warn};
@@ -153,6 +157,8 @@ pub(super) fn assert_not_forked(
     tx_digest: &TransactionDigest,
     expected_digest: &TransactionEffectsDigest,
     actual_effects_digest: &TransactionEffectsDigest,
+    transaction: &VerifiedExecutableTransaction,
+    expected_effects: &TransactionEffects,
     cache_reader: &dyn TransactionCacheRead,
 ) {
     if *expected_digest != *actual_effects_digest {
@@ -165,8 +171,11 @@ pub(super) fn assert_not_forked(
             ?checkpoint,
             ?tx_digest,
             ?expected_digest,
+            ?actual_effects_digest,
+            ?transaction,
+            ?expected_effects,
             ?actual_effects,
-            "fork detected!"
+            "transaction fork detected!"
         );
         panic!(
             "When executing checkpoint {}, transaction {} \
@@ -183,6 +192,7 @@ pub(super) fn assert_checkpoint_not_forked(
     locally_built_checkpoint: &CheckpointSummary,
     verified_checkpoint: &VerifiedCheckpoint,
     checkpoint_store: &CheckpointStore,
+    cache_reader: &dyn TransactionCacheRead,
 ) {
     assert_eq!(
         locally_built_checkpoint.sequence_number(),
@@ -195,9 +205,16 @@ pub(super) fn assert_checkpoint_not_forked(
     }
 
     let verified_checkpoint_summary = verified_checkpoint.data();
+    let sequence_number = *locally_built_checkpoint.sequence_number();
 
     if locally_built_checkpoint.content_digest == verified_checkpoint_summary.content_digest {
         // fork is in the checkpoint header
+        if let Some(local_contents) = checkpoint_store
+            .get_checkpoint_contents(&locally_built_checkpoint.content_digest)
+            .expect("db error")
+        {
+            dump_checkpoint_transactions("local", sequence_number, &local_contents, cache_reader);
+        }
         fatal!(
             "Checkpoint fork detected in header! Locally built checkpoint: {:?}, verified checkpoint: {:?}",
             locally_built_checkpoint,
@@ -215,6 +232,14 @@ pub(super) fn assert_checkpoint_not_forked(
             .expect("contents must exist if checkpoint has been synced!");
 
         // fork is in the checkpoint contents
+        dump_checkpoint_transactions("local", sequence_number, &local_contents, cache_reader);
+        dump_checkpoint_transactions(
+            "verified",
+            sequence_number,
+            &verified_contents,
+            cache_reader,
+        );
+
         let mut local_contents_iter = local_contents.iter();
         let mut verified_contents_iter = verified_contents.iter();
         let mut pos = 0;
@@ -251,6 +276,25 @@ pub(super) fn assert_checkpoint_not_forked(
             verified_checkpoint
         );
     }
+}
+
+fn dump_checkpoint_transactions(
+    side: &str,
+    sequence_number: CheckpointSequenceNumber,
+    contents: &CheckpointContents,
+    cache_reader: &dyn TransactionCacheRead,
+) {
+    let tx_digests: Vec<_> = contents.iter().map(|digests| digests.transaction).collect();
+    let transactions = cache_reader.multi_get_transaction_blocks(&tx_digests);
+    let effects = cache_reader.multi_get_executed_effects(&tx_digests);
+    error!(
+        side,
+        sequence_number,
+        ?tx_digests,
+        ?transactions,
+        ?effects,
+        "checkpoint fork: dumping full transaction data"
+    );
 }
 
 /// SequenceWatch is just a wrapper around a tokio::watch that can wait for a

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -58,6 +58,7 @@ use std::io::Write;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::Weak;
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime};
@@ -348,6 +349,7 @@ pub struct CheckpointStore {
     pub(crate) tables: CheckpointStoreTables,
     synced_checkpoint_notify_read: NotifyRead<CheckpointSequenceNumber, VerifiedCheckpoint>,
     executed_checkpoint_notify_read: NotifyRead<CheckpointSequenceNumber, VerifiedCheckpoint>,
+    transaction_cache_reader: OnceLock<Arc<dyn TransactionCacheRead>>,
 }
 
 impl CheckpointStore {
@@ -357,6 +359,7 @@ impl CheckpointStore {
             tables,
             synced_checkpoint_notify_read: NotifyRead::new(),
             executed_checkpoint_notify_read: NotifyRead::new(),
+            transaction_cache_reader: OnceLock::new(),
         })
     }
 
@@ -375,6 +378,7 @@ impl CheckpointStore {
             tables,
             synced_checkpoint_notify_read: NotifyRead::new(),
             executed_checkpoint_notify_read: NotifyRead::new(),
+            transaction_cache_reader: OnceLock::new(),
         })
     }
 
@@ -735,6 +739,21 @@ impl CheckpointStore {
                 "Local checkpoint fork detected!",
             );
 
+            if let Some(cache_reader) = self.transaction_cache_reader.get() {
+                self.dump_checkpoint_fork_transactions(
+                    "local",
+                    *local_checkpoint.sequence_number(),
+                    &local_checkpoint.content_digest,
+                    cache_reader.as_ref(),
+                );
+                self.dump_checkpoint_fork_transactions(
+                    "verified",
+                    *verified_checkpoint.sequence_number(),
+                    &verified_checkpoint.content_digest,
+                    cache_reader.as_ref(),
+                );
+            }
+
             // Record the fork in the database before crashing
             if let Err(e) = self.record_checkpoint_fork_detected(
                 *local_checkpoint.sequence_number(),
@@ -772,6 +791,33 @@ impl CheckpointStore {
                 local_checkpoint.sequence_number()
             );
         }
+    }
+
+    pub fn set_transaction_cache_reader(&self, cache_reader: Arc<dyn TransactionCacheRead>) {
+        let _ = self.transaction_cache_reader.set(cache_reader);
+    }
+
+    fn dump_checkpoint_fork_transactions(
+        &self,
+        side: &str,
+        sequence_number: CheckpointSequenceNumber,
+        content_digest: &CheckpointContentsDigest,
+        cache_reader: &dyn TransactionCacheRead,
+    ) {
+        let Some(contents) = self.get_checkpoint_contents(content_digest).ok().flatten() else {
+            return;
+        };
+        let tx_digests: Vec<_> = contents.iter().map(|digests| digests.transaction).collect();
+        let transactions = cache_reader.multi_get_transaction_blocks(&tx_digests);
+        let effects = cache_reader.multi_get_executed_effects(&tx_digests);
+        error!(
+            side,
+            sequence_number,
+            ?tx_digests,
+            ?transactions,
+            ?effects,
+            "checkpoint fork: dumping full transaction data"
+        );
     }
 
     // Called by consensus (ConsensusAggregator).

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -561,6 +561,8 @@ impl SuiNode {
             &store,
             backpressure_manager.clone(),
         );
+        checkpoint_store
+            .set_transaction_cache_reader(cache_traits.transaction_cache_reader.clone());
 
         let auth_agg = {
             let safe_client_metrics_base = SafeClientMetricsBase::new(&prometheus_registry);


### PR DESCRIPTION
## Description

When a validator detects a fork it panics, but the logs didn't contain enough information to root-cause which transaction(s) or effects diverged. This adds full diagnostic dumps at the fork-detection sites: the full transaction data and executed effects for the relevant transactions, logged immediately before the existing panic/fatal.

This is a logging-only change (no change to transaction processing), so nothing requires protocol-config gating.

### Checkpoint executor (validator replay path)
- `assert_not_forked` (transaction effects fork): now also logs the full transaction and the full expected + actual effects, not just digests.
- `assert_checkpoint_not_forked` (checkpoint fork): dumps the full transaction data + executed effects for every transaction in the checkpoint (both local and verified sides for a contents fork). Threads the transaction cache reader from the executor.

### Checkpoint store (`check_for_checkpoint_fork`)
This is the path that fires in practice (state sync / aggregation), and it previously logged only the checkpoint summaries and contents digests. `CheckpointStore` now holds a set-once `transaction_cache_reader` (an `OnceLock`, set during node startup once the execution cache is built — it can't be a constructor arg because the cache transitively depends on the store via the backpressure manager). On a fork it now dumps the full transaction data + effects for the local and verified contents. Entries not present locally (e.g. verified contents not yet synced) are skipped gracefully.

## Test plan

Verified manually with the existing fork simtest:

```
cargo simtest --no-capture -p sui-benchmark test_fork_recovery_transaction_effects_simulation
```

The test triggers a real checkpoint fork; the dump fires with `side="local"`, the forked checkpoint's sequence number, and full `TransactionDataV1` / `GasData` / effects for every transaction in the checkpoint.

- `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-core checkpoint` (29 passed)
- `cargo xclippy` clean on sui-core and sui-node, `cargo fmt --all` clean