### PR TITLE
[typed-store] Add DBMap::snapshot_iterator for point-in-time iteration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,7 +180,7 @@ jobs:
           swap-size-gb: 256
       - name: cargo test with tidehunter
         run: |
-          RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo nextest run --profile ci --cargo-quiet -p sui-core --features typed-store/tidehunter
+          RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo nextest run --profile ci --cargo-quiet -p sui-core -p typed-store --features typed-store/tidehunter
       - name: cargo check sui-tool with tidehunter + tideconsole
         run: |
           RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo check --quiet -p sui-tool --features typed-store/tidehunter,sui-tool/tideconsole

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8484,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2e0cd5669b1b6776e204e9ad0385189a65a62236#2e0cd5669b1b6776e204e9ad0385189a65a62236"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7dc059d320721f0c15ed276c104b113e63223fec#7dc059d320721f0c15ed276c104b113e63223fec"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18183,7 +18183,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2e0cd5669b1b6776e204e9ad0385189a65a62236#2e0cd5669b1b6776e204e9ad0385189a65a62236"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7dc059d320721f0c15ed276c104b113e63223fec#7dc059d320721f0c15ed276c104b113e63223fec"
 dependencies = [
  "anyhow",
  "clap",
@@ -18198,7 +18198,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2e0cd5669b1b6776e204e9ad0385189a65a62236#2e0cd5669b1b6776e204e9ad0385189a65a62236"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7dc059d320721f0c15ed276c104b113e63223fec#7dc059d320721f0c15ed276c104b113e63223fec"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8484,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7dc059d320721f0c15ed276c104b113e63223fec#7dc059d320721f0c15ed276c104b113e63223fec"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=131e31eccdbddf5a859b8466aafda10868c2850a#131e31eccdbddf5a859b8466aafda10868c2850a"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18183,7 +18183,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7dc059d320721f0c15ed276c104b113e63223fec#7dc059d320721f0c15ed276c104b113e63223fec"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=131e31eccdbddf5a859b8466aafda10868c2850a#131e31eccdbddf5a859b8466aafda10868c2850a"
 dependencies = [
  "anyhow",
  "clap",
@@ -18198,7 +18198,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7dc059d320721f0c15ed276c104b113e63223fec#7dc059d320721f0c15ed276c104b113e63223fec"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=131e31eccdbddf5a859b8466aafda10868c2850a#131e31eccdbddf5a859b8466aafda10868c2850a"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -55,7 +55,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "7dc059d320721f0c15ed276c104b113e63223fec", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "131e31eccdbddf5a859b8466aafda10868c2850a", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -55,7 +55,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "2e0cd5669b1b6776e204e9ad0385189a65a62236", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "7dc059d320721f0c15ed276c104b113e63223fec", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "2e0cd5669b1b6776e204e9ad0385189a65a62236", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "7dc059d320721f0c15ed276c104b113e63223fec", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "7dc059d320721f0c15ed276c104b113e63223fec", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "131e31eccdbddf5a859b8466aafda10868c2850a", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1184,6 +1184,76 @@ impl<K, V> DBMap<K, V> {
             },
         }
     }
