### PR TITLE
feat(consensus): wait for transaction-vote target blocks before accepting (flag-gated, default off)

### DIFF
--- a/consensus/config/src/consensus_protocol_config.rs
+++ b/consensus/config/src/consensus_protocol_config.rs
@@ -31,6 +31,8 @@ pub struct ConsensusProtocolConfig {
     leader_schedule_window_size: u32,
     /// Number of commit indices that use the same Mysticeti v3 leader schedule.
     leader_schedule_update_interval: u32,
+    /// Whether to enforce transaction-vote targets as block acceptance dependencies.
+    enforce_transaction_vote_dependencies: bool,
 }
 
 impl Default for ConsensusProtocolConfig {
@@ -48,6 +50,7 @@ impl Default for ConsensusProtocolConfig {
             enable_v3: false,
             leader_schedule_window_size: 600,
             leader_schedule_update_interval: 60,
+            enforce_transaction_vote_dependencies: false,
         }
     }
 }
@@ -66,6 +69,7 @@ impl ConsensusProtocolConfig {
         enable_v3: bool,
         leader_schedule_window_size: u32,
         leader_schedule_update_interval: u32,
+        enforce_transaction_vote_dependencies: bool,
     ) -> Self {
         Self {
             protocol_version,
@@ -80,6 +84,7 @@ impl ConsensusProtocolConfig {
             enable_v3,
             leader_schedule_window_size,
             leader_schedule_update_interval,
+            enforce_transaction_vote_dependencies,
         }
     }
 
@@ -99,6 +104,9 @@ impl ConsensusProtocolConfig {
             enable_v3: false,
             leader_schedule_window_size: 600,
             leader_schedule_update_interval: 60,
+            // Kept false in for_testing so existing tests are unaffected; tests that exercise the
+            // enforcement opt in via set_enforce_transaction_vote_dependencies_for_testing.
+            enforce_transaction_vote_dependencies: false,
         }
     }
 
@@ -155,6 +163,10 @@ impl ConsensusProtocolConfig {
         self.leader_schedule_update_interval.max(1)
     }
 
+    pub fn enforce_transaction_vote_dependencies(&self) -> bool {
+        self.enforce_transaction_vote_dependencies
+    }
+
     // Test setter methods
 
     pub fn set_gc_depth_for_testing(&mut self, val: u32) {
@@ -195,5 +207,9 @@ impl ConsensusProtocolConfig {
 
     pub fn set_leader_schedule_update_interval_for_testing(&mut self, val: u32) {
         self.leader_schedule_update_interval = val;
+    }
+
+    pub fn set_enforce_transaction_vote_dependencies_for_testing(&mut self, val: bool) {
+        self.enforce_transaction_vote_dependencies = val;
     }
 }

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -353,6 +353,70 @@ impl BlockManager {
             }
         }
 
+        // When enabled, treat each transaction-vote target block as an additional acceptance
+        // dependency, reusing the same missing-ancestor machinery: the block is suspended until the
+        // target is present, and missing targets are scheduled for fetching.
+        //
+        // TODO(reviewed follow-up): this suspend-until-present approach is GC-bounded (we only
+        // consider targets with round > gc_round) but does not reject vote targets that are not in
+        // the block's causal history, so a Byzantine author could "stamp" arbitrary in-window refs
+        // and force suspension on blocks that may never arrive (within the GC window). A stricter
+        // rule would REJECT any vote target not reachable from the block's ancestors, which
+        // requires causal-history (ancestor) traversal here. That tighter check is intentionally
+        // deferred to a follow-up after review.
+        if self
+            .context
+            .protocol_config
+            .enforce_transaction_vote_dependencies()
+        {
+            // Dedup targets via a set: a block may vote on the same target more than once, and a
+            // vote target may also be an ancestor (already handled above).
+            let vote_targets = block
+                .transaction_votes()
+                .iter()
+                .map(|vote| vote.block_ref)
+                .filter(|target| target.round == GENESIS_ROUND || target.round > gc_round)
+                .filter(|target| !missing_ancestors.contains(target))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+
+            for (found, target) in dag_state
+                .contains_blocks(vote_targets.clone())
+                .into_iter()
+                .zip_debug_eq(vote_targets.iter())
+            {
+                if !found {
+                    missing_ancestors.insert(*target);
+
+                    self.missing_ancestors
+                        .entry(*target)
+                        .or_default()
+                        .insert(block_ref);
+
+                    let target_hostname = &self.context.committee.authority(target.author).hostname;
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .block_manager_missing_ancestors_by_authority
+                        .with_label_values(&[target_hostname])
+                        .inc();
+
+                    if !self.suspended_blocks.contains_key(target) {
+                        ancestors_to_fetch.insert(*target);
+                        if self.missing_blocks.insert(*target) {
+                            self.context
+                                .metrics
+                                .node_metrics
+                                .block_manager_missing_blocks_by_authority
+                                .with_label_values(&[target_hostname])
+                                .inc();
+                        }
+                    }
+                }
+            }
+        }
+
         // Remove the block ref from the `missing_blocks` - if exists - since we now have received the block. The block
         // might still get suspended, but we won't report it as missing in order to not re-fetch.
         self.missing_blocks.remove(&block.reference());
