### PR TITLE
[consensus] add v3 FlexCommitter

### DIFF
--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -382,11 +382,12 @@ mod tests {
                     .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
                     .cloned()
                     .collect::<Vec<_>>();
-                let blocks = dag_state
-                    .read()
-                    .get_blocks(&block_refs)
-                    .into_iter()
-                    .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+                let block_opts = dag_state.read().get_blocks(&block_refs);
+                let blocks = block_opts.iter().map(|block_opt| {
+                    block_opt
+                        .as_ref()
+                        .expect("We should have all blocks in dag state.")
+                });
                 median_timestamp_by_stake(&context, blocks).unwrap()
             };
 

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -1,0 +1,494 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// FlexCommitter is wired into Core in a follow-up PR.
+#![allow(dead_code)]
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use consensus_config::{DIGEST_LENGTH, DefaultHashFunction};
+use consensus_types::block::{BlockRef, BlockTimestampMs, Round};
+use fastcrypto::hash::HashFunction as _;
+use itertools::Itertools as _;
+use parking_lot::RwLock;
+use rand::{SeedableRng as _, rngs::StdRng, seq::SliceRandom as _};
+
+use crate::{
+    BlockAPI, VerifiedBlock,
+    block::Slot,
+    commit::{Commit, CommitAPI, CommittedSubDag, LeaderStatus, TrustedCommit},
+    context::Context,
+    dag_state::DagState,
+    leader_schedule_v3::NextCommitLeaderSchedule,
+    leader_slot_decider::{INDIRECT_COMMIT_DEPTH, LeaderSlotDecider},
+};
+
+#[cfg(test)]
+#[path = "tests/flex_committer_tests.rs"]
+mod flex_committer_tests;
+
+/// FlexCommitter supports committing multiple and varying number of leaders per round,
+/// based on DagState and the schedule for next commit leaders.
+pub(crate) struct FlexCommitter {
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    slot_decider: LeaderSlotDecider,
+    pending_commit_state: PendingCommitState,
+}
+
+impl FlexCommitter {
+    pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
+        let slot_decider = LeaderSlotDecider::new(context.clone(), dag_state.clone());
+        Self {
+            context,
+            dag_state,
+            slot_decider,
+            pending_commit_state: PendingCommitState::default(),
+        }
+    }
+
+    /// Attempts to create a commit based on the current DagState.
+    pub(crate) fn try_commit(
+        &mut self,
+        next_commit_leaders: NextCommitLeaderSchedule,
+    ) -> Option<(TrustedCommit, CommittedSubDag)> {
+        self.maybe_refresh_pending_commit_state(next_commit_leaders);
+
+        self.try_direct_commit();
+        if let Some(commit_leader_round) = self.find_commit_leader_round() {
+            return self.build_commit(commit_leader_round);
+        }
+
+        self.try_indirect_commit();
+        if let Some(commit_leader_round) = self.find_commit_leader_round() {
+            return self.build_commit(commit_leader_round);
+        }
+
+        None
+    }
+
+    fn maybe_refresh_pending_commit_state(
+        &mut self,
+        next_commit_leaders: NextCommitLeaderSchedule,
+    ) {
+        if self
+            .pending_commit_state
+            .next_commit_leaders
+            .next_commit_index
+            == next_commit_leaders.next_commit_index
+        {
+            // Use cached pending commit state for the same commit index.
+            return;
+        }
+        assert!(
+            self.pending_commit_state
+                .next_commit_leaders
+                .next_commit_index
+                < next_commit_leaders.next_commit_index,
+            "next_commit_index should only move forward: {} vs {}",
+            self.pending_commit_state
+                .next_commit_leaders
+                .next_commit_index,
+            next_commit_leaders.next_commit_index
+        );
+        self.pending_commit_state = PendingCommitState {
+            next_commit_leaders,
+            rounds: vec![],
+        };
+    }
+
+    /// Runs the direct commit rule on every leader slot pending to be decided.
+    fn try_direct_commit(&mut self) {
+        let min_next_leader_round = self
+            .pending_commit_state
+            .next_commit_leaders
+            .min_next_leader_round;
+        let highest_accepted_round = self.dag_state.read().highest_accepted_round();
+
+        for leader_round in min_next_leader_round..highest_accepted_round {
+            let round_state = self
+                .pending_commit_state
+                .get_or_create_round_state(leader_round);
+            let slots_to_decide = round_state
+                .leader_slots
+                .iter()
+                .filter_map(|s| {
+                    if matches!(s.leader_status, LeaderStatus::Undecided(_)) {
+                        Some(s.slot)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            for slot in slots_to_decide {
+                let status = self.slot_decider.try_direct_decide(slot);
+                round_state.update_slot_decision(slot, status);
+            }
+        }
+    }
+
+    fn try_indirect_commit(&mut self) {
+        let min_next_leader_round = self
+            .pending_commit_state
+            .next_commit_leaders
+            .min_next_leader_round;
+        let highest_accepted_round = self.dag_state.read().highest_accepted_round();
+        // Decide leaders from highest to lowest round, because lower rounds need anchor blocks in
+        // higher rounds to be decided first.
+        for round in (min_next_leader_round
+            ..=(highest_accepted_round.saturating_sub(INDIRECT_COMMIT_DEPTH)))
+            .rev()
+        {
+            let Some(anchor_block) = self.find_anchor_block(round + INDIRECT_COMMIT_DEPTH) else {
+                // Skip when there is no anchor block for this round yet.
+                continue;
+            };
+            self.decide_with_anchor_block(anchor_block.clone(), round);
+        }
+    }
+
+    fn find_anchor_block(&self, start_round: Round) -> Option<VerifiedBlock> {
+        let start_index = start_round
+            - self
+                .pending_commit_state
+                .next_commit_leaders
+                .min_next_leader_round;
+        for index in start_index as usize..self.pending_commit_state.rounds.len() {
+            let round_state = &self.pending_commit_state.rounds[index];
+            for slot in &round_state.leader_slots {
+                match &slot.leader_status {
+                    // First committed block becomes the anchor block, where there is no undecided slot before it.
+                    LeaderStatus::Commit(block) => return Some(block.clone()),
+                    // There cannot be an anchor block after an undecided.
+                    LeaderStatus::Undecided(_) => return None,
+                    // Continue searching for an anchor block after skipped slots.
+                    LeaderStatus::Skip(_) => {}
+                }
+            }
+        }
+        None
+    }
+
+    // Finds leader slots on `decision_round` and calls indirect commit rule with `anchor_block`
+    // to decide on their statuses.
+    fn decide_with_anchor_block(&mut self, anchor_block: VerifiedBlock, decision_round: Round) {
+        let round_state = self
+            .pending_commit_state
+            .get_or_create_round_state(decision_round);
+        if round_state.undecided_slots.is_empty() {
+            // Skip indirect commit when the round has already been fully decided.
+            return;
+        }
+
+        let slots: Vec<Slot> = round_state.leader_slots.iter().map(|s| s.slot).collect();
+        let statuses = self.slot_decider.try_indirect_decide(&anchor_block, &slots);
+        for (slot, status) in slots.into_iter().zip_eq(statuses) {
+            round_state.update_slot_decision(slot, status);
+        }
+    }
+
+    // The next commit leader round must have all slots decided in this and earlier rounds,
+    // and at least one slot in this round committed.
+    fn find_commit_leader_round(&self) -> Option<Round> {
+        for round_state in &self.pending_commit_state.rounds {
+            if !round_state.undecided_slots.is_empty() {
+                // Found undecided slot, so this and later rounds cannot be committed yet.
+                return None;
+            }
+            if round_state.num_committed > 0 {
+                // Found a fully decided round with at least one committed leader, so it can be committed.
+                return Some(round_state.round);
+            }
+            // This round is fully decided but has no committed leader, so it is skipped.
+        }
+        None
+    }
+
+    /// Builds a single commit with leaders from `commit_leader_round`.
+    ///
+    /// Traversal starts from all committed leaders in `commit_leader_round`,
+    /// read from `pending_commit_state`. Other committed blocks are selected
+    /// via DFS from the leaders. Only uncommitted blocks above GC round are selected.
+    ///
+    /// Committed blocks are ordered deterministically: by round ascending, then
+    /// by `hash(seed || block_digest)` within a round. The last block of the
+    /// sorted leader round becomes the commit's named `leader`.
+    fn build_commit(
+        &mut self,
+        commit_leader_round: Round,
+    ) -> Option<(TrustedCommit, CommittedSubDag)> {
+        let committed_leaders: Vec<VerifiedBlock> = {
+            let round_state = self
+                .pending_commit_state
+                .get_or_create_round_state(commit_leader_round);
+            round_state
+                .leader_slots
+                .iter()
+                .filter_map(|s| match &s.leader_status {
+                    LeaderStatus::Commit(block) => Some(block.clone()),
+                    LeaderStatus::Undecided(slot) => panic!("Unexpected undecided slot {}", slot),
+                    _ => None,
+                })
+                .collect()
+        };
+        assert!(!committed_leaders.is_empty(), "No committed leaders found");
+
+        let mut dag_state = self.dag_state.write();
+        let last_commit_digest = dag_state.last_commit_digest();
+        let gc_round = dag_state.gc_round();
+
+        // DFS from all committed leaders. For each block, select its uncommitted
+        // ancestors above gc_round, mark them committed, and continue until the
+        // frontier is empty.
+        for leader in &committed_leaders {
+            assert!(
+                dag_state.set_committed(&leader.reference()),
+                "Leader block {:?} attempted to be committed twice",
+                leader.reference()
+            );
+        }
+        let mut to_visit: Vec<VerifiedBlock> = committed_leaders.clone();
+        let mut to_commit: Vec<VerifiedBlock> = Vec::new();
+        while let Some(block) = to_visit.pop() {
+            to_commit.push(block.clone());
+            let uncommitted_ancestor_refs: Vec<BlockRef> = block
+                .ancestors()
+                .iter()
+                .copied()
+                .filter(|a| a.round > gc_round && !dag_state.is_committed(a))
+                .collect();
+            for ancestor_ref in uncommitted_ancestor_refs {
+                if !dag_state.set_committed(&ancestor_ref) {
+                    continue;
+                }
+                to_visit.push(dag_state.get_block(&ancestor_ref).unwrap());
+            }
+        }
+        assert!(
+            to_commit.iter().all(|b| b.round() > gc_round),
+            "No blocks at or below gc_round {gc_round} should be committed"
+        );
+        drop(dag_state);
+
+        // Sort the committed blocks deterministically, first by round ascending,
+        // then by deterministic hash specific to this commit and each block.
+        let seed = compute_sort_seed(&committed_leaders);
+        sort_committed_blocks(&mut to_commit, &seed);
+
+        // Named leader = the committed leader that ended up last among the
+        // committed leaders in the sorted sub-dag.
+        let leader_ref = to_commit
+            .last()
+            .map(|b| b.reference())
+            .expect("At least one committed leader must be in to_commit");
+        assert_eq!(leader_ref.round, commit_leader_round);
+
+        // Compute deterministic commit timestamp from leader parents.
+        let timestamp_ms =
+            calculate_commit_timestamp(&self.context, &self.dag_state.read(), &committed_leaders);
+
+        let commit = Commit::new(
+            self.pending_commit_state
+                .next_commit_leaders
+                .next_commit_index,
+            last_commit_digest,
+            timestamp_ms,
+            leader_ref,
+            to_commit.iter().map(|b| b.reference()).collect(),
+        );
+        let serialized = commit
+            .serialize()
+            .unwrap_or_else(|e| panic!("Failed to serialize commit: {e}"));
+        let trusted_commit = TrustedCommit::new_trusted(commit, serialized);
+        let sub_dag = CommittedSubDag::new(
+            leader_ref,
+            to_commit,
+            timestamp_ms,
+            trusted_commit.reference(),
+        );
+        Some((trusted_commit, sub_dag))
+    }
+
+    /// Builds a CommittedSubDag for a certified commit synced from a peer, and
+    /// marks every committed block in DagState. The commit is already
+    /// quorum-certified, so the commit rule is skipped here — unlike local
+    /// commits, which are produced by `build_commit`.
+    pub(crate) fn handle_certified_commit(&self, commit: &TrustedCommit) -> CommittedSubDag {
+        let mut dag_state = self.dag_state.write();
+        for block_ref in commit.blocks() {
+            assert!(
+                dag_state.set_committed(block_ref),
+                "Block {:?} attempted to be committed twice",
+                block_ref
+            );
+        }
+        let blocks: Vec<VerifiedBlock> = dag_state
+            .get_blocks(commit.blocks())
+            .into_iter()
+            .map(|b| b.expect("All blocks referenced by a trusted commit must be in DagState"))
+            .collect();
+        drop(dag_state);
+
+        let mut subdag = CommittedSubDag::new(
+            commit.leader(),
+            blocks,
+            commit.timestamp_ms(),
+            commit.reference(),
+        );
+        subdag.decided_with_local_blocks = false;
+        subdag
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct PendingCommitState {
+    next_commit_leaders: NextCommitLeaderSchedule,
+    rounds: Vec<RoundState>,
+}
+
+impl PendingCommitState {
+    fn get_or_create_round_state(&mut self, round: Round) -> &mut RoundState {
+        let add_from_round = self
+            .rounds
+            .last()
+            .map(|state| state.round + 1)
+            .unwrap_or(self.next_commit_leaders.min_next_leader_round);
+        // No-op if the round's state exists.
+        for r in add_from_round..=round {
+            let mut seed_bytes = [0u8; 32];
+            seed_bytes[28..].copy_from_slice(&r.to_le_bytes());
+            let mut rng = StdRng::from_seed(seed_bytes);
+            let mut leaders = self
+                .next_commit_leaders
+                .allowed_leaders
+                .choose_multiple(&mut rng, self.next_commit_leaders.num_leaders())
+                .cloned()
+                .collect::<Vec<_>>();
+            leaders.shuffle(&mut rng);
+            let leader_slots: Vec<LeaderSlot> = leaders
+                .into_iter()
+                .map(|leader| {
+                    let slot = Slot::new(r, leader);
+                    LeaderSlot {
+                        slot,
+                        leader_status: LeaderStatus::Undecided(slot),
+                    }
+                })
+                .collect();
+            let undecided_slots: BTreeSet<Slot> = leader_slots.iter().map(|s| s.slot).collect();
+            self.rounds.push(RoundState {
+                round: r,
+                leader_slots,
+                undecided_slots,
+                num_committed: 0,
+            });
+        }
+        let index = round
+            .checked_sub(self.next_commit_leaders.min_next_leader_round)
+            .unwrap() as usize;
+        &mut self.rounds[index]
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RoundState {
+    round: Round,
+    leader_slots: Vec<LeaderSlot>,
+    undecided_slots: BTreeSet<Slot>,
+    num_committed: usize,
+}
+
+impl RoundState {
+    fn update_slot_decision(&mut self, slot: Slot, new_status: LeaderStatus) {
+        let leader_slot = self
+            .leader_slots
+            .iter_mut()
+            .find(|s| s.slot == slot)
+            .unwrap_or_else(|| panic!("Slot {} must be in round {}", slot, self.round));
+        if matches!(new_status, LeaderStatus::Undecided(_)) {
+            if matches!(leader_slot.leader_status, LeaderStatus::Undecided(_)) {
+                // No-op if the status is still undecided.
+                return;
+            } else {
+                // Undeciding a previously decided slot should not happen.
+                panic!(
+                    "Cannot undecide slot {}: {:?} vs {:?}",
+                    slot, leader_slot.leader_status, new_status
+                );
+            }
+        }
+        if self.undecided_slots.remove(&slot) {
+            if matches!(new_status, LeaderStatus::Commit(_)) {
+                self.num_committed += 1;
+            }
+            leader_slot.leader_status = new_status;
+        } else {
+            assert_eq!(
+                leader_slot.leader_status, new_status,
+                "Cannot update slot {} decision: {:?} vs {:?}",
+                slot, leader_slot.leader_status, new_status
+            );
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LeaderSlot {
+    slot: Slot,
+    leader_status: LeaderStatus,
+}
+
+/// From a deterministic array of leaders, compute a deterministic digest used as seed for sort.
+fn compute_sort_seed(committed_leaders: &[VerifiedBlock]) -> [u8; DIGEST_LENGTH] {
+    let mut hasher = DefaultHashFunction::new();
+    for leader in committed_leaders {
+        hasher.update(leader.digest().as_ref());
+    }
+    hasher.finalize().into()
+}
+
+/// Per-block sort key:
+/// - Primary part: block round.
+/// - Secondary part: hash of seed and block digest.
+fn block_sort_key(
+    seed: &[u8; DIGEST_LENGTH],
+    block_ref: &BlockRef,
+) -> (Round, [u8; DIGEST_LENGTH]) {
+    let mut hasher = DefaultHashFunction::new();
+    hasher.update(seed);
+    hasher.update(block_ref.digest);
+    (block_ref.round, hasher.finalize().into())
+}
+
+fn sort_committed_blocks(blocks: &mut [VerifiedBlock], seed: &[u8; DIGEST_LENGTH]) {
+    blocks.sort_by_cached_key(|b| block_sort_key(seed, &b.reference()));
+}
+
+/// Takes the union of each committed leader's parent-round ancestors,
+/// and returns the median timestamp of parent blocks weighted by stake.
+/// Monotonicity is enforced against `last_commit_timestamp_ms`.
+fn calculate_commit_timestamp(
+    context: &Context,
+    dag_state: &DagState,
+    committed_leaders: &[VerifiedBlock],
+) -> BlockTimestampMs {
+    let leader_round = committed_leaders[0].round();
+    debug_assert!(committed_leaders.iter().all(|b| b.round() == leader_round));
+
+    let mut parent_refs: BTreeSet<BlockRef> = BTreeSet::new();
+    for leader in committed_leaders {
+        for ancestor in leader.ancestors() {
+            if ancestor.round == leader_round.saturating_sub(1) {
+                parent_refs.insert(*ancestor);
+            }
+        }
+    }
+    let parent_refs: Vec<BlockRef> = parent_refs.into_iter().collect();
+    let blocks = dag_state
+        .get_blocks(&parent_refs)
+        .into_iter()
+        .map(|b| b.expect("Parent block must be in dag state"));
+    let ts = crate::linearizer::median_timestamp_by_stake(context, blocks)
+        .unwrap_or_else(|e| panic!("Cannot compute commit timestamp: {e}"));
+    ts.max(dag_state.last_commit_timestamp_ms())
+}

--- a/consensus/core/src/flex_committer.rs
+++ b/consensus/core/src/flex_committer.rs
@@ -1,12 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// FlexCommitter is wired into Core in a follow-up PR.
+// FlexCommitter will be wired into Core in a follow-up PR.
 #![allow(dead_code)]
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
-use consensus_config::{DIGEST_LENGTH, DefaultHashFunction};
+use consensus_config::{AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction, Stake};
 use consensus_types::block::{BlockRef, BlockTimestampMs, Round};
 use fastcrypto::hash::HashFunction as _;
 use itertools::Itertools as _;
@@ -16,7 +19,7 @@ use rand::{SeedableRng as _, rngs::StdRng, seq::SliceRandom as _};
 use crate::{
     BlockAPI, VerifiedBlock,
     block::Slot,
-    commit::{Commit, CommitAPI, CommittedSubDag, LeaderStatus, TrustedCommit},
+    commit::{Commit, CommitAPI, CommittedSubDag, Decision, LeaderStatus, TrustedCommit},
     context::Context,
     dag_state::DagState,
     leader_schedule_v3::NextCommitLeaderSchedule,
@@ -71,6 +74,8 @@ impl FlexCommitter {
         &mut self,
         next_commit_leaders: NextCommitLeaderSchedule,
     ) {
+        // pending_commit_state.next_commit_leaders contain the schedule for next commit,
+        // and are associated with the other internal state.
         if self
             .pending_commit_state
             .next_commit_leaders
@@ -90,6 +95,15 @@ impl FlexCommitter {
                 .next_commit_leaders
                 .next_commit_index,
             next_commit_leaders.next_commit_index
+        );
+        tracing::debug!(
+            "Refreshing pending commit state: old_commit_index={}, new_commit_index={}, min_next_leader_round={}, num_leaders={}",
+            self.pending_commit_state
+                .next_commit_leaders
+                .next_commit_index,
+            next_commit_leaders.next_commit_index,
+            next_commit_leaders.min_next_leader_round,
+            next_commit_leaders.num_leaders(),
         );
         self.pending_commit_state = PendingCommitState {
             next_commit_leaders,
@@ -122,7 +136,10 @@ impl FlexCommitter {
                 .collect::<Vec<_>>();
             for slot in slots_to_decide {
                 let status = self.slot_decider.try_direct_decide(slot);
-                round_state.update_slot_decision(slot, status);
+                if status.is_decided() {
+                    tracing::debug!("Direct decision for slot {slot}: {status}");
+                }
+                round_state.update_slot_decision(slot, status, Decision::Direct);
             }
         }
     }
@@ -157,7 +174,9 @@ impl FlexCommitter {
             let round_state = &self.pending_commit_state.rounds[index];
             for slot in &round_state.leader_slots {
                 match &slot.leader_status {
-                    // First committed block becomes the anchor block, where there is no undecided slot before it.
+                    // First committed block becomes the anchor block, when there is no undecided slot before it.
+                    // Every validator will select the same anchor block.
+                    // This rule of choosing anchor block minimizes the chance of encountering undecided slots before it.
                     LeaderStatus::Commit(block) => return Some(block.clone()),
                     // There cannot be an anchor block after an undecided.
                     LeaderStatus::Undecided(_) => return None,
@@ -182,8 +201,17 @@ impl FlexCommitter {
 
         let slots: Vec<Slot> = round_state.leader_slots.iter().map(|s| s.slot).collect();
         let statuses = self.slot_decider.try_indirect_decide(&anchor_block, &slots);
+        let anchor_ref = anchor_block.reference();
         for (slot, status) in slots.into_iter().zip_eq(statuses) {
-            round_state.update_slot_decision(slot, status);
+            // Only log slots the indirect rule actually decides. Slots already decided
+            // by the direct rule are re-evaluated (and asserted consistent) but their
+            // decision is kept, so they should not appear as indirect decisions.
+            if round_state.undecided_slots.contains(&slot) {
+                tracing::debug!(
+                    "Indirect decision for slot {slot} using anchor {anchor_ref}: {status}"
+                );
+            }
+            round_state.update_slot_decision(slot, status, Decision::Indirect);
         }
     }
 
@@ -217,20 +245,36 @@ impl FlexCommitter {
         &mut self,
         commit_leader_round: Round,
     ) -> Option<(TrustedCommit, CommittedSubDag)> {
-        let committed_leaders: Vec<VerifiedBlock> = {
-            let round_state = self
-                .pending_commit_state
-                .get_or_create_round_state(commit_leader_round);
-            round_state
-                .leader_slots
-                .iter()
-                .filter_map(|s| match &s.leader_status {
-                    LeaderStatus::Commit(block) => Some(block.clone()),
-                    LeaderStatus::Undecided(slot) => panic!("Unexpected undecided slot {}", slot),
-                    _ => None,
-                })
-                .collect()
-        };
+        let round_state = self
+            .pending_commit_state
+            .get_round_state(commit_leader_round);
+        let mut committed_leaders = Vec::new();
+        for s in &round_state.leader_slots {
+            // Record every decided leader slot in the commit round: the authority
+            // whose slot it is, how it was decided (direct/indirect), and whether
+            // it was committed or skipped.
+            let (authority, outcome) = match &s.leader_status {
+                LeaderStatus::Commit(block) => {
+                    committed_leaders.push(block.clone());
+                    (block.author(), "commit")
+                }
+                LeaderStatus::Skip(slot) => (slot.authority, "skip"),
+                LeaderStatus::Undecided(slot) => panic!("Unexpected undecided slot {}", slot),
+            };
+            let decision = match s.decision.expect("Decided slot must have a decision") {
+                Decision::Direct => "direct",
+                Decision::Indirect => "indirect",
+                Decision::Certified => "certified",
+            };
+            let commit_type = format!("{decision}-{outcome}");
+            let leader_host: &str = &self.context.committee.authority(authority).hostname;
+            self.context
+                .metrics
+                .node_metrics
+                .committed_leaders_total
+                .with_label_values(&[leader_host, &commit_type])
+                .inc();
+        }
         assert!(!committed_leaders.is_empty(), "No committed leaders found");
 
         let mut dag_state = self.dag_state.write();
@@ -306,6 +350,22 @@ impl FlexCommitter {
             timestamp_ms,
             trusted_commit.reference(),
         );
+
+        tracing::debug!(
+            "Built commit {} for leader round {} with {} committed leaders and {} blocks. Scheduled min next leader round {}, num allowed leaders {}",
+            trusted_commit.reference(),
+            commit_leader_round,
+            committed_leaders.len(),
+            sub_dag.blocks.len(),
+            self.pending_commit_state
+                .next_commit_leaders
+                .min_next_leader_round,
+            self.pending_commit_state
+                .next_commit_leaders
+                .allowed_leaders
+                .len(),
+        );
+
         Some((trusted_commit, sub_dag))
     }
 
@@ -314,6 +374,12 @@ impl FlexCommitter {
     /// quorum-certified, so the commit rule is skipped here — unlike local
     /// commits, which are produced by `build_commit`.
     pub(crate) fn handle_certified_commit(&self, commit: &TrustedCommit) -> CommittedSubDag {
+        tracing::debug!(
+            "Handling certified commit {} with leader {} and {} blocks",
+            commit.reference(),
+            commit.leader(),
+            commit.blocks().len()
+        );
         let mut dag_state = self.dag_state.write();
         for block_ref in commit.blocks() {
             assert!(
@@ -340,13 +406,27 @@ impl FlexCommitter {
     }
 }
 
+/// Tracks intermediate state related to generating the next commit.
+/// This state resets when encountering a more advanced leader schedule.
 #[derive(Clone, Debug, Default)]
 struct PendingCommitState {
+    // Leader schedule for generating the upcoming commit.
     next_commit_leaders: NextCommitLeaderSchedule,
+    // Intermediate state per round.
     rounds: Vec<RoundState>,
 }
 
 impl PendingCommitState {
+    /// Returns the round' state and panics if it doesn't exist.
+    /// Use `get_or_create_round_state` to create it if needed.
+    fn get_round_state(&mut self, round: Round) -> &mut RoundState {
+        let index = round
+            .checked_sub(self.next_commit_leaders.min_next_leader_round)
+            .unwrap() as usize;
+        self.rounds.get_mut(index).unwrap()
+    }
+
+    /// Populate state up to round, if they don't exist yet. Then return the round's state.
     fn get_or_create_round_state(&mut self, round: Round) -> &mut RoundState {
         let add_from_round = self
             .rounds
@@ -358,12 +438,7 @@ impl PendingCommitState {
             let mut seed_bytes = [0u8; 32];
             seed_bytes[28..].copy_from_slice(&r.to_le_bytes());
             let mut rng = StdRng::from_seed(seed_bytes);
-            let mut leaders = self
-                .next_commit_leaders
-                .allowed_leaders
-                .choose_multiple(&mut rng, self.next_commit_leaders.num_leaders())
-                .cloned()
-                .collect::<Vec<_>>();
+            let mut leaders = self.next_commit_leaders.allowed_leaders.clone();
             leaders.shuffle(&mut rng);
             let leader_slots: Vec<LeaderSlot> = leaders
                 .into_iter()
@@ -372,6 +447,7 @@ impl PendingCommitState {
                     LeaderSlot {
                         slot,
                         leader_status: LeaderStatus::Undecided(slot),
+                        decision: None,
                     }
                 })
                 .collect();
@@ -383,23 +459,26 @@ impl PendingCommitState {
                 num_committed: 0,
             });
         }
-        let index = round
-            .checked_sub(self.next_commit_leaders.min_next_leader_round)
-            .unwrap() as usize;
-        &mut self.rounds[index]
+
+        self.get_round_state(round)
     }
 }
 
+/// Per-round intermediate state computed with commit rule and current leader schedule
 #[derive(Clone, Debug)]
 struct RoundState {
     round: Round,
+    // Leader slots selected in the round, in order.
     leader_slots: Vec<LeaderSlot>,
+    // Leader slots that haven't decided.
     undecided_slots: BTreeSet<Slot>,
+    // Number of leader slots voted to be committed.
+    // They may not appear in an actual commit as leaders though.
     num_committed: usize,
 }
 
 impl RoundState {
-    fn update_slot_decision(&mut self, slot: Slot, new_status: LeaderStatus) {
+    fn update_slot_decision(&mut self, slot: Slot, new_status: LeaderStatus, decision: Decision) {
         let leader_slot = self
             .leader_slots
             .iter_mut()
@@ -422,6 +501,10 @@ impl RoundState {
                 self.num_committed += 1;
             }
             leader_slot.leader_status = new_status;
+            // Record the rule that first decided this slot. A slot decided by the direct
+            // rule may be re-evaluated by the indirect rule in the same round, but the
+            // initial decision is kept (the else branch leaves `decision` untouched).
+            leader_slot.decision = Some(decision);
         } else {
             assert_eq!(
                 leader_slot.leader_status, new_status,
@@ -436,6 +519,8 @@ impl RoundState {
 struct LeaderSlot {
     slot: Slot,
     leader_status: LeaderStatus,
+    // Which commit rule decided the slot (direct or indirect), or None while undecided.
+    decision: Option<Decision>,
 }
 
 /// From a deterministic array of leaders, compute a deterministic digest used as seed for sort.
@@ -475,19 +560,30 @@ fn calculate_commit_timestamp(
     let leader_round = committed_leaders[0].round();
     debug_assert!(committed_leaders.iter().all(|b| b.round() == leader_round));
 
-    let mut parent_refs: BTreeSet<BlockRef> = BTreeSet::new();
+    // When there are enough leader stake, use leaders to compute the commit timestamp.
+    let total_leader_stake = committed_leaders
+        .iter()
+        .map(|b| context.committee.stake(b.author()))
+        .sum::<Stake>();
+    if total_leader_stake >= context.committee.certification_threshold() {
+        let ts = crate::linearizer::median_timestamp_by_stake(context, committed_leaders)
+            .unwrap_or_else(|e| panic!("Cannot compute commit timestamp: {e}"));
+        return ts.max(dag_state.last_commit_timestamp_ms());
+    }
+
+    let mut parent_refs: BTreeMap<AuthorityIndex, BlockRef> = BTreeMap::new();
     for leader in committed_leaders {
         for ancestor in leader.ancestors() {
-            if ancestor.round == leader_round.saturating_sub(1) {
-                parent_refs.insert(*ancestor);
+            if ancestor.round + 1 == leader_round {
+                parent_refs.insert(ancestor.author, *ancestor);
             }
         }
     }
-    let parent_refs: Vec<BlockRef> = parent_refs.into_iter().collect();
-    let blocks = dag_state
-        .get_blocks(&parent_refs)
-        .into_iter()
-        .map(|b| b.expect("Parent block must be in dag state"));
+    let parent_refs: Vec<BlockRef> = parent_refs.values().cloned().collect();
+    let block_opts = dag_state.get_blocks(&parent_refs);
+    let blocks = block_opts
+        .iter()
+        .map(|b| b.as_ref().expect("Parent block must be in dag state"));
     let ts = crate::linearizer::median_timestamp_by_stake(context, blocks)
         .unwrap_or_else(|e| panic!("Cannot compute commit timestamp: {e}"));
     ts.max(dag_state.last_commit_timestamp_ms())

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -21,6 +21,7 @@ mod core;
 mod core_thread;
 mod dag_state;
 mod error;
+mod flex_committer;
 mod leader_schedule;
 mod leader_schedule_v3;
 mod leader_scoring;

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -137,10 +137,12 @@ impl Linearizer {
                 .cloned()
                 .collect::<Vec<_>>();
             // Get the blocks from dag state which should not fail.
-            let blocks = dag_state
-                .get_blocks(&block_refs)
-                .into_iter()
-                .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+            let block_opts = dag_state.get_blocks(&block_refs);
+            let blocks = block_opts.iter().map(|block_opt| {
+                block_opt
+                    .as_ref()
+                    .expect("We should have all blocks in dag state.")
+            });
             median_timestamp_by_stake(context, blocks).unwrap_or_else(|e| {
                 panic!(
                     "Cannot compute median timestamp for leader block {:?} ancestors: {}",
@@ -288,9 +290,9 @@ impl Linearizer {
 /// Computes the median timestamp of the blocks weighted by the stake of their authorities.
 /// This function assumes each block comes from a different authority of the same round.
 /// Error is returned if no blocks are provided or total stake is less than quorum threshold.
-pub(crate) fn median_timestamp_by_stake(
+pub(crate) fn median_timestamp_by_stake<'a>(
     context: &Context,
-    blocks: impl Iterator<Item = VerifiedBlock>,
+    blocks: impl IntoIterator<Item = &'a VerifiedBlock>,
 ) -> Result<BlockTimestampMs, String> {
     let mut total_stake = 0;
     let mut timestamps = vec![];
@@ -387,11 +389,12 @@ mod tests {
                     .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
                     .cloned()
                     .collect::<Vec<_>>();
-                let blocks = dag_state
-                    .read()
-                    .get_blocks(&block_refs)
-                    .into_iter()
-                    .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+                let block_opts = dag_state.read().get_blocks(&block_refs);
+                let blocks = block_opts.iter().map(|block_opt| {
+                    block_opt
+                        .as_ref()
+                        .expect("We should have all blocks in dag state.")
+                });
 
                 median_timestamp_by_stake(&context, blocks).unwrap()
             };
@@ -509,13 +512,10 @@ mod tests {
 
         let expected_ts = median_timestamp_by_stake(
             &context,
-            subdag.blocks.iter().filter_map(|block| {
-                if block.round() == subdag.leader.round - 1 {
-                    Some(block.clone())
-                } else {
-                    None
-                }
-            }),
+            subdag
+                .blocks
+                .iter()
+                .filter(|block| block.round() == subdag.leader.round - 1),
         )
         .unwrap();
         assert_eq!(subdag.timestamp_ms, expected_ts);
@@ -605,11 +605,12 @@ mod tests {
                     .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
                     .cloned()
                     .collect::<Vec<_>>();
-                let blocks = dag_state
-                    .read()
-                    .get_blocks(&block_refs)
-                    .into_iter()
-                    .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+                let block_opts = dag_state.read().get_blocks(&block_refs);
+                let blocks = block_opts.iter().map(|block_opt| {
+                    block_opt
+                        .as_ref()
+                        .expect("We should have all blocks in dag state.")
+                });
 
                 median_timestamp_by_stake(&context, blocks).unwrap()
             };
@@ -708,11 +709,12 @@ mod tests {
                     .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
                     .cloned()
                     .collect::<Vec<_>>();
-                let blocks = dag_state
-                    .read()
-                    .get_blocks(&block_refs)
-                    .into_iter()
-                    .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+                let block_opts = dag_state.read().get_blocks(&block_refs);
+                let blocks = block_opts.iter().map(|block_opt| {
+                    block_opt
+                        .as_ref()
+                        .expect("We should have all blocks in dag state.")
+                });
 
                 median_timestamp_by_stake(&context, blocks).unwrap()
             };
@@ -913,12 +915,12 @@ mod tests {
         let context = Arc::new(context);
 
         // No blocks provided
-        let err = median_timestamp_by_stake(&context, vec![].into_iter()).unwrap_err();
+        let err = median_timestamp_by_stake(&context, &[] as &[VerifiedBlock]).unwrap_err();
         assert_eq!(err, "No blocks provided");
 
         // Blocks provided but total stake is less than quorum threshold
         let block = VerifiedBlock::new_for_test(TestBlock::new(5, 0).build());
-        let err = median_timestamp_by_stake(&context, vec![block].into_iter()).unwrap_err();
+        let err = median_timestamp_by_stake(&context, &[block]).unwrap_err();
         assert_eq!(err, "Total stake 1 < quorum threshold 3");
     }
 }

--- a/consensus/core/src/tests/flex_committer_tests.rs
+++ b/consensus/core/src/tests/flex_committer_tests.rs
@@ -1,0 +1,706 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use consensus_config::{AuthorityIndex, DIGEST_LENGTH};
+use consensus_types::block::Round;
+use parking_lot::RwLock;
+
+use crate::{
+    VerifiedBlock,
+    block::{BlockAPI, Slot, TestBlock},
+    commit::{CommitAPI, CommitIndex, LeaderStatus},
+    context::Context,
+    dag_state::DagState,
+    flex_committer::{FlexCommitter, LeaderSlot, RoundState, sort_committed_blocks},
+    leader_schedule_v3::NextCommitLeaderSchedule,
+    storage::mem_store::MemStore,
+    test_dag::{build_dag, build_dag_layer},
+};
+
+fn setup(num_authorities: usize) -> (Arc<Context>, Arc<RwLock<DagState>>, FlexCommitter) {
+    let (mut context, _) = Context::new_for_test(num_authorities);
+    context.protocol_config.set_enable_v3_for_testing(true);
+    let context = Arc::new(context);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = FlexCommitter::new(context.clone(), dag_state.clone());
+    (context, dag_state, committer)
+}
+
+fn next_commit_leader_schedule(allowed: Vec<AuthorityIndex>) -> NextCommitLeaderSchedule {
+    NextCommitLeaderSchedule {
+        // > 0 to force `maybe_refresh_pending_commit_state` to install our
+        // allowed_leaders. The default index is 0.
+        next_commit_index: 1,
+        min_next_leader_round: 1,
+        allowed_leaders: allowed,
+    }
+}
+
+/// Schedule builder with explicit index / min round / allowed leaders.
+fn schedule(
+    next_commit_index: CommitIndex,
+    min_next_leader_round: Round,
+    allowed: &[u32],
+) -> NextCommitLeaderSchedule {
+    NextCommitLeaderSchedule {
+        next_commit_index,
+        min_next_leader_round,
+        allowed_leaders: allowed
+            .iter()
+            .map(|a| AuthorityIndex::new_for_test(*a))
+            .collect(),
+    }
+}
+
+// ---- White-box helpers for unit tests on the internal commit state ----
+
+fn commit_block(round: Round, author: u32) -> VerifiedBlock {
+    VerifiedBlock::new_for_test(TestBlock::new(round, author).build())
+}
+
+fn skip(round: Round, author: u32) -> LeaderStatus {
+    LeaderStatus::Skip(Slot::new(round, AuthorityIndex::new_for_test(author)))
+}
+
+fn undecided(round: Round, author: u32) -> LeaderStatus {
+    LeaderStatus::Undecided(Slot::new(round, AuthorityIndex::new_for_test(author)))
+}
+
+/// Builds a `RoundState` directly from leader statuses, deriving `undecided_slots`
+/// and `num_committed` the same way the production code maintains them.
+fn round_state(round: Round, statuses: Vec<LeaderStatus>) -> RoundState {
+    let leader_slots: Vec<LeaderSlot> = statuses
+        .into_iter()
+        .map(|leader_status| {
+            let slot = match &leader_status {
+                LeaderStatus::Commit(block) => Slot::new(block.round(), block.author()),
+                LeaderStatus::Skip(slot) | LeaderStatus::Undecided(slot) => *slot,
+            };
+            LeaderSlot {
+                slot,
+                leader_status,
+            }
+        })
+        .collect();
+    let undecided_slots: BTreeSet<Slot> = leader_slots
+        .iter()
+        .filter(|s| matches!(s.leader_status, LeaderStatus::Undecided(_)))
+        .map(|s| s.slot)
+        .collect();
+    let num_committed = leader_slots
+        .iter()
+        .filter(|s| matches!(s.leader_status, LeaderStatus::Commit(_)))
+        .count();
+    RoundState {
+        round,
+        leader_slots,
+        undecided_slots,
+        num_committed,
+    }
+}
+
+/// Installs `rounds` directly into the committer's pending state, starting at
+/// `min_next_leader_round`. Bypasses DAG-driven decision so that
+/// `find_anchor_block` / `find_commit_leader_round` can be unit-tested against
+/// arbitrary leader-status sequences.
+fn install_rounds(
+    committer: &mut FlexCommitter,
+    min_next_leader_round: Round,
+    rounds: Vec<RoundState>,
+) {
+    committer.maybe_refresh_pending_commit_state(schedule(1, min_next_leader_round, &[0]));
+    committer.pending_commit_state.rounds = rounds;
+}
+
+fn build_blocks(rounds_x_authorities: &[(Round, u32)]) -> Vec<VerifiedBlock> {
+    rounds_x_authorities
+        .iter()
+        .map(|(r, a)| VerifiedBlock::new_for_test(TestBlock::new(*r, *a).build()))
+        .collect()
+}
+
+// =================== Unit tests ===================
+
+#[test]
+fn committed_blocks_are_total_ordered_and_round_major() {
+    let inputs = build_blocks(&[
+        (1, 0),
+        (1, 1),
+        (1, 2),
+        (1, 3),
+        (2, 0),
+        (2, 1),
+        (2, 2),
+        (2, 3),
+    ]);
+    let seed = [7u8; DIGEST_LENGTH];
+
+    let mut a = inputs.clone();
+    let mut b = inputs.clone();
+    b.reverse();
+    let mut c = inputs.clone();
+    c.rotate_left(3);
+
+    sort_committed_blocks(&mut a, &seed);
+    sort_committed_blocks(&mut b, &seed);
+    sort_committed_blocks(&mut c, &seed);
+
+    let refs = |v: &[VerifiedBlock]| v.iter().map(|b| b.reference()).collect::<Vec<_>>();
+    assert_eq!(
+        refs(&a),
+        refs(&b),
+        "sort must be deterministic regardless of input order"
+    );
+    assert_eq!(refs(&a), refs(&c));
+
+    // Round-major, ascending.
+    let rounds: Vec<Round> = a.iter().map(|b| b.round()).collect();
+    assert!(
+        rounds.windows(2).all(|w| w[0] <= w[1]),
+        "rounds must be non-decreasing"
+    );
+}
+
+#[test]
+fn committed_blocks_within_round_are_not_author_ascending() {
+    // With 4 distinct authorities in one round, a meaningful shuffle will
+    // not leave them in author-ascending order for every seed.
+    let inputs = build_blocks(&[(1, 0), (1, 1), (1, 2), (1, 3)]);
+
+    // Try several seeds — at least one should scramble the author order.
+    let mut any_scrambled = false;
+    for s in 0u8..16 {
+        let seed = [s; DIGEST_LENGTH];
+        let mut v = inputs.clone();
+        sort_committed_blocks(&mut v, &seed);
+        let authors: Vec<u32> = v.iter().map(|b| b.author().value() as u32).collect();
+        if authors != vec![0, 1, 2, 3] {
+            any_scrambled = true;
+            break;
+        }
+    }
+    assert!(
+        any_scrambled,
+        "v3 sort should not always leave authors in ascending order"
+    );
+}
+
+/// The within-round order must depend on the seed; a sort that ignored the seed
+/// (e.g. ordering by block digest alone) would be deterministic but seed-blind.
+#[test]
+fn committed_blocks_within_round_order_depends_on_seed() {
+    let inputs = build_blocks(&[(1, 0), (1, 1), (1, 2), (1, 3)]);
+    let order_for = |seed: [u8; DIGEST_LENGTH]| {
+        let mut v = inputs.clone();
+        sort_committed_blocks(&mut v, &seed);
+        v.iter().map(|b| b.reference()).collect::<Vec<_>>()
+    };
+
+    let baseline = order_for([0u8; DIGEST_LENGTH]);
+    let changed = (1u8..=64).any(|s| order_for([s; DIGEST_LENGTH]) != baseline);
+    assert!(changed, "within-round order must depend on the seed");
+}
+
+/// Refreshing with the same `next_commit_index` is a no-op: the accumulated
+/// round state and existing schedule are preserved.
+#[test]
+fn maybe_refresh_is_noop_on_same_index() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
+    committer.pending_commit_state.get_or_create_round_state(3);
+    let rounds_len = committer.pending_commit_state.rounds.len();
+    assert!(rounds_len > 0);
+
+    // Same index but different allowed_leaders → must not reset.
+    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0, 1, 2]));
+    assert_eq!(committer.pending_commit_state.rounds.len(), rounds_len);
+    assert_eq!(
+        committer
+            .pending_commit_state
+            .next_commit_leaders
+            .allowed_leaders
+            .len(),
+        1,
+        "same-index refresh must not replace the schedule",
+    );
+}
+
+/// A higher `next_commit_index` resets the pending state and installs the new schedule.
+#[test]
+fn maybe_refresh_resets_on_higher_index() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
+    committer.pending_commit_state.get_or_create_round_state(3);
+    assert!(!committer.pending_commit_state.rounds.is_empty());
+
+    committer.maybe_refresh_pending_commit_state(schedule(2, 5, &[0, 1, 2, 3]));
+    assert!(
+        committer.pending_commit_state.rounds.is_empty(),
+        "rounds must be cleared on reset",
+    );
+    let installed = &committer.pending_commit_state.next_commit_leaders;
+    assert_eq!(installed.next_commit_index, 2);
+    assert_eq!(installed.min_next_leader_round, 5);
+    assert_eq!(installed.allowed_leaders.len(), 4);
+}
+
+/// `next_commit_index` must move forward; a lower index panics.
+#[test]
+#[should_panic(expected = "next_commit_index should only move forward")]
+fn maybe_refresh_panics_on_lower_index() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    committer.maybe_refresh_pending_commit_state(schedule(3, 1, &[0]));
+    committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
+}
+
+/// The first committed leader, scanning from `start_round`, becomes the anchor.
+#[test]
+fn find_anchor_block_returns_first_committed() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    let anchor = commit_block(2, 1);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![skip(1, 0)]),
+            round_state(2, vec![LeaderStatus::Commit(anchor.clone())]),
+            round_state(3, vec![LeaderStatus::Commit(commit_block(3, 2))]),
+        ],
+    );
+    assert_eq!(
+        committer.find_anchor_block(1).unwrap().reference(),
+        anchor.reference(),
+    );
+}
+
+/// An undecided slot before any commit means no anchor is available.
+#[test]
+fn find_anchor_block_none_when_undecided_first() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![undecided(1, 0)]),
+            round_state(2, vec![LeaderStatus::Commit(commit_block(2, 1))]),
+        ],
+    );
+    assert!(committer.find_anchor_block(1).is_none());
+}
+
+/// Skipped slots — within and across rounds — are passed over until a commit.
+#[test]
+fn find_anchor_block_skips_past_skipped_slots() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    let anchor = commit_block(2, 3);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![skip(1, 0), skip(1, 1)]),
+            round_state(2, vec![skip(2, 2), LeaderStatus::Commit(anchor.clone())]),
+        ],
+    );
+    assert_eq!(
+        committer.find_anchor_block(1).unwrap().reference(),
+        anchor.reference(),
+    );
+}
+
+/// `start_round` skips earlier rounds entirely, even committed ones.
+#[test]
+fn find_anchor_block_respects_start_round() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    let later = commit_block(2, 0);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![LeaderStatus::Commit(commit_block(1, 0))]),
+            round_state(2, vec![LeaderStatus::Commit(later.clone())]),
+        ],
+    );
+    assert_eq!(
+        committer.find_anchor_block(2).unwrap().reference(),
+        later.reference(),
+    );
+}
+
+/// All-skip rounds yield no anchor.
+#[test]
+fn find_anchor_block_none_when_all_skipped() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![skip(1, 0)]),
+            round_state(2, vec![skip(2, 0)]),
+        ],
+    );
+    assert!(committer.find_anchor_block(1).is_none());
+}
+
+/// An undecided slot blocks committing, even if a later round is committed.
+#[test]
+fn find_commit_leader_round_none_when_undecided() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![undecided(1, 0)]),
+            round_state(2, vec![LeaderStatus::Commit(commit_block(2, 0))]),
+        ],
+    );
+    assert!(committer.find_commit_leader_round().is_none());
+}
+
+/// The earliest fully-decided round with a committed leader is the commit round.
+#[test]
+fn find_commit_leader_round_returns_first_committed_round() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![LeaderStatus::Commit(commit_block(1, 0))]),
+            round_state(2, vec![LeaderStatus::Commit(commit_block(2, 0))]),
+        ],
+    );
+    assert_eq!(committer.find_commit_leader_round(), Some(1));
+}
+
+/// Fully-decided all-skip rounds are passed over to a later committed round.
+#[test]
+fn find_commit_leader_round_skips_all_skip_rounds() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![skip(1, 0)]),
+            round_state(2, vec![skip(2, 0), skip(2, 1)]),
+            round_state(3, vec![LeaderStatus::Commit(commit_block(3, 0))]),
+        ],
+    );
+    assert_eq!(committer.find_commit_leader_round(), Some(3));
+}
+
+/// A later undecided round blocks committing, even past earlier all-skip rounds.
+#[test]
+fn find_commit_leader_round_none_when_later_round_undecided() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![
+            round_state(1, vec![skip(1, 0)]),
+            round_state(2, vec![undecided(2, 0)]),
+        ],
+    );
+    assert!(committer.find_commit_leader_round().is_none());
+}
+
+/// A round with a mix of committed and undecided slots is not yet committable.
+#[test]
+fn find_commit_leader_round_none_when_round_partially_decided() {
+    let (_context, _dag_state, mut committer) = setup(4);
+    install_rounds(
+        &mut committer,
+        1,
+        vec![round_state(
+            1,
+            vec![LeaderStatus::Commit(commit_block(1, 0)), undecided(1, 1)],
+        )],
+    );
+    assert!(committer.find_commit_leader_round().is_none());
+}
+
+// =================== Functional `try_commit` tests ===================
+
+/// One leader per round, fully connected DAG → committer emits a commit
+/// rooted at that leader.
+#[tokio::test]
+async fn try_commit_single_leader_committed() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    build_dag(context, dag_state, None, 2);
+
+    let next = next_commit_leader_schedule(vec![AuthorityIndex::new_for_test(0)]);
+    let (commit, subdag) = committer
+        .try_commit(next)
+        .expect("expected a commit when round 1 is fully voted");
+
+    assert_eq!(commit.leader().round, 1);
+    assert_eq!(commit.leader().author, AuthorityIndex::new_for_test(0));
+    assert!(
+        subdag
+            .blocks
+            .iter()
+            .any(|b| b.round() == 1 && b.author() == AuthorityIndex::new_for_test(0)),
+        "sub-dag must include the leader block",
+    );
+}
+
+/// One leader per round, no round-2 block references it → all slots Skip,
+/// no commit emitted.
+#[tokio::test]
+async fn try_commit_single_leader_all_skipped() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_without_leader: Vec<_> = refs_round_1
+        .into_iter()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(0))
+        .collect();
+    build_dag(context, dag_state, Some(refs_without_leader), 2);
+
+    let next = next_commit_leader_schedule(vec![AuthorityIndex::new_for_test(0)]);
+    assert!(committer.try_commit(next).is_none());
+}
+
+/// One leader per round, no round-2 blocks at all → slot Undecided, no
+/// commit emitted (and no anchor available for indirect commit).
+#[tokio::test]
+async fn try_commit_single_leader_undecided() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    build_dag(context, dag_state, None, 1);
+
+    let next = next_commit_leader_schedule(vec![AuthorityIndex::new_for_test(0)]);
+    assert!(committer.try_commit(next).is_none());
+}
+
+/// Commits must be emitted in round order: while an earlier round still has
+/// Undecided slots, no later round may be committed — even if the later
+/// round is fully decided and has a committed leader.
+///
+/// DAG shape (the leader at every round is authority 0):
+///   - Round 1: full layer (4 blocks).
+///   - Round 2: split layer — authorities 0, 1 reference all of round 1
+///     (vote for the round-1 leader), authorities 2, 3 omit it (blame).
+///     Stake for / against the round-1 leader is 2/2, neither side reaches
+///     quorum — round 1 stays Undecided.
+///   - Round 3: full layer on top of round 2, so the round-2 leader has 4
+///     votes and would direct-commit on its own.
+///
+/// `try_commit` must therefore return `None`: the round-1 ambiguity blocks
+/// emitting the round-2 commit until indirect-commit can resolve round 1.
+#[tokio::test]
+async fn try_commit_does_not_skip_undecided_prefix_round() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+    let leader = AuthorityIndex::new_for_test(0);
+
+    // Round 1: full layer.
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_round_1_without_leader: Vec<_> = refs_round_1
+        .iter()
+        .copied()
+        .filter(|r| r.author != leader)
+        .collect();
+
+    // Round 2: 2 voters for the round-1 leader, 2 blames against it.
+    let mut authorities = context.committee.authorities();
+    let mut connections = Vec::with_capacity(4);
+    for _ in 0..2 {
+        connections.push((authorities.next().unwrap().0, refs_round_1.clone()));
+    }
+    for _ in 0..2 {
+        connections.push((
+            authorities.next().unwrap().0,
+            refs_round_1_without_leader.clone(),
+        ));
+    }
+    let refs_round_2 = build_dag_layer(connections, dag_state.clone());
+
+    // Round 3: full layer — the round-2 leader has a quorum of votes.
+    build_dag(context.clone(), dag_state, Some(refs_round_2), 3);
+
+    let next = next_commit_leader_schedule(vec![leader]);
+    assert!(
+        committer.try_commit(next).is_none(),
+        "round 2 must not be committed while round 1 remains undecided",
+    );
+}
+
+/// All four authorities are leaders at round 1, fully connected DAG → one
+/// commit emitted whose sub-dag bundles every committed leader block.
+#[tokio::test]
+async fn try_commit_multi_leader_all_committed() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    build_dag(context, dag_state, None, 2);
+
+    let allowed: Vec<_> = (0..4).map(AuthorityIndex::new_for_test).collect();
+    let next = next_commit_leader_schedule(allowed);
+    let (commit, subdag) = committer
+        .try_commit(next)
+        .expect("expected a commit when all leaders fully voted");
+
+    assert_eq!(commit.leader().round, 1);
+    let round_1_authors: BTreeSet<AuthorityIndex> = subdag
+        .blocks
+        .iter()
+        .filter(|b| b.round() == 1)
+        .map(|b| b.author())
+        .collect();
+    let expected: BTreeSet<AuthorityIndex> = (0..4).map(AuthorityIndex::new_for_test).collect();
+    assert_eq!(round_1_authors, expected);
+}
+
+/// All four authorities are leaders at round 1; round 2 omits authority-0's
+/// block. Three slots Commit + one slot Skip — the round is still
+/// committable, and the sub-dag excludes the skipped leader.
+#[tokio::test]
+async fn try_commit_multi_leader_some_skipped() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_without_leader_0: Vec<_> = refs_round_1
+        .into_iter()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(0))
+        .collect();
+    build_dag(context, dag_state, Some(refs_without_leader_0), 2);
+
+    let allowed: Vec<_> = (0..4).map(AuthorityIndex::new_for_test).collect();
+    let next = next_commit_leader_schedule(allowed);
+    let (commit, subdag) = committer
+        .try_commit(next)
+        .expect("expected a commit — three leaders committed, one skipped");
+
+    assert_eq!(commit.leader().round, 1);
+    assert_ne!(
+        commit.leader().author,
+        AuthorityIndex::new_for_test(0),
+        "skipped leader must not be the named commit leader",
+    );
+    let round_1_authors: BTreeSet<AuthorityIndex> = subdag
+        .blocks
+        .iter()
+        .filter(|b| b.round() == 1)
+        .map(|b| b.author())
+        .collect();
+    let expected: BTreeSet<AuthorityIndex> = (1..4).map(AuthorityIndex::new_for_test).collect();
+    assert_eq!(
+        round_1_authors, expected,
+        "skipped leader's block is not in the sub-dag",
+    );
+}
+
+/// All four authorities are leaders, but round 2 is a "diagonal" — each
+/// authority's round-2 block references only its own round-1 block. Every
+/// leader gets exactly one vote and three blames → all slots Skip → no
+/// commit.
+#[tokio::test]
+async fn try_commit_multi_leader_all_skipped() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+
+    let connections: Vec<_> = context
+        .committee
+        .authorities()
+        .map(|(idx, _)| {
+            let own = refs_round_1
+                .iter()
+                .find(|r| r.author == idx)
+                .copied()
+                .expect("each authority has a round-1 block");
+            (idx, vec![own])
+        })
+        .collect();
+    build_dag_layer(connections, dag_state.clone());
+
+    let allowed: Vec<_> = (0..4).map(AuthorityIndex::new_for_test).collect();
+    let next = next_commit_leader_schedule(allowed);
+    assert!(committer.try_commit(next).is_none());
+}
+
+/// Drives the committer across three schedules — varying the allowed-leader
+/// count each time — with a fully-skipped leader round in the middle.
+///
+/// DAG (4 authorities, quorum 3):
+///   - Rounds 1, 2: full layers.
+///   - Round 3: every block omits authority-0's round-2 block (blames it), so
+///     the round-2 leader 0 collects a quorum of blames.
+///   - Rounds 4, 5: full layers.
+///
+/// Schedule 1 (idx 1, min 1, leaders {0,1}): round 1 fully voted → commit round 1.
+/// Schedule 2 (idx 2, min 2, leaders {0}):   round-2 leader 0 is blamed → round 2
+///   is fully skipped; round-3 leader 0 is voted by round 4 → commit round 3.
+/// Schedule 3 (idx 3, min 4, leaders {0,1,2,3}): round 4 fully voted → commit
+///   round 4 with all four leaders.
+#[tokio::test]
+async fn try_commit_multiple_schedules_with_skipped_round() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state, mut committer) = setup(4);
+
+    // Rounds 1 and 2: fully connected.
+    let refs_round_1 = build_dag(context.clone(), dag_state.clone(), None, 1);
+    let refs_round_2 = build_dag(context.clone(), dag_state.clone(), Some(refs_round_1), 2);
+
+    // Round 3: every authority omits authority-0's round-2 block, so round-2
+    // leader 0 is blamed by a quorum and will be skipped.
+    let refs_round_2_without_0: Vec<_> = refs_round_2
+        .iter()
+        .copied()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(0))
+        .collect();
+    let connections: Vec<_> = context
+        .committee
+        .authorities()
+        .map(|(idx, _)| (idx, refs_round_2_without_0.clone()))
+        .collect();
+    let refs_round_3 = build_dag_layer(connections, dag_state.clone());
+
+    // Rounds 4 and 5: fully connected on top of round 3.
+    let refs_round_4 = build_dag(context.clone(), dag_state.clone(), Some(refs_round_3), 4);
+    build_dag(context.clone(), dag_state.clone(), Some(refs_round_4), 5);
+
+    // Schedule 1: two leaders at round 1, both committed.
+    let (commit1, _) = committer
+        .try_commit(schedule(1, 1, &[0, 1]))
+        .expect("round 1 fully voted → commit");
+    assert_eq!(commit1.leader().round, 1);
+
+    // Schedule 2: single leader. Round 2 is fully skipped (leader 0 blamed),
+    // so the commit lands on round 3.
+    let (commit2, _) = committer
+        .try_commit(schedule(2, 2, &[0]))
+        .expect("round 2 skipped, round 3 committed");
+    assert_eq!(
+        commit2.leader().round,
+        3,
+        "round 2 was fully skipped, so the commit is round 3",
+    );
+
+    // Schedule 3: four leaders at round 4, all committed.
+    let (commit3, subdag3) = committer
+        .try_commit(schedule(3, 4, &[0, 1, 2, 3]))
+        .expect("round 4 fully voted → commit");
+    assert_eq!(commit3.leader().round, 4);
+    let round_4_leaders: BTreeSet<AuthorityIndex> = subdag3
+        .blocks
+        .iter()
+        .filter(|b| b.round() == 4)
+        .map(|b| b.author())
+        .collect();
+    let expected: BTreeSet<AuthorityIndex> = (0..4).map(AuthorityIndex::new_for_test).collect();
+    assert_eq!(
+        round_4_leaders, expected,
+        "all four round-4 leaders committed",
+    );
+}

