### PR TITLE
Enforce soft bundle gas price equality

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -668,6 +668,8 @@ impl ValidatorService {
         let mut total_size_bytes = 0;
         // Traffic control spam weight to use for the transaction.
         let mut spam_weight = Weight::zero();
+        // First gas price seen in this soft bundle.
+        let mut expected_soft_bundle_gas_price = None;
 
         let req_type = if is_ping_request {
             "ping"
@@ -700,6 +702,28 @@ impl ValidatorService {
 
             // Ok to fail the request when any transaction is invalid.
             let tx_size = transaction.validity_check(&epoch_store.tx_validity_check_context())?;
+            let tx_digest = *transaction.digest();
+
+            // Soft bundles require all transactions to use the same gas price.
+            if is_soft_bundle_request {
+                let gas_price = transaction.data().transaction_data().gas_price();
+                if let Some(expected) = expected_soft_bundle_gas_price {
+                    fp_ensure!(
+                        gas_price == expected,
+                        SuiErrorKind::UserInputError {
+                            error: UserInputError::GasPriceMismatchError {
+                                digest: tx_digest,
+                                expected,
+                                actual: gas_price,
+                            }
+                        }
+                        .into()
+                    );
+                } else {
+                    expected_soft_bundle_gas_price = Some(gas_price);
+                }
+            }
+
             let is_gasless = transaction
                 .data()
                 .transaction_data()
@@ -788,7 +812,6 @@ impl ValidatorService {
                 }
             };
 
-            let tx_digest = *verified_transaction.tx().digest();
             debug!(
                 ?tx_digest,
                 "handle_submit_transaction: verified transaction"

--- a/crates/sui-e2e-tests/tests/soft_bundle_tests.rs
+++ b/crates/sui-e2e-tests/tests/soft_bundle_tests.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_macros::sim_test;
+use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::messages_grpc::{RawSubmitTxRequest, SubmitTxType};
+use test_cluster::TestClusterBuilder;
+
+/// Soft bundles require all transactions to use the same gas price.
+#[sim_test]
+async fn test_soft_bundle_rejects_mixed_gas_prices() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_accounts(vec![AccountConfig {
+            address: None,
+            gas_amounts: vec![DEFAULT_GAS_AMOUNT; 2],
+        }])
+        .build()
+        .await;
+
+    let accounts_and_gas = test_cluster
+        .wallet
+        .get_all_accounts_and_gas_objects()
+        .await
+        .unwrap();
+    let sender = accounts_and_gas[0].0;
+    let gas_coins = &accounts_and_gas[0].1;
+    let rgp = test_cluster.get_reference_gas_price().await;
+
+    let tx1 = TestTransactionBuilder::new(sender, gas_coins[0], rgp)
+        .transfer_sui(Some(1), sender)
+        .build();
+    let signed_tx1 = test_cluster.wallet.sign_transaction(&tx1).await;
+
+    let tx2 = TestTransactionBuilder::new(sender, gas_coins[1], rgp * 2)
+        .transfer_sui(Some(1), sender)
+        .build();
+    let signed_tx2 = test_cluster.wallet.sign_transaction(&tx2).await;
+
+    let mut validator_client = test_cluster
+        .authority_aggregator()
+        .authority_clients
+        .iter()
+        .next()
+        .unwrap()
+        .1
+        .authority_client()
+        .get_client_for_testing()
+        .unwrap();
+
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&signed_tx1).unwrap().into(),
+            bcs::to_bytes(&signed_tx2).unwrap().into(),
+        ],
+        submit_type: SubmitTxType::SoftBundle.into(),
+    };
+
+    let error = validator_client
+        .submit_transaction(request)
+        .await
+        .expect_err("soft bundle with mixed gas prices must be rejected");
+
+    assert!(
+        error.to_string().contains("Gas price for transaction")
+            && error.to_string().contains("in Soft Bundle mismatch"),
+        "expected gas price mismatch error, got: {error}"
+    );
+}


### PR DESCRIPTION
Summary:
- Enforce a single gas price across soft-bundle submissions in validator transaction submission.
- Add an e2e regression simtest for rejecting soft bundles with mixed gas prices.

Tests:
- SUI_SKIP_SIMTESTS=1 cargo nextest run --no-capture -p sui-core
- cargo simtest --no-capture -p sui-e2e-tests test_soft_bundle_rejects_mixed_gas_prices
- cargo xclippy -D warnings (crates/sui-core)
- cargo xclippy -D warnings (crates/sui-e2e-tests)
- cargo fmt --all