### PR TITLE
Bound total gas payment to i64::MAX in check_gas

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2417,9 +2417,9 @@ impl AuthorityState {
             .into());
         }
 
-        // Compute input/receiving object kinds before mock gas injection so the mock
-        // gas reference is not included in input_object_kinds (it is added to
-        // input_objects directly after object loading).
+        // Full validity check including gas budget and price.
+        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
+
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2417,9 +2417,9 @@ impl AuthorityState {
             .into());
         }
 
-        // Full validity check including gas budget and price.
-        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
-
+        // Compute input/receiving object kinds before mock gas injection so the mock
+        // gas reference is not included in input_object_kinds (it is added to
+        // input_objects directly after object loading).
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2452,6 +2452,7 @@ impl AuthorityState {
         // Full validity check including gas budget and price.
         transaction.validity_check(&epoch_store.tx_validity_check_context())?;
 
+
         let declared_withdrawals = self.pre_object_load_checks(
             &transaction,
             &[],

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1797,7 +1797,7 @@ async fn test_package_size_limit() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
     let gas_payment_object =
-        Object::with_id_owner_gas_for_testing(gas_payment_object_id, sender, u64::MAX);
+        Object::with_id_owner_gas_for_testing(gas_payment_object_id, sender, i64::MAX as u64);
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     let mut package = Vec::new();
     let mut modules_size = 0;

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -807,10 +807,8 @@ async fn test_bad_gas_payment_all_paths() {
     }
 
     // Package object as sole payment.
-    // All entry points return GasObjectNotOwnedObject { owner: Immutable }: even
-    // dev-inspect paths that pass gas_ownership_checks=false still hit the ownership
-    // check, because check_gas_balance in gas_v2.rs calls check_gas_objects
-    // unconditionally.
+    // All entry points return GasObjectNotOwnedObject { owner: Immutable }: the
+    // early is_address_owned() check in check_gas catches it before balance computation.
     let package_ref = env
         .validator
         .get_object(&SUI_FRAMEWORK_PACKAGE_ID)

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -2632,9 +2632,8 @@ async fn test_address_balance_paid_budget_above_i64_max_succeeds() {
 
 // Gas-payment coin reservations must be for SUI. A reservation for a custom coin type
 // (even one with an oversized balance) must be rejected before reaching smash_gas.
-// validity_check_no_gas_check now enforces the SUI-type constraint on all paths
-// including simulate/dry-run, so the error is consistent regardless of whether
-// the total also exceeds the i64::MAX bound.
+// check_gas enforces the SUI-type constraint on all paths including simulate/dry-run,
+// so the error is consistent regardless of whether the total also exceeds i64::MAX.
 #[sim_test]
 async fn dryrun_rejects_non_sui_gas_coin_reservation() {
     if has_mainnet_protocol_config_override() {

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(deprecated)]
+
 use move_core_types::ident_str;
 use sui_macros::*;
 use sui_simulator::has_mainnet_protocol_config_override;
@@ -2312,7 +2314,7 @@ async fn test_poc_oversized_address_balance_gas_reservation_panics() {
         return;
     }
 
-    let mut test_env = TestEnvBuilder::new()
+    let test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.enable_coin_reservation_for_testing();
             cfg
@@ -2360,7 +2362,7 @@ async fn test_poc_gas_reservation_dedup_overflow_panics() {
         return;
     }
 
-    let mut test_env = TestEnvBuilder::new()
+    let test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.enable_coin_reservation_for_testing();
             cfg

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -2310,17 +2310,7 @@ async fn test_fake_coin_reservation_dev_inspect_safe_when_flag_disabled() {
 // the accumulator object does not exist pre_object_load_checks fires first.
 #[sim_test]
 async fn test_poc_oversized_address_balance_gas_reservation_panics() {
-    if has_mainnet_protocol_config_override() {
-        return;
-    }
-
-    let test_env = TestEnvBuilder::new()
-        .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_coin_reservation_for_testing();
-            cfg
-        }))
-        .build()
-        .await;
+    let test_env = TestEnvBuilder::new().build().await;
 
     let (sender, real_gas_coin) = test_env.get_sender_and_gas(0);
     let oversized_reservation = test_env.encode_coin_reservation(sender, 0, i64::MAX as u64 + 1);
@@ -2358,17 +2348,7 @@ async fn test_poc_oversized_address_balance_gas_reservation_panics() {
 // fires first.
 #[sim_test]
 async fn test_poc_gas_reservation_dedup_overflow_panics() {
-    if has_mainnet_protocol_config_override() {
-        return;
-    }
-
-    let test_env = TestEnvBuilder::new()
-        .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_coin_reservation_for_testing();
-            cfg
-        }))
-        .build()
-        .await;
+    let test_env = TestEnvBuilder::new().build().await;
 
     let (sender, real_gas_coin) = test_env.get_sender_and_gas(0);
     let reservation_0 = test_env.encode_coin_reservation(sender, 0, i64::MAX as u64);
@@ -2411,19 +2391,11 @@ async fn test_poc_gas_reservation_dedup_overflow_panics() {
 // check_gas rejects this via the combined total (coin + reservation) bound.
 #[sim_test]
 async fn test_poc_smash_target_deposit_overflow_panics() {
-    if has_mainnet_protocol_config_override() {
-        return;
-    }
-
     // Coin value must exceed i64::MAX to make deposit overflow.
     // Leave 100M MIST spare so there is enough for the setup transaction's gas.
     let huge_gas: u64 = i64::MAX as u64 + 100_000_000;
 
     let mut test_env = TestEnvBuilder::new()
-        .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_coin_reservation_for_testing();
-            cfg
-        }))
         .with_test_cluster_builder_cb(Box::new(move |b| {
             b.with_accounts(vec![
                 AccountConfig {
@@ -2562,10 +2534,6 @@ async fn test_gas_budget_exceeding_i64_max_is_rejected() {
 // execution behavior.
 #[sim_test]
 async fn test_address_balance_paid_budget_above_i64_max_succeeds() {
-    if has_mainnet_protocol_config_override() {
-        return;
-    }
-
     // Use two coins: a huge one whose value we move into address balance, and a
     // normal one to pay gas for the funding tx (otherwise the funding tx's own
     // i64::MAX check would reject the huge gas coin).
@@ -2574,7 +2542,6 @@ async fn test_address_balance_paid_budget_above_i64_max_succeeds() {
 
     let mut test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_address_balance_gas_payments_for_testing();
             cfg.set_max_tx_gas_for_testing(u64::MAX);
             cfg.set_max_gas_price_for_testing(u64::MAX);
             cfg
@@ -2636,17 +2603,7 @@ async fn test_address_balance_paid_budget_above_i64_max_succeeds() {
 // so the error is consistent regardless of whether the total also exceeds i64::MAX.
 #[sim_test]
 async fn dryrun_rejects_non_sui_gas_coin_reservation() {
-    if has_mainnet_protocol_config_override() {
-        return;
-    }
-
-    let mut test_env = TestEnvBuilder::new()
-        .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_coin_reservation_for_testing();
-            cfg
-        }))
-        .build()
-        .await;
+    let mut test_env = TestEnvBuilder::new().build().await;
 
     let (sender, _) = test_env.get_sender_and_gas(0);
     let oversized: u64 = (i64::MAX as u64) + 1;
@@ -2695,17 +2652,7 @@ async fn dryrun_rejects_non_sui_gas_coin_reservation() {
 // `dev_inspect_transaction_block` with `skip_checks=true`.
 #[sim_test]
 async fn dev_inspect_rejects_non_sui_gas_coin_reservation() {
-    if has_mainnet_protocol_config_override() {
-        return;
-    }
-
-    let mut test_env = TestEnvBuilder::new()
-        .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_coin_reservation_for_testing();
-            cfg
-        }))
-        .build()
-        .await;
+    let mut test_env = TestEnvBuilder::new().build().await;
 
     let (sender, _) = test_env.get_sender_and_gas(0);
     let oversized: u64 = (i64::MAX as u64) + 1;

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -2443,19 +2443,29 @@ async fn test_poc_smash_target_deposit_overflow_panics() {
         .build()
         .await;
 
-    let (sender, _) = test_env.get_sender_and_gas(0);
-
-    // Fund 1 MIST into sender's address balance so check_amounts_available passes for the
-    // tiny coin reservation. Use account 1 (normal-sized gas) to pay for the funding
-    // transaction so the huge coin is not used as gas payment here.
-    let (funder, funder_gas) = test_env.get_sender_and_gas(1);
+    // `gas_objects` is a BTreeMap, so positional lookup by `get_sender_and_gas(i)` returns
+    // accounts in SuiAddress sort order rather than the order they were configured. Identify
+    // accounts by their gas-object layout instead: the huge-gas account has exactly 1 coin,
+    // the funding accounts have 2.
+    let sender = *test_env
+        .gas_objects
+        .iter()
+        .find(|(_, gas)| gas.len() == 1)
+        .expect("huge-gas account should have 1 gas object")
+        .0;
+    let (funder, funder_gas) = test_env
+        .gas_objects
+        .iter()
+        .find(|(_, gas)| gas.len() == 2)
+        .map(|(addr, gas)| (*addr, gas[0]))
+        .expect("default-gas account should have 2 gas objects");
     let funding_tx = test_env
         .tx_builder_with_gas_objects(funder, vec![funder_gas])
         .transfer_sui_to_address_balance(FundSource::coin(funder_gas), vec![(1, sender)])
         .build();
     test_env.exec_tx_directly(funding_tx).await.unwrap();
 
-    let (_, huge_gas_coin) = test_env.get_sender_and_gas(0);
+    let huge_gas_coin = test_env.gas_objects[&sender][0];
     let small_reservation = test_env.encode_coin_reservation(sender, 0, 1);
 
     // gas_data.payment = [small_reservation (smash target), huge_gas_coin (smashed)]

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -4,6 +4,7 @@
 use move_core_types::ident_str;
 use sui_macros::*;
 use sui_simulator::has_mainnet_protocol_config_override;
+use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_test_transaction_builder::{FundSource, TestTransactionBuilder};
 use sui_types::{
     base_types::{FullObjectRef, ObjectID, ObjectRef, SequenceNumber, SuiAddress},
@@ -2166,25 +2167,14 @@ async fn test_fake_coin_reservation_dry_run_does_not_panic() {
         .fullnode_handle
         .sui_node
         .with(|node| node.state().clone());
-    let join = tokio::task::spawn(async move { state.dry_exec_transaction(tx_data).await });
-
-    match join.await {
-        Ok(Ok(_)) => panic!("dry-run with fake coin reservation should have errored"),
-        Ok(Err(e)) => {
-            let msg = e.to_string();
-            assert!(
-                msg.contains("InvalidWithdrawReservation") || msg.contains("not found"),
-                "unexpected error: {msg}"
-            );
-        }
-        Err(join_err) if join_err.is_panic() => {
-            panic!(
-                "dryRunTransactionBlock panicked on fake coin reservation: {:?}",
-                join_err
-            );
-        }
-        Err(e) => panic!("unexpected join error: {e:?}"),
-    }
+    let result = state.dry_exec_transaction(tx_data).await;
+    let msg = result
+        .expect_err("dry-run with fake coin reservation should have errored")
+        .to_string();
+    assert!(
+        msg.contains("InvalidWithdrawReservation") || msg.contains("not found"),
+        "unexpected error: {msg}"
+    );
 }
 
 #[sim_test]
@@ -2208,38 +2198,25 @@ async fn test_fake_coin_reservation_dev_inspect_does_not_panic() {
         .fullnode_handle
         .sui_node
         .with(|node| node.state().clone());
-    let join = tokio::task::spawn(async move {
-        state
-            .dev_inspect_transaction_block(
-                sender,
-                tx_kind,
-                None,
-                None,
-                None,
-                None,
-                None,
-                /* skip_checks */ Some(true),
-            )
-            .await
-    });
-
-    match join.await {
-        Ok(Ok(_)) => panic!("dev-inspect with fake coin reservation should have errored"),
-        Ok(Err(e)) => {
-            let msg = e.to_string();
-            assert!(
-                msg.contains("InvalidWithdrawReservation") || msg.contains("not found"),
-                "unexpected error: {msg}"
-            );
-        }
-        Err(join_err) if join_err.is_panic() => {
-            panic!(
-                "devInspectTransactionBlock panicked on fake coin reservation: {:?}",
-                join_err
-            );
-        }
-        Err(e) => panic!("unexpected join error: {e:?}"),
-    }
+    let result = state
+        .dev_inspect_transaction_block(
+            sender,
+            tx_kind,
+            None,
+            None,
+            None,
+            None,
+            None,
+            /* skip_checks */ Some(true),
+        )
+        .await;
+    let msg = result
+        .expect_err("dev-inspect with fake coin reservation should have errored")
+        .to_string();
+    assert!(
+        msg.contains("InvalidWithdrawReservation") || msg.contains("not found"),
+        "unexpected error: {msg}"
+    );
 }
 
 #[sim_test]
@@ -2274,25 +2251,13 @@ async fn test_fake_coin_reservation_dry_run_safe_when_flag_disabled() {
         .fullnode_handle
         .sui_node
         .with(|node| node.state().clone());
-    let join = tokio::task::spawn(async move { state.dry_exec_transaction(tx_data).await });
-
-    match join.await {
-        Ok(Ok(_)) => panic!("dry-run with fake coin reservation should have errored"),
-        Ok(Err(e)) => {
-            assert!(
-                e.to_string()
-                    .contains("coin reservation backward compatibility layer is not enabled"),
-                "expected gating rejection, got: {e}"
-            );
-        }
-        Err(join_err) if join_err.is_panic() => {
-            panic!(
-                "dryRunTransactionBlock panicked with coin reservation flag disabled: {:?}",
-                join_err
-            );
-        }
-        Err(e) => panic!("unexpected join error: {e:?}"),
-    }
+    let result = state.dry_exec_transaction(tx_data).await;
+    let e = result.expect_err("dry-run with fake coin reservation should have errored");
+    assert!(
+        e.to_string()
+            .contains("coin reservation backward compatibility layer is not enabled"),
+        "expected gating rejection, got: {e}"
+    );
 }
 
 #[sim_test]
@@ -2316,36 +2281,387 @@ async fn test_fake_coin_reservation_dev_inspect_safe_when_flag_disabled() {
         .fullnode_handle
         .sui_node
         .with(|node| node.state().clone());
-    let join = tokio::task::spawn(async move {
-        state
-            .dev_inspect_transaction_block(
-                sender,
-                tx_kind,
-                None,
-                None,
-                None,
-                None,
-                None,
-                /* skip_checks */ Some(true),
-            )
-            .await
+    let result = state
+        .dev_inspect_transaction_block(
+            sender,
+            tx_kind,
+            None,
+            None,
+            None,
+            None,
+            None,
+            /* skip_checks */ Some(true),
+        )
+        .await;
+    let e = result.expect_err("dev-inspect with fake coin reservation should have errored");
+    assert!(
+        e.to_string()
+            .contains("coin reservation backward compatibility layer is not enabled"),
+        "expected gating rejection, got: {e}"
+    );
+}
+
+// When a gas payment includes a coin reservation whose encoded amount exceeds i64::MAX,
+// smash_gas would call i64::try_from(*reservation).unwrap() and panic.
+// check_gas rejects the transaction once coin objects are loaded: the combined total of
+// all gas payment values (coins + reservations) must fit in i64. In the common case where
+// the accumulator object does not exist pre_object_load_checks fires first.
+#[sim_test]
+async fn test_poc_oversized_address_balance_gas_reservation_panics() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let (sender, real_gas_coin) = test_env.get_sender_and_gas(0);
+    let oversized_reservation = test_env.encode_coin_reservation(sender, 0, i64::MAX as u64 + 1);
+
+    let tx_data = test_env
+        .tx_builder_with_gas_objects(sender, vec![real_gas_coin, oversized_reservation])
+        .build();
+
+    // Both dry-run and execution are rejected. Without a funded balance the
+    // accumulator object does not exist so pre_object_load_checks fires first;
+    // with sufficient balance check_gas catches it via the combined total bound.
+    test_env
+        .cluster
+        .sui_client()
+        .read_api()
+        .dry_run_transaction_block(tx_data.clone())
+        .await
+        .expect_err("dry-run should reject oversized reservation");
+
+    let signed_tx = test_env.cluster.sign_transaction(&tx_data).await;
+    test_env
+        .cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await
+        .expect_err("execution should reject oversized reservation");
+}
+
+// When two gas-payment coin reservations for the same (sender, SUI) key are present,
+// PaymentKind::smash deduplicates them by summing their amounts. With amounts i64::MAX
+// and 1 the merged total is i64::MAX+1, which fits in u64 but not i64. smash_gas would
+// call i64::try_from(i64::MAX+1).unwrap() and panic.
+// check_gas rejects the transaction via the combined total bound once coins are loaded.
+// In the common case the accumulator object does not exist and pre_object_load_checks
+// fires first.
+#[sim_test]
+async fn test_poc_gas_reservation_dedup_overflow_panics() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let (sender, real_gas_coin) = test_env.get_sender_and_gas(0);
+    let reservation_0 = test_env.encode_coin_reservation(sender, 0, i64::MAX as u64);
+    let reservation_1 = test_env.encode_coin_reservation(sender, 0, 1);
+    let tx_data = test_env
+        .tx_builder_with_gas_objects(sender, vec![real_gas_coin, reservation_0, reservation_1])
+        .build();
+
+    // Both dry-run and execution are rejected. The accumulated reservation total
+    // (i64::MAX + 1) exceeds any realistic on-chain balance, so pre_object_load_checks
+    // fires first ("not found" or "less than requested"); check_gas would catch it
+    // via the combined total bound if the balance were sufficient.
+    test_env
+        .cluster
+        .sui_client()
+        .read_api()
+        .dry_run_transaction_block(tx_data.clone())
+        .await
+        .expect_err("dry-run should reject dedup-overflow reservations");
+
+    let signed_tx = test_env.cluster.sign_transaction(&tx_data).await;
+    test_env
+        .cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await
+        .expect_err("execution should reject dedup-overflow reservations");
+}
+
+// When a coin reservation comes first in gas_data.payment it becomes the
+// AddressBalance smash target. smash_gas then computes:
+//
+//   deposit = total_smashed - reservation_amount
+//           = (reservation_amount + real_coin_value) - reservation_amount
+//           = real_coin_value
+//
+// and calls i64::try_from(deposit).unwrap(), which panics if the real gas
+// coin's value exceeds i64::MAX. The reservation amount can be as small as
+// 1 MIST; only the coin value needs to exceed the bound.
+// check_gas rejects this via the combined total (coin + reservation) bound.
+#[sim_test]
+async fn test_poc_smash_target_deposit_overflow_panics() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    // Coin value must exceed i64::MAX to make deposit overflow.
+    // Leave 100M MIST spare so there is enough for the setup transaction's gas.
+    let huge_gas: u64 = i64::MAX as u64 + 100_000_000;
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .with_test_cluster_builder_cb(Box::new(move |b| {
+            b.with_accounts(vec![
+                AccountConfig {
+                    address: None,
+                    gas_amounts: vec![huge_gas],
+                },
+                AccountConfig {
+                    address: None,
+                    gas_amounts: vec![DEFAULT_GAS_AMOUNT, DEFAULT_GAS_AMOUNT],
+                },
+                AccountConfig {
+                    address: None,
+                    gas_amounts: vec![DEFAULT_GAS_AMOUNT, DEFAULT_GAS_AMOUNT],
+                },
+            ])
+        }))
+        .build()
+        .await;
+
+    let (sender, _) = test_env.get_sender_and_gas(0);
+
+    // Fund 1 MIST into sender's address balance so check_amounts_available passes for the
+    // tiny coin reservation. Use account 1 (normal-sized gas) to pay for the funding
+    // transaction so the huge coin is not used as gas payment here.
+    let (funder, funder_gas) = test_env.get_sender_and_gas(1);
+    let funding_tx = test_env
+        .tx_builder_with_gas_objects(funder, vec![funder_gas])
+        .transfer_sui_to_address_balance(FundSource::coin(funder_gas), vec![(1, sender)])
+        .build();
+    test_env.exec_tx_directly(funding_tx).await.unwrap();
+
+    let (_, huge_gas_coin) = test_env.get_sender_and_gas(0);
+    let small_reservation = test_env.encode_coin_reservation(sender, 0, 1);
+
+    // gas_data.payment = [small_reservation (smash target), huge_gas_coin (smashed)]
+    // check_gas: total = 1 + huge_coin_value > i64::MAX → rejected by combined total bound.
+    let tx_data = test_env
+        .tx_builder_with_gas_objects(sender, vec![small_reservation, huge_gas_coin])
+        .build();
+
+    let total_msg = "Total gas payment (coins + reservations) exceeds i64::MAX";
+
+    // Dry-run via JSON-RPC — check_gas rejects the combined total before execution.
+    let err = test_env
+        .cluster
+        .sui_client()
+        .read_api()
+        .dry_run_transaction_block(tx_data.clone())
+        .await
+        .expect_err("dry-run should reject total gas exceeding i64::MAX");
+    assert!(
+        err.to_string().contains(total_msg),
+        "unexpected error: {err}"
+    );
+
+    // Real execution via gRPC — check_gas rejects at signing time.
+    let signed_tx = test_env.cluster.sign_transaction(&tx_data).await;
+    let err = test_env
+        .cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await
+        .expect_err("execution should reject total gas exceeding i64::MAX");
+    assert!(
+        err.to_string().contains(total_msg),
+        "unexpected error: {err}"
+    );
+}
+
+// A gas budget exceeding i64::MAX would cause smash_gas to set the gas coin's value
+// to a u128 total that overflows i64 when computing the signed accumulator delta,
+// but it is always rejected by check_gas_data (GasBudgetTooHigh) before reaching
+// smash_gas. max_tx_gas in the protocol config is far below i64::MAX.
+#[sim_test]
+async fn test_gas_budget_exceeding_i64_max_is_rejected() {
+    let test_env = TestEnvBuilder::new().build().await;
+
+    let (sender, real_gas_coin) = test_env.get_sender_and_gas(0);
+
+    let tx_data = TransactionData::V1(TransactionDataV1 {
+        kind: TransactionKind::ProgrammableTransaction(
+            ProgrammableTransactionBuilder::new().finish(),
+        ),
+        sender,
+        gas_data: GasData {
+            payment: vec![real_gas_coin],
+            owner: sender,
+            price: test_env.rgp,
+            budget: i64::MAX as u64 + 1,
+        },
+        expiration: TransactionExpiration::None,
     });
 
-    match join.await {
-        Ok(Ok(_)) => panic!("dev-inspect with fake coin reservation should have errored"),
-        Ok(Err(e)) => {
-            assert!(
-                e.to_string()
-                    .contains("coin reservation backward compatibility layer is not enabled"),
-                "expected gating rejection, got: {e}"
-            );
-        }
-        Err(join_err) if join_err.is_panic() => {
-            panic!(
-                "devInspectTransactionBlock panicked with coin reservation flag disabled: {:?}",
-                join_err
-            );
-        }
-        Err(e) => panic!("unexpected join error: {e:?}"),
+    // Dry-run via JSON-RPC.
+    test_env
+        .cluster
+        .sui_client()
+        .read_api()
+        .dry_run_transaction_block(tx_data.clone())
+        .await
+        .expect_err("gas budget > i64::MAX should be rejected");
+
+    // Real execution via gRPC.
+    let signed_tx = test_env.cluster.sign_transaction(&tx_data).await;
+    test_env
+        .cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await
+        .expect_err("gas budget > i64::MAX should be rejected");
+}
+
+// Gas-payment coin reservations must be for SUI. A reservation for a custom coin type
+// (even one with an oversized balance) must be rejected before reaching smash_gas.
+// validity_check_no_gas_check now enforces the SUI-type constraint on all paths
+// including simulate/dry-run, so the error is consistent regardless of whether
+// the total also exceeds the i64::MAX bound.
+#[sim_test]
+async fn dryrun_rejects_non_sui_gas_coin_reservation() {
+    if has_mainnet_protocol_config_override() {
+        return;
     }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let (sender, _) = test_env.get_sender_and_gas(0);
+    let oversized: u64 = (i64::MAX as u64) + 1;
+
+    // Single mint of `oversized` into a Coin<TRUSTED_COIN>, then move the whole
+    // coin into the sender's address balance for that type. Avoids the helper
+    // path which mints twice and would overflow total supply.
+    let (package_id, coin_type, treasury_cap) = test_env.publish_trusted_coin(sender).await;
+    let (custom_coin, _new_cap) = test_env
+        .mint_trusted_coin(sender, package_id, treasury_cap, oversized)
+        .await;
+    let tx = test_env
+        .tx_builder(sender)
+        .transfer_funds_to_address_balance(
+            FundSource::Coin(custom_coin),
+            vec![(oversized, sender)],
+            coin_type.clone(),
+        )
+        .build();
+    test_env.exec_tx_directly(tx).await.unwrap();
+
+    let (sender, real_gas_coin) = test_env.get_sender_and_gas(0);
+    let custom_reservation =
+        test_env.encode_coin_reservation_for_type(sender, 0, oversized, coin_type);
+
+    let tx_data = test_env
+        .tx_builder_with_gas_objects(sender, vec![real_gas_coin, custom_reservation])
+        .build();
+
+    let state = test_env
+        .cluster
+        .fullnode_handle
+        .sui_node
+        .with(|node| node.state().clone());
+    let result = state.dry_exec_transaction(tx_data).await;
+    let msg = result
+        .expect_err("dry-run should reject non-SUI gas reservation")
+        .to_string();
+    assert!(
+        msg.contains("Gas object is not an owned object"),
+        "expected non-SUI gas reservation to be rejected, got: {msg}"
+    );
+}
+
+// Same scenario as `dryrun_rejects_non_sui_gas_coin_reservation`, exercised through
+// `dev_inspect_transaction_block` with `skip_checks=true`.
+#[sim_test]
+async fn dev_inspect_rejects_non_sui_gas_coin_reservation() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let (sender, _) = test_env.get_sender_and_gas(0);
+    let oversized: u64 = (i64::MAX as u64) + 1;
+
+    let (package_id, coin_type, treasury_cap) = test_env.publish_trusted_coin(sender).await;
+    let (custom_coin, _new_cap) = test_env
+        .mint_trusted_coin(sender, package_id, treasury_cap, oversized)
+        .await;
+    let tx = test_env
+        .tx_builder(sender)
+        .transfer_funds_to_address_balance(
+            FundSource::Coin(custom_coin),
+            vec![(oversized, sender)],
+            coin_type.clone(),
+        )
+        .build();
+    test_env.exec_tx_directly(tx).await.unwrap();
+
+    let (sender, _) = test_env.get_sender_and_gas(0);
+    let custom_reservation =
+        test_env.encode_coin_reservation_for_type(sender, 0, oversized, coin_type);
+
+    // Build a trivial PTB and submit via dev_inspect with the custom-coin
+    // reservation as gas.
+    let kind = {
+        let builder = ProgrammableTransactionBuilder::new();
+        TransactionKind::ProgrammableTransaction(builder.finish())
+    };
+
+    let state = test_env
+        .cluster
+        .fullnode_handle
+        .sui_node
+        .with(|node| node.state().clone());
+    let result = state
+        .dev_inspect_transaction_block(
+            sender,
+            kind,
+            None,
+            None,
+            None,
+            Some(vec![custom_reservation]),
+            None,
+            /* skip_checks */ Some(true),
+        )
+        .await;
+    let msg = result
+        .expect_err("dev_inspect should reject non-SUI gas reservation")
+        .to_string();
+    assert!(
+        msg.contains("Gas object is not an owned object"),
+        "expected non-SUI gas reservation to be rejected, got: {msg}"
+    );
 }

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -2546,6 +2546,90 @@ async fn test_gas_budget_exceeding_i64_max_is_rejected() {
         .expect_err("gas budget > i64::MAX should be rejected");
 }
 
+// Address-balance-paid gas with gas_budget > i64::MAX executes successfully.
+//
+// When gas_data.payment = [], payment_kind() builds a single
+// `PaymentMethod::AddressBalance(owner, gas_budget)` smash_target. smash_gas
+// never converts the smash_target reservation to i64: the smashed_payments loop
+// at gas_charger.rs:609 is empty, and the smash_target branch at line 632
+// computes `deposit = total_smashed - reservation = 0` and skips the conversion.
+// The gas charge at the end of the tx uses `net_gas_usage` (actual usage), which
+// is bounded far below i64::MAX. So check_gas's combined-total bound does not
+// need to include the budget here — the path is safe even when budget > i64::MAX.
+//
+// max_tx_gas / max_gas_price are raised so check_gas_data doesn't short-circuit
+// the path on GasBudgetTooHigh / GasPriceTooHigh, exercising the actual
+// execution behavior.
+#[sim_test]
+async fn test_address_balance_paid_budget_above_i64_max_succeeds() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    // Use two coins: a huge one whose value we move into address balance, and a
+    // normal one to pay gas for the funding tx (otherwise the funding tx's own
+    // i64::MAX check would reject the huge gas coin).
+    let huge_coin_value: u64 = i64::MAX as u64 + 1;
+    let small_gas_value: u64 = 1_000_000_000_000;
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_address_balance_gas_payments_for_testing();
+            cfg.set_max_tx_gas_for_testing(u64::MAX);
+            cfg.set_max_gas_price_for_testing(u64::MAX);
+            cfg
+        }))
+        .with_test_cluster_builder_cb(Box::new(move |b| {
+            b.with_accounts(vec![AccountConfig {
+                address: None,
+                gas_amounts: vec![huge_coin_value, small_gas_value],
+            }])
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+    // gas_objects is BTreeMap-ordered and gas-coin order within an account is
+    // wallet-list order — neither tracks the AccountConfig ordering. Pick the
+    // huge vs small coin by value via wallet.gas_objects.
+    let mut owned = test_env.cluster.wallet.gas_objects(sender).await.unwrap();
+    owned.sort_by_key(|(value, _)| std::cmp::Reverse(*value));
+    let huge_coin = owned[0].1.compute_object_reference();
+    let small_gas_coin = owned[1].1.compute_object_reference();
+
+    // Move (i64::MAX + 1) MIST from the huge coin into sender's address balance,
+    // paying funding-tx gas from the small coin.
+    let funding_tx = test_env
+        .tx_builder_with_gas_objects(sender, vec![small_gas_coin])
+        .transfer_sui_to_address_balance(
+            FundSource::coin(huge_coin),
+            vec![(huge_coin_value, sender)],
+        )
+        .build();
+    test_env.exec_tx_directly(funding_tx).await.unwrap();
+
+    // Address-balance-paid tx: gas.payment = [], price > 0, PT kind. The budget
+    // becomes the AddressBalance reservation amount in payment_kind(). Validators
+    // execute this successfully; no overflow occurs in smash_gas.
+    let tx = test_env
+        .tx_builder_with_gas_objects(sender, vec![])
+        .with_address_balance_gas(test_env.chain_id, 0, 0)
+        .with_gas_budget(i64::MAX as u64 + 1)
+        .build();
+    let signed_tx = test_env.cluster.sign_transaction(&tx).await;
+    let executed = test_env
+        .cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await
+        .expect("execution should succeed");
+    assert!(
+        executed.effects.status().is_ok(),
+        "tx should succeed, got: {:?}",
+        executed.effects.status()
+    );
+}
+
 // Gas-payment coin reservations must be for SUI. A reservation for a custom coin type
 // (even one with an oversized balance) must be rejected before reaching smash_gas.
 // validity_check_no_gas_check now enforces the SUI-type constraint on all paths

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -4153,7 +4153,6 @@ async fn test_poc_net_ptb_gas_coverage_panics() {
     let (package_id, vault_id) = test_env
         .setup_funded_object_balance_vault(200_000_000_000)
         .await;
-    let vault_oref = test_env.cluster.get_latest_object_ref(&vault_id).await;
 
     // The bug requires gas_coin_value + gas_budget < withdrawal_amount.
     // Split a dedicated small gas coin (50M MIST) so this condition is satisfied:
@@ -4258,9 +4257,9 @@ async fn test_poc_net_ptb_gas_coverage_panics() {
     });
 
     // Dry-run via JSON-RPC (sui_dryRunTransactionBlock).
-    test_env
-        .cluster
-        .sui_client()
+    #[allow(deprecated)]
+    let sui_client = test_env.cluster.sui_client();
+    sui_client
         .read_api()
         .dry_run_transaction_block(tx_data.clone())
         .await

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -4117,3 +4117,163 @@ async fn address_balance_gas_transfer_storage_objects_out_of_gas_no_panic() {
     // Reconfig runs SUI conservation invariant checks across the epoch boundary
     test_env.cluster.trigger_reconfiguration().await;
 }
+
+// check_address_balance_changes_impl compared the actual balance change against the PTB's
+// *net* change at each address. When a PTB:
+//   (a) withdraws 150B MIST from vault's address balance (PTB Split of 150B at vault_addr)
+//   (b) sends the gas coin to vault via coin::send_funds<SUI>(GasCoin, vault_addr),
+//       depositing (gas_coin_value + gas_budget) at vault_addr as PTB events,
+//
+// the net ptb_change[vault_addr] = gas_coin_value + gas_budget - 150B. When the gas coin
+// is small relative to the withdrawal (gas_coin_value + gas_budget < 150B) this is
+// negative. Gas charging then emits a runtime Split at vault_addr, making actual <
+// ptb_change and triggering the invariant assertion.
+//
+// A regular sender gas coin with billions of MIST keeps ptb_change positive and masks
+// the condition. We use a dedicated small gas coin (50M MIST) to satisfy it.
+#[sim_test]
+async fn test_poc_net_ptb_gas_coverage_panics() {
+    if has_mainnet_protocol_config_override() {
+        return;
+    }
+
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_address_balance_gas_payments_for_testing();
+            cfg.set_enable_object_funds_withdraw_for_testing(true);
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(0);
+    let recipient = test_env.get_sender(1);
+
+    // Fund vault's address balance with 200B MIST (well above the 150B withdrawal).
+    let (package_id, vault_id) = test_env
+        .setup_funded_object_balance_vault(200_000_000_000)
+        .await;
+    let vault_oref = test_env.cluster.get_latest_object_ref(&vault_id).await;
+
+    // The bug requires gas_coin_value + gas_budget < withdrawal_amount.
+    // Split a dedicated small gas coin (50M MIST) so this condition is satisfied:
+    //   50M + 10M = 60M << 150B  →  ptb_change[vault] < 0
+    let gas_budget = 10_000_000u64; // 10M MIST
+    let small_gas_coin_value = 50_000_000u64; // 50M MIST
+    let withdrawal_amount = 150_000_000_000u64; // 150B MIST
+
+    let (_, sender_gas) = test_env.get_sender_and_gas(0);
+    let split_tx = TransactionData::V1(TransactionDataV1 {
+        kind: {
+            let mut b = ProgrammableTransactionBuilder::new();
+            let amount = b.pure(small_gas_coin_value).unwrap();
+            let Argument::Result(split_idx) =
+                b.command(Command::SplitCoins(Argument::GasCoin, vec![amount]))
+            else {
+                unreachable!()
+            };
+            // Transfer the split coin to sender so it appears in created objects.
+            let sender_arg = b.pure(sender).unwrap();
+            b.command(Command::TransferObjects(
+                vec![Argument::NestedResult(split_idx, 0)],
+                sender_arg,
+            ));
+            TransactionKind::ProgrammableTransaction(b.finish())
+        },
+        sender,
+        gas_data: GasData {
+            payment: vec![sender_gas],
+            owner: sender,
+            price: test_env.rgp,
+            budget: gas_budget,
+        },
+        expiration: TransactionExpiration::None,
+    });
+    let (split_digest, split_effects) = test_env.exec_tx_directly(split_tx).await.unwrap();
+    test_env
+        .cluster
+        .wait_for_tx_settlement(&[split_digest])
+        .await;
+    let small_gas_coin = split_effects
+        .created()
+        .into_iter()
+        .next()
+        .expect("split should create a new coin")
+        .0;
+
+    let vault_oref = test_env.cluster.get_latest_object_ref(&vault_id).await;
+
+    // PTB with the small gas coin as payment:
+    //   1. withdraw_funds<SUI>(vault, 150B) — PTB Split(150B) at vault_addr
+    //   2. balance::send_funds<SUI>(balance, recipient) — PTB Merge(150B) at recipient
+    //   3. coin::send_funds<SUI>(GasCoin, vault_addr) — PTB Merge(small_coin + gas_budget) at vault_addr,
+    //      overrides gas charge location to AddressBalance(vault_addr)
+    //
+    // ptb_change[vault_addr] = (50M + 10M) − 150B ≈ −150B  (negative)
+    // runtime gas charge emits Split(gas_cost) at vault_addr
+    // actual[vault_addr] = ptb_change − gas_cost < ptb_change
+    // assert_invariant!(actual >= ptb_change.min(0)) ≡ −gas_cost >= 0 — always false.
+    let mut builder = ProgrammableTransactionBuilder::new();
+
+    let vault_arg = builder
+        .obj(ObjectArg::ImmOrOwnedObject(vault_oref))
+        .unwrap();
+    let withdraw_amount_arg = builder.pure(withdrawal_amount).unwrap();
+    let balance = builder.programmable_move_call(
+        package_id,
+        Identifier::new("object_balance").unwrap(),
+        Identifier::new("withdraw_funds").unwrap(),
+        vec![GAS::type_tag()],
+        vec![vault_arg, withdraw_amount_arg],
+    );
+
+    let recipient_arg = builder.pure(recipient).unwrap();
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("balance").unwrap(),
+        Identifier::new("send_funds").unwrap(),
+        vec![GAS::type_tag()],
+        vec![balance, recipient_arg],
+    );
+
+    let vault_addr_arg = builder.pure(SuiAddress::from(vault_id)).unwrap();
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("coin").unwrap(),
+        Identifier::new("send_funds").unwrap(),
+        vec![GAS::type_tag()],
+        vec![Argument::GasCoin, vault_addr_arg],
+    );
+
+    let tx_data = TransactionData::V1(TransactionDataV1 {
+        kind: TransactionKind::ProgrammableTransaction(builder.finish()),
+        sender,
+        gas_data: GasData {
+            payment: vec![small_gas_coin], // small coin: value + gas_budget << withdrawal
+            owner: sender,
+            price: test_env.rgp,
+            budget: gas_budget,
+        },
+        expiration: TransactionExpiration::None,
+    });
+
+    // Dry-run via JSON-RPC (sui_dryRunTransactionBlock).
+    test_env
+        .cluster
+        .sui_client()
+        .read_api()
+        .dry_run_transaction_block(tx_data.clone())
+        .await
+        .unwrap();
+
+    // Real execution via gRPC — fully legitimate transaction with a real gas coin; validators
+    // sign it without issue. check_address_balance_changes_impl panics after PTB execution
+    // detects actual < ptb_change (the gas cost makes actual more negative than ptb_change).
+    let signed_tx = test_env.cluster.sign_transaction(&tx_data).await;
+    test_env
+        .cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await
+        .unwrap();
+}

--- a/crates/sui-e2e-tests/tests/gasless_tests.rs
+++ b/crates/sui-e2e-tests/tests/gasless_tests.rs
@@ -1002,3 +1002,127 @@ async fn test_gasless_rate_limit_rejects() {
 
     test_env.trigger_reconfiguration().await;
 }
+
+// `compute_input_reservations` aggregates FundsWithdrawalArg amounts via checked `+=`
+// under `#[sui_macros::with_checked_arithmetic]`. Two same-(sender, type) withdrawal
+// args with amounts u64::MAX and 1 would overflow before PTB execution begins.
+//
+// `pre_object_load_checks` is called unconditionally inside `simulate_transaction` on
+// all paths including TransactionChecks::Disabled. It calls
+// `process_funds_withdrawals_for_signing` → `accumulate_funds_withdrawals` with its own
+// `checked_add`, returning "Balance withdraw reservation overflow" before the executor
+// is invoked. No RPC path reaches `compute_input_reservations` with overflowing sums.
+// This test documents that behavior.
+#[cfg_attr(not(msim), ignore)]
+#[sim_test]
+async fn test_poc_gasless_withdrawal_reservation_overflow_panics() {
+    let test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_gasless_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let sender = test_env.get_sender(1);
+    let recipient = test_env.get_sender(2);
+    let coin_type = GAS::type_tag();
+    transaction::add_gasless_token_for_testing(coin_type.to_canonical_string(true), 0);
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+
+    let withdrawal_0 = builder
+        .funds_withdrawal(FundsWithdrawalArg::balance_from_sender(
+            u64::MAX,
+            coin_type.clone(),
+        ))
+        .unwrap();
+    let balance_0 = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("balance").unwrap(),
+        Identifier::new("redeem_funds").unwrap(),
+        vec![coin_type.clone()],
+        vec![withdrawal_0],
+    );
+    let recipient_0 = builder.pure(recipient).unwrap();
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("balance").unwrap(),
+        Identifier::new("send_funds").unwrap(),
+        vec![coin_type.clone()],
+        vec![balance_0, recipient_0],
+    );
+
+    let withdrawal_1 = builder
+        .funds_withdrawal(FundsWithdrawalArg::balance_from_sender(
+            1,
+            coin_type.clone(),
+        ))
+        .unwrap();
+    let balance_1 = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("balance").unwrap(),
+        Identifier::new("redeem_funds").unwrap(),
+        vec![coin_type.clone()],
+        vec![withdrawal_1],
+    );
+    let recipient_1 = builder.pure(recipient).unwrap();
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("balance").unwrap(),
+        Identifier::new("send_funds").unwrap(),
+        vec![coin_type],
+        vec![balance_1, recipient_1],
+    );
+
+    let tx_data = test_env.gasless_transaction_data(
+        TransactionKind::ProgrammableTransaction(builder.finish()),
+        sender,
+        0,
+        0,
+    );
+
+    let overflow_msg = "Balance withdraw reservation overflow";
+
+    // Dry-run via JSON-RPC (sui_dryRunTransactionBlock, TransactionChecks::Enabled).
+    // pre_object_load_checks → accumulate_funds_withdrawals → checked_add catches u64::MAX+1
+    // and returns a graceful error; compute_input_reservations is never reached.
+    let result = test_env
+        .cluster
+        .sui_client()
+        .read_api()
+        .dry_run_transaction_block(tx_data.clone())
+        .await;
+    let err = result.expect_err("dry-run should reject overflowing withdrawal sum");
+    assert!(
+        err.to_string().contains(overflow_msg),
+        "unexpected dry-run error: {err}"
+    );
+
+    // gRPC simulate with checks=disabled (dev-inspect path).
+    // pre_object_load_checks is still called unconditionally before the dev-inspect fork.
+    let result = test_env
+        .cluster
+        .grpc_client()
+        .simulate_transaction(&tx_data, false, false)
+        .await;
+    let err = result.expect_err("gRPC simulate should reject overflowing withdrawal sum");
+    assert!(
+        err.to_string().contains(overflow_msg),
+        "unexpected gRPC simulate error: {err}"
+    );
+
+    // Real execution via gRPC: validators call pre_object_load_checks during handle_transaction,
+    // so the certificate is never formed and the overflowing reservation never reaches execution.
+    let signed_tx = test_env.cluster.sign_transaction(&tx_data).await;
+    let result = test_env
+        .cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await;
+    let err = result.expect_err("execution should reject overflowing withdrawal sum");
+    assert!(
+        err.to_string().contains(overflow_msg),
+        "unexpected execution error: {err}"
+    );
+}

--- a/crates/sui-e2e-tests/tests/gasless_tests.rs
+++ b/crates/sui-e2e-tests/tests/gasless_tests.rs
@@ -1087,9 +1087,9 @@ async fn test_poc_gasless_withdrawal_reservation_overflow_panics() {
     // Dry-run via JSON-RPC (sui_dryRunTransactionBlock, TransactionChecks::Enabled).
     // pre_object_load_checks → accumulate_funds_withdrawals → checked_add catches u64::MAX+1
     // and returns a graceful error; compute_input_reservations is never reached.
-    let result = test_env
-        .cluster
-        .sui_client()
+    #[allow(deprecated)]
+    let sui_client = test_env.cluster.sui_client();
+    let result = sui_client
         .read_api()
         .dry_run_transaction_block(tx_data.clone())
         .await;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -355,6 +355,9 @@ const MAINNET_USDB: &str =
 // Version 126: Enable early_exit_on_iffw (gates the gas-underflow fix
 //              shipped to mainnet out-of-band in #26816).
 // Version 127: Enable always_advance_dkg_to_resolution.
+//              Enable additional_gas_input_checks (gates the gas-payment input
+//              validation tightening: rejects non-gas-coin objects and
+//              combined coin+reservation totals exceeding i64::MAX).
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1130,6 +1133,13 @@ struct FeatureFlags {
     // If true, exit early for IFWW transactions.
     #[serde(skip_serializing_if = "is_false")]
     early_exit_on_iffw: bool,
+
+    // If true, check_gas performs additional input validation on gas payment:
+    // - rejects non-gas-coin objects (InvalidGasObject)
+    // - rejects gas payments whose combined coin+reservation total exceeds i64::MAX
+    //   (InvalidWithdrawReservation), preventing an overflow panic in smash_gas
+    #[serde(skip_serializing_if = "is_false")]
+    additional_gas_input_checks: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2875,6 +2885,10 @@ impl ProtocolConfig {
 
     pub fn early_exit_on_iffw(&self) -> bool {
         self.feature_flags.early_exit_on_iffw
+    }
+
+    pub fn additional_gas_input_checks(&self) -> bool {
+        self.feature_flags.additional_gas_input_checks
     }
 }
 
@@ -5004,6 +5018,7 @@ impl ProtocolConfig {
                 }
                 127 => {
                     cfg.feature_flags.always_advance_dkg_to_resolution = true;
+                    cfg.feature_flags.additional_gas_input_checks = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_127.snap
@@ -168,6 +168,7 @@ feature_flags:
   limit_groth16_pvk_inputs: true
   granular_post_execution_checks: true
   early_exit_on_iffw: true
+  additional_gas_input_checks: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
@@ -169,6 +169,7 @@ feature_flags:
   limit_groth16_pvk_inputs: true
   granular_post_execution_checks: true
   early_exit_on_iffw: true
+  additional_gas_input_checks: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_127.snap
@@ -173,6 +173,7 @@ feature_flags:
   limit_groth16_pvk_inputs: true
   granular_post_execution_checks: true
   early_exit_on_iffw: true
+  additional_gas_input_checks: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -421,11 +421,13 @@ mod checked {
         // path never converts the budget to i64.)
         let mut total: u128 = 0;
 
+        let extra_gas_checks = protocol_config.additional_gas_input_checks();
+
         let (gas_objects, available_address_balance_gas) = if gas_paid_from_address_balance {
             // When paying from address balance via gas_data.payment = [], the budget is reserved by the scheduler
             // and guaranteed to be available.
             (vec![], gas_budget)
-        } else {
+        } else if extra_gas_checks {
             // Gas payment may include a mix of coin objects and coin reservations (withdrawals).
             // Sum up the reservation amounts separately since they don't have input objects.
             let mut available_address_balance_gas: u64 = 0;
@@ -461,10 +463,31 @@ mod checked {
                 }
             }
             (gas_objects, available_address_balance_gas)
+        } else {
+            // Pre-additional_gas_input_checks behavior: build gas_objects without
+            // the is_gas_coin / is_address_owned / balance-summing checks. Owner
+            // and balance are still enforced downstream by check_gas_balance.
+            let mut available_address_balance_gas: u64 = 0;
+            let mut gas_objects = vec![];
+            for obj_ref in gas {
+                if let Ok(parsed) = ParsedDigest::try_from(obj_ref.2) {
+                    available_address_balance_gas =
+                        available_address_balance_gas.saturating_add(parsed.reservation_amount());
+                } else {
+                    let obj = *objects
+                        .get(&obj_ref.0)
+                        .ok_or(UserInputError::ObjectNotFound {
+                            object_id: obj_ref.0,
+                            version: Some(obj_ref.1),
+                        })?;
+                    gas_objects.push(obj);
+                }
+            }
+            (gas_objects, available_address_balance_gas)
         };
 
         if !is_gasless {
-            if i64::try_from(total).is_err() {
+            if extra_gas_checks && i64::try_from(total).is_err() {
                 return Err(UserInputError::InvalidWithdrawReservation {
                     error: "Total gas payment (coins + reservations) exceeds i64::MAX".to_string(),
                 }

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -455,7 +455,7 @@ mod checked {
                         }
                         .into());
                     }
-                    if gas_ownership_checks && !object.is_address_owned() {
+                    if !object.is_address_owned() {
                         return Err(UserInputError::GasObjectNotOwnedObject {
                             owner: object.owner.clone(),
                         }

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -421,6 +421,13 @@ mod checked {
         // load all gas coins (skip coin reservations - they're not loaded as input objects)
         let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
 
+        let gas_owner = transaction.gas_owner();
+
+        // Total of coin balances + reservation amounts. Limit to i64::MAX so smash_gas's
+        // i64 conversion doesn't overflow. (Not summed for address-balance-paid gas; that
+        // path never converts the budget to i64.)
+        let mut total: u128 = 0;
+
         let (gas_objects, available_address_balance_gas) = if gas_paid_from_address_balance {
             // When paying from address balance via gas_data.payment = [], the budget is reserved by the scheduler
             // and guaranteed to be available.
@@ -432,14 +439,25 @@ mod checked {
             let mut gas_objects = vec![];
             for obj_ref in gas {
                 if let Ok(parsed) = ParsedDigest::try_from(obj_ref.2) {
+                    let amount = parsed.reservation_amount();
                     available_address_balance_gas =
-                        available_address_balance_gas.saturating_add(parsed.reservation_amount());
+                        available_address_balance_gas.saturating_add(amount);
+                    total += amount as u128;
                 } else {
-                    let obj = objects.get(&obj_ref.0);
-                    let obj = *obj.ok_or(UserInputError::ObjectNotFound {
-                        object_id: obj_ref.0,
-                        version: Some(obj_ref.1),
-                    })?;
+                    let obj = *objects
+                        .get(&obj_ref.0)
+                        .ok_or(UserInputError::ObjectNotFound {
+                            object_id: obj_ref.0,
+                            version: Some(obj_ref.1),
+                        })?;
+                    let object = obj.as_object().ok_or(UserInputError::MissingGasPayment)?;
+                    if gas_ownership_checks && object.owner != Owner::AddressOwner(gas_owner) {
+                        return Err(UserInputError::GasObjectNotOwnedObject {
+                            owner: object.owner.clone(),
+                        }
+                        .into());
+                    }
+                    total += sui_types::gas::get_gas_balance(object)? as u128;
                     gas_objects.push(obj);
                 }
             }
@@ -447,6 +465,13 @@ mod checked {
         };
 
         if !is_gasless {
+            if i64::try_from(total).is_err() {
+                return Err(UserInputError::InvalidWithdrawReservation {
+                    error: "Total gas payment (coins + reservations) exceeds i64::MAX".to_string(),
+                }
+                .into());
+            }
+
             if gas_ownership_checks {
                 gas_status.check_gas_objects(&gas_objects)?;
             }
@@ -455,34 +480,6 @@ mod checked {
                 gas_budget,
                 available_address_balance_gas,
             )?;
-
-            // smash_gas converts gas payment amounts to i64 via unwrap(). The combined
-            // total of all gas payment values (real coin balances + coin reservation amounts)
-            // must fit in i64. In production this is never an issue since reaching i64::MAX
-            // would require ~92% of the total SUI supply.
-            //
-            // Note: when paying from address balance (gas_data.payment = []), the budget
-            // is the AddressBalance reservation in payment_kind(), but smash_gas never
-            // converts it to i64 (smashed_payments is empty so line 609 doesn't fire, and
-            // deposit = total_smashed - reservation = 0 so line 632 is skipped). So we
-            // intentionally don't sum available_address_balance_gas here.
-            let mut total: u128 = 0;
-            for obj in &gas_objects {
-                if let Some(object) = obj.as_object() {
-                    total += sui_types::gas::get_gas_balance(object).unwrap_or(0) as u128;
-                }
-            }
-            for obj_ref in gas {
-                if let Ok(parsed) = ParsedDigest::try_from(obj_ref.2) {
-                    total += parsed.reservation_amount() as u128;
-                }
-            }
-            if i64::try_from(total).is_err() {
-                return Err(UserInputError::InvalidWithdrawReservation {
-                    error: "Total gas payment (coins + reservations) exceeds i64::MAX".to_string(),
-                }
-                .into());
-            }
         }
         Ok(gas_status)
     }

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -57,7 +57,6 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
         transaction: &TransactionData,
-        gas_ownership_checks: bool,
     ) -> SuiResult<SuiGasStatus> {
         if transaction.kind().is_system_tx() {
             Ok(SuiGasStatus::new_unmetered())
@@ -70,7 +69,6 @@ mod checked {
                 reference_gas_price,
                 gas,
                 transaction,
-                gas_ownership_checks,
                 is_gasless,
             )
         }
@@ -201,11 +199,10 @@ mod checked {
 
         let gas_status = get_gas_status(
             &input_objects,
-            &transaction.gas_data().payment, //gas,
+            &transaction.gas_data().payment,
             config,
             reference_gas_price,
             transaction,
-            false, // gas_ownership_checks - false means mostly transaction level checks
         )?;
 
         Ok((gas_status, input_objects.into_checked()))
@@ -232,7 +229,6 @@ mod checked {
             protocol_config,
             reference_gas_price,
             transaction,
-            true, // gas_ownership_checks
         )?;
         check_objects(transaction, input_objects, protocol_config)?;
         check_replay_protection(transaction, input_objects)?;
@@ -401,7 +397,6 @@ mod checked {
         reference_gas_price: u64,
         gas: &[ObjectRef],
         transaction: &TransactionData,
-        gas_ownership_checks: bool,
         is_gasless: bool,
     ) -> SuiResult<SuiGasStatus> {
         let gas_budget = transaction.gas_budget();
@@ -476,9 +471,6 @@ mod checked {
                 .into());
             }
 
-            if gas_ownership_checks {
-                gas_status.check_gas_objects(&gas_objects)?;
-            }
             gas_status.check_gas_balance(
                 &gas_objects,
                 gas_budget,

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -460,6 +460,12 @@ mod checked {
             // total of all gas payment values (real coin balances + coin reservation amounts)
             // must fit in i64. In production this is never an issue since reaching i64::MAX
             // would require ~92% of the total SUI supply.
+            //
+            // Note: when paying from address balance (gas_data.payment = []), the budget
+            // is the AddressBalance reservation in payment_kind(), but smash_gas never
+            // converts it to i64 (smashed_payments is empty so line 609 doesn't fire, and
+            // deposit = total_smashed - reservation = 0 so line 632 is skipped). So we
+            // intentionally don't sum available_address_balance_gas here.
             let mut total: u128 = 0;
             for obj in &gas_objects {
                 if let Some(object) = obj.as_object() {

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -451,6 +451,12 @@ mod checked {
                             version: Some(obj_ref.1),
                         })?;
                     let object = obj.as_object().ok_or(UserInputError::MissingGasPayment)?;
+                    if !object.is_gas_coin() {
+                        return Err(UserInputError::InvalidGasObject {
+                            object_id: object.id(),
+                        }
+                        .into());
+                    }
                     if gas_ownership_checks && object.owner != Owner::AddressOwner(gas_owner) {
                         return Err(UserInputError::GasObjectNotOwnedObject {
                             owner: object.owner.clone(),

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -455,6 +455,28 @@ mod checked {
                 gas_budget,
                 available_address_balance_gas,
             )?;
+
+            // smash_gas converts gas payment amounts to i64 via unwrap(). The combined
+            // total of all gas payment values (real coin balances + coin reservation amounts)
+            // must fit in i64. In production this is never an issue since reaching i64::MAX
+            // would require ~92% of the total SUI supply.
+            let mut total: u128 = 0;
+            for obj in &gas_objects {
+                if let Some(object) = obj.as_object() {
+                    total += sui_types::gas::get_gas_balance(object).unwrap_or(0) as u128;
+                }
+            }
+            for obj_ref in gas {
+                if let Ok(parsed) = ParsedDigest::try_from(obj_ref.2) {
+                    total += parsed.reservation_amount() as u128;
+                }
+            }
+            if i64::try_from(total).is_err() {
+                return Err(UserInputError::InvalidWithdrawReservation {
+                    error: "Total gas payment (coins + reservations) exceeds i64::MAX".to_string(),
+                }
+                .into());
+            }
         }
         Ok(gas_status)
     }

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -421,8 +421,6 @@ mod checked {
         // load all gas coins (skip coin reservations - they're not loaded as input objects)
         let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
 
-        let gas_owner = transaction.gas_owner();
-
         // Total of coin balances + reservation amounts. Limit to i64::MAX so smash_gas's
         // i64 conversion doesn't overflow. (Not summed for address-balance-paid gas; that
         // path never converts the budget to i64.)
@@ -457,7 +455,7 @@ mod checked {
                         }
                         .into());
                     }
-                    if gas_ownership_checks && object.owner != Owner::AddressOwner(gas_owner) {
+                    if gas_ownership_checks && !object.is_address_owned() {
                         return Err(UserInputError::GasObjectNotOwnedObject {
                             owner: object.owner.clone(),
                         }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3465,6 +3465,7 @@ impl TransactionDataAPI for TransactionDataV1 {
         Ok(())
     }
 
+
     /// Check if the transaction is sponsored (namely gas owner != sender)
     fn is_sponsored_tx(&self) -> bool {
         self.gas_owner() != self.sender
@@ -3539,6 +3540,22 @@ impl TransactionDataAPI for TransactionDataV1 {
 }
 
 impl TransactionDataV1 {
+    fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult {
+        self.kind().validity_check(config)?;
+
+        if config.enable_gasless() && self.is_gasless_transaction() {
+            let TransactionKind::ProgrammableTransaction(pt) = &self.kind else {
+                debug_fatal!("gasless transaction is not a ProgrammableTransaction");
+                return Err(UserInputError::Unsupported(
+                    "Gasless transactions must be programmable transactions".to_string(),
+                ));
+            };
+            pt.validate_gasless_transaction(config)?;
+        }
+
+        self.check_sponsorship()
+    }
+
     fn accumulate_funds_withdrawals(
         &self,
         chain_identifier: ChainIdentifier,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3540,22 +3540,6 @@ impl TransactionDataAPI for TransactionDataV1 {
 }
 
 impl TransactionDataV1 {
-    fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult {
-        self.kind().validity_check(config)?;
-
-        if config.enable_gasless() && self.is_gasless_transaction() {
-            let TransactionKind::ProgrammableTransaction(pt) = &self.kind else {
-                debug_fatal!("gasless transaction is not a ProgrammableTransaction");
-                return Err(UserInputError::Unsupported(
-                    "Gasless transactions must be programmable transactions".to_string(),
-                ));
-            };
-            pt.validate_gasless_transaction(config)?;
-        }
-
-        self.check_sponsorship()
-    }
-
     fn accumulate_funds_withdrawals(
         &self,
         chain_identifier: ChainIdentifier,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -209,7 +209,7 @@ mod checked {
                 .collect();
             PaymentKind::smash(payment_methods).expect(
                 "unable to create a payment kind from payment methods. \
-                 Should not be possible wit ha non-empty vector",
+                 Should not be possible with a non-empty vector",
             )
         }
     }

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -247,10 +247,6 @@ pub mod checked {
         // This function is called when the transaction is about to be executed.
         // It will smash all gas coins into a single one and set the logical gas coin
         // to be the first one in the list.
-        // After this call, `gas_coin` will return it id of the gas coin.
-        // This function panics if errors are found while operation on the gas coins.
-        // Transaction and certificate input checks must have insured that all gas coins
-        // are correct.
         fn smash_gas(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             match &mut self.payment {
                 PaymentMetadata::Unmetered | PaymentMetadata::Gasless => (),
@@ -715,6 +711,8 @@ pub mod checked {
                             unreachable!("Payment method does not match location")
                         };
                         assert_eq!(*addr, other, "Payment method does not match location");
+                        // validity_check guarantees the total of all reservation amounts fits in
+                        // i64, so this addition and the i64 conversion in smash_gas are both safe.
                         *amount += additional;
                     }
                     (indexmap::map::Entry::Occupied(_), _) => {

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -711,8 +711,9 @@ pub mod checked {
                             unreachable!("Payment method does not match location")
                         };
                         assert_eq!(*addr, other, "Payment method does not match location");
-                        // validity_check guarantees the total of all reservation amounts fits in
-                        // i64, so this addition and the i64 conversion in smash_gas are both safe.
+                        // sui_transaction_checks::check_gas guarantees the total of all gas
+                        // payment values (coin balances + reservation amounts) fits in i64,
+                        // so this addition and the i64 conversion in smash_gas are both safe.
                         *amount += additional;
                     }
                     (indexmap::map::Entry::Occupied(_), _) => {


### PR DESCRIPTION
Enforces that the combined total of all gas-payment values (coin balances plus reservation amounts) fits in `i64`, rejecting transactions that exceed it during `check_gas`. This guarantees the `i64` conversions in `smash_gas` cannot overflow.

Also moves the SUI-coin-type and ownership checks inline into the gas-payment loop so they apply consistently across execution, dry-run, and simulate paths, and unifies `validity_check` / `validity_check_no_gas_check` with mock-gas injection reordered so gas budget and price are validated consistently in the simulate/dev-inspect path.

Adds tests for the total-bound rejection, dry-run gas budget/price validation, and rejection of non-SUI gas reservations.