@@ -613,7 +677,7 @@ mod tests {
 
     use crate::{
         CommitDigest,
-        block::{BlockAPI, VerifiedBlock},
+        block::{BlockAPI, BlockTransactionVotes, TestBlock, VerifiedBlock},
         block_manager::BlockManager,
         commit::TrustedCommit,
         context::Context,
@@ -1192,5 +1256,152 @@ mod tests {
         // If the median based timestamp is enabled then all the blocks should be accepted
         assert_eq!(all_blocks, accepted_blocks);
         assert!(missing.is_empty());
+    }
+
+    /// Builds round-1 blocks (one per authority) rooted at genesis. Returns them as VerifiedBlocks
+    /// in author-index order. The block manager treats genesis ancestors as present, so these
+    /// blocks have a complete causal history and can be accepted directly.
+    fn round_1_blocks(genesis_refs: &[BlockRef]) -> Vec<VerifiedBlock> {
+        (0..4)
+            .map(|author| {
+                let block = TestBlock::new(1, author)
+                    .set_ancestors(genesis_refs.to_vec())
+                    .build();
+                VerifiedBlock::new_for_test(block)
+            })
+            .collect()
+    }
+
+    /// With the enforcement flag ON, a block voting on an ABSENT (non-ancestor) target must be
+    /// suspended, and must be unsuspended once that target arrives.
+    #[tokio::test]
+    async fn enforce_transaction_vote_dependencies_suspends_then_unsuspends() {
+        // GIVEN
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_enforce_transaction_vote_dependencies_for_testing(true);
+        context.protocol_config.set_gc_depth_for_testing(10);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
+
+        let dag_builder = DagBuilder::new(context.clone());
+        let genesis_refs = dag_builder.genesis_block_refs();
+
+        let r1 = round_1_blocks(&genesis_refs);
+
+        // Accept authorities 1, 2, 3 at round 1. Hold back authority 0's round-1 block, which will
+        // be the absent transaction-vote target.
+        let (accepted, _missing) =
+            block_manager.try_accept_blocks(vec![r1[1].clone(), r1[2].clone(), r1[3].clone()]);
+        assert_eq!(accepted.len(), 3);
+
+        // A round-2 block by authority 1 whose ancestors (authorities 1, 2, 3 at round 1) are all
+        // present, so it would normally be accepted. It votes on authority 0's round-1 block, which
+        // is NOT an ancestor and is absent.
+        let vote_target = r1[0].reference();
+        let round_2 = TestBlock::new(2, 1)
+            .set_ancestors(vec![
+                r1[1].reference(),
+                r1[2].reference(),
+                r1[3].reference(),
+            ])
+            .set_transaction_votes(vec![BlockTransactionVotes {
+                block_ref: vote_target,
+                rejects: vec![],
+            }])
+            .build();
+        let round_2 = VerifiedBlock::new_for_test(round_2);
+
+        // WHEN
+        let (accepted, missing) = block_manager.try_accept_blocks(vec![round_2.clone()]);
+
+        // THEN the block is suspended on the absent vote target.
+        assert!(accepted.is_empty());
+        assert!(
+            missing.contains(&vote_target),
+            "absent vote target should be reported as missing"
+        );
+        assert_eq!(
+            block_manager.suspended_blocks(),
+            vec![round_2.reference()],
+            "block should be suspended on its absent vote target"
+        );
+        // The suspension must come from the gated vote-dependency branch, not the normal ancestor
+        // path: authority 0 is NOT an ancestor of round_2, so the only way its missing-ancestor
+        // counter is incremented is by treating the vote target as an acceptance dependency. This
+        // confirms the enforcement path actually ran and was not trivially bypassed.
+        let target_hostname = &context.committee.authority(vote_target.author).hostname;
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .block_manager_missing_ancestors_by_authority
+                .with_label_values(&[target_hostname])
+                .get(),
+            1,
+            "the vote target's author should be recorded as a missing acceptance dependency"
+        );
+
+        // WHEN the vote target arrives.
+        let (accepted, _missing) = block_manager.try_accept_blocks(vec![r1[0].clone()]);
+
+        // THEN both the target and the previously suspended block are accepted.
+        let accepted_refs = accepted.iter().map(|b| b.reference()).collect::<Vec<_>>();
+        assert!(accepted_refs.contains(&vote_target));
+        assert!(accepted_refs.contains(&round_2.reference()));
+        assert!(block_manager.is_empty());
+    }
+
+    /// With the enforcement flag OFF (default), a block is accepted regardless of whether its
+    /// transaction-vote targets are present. Pins behavior-neutrality of the default-off path.
+    #[tokio::test]
+    async fn transaction_vote_dependencies_not_enforced_by_default() {
+        // GIVEN
+        let (context, _key_pairs) = Context::new_for_test(4);
+        assert!(
+            !context
+                .protocol_config
+                .enforce_transaction_vote_dependencies()
+        );
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
+
+        let dag_builder = DagBuilder::new(context.clone());
+        let genesis_refs = dag_builder.genesis_block_refs();
+
+        let r1 = round_1_blocks(&genesis_refs);
+
+        // Accept authorities 1, 2, 3 at round 1, hold back authority 0.
+        let (accepted, _missing) =
+            block_manager.try_accept_blocks(vec![r1[1].clone(), r1[2].clone(), r1[3].clone()]);
+        assert_eq!(accepted.len(), 3);
+
+        // A round-2 block voting on the absent authority-0 round-1 block. With the flag OFF, the
+        // absent vote target is ignored and the block is accepted immediately.
+        let round_2 = TestBlock::new(2, 1)
+            .set_ancestors(vec![
+                r1[1].reference(),
+                r1[2].reference(),
+                r1[3].reference(),
+            ])
+            .set_transaction_votes(vec![BlockTransactionVotes {
+                block_ref: r1[0].reference(),
+                rejects: vec![],
+            }])
+            .build();
+        let round_2 = VerifiedBlock::new_for_test(round_2);
+
+        // WHEN
+        let (accepted, missing) = block_manager.try_accept_blocks(vec![round_2.clone()]);
+
+        // THEN the block is accepted and nothing is missing/suspended.
+        assert_eq!(accepted, vec![round_2.clone()]);
+        assert!(missing.is_empty());
+        assert!(block_manager.is_empty());
     }
 }

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -146,9 +146,62 @@ impl SignedBlockVerifier {
             });
         }
 