+
+    /// Iterates the whole table as a consistent point-in-time snapshot.
+    /// Equivalent to `snapshot_iterator_with_bounds(None, None, false)`.
+    pub fn snapshot_iterator(&self) -> DbIterator<'_, (K, V)>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        self.snapshot_iterator_with_bounds(None, None, false)
+    }
+
+    /// Iterates the table as a consistent point-in-time snapshot, optionally
+    /// bounded and/or reversed.
+    ///
+    /// RocksDB and in-memory iterators are already snapshot-consistent from the
+    /// moment they are created, so this delegates to the regular iterators. The
+    /// tidehunter backend's live iterator is not stable under concurrent writes,
+    /// so this opens a short-lived checkpoint and iterates that frontier instead;
+    /// the returned iterator owns the checkpoint, pinning the snapshot for its
+    /// lifetime.
+    ///
+    /// Bound semantics match the regular iterators: forward is `[lower, upper)`
+    /// (upper exclusive), reverse is `[lower, upper]` (both inclusive).
+    pub fn snapshot_iterator_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+        reverse: bool,
+    ) -> DbIterator<'_, (K, V)>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        #[cfg(tidehunter)]
+        if let Storage::TideHunter(db) = &self.db.storage {
+            let ColumnFamily::TideHunter((ks, prefix)) = &self.column_family else {
+                unreachable!("storage backend invariant violation");
+            };
+            // Mirror the bound computation of the regular iterators so the snapshot
+            // observes the same key range: forward via `iterator_bounds` (upper
+            // exclusive), reverse via an inclusive range.
+            let (lower, upper) = if reverse {
+                iterator_bounds_with_range::<K>((
+                    lower_bound
+                        .as_ref()
+                        .map(Bound::Included)
+                        .unwrap_or(Bound::Unbounded),
+                    upper_bound
+                        .as_ref()
+                        .map(Bound::Included)
+                        .unwrap_or(Bound::Unbounded),
+                ))
+            } else {
+                iterator_bounds(lower_bound, upper_bound)
+            };
+            let mut iter = db.checkpoint().iterator(*ks);
+            apply_range_bounds(&mut iter, lower, upper, prefix);
+            if reverse {
+                iter.reverse();
+            }
+            return Box::new(transform_th_iterator(iter, prefix, self.start_iter_timer()));
+        }
+        if reverse {
+            // Infallible across all backends; only the `Result` shape differs.
+            self.reversed_safe_iter_with_bounds(lower_bound, upper_bound)
+                .expect("reversed iterator construction is infallible")
+        } else {
+            self.safe_iter_with_bounds(lower_bound, upper_bound)
+        }
+    }
 }
 
 pub enum StorageWriteBatch {

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -875,3 +875,69 @@ async fn test_safe_iter_returns_error_on_deserialization_failure() {
         "Data should still exist in the database"
     );
 }
