### PR TITLE
[EXPERIMENT - do not merge] Blind test: would flipping skip_signing_phase_withdraw_balance_check at base catch the IFFW bug?

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1025,9 +1025,11 @@ impl AuthorityState {
             self.coin_reservation_resolver.as_ref(),
         )?;
 
-        self.execution_cache_trait_pointers
-            .account_funds_read
-            .check_amounts_available(&declared_withdrawals)?;
+        if !protocol_config.skip_signing_phase_withdraw_balance_check() {
+            self.execution_cache_trait_pointers
+                .account_funds_read
+                .check_amounts_available(&declared_withdrawals)?;
+        }
 
         if protocol_config.gasless_verify_remaining_balance() && tx_data.is_gasless_transaction() {
             let min_amounts =

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -7,9 +7,7 @@ use std::sync::Arc;
 
 use super::*;
 
-use crate::authority::authority_test_utils::{
-    init_state_validator_with_fullnode, submit_and_execute,
-};
+use crate::authority::authority_test_utils::submit_and_execute;
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
@@ -92,7 +90,22 @@ struct TestEnv {
 
 // Makes a validator, a full node and the data to work with
 async fn setup_test_env() -> TestEnv {
-    let (validator, fullnode) = init_state_validator_with_fullnode().await;
+    // Several of these tests assert that gas paid from an empty/insufficient address
+    // balance is rejected at signing time with InvalidWithdrawReservation. That check is
+    // skipped by default in non-production environments, so keep it on here.
+    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+    protocol_config.set_skip_signing_phase_withdraw_balance_check_for_testing(false);
+
+    let validator = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config.clone())
+        .build()
+        .await;
+    let fullnode_key_pair = get_authority_key_pair().1;
+    let fullnode = TestAuthorityBuilder::new()
+        .with_keypair(&fullnode_key_pair)
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
 
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
 

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -26,6 +26,8 @@ async fn test_coin_reservation_validation() {
     let mut test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.enable_coin_reservation_for_testing();
+            // This test exercises the signing-phase rejection, so keep that check on.
+            cfg.set_skip_signing_phase_withdraw_balance_check_for_testing(false);
             cfg
         }))
         .build()
@@ -659,6 +661,8 @@ async fn test_coin_reservation_enforced_when_not_used() {
     let mut test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.enable_coin_reservation_for_testing();
+            // This test exercises the signing-phase rejection, so keep that check on.
+            cfg.set_skip_signing_phase_withdraw_balance_check_for_testing(false);
             cfg
         }))
         .build()

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -436,7 +436,14 @@ async fn test_deposit_and_withdraw_with_larger_reservation() {
 
 #[sim_test]
 async fn test_withdraw_non_existent_balance() {
-    let mut test_env = TestEnvBuilder::new().build().await;
+    // This test exercises the signing-phase rejection, so keep that check on.
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.set_skip_signing_phase_withdraw_balance_check_for_testing(false);
+            cfg
+        }))
+        .build()
+        .await;
 
     let sender = test_env.get_sender(0);
 
@@ -455,7 +462,15 @@ async fn test_withdraw_non_existent_balance() {
 
 #[sim_test]
 async fn test_withdraw_insufficient_balance() {
-    let mut test_env = TestEnvBuilder::new().build().await;
+    // The first half of this test exercises the signing-phase rejection, so keep that
+    // check on. The soft-bundle half then still exposes the execution-time failure.
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.set_skip_signing_phase_withdraw_balance_check_for_testing(false);
+            cfg
+        }))
+        .build()
+        .await;
 
     let (sender, gas) = test_env.get_sender_and_all_gas(0);
     let gas1 = gas[0];