+        // When enabled, perform stateless well-formedness checks on transaction votes. These
+        // mirror the ancestor checks: each voted-on target must have a valid author index and a
+        // round strictly below the block's round, and a target at the genesis round must be a
+        // known genesis block ref. Presence of the target block itself is enforced later as an
+        // acceptance dependency in BlockManager.
+        if self
+            .context
+            .protocol_config
+            .enforce_transaction_vote_dependencies()
+        {
+            self.check_transaction_votes(block)?;
+        }
+
         let batch: Vec<_> = block.transactions().iter().map(|t| t.data()).collect();
 
         self.check_transactions(&batch)
+    }
+
+    /// Stateless validation of a block's `transaction_votes`. Always safe to call: it uses
+    /// `transaction_votes()` (which returns `&[]` on V1) and never `transaction_votes_cutoff_round()`
+    /// (which panics on V1/V2).
+    fn check_transaction_votes(&self, block: &SignedBlock) -> ConsensusResult<()> {
+        let committee = &self.context.committee;
+        let votes = block.transaction_votes();
+
+        // Cap the number of vote entries. Each ancestor can be voted on at most once, and the
+        // number of ancestors is itself bounded by the committee size, so use that as the bound.
+        let max_vote_entries = committee.size();
+        if votes.len() > max_vote_entries {
+            return Err(ConsensusError::TooManyTransactionVotes {
+                count: votes.len(),
+                limit: max_vote_entries,
+            });
+        }
+
+        for vote in votes {
+            let target = &vote.block_ref;
+            if !committee.is_valid_index(target.author) {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    index: target.author,
+                    max: committee.size() - 1,
+                });
+            }
+            if target.round >= block.round() {
+                return Err(ConsensusError::InvalidTransactionVoteRound {
+                    target: target.round,
+                    block: block.round(),
+                });
+            }
+            // Mirror the ancestor genesis check: a target at the genesis round must be a known
+            // genesis block ref.
+            if target.round == GENESIS_ROUND && !self.genesis.contains(target) {
+                return Err(ConsensusError::InvalidGenesisAncestor(*target));
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn check_transactions(&self, batch: &[&[u8]]) -> ConsensusResult<()> {
@@ -246,7 +299,7 @@ mod test {
 
     use super::*;
     use crate::{
-        block::{TestBlock, Transaction},
+        block::{BlockTransactionVotes, TestBlock, Transaction},
         context::Context,
         transaction::{TransactionVerifier, ValidationError},
     };
@@ -653,5 +706,174 @@ mod test {
                 Err(ConsensusError::InvalidTransaction(_))
             ));
         }
+    }
+
+    // When `enforce_transaction_vote_dependencies` is ON, malformed transaction-vote refs (invalid
+    // author index, round >= block round, fake genesis ref) and too many vote entries must be
+    // rejected by the verifier. Also verifies that a V2 block carrying transaction_votes never
+    // triggers the cutoff-round panic.
+    #[tokio::test]
+    async fn test_verify_transaction_votes_enforced() {
+        let mut protocol_config = ConsensusProtocolConfig::for_testing();
+        protocol_config.set_enforce_transaction_vote_dependencies_for_testing(true);
+
+        let (context, keypairs) = Context::new_for_test(4);
+        let context = Arc::new(context.with_protocol_config(protocol_config));
+
+        const AUTHOR: u32 = 2;
+        let author_protocol_keypair = &keypairs[AUTHOR as usize].1;
+        let verifier = SignedBlockVerifier::new(context.clone(), Arc::new(TxnSizeVerifier {}));
+
+        let base_block = TestBlock::new(10, AUTHOR)
+            .set_ancestors_raw(vec![
+                BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+                BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockDigest::MIN),
+            ])
+            .set_transactions(vec![Transaction::new(vec![4; 8])]);
+
+        // A well-formed transaction vote on an earlier-round target passes verification. This is a
+        // V2 block with transaction_votes, exercising the safe `transaction_votes()` path (no
+        // cutoff-round panic).
+        {
+            let block = base_block
+                .clone()
+                .set_transaction_votes(vec![BlockTransactionVotes {
+                    block_ref: BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+                    rejects: vec![0],
+                }])
+                .build();
+            let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
+            verifier.verify_block(&signed_block).unwrap();
+        }
+
+        // Vote target with an invalid author index is rejected.
+        {
+            let block = base_block
+                .clone()
+                .set_transaction_votes(vec![BlockTransactionVotes {
+                    block_ref: BlockRef::new(9, AuthorityIndex::new_for_test(4), BlockDigest::MIN),
+                    rejects: vec![],
+                }])
+                .build();
+            let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify_block(&signed_block),
+                Err(ConsensusError::InvalidAuthorityIndex { index: _, max: _ })
+            ));
+        }
+
+        // Vote target with round equal to the block's round is rejected.
+        {
+            let block = base_block
+                .clone()
+                .set_transaction_votes(vec![BlockTransactionVotes {
+                    block_ref: BlockRef::new(10, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+                    rejects: vec![],
+                }])
+                .build();
+            let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify_block(&signed_block),
+                Err(ConsensusError::InvalidTransactionVoteRound {
+                    target: _,
+                    block: _
+                })
+            ));
+        }
+
+        // Too many vote entries (> committee size) are rejected.
+        {
+            let votes = (0..context.committee.size() + 1)
+                .map(|i| BlockTransactionVotes {
+                    block_ref: BlockRef::new(
+                        9,
+                        AuthorityIndex::new_for_test((i % 4) as u32),
+                        BlockDigest::MIN,
+                    ),
+                    rejects: vec![],
+                })
+                .collect();
+            let block = base_block.clone().set_transaction_votes(votes).build();
+            let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify_block(&signed_block),
+                Err(ConsensusError::TooManyTransactionVotes { count: _, limit: _ })
+            ));
+        }
+
+        // A vote target at the genesis round that is not a known genesis block ref is rejected.
+        {
+            let block = base_block
+                .clone()
+                .set_transaction_votes(vec![BlockTransactionVotes {
+                    block_ref: BlockRef::new(
+                        GENESIS_ROUND,
+                        AuthorityIndex::new_for_test(1),
+                        BlockDigest::MIN,
+                    ),
+                    rejects: vec![],
+                }])
+                .build();
+            let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify_block(&signed_block),
+                Err(ConsensusError::InvalidGenesisAncestor(_))
+            ));
+        }
+
+        // A vote target that is a known genesis block ref is accepted.
+        {
+            let genesis_ref = genesis_blocks(&context)
+                .into_iter()
+                .map(|b| b.reference())
+                .next()
+                .expect("at least one genesis block");
+            let block = base_block
+                .clone()
+                .set_transaction_votes(vec![BlockTransactionVotes {
+                    block_ref: genesis_ref,
+                    rejects: vec![],
+                }])
+                .build();
+            let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
+            verifier.verify_block(&signed_block).unwrap();
+        }
+    }
+
+    // When the flag is OFF (default), malformed transaction-vote refs do NOT cause verifier
+    // rejection. This pins behavior-neutrality of the default-off path.
+    #[tokio::test]
+    async fn test_verify_transaction_votes_not_enforced_by_default() {
+        let (context, keypairs) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        assert!(
+            !context
+                .protocol_config
+                .enforce_transaction_vote_dependencies()
+        );
+
+        const AUTHOR: u32 = 2;
+        let author_protocol_keypair = &keypairs[AUTHOR as usize].1;
+        let verifier = SignedBlockVerifier::new(context.clone(), Arc::new(TxnSizeVerifier {}));
+
+        // A malformed vote target (invalid author, round >= block round) would be rejected with the
+        // flag ON, but is ignored by the verifier with the flag OFF.
+        let block = TestBlock::new(10, AUTHOR)
+            .set_ancestors_raw(vec![
+                BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockDigest::MIN),
+                BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockDigest::MIN),
+            ])
+            .set_transactions(vec![Transaction::new(vec![4; 8])])
+            .set_transaction_votes(vec![BlockTransactionVotes {
+                block_ref: BlockRef::new(11, AuthorityIndex::new_for_test(4), BlockDigest::MIN),
+                rejects: vec![],
+            }])
+            .build();
+        let signed_block = SignedBlock::new(block, author_protocol_keypair).unwrap();
+        verifier.verify_block(&signed_block).unwrap();
     }
 }

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -128,6 +128,14 @@ pub enum ConsensusError {
     #[error("Insufficient stake from parents: {parent_stakes} < {quorum}")]
     InsufficientParentStakes { parent_stakes: Stake, quorum: Stake },
 
+    #[error("Block contains too many transaction vote entries: {count} > {limit}")]
+    TooManyTransactionVotes { count: usize, limit: usize },
+
+    #[error(
+        "Transaction vote target round ({target}) should be lower than the block's round ({block})"
+    )]
+    InvalidTransactionVoteRound { target: Round, block: Round },
+
     #[error("Invalid transaction: {0}")]
     InvalidTransaction(String),
 

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -340,6 +340,219 @@ mod consensus_tests {
         );
     }
 