+
+#[cfg(tidehunter)]
+fn open_th_map(name: &str) -> DBMap<u64, String> {
+    use crate::tidehunter_util::{KeyShapeBuilder, KeyType, ThConfig, add_key_space, open};
+    let mut builder = KeyShapeBuilder::new();
+    // u64 keys serialize to 8 fixed bytes via `be_fix_int_ser`.
+    let config = ThConfig::new(8, 16, KeyType::uniform(1));
+    let ks = add_key_space(&mut builder, name, &config);
+    let key_shape = builder.build();
+    let metric_conf = MetricConf::new("test_snapshot_iter");
+    let (inner_db, registry_id) = open(temp_dir().as_path(), key_shape, &metric_conf);
+    let db = Arc::new(Database::new(
+        Storage::TideHunter(inner_db),
+        metric_conf,
+        Some(registry_id),
+    ));
+    DBMap::reopen_th(db, name, ks, None)
+}
+
+#[cfg(tidehunter)]
+#[tokio::test]
+async fn test_snapshot_iterator_tidehunter_point_in_time() {
+    let db = open_th_map("snapshot_iter");
+    db.insert(&1, &"a".to_string()).unwrap();
+    db.insert(&2, &"b".to_string()).unwrap();
+    db.insert(&3, &"c".to_string()).unwrap();
+
+    // Open the snapshot iterator (captures the frontier now), THEN mutate the
+    // live map: overwrite k1, delete k2, add k4.
+    let iter = db.snapshot_iterator();
+    db.insert(&1, &"A".to_string()).unwrap();
+    db.remove(&2).unwrap();
+    db.insert(&4, &"d".to_string()).unwrap();
+
+    // The iterator still yields the pre-mutation snapshot, even though the live
+    // map has advanced (this is what the tidehunter checkpoint buys us; a plain
+    // tidehunter iterator would not be stable here).
+    let snapshot: Vec<(u64, String)> = iter.map(Result::unwrap).collect();
+    assert_eq!(
+        snapshot,
+        vec![
+            (1, "a".to_string()),
+            (2, "b".to_string()),
+            (3, "c".to_string())
+        ]
+    );
+
+    // A fresh snapshot iterator observes the latest state.
+    let live: Vec<(u64, String)> = db.snapshot_iterator().map(Result::unwrap).collect();
+    assert_eq!(
+        live,
+        vec![
+            (1, "A".to_string()),
+            (3, "c".to_string()),
+            (4, "d".to_string())
+        ]
+    );
+
+    // Bounds and reverse work on the snapshot too: reverse [1, 3] inclusive over
+    // the live state {1, 3, 4} yields keys 3 then 1.
+    let reversed: Vec<(u64, String)> = db
+        .snapshot_iterator_with_bounds(Some(1), Some(3), true)
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(reversed, vec![(3, "c".to_string()), (1, "A".to_string())]);
+}

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -284,7 +284,7 @@ async fn test_sampling_time() {
 mod tidehunter_tests {
     use super::*;
     use std::collections::BTreeMap;
-    use typed_store::tidehunter_util::ThConfig;
+    use typed_store::tidehunter_util::{KeyType, ThConfig};
 
     #[derive(DBMapUtils)]
     #[tidehunter]
@@ -297,8 +297,8 @@ mod tidehunter_tests {
     async fn test_tidehunter_map() {
         let primary_path = temp_dir();
         let configs = vec![
-            ("table1".to_string(), ThConfig::new(11, 1, 1)),
-            ("table2".to_string(), ThConfig::new(11, 1, 1)),
+            ("table1".to_string(), ThConfig::new(11, 1, KeyType::uniform(1))),
+            ("table2".to_string(), ThConfig::new(11, 1, KeyType::uniform(1))),
         ];
         let db = ThTable::open_tables_read_write(
             primary_path.clone(),

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -297,8 +297,14 @@ mod tidehunter_tests {
     async fn test_tidehunter_map() {
         let primary_path = temp_dir();
         let configs = vec![
-            ("table1".to_string(), ThConfig::new(11, 1, KeyType::uniform(1))),
-            ("table2".to_string(), ThConfig::new(11, 1, KeyType::uniform(1))),
+            (
+                "table1".to_string(),
+                ThConfig::new(11, 1, KeyType::uniform(1)),
+            ),
+            (
+                "table2".to_string(),
+                ThConfig::new(11, 1, KeyType::uniform(1)),
+            ),
         ];
         let db = ThTable::open_tables_read_write(
             primary_path.clone(),


### PR DESCRIPTION
## Summary

Adds `DBMap::snapshot_iterator()` and `DBMap::snapshot_iterator_with_bounds(lower, upper, reverse)` — iterators over a **consistent point-in-time view** of a table, with optional bounds and direction.

- **RocksDB / in-memory**: their iterators are already snapshot-consistent from the moment they're created, so this just delegates to the regular `safe_iter_with_bounds` / `reversed_safe_iter_with_bounds`.
- **tidehunter**: the live iterator is *not* stable under concurrent writes, so this opens a short-lived `Db::checkpoint()` and iterates that frontier instead. The returned iterator owns the checkpoint, pinning the snapshot for its lifetime.
- Bound semantics match the existing iterators: forward `[lower, upper)` (upper exclusive), reverse `[lower, upper]` (both inclusive).

All tidehunter-specific code is `#[cfg(tidehunter)]`-gated; the rocksdb build is unchanged.

Bumps the tidehunter pin to `7dc059d`, which provides the `Db::checkpoint()` API (used only on the tidehunter path).

## Test plan

- `cargo check -p typed-store` (default/rocksdb) — clean
- `cargo clippy -p typed-store --all-targets` (default) — clean
- `USE_TIDEHUNTER=1 cargo check/clippy -p typed-store --lib` — clean
- `USE_TIDEHUNTER=1 cargo check -p sui-core --lib` — compiles against the new rev

🤖 Generated with [Claude Code](https://claude.com/claude-code)