### PR TITLE
fix(sui): `sui start` resumes the embedded fullnode — always-gRPC ingestion (alt to #26884, #26887)

### DIFF
--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -49,6 +49,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_rpc_port: Option<u16>,
     fullnode_rpc_addr: Option<SocketAddr>,
     fullnode_rpc_config: Option<sui_config::RpcConfig>,
+    fullnode_config: Option<NodeConfig>,
     supported_protocol_versions_config: ProtocolVersionsConfig,
     // Default to supported_protocol_versions_config, but can be overridden.
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
@@ -85,6 +86,7 @@ impl SwarmBuilder {
             fullnode_rpc_port: None,
             fullnode_rpc_addr: None,
             fullnode_rpc_config: None,
+            fullnode_config: None,
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             fullnode_supported_protocol_versions_config: None,
             db_checkpoint_config: DBCheckpointConfig::default(),
@@ -121,6 +123,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_rpc_port: self.fullnode_rpc_port,
             fullnode_rpc_addr: self.fullnode_rpc_addr,
             fullnode_rpc_config: self.fullnode_rpc_config.clone(),
+            fullnode_config: self.fullnode_config,
             supported_protocol_versions_config: self.supported_protocol_versions_config,
             fullnode_supported_protocol_versions_config: self
                 .fullnode_supported_protocol_versions_config,
@@ -224,6 +227,11 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_fullnode_rpc_config(mut self, fullnode_rpc_config: sui_config::RpcConfig) -> Self {
         self.fullnode_rpc_config = Some(fullnode_rpc_config);
+        self
+    }
+
+    pub fn with_fullnode_config(mut self, fullnode_config: NodeConfig) -> Self {
+        self.fullnode_config = Some(fullnode_config);
         self
     }
 
@@ -484,22 +492,27 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
         }
 
         if self.fullnode_count > 0 {
+            let mut prebuilt_fullnode_config = self.fullnode_config;
             (0..self.fullnode_count).for_each(|idx| {
-                let mut builder = fullnode_config_builder.clone();
-                if idx == 0 {
-                    // Only the first fullnode is used as the rpc fullnode, we can only use the
-                    // same address once.
-                    if let Some(rpc_addr) = self.fullnode_rpc_addr {
-                        builder = builder.with_rpc_addr(rpc_addr);
+                let config = if idx == 0 && prebuilt_fullnode_config.is_some() {
+                    prebuilt_fullnode_config.take().unwrap()
+                } else {
+                    let mut builder = fullnode_config_builder.clone();
+                    if idx == 0 {
+                        // Only the first fullnode is used as the rpc fullnode, we can only use the
+                        // same address once.
+                        if let Some(rpc_addr) = self.fullnode_rpc_addr {
+                            builder = builder.with_rpc_addr(rpc_addr);
+                        }
+                        if let Some(rpc_port) = self.fullnode_rpc_port {
+                            builder = builder.with_rpc_port(rpc_port);
+                        }
+                        if let Some(rpc_config) = &self.fullnode_rpc_config {
+                            builder = builder.with_rpc_config(rpc_config.clone());
+                        }
                     }
-                    if let Some(rpc_port) = self.fullnode_rpc_port {
-                        builder = builder.with_rpc_port(rpc_port);
-                    }
-                    if let Some(rpc_config) = &self.fullnode_rpc_config {
-                        builder = builder.with_rpc_config(rpc_config.clone());
-                    }
-                }
-                let config = builder.build(&mut OsRng, &network_config);
+                    builder.build(&mut OsRng, &network_config)
+                };
                 info!(
                     "SwarmBuilder configuring full node with name {}",
                     config.protocol_public_key()

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -33,7 +33,7 @@ use sui_bridge::sui_transaction_builder::build_committee_register_transaction;
 use sui_config::node::Genesis;
 use sui_config::p2p::SeedPeer;
 use sui_config::{
-    Config, FULL_NODE_DB_PATH, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
+    Config, FULL_NODE_DB_PATH, NodeConfig, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
     SUI_NETWORK_CONFIG, genesis_blob_exists, sui_config_dir,
 };
 use sui_config::{
@@ -857,7 +857,7 @@ async fn start(
     force_regenesis: bool,
     epoch_duration_ms: Option<u64>,
     fullnode_rpc_port: u16,
-    mut data_ingestion_dir: Option<PathBuf>,
+    data_ingestion_dir: Option<PathBuf>,
     no_full_node: bool,
     committee_size: Option<usize>,
 ) -> Result<(), anyhow::Error> {
@@ -1021,13 +1021,10 @@ async fn start(
         sui_config_path
     };
 
-    // the indexer and consistent store require the fullnode's data ingestion directory
-    // note that this overrides the default configuration that is set when running the genesis
-    // command, which sets data_ingestion_dir to None.
-    if (with_indexer.is_some() || with_consistent_store.is_some()) && data_ingestion_dir.is_none() {
-        data_ingestion_dir = Some(mysten_common::tempdir()?.keep())
-    }
-
+    // The embedded indexer and consistent store ingest from the fullnode's gRPC (which serves all
+    // checkpoints), so a resumed fullnode that didn't re-write old checkpoints locally is a
+    // non-issue and no local data-ingestion dir is needed. An explicitly-provided
+    // `--data-ingestion-dir` is still honored so an operator can feed an external consumer.
     if let Some(ref dir) = data_ingestion_dir {
         swarm_builder = swarm_builder.with_data_ingestion_dir(dir.clone());
     }
@@ -1046,7 +1043,40 @@ async fn start(
         swarm_builder = swarm_builder
             .with_fullnode_count(1)
             .with_fullnode_rpc_addr(fullnode_rpc_address)
-            .with_fullnode_rpc_config(rpc_config);
+            .with_fullnode_rpc_config(rpc_config.clone());
+
+        let fullnode_config_path = config_dir.join(SUI_FULLNODE_CONFIG);
+        if fullnode_config_path.exists() {
+            let mut fullnode_config: NodeConfig = PersistedConfig::read(&fullnode_config_path)
+                .map_err(|err| {
+                    err.context(format!(
+                        "Cannot open Sui fullnode config file at {:?}",
+                        fullnode_config_path
+                    ))
+                })?;
+            fullnode_config.json_rpc_address = fullnode_rpc_address;
+            fullnode_config.rpc = Some(rpc_config);
+            // reassign the non-RPC bind addresses to free ports; the genesis-time ports may now be
+            // occupied. mirrors how FullnodeConfigBuilder assigns them. json_rpc_address, db_path,
+            // key-pairs and genesis stay as persisted.
+            let localhost = sui_config::local_ip_utils::localhost_for_testing();
+            fullnode_config.metrics_address =
+                sui_config::local_ip_utils::new_local_tcp_socket_for_testing();
+            fullnode_config.admin_interface_port =
+                sui_config::local_ip_utils::get_available_port(&localhost);
+            fullnode_config.network_address =
+                sui_config::local_ip_utils::new_tcp_address_for_testing(&localhost);
+            fullnode_config.p2p_config.listen_address =
+                sui_config::local_ip_utils::new_udp_address_for_testing(&localhost)
+                    .udp_multiaddr_to_listen_address()
+                    .unwrap();
+            if let Some(ref dir) = data_ingestion_dir {
+                fullnode_config
+                    .checkpoint_executor_config
+                    .data_ingestion_dir = Some(dir.clone());
+            }
+            swarm_builder = swarm_builder.with_fullnode_config(fullnode_config);
+        }
     }
 
     let mut swarm = swarm_builder.build();
@@ -1058,6 +1088,16 @@ async fn start(
         .trim_end_matches("/")
         .to_string();
     info!("Fullnode RPC URL: {fullnode_rpc_url}");
+
+    // The embedded indexer and consistent store always ingest from the fullnode's gRPC (which
+    // serves all checkpoints), so a resumed fullnode that didn't re-write old checkpoints locally
+    // is a non-issue.
+    let ingestion_client_args = || -> anyhow::Result<IngestionClientArgs> {
+        Ok(IngestionClientArgs {
+            rpc_api_url: Some(socket_addr_to_url(fullnode_rpc_address)?),
+            ..Default::default()
+        })
+    };
 
     let prometheus_registry = Registry::new();
     let mut rpc_services = Service::new();
@@ -1095,10 +1135,7 @@ async fn start(
 
     let pipelines = if let Some(ref db_url) = database_url {
         let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: data_ingestion_dir.clone(),
-                ..Default::default()
-            },
+            ingestion: ingestion_client_args()?,
             ..Default::default()
         };
 
@@ -1128,10 +1165,7 @@ async fn start(
             .context("Invalid consistent store host and port")?;
 
         let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: data_ingestion_dir.clone(),
-                ..Default::default()
-            },
+            ingestion: ingestion_client_args()?,
             ..Default::default()
         };
 
@@ -1469,7 +1503,7 @@ async fn genesis(
     info!("Client keystore is stored in {:?}.", keystore_path);
 
     let fullnode_config = FullnodeConfigBuilder::new()
-        .with_config_directory(FULL_NODE_DB_PATH.into())
+        .with_config_directory(sui_config_dir.to_path_buf())
         .with_rpc_addr(sui_config::node::default_json_rpc_address())
         .build(&mut OsRng, &network_config);
 


### PR DESCRIPTION
## Summary

This is the **simplest** of three alternatives that all share the same core fix: make `sui start` **resume** the embedded fullnode from its persisted config + db instead of rebuilding it from scratch (which minted a fresh keypair/db each boot and re-synced the whole chain from genesis). See #26884 for the full diagnosis of the resume bug and the doubled genesis db-path.

The three PRs differ **only** in how the embedded indexer + consistent-store get their checkpoints:

- **#26884** — resume → fullnode gRPC, cold boot → local checkpoint files (a `resuming` conditional + an auto-defaulted local data-ingestion dir).
- **#26887** — hybrid: local-file primary with gRPC fallback (touches the shared `sui-indexer-alt-framework` crate).
- **this PR** — **always gRPC**: the embedded indexer / consistent-store ingest from the fullnode's gRPC (which serves *all* checkpoints) on **both** cold boot and resume. No `resuming` conditional, no local-file ingestion lifecycle, and **no change to the shared framework crate at all**.

Because the fullnode's gRPC serves every checkpoint, a resumed fullnode that didn't re-write its already-executed checkpoints to a local dir is simply a non-issue — there is nothing to special-case. An explicitly-provided `--data-ingestion-dir` is still honored so an operator can feed an external consumer; we just no longer auto-create one for the embedded indexer.

## What's in this PR

Same core resume fix as #26884:
- Resume the embedded fullnode from the persisted `fullnode.yaml` + db (via `with_fullnode_config`).
- Fix the doubled genesis fullnode db-path (`full_node_db/full_node_db/<key>` → single, absolute level).
- Regenerate the non-RPC bind ports (metrics/admin/network/p2p) on the resume path, since the genesis-time ports may now be occupied.

Plus the always-gRPC simplification:
- Ingestion `IngestionClientArgs` for both the indexer and consistent-store unconditionally use `rpc_api_url: Some(socket_addr_to_url(fullnode_rpc_address))`.
- Removed the `resuming` variable and its derivation entirely (now dead).
- Removed the auto-default local `data_ingestion_dir` block.

All scoped to `sui start`; `crates/sui-indexer-alt-framework` is untouched.

## Trade-offs vs the alternatives

| | local-file used | gRPC used | shared-framework change | blast radius | complexity |
|---|---|---|---|---|---|
| #26884 (resume→gRPC, cold→local) | cold boot | resume | none | `sui start` only | medium (`resuming` conditional + auto-default dir) |
| #26887 (hybrid local+gRPC fallback) | primary | fallback | **yes** (framework) | `sui start` + shared crate | highest (dual-source fallback logic) |
| **this PR (always gRPC)** | only if `--data-ingestion-dir` given | always | **none** | `sui start` only | **lowest** (no conditional, no dir lifecycle) |

## Downside

Cold-boot initial sync for the embedded indexer/consistent-store now also goes over gRPC instead of reading local checkpoint files. For a local `sui start` cluster this is negligible, but it's the one behavior that #26884 retains (local-file on cold boot) and this PR trades away for simplicity.

## Alternatives

- #26884 — resume → gRPC, cold boot → local-file.
- #26887 — hybrid local-file primary + gRPC fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