+    /// Multi-node test for the `enforce_transaction_vote_dependencies` feature with the flag ON.
+    ///
+    /// When the flag is ON, a block's transaction-vote targets become additional acceptance
+    /// dependencies in `BlockManager`. In honest operation a block's vote targets are always within
+    /// its causal history (votes are derived from `link_causal_history` of the block's ancestors),
+    /// so the targets are present by the time the voting block is accepted and the enforcement is a
+    /// no-op for liveness. This test stands up a live, all-honest committee and asserts:
+    ///   (a) consensus stays LIVE: commits advance well past genesis on every authority;
+    ///   (b) blocks carrying transaction-votes on present targets are accepted, and the enforcement
+    ///       processes real vote targets (not a trivially-empty set): the deterministic verifier
+    ///       rejects half the transactions, so finalized commits carry reject votes -- the V2
+    ///       transaction-votes whose targets BlockManager treats as acceptance dependencies;
+    ///   (d) parity: the flag-ON run commits the SAME set of transactions as an identical flag-OFF
+    ///       control run (the enforcement neither drops nor stalls any transaction).
+    ///
+    /// The deterministic suspend -> arrive -> unsuspend path (c) is covered by the
+    /// `enforce_transaction_vote_dependencies_suspends_then_unsuspends` unit test in
+    /// `consensus/core/src/block_manager.rs`, which can withhold a specific vote target; in a live
+    /// honest committee a vote target is never absent (see above), so that path cannot be forced
+    /// here without injecting Byzantine behavior.
+    #[sim_test(config = "test_config()")]
+    async fn test_enforce_transaction_vote_dependencies_liveness_and_parity() {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(RegistryService::new(db_registry));
+
+        // A fixed, deterministic workload so the committed transaction set is well-defined and can
+        // be compared across the flag-OFF and flag-ON runs.
+        const NUM_OF_AUTHORITIES: usize = 4;
+        const NUM_TRANSACTIONS: u16 = 400;
+
+        // Control run with the flag OFF, then the run under test with the flag ON.
+        let (off_committed, off_reject_voted_blocks) =
+            run_vote_dependency_workload(NUM_OF_AUTHORITIES, NUM_TRANSACTIONS, false).await;
+        let (on_committed, on_reject_voted_blocks) =
+            run_vote_dependency_workload(NUM_OF_AUTHORITIES, NUM_TRANSACTIONS, true).await;
+
+        // (d) Parity: both runs commit the full submitted transaction set, and the two committed
+        // sets are identical. Enforcement neither drops nor stalls any transaction.
+        let expected: std::collections::BTreeSet<Vec<u8>> = (0..NUM_TRANSACTIONS)
+            .map(vote_dependency_transaction)
+            .collect();
+        assert_eq!(
+            off_committed, expected,
+            "flag-OFF control should commit every submitted transaction"
+        );
+        assert_eq!(
+            on_committed, expected,
+            "flag-ON run should commit every submitted transaction"
+        );
+        assert_eq!(
+            on_committed, off_committed,
+            "flag-ON and flag-OFF runs must commit the same transaction set (parity)"
+        );
+
+        // (b) The enforcement path is exercised on real targets, not trivially bypassed: the
+        // deterministic verifier rejects half the transactions, so finalized commits carry reject
+        // votes. Reject votes are the V2 transaction-votes whose targets BlockManager treats as
+        // acceptance dependencies under the flag; a positive count proves the flag-ON run processed
+        // real, present vote targets end-to-end rather than an empty vote set.
+        assert!(
+            on_reject_voted_blocks > 0,
+            "flag-ON run should commit blocks with reject votes so the enforcement path processes \
+             real vote targets"
+        );
+        // Sanity: the control run also produced reject votes, confirming the workload exercises V2
+        // transaction-voting in both configurations.
+        assert!(
+            off_reject_voted_blocks > 0,
+            "flag-OFF control should also produce reject votes"
+        );
+    }
+
+    /// The deterministic payload for transaction `i` in the vote-dependency workload.
+    fn vote_dependency_transaction(i: u16) -> Vec<u8> {
+        let mut txn = vec![0u8; 16];
+        txn[0..2].copy_from_slice(&i.to_le_bytes());
+        txn
+    }
+
+    /// Runs a live committee with `enforce_transaction_vote_dependencies` set to `enforce`, submits
+    /// a fixed deterministic set of `num_transactions`, and drains finalized commits until all of
+    /// them are committed.
+    ///
+    /// Returns the set of committed transaction payloads and the number of committed blocks whose
+    /// transactions received reject votes. (a) Liveness is asserted internally: every authority must
+    /// advance commits, and the drain must complete within the timeout.
+    async fn run_vote_dependency_workload(
+        num_of_authorities: usize,
+        num_transactions: u16,
+        enforce: bool,
+    ) -> (std::collections::BTreeSet<Vec<u8>>, usize) {
+        // Each transaction whose first byte is odd is deterministically rejected, so V2 blocks carry
+        // reject votes on real, present targets in both the flag-ON and flag-OFF runs.
+        let (committee, keypairs) = local_committee_and_keys(0, vec![1; num_of_authorities]);
+        let mut protocol_config = ConsensusProtocolConfig::for_testing();
+        // Use a generous GC depth and pace submissions (below) so that, in this all-honest
+        // committee, every submitted transaction is committed on a finalized subdag rather than
+        // garbage-collected. This makes the "commit the full submitted set" parity check reliable.
+        protocol_config.set_gc_depth_for_testing(30);
+        // transaction_voting_enabled is already true in for_testing(), so V2 transaction-votes are
+        // produced. Opt this run into the enforcement under test.
+        protocol_config.set_enforce_transaction_vote_dependencies_for_testing(enforce);
+        assert_eq!(
+            protocol_config.enforce_transaction_vote_dependencies(),
+            enforce
+        );
+        assert!(
+            protocol_config.transaction_voting_enabled(),
+            "V2 transaction-votes must be enabled for this test"
+        );
+
+        let mut authorities = Vec::with_capacity(committee.size());
+        let mut transaction_clients = Vec::with_capacity(committee.size());
+
+        for (authority_index, _authority_info) in committee.authorities() {
+            let db_dir = Arc::new(TempDir::new().unwrap());
+            let mut params = default_parameters();
+            params.db_path = db_dir.path().to_path_buf();
+
+            let config = Config {
+                authority_index,
+                db_dir,
+                committee: committee.clone(),
+                keypairs: keypairs.clone(),
+                boot_counter: 0,
+                protocol_config: protocol_config.clone(),
+                clock_drift: 0,
+                transaction_verifier: Arc::new(DeterministicRejectVerifier {}),
+                parameters: params,
+                observer_network_keypair: None,
+                observer_ip: None,
+            };
+            let node = AuthorityNode::new(config);
+            node.start().await.unwrap();
+            node.spawn_committed_subdag_consumer().unwrap();
+            transaction_clients.push(node.transaction_client());
+            authorities.push(node);
+        }
+
+        let mut commit_consumer_receivers = vec![];
+        for authority in &authorities {
+            commit_consumer_receivers.push(authority.commit_consumer_receiver());
+        }
+
+        // Submit the fixed deterministic workload, round-robin across authorities.
+        let transaction_clients_clone = transaction_clients.clone();
+        let submit_handle = tokio::spawn(async move {
+            for i in 0..num_transactions {
+                let txn = vote_dependency_transaction(i);
+                transaction_clients_clone[i as usize % transaction_clients_clone.len()]
+                    .submit(vec![txn])
+                    .await
+                    .unwrap();
+                // Pace submissions so blocks are committed before they age out of the GC window.
+                if i % 8 == 0 {
+                    sleep(Duration::from_millis(50)).await;
+                }
+            }
+        });
+        submit_handle.await.unwrap();
+
+        // Drain finalized commits from every authority until all submitted transactions are
+        // committed, cross-checking that authorities agree on the commit sequence (safety) as we go.
+        let mut committed: std::collections::BTreeSet<Vec<u8>> = std::collections::BTreeSet::new();
+        // Count blocks whose transactions received reject votes. Reject votes are exactly the V2
+        // transaction-votes whose targets the enforcement path treats as acceptance dependencies, so
+        // a positive count proves the enforcement processed real, present vote targets end-to-end
+        // (and was not trivially bypassed). We read the public `rejected_transactions_by_block`
+        // rather than the (crate-private) `transaction_votes()` slice type.
+        let mut reject_voted_blocks = 0usize;
+        let mut highest_commit_index = 0u32;
+        while committed.len() < num_transactions as usize {
+            let mut last_sub_dag_commit_ref = None;
+            for receiver in commit_consumer_receivers.iter_mut() {
+                let sub_dag = timeout(Duration::from_secs(90), receiver.recv())
+                    .await
+                    .expect("Timeout waiting for subdag draining commits")
+                    .expect("Commit consumer closed unexpectedly");
+
+                // Safety: all authorities must output the same commit at each index.
+                if let Some(expected_ref) = last_sub_dag_commit_ref {
+                    assert_eq!(expected_ref, sub_dag.commit_ref);
+                } else {
+                    last_sub_dag_commit_ref = Some(sub_dag.commit_ref);
+                    highest_commit_index = sub_dag.commit_ref.index;
+                    reject_voted_blocks += sub_dag
+                        .rejected_transactions_by_block
+                        .values()
+                        .filter(|rejected| !rejected.is_empty())
+                        .count();
+                    for block in &sub_dag.blocks {
+                        for txn in block.transactions() {
+                            committed.insert(txn.data().to_vec());
+                        }
+                    }
+                }
+            }
+        }
+
+        // (a) Liveness: commits advanced well past genesis.
+        assert!(
+            highest_commit_index > 1,
+            "consensus should advance commits beyond genesis (highest index {highest_commit_index})"
+        );
+
+        for authority in authorities {
+            authority.stop();
+        }
+
+        (committed, reject_voted_blocks)
+    }
+
     // Test with multiple Observer nodes in a chain
     #[sim_test(config = "test_config()")]
     async fn test_observer_chain_connectivity() {
@@ -598,6 +811,31 @@ mod consensus_tests {
                     .unwrap())
             }
             _ => Err(format!("Unsupported multiaddr format: {}", addr)),