@@ -3849,7 +3864,14 @@ fn create_redeem_and_transfer_transaction(
 /// the total funds required by a transaction.
 #[sim_test]
 async fn test_explicit_withdrawal_plus_implicit_gas_exceeds_balance() {
-    let mut test_env = TestEnvBuilder::new().build().await;
+    // This test exercises the signing-phase rejection, so keep that check on.
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.set_skip_signing_phase_withdraw_balance_check_for_testing(false);
+            cfg
+        }))
+        .build()
+        .await;
 
     let (sender, gas_coin) = test_env.get_sender_and_gas(0);
     let receiver = SuiAddress::random_for_testing_only();

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1091,6 +1091,9 @@ struct FeatureFlags {
     gasless_verify_remaining_balance: bool,
 
     #[serde(skip_serializing_if = "is_false")]
+    skip_signing_phase_withdraw_balance_check: bool,
+
+    #[serde(skip_serializing_if = "is_false")]
     disallow_jump_orphans: bool,
 
     // If true, return early on type mismatch in receive_object.
@@ -2810,6 +2813,10 @@ impl ProtocolConfig {
 
     pub fn gasless_verify_remaining_balance(&self) -> bool {
         self.feature_flags.gasless_verify_remaining_balance
+    }
+
+    pub fn skip_signing_phase_withdraw_balance_check(&self) -> bool {
+        self.feature_flags.skip_signing_phase_withdraw_balance_check
     }
 
     pub fn gasless_allowed_token_types(&self) -> &[(String, u64)] {
@@ -4979,6 +4986,12 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.timestamp_based_epoch_close = true;
                     }
+                    // EXPERIMENT: skip the signing-phase withdraw balance check in
+                    // non-production environments so existing tests reach the execution-time
+                    // insufficient-balance path.
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.feature_flags.skip_signing_phase_withdraw_balance_check = true;
+                    }
                 }
                 // Use this template when making changes:
                 //
@@ -5389,6 +5402,10 @@ impl ProtocolConfig {
 
     pub fn enable_multi_epoch_transaction_expiration_for_testing(&mut self) {
         self.feature_flags.enable_multi_epoch_transaction_expiration = true;
+    }
+
+    pub fn set_skip_signing_phase_withdraw_balance_check_for_testing(&mut self, val: bool) {
+        self.feature_flags.skip_signing_phase_withdraw_balance_check = val;
     }
 
     pub fn enable_authenticated_event_streams_for_testing(&mut self) {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_125.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_125.snap
@@ -166,6 +166,7 @@ feature_flags:
   use_coin_party_owner: true
   enable_gasless: true
   gasless_verify_remaining_balance: true
+  skip_signing_phase_withdraw_balance_check: true
   disallow_jump_orphans: true
   early_return_receive_object_mismatched_type: true
   timestamp_based_epoch_close: true


### PR DESCRIPTION
## Not for merge — CI experiment only

**Base of this PR is `xun/iffw-blind-base` = commit 53ac9eff (2026-05-28), which predates the #26816/#26832 IFFW gas-underflow fixes.** At that commit the bug is present: an `InsufficientFundsForWithdraw` transaction whose gas is paid from address balance underflows the (drained) balance at settlement and trips `settlement transaction cannot fail` in the settlement scheduler, crashing the node.

### Question
Would simply introducing `skip_signing_phase_withdraw_balance_check` (on by default in non-production) have caused the **pre-existing** test suite to catch this bug — *without anyone writing a test that targets it* (since the bug was unknown at the time)?

### What this diff is
The realistic 'introduce the flag' change, applied at base:
- new feature flag + getter + setter, enabled by default for non-mainnet/non-testnet at v125
- `pre_object_load_checks` skips `check_amounts_available` when the flag is on
- the handful of tests that *assert* signing-phase rejection are opted out (flag forced false), exactly as a developer introducing the flag would do
- **no new tests added**

### How to read CI
- **Only assertion-text failures (e.g. "is less than requested")** ⇒ existing tests would NOT have caught the bug; the flag is a testing *enabler*, not a retroactive detector.
- **A `settlement transaction cannot fail` panic in any test** ⇒ existing tests WOULD have caught it blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)