--- a/consensus/core/src/tests/flex_committer_tests.rs
+++ b/consensus/core/src/tests/flex_committer_tests.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use crate::{
     VerifiedBlock,
     block::{BlockAPI, Slot, TestBlock},
-    commit::{CommitAPI, CommitIndex, LeaderStatus},
+    commit::{CommitAPI, CommitIndex, Decision, LeaderStatus},
     context::Context,
     dag_state::DagState,
     flex_committer::{FlexCommitter, LeaderSlot, RoundState, sort_committed_blocks},
@@ -81,9 +81,16 @@ fn round_state(round: Round, statuses: Vec<LeaderStatus>) -> RoundState {
                 LeaderStatus::Commit(block) => Slot::new(block.round(), block.author()),
                 LeaderStatus::Skip(slot) | LeaderStatus::Undecided(slot) => *slot,
             };
+            // Decided slots in the test fixture are treated as direct decisions;
+            // undecided slots carry no decision.
+            let decision = match &leader_status {
+                LeaderStatus::Commit(_) | LeaderStatus::Skip(_) => Some(Decision::Direct),
+                LeaderStatus::Undecided(_) => None,
+            };
             LeaderSlot {
                 slot,
                 leader_status,
+                decision,
             }
         })
         .collect();
@@ -126,8 +133,8 @@ fn build_blocks(rounds_x_authorities: &[(Round, u32)]) -> Vec<VerifiedBlock> {
 
 // =================== Unit tests ===================
 
-#[test]
-fn committed_blocks_are_total_ordered_and_round_major() {
+#[tokio::test]
+async fn committed_blocks_are_total_ordered_and_round_major() {
     let inputs = build_blocks(&[
         (1, 0),
         (1, 1),
@@ -166,8 +173,8 @@ fn committed_blocks_are_total_ordered_and_round_major() {
     );
 }
 
-#[test]
-fn committed_blocks_within_round_are_not_author_ascending() {
+#[tokio::test]
+async fn committed_blocks_within_round_are_not_author_ascending() {
     // With 4 distinct authorities in one round, a meaningful shuffle will
     // not leave them in author-ascending order for every seed.
     let inputs = build_blocks(&[(1, 0), (1, 1), (1, 2), (1, 3)]);
@@ -192,8 +199,8 @@ fn committed_blocks_within_round_are_not_author_ascending() {
 
 /// The within-round order must depend on the seed; a sort that ignored the seed
 /// (e.g. ordering by block digest alone) would be deterministic but seed-blind.
-#[test]
-fn committed_blocks_within_round_order_depends_on_seed() {
+#[tokio::test]
+async fn committed_blocks_within_round_order_depends_on_seed() {
     let inputs = build_blocks(&[(1, 0), (1, 1), (1, 2), (1, 3)]);
     let order_for = |seed: [u8; DIGEST_LENGTH]| {
         let mut v = inputs.clone();
@@ -208,8 +215,8 @@ fn committed_blocks_within_round_order_depends_on_seed() {
 
 /// Refreshing with the same `next_commit_index` is a no-op: the accumulated
 /// round state and existing schedule are preserved.
-#[test]
-fn maybe_refresh_is_noop_on_same_index() {
+#[tokio::test]
+async fn maybe_refresh_is_noop_on_same_index() {
     let (_context, _dag_state, mut committer) = setup(4);
     committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
     committer.pending_commit_state.get_or_create_round_state(3);
@@ -231,8 +238,8 @@ fn maybe_refresh_is_noop_on_same_index() {
 }
 
 /// A higher `next_commit_index` resets the pending state and installs the new schedule.
-#[test]
-fn maybe_refresh_resets_on_higher_index() {
+#[tokio::test]
+async fn maybe_refresh_resets_on_higher_index() {
     let (_context, _dag_state, mut committer) = setup(4);
     committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
     committer.pending_commit_state.get_or_create_round_state(3);
@@ -250,17 +257,17 @@ fn maybe_refresh_resets_on_higher_index() {
 }
 
 /// `next_commit_index` must move forward; a lower index panics.
-#[test]
+#[tokio::test]
 #[should_panic(expected = "next_commit_index should only move forward")]
-fn maybe_refresh_panics_on_lower_index() {
+async fn maybe_refresh_panics_on_lower_index() {
     let (_context, _dag_state, mut committer) = setup(4);
     committer.maybe_refresh_pending_commit_state(schedule(3, 1, &[0]));
     committer.maybe_refresh_pending_commit_state(schedule(1, 1, &[0]));
 }
 
 /// The first committed leader, scanning from `start_round`, becomes the anchor.
-#[test]
-fn find_anchor_block_returns_first_committed() {
+#[tokio::test]
+async fn find_anchor_block_returns_first_committed() {
     let (_context, _dag_state, mut committer) = setup(4);
     let anchor = commit_block(2, 1);
     install_rounds(
@@ -279,8 +286,8 @@ fn find_anchor_block_returns_first_committed() {
 }
 
 /// An undecided slot before any commit means no anchor is available.
-#[test]
-fn find_anchor_block_none_when_undecided_first() {
+#[tokio::test]
+async fn find_anchor_block_none_when_undecided_first() {
     let (_context, _dag_state, mut committer) = setup(4);
     install_rounds(
         &mut committer,
@@ -294,8 +301,8 @@ fn find_anchor_block_none_when_undecided_first() {
 }
 
 /// Skipped slots — within and across rounds — are passed over until a commit.
-#[test]
-fn find_anchor_block_skips_past_skipped_slots() {
+#[tokio::test]
+async fn find_anchor_block_skips_past_skipped_slots() {
     let (_context, _dag_state, mut committer) = setup(4);
     let anchor = commit_block(2, 3);
     install_rounds(
@@ -313,8 +320,8 @@ fn find_anchor_block_skips_past_skipped_slots() {
 }
 
 /// `start_round` skips earlier rounds entirely, even committed ones.
-#[test]
-fn find_anchor_block_respects_start_round() {
+#[tokio::test]
+async fn find_anchor_block_respects_start_round() {
     let (_context, _dag_state, mut committer) = setup(4);
     let later = commit_block(2, 0);
     install_rounds(
@@ -332,8 +339,8 @@ fn find_anchor_block_respects_start_round() {
 }
 
 /// All-skip rounds yield no anchor.
-#[test]
-fn find_anchor_block_none_when_all_skipped() {
+#[tokio::test]
+async fn find_anchor_block_none_when_all_skipped() {
     let (_context, _dag_state, mut committer) = setup(4);
     install_rounds(
         &mut committer,
@@ -347,8 +354,8 @@ fn find_anchor_block_none_when_all_skipped() {
 }
 
 /// An undecided slot blocks committing, even if a later round is committed.
-#[test]
-fn find_commit_leader_round_none_when_undecided() {
+#[tokio::test]
+async fn find_commit_leader_round_none_when_undecided() {
     let (_context, _dag_state, mut committer) = setup(4);
     install_rounds(
         &mut committer,
@@ -362,8 +369,8 @@ fn find_commit_leader_round_none_when_undecided() {
 }
 
 /// The earliest fully-decided round with a committed leader is the commit round.
-#[test]
-fn find_commit_leader_round_returns_first_committed_round() {
+#[tokio::test]
+async fn find_commit_leader_round_returns_first_committed_round() {
     let (_context, _dag_state, mut committer) = setup(4);
     install_rounds(
         &mut committer,
@@ -377,8 +384,8 @@ fn find_commit_leader_round_returns_first_committed_round() {
 }
 
 /// Fully-decided all-skip rounds are passed over to a later committed round.
-#[test]
-fn find_commit_leader_round_skips_all_skip_rounds() {
+#[tokio::test]
+async fn find_commit_leader_round_skips_all_skip_rounds() {
     let (_context, _dag_state, mut committer) = setup(4);
     install_rounds(
         &mut committer,
@@ -393,8 +400,8 @@ fn find_commit_leader_round_skips_all_skip_rounds() {
 }
 
 /// A later undecided round blocks committing, even past earlier all-skip rounds.
-#[test]
-fn find_commit_leader_round_none_when_later_round_undecided() {
+#[tokio::test]
+async fn find_commit_leader_round_none_when_later_round_undecided() {
     let (_context, _dag_state, mut committer) = setup(4);
     install_rounds(
         &mut committer,
@@ -408,8 +415,8 @@ fn find_commit_leader_round_none_when_later_round_undecided() {
 }
 
 /// A round with a mix of committed and undecided slots is not yet committable.
-#[test]
-fn find_commit_leader_round_none_when_round_partially_decided() {
+#[tokio::test]
+async fn find_commit_leader_round_none_when_round_partially_decided() {
     let (_context, _dag_state, mut committer) = setup(4);
     install_rounds(
         &mut committer,


### PR DESCRIPTION
## Description 

Add `FlexCommitter`, which calls `LeaderSlotDecider` to produce commits over multiple leaders per-round.

## Test plan 

CI