+        }
+    }
+
+    // Transaction verifier that votes deterministically by transaction content: a transaction is
+    // rejected iff its first byte is odd. Determinism keeps the produced reject votes identical
+    // across the flag-OFF and flag-ON runs, which is required for the parity assertion.
+    struct DeterministicRejectVerifier {}
+
+    impl TransactionVerifier for DeterministicRejectVerifier {
+        fn verify_batch(&self, _transactions: &[&[u8]]) -> Result<(), ValidationError> {
+            Ok(())
+        }
+
+        fn verify_and_vote_batch(
+            &self,
+            _block_ref: &BlockRef,
+            batch: &[&[u8]],
+        ) -> Result<Vec<TransactionIndex>, ValidationError> {
+            let mut rejected_indices = vec![];
+            for (index, transaction) in batch.iter().enumerate() {
+                if transaction.first().is_some_and(|b| b % 2 == 1) {
+                    rejected_indices.push(index as TransactionIndex);
+                }
+            }
+            Ok(rejected_indices)
         }
     }
 

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -164,6 +164,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         /* enable_v3 */ false,
         /* leader_schedule_window_size */ 300,
         /* leader_schedule_update_interval */ 12,
+        config.consensus_enforce_transaction_vote_dependencies(),
     )
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -805,6 +805,12 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     consensus_zstd_compression: bool,
 
