### PR TITLE
fix(sui): `sui start` resumes the embedded fullnode — hybrid local+RPC ingestion (alt to #26884)

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -178,6 +178,38 @@ pub enum CheckpointError {
 
 pub type CheckpointResult = Result<Checkpoint, CheckpointError>;
 
+/// Tries `primary` first and falls back to `secondary` for checkpoints the primary doesn't have.
+/// Used to back a local-file ingestion source with a fullnode RPC source so a resumed fullnode
+/// (which only re-writes new checkpoint files) can still serve already-executed checkpoints.
+struct FallbackIngestionClient {
+    primary: Arc<dyn IngestionClientTrait>,
+    secondary: Arc<dyn IngestionClientTrait>,
+}
+
+#[async_trait]
+impl IngestionClientTrait for FallbackIngestionClient {
+    async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
+        match self.primary.chain_id().await {
+            Ok(chain_id) => Ok(chain_id),
+            Err(_) => self.secondary.chain_id().await,
+        }
+    }
+
+    async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
+        match self.primary.checkpoint(checkpoint).await {
+            Err(CheckpointError::NotFound) => self.secondary.checkpoint(checkpoint).await,
+            result => result,
+        }
+    }
+
+    async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+        match self.primary.latest_checkpoint_number().await {
+            Ok(number) => Ok(number),
+            Err(_) => self.secondary.latest_checkpoint_number().await,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct IngestionClient {
     client: Arc<dyn IngestionClientTrait>,
@@ -194,61 +226,107 @@ pub struct CheckpointEnvelope {
 }
 
 impl IngestionClient {
-    /// Construct a new ingestion client. Its source is determined by `args`.
+    /// Construct a new ingestion client. Its source(s) are determined by `args`. When both an
+    /// object-store source (the first of `remote_store_url`/`remote_store_s3`/`remote_store_gcs`/
+    /// `remote_store_azure`/`local_ingestion_path` that is set) and `rpc_api_url` are provided, the
+    /// store is the primary and the gRPC source backfills checkpoints the store does not have (see
+    /// `FallbackIngestionClient`).
     pub fn new(args: IngestionClientArgs, metrics: Arc<IngestionMetrics>) -> IngestionResult<Self> {
-        // TODO: Support stacking multiple ingestion clients for redundancy/failover.
+        let store_client = Self::store_client(&args, &metrics)?;
+        let grpc_client = match args.rpc_api_url.as_ref() {
+            Some(url) => Some(Self::grpc_client(
+                url.clone(),
+                args.rpc_username,
+                args.rpc_password,
+                &metrics,
+            )?),
+            None => None,
+        };
+
+        let client: Arc<dyn IngestionClientTrait> = match (store_client, grpc_client) {
+            (Some(primary), Some(secondary)) => {
+                Arc::new(FallbackIngestionClient { primary, secondary })
+            }
+            (Some(store), None) => store,
+            (None, Some(grpc)) => grpc,
+            (None, None) => panic!(
+                "One of remote_store_url, remote_store_s3, remote_store_gcs, remote_store_azure, \
+                local_ingestion_path or rpc_api_url must be provided"
+            ),
+        };
+
+        Ok(Self::from_trait(client, metrics))
+    }
+
+    /// Build an object-store-backed ingestion client trait object from the first store source set
+    /// in `args`, if any.
+    fn store_client(
+        args: &IngestionClientArgs,
+        metrics: &Arc<IngestionMetrics>,
+    ) -> IngestionResult<Option<Arc<dyn IngestionClientTrait>>> {
         let retry = super::store_client::retry_config();
-        let client = if let Some(url) = args.remote_store_url.as_ref() {
-            let store = HttpBuilder::new()
+        let store: Arc<dyn ObjectStore> = if let Some(url) = args.remote_store_url.as_ref() {
+            HttpBuilder::new()
                 .with_url(url.to_string())
                 .with_client_options(args.client_options().with_allow_http(true))
                 .with_retry(retry)
                 .build()
-                .map(Arc::new)?;
-            IngestionClient::with_store(store, metrics.clone())?
+                .map(Arc::new)?
         } else if let Some(bucket) = args.remote_store_s3.as_ref() {
-            let store = AmazonS3Builder::from_env()
+            AmazonS3Builder::from_env()
                 .with_client_options(args.client_options())
                 .with_retry(retry)
                 .with_imdsv1_fallback()
                 .with_bucket_name(bucket)
                 .build()
-                .map(Arc::new)?;
-            IngestionClient::with_store(store, metrics.clone())?
+                .map(Arc::new)?
         } else if let Some(bucket) = args.remote_store_gcs.as_ref() {
-            let store = GoogleCloudStorageBuilder::from_env()
+            GoogleCloudStorageBuilder::from_env()
                 .with_client_options(args.client_options())
                 .with_retry(retry)
                 .with_bucket_name(bucket)
                 .build()
-                .map(Arc::new)?;
-            IngestionClient::with_store(store, metrics.clone())?
+                .map(Arc::new)?
         } else if let Some(container) = args.remote_store_azure.as_ref() {
-            let store = MicrosoftAzureBuilder::from_env()
+            MicrosoftAzureBuilder::from_env()
                 .with_client_options(args.client_options())
                 .with_retry(retry)
                 .with_container_name(container)
                 .build()
-                .map(Arc::new)?;
-            IngestionClient::with_store(store, metrics.clone())?
+                .map(Arc::new)?
         } else if let Some(path) = args.local_ingestion_path.as_ref() {
-            let store = LocalFileSystem::new_with_prefix(path).map(Arc::new)?;
-            IngestionClient::with_store(store, metrics.clone())?
-        } else if let Some(rpc_api_url) = args.rpc_api_url.as_ref() {
-            IngestionClient::with_grpc(
-                rpc_api_url.clone(),
-                args.rpc_username,
-                args.rpc_password,
-                metrics.clone(),
-            )?
+            LocalFileSystem::new_with_prefix(path).map(Arc::new)?
         } else {
-            panic!(
-                "One of remote_store_url, remote_store_s3, remote_store_gcs, remote_store_azure, \
-                local_ingestion_path or rpc_api_url must be provided"
-            );
+            return Ok(None);
         };
 
-        Ok(client)
+        Ok(Some(Arc::new(StoreIngestionClient::new(
+            store,
+            Some(metrics.total_ingested_bytes.clone()),
+        ))))
+    }
+
+    /// Build a gRPC fullnode-backed ingestion client trait object.
+    fn grpc_client(
+        url: Url,
+        username: Option<String>,
+        password: Option<String>,
+        metrics: &Arc<IngestionMetrics>,
+    ) -> IngestionResult<Arc<dyn IngestionClientTrait>> {
+        let byte_count_layer = CallbackLayer::new(ByteCountMakeCallbackHandler::new(
+            metrics.total_ingested_bytes.clone(),
+        ));
+        let client = Client::new(url.to_string())?
+            .with_max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
+            .request_layer(byte_count_layer);
+        let client = if let Some(username) = username {
+            let mut headers = HeadersInterceptor::new();
+            headers.basic_auth(username, password);
+            client.with_headers(headers)
+        } else {
+            client
+        };
+        Ok(Arc::new(client))
     }
 
     /// An ingestion client that fetches checkpoints from a remote object store.
@@ -270,20 +348,8 @@ impl IngestionClient {
         password: Option<String>,
         metrics: Arc<IngestionMetrics>,
     ) -> IngestionResult<Self> {
-        let byte_count_layer = CallbackLayer::new(ByteCountMakeCallbackHandler::new(
-            metrics.total_ingested_bytes.clone(),
-        ));
-        let client = Client::new(url.to_string())?
-            .with_max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
-            .request_layer(byte_count_layer);
-        let client = if let Some(username) = username {
-            let mut headers = HeadersInterceptor::new();
-            headers.basic_auth(username, password);
-            client.with_headers(headers)
-        } else {
-            client
-        };
-        Ok(Self::from_trait(Arc::new(client), metrics))
+        let client = Self::grpc_client(url, username, password, &metrics)?;
+        Ok(Self::from_trait(client, metrics))
     }
 
     /// The metrics handle this client reports against. Callers constructing peer services (e.g. an
@@ -838,6 +904,42 @@ pub(crate) mod tests {
         assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
         assert_eq!(client.metrics.total_ingested_events.get(), 0);
         assert_eq!(client.metrics.total_ingested_objects.get(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_fallback_serves_missing_from_secondary() {
+        let registry = Registry::new_custom(Some("test".to_string()), None).unwrap();
+        let metrics = IngestionMetrics::new(None, &registry);
+
+        // Primary lacks checkpoint 0, secondary has it.
+        let primary = Arc::new(MockIngestionClient::default());
+        let secondary = Arc::new(MockIngestionClient::default());
+        secondary.insert_checkpoints([0]);
+
+        let fallback = FallbackIngestionClient { primary, secondary };
+        let client = IngestionClient::from_trait(Arc::new(fallback), metrics);
+
+        let result = client.checkpoint(0).await.unwrap();
+        assert_eq!(result.checkpoint.summary.sequence_number(), &0);
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fallback_serves_present_from_primary() {
+        let registry = Registry::new_custom(Some("test".to_string()), None).unwrap();
+        let metrics = IngestionMetrics::new(None, &registry);
+
+        // Primary has checkpoint 5; secondary is empty.
+        let primary = Arc::new(MockIngestionClient::default());
+        primary.insert_checkpoints([5]);
+        let secondary = Arc::new(MockIngestionClient::default());
+
+        let fallback = FallbackIngestionClient { primary, secondary };
+        let client = IngestionClient::from_trait(Arc::new(fallback), metrics);
+
+        let result = client.checkpoint(5).await.unwrap();
+        assert_eq!(result.checkpoint.summary.sequence_number(), &5);
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
     }
 
     #[tokio::test]

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -49,6 +49,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_rpc_port: Option<u16>,
     fullnode_rpc_addr: Option<SocketAddr>,
     fullnode_rpc_config: Option<sui_config::RpcConfig>,
+    fullnode_config: Option<NodeConfig>,
     supported_protocol_versions_config: ProtocolVersionsConfig,
     // Default to supported_protocol_versions_config, but can be overridden.
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
@@ -85,6 +86,7 @@ impl SwarmBuilder {
             fullnode_rpc_port: None,
             fullnode_rpc_addr: None,
             fullnode_rpc_config: None,
+            fullnode_config: None,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             fullnode_supported_protocol_versions_config: None,
             db_checkpoint_config: DBCheckpointConfig::default(),
@@ -121,6 +123,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_rpc_port: self.fullnode_rpc_port,
             fullnode_rpc_addr: self.fullnode_rpc_addr,
             fullnode_rpc_config: self.fullnode_rpc_config.clone(),
+            fullnode_config: self.fullnode_config,
             supported_protocol_versions_config: self.supported_protocol_versions_config,
             fullnode_supported_protocol_versions_config: self
                 .fullnode_supported_protocol_versions_config,
@@ -224,6 +227,11 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_fullnode_rpc_config(mut self, fullnode_rpc_config: sui_config::RpcConfig) -> Self {
         self.fullnode_rpc_config = Some(fullnode_rpc_config);
+        self
+    }
+
+    pub fn with_fullnode_config(mut self, fullnode_config: NodeConfig) -> Self {
+        self.fullnode_config = Some(fullnode_config);
         self
     }
 
@@ -484,22 +492,27 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
         }
 
         if self.fullnode_count > 0 {
+            let mut prebuilt_fullnode_config = self.fullnode_config;
             (0..self.fullnode_count).for_each(|idx| {
-                let mut builder = fullnode_config_builder.clone();
-                if idx == 0 {
-                    // Only the first fullnode is used as the rpc fullnode, we can only use the
-                    // same address once.
-                    if let Some(rpc_addr) = self.fullnode_rpc_addr {
-                        builder = builder.with_rpc_addr(rpc_addr);
+                let config = if idx == 0 && prebuilt_fullnode_config.is_some() {
+                    prebuilt_fullnode_config.take().unwrap()
+                } else {
+                    let mut builder = fullnode_config_builder.clone();
+                    if idx == 0 {
+                        // Only the first fullnode is used as the rpc fullnode, we can only use the
+                        // same address once.
+                        if let Some(rpc_addr) = self.fullnode_rpc_addr {
+                            builder = builder.with_rpc_addr(rpc_addr);
+                        }
+                        if let Some(rpc_port) = self.fullnode_rpc_port {
+                            builder = builder.with_rpc_port(rpc_port);
+                        }
+                        if let Some(rpc_config) = &self.fullnode_rpc_config {
+                            builder = builder.with_rpc_config(rpc_config.clone());
+                        }
                     }
-                    if let Some(rpc_port) = self.fullnode_rpc_port {
-                        builder = builder.with_rpc_port(rpc_port);
-                    }
-                    if let Some(rpc_config) = &self.fullnode_rpc_config {
-                        builder = builder.with_rpc_config(rpc_config.clone());
-                    }
-                }
-                let config = builder.build(&mut OsRng, &network_config);
+                    builder.build(&mut OsRng, &network_config)
+                };
                 info!(
                     "SwarmBuilder configuring full node with name {}",
                     config.protocol_public_key()

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -33,7 +33,7 @@ use sui_bridge::sui_transaction_builder::build_committee_register_transaction;
 use sui_config::node::Genesis;
 use sui_config::p2p::SeedPeer;
 use sui_config::{
-    Config, FULL_NODE_DB_PATH, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
+    Config, FULL_NODE_DB_PATH, NodeConfig, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
     SUI_NETWORK_CONFIG, genesis_blob_exists, sui_config_dir,
 };
 use sui_config::{
@@ -1024,8 +1024,13 @@ async fn start(
     // the indexer and consistent store require the fullnode's data ingestion directory
     // note that this overrides the default configuration that is set when running the genesis
     // command, which sets data_ingestion_dir to None.
+    // a resumed fullnode only writes new checkpoints, so use a stable dir under config_dir: a
+    // per-run tempdir would drop checkpoints the persisted indexer/consistent-store have not yet
+    // consumed. under --force-regenesis config_dir is itself a tempdir, so this stays ephemeral.
     if (with_indexer.is_some() || with_consistent_store.is_some()) && data_ingestion_dir.is_none() {
-        data_ingestion_dir = Some(mysten_common::tempdir()?.keep())
+        let dir = config_dir.join("ingestion");
+        std::fs::create_dir_all(&dir)?;
+        data_ingestion_dir = Some(dir);
     }
 
     if let Some(ref dir) = data_ingestion_dir {
@@ -1046,7 +1051,40 @@ async fn start(
         swarm_builder = swarm_builder
             .with_fullnode_count(1)
             .with_fullnode_rpc_addr(fullnode_rpc_address)
-            .with_fullnode_rpc_config(rpc_config);
+            .with_fullnode_rpc_config(rpc_config.clone());
+
+        let fullnode_config_path = config_dir.join(SUI_FULLNODE_CONFIG);
+        if fullnode_config_path.exists() {
+            let mut fullnode_config: NodeConfig = PersistedConfig::read(&fullnode_config_path)
+                .map_err(|err| {
+                    err.context(format!(
+                        "Cannot open Sui fullnode config file at {:?}",
+                        fullnode_config_path
+                    ))
+                })?;
+            fullnode_config.json_rpc_address = fullnode_rpc_address;
+            fullnode_config.rpc = Some(rpc_config);
+            // reassign the non-RPC bind addresses to free ports; the genesis-time ports may now be
+            // occupied. mirrors how FullnodeConfigBuilder assigns them. json_rpc_address, db_path,
+            // key-pairs and genesis stay as persisted.
+            let localhost = sui_config::local_ip_utils::localhost_for_testing();
+            fullnode_config.metrics_address =
+                sui_config::local_ip_utils::new_local_tcp_socket_for_testing();
+            fullnode_config.admin_interface_port =
+                sui_config::local_ip_utils::get_available_port(&localhost);
+            fullnode_config.network_address =
+                sui_config::local_ip_utils::new_tcp_address_for_testing(&localhost);
+            fullnode_config.p2p_config.listen_address =
+                sui_config::local_ip_utils::new_udp_address_for_testing(&localhost)
+                    .udp_multiaddr_to_listen_address()
+                    .unwrap();
+            if let Some(ref dir) = data_ingestion_dir {
+                fullnode_config
+                    .checkpoint_executor_config
+                    .data_ingestion_dir = Some(dir.clone());
+            }
+            swarm_builder = swarm_builder.with_fullnode_config(fullnode_config);
+        }
     }
 
     let mut swarm = swarm_builder.build();
@@ -1097,6 +1135,9 @@ async fn start(
         let client_args = ClientArgs {
             ingestion: IngestionClientArgs {
                 local_ingestion_path: data_ingestion_dir.clone(),
+                // Back the local ingestion dir with the embedded fullnode's gRPC so checkpoints a
+                // resumed fullnode did not re-write to disk are still served.
+                rpc_api_url: Some(socket_addr_to_url(fullnode_rpc_address)?),
                 ..Default::default()
             },
             ..Default::default()
@@ -1130,6 +1171,9 @@ async fn start(
         let client_args = ClientArgs {
             ingestion: IngestionClientArgs {
                 local_ingestion_path: data_ingestion_dir.clone(),
+                // Back the local ingestion dir with the embedded fullnode's gRPC so checkpoints a
+                // resumed fullnode did not re-write to disk are still served.
+                rpc_api_url: Some(socket_addr_to_url(fullnode_rpc_address)?),
                 ..Default::default()
             },
             ..Default::default()
@@ -1469,7 +1513,7 @@ async fn genesis(
     info!("Client keystore is stored in {:?}.", keystore_path);
 
     let fullnode_config = FullnodeConfigBuilder::new()
-        .with_config_directory(FULL_NODE_DB_PATH.into())
+        .with_config_directory(sui_config_dir.to_path_buf())
         .with_rpc_addr(sui_config::node::default_json_rpc_address())
         .build(&mut OsRng, &network_config);
 


### PR DESCRIPTION
**This is an alternative to #26884** — same core fix (make `sui start` resume the embedded fullnode from its persisted config + DB instead of re-syncing from genesis every boot), but a different way to handle the embedded indexer/consistent-store ingestion on resume. Opening both so maintainers can pick the preferred approach; happy to close whichever isn't wanted.

## The shared problem
On resume the fullnode only writes *new* checkpoints to the local ingestion dir (`store_checkpoint_locally` is a side-effect of *executing* a checkpoint, and the executor resumes at `H+1`), so a freshly-enabled embedded indexer can need `0..H` that aren't on disk → `IngestionClient::wait_for` retries `NotFound` forever. The data is still in the fullnode's DB / served over gRPC.

## This PR's approach — hybrid: local-file primary + gRPC fallback
- Keeps **local-file ingestion as the primary everywhere** (preserving what looks like an intentional perf choice — per-checkpoint gRPC is heavier), and persists the local ingestion dir under `config_dir/ingestion` so it survives restarts.
- Adds a `FallbackIngestionClient` to `sui-indexer-alt-framework`: tries the primary source, and on `NotFound` falls back to a secondary. `sui start` wires the embedded indexer/consistent-store with **local-file primary + the fullnode's gRPC as fallback**, so checkpoints a resumed fullnode didn't re-write locally are backfilled from the fullnode's RPC — no hang, and the fast local path is used whenever the file exists.
- Cost: a small **additive** change to the shared `sui-indexer-alt-framework` crate (`FallbackIngestionClient` + `IngestionClient::new` combining two sources when both are set). The CLI `ArgGroup` (single-source) is unchanged — the fallback is only reachable via programmatic construction (only `sui start` sets both). Existing single-source behavior is preserved; covered by 2 new unit tests.

## vs #26884
#26884 takes the simpler, fully `sui start`-scoped route: on a **resuming** start it switches the indexer ingestion entirely to the fullnode's gRPC (cold boot stays local-file), with **no change to the shared framework crate**. The trade-off: a resuming start ingests over gRPC even when the persisted local files would suffice.

| | #26884 (resume → gRPC) | this PR (hybrid) |
|---|---|---|
| local-file as primary | cold boot only | always (perf preserved) |
| gRPC used | all resume ingestion | only to backfill missing checkpoints |
| `sui-indexer-alt-framework` change | none | small additive (`FallbackIngestionClient`) |
| blast radius | `sui start` only | + the shared indexer framework |

If local-file ingestion was chosen for perf, this hybrid preserves it; if minimal blast radius is preferred, #26884 is tighter.

`cargo check -p sui`/`-p sui-indexer-alt-framework`, `cargo clippy`, `cargo fmt --check`, and the framework ingestion tests (incl. the new fallback tests + `test_args_multiple_ingestion_sources_are_rejected`) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
