### PR TITLE
composite workload: regression test for IFFW gas-smashing underflow

### DIFF
--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -36,7 +36,10 @@ use std::time::Duration;
 use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::TypeTag;
+use sui_types::accumulator_root::AccumulatorValue;
+use sui_types::balance::Balance;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
+use sui_types::coin_reservation::ParsedObjectRefWithdrawal;
 use sui_types::crypto::{AccountKeyPair, get_key_pair};
 use sui_types::digests::TransactionDigest;
 use sui_types::gas_coin::GAS;
@@ -286,6 +289,10 @@ pub struct CompositeWorkloadConfig {
     pub shared_counter_hotness: f32,
     pub address_balance_amount: u64,
     pub address_balance_gas_probability: f32,
+    /// Probability that a tx's gas payment is built as a mix of a real coin and a coin-reservation
+    /// digest entry (in randomized order). Exercises the gas-smashing path that combines an
+    /// `ObjectRef` gas coin with an address-balance reservation.
+    pub mixed_gas_payment_probability: f32,
     pub conflicting_transaction_probability: f32,
     pub alias_tx_probability: f32,
     pub alias_txs_before_revoke: u32,
@@ -376,6 +383,7 @@ impl Default for CompositeWorkloadConfig {
             shared_counter_hotness: 0.5,
             address_balance_amount: 1000,
             address_balance_gas_probability: 0.5,
+            mixed_gas_payment_probability: 0.05,
             conflicting_transaction_probability: 0.1,
             alias_tx_probability: 0.0,
             alias_txs_before_revoke: 3,
@@ -485,6 +493,10 @@ enum BatchTxKind {
 #[derive(Clone)]
 struct BatchTxInfo {
     gas_idx: usize,
+    /// Index of a second real gas coin used by this tx (only populated by the
+    /// mixed-payment branch when it claims a spare from `current_batch_gas`). Its
+    /// tracked version must also be refreshed from effects.
+    extra_gas_idx: Option<usize>,
     op_set: OperationSet,
     kind: BatchTxKind,
 }
@@ -740,6 +752,7 @@ impl CompositePayload {
             tx,
             BatchTxInfo {
                 gas_idx,
+                extra_gas_idx: None,
                 op_set,
                 kind,
             },
@@ -946,7 +959,13 @@ impl Payload for CompositePayload {
 
         let mut rng = get_rng();
 
+        // Spare gas coins available beyond the per-tx allocation and the optional alias
+        // slot. The mixed-payment branch can claim these to build 2-real-coin payments.
+        let alias_offset = if alias_tx_needed { 1 } else { 0 };
+        let mut next_spare_gas_idx = batch_size + alias_offset;
+
         for (i, gas) in current_batch_gas.iter().take(batch_size).enumerate() {
+            let mut extra_gas_idx_opt: Option<usize> = None;
             let builder = if !address_balance_gas_disabled
                 && rng.gen_bool(self.config.address_balance_gas_probability as f64)
             {
@@ -958,6 +977,40 @@ impl Payload for CompositePayload {
                     current_epoch,
                     nonce,
                 )
+            } else if !address_balance_gas_disabled
+                && rng.gen_bool(self.config.mixed_gas_payment_probability as f64)
+            {
+                used_gas.push(i);
+                // Mix 1-2 real coins with 1-2 coin-reservation digest entries and shuffle.
+                // When such a tx is cancelled for insufficient funds (IFFW), each
+                // address-balance entry left in the payment list is settled as a Split
+                // against the (possibly depleted) accumulator: the gas-smashing path under test.
+                let sui_balance_type = Balance::type_tag(GAS::type_tag());
+                let accumulator_obj_id = AccumulatorValue::get_field_id(sender, &sui_balance_type)
+                    .expect("Failed to compute accumulator object ID");
+                // Sized in the same order of magnitude as the AB amount: large enough that
+                // concurrent overdraw can leave it underfunded, but not so large that signing
+                // or scheduling rejects it. base+1 gives the second fake coin a distinct digest.
+                let base_reservation = std::cmp::max(1, self.config.address_balance_amount * 10);
+
+                let mut payment = vec![*gas];
+                if rng.gen_bool(0.5) && next_spare_gas_idx < current_batch_gas.len() {
+                    payment.push(current_batch_gas[next_spare_gas_idx]);
+                    extra_gas_idx_opt = Some(next_spare_gas_idx);
+                    next_spare_gas_idx += 1;
+                }
+                let num_fakes = if rng.gen_bool(0.5) { 2 } else { 1 };
+                for k in 0..num_fakes {
+                    let fake_coin = ParsedObjectRefWithdrawal::new(
+                        *accumulator_obj_id.inner(),
+                        current_epoch,
+                        base_reservation + k as u64,
+                    )
+                    .encode(SequenceNumber::new(), self.pool.chain_identifier);
+                    payment.push(fake_coin);
+                }
+                payment.shuffle(&mut rng);
+                TestTransactionBuilder::new_with_gas_objects(sender, payment, rgp)
             } else {
                 used_gas.push(i);
                 TestTransactionBuilder::new(sender, *gas, rgp)
@@ -967,6 +1020,7 @@ impl Payload for CompositePayload {
                 self.generate_transaction(builder, &account_state, &keypair, current_epoch);
             self.current_batch_txs.push(BatchTxInfo {
                 gas_idx: i,
+                extra_gas_idx: extra_gas_idx_opt,
                 op_set,
                 kind: BatchTxKind::Normal,
             });
@@ -987,6 +1041,7 @@ impl Payload for CompositePayload {
                     self.generate_transaction(builder, &account_state, &keypair, current_epoch);
                 self.current_batch_txs.push(BatchTxInfo {
                     gas_idx: *gas_idx,
+                    extra_gas_idx: None,
                     op_set,
                     kind: BatchTxKind::Normal,
                 });
@@ -1068,6 +1123,9 @@ impl Payload for CompositePayload {
                         metrics.record_abort(tx_info.op_set.clone());
                     }
                     update_gas!(&mut gas.0[tx_info.gas_idx], effects);
+                    if let Some(extra_idx) = tx_info.extra_gas_idx {
+                        update_gas!(&mut gas.0[extra_idx], effects);
+                    }
                 }
                 BatchedTransactionStatus::PermanentFailure { error } => {
                     permanent_failure_count += 1;

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -13,7 +13,7 @@ mod checked {
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::runtime::MoveRuntime;
-    use mysten_common::{debug_fatal, in_test_configuration};
+    use mysten_common::{assert_reachable, debug_fatal, in_test_configuration};
     use std::collections::BTreeMap;
     use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
@@ -314,6 +314,7 @@ mod checked {
         // fall through to the address-balance gas-payment pruning hotfix instead); everywhere else
         // it applies based on `early_exit_on_iffw`.
         if should_short_circuit_insufficient_funds(&execution_params, protocol_config) {
+            assert_reachable!("IFFW short-circuit fired");
             temporary_store.ensure_active_inputs_mutated();
             transaction_dependencies.remove(&TransactionDigest::genesis_marker());
 

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -11,6 +11,7 @@ pub mod checked {
     use crate::temporary_store::TemporaryStore;
     use either::Either;
     use indexmap::IndexMap;
+    use mysten_common::assert_reachable;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::deny_list_v2::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS;
     use sui_types::digests::TransactionDigest;
@@ -606,6 +607,7 @@ pub mod checked {
                 assert_ne!(location, smash_location, "Payment methods must be unique");
                 match payment_method {
                     PaymentMethod::AddressBalance(sui_address, reservation) => {
+                        assert_reachable!("smashed payment is address-balance reservation");
                         let balance_type = sui_types::balance::Balance::type_tag(
                             sui_types::gas_coin::GAS::type_tag(),
                         );
@@ -618,12 +620,14 @@ pub mod checked {
                         temporary_store.add_accumulator_event(event);
                     }
                     PaymentMethod::Coin((id, _, _)) => {
+                        assert_reachable!("smashed payment is coin object");
                         temporary_store.delete_input_object(id);
                     }
                 }
             }
             match &self.smash_target {
                 PaymentMethod::AddressBalance(sui_address, reservation) => {
+                    assert_reachable!("smash target is address-balance reservation");
                     // The reservation here is only a maximal withdrawal from this address balance
                     // We do not need to withdraw here unless necessary, which will be done during
                     // gas charging


### PR DESCRIPTION
## Summary

Adds a randomized mixed-payment branch to the composite workload so that the IFFW (`InsufficientFundsForWithdraw`) gas-smashing settlement path is exercised continuously by simtest. With some probability, the gas builder constructs `gas_data.payment` as a `[real_coin, coin_reservation]` pair in randomized order (50/50 swap), using a reservation amount roughly an order of magnitude above the per-account address balance.

This is the path where the recent settlement-underflow bug lived: when a tx with mixed payment was cancelled with IFFW, the AB leg of gas smashing emitted a Split against an already-depleted accumulator, and `0x2::accumulator::update_u128` would abort during settlement — a settlement-tx-cannot-fail invariant violation.

## Verification

- Default `mixed_gas_payment_probability = 0.1` keeps composite throughput in range (~97s vs 67s baseline, still passing the workload's signed-tx-count assertion).
- With both IFFW gates locally short-circuited (simulating the pre-fix state), the same workload trips the `settlement transaction cannot fail` panic in `settlement_scheduler.rs:380` — the underflow inside `0x2::accumulator::update_u128`. This was reproduced once during development and the panic shape matches the original incident.
- With the upstream IFFW handling intact, the workload passes.

## Test plan

- [x] `cargo simtest -p sui-benchmark --test simtest test_composite_workload`
- [x] `cargo xclippy -D warnings -p sui-benchmark`
- [x] `cargo fmt`