+    // If true, enforce that a block's transaction-vote targets (the `block_ref`s in
+    // `transaction_votes`) are well-formed and present before the block is accepted. The voted-on
+    // target blocks become additional acceptance dependencies, treated like missing ancestors.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_enforce_transaction_vote_dependencies: bool,
+
     // If true, enables the optimizations for child object mutations, removing unnecessary mutations
     #[serde(skip_serializing_if = "is_false")]
     minimize_child_object_mutations: bool,
@@ -2526,6 +2532,11 @@ impl ProtocolConfig {
 
     pub fn consensus_zstd_compression(&self) -> bool {
         self.feature_flags.consensus_zstd_compression
+    }
+
+    pub fn consensus_enforce_transaction_vote_dependencies(&self) -> bool {
+        self.feature_flags
+            .consensus_enforce_transaction_vote_dependencies
     }
 
     pub fn enable_nitro_attestation(&self) -> bool {


### PR DESCRIPTION
## What
Adds protocol feature flag `consensus_enforce_transaction_vote_dependencies` (default **off**, snapshot-neutral). When enabled, a block is not accepted until the blocks it casts transaction-votes on are present in the DAG — reusing the existing suspension/fetch machinery — plus structural guardrails on vote targets.

## Why
Prerequisite for bandwidth-efficient ("minimal") block propagation: re-inflating a block's stripped vote-target digests requires those target blocks to be present locally. Also closes the gap where unvalidated "stamp" votes were accepted.

## Changes (all gated; flag-off is a no-op)
- `block_manager::try_accept_one_block`: in-GC-window vote targets become acceptance dependencies (suspend-until-present, deduped; reuses `suspended_blocks`/`missing_ancestors`/fetch).
- `block_verifier`: vote-target guardrails — valid author, `round < block.round`, genesis-ref check, cardinality cap (≤ committee size).

## Testing
- consensus-core unit tests (`block_manager`, `block_verifier`).
- Flag-ON multi-node simtest (`consensus/simtests`): liveness, flag-on/off commit **parity**, and reject-votes actually processed (enforcement path exercised, not bypassed).
- `cargo check` / `clippy` / `fmt` clean; `sui-protocol-config` snapshots unchanged.