### PR TITLE
fix(sui): `sui start` resumes the embedded fullnode (index over the fullnode gRPC)

### DIFF
--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -49,6 +49,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_rpc_port: Option<u16>,
     fullnode_rpc_addr: Option<SocketAddr>,
     fullnode_rpc_config: Option<sui_config::RpcConfig>,
+    fullnode_config: Option<NodeConfig>,
     supported_protocol_versions_config: ProtocolVersionsConfig,
     // Default to supported_protocol_versions_config, but can be overridden.
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
@@ -85,6 +86,7 @@ impl SwarmBuilder {
             fullnode_rpc_port: None,
             fullnode_rpc_addr: None,
             fullnode_rpc_config: None,
+            fullnode_config: None,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             fullnode_supported_protocol_versions_config: None,
             db_checkpoint_config: DBCheckpointConfig::default(),
@@ -121,6 +123,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_rpc_port: self.fullnode_rpc_port,
             fullnode_rpc_addr: self.fullnode_rpc_addr,
             fullnode_rpc_config: self.fullnode_rpc_config.clone(),
+            fullnode_config: self.fullnode_config,
             supported_protocol_versions_config: self.supported_protocol_versions_config,
             fullnode_supported_protocol_versions_config: self
                 .fullnode_supported_protocol_versions_config,
@@ -224,6 +227,11 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_fullnode_rpc_config(mut self, fullnode_rpc_config: sui_config::RpcConfig) -> Self {
         self.fullnode_rpc_config = Some(fullnode_rpc_config);
+        self
+    }
+
+    pub fn with_fullnode_config(mut self, fullnode_config: NodeConfig) -> Self {
+        self.fullnode_config = Some(fullnode_config);
         self
     }
 
@@ -484,22 +492,27 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
         }
 
         if self.fullnode_count > 0 {
+            let mut prebuilt_fullnode_config = self.fullnode_config;
             (0..self.fullnode_count).for_each(|idx| {
-                let mut builder = fullnode_config_builder.clone();
-                if idx == 0 {
-                    // Only the first fullnode is used as the rpc fullnode, we can only use the
-                    // same address once.
-                    if let Some(rpc_addr) = self.fullnode_rpc_addr {
-                        builder = builder.with_rpc_addr(rpc_addr);
+                let config = if idx == 0 && prebuilt_fullnode_config.is_some() {
+                    prebuilt_fullnode_config.take().unwrap()
+                } else {
+                    let mut builder = fullnode_config_builder.clone();
+                    if idx == 0 {
+                        // Only the first fullnode is used as the rpc fullnode, we can only use the
+                        // same address once.
+                        if let Some(rpc_addr) = self.fullnode_rpc_addr {
+                            builder = builder.with_rpc_addr(rpc_addr);
+                        }
+                        if let Some(rpc_port) = self.fullnode_rpc_port {
+                            builder = builder.with_rpc_port(rpc_port);
+                        }
+                        if let Some(rpc_config) = &self.fullnode_rpc_config {
+                            builder = builder.with_rpc_config(rpc_config.clone());
+                        }
                     }
-                    if let Some(rpc_port) = self.fullnode_rpc_port {
-                        builder = builder.with_rpc_port(rpc_port);
-                    }
-                    if let Some(rpc_config) = &self.fullnode_rpc_config {
-                        builder = builder.with_rpc_config(rpc_config.clone());
-                    }
-                }
-                let config = builder.build(&mut OsRng, &network_config);
+                    builder.build(&mut OsRng, &network_config)
+                };
                 info!(
                     "SwarmBuilder configuring full node with name {}",
                     config.protocol_public_key()

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -33,7 +33,7 @@ use sui_bridge::sui_transaction_builder::build_committee_register_transaction;
 use sui_config::node::Genesis;
 use sui_config::p2p::SeedPeer;
 use sui_config::{
-    Config, FULL_NODE_DB_PATH, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
+    Config, FULL_NODE_DB_PATH, NodeConfig, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
     SUI_NETWORK_CONFIG, genesis_blob_exists, sui_config_dir,
 };
 use sui_config::{
@@ -48,7 +48,9 @@ use sui_indexer_alt_consistent_store::{
 };
 use sui_indexer_alt_framework::{
     IndexerArgs,
-    ingestion::{ClientArgs, ingestion_client::IngestionClientArgs},
+    ingestion::{
+        ClientArgs, ingestion_client::IngestionClientArgs, streaming_client::StreamingClientArgs,
+    },
 };
 use sui_indexer_alt_graphql::{
     RpcArgs as GraphQlArgs, args::SubscriptionArgs, config::RpcConfig as GraphQlConfig,
@@ -857,7 +859,7 @@ async fn start(
     force_regenesis: bool,
     epoch_duration_ms: Option<u64>,
     fullnode_rpc_port: u16,
-    mut data_ingestion_dir: Option<PathBuf>,
+    data_ingestion_dir: Option<PathBuf>,
     no_full_node: bool,
     committee_size: Option<usize>,
 ) -> Result<(), anyhow::Error> {
@@ -1021,13 +1023,6 @@ async fn start(
         sui_config_path
     };
 
-    // the indexer and consistent store require the fullnode's data ingestion directory
-    // note that this overrides the default configuration that is set when running the genesis
-    // command, which sets data_ingestion_dir to None.
-    if (with_indexer.is_some() || with_consistent_store.is_some()) && data_ingestion_dir.is_none() {
-        data_ingestion_dir = Some(mysten_common::tempdir()?.keep())
-    }
-
     if let Some(ref dir) = data_ingestion_dir {
         swarm_builder = swarm_builder.with_data_ingestion_dir(dir.clone());
     }
@@ -1046,7 +1041,37 @@ async fn start(
         swarm_builder = swarm_builder
             .with_fullnode_count(1)
             .with_fullnode_rpc_addr(fullnode_rpc_address)
-            .with_fullnode_rpc_config(rpc_config);
+            .with_fullnode_rpc_config(rpc_config.clone());
+
+        let fullnode_config_path = config_dir.join(SUI_FULLNODE_CONFIG);
+        if fullnode_config_path.exists() {
+            let mut fullnode_config: NodeConfig = PersistedConfig::read(&fullnode_config_path)
+                .map_err(|err| {
+                    err.context(format!(
+                        "Cannot open Sui fullnode config file at {:?}",
+                        fullnode_config_path
+                    ))
+                })?;
+            fullnode_config.json_rpc_address = fullnode_rpc_address;
+            fullnode_config.rpc = Some(rpc_config);
+            let localhost = sui_config::local_ip_utils::localhost_for_testing();
+            fullnode_config.metrics_address =
+                sui_config::local_ip_utils::new_local_tcp_socket_for_testing();
+            fullnode_config.admin_interface_port =
+                sui_config::local_ip_utils::get_available_port(&localhost);
+            fullnode_config.network_address =
+                sui_config::local_ip_utils::new_tcp_address_for_testing(&localhost);
+            fullnode_config.p2p_config.listen_address =
+                sui_config::local_ip_utils::new_udp_address_for_testing(&localhost)
+                    .udp_multiaddr_to_listen_address()
+                    .unwrap();
+            if let Some(ref dir) = data_ingestion_dir {
+                fullnode_config
+                    .checkpoint_executor_config
+                    .data_ingestion_dir = Some(dir.clone());
+            }
+            swarm_builder = swarm_builder.with_fullnode_config(fullnode_config);
+        }
     }
 
     let mut swarm = swarm_builder.build();
@@ -1058,6 +1083,22 @@ async fn start(
         .trim_end_matches("/")
         .to_string();
     info!("Fullnode RPC URL: {fullnode_rpc_url}");
+
+    let fullnode_grpc_url = socket_addr_to_url(fullnode_rpc_address)?;
+    let client_args = ClientArgs {
+        ingestion: IngestionClientArgs {
+            rpc_api_url: Some(fullnode_grpc_url.clone()),
+            ..Default::default()
+        },
+        streaming: StreamingClientArgs {
+            streaming_url: Some(
+                fullnode_grpc_url
+                    .as_str()
+                    .parse()
+                    .context("Failed to parse fullnode gRPC URL into a streaming URI")?,
+            ),
+        },
+    };
 
     let prometheus_registry = Registry::new();
     let mut rpc_services = Service::new();
@@ -1094,19 +1135,11 @@ async fn start(
     };
 
     let pipelines = if let Some(ref db_url) = database_url {
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: data_ingestion_dir.clone(),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
         let indexer = setup_indexer(
             db_url.clone(),
             DbArgs::default(),
             IndexerArgs::default(),
-            client_args,
+            client_args.clone(),
             IndexerConfig::for_test(),
             None,
             &prometheus_registry,
@@ -1127,14 +1160,6 @@ async fn start(
         let address = parse_host_port(input, DEFAULT_CONSISTENT_STORE_PORT)
             .context("Invalid consistent store host and port")?;
 
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: data_ingestion_dir.clone(),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
         let consistent_args = ConsistentArgs {
             rpc_listen_address: address,
             ..Default::default()
@@ -1144,7 +1169,7 @@ async fn start(
             start_consistent_store(
                 config_dir.join("consistent_store"),
                 IndexerArgs::default(),
-                client_args,
+                client_args.clone(),
                 consistent_args,
                 "0.0.0",
                 ConsistentConfig::for_test(),
@@ -1469,7 +1494,7 @@ async fn genesis(
     info!("Client keystore is stored in {:?}.", keystore_path);
 
     let fullnode_config = FullnodeConfigBuilder::new()
-        .with_config_directory(FULL_NODE_DB_PATH.into())
+        .with_config_directory(sui_config_dir.to_path_buf())
         .with_rpc_addr(sui_config::node::default_json_rpc_address())
         .build(&mut OsRng, &network_config);
 


### PR DESCRIPTION
## Problem

`sui start` against an **existing persisted config dir** (created by `sui genesis -f`) loads `network.yaml` so validators resume from their `authorities_db` — but the embedded RPC fullnode was rebuilt from scratch every invocation and the `fullnode.yaml` genesis saved was never read back, so the fullnode re-synced the whole (growing) chain from genesis on every restart while the validator resumed:

```
fullnode:  executed=0    ... Creating new epoch start config from genesis ... execute_checkpoint{seq=0}
validator: executed=4433 ... Loading epoch start config from DB
```

On disk it leaked one orphaned `full_node_db/<key>/` per boot (~11M → ~173M over 16 boots, ≈ 1.4 GB), because each restart minted a new fullnode identity → new db dir.

## Root cause

- `crates/sui-swarm-config/src/node_config_builder.rs` — `FullnodeConfigBuilder::build()` mints a fresh random keypair every call and derives `db_path` from it; no way to give the fullnode a stable identity.
- `crates/sui/src/sui_commands.rs` (start) loaded `network.yaml` but never read back `fullnode.yaml` — `SwarmBuilder::build()` always rebuilt the fullnode fresh.
- Doubled db path: genesis built the fullnode with `with_config_directory(FULL_NODE_DB_PATH.into())`, so `build()` joined `full_node_db` again → relative `full_node_db/full_node_db/<key>` (validators pass the real config dir → single absolute level, which is why validators resumed and the fullnode didn't).

## The fix (scoped to `sui start` + `sui-swarm`; no shared-crate change)

- **Resume the embedded fullnode** — when `<config_dir>/fullnode.yaml` exists, load and run it via the new `SwarmBuilder::with_fullnode_config(NodeConfig)` instead of generating a fresh fullnode; the persisted identity + db path are preserved so it resumes from its db. The field defaults to `None`, so existing `SwarmBuilder` callers (tests, `test-cluster`, e2e) are unchanged.
- **Index over the fullnode's gRPC** — the embedded indexer + consistent-store now ingest from the fullnode's gRPC (`rpc_api_url = socket_addr_to_url(fullnode_rpc_address)`) instead of a local ingestion directory. A resumed fullnode only writes *new* checkpoints to a local dir, so local-file ingestion would strand a consumer that needs already-executed checkpoints; the fullnode serves them all over gRPC. **Enabling an indexer no longer implies/sets up a data-ingestion directory** (an explicit `--data-ingestion-dir` is still honored).
- **Fix the doubled genesis db path** — build the persisted fullnode with the real config dir (like validators) → absolute, single-level `<config_dir>/full_node_db/<key>`.
- **Regenerate non-RPC bind ports** (metrics/admin/network/p2p) on the persisted path so genesis-time ports that may now be occupied don't fail bind.

## Compatibility

- Cold boot / `--force-regenesis`: no persisted `fullnode.yaml` to reuse → existing fresh-build path, behavior unchanged.
- **No change to any shared crate** — `git diff upstream/main -- crates/sui-indexer-alt-framework` is empty. The diff is `crates/sui/src/sui_commands.rs` + `crates/sui-swarm/src/memory/swarm.rs` only.

## Notes

Three ingestion strategies were explored — resume→gRPC, hybrid (local primary + gRPC fallback), and always-gRPC. Per review, **always-gRPC** was chosen (simplest, no local-file ingestion lifecycle, no shared-framework change). The alternatives (#26887 hybrid, #26888 always-gRPC sibling) are closed in favor of this PR.

## Testing

`cargo check -p sui` / `-p sui-indexer-alt-framework`, `cargo clippy`, `cargo fmt --check`, and the framework ingestion tests pass; full CI is green on this commit (verified green on the identical #26888 before consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
