### PR TITLE
Remove unnecessary async from AuthorityState methods

### DIFF
--- a/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
@@ -63,7 +63,6 @@ impl TestEnv {
         let cert = VerifiedExecutableTransaction::new_for_testing(tx, &keypair);
         let (effects, ..) = authority
             .try_execute_immediately(&cert, ExecutionEnv::new(), &epoch_store)
-            .await
             .unwrap();
         assert!(effects.status().is_ok());
         let package_id = effects
@@ -81,7 +80,6 @@ impl TestEnv {
         let cert = VerifiedExecutableTransaction::new_for_testing(tx, &keypair);
         let (effects, ..) = authority
             .try_execute_immediately(&cert, ExecutionEnv::new(), &epoch_store)
-            .await
             .unwrap();
         assert!(effects.status().is_ok());
         let vault_obj = effects.created().into_iter().next().unwrap().0;
@@ -96,10 +94,9 @@ impl TestEnv {
         }
     }
 
-    pub async fn oref(&self, object_id: &ObjectID) -> ObjectRef {
+    pub fn oref(&self, object_id: &ObjectID) -> ObjectRef {
         self.authority
             .get_object(object_id)
-            .await
             .unwrap()
             .compute_object_reference()
     }
@@ -109,7 +106,7 @@ impl TestEnv {
     }
 
     pub async fn fund_address(&self, address: SuiAddress, amount: u64) {
-        let gas = self.oref(&self.gas_obj).await;
+        let gas = self.oref(&self.gas_obj);
         let tx = TestTransactionBuilder::new(self.sender, gas, self.rgp())
             .transfer_sui_to_address_balance(FundSource::coin(gas), vec![(amount, address)])
             .build();
@@ -118,7 +115,6 @@ impl TestEnv {
         let (effects, ..) = self
             .authority
             .try_execute_immediately(&cert, ExecutionEnv::new(), &self.epoch_store)
-            .await
             .unwrap();
         assert!(effects.status().is_ok());
 
@@ -143,16 +139,16 @@ async fn test_object_withdraw_basic_flow() {
 
     env.fund_address(env.vault_obj.into(), 1000).await;
 
-    let gas = env.oref(&env.gas_obj).await;
+    let gas = env.oref(&env.gas_obj);
     let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
         .transfer_sui_to_address_balance(
-            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
+            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
             vec![(1000, env.sender)],
         )
         .build();
     let cert = VerifiedExecutableTransaction::new_for_testing(tx, &env.keypair);
 
-    let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).await.1;
+    let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).1;
     let effects = env
         .authority
         .try_execute_immediately(
@@ -161,7 +157,6 @@ async fn test_object_withdraw_basic_flow() {
                 .with_assigned_versions(AssignedVersions::new(vec![], Some(accumulator_version))),
             &env.epoch_store,
         )
-        .await
         .unwrap()
         .0;
     assert!(effects.status().is_ok());
@@ -177,16 +172,16 @@ async fn test_object_withdraw_multiple_withdraws() {
     // Withdraw from the same object account 3 times, each 300.
     // All withdraws should be sufficient.
     for _ in 0..3 {
-        let gas = env.oref(&env.gas_obj).await;
+        let gas = env.oref(&env.gas_obj);
         let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
             .transfer_sui_to_address_balance(
-                FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
+                FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
                 vec![(300, env.sender)],
             )
             .build();
         let cert = VerifiedExecutableTransaction::new_for_testing(tx, &env.keypair);
 
-        let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).await.1;
+        let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).1;
         let effects = env
             .authority
             // Fastpath execution
@@ -198,7 +193,6 @@ async fn test_object_withdraw_multiple_withdraws() {
                 )),
                 &env.epoch_store,
             )
-            .await
             .unwrap()
             .0;
         assert!(effects.status().is_ok());
@@ -216,17 +210,17 @@ async fn test_object_withdraw_multiple_withdraws() {
     // The first 2 withdraws should be sufficient, the last one should be insufficient.
     // This test exercises the case where we have to track unsettled balance withdraws from the same consensus commit.
     for i in 0..3 {
-        let gas = env.oref(&env.gas_obj).await;
+        let gas = env.oref(&env.gas_obj);
         let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
             .transfer_sui_to_address_balance(
-                FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
+                FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
                 vec![(40, env.sender)],
             )
             .build();
         let cert = VerifiedExecutableTransaction::new_for_testing(tx, &env.keypair);
         let digest = *cert.digest();
 
-        let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).await.1;
+        let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).1;
         let output = env
             .authority
             // Fastpath execution
@@ -237,8 +231,7 @@ async fn test_object_withdraw_multiple_withdraws() {
                     Some(accumulator_version),
                 )),
                 &env.epoch_store,
-            )
-            .await;
+            );
         let effects = if i < 2 {
             let effects = output.unwrap().0;
             assert!(effects.status().is_ok());
@@ -281,25 +274,22 @@ async fn test_object_withdraw_and_deposit_same_transaction() {
     // The max net withdraws for this account should be 3, because at any given moment,
     // the net withdraws is at most 3.
     // Since the account has a balance of 2, the transaction should fail.
-    let gas = env.oref(&env.gas_obj).await;
+    let gas = env.oref(&env.gas_obj);
     let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
         .transfer_sui_to_address_balance(
-            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
+            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
             vec![(3, env.vault_obj.into())],
         )
         .build();
     let cert = VerifiedExecutableTransaction::new_for_testing(tx, &env.keypair);
     let digest = *cert.digest();
-    let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).await.1;
-    let output = env
-        .authority
-        .try_execute_immediately(
-            &cert,
-            ExecutionEnv::new()
-                .with_assigned_versions(AssignedVersions::new(vec![], Some(accumulator_version))),
-            &env.epoch_store,
-        )
-        .await;
+    let accumulator_version = env.oref(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).1;
+    let output = env.authority.try_execute_immediately(
+        &cert,
+        ExecutionEnv::new()
+            .with_assigned_versions(AssignedVersions::new(vec![], Some(accumulator_version))),
+        &env.epoch_store,
+    );
     assert!(matches!(output, ExecutionOutput::RetryLater));
     let effects = env
         .authority
@@ -313,16 +303,16 @@ async fn test_object_withdraw_and_deposit_same_transaction() {
         })
     ));
 
-    let gas = env.oref(&env.gas_obj).await;
+    let gas = env.oref(&env.gas_obj);
     // Now we try with withdraw 2 and deposit 2, which should be sufficient,
     // even if we do it twice.
     let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
         .transfer_sui_to_address_balance(
-            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
+            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
             vec![(2, env.vault_obj.into())],
         )
         .transfer_sui_to_address_balance(
-            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
+            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
             vec![(2, env.vault_obj.into())],
         )
         .build();
@@ -335,7 +325,6 @@ async fn test_object_withdraw_and_deposit_same_transaction() {
                 .with_assigned_versions(AssignedVersions::new(vec![], Some(accumulator_version))),
             &env.epoch_store,
         )
-        .await
         .unwrap()
         .0;
     assert!(effects.status().is_ok());
@@ -343,24 +332,21 @@ async fn test_object_withdraw_and_deposit_same_transaction() {
     // Now try to withdraw 1 and deposit 1. Since the previous
     // transaction has a pending withdraw of 2, there is no more balance available.
     // This should fail.
-    let gas = env.oref(&env.gas_obj).await;
+    let gas = env.oref(&env.gas_obj);
     let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
         .transfer_sui_to_address_balance(
-            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
+            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
             vec![(1, env.vault_obj.into())],
         )
         .build();
     let cert = VerifiedExecutableTransaction::new_for_testing(tx, &env.keypair);
     let digest = *cert.digest();
-    let output = env
-        .authority
-        .try_execute_immediately(
-            &cert,
-            ExecutionEnv::new()
-                .with_assigned_versions(AssignedVersions::new(vec![], Some(accumulator_version))),
-            &env.epoch_store,
-        )
-        .await;
+    let output = env.authority.try_execute_immediately(
+        &cert,
+        ExecutionEnv::new()
+            .with_assigned_versions(AssignedVersions::new(vec![], Some(accumulator_version))),
+        &env.epoch_store,
+    );
     assert!(matches!(output, ExecutionOutput::RetryLater));
     let effects = env
         .authority

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1455,7 +1455,7 @@ impl AuthorityState {
     ///
     /// Should only be called within sui-core.
     #[instrument(level = "trace", skip_all)]
-    pub async fn try_execute_immediately(
+    pub fn try_execute_immediately(
         &self,
         certificate: &VerifiedExecutableTransaction,
         mut execution_env: ExecutionEnv,
@@ -1647,7 +1647,6 @@ impl AuthorityState {
                 execution_env,
                 &epoch_store,
             )
-            .await
             .unwrap();
         let signed_effects = self.sign_effects(effects, &epoch_store).unwrap();
         (signed_effects, execution_error_opt)
@@ -1661,7 +1660,6 @@ impl AuthorityState {
         let epoch_store = self.epoch_store_for_testing();
         let (effects, execution_error_opt) = self
             .try_execute_immediately(executable, execution_env, &epoch_store)
-            .await
             .unwrap();
         self.flush_post_processing(executable.digest()).await;
         let signed_effects = self.sign_effects(effects, &epoch_store).unwrap();
@@ -3394,15 +3392,14 @@ impl AuthorityState {
 
         let requested_object_seq = match request.request_kind {
             ObjectInfoRequestKind::LatestObjectInfo => {
-                let (_, seq, _) = self
-                    .get_object_or_tombstone(request.object_id)
-                    .await
-                    .ok_or_else(|| {
-                        SuiError::from(UserInputError::ObjectNotFound {
-                            object_id: request.object_id,
-                            version: None,
-                        })
-                    })?;
+                let (_, seq, _) =
+                    self.get_object_or_tombstone(request.object_id)
+                        .ok_or_else(|| {
+                            SuiError::from(UserInputError::ObjectNotFound {
+                                object_id: request.object_id,
+                                version: None,
+                            })
+                        })?;
                 seq
             }
             ObjectInfoRequestKind::PastObjectInfoDebug(seq) => seq,
@@ -3439,8 +3436,7 @@ impl AuthorityState {
             // Only address owned objects have locks.
             None
         } else {
-            self.get_transaction_lock(&object.compute_object_reference(), &epoch_store)
-                .await?
+            self.get_transaction_lock(&object.compute_object_reference(), &epoch_store)?
                 .map(|s| s.into_inner())
         };
 
@@ -3698,15 +3694,12 @@ impl AuthorityState {
             && epoch_store.protocol_config().enable_object_funds_withdraw()
         {
             if self.object_funds_checker.load().is_none() {
-                let inner = self
-                    .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
-                    .await
-                    .map(|o| {
-                        Arc::new(ObjectFundsChecker::new(
-                            o.version(),
-                            self.object_funds_checker_metrics.clone(),
-                        ))
-                    });
+                let inner = self.get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID).map(|o| {
+                    Arc::new(ObjectFundsChecker::new(
+                        o.version(),
+                        self.object_funds_checker_metrics.clone(),
+                    ))
+                });
                 self.object_funds_checker.store(inner);
             }
         } else {
@@ -4037,7 +4030,6 @@ impl AuthorityState {
     ) -> Vec<(VerifiedExecutableTransaction, ExecutionEnv)> {
         let accumulator_version = self
             .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
-            .await
             .unwrap()
             .version();
         // Use provided checkpoint sequence, or fall back to accumulator version.
@@ -4088,7 +4080,6 @@ impl AuthorityState {
             let env = ExecutionEnv::new().with_assigned_versions(assigned);
             let (effects, _) = self
                 .try_execute_immediately(&tx.clone(), env.clone(), &epoch_store)
-                .await
                 .unwrap();
             assert!(effects.status().is_ok());
             replay_txns.push((tx, env));
@@ -4118,7 +4109,6 @@ impl AuthorityState {
         let env = ExecutionEnv::new().with_assigned_versions(barrier_assigned);
         let (effects, _) = self
             .try_execute_immediately(&barrier.clone(), env.clone(), &epoch_store)
-            .await
             .unwrap();
         assert!(effects.status().is_ok());
         replay_txns.push((barrier, env));
@@ -4144,7 +4134,6 @@ impl AuthorityState {
         for (tx, env) in txns {
             let (effects, _) = self
                 .try_execute_immediately(tx, env.clone(), &epoch_store)
-                .await
                 .unwrap();
             assert!(effects.status().is_ok());
         }
@@ -4392,14 +4381,13 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+    pub fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
         self.get_object_store().get_object(object_id)
     }
 
-    pub async fn get_sui_system_package_object_ref(&self) -> SuiResult<ObjectRef> {
+    pub fn get_sui_system_package_object_ref(&self) -> SuiResult<ObjectRef> {
         Ok(self
             .get_object(&SUI_SYSTEM_ADDRESS.into())
-            .await
             .expect("framework object should always exist")
             .compute_object_reference())
     }
@@ -4729,11 +4717,7 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn get_move_objects<T>(
-        &self,
-        owner: SuiAddress,
-        type_: MoveObjectType,
-    ) -> SuiResult<Vec<T>>
+    pub fn get_move_objects<T>(&self, owner: SuiAddress, type_: MoveObjectType) -> SuiResult<Vec<T>>
     where
         T: DeserializeOwned,
     {
@@ -5211,17 +5195,14 @@ impl AuthorityState {
         Ok(events)
     }
 
-    pub async fn insert_genesis_object(&self, object: Object) {
+    pub fn insert_genesis_object(&self, object: Object) {
         self.get_reconfig_api().insert_genesis_object(object);
     }
 
-    pub async fn insert_genesis_objects(&self, objects: &[Object]) {
-        futures::future::join_all(
-            objects
-                .iter()
-                .map(|o| self.insert_genesis_object(o.clone())),
-        )
-        .await;
+    pub fn insert_genesis_objects(&self, objects: &[Object]) {
+        for o in objects {
+            self.insert_genesis_object(o.clone());
+        }
     }
 
     /// Make a status response for a transaction
@@ -5412,7 +5393,7 @@ impl AuthorityState {
     /// Returns None if a lock record is initialized for the given ObjectRef but not yet locked by any transaction,
     ///     or cannot find the transaction in transaction table, because of data race etc.
     #[instrument(level = "trace", skip_all)]
-    pub async fn get_transaction_lock(
+    pub fn get_transaction_lock(
         &self,
         object_ref: &ObjectRef,
         epoch_store: &AuthorityPerEpochStore,
@@ -5437,11 +5418,11 @@ impl AuthorityState {
         epoch_store.get_signed_transaction(&lock_info.tx_digest)
     }
 
-    pub async fn get_objects(&self, objects: &[ObjectID]) -> Vec<Option<Object>> {
+    pub fn get_objects(&self, objects: &[ObjectID]) -> Vec<Option<Object>> {
         self.get_object_cache_reader().get_objects(objects)
     }
 
-    pub async fn get_object_or_tombstone(&self, object_id: ObjectID) -> Option<ObjectRef> {
+    pub fn get_object_or_tombstone(&self, object_id: ObjectID) -> Option<ObjectRef> {
         self.get_object_cache_reader()
             .get_latest_object_ref_or_tombstone(object_id)
     }
@@ -5552,7 +5533,7 @@ impl AuthorityState {
         binary_config: &BinaryConfig,
     ) -> Option<Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>> {
         let ids: Vec<_> = system_packages.iter().map(|(id, _, _)| *id).collect();
-        let objects = self.get_objects(&ids).await;
+        let objects = self.get_objects(&ids);
 
         let mut res = Vec::with_capacity(system_packages.len());
         for (system_package_ref, object) in system_packages.into_iter().zip_debug_eq(objects.iter())

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -291,7 +291,7 @@ pub async fn init_state_with_ids<I: IntoIterator<Item = (SuiAddress, ObjectID)>>
     let state = TestAuthorityBuilder::new().build().await;
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     state
 }
@@ -308,7 +308,7 @@ pub async fn init_state_with_ids_and_versions<
             version,
             Owner::AddressOwner(address),
         );
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     state
 }
@@ -332,7 +332,7 @@ pub async fn init_state_with_objects_and_committee<I: IntoIterator<Item = Object
 ) -> Arc<AuthorityState> {
     let state = init_state_with_committee(genesis, authority_key).await;
     for o in objects {
-        state.insert_genesis_object(o).await;
+        state.insert_genesis_object(o);
     }
     state
 }
@@ -356,7 +356,7 @@ pub async fn init_state_with_ids_and_expensive_checks<
         .await;
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     state
 }

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -1171,7 +1171,6 @@ mod tests {
         let acc_version = ctx
             .authority
             .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
-            .await
             .unwrap()
             .version();
 
@@ -1217,7 +1216,6 @@ mod tests {
         let acc_version = ctx
             .authority
             .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
-            .await
             .unwrap()
             .version();
 
@@ -1310,7 +1308,6 @@ mod tests {
         let acc_version = ctx
             .authority
             .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
-            .await
             .unwrap()
             .version();
 

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -463,7 +463,6 @@ impl<'a> TestAuthorityBuilder<'a> {
                 ExecutionEnv::new(),
                 &state.epoch_store_for_testing(),
             )
-            .await
             .unwrap();
 
         let batch = state

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -1031,7 +1031,6 @@ mod tests {
             VerifiedExecutableTransaction::new_from_consensus(transaction.clone().into_tx(), 0);
         let (executed_effects, _) = state
             .try_execute_immediately(&cert, ExecutionEnv::new(), &state.epoch_store_for_testing())
-            .await
             .unwrap();
 
         // Verify the transaction is executed.

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -121,7 +121,7 @@ pub async fn execution_process(
                 &certificate,
                 execution_env,
                 &epoch_store_clone,
-            ).await {
+            ) {
                 ExecutionOutput::Success(_) => {
                     authority
                         .metrics

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -138,7 +138,7 @@ impl TestCallArg {
     }
 
     async fn call_arg_from_id(object_id: ObjectID, state: &AuthorityState) -> ObjectArg {
-        let object = state.get_object(&object_id).await.unwrap();
+        let object = state.get_object(&object_id).unwrap();
         match &object.owner {
             Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
                 ObjectArg::ImmOrOwnedObject(object.compute_object_reference())
@@ -204,7 +204,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
         .unwrap();
         effects.status().unwrap();
         let shared_object_id = effects.created()[0].0.0;
-        let mut shared_object = authority.get_object(&shared_object_id).await.unwrap();
+        let mut shared_object = authority.get_object(&shared_object_id).unwrap();
         if let Some(initial_shared_version) = initial_shared_version_override {
             shared_object
                 .data
@@ -223,10 +223,10 @@ async fn construct_shared_object_transaction_with_sequence_number(
     // Make a sample transaction.
     let (validator, fullnode, package) =
         init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
-    validator.insert_genesis_object(shared_object.clone()).await;
-    fullnode.insert_genesis_object(shared_object.clone()).await;
+    validator.insert_genesis_object(shared_object.clone());
+    fullnode.insert_genesis_object(shared_object.clone());
     let rgp = validator.reference_gas_price_for_testing().unwrap();
-    let gas_object = validator.get_object(&gas_object_id).await;
+    let gas_object = validator.get_object(&gas_object_id);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let data = TransactionData::new_move_call(
         sender,
@@ -261,11 +261,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
 async fn test_dry_run_transaction_block() {
     let (validator, fullnode, transaction, gas_object_id, shared_object_id) =
         construct_shared_object_transaction_with_sequence_number(None).await;
-    let initial_shared_object_version = validator
-        .get_object(&shared_object_id)
-        .await
-        .unwrap()
-        .version();
+    let initial_shared_object_version = validator.get_object(&shared_object_id).unwrap().version();
 
     let (response, _, _, _) = fullnode
         .dry_exec_transaction(transaction.data().intent_message().value.clone())
@@ -275,13 +271,9 @@ async fn test_dry_run_transaction_block() {
     let gas_usage = response.effects.gas_cost_summary();
 
     // Make sure that objects are not mutated after dry run.
-    let gas_object_version = fullnode.get_object(&gas_object_id).await.unwrap().version();
+    let gas_object_version = fullnode.get_object(&gas_object_id).unwrap().version();
     assert_eq!(gas_object_version, OBJECT_START_VERSION);
-    let shared_object_version = fullnode
-        .get_object(&shared_object_id)
-        .await
-        .unwrap()
-        .version();
+    let shared_object_version = fullnode.get_object(&shared_object_id).unwrap().version();
     assert_eq!(shared_object_version, initial_shared_object_version);
 
     let txn_data = &transaction.data().intent_message().value;
@@ -387,7 +379,7 @@ async fn test_dev_inspect_object_by_bytes() {
     .await
     .unwrap();
     let created_object_id = effects.created()[0].0.0;
-    let created_object = validator.get_object(&created_object_id).await.unwrap();
+    let created_object = validator.get_object(&created_object_id).unwrap();
     let created_object_bytes = created_object
         .data
         .try_as_move()
@@ -457,7 +449,7 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(effects.unwrapped_then_deleted().is_empty());
 
     // compare the bytes
-    let updated_object = validator.get_object(&created_object_id).await.unwrap();
+    let updated_object = validator.get_object(&created_object_id).unwrap();
     let updated_object_bytes = updated_object.data.try_as_move().unwrap().contents();
     assert_eq!(updated_object_bytes, updated_reference_bytes)
 }
@@ -490,7 +482,7 @@ async fn test_dev_inspect_unowned_object() {
     .await
     .unwrap();
     let created_object_id = effects.created()[0].0.0;
-    let created_object = validator.get_object(&created_object_id).await.unwrap();
+    let created_object = validator.get_object(&created_object_id).unwrap();
     assert!(alice != bob);
     assert_eq!(created_object.owner, Owner::AddressOwner(bob));
 
@@ -558,7 +550,7 @@ async fn test_dev_inspect_dynamic_field() {
                 .unwrap();
                 assert!(effects.status().is_ok(), "{:#?}", effects.status());
                 let created_object_id = effects.created()[0].0.0;
-                let created_object = validator.get_object(&created_object_id).await.unwrap();
+                let created_object = validator.get_object(&created_object_id).unwrap();
                 created_object
                     .data
                     .try_as_move()
@@ -664,7 +656,7 @@ async fn test_dev_inspect_return_values() {
     .await
     .unwrap();
     let created_object_id = effects.created()[0].0.0;
-    let created_object = validator.get_object(&created_object_id).await.unwrap();
+    let created_object = validator.get_object(&created_object_id).unwrap();
     let created_object_bytes = created_object
         .data
         .try_as_move()
@@ -1011,8 +1003,8 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     let (fullnode, _object_basics) = publish_object_basics(fullnode).await;
     let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
     let gas_object_ref = gas_object.compute_object_reference();
-    validator.insert_genesis_object(gas_object.clone()).await;
-    fullnode.insert_genesis_object(gas_object).await;
+    validator.insert_genesis_object(gas_object.clone());
+    fullnode.insert_genesis_object(gas_object);
     // create the parent
     let effects = call_move_(
         &validator,
@@ -1079,7 +1071,7 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     assert_eq!(effects.created().len(), 1);
 
     // make sure the parent was updated
-    let new_parent = fullnode.get_object(&parent.0).await.unwrap();
+    let new_parent = fullnode.get_object(&parent.0).unwrap();
     assert!(parent.1 < new_parent.version());
 
     // no child to delete since we are using the old version of the parent
@@ -1142,8 +1134,8 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
         Owner::AddressOwner(sender),
     );
     let gas_object_ref = gas_object.compute_object_reference();
-    validator.insert_genesis_object(gas_object.clone()).await;
-    fullnode.insert_genesis_object(gas_object).await;
+    validator.insert_genesis_object(gas_object.clone());
+    fullnode.insert_genesis_object(gas_object);
     let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     let pt = ProgrammableTransaction {
         inputs: vec![
@@ -1188,8 +1180,8 @@ async fn test_handle_transfer_transaction_bad_signature() {
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -1217,14 +1209,13 @@ async fn test_handle_transfer_transaction_bad_signature() {
     // verify_user_input (transaction.rs)
     // assert_eq!(metrics.signature_errors.get(), 1);
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
     assert!(
         authority_state
             .get_transaction_lock(
                 &object.compute_object_reference(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1235,7 +1226,6 @@ async fn test_handle_transfer_transaction_bad_signature() {
                 &object.compute_object_reference(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1253,8 +1243,8 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
     ])
     .await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -1296,8 +1286,8 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let unknown_sender_transfer_transaction = init_transfer_transaction(
         &authority_state,
@@ -1314,14 +1304,13 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         handle_transaction_for_test(&authority_state, unknown_sender_transfer_transaction).is_err()
     );
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
     assert!(
         authority_state
             .get_transaction_lock(
                 &object.compute_object_reference(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1332,7 +1321,6 @@ async fn test_handle_transfer_transaction_unknown_sender() {
                 &object.compute_object_reference(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1350,8 +1338,8 @@ async fn test_handle_transfer_transaction_ok() {
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let before_object_version = object.version();
     let after_object_version =
@@ -1378,7 +1366,7 @@ async fn test_handle_transfer_transaction_ok() {
     assert!(effects.status().is_ok());
 
     // Verify the object was transferred to the recipient
-    let transferred_object = authority_state.get_object(&object_id).await.unwrap();
+    let transferred_object = authority_state.get_object(&object_id).unwrap();
     assert_eq!(transferred_object.version(), after_object_version);
     assert_eq!(transferred_object.owner, Owner::AddressOwner(recipient));
 }
@@ -1395,8 +1383,8 @@ async fn test_handle_sponsored_transaction() {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
@@ -1520,11 +1508,8 @@ async fn test_transfer_package() {
     let object_id = ObjectID::random();
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority_state.get_object(&object_id).await.unwrap();
-    let package_object_ref = authority_state
-        .get_sui_system_package_object_ref()
-        .await
-        .unwrap();
+    let gas_object = authority_state.get_object(&object_id).unwrap();
+    let package_object_ref = authority_state.get_sui_system_package_object_ref().unwrap();
     // We are trying to transfer the genesis package object, which is immutable.
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
@@ -1551,10 +1536,8 @@ async fn test_immutable_gas() {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let imm_object_id = ObjectID::random();
     let imm_object = Object::immutable_with_id_for_testing(imm_object_id);
-    authority_state
-        .insert_genesis_object(imm_object.clone())
-        .await;
-    let mut_object = authority_state.get_object(&mut_object_id).await.unwrap();
+    authority_state.insert_genesis_object(imm_object.clone());
+    let mut_object = authority_state.get_object(&mut_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -1583,9 +1566,7 @@ async fn test_objected_owned_gas() {
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let child_object_id = ObjectID::random();
     let child_object = Object::with_object_owner_for_testing(child_object_id, parent_object_id);
-    authority_state
-        .insert_genesis_object(child_object.clone())
-        .await;
+    authority_state.insert_genesis_object(child_object.clone());
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let data = TransactionData::new_transfer_sui(
         recipient,
@@ -1683,12 +1664,12 @@ async fn test_publish_dependent_module_ok() {
     .fresh_id();
 
     // Object does not exist
-    assert!(authority.get_object(&dependent_module_id).await.is_none());
+    assert!(authority.get_object(&dependent_module_id).is_none());
     let signed_effects = submit_and_execute(&authority, transaction).await.unwrap().1;
     signed_effects.into_data().status().unwrap();
 
     // check that the dependent module got published
-    assert!(authority.get_object(&dependent_module_id).await.is_some());
+    assert!(authority.get_object(&dependent_module_id).is_some());
 }
 
 // Test that publishing a module with no dependencies works
@@ -1705,7 +1686,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let gas_payment_object =
         Object::with_id_owner_gas_for_testing(gas_payment_object_id, sender, gas_balance);
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
-    authority.insert_genesis_object(gas_payment_object).await;
+    authority.insert_genesis_object(gas_payment_object);
 
     let module = file_format::empty_module();
     let mut module_bytes = Vec::new();
@@ -1804,7 +1785,6 @@ async fn test_publish_non_existing_dependent_module() {
     assert_eq!(
         authority
             .get_object(&gas_payment_object_id)
-            .await
             .unwrap()
             .version(),
         gas_payment_object_ref.1
@@ -1876,7 +1856,7 @@ async fn test_publish_module_with_unpublishable_magic() {
     let gas_payment_object =
         Object::with_id_owner_gas_for_testing(gas_payment_object_id, sender, gas_balance);
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
-    authority.insert_genesis_object(gas_payment_object).await;
+    authority.insert_genesis_object(gas_payment_object);
 
     let module = file_format::empty_unpublishable_module();
     let mut module_bytes = Vec::new();
@@ -1920,7 +1900,7 @@ async fn test_publish_module_with_unpublishable_magic_swapped() {
     let gas_payment_object =
         Object::with_id_owner_gas_for_testing(gas_payment_object_id, sender, gas_balance);
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
-    authority.insert_genesis_object(gas_payment_object).await;
+    authority.insert_genesis_object(gas_payment_object);
 
     let module = file_format::empty_unpublishable_module();
     let mut module_bytes = Vec::new();
@@ -1973,10 +1953,7 @@ async fn test_handle_move_transaction() {
 
     let created_object_id = effects.created()[0].0.0;
     // check that transaction actually created an object with the expected ID, owner
-    let created_obj = authority_state
-        .get_object(&created_object_id)
-        .await
-        .unwrap();
+    let created_obj = authority_state.get_object(&created_object_id).unwrap();
     assert_eq!(
         created_obj.owner.get_address_owner_address().unwrap(),
         sender
@@ -1994,8 +1971,8 @@ async fn test_handle_transfer_transaction_double_spend() {
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -2019,7 +1996,7 @@ async fn test_handle_transfer_sui_with_amount_insufficient_gas() {
     let object_id = ObjectID::random();
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
     let data = TransactionData::new_transfer_sui(
         recipient,
         sender,
@@ -2050,7 +2027,7 @@ async fn test_missing_package() {
         init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let non_existent_package = ObjectID::MAX;
     let gas_object_ref = gas_object.compute_object_reference();
     let data = TransactionData::new_move_call(
@@ -2090,15 +2067,15 @@ async fn test_type_argument_dependencies() {
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let gas1 = {
-        let o = authority_state.get_object(&gas1).await.unwrap();
+        let o = authority_state.get_object(&gas1).unwrap();
         o.compute_object_reference()
     };
     let gas2 = {
-        let o = authority_state.get_object(&gas2).await.unwrap();
+        let o = authority_state.get_object(&gas2).unwrap();
         o.compute_object_reference()
     };
     let gas3 = {
-        let o = authority_state.get_object(&gas3).await.unwrap();
+        let o = authority_state.get_object(&gas3).unwrap();
         o.compute_object_reference()
     };
     // primitive type tag succeeds
@@ -2182,8 +2159,8 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
     let gas_object_id = ObjectID::random();
     let authority_state =
         init_state_with_ids(vec![(address, object_id), (address, gas_object_id)]).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let transfer_transaction = init_transfer_transaction(
@@ -2210,8 +2187,8 @@ async fn test_handle_confirmation_transaction_ok() {
     let gas_object_id = ObjectID::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let next_sequence_number =
         SequenceNumber::lamport_increment([object.version(), gas_object.version()]);
@@ -2228,7 +2205,7 @@ async fn test_handle_confirmation_transaction_ok() {
         rgp,
     );
 
-    let old_account = authority_state.get_object(&object_id).await.unwrap();
+    let old_account = authority_state.get_object(&object_id).unwrap();
 
     let (_, signed_effects) =
         submit_and_execute(&authority_state, transfer_transaction.into_inner())
@@ -2237,7 +2214,7 @@ async fn test_handle_confirmation_transaction_ok() {
     signed_effects.data().status().unwrap();
     // Key check: the ownership has changed
 
-    let new_account = authority_state.get_object(&object_id).await.unwrap();
+    let new_account = authority_state.get_object(&object_id).unwrap();
     assert_eq!(
         new_account.owner.get_address_owner_address().unwrap(),
         recipient
@@ -2251,7 +2228,6 @@ async fn test_handle_confirmation_transaction_ok() {
                 &(object_id, 1.into(), old_account.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .is_err()
     );
     assert!(
@@ -2260,7 +2236,6 @@ async fn test_handle_confirmation_transaction_ok() {
                 &(object_id, 2.into(), new_account.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .expect("Exists")
             .is_none()
     );
@@ -2274,8 +2249,8 @@ async fn test_handle_confirmation_transaction_idempotent() {
     let gas_object_id = ObjectID::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let transfer_transaction = init_transfer_transaction(
@@ -2351,7 +2326,6 @@ async fn test_move_call_mutable_object_not_mutated() {
 
     let gas_version = authority_state
         .get_object(&gas_object_id)
-        .await
         .unwrap()
         .version();
 
@@ -2379,7 +2353,6 @@ async fn test_move_call_mutable_object_not_mutated() {
     assert_eq!(
         authority_state
             .get_object(&new_object_id1)
-            .await
             .unwrap()
             .version(),
         next_object_version
@@ -2387,7 +2360,6 @@ async fn test_move_call_mutable_object_not_mutated() {
     assert_eq!(
         authority_state
             .get_object(&new_object_id2)
-            .await
             .unwrap()
             .version(),
         next_object_version
@@ -2421,12 +2393,10 @@ async fn test_move_call_insufficient_gas() {
         recipient,
         authority_state
             .get_object(&object_id)
-            .await
             .unwrap()
             .compute_object_reference(),
         authority_state
             .get_object(&gas_object_id1)
-            .await
             .unwrap()
             .compute_object_reference(),
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
@@ -2441,13 +2411,11 @@ async fn test_move_call_insufficient_gas() {
 
     let obj_ref = authority_state
         .get_object(&object_id)
-        .await
         .unwrap()
         .compute_object_reference();
 
     let gas_ref = authority_state
         .get_object(&gas_object_id2)
-        .await
         .unwrap()
         .compute_object_reference();
 
@@ -2480,7 +2448,7 @@ async fn test_move_call_insufficient_gas() {
         .1;
     let effects = signed_effects.into_data();
     assert!(effects.status().is_err());
-    let obj = authority_state.get_object(&object_id).await.unwrap();
+    let obj = authority_state.get_object(&object_id).unwrap();
     assert_eq!(obj.previous_transaction, tx_digest);
     assert_eq!(obj.version(), next_object_version);
     assert_eq!(obj.owner.get_address_owner_address().unwrap(), recipient);
@@ -2564,7 +2532,6 @@ async fn test_get_latest_parent_entry_genesis() {
     assert!(
         authority_state
             .get_object_or_tombstone(ObjectID::ZERO)
-            .await
             .is_none()
     );
 }
@@ -2621,7 +2588,6 @@ async fn test_get_latest_parent_entry() {
     // Check entry for object to be deleted is returned
     let obj_ref = authority_state
         .get_object_or_tombstone(new_object_id1)
-        .await
         .unwrap();
     assert_eq!(obj_ref.0, new_object_id1);
     assert_eq!(obj_ref.1, update_version);
@@ -2654,14 +2620,12 @@ async fn test_get_latest_parent_entry() {
     assert!(
         authority_state
             .get_object_or_tombstone(unknown_object_id)
-            .await
             .is_none()
     );
 
     // Check gas object is returned.
     let obj_ref = authority_state
         .get_object_or_tombstone(gas_object_id)
-        .await
         .unwrap();
     assert_eq!(obj_ref.0, gas_object_id);
     assert_eq!(obj_ref.1, delete_version);
@@ -2669,7 +2633,6 @@ async fn test_get_latest_parent_entry() {
     // Check entry for deleted object is returned
     let obj_ref = authority_state
         .get_object_or_tombstone(new_object_id1)
-        .await
         .unwrap();
     assert_eq!(obj_ref.0, new_object_id1);
     assert_eq!(obj_ref.1, delete_version);
@@ -2682,7 +2645,7 @@ async fn test_account_state_ok() {
     let object_id = dbg_object_id(1);
 
     let authority_state = init_state_with_object_id(sender, object_id).await;
-    authority_state.get_object(&object_id).await.unwrap();
+    authority_state.get_object(&object_id).unwrap();
 }
 
 #[tokio::test]
@@ -2690,7 +2653,7 @@ async fn test_account_state_unknown_account() {
     let sender = dbg_addr(1);
     let unknown_address = dbg_object_id(99);
     let authority_state = init_state_with_object_id(sender, ObjectID::random()).await;
-    assert!(authority_state.get_object(&unknown_address).await.is_none());
+    assert!(authority_state.get_object(&unknown_address).is_none());
 }
 
 #[tokio::test]
@@ -2732,7 +2695,7 @@ async fn test_authority_persist() {
     let obj = Object::with_id_owner_for_testing(object_id, recipient);
 
     // Store an object
-    authority.insert_genesis_object(obj).await;
+    authority.insert_genesis_object(obj);
 
     // Close the authority
     drop(authority);
@@ -2751,7 +2714,7 @@ async fn test_authority_persist() {
             .await
             .unwrap();
     let authority2 = init_state(&genesis, authority_key, store).await;
-    let obj2 = authority2.get_object(&object_id).await.unwrap();
+    let obj2 = authority2.get_object(&object_id).unwrap();
 
     // Check the object is present
     assert_eq!(obj2.id(), object_id);
@@ -2986,7 +2949,6 @@ async fn test_genesis_sui_system_state_object() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let wrapper = authority_state
         .get_object(&SUI_SYSTEM_STATE_OBJECT_ID)
-        .await
         .unwrap();
     assert_eq!(wrapper.version(), SequenceNumber::from(1));
     let move_object = wrapper.data.try_as_move().unwrap();
@@ -3046,7 +3008,7 @@ async fn test_transfer_sui_no_amount() {
         Owner::AddressOwner(recipient)
     );
     let new_balance =
-        sui_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).await.unwrap())
+        sui_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).unwrap())
             .unwrap();
     assert_eq!(
         new_balance as i64 + effects.gas_cost_summary().net_gas_usage(),
@@ -3086,13 +3048,12 @@ async fn test_transfer_sui_with_amount() {
     assert_eq!(effects.created()[0].1, Owner::AddressOwner(recipient));
     let new_gas = authority_state
         .get_object(&effects.created()[0].0.0)
-        .await
         .unwrap();
     assert_eq!(sui_types::gas::get_gas_balance(&new_gas).unwrap(), 500);
     assert!(gas_ref.1 < effects.gas_object().unwrap().0.1);
     assert_eq!(effects.gas_object().unwrap().1, Owner::AddressOwner(sender));
     let new_balance =
-        sui_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).await.unwrap())
+        sui_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).unwrap())
             .unwrap();
     assert_eq!(
         new_balance as i64 + effects.gas_cost_summary().net_gas_usage() + 500,
@@ -3732,8 +3693,8 @@ async fn test_iter_live_object_set() {
         })
         .collect();
 
-    let gas_obj = authority.get_object(&gas).await.unwrap();
-    let obj = authority.get_object(&obj_id).await.unwrap();
+    let gas_obj = authority.get_object(&gas).unwrap();
+    let obj = authority.get_object(&obj_id).unwrap();
 
     let rgp = authority.reference_gas_price_for_testing().unwrap();
     let transfer_transaction = init_transfer_transaction(
@@ -3903,8 +3864,8 @@ async fn test_clever_abort_error() {
         SequenceNumber::from_u64(SequenceNumber::MAX.value() - 1),
         Owner::AddressOwner(sender),
     );
-    validator.insert_genesis_object(gas_object.clone()).await;
-    fullnode.insert_genesis_object(gas_object).await;
+    validator.insert_genesis_object(gas_object.clone());
+    fullnode.insert_genesis_object(gas_object);
 
     let rgp = fullnode.reference_gas_price_for_testing().unwrap();
 
@@ -4117,7 +4078,7 @@ pub async fn init_state_with_objects_and_object_basics<I: IntoIterator<Item = Ob
 ) -> (Arc<AuthorityState>, ObjectRef) {
     let state = TestAuthorityBuilder::new().build().await;
     for obj in objects {
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     publish_object_basics(state).await
 }
@@ -4131,7 +4092,7 @@ pub async fn init_state_with_ids_and_object_basics<
     let state = TestAuthorityBuilder::new().build().await;
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     publish_object_basics(state).await
 }
@@ -4155,7 +4116,7 @@ pub async fn publish_object_basics(state: Arc<AuthorityState>) -> (Arc<Authority
     )
     .unwrap();
     let pkg_ref = pkg.compute_object_reference();
-    state.insert_genesis_object(pkg).await;
+    state.insert_genesis_object(pkg);
     (state, pkg_ref)
 }
 
@@ -4177,7 +4138,7 @@ pub async fn publish_aborts(state: Arc<AuthorityState>) -> (Arc<AuthorityState>,
     )
     .unwrap();
     let pkg_ref = pkg.compute_object_reference();
-    state.insert_genesis_object(pkg).await;
+    state.insert_genesis_object(pkg);
     (state, pkg_ref)
 }
 
@@ -4190,8 +4151,8 @@ pub async fn init_state_with_ids_and_object_basics_with_fullnode<
     let (validator, fullnode) = init_state_validator_with_fullnode().await;
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
-        validator.insert_genesis_object(obj.clone()).await;
-        fullnode.insert_genesis_object(obj).await;
+        validator.insert_genesis_object(obj.clone());
+        fullnode.insert_genesis_object(obj);
     }
 
     // add object_basics package object to genesis, since lots of test use it
@@ -4212,8 +4173,8 @@ pub async fn init_state_with_ids_and_object_basics_with_fullnode<
     )
     .unwrap();
     let pkg_ref = pkg.compute_object_reference();
-    validator.insert_genesis_object(pkg.clone()).await;
-    fullnode.insert_genesis_object(pkg).await;
+    validator.insert_genesis_object(pkg.clone());
+    fullnode.insert_genesis_object(pkg);
     (validator, fullnode, pkg_ref)
 }
 
@@ -4257,7 +4218,7 @@ pub async fn call_move_(
     test_args: Vec<TestCallArg>,
     with_shared: bool, // Move call includes shared objects
 ) -> SuiResult<TransactionEffects> {
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let mut builder = ProgrammableTransactionBuilder::new();
     let mut args = vec![];
@@ -4339,7 +4300,7 @@ pub async fn build_programmable_transaction(
     gas_unit: u64,
 ) -> SuiResult<Transaction> {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let data =
         TransactionData::new_programmable(*sender, vec![gas_object_ref], pt, rgp * gas_unit, rgp);
@@ -4358,7 +4319,7 @@ async fn execute_programmable_transaction_(
     gas_unit: u64,
 ) -> SuiResult<TransactionEffects> {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let data =
         TransactionData::new_programmable(*sender, vec![gas_object_ref], pt, rgp * gas_unit, rgp);
@@ -4387,7 +4348,7 @@ async fn call_move_with_gas_coins(
 ) -> SuiResult<TransactionEffects> {
     let mut gas_object_refs = vec![];
     for obj_id in gas_object_ids {
-        let gas_object = authority.get_object(obj_id).await;
+        let gas_object = authority.get_object(obj_id);
         let gas_ref = gas_object.unwrap().compute_object_reference();
         gas_object_refs.push(gas_ref);
     }
@@ -4751,11 +4712,7 @@ async fn test_shared_object_transaction_ok() {
         .await;
 
     // Ensure shared object sequence number increased.
-    let shared_object_version = authority
-        .get_object(&shared_object_id)
-        .await
-        .unwrap()
-        .version();
+    let shared_object_version = authority.get_object(&shared_object_id).unwrap().version();
     assert_eq!(shared_object_version, SequenceNumber::from(2));
 }
 
@@ -5239,8 +5196,7 @@ async fn test_gas_smashing() {
         }
         // balance on first coin is correct
         let balance =
-            sui_types::gas::get_gas_balance(&state.get_object(&gas_coin_ids[0]).await.unwrap())
-                .unwrap();
+            sui_types::gas::get_gas_balance(&state.get_object(&gas_coin_ids[0]).unwrap()).unwrap();
         let gas_used = effects.gas_cost_summary().gas_used();
         assert!(reference_gas_used > balance);
         assert_eq!(reference_gas_used, balance + gas_used);
@@ -5474,7 +5430,7 @@ async fn test_publish_transitive_dependencies_ok() {
     let rgp = state.reference_gas_price_for_testing().unwrap();
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.compute_object_reference();
 
     // Publish `package C`
@@ -5644,7 +5600,7 @@ async fn test_publish_missing_dependency() {
     let state = init_state_with_ids(vec![(sender, gas_id)]).await;
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.compute_object_reference();
 
     // Module bytes
@@ -5688,7 +5644,7 @@ async fn test_publish_missing_transitive_dependency() {
     let state = init_state_with_ids(vec![(sender, gas_id)]).await;
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.compute_object_reference();
 
     // Module bytes
@@ -5732,7 +5688,7 @@ async fn test_publish_not_a_package_dependency() {
     let state = init_state_with_ids(vec![(sender, gas_id)]).await;
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.compute_object_reference();
 
     // Module bytes
@@ -5964,7 +5920,7 @@ async fn test_consensus_handler_per_object_congestion_control() {
     let mut genesis_objects = gas_objects_commit_1.clone();
     genesis_objects.extend(gas_objects_commit_2.clone());
     genesis_objects.extend(shared_objects.clone());
-    authority.insert_genesis_objects(&genesis_objects).await;
+    authority.insert_genesis_objects(&genesis_objects);
 
     // Register failpoint to seed initial congestion on shared_objects[0].
     // This gives obj 0 a high initial accumulated cost that limits throughput,
@@ -6238,7 +6194,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     genesis_objects.extend(gas_objects_cancelled_txn.clone());
     genesis_objects.extend(shared_objects.clone());
     genesis_objects.extend(owned_objects_cancelled_txn.clone());
-    authority.insert_genesis_objects(&genesis_objects).await;
+    authority.insert_genesis_objects(&genesis_objects);
 
     // Register failpoint to seed initial congestion tracker with very high accumulated cost
     // for shared_objects[0]. This causes immediate congestion, ensuring transactions are
@@ -6513,7 +6469,6 @@ async fn test_insufficient_balance_for_withdraw_early_error() {
     // Test that the transaction fails with InsufficientFundsForWithdraw error
     let (effects, execution_error) = state
         .try_execute_immediately(&certificate, execution_env, &epoch_store)
-        .await
         .unwrap();
 
     // Check that we got an execution error due to insufficient balance
@@ -6564,9 +6519,7 @@ async fn test_should_wait_for_dependency_object() {
     let test_object = Object::with_id_owner_for_testing(test_obj_id, sender);
     let current_version = test_object.version();
     let current_ref = test_object.compute_object_reference();
-    authority_state
-        .insert_genesis_object(test_object.clone())
-        .await;
+    authority_state.insert_genesis_object(test_object.clone());
 
     // Test case: Current version - should not wait
     let result = authority_state.should_wait_for_dependency_object(current_ref);
@@ -6603,9 +6556,7 @@ async fn test_should_wait_for_dependency_object() {
         ObjectDigest::OBJECT_DIGEST_DELETED,
     );
     let deleted_obj = Object::with_id_owner_for_testing(deleted_obj_id, sender);
-    authority_state
-        .insert_genesis_object(deleted_obj.clone())
-        .await;
+    authority_state.insert_genesis_object(deleted_obj.clone());
     let result = authority_state.should_wait_for_dependency_object(deleted_obj_ref);
     assert!(result.is_none(), "Should not wait for deleted object");
 }

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -42,7 +42,6 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
                 FullObjectRef::from_fastpath_ref(
                     authority_state
                         .get_object(obj_id)
-                        .await
                         .unwrap()
                         .compute_object_reference(),
                 ),
@@ -68,7 +67,6 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
         vec![
             authority_state
                 .get_object(&all_ids[N])
-                .await
                 .unwrap()
                 .compute_object_reference(),
         ],
@@ -128,7 +126,6 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
                 FullObjectRef::from_fastpath_ref(
                     authority_state
                         .get_object(obj_id)
-                        .await
                         .unwrap()
                         .compute_object_reference(),
                 ),
@@ -149,7 +146,6 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
         vec![
             authority_state
                 .get_object(&all_ids[N])
-                .await
                 .unwrap()
                 .compute_object_reference(),
         ],
@@ -184,9 +180,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
         sender,
         49999, // We need 50000
     );
-    authority_state
-        .insert_genesis_object(gas_object.clone())
-        .await;
+    authority_state.insert_genesis_object(gas_object.clone());
 
     const N: usize = 10;
     let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
@@ -37,7 +37,7 @@ async fn test_regulated_coin_v1_creation() {
     let mut metadata_object = None;
     let mut regulated_metadata_object = None;
     for (oref, _owner) in env.publish_effects.created() {
-        let object = env.authority.get_object(&oref.0).await.unwrap();
+        let object = env.authority.get_object(&oref.0).unwrap();
         if object.is_package() {
             continue;
         }
@@ -344,7 +344,6 @@ impl TestEnv {
     async fn get_latest_object_ref(&self, id: &ObjectID) -> ObjectRef {
         self.authority
             .get_object(id)
-            .await
             .unwrap()
             .compute_object_reference()
     }
@@ -355,7 +354,7 @@ impl TestEnv {
         let mut regulated_metadata_object = None;
         let mut package_id = None;
         for (oref, _owner) in self.publish_effects.created() {
-            let object = self.authority.get_object(&oref.0).await.unwrap();
+            let object = self.authority.get_object(&oref.0).unwrap();
             if object.is_package() {
                 package_id = Some(object.id());
                 continue;

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -82,9 +82,7 @@ impl TestSetup {
 
         let gas_object_id = ObjectID::random();
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-        setup_authority_state
-            .insert_genesis_object(gas_object.clone())
-            .await;
+        setup_authority_state.insert_genesis_object(gas_object.clone());
 
         let package = build_and_publish_test_package(
             &setup_authority_state,
@@ -179,19 +177,17 @@ impl TestSetup {
         genesis_objects.push(TestSetup::convert_to_genesis_obj(
             self.setup_authority_state
                 .get_object(&self.package.0)
-                .await
                 .unwrap(),
         ));
         genesis_objects.push(TestSetup::convert_to_genesis_obj(
             self.setup_authority_state
                 .get_object(&self.gas_object_id)
-                .await
                 .unwrap(),
         ));
 
         for obj in objects {
             genesis_objects.push(TestSetup::convert_to_genesis_obj(
-                self.setup_authority_state.get_object(obj).await.unwrap(),
+                self.setup_authority_state.get_object(obj).unwrap(),
             ));
         }
         genesis_objects
@@ -228,17 +224,13 @@ async fn test_congestion_control_execution_cancellation() {
         .with_protocol_config(test_setup.protocol_config.clone())
         .build()
         .await;
-    authority_state
-        .insert_genesis_objects(&genesis_objects)
-        .await;
+    authority_state.insert_genesis_objects(&genesis_objects);
     let authority_state_2 = TestAuthorityBuilder::new()
         .with_reference_gas_price(TEST_ONLY_GAS_PRICE)
         .with_protocol_config(test_setup.protocol_config.clone())
         .build()
         .await;
-    authority_state_2
-        .insert_genesis_objects(&genesis_objects)
-        .await;
+    authority_state_2.insert_genesis_objects(&genesis_objects);
 
     // Initialize shared object queue so that any transaction touches shared_object_1 should result in congestion and cancellation.
     // Set initial cost of 10 for shared_object_1, which with 0% target_utilization and 0 burst limit
@@ -286,7 +278,6 @@ async fn test_congestion_control_execution_cancellation() {
         .unwrap();
     let owned_object_ref = authority_state
         .get_object(&owned_object.0)
-        .await
         .unwrap()
         .compute_object_reference();
     let arg3 = txn_builder

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -75,7 +75,7 @@ pub async fn test_user_transactions_with_gas_objects(
     };
     for gas_object in gas_objects {
         // Object digest may be different in genesis than originally generated.
-        let gas_object = authority.get_object(&gas_object.id()).await.unwrap();
+        let gas_object = authority.get_object(&gas_object.id()).unwrap();
         // Make a sample transaction.
         let module = "object_basics";
         let function = "create";
@@ -123,10 +123,10 @@ pub async fn test_user_transaction(
     let rgp = epoch_store.reference_gas_price();
 
     // Object digest may be different in genesis than originally generated.
-    let gas_object = authority.get_object(&gas_object.id()).await.unwrap();
+    let gas_object = authority.get_object(&gas_object.id()).unwrap();
     let mut input_objs = vec![];
     for obj in input_objects {
-        input_objs.push(authority.get_object(&obj.id()).await.unwrap());
+        input_objs.push(authority.get_object(&obj.id()).unwrap());
     }
 
     let mut object_args: Vec<_> = input_objs

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -772,9 +772,7 @@ async fn test_authority_txn_validation_pushback() {
         .with_authority_overload_config(overload_config)
         .build()
         .await;
-    authority_state
-        .insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()])
-        .await;
+    authority_state.insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()]);
 
     // Create a validator service around the `authority_state`.
     let consensus_adapter = Arc::new(ConsensusAdapter::new(

--- a/crates/sui-core/src/unit_tests/gas_data_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_data_tests.rs
@@ -100,14 +100,14 @@ async fn setup_test_env() -> TestEnv {
     let gas_object =
         Object::with_id_owner_gas_for_testing(gas_object_id, sender, GAS_VALUE_FOR_TESTING);
     let gas_object_ref = gas_object.compute_object_reference();
-    validator.insert_genesis_object(gas_object.clone()).await;
-    fullnode.insert_genesis_object(gas_object).await;
+    validator.insert_genesis_object(gas_object.clone());
+    fullnode.insert_genesis_object(gas_object);
 
     let object_id = ObjectID::random();
     let object = Object::with_id_owner_for_testing(object_id, sender);
     let object_ref = object.compute_object_reference();
-    validator.insert_genesis_object(object.clone()).await;
-    fullnode.insert_genesis_object(object).await;
+    validator.insert_genesis_object(object.clone());
+    fullnode.insert_genesis_object(object);
 
     let extra_object_id = ObjectID::random();
     let extra_object = {
@@ -138,16 +138,16 @@ async fn setup_test_env() -> TestEnv {
         )
     };
     let extra_object_ref = extra_object.compute_object_reference();
-    validator.insert_genesis_object(extra_object.clone()).await;
-    fullnode.insert_genesis_object(extra_object).await;
+    validator.insert_genesis_object(extra_object.clone());
+    fullnode.insert_genesis_object(extra_object);
 
     let mut gas_coin_refs = Vec::new();
     for _ in 0..3 {
         let id = ObjectID::random();
         let obj = Object::with_id_owner_gas_for_testing(id, sender, GAS_VALUE_FOR_TESTING);
         gas_coin_refs.push(obj.compute_object_reference());
-        validator.insert_genesis_object(obj.clone()).await;
-        fullnode.insert_genesis_object(obj).await;
+        validator.insert_genesis_object(obj.clone());
+        fullnode.insert_genesis_object(obj);
     }
 
     let other_owner = SuiAddress::random_for_testing_only();
@@ -158,10 +158,8 @@ async fn setup_test_env() -> TestEnv {
         GAS_VALUE_FOR_TESTING,
     );
     let other_owner_coin_ref = other_owner_coin.compute_object_reference();
-    validator
-        .insert_genesis_object(other_owner_coin.clone())
-        .await;
-    fullnode.insert_genesis_object(other_owner_coin).await;
+    validator.insert_genesis_object(other_owner_coin.clone());
+    fullnode.insert_genesis_object(other_owner_coin);
 
     let rgp = validator.reference_gas_price_for_testing().unwrap();
 
@@ -816,7 +814,6 @@ async fn test_bad_gas_payment_all_paths() {
     let package_ref = env
         .validator
         .get_object(&SUI_FRAMEWORK_PACKAGE_ID)
-        .await
         .unwrap()
         .compute_object_reference();
     {

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -163,12 +163,12 @@ where
     let gas_coin_ids: Vec<_> = gas_coins.iter().map(|obj| obj.id()).collect();
     let authority_state = TestAuthorityBuilder::new().build().await;
     for obj in gas_coins {
-        authority_state.insert_genesis_object(obj).await;
+        authority_state.insert_genesis_object(obj);
     }
 
     let gas_object_id = ObjectID::random();
     let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_amount);
-    authority_state.insert_genesis_object(gas_coin).await;
+    authority_state.insert_genesis_object(gas_coin);
     // touch gas coins so that `storage_rebate` is set (not 0 as in genesis)
     touch_gas_coins(
         &authority_state,
@@ -188,7 +188,6 @@ where
     for coin_id in &gas_coin_ids {
         let coin_ref = authority_state
             .get_object(coin_id)
-            .await
             .unwrap()
             .compute_object_reference();
         gas_coin_refs.push(coin_ref);
@@ -236,7 +235,7 @@ where
         );
     }
     let gas_ref = effects.gas_object().unwrap().0;
-    let gas_object = authority_state.get_object(&gas_ref.0).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_ref.0).unwrap();
     let final_value = GasCoin::try_from(&gas_object)?.value();
     let summary = effects.gas_cost_summary();
 
@@ -280,7 +279,6 @@ async fn touch_gas_coins(
     for coin_id in coin_ids {
         let coin_ref = authority_state
             .get_object(coin_id)
-            .await
             .unwrap()
             .compute_object_reference();
         builder
@@ -291,7 +289,6 @@ async fn touch_gas_coins(
     let kind = TransactionKind::ProgrammableTransaction(pt);
     let gas_object_ref = authority_state
         .get_object(&gas_object_id)
-        .await
         .unwrap()
         .compute_object_reference();
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
@@ -512,7 +509,6 @@ async fn test_native_transfer_sufficient_gas() -> SuiResult {
     let gas_object = result
         .authority_state
         .get_object(&result.gas_object_id)
-        .await
         .unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
@@ -556,7 +552,7 @@ async fn test_transfer_sui_insufficient_gas() {
     let gas_object_id = ObjectID::random();
     let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, *MAX_GAS_BUDGET);
     let gas_object_ref = gas_object.compute_object_reference();
-    authority_state.insert_genesis_object(gas_object).await;
+    authority_state.insert_genesis_object(gas_object);
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
     let pt = {
@@ -603,7 +599,7 @@ async fn test_invalid_gas_owners() {
 
     let init_object = |o: Object| async {
         let obj_ref = o.compute_object_reference();
-        authority_state.insert_genesis_object(o).await;
+        authority_state.insert_genesis_object(o);
         obj_ref
     };
 
@@ -740,7 +736,6 @@ async fn test_native_transfer_insufficient_gas_execution() {
     let gas_object = result
         .authority_state
         .get_object(&result.gas_object_id)
-        .await
         .unwrap();
     let gas_coin = GasCoin::try_from(&gas_object).unwrap();
     assert_eq!(gas_coin.value(), 0);
@@ -779,7 +774,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
     let gas_cost = effects.gas_cost_summary();
     assert!(gas_cost.storage_cost > 0);
 
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let gas_size = gas_object.object_size_for_gas_metering();
     let expected_gas_balance = GAS_VALUE_FOR_TESTING - gas_cost.net_gas_usage() as u64;
     assert_eq!(
@@ -817,7 +812,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
 
     assert!(gas_cost.gas_used() > 0);
 
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let expected_gas_balance = expected_gas_balance - gas_cost.net_gas_usage() as u64;
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
@@ -834,7 +829,7 @@ async fn test_move_call_gas() -> SuiResult {
     let (authority_state, package_object_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let module = ident_str!("object_basics").to_owned();
     let function = ident_str!("create").to_owned();
@@ -863,7 +858,7 @@ async fn test_move_call_gas() -> SuiResult {
     let gas_cost = effects.gas_cost_summary();
     assert!(gas_cost.storage_cost > 0);
     assert_eq!(gas_cost.storage_rebate, 0);
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let expected_gas_balance = GAS_VALUE_FOR_TESTING - gas_cost.net_gas_usage() as u64;
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
@@ -931,7 +926,7 @@ async fn test_tx_gas_coins_input_coins() {
         .iter()
         .map(|obj| obj.compute_object_reference())
         .collect::<Vec<_>>();
-    authority_state.insert_genesis_objects(&gas_coins).await;
+    authority_state.insert_genesis_objects(&gas_coins);
     let coins = (0..260)
         .map(|_| Object::with_owner_for_testing(sender))
         .collect::<Vec<_>>();
@@ -939,10 +934,10 @@ async fn test_tx_gas_coins_input_coins() {
         .iter()
         .map(|obj| obj.compute_object_reference())
         .collect::<Vec<_>>();
-    authority_state.insert_genesis_objects(&coins).await;
+    authority_state.insert_genesis_objects(&coins);
     let coin = Object::with_owner_for_testing(sender);
     let coin_ref = coin.compute_object_reference();
-    authority_state.insert_genesis_object(coin).await;
+    authority_state.insert_genesis_object(coin);
 
     async fn run_merge(
         authority_state: &AuthorityState,
@@ -1032,8 +1027,8 @@ async fn execute_transfer_with_price(
     let gas_object_id = ObjectID::random();
     let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_balance);
     let gas_object_ref = gas_object.compute_object_reference();
-    authority_state.insert_genesis_object(gas_object).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    authority_state.insert_genesis_object(gas_object);
+    let object = authority_state.get_object(&object_id).unwrap();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
@@ -1089,7 +1084,7 @@ async fn test_gas_price_capping_for_aborted_transactions() {
     let gas_amount = budget * 10;
     let gas_object_id = ObjectID::random();
     let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_amount);
-    authority_state.insert_genesis_object(gas_coin).await;
+    authority_state.insert_genesis_object(gas_coin);
 
     // Publish the move_random package
     let package =
@@ -1098,7 +1093,6 @@ async fn test_gas_price_capping_for_aborted_transactions() {
     // Create a transaction that will abort
     let gas_coin_ref = authority_state
         .get_object(&gas_object_id)
-        .await
         .unwrap()
         .compute_object_reference();
 

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -54,7 +54,7 @@ async fn test_object_wrapping_unwrapping() {
     )
     .await;
 
-    let gas_version = authority.get_object(&gas).await.unwrap().version();
+    let gas_version = authority.get_object(&gas).unwrap().version();
     let create_child_version = SequenceNumber::lamport_increment([gas_version]);
 
     // Create a Child object.
@@ -344,7 +344,7 @@ async fn test_object_owning_another_object() {
         | Owner::ConsensusAddressOwner { .. }
         | Owner::Party { .. } => panic!(),
     };
-    let field_object = authority.get_object(&field_id).await.unwrap();
+    let field_object = authority.get_object(&field_id).unwrap();
     assert_eq!(field_object.owner, parent.0);
 
     // Mutate the child directly will now fail because we need the parent to authenticate.
@@ -2833,7 +2833,7 @@ pub async fn build_and_try_publish_test_package(
     let all_module_bytes = compiled_package.get_package_bytes(with_unpublished_deps);
     let dependencies = compiled_package.get_dependency_storage_package_ids();
 
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
 
     let data = TransactionData::new_module(
@@ -2883,7 +2883,7 @@ pub async fn build_and_publish_package_with_upgrade_cap(
     let gas_price = authority.reference_gas_price_for_testing().unwrap();
     let gas_budget = TEST_ONLY_GAS_UNIT_FOR_PUBLISH * gas_price;
     let effects = {
-        let gas_object = authority.get_object(gas_object_id).await;
+        let gas_object = authority.get_object(gas_object_id);
         let gas_object_ref = gas_object.unwrap().compute_object_reference();
 
         let data = TransactionData::new_module(
@@ -2981,7 +2981,7 @@ pub async fn collect_packages_and_upgrade_caps(
         if !matches!(owner, Owner::AddressOwner(_)) {
             continue;
         }
-        let cap = authority.get_object(&obj_ref.0).await.unwrap();
+        let cap = authority.get_object(&obj_ref.0).unwrap();
         let bcs = cap.data.try_as_move().unwrap().contents();
         let obj: UpgradeCap = bcs::from_bytes(bcs).unwrap();
         let pkg = packages.get(&obj.package.bytes).unwrap();
@@ -2999,7 +2999,7 @@ pub async fn run_multi_txns(
 ) -> Result<(VerifiedExecutableTransaction, SignedTransactionEffects), SuiError> {
     // build the transaction data
     let pt = builder.finish();
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let gas_price = authority.reference_gas_price_for_testing().unwrap();
     let gas_budget = pt.non_system_packages_to_be_published().count() as u64

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -96,7 +96,7 @@ async fn test_publish_empty_package() {
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
 
     // empty package
@@ -145,7 +145,7 @@ async fn test_publish_duplicate_modules() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
@@ -178,7 +178,7 @@ async fn test_publish_extraneous_bytes_modules() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
@@ -199,7 +199,7 @@ async fn test_publish_extraneous_bytes_modules() {
     assert_eq!(result.status(), &ExecutionStatus::Success);
 
     // make the bytes invalid
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let mut modules = correct_modules.clone();
     modules[0].push(0);
@@ -223,7 +223,7 @@ async fn test_publish_extraneous_bytes_modules() {
     );
 
     // make the bytes invalid, in a different way
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let mut modules = correct_modules.clone();
     let first_module = modules[0].clone();
@@ -248,7 +248,7 @@ async fn test_publish_extraneous_bytes_modules() {
     );
 
     // make the bytes invalid by adding metadata
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let mut modules = correct_modules.clone();
     let new_bytes = {

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -194,7 +194,7 @@ impl UpgradeStateRunner {
         let gas_object_id = ObjectID::random();
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
         let authority_state = TestAuthorityBuilder::new().build().await;
-        authority_state.insert_genesis_object(gas_object).await;
+        authority_state.insert_genesis_object(gas_object);
         let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
         let (package, upgrade_cap) = build_and_publish_test_package_with_upgrade_cap(
@@ -224,7 +224,7 @@ impl UpgradeStateRunner {
         let gas_object_id = ObjectID::random();
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
         let authority_state = TestAuthorityBuilder::new().build().await;
-        authority_state.insert_genesis_object(gas_object).await;
+        authority_state.insert_genesis_object(gas_object);
         let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
         let (package, upgrade_cap) = build_and_publish_package_with_upgrade_cap(

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -4,7 +4,6 @@
 use crate::authority::AuthorityState;
 use crate::authority::authority_tests::{init_state_with_committee, submit_and_execute};
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
-use futures::future::join_all;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
@@ -169,21 +168,9 @@ async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
     let created_obj_id1 = effects.created()[0].0.0;
     let created_obj_id2 = effects.created()[1].0.0;
     let created_obj_id3 = effects.created()[2].0.0;
-    let created_obj1 = res
-        .authority_state
-        .get_object(&created_obj_id1)
-        .await
-        .unwrap();
-    let created_obj2 = res
-        .authority_state
-        .get_object(&created_obj_id2)
-        .await
-        .unwrap();
-    let created_obj3 = res
-        .authority_state
-        .get_object(&created_obj_id3)
-        .await
-        .unwrap();
+    let created_obj1 = res.authority_state.get_object(&created_obj_id1).unwrap();
+    let created_obj2 = res.authority_state.get_object(&created_obj_id2).unwrap();
+    let created_obj3 = res.authority_state.get_object(&created_obj_id3).unwrap();
 
     let addr1 = effects.created()[0].1.get_owner_address()?;
     let addr2 = effects.created()[1].1.get_owner_address()?;
@@ -209,7 +196,7 @@ async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
         sender
     );
     let gas_used = effects.gas_cost_summary().net_gas_usage() as u64;
-    let gas_object = res.authority_state.get_object(&object_id).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id).unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
         coin_amount - 100 - 200 - 300 - gas_used,
@@ -248,16 +235,8 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     assert_eq!(effects.created().len(), 2);
     let created_obj_id1 = effects.created()[0].0.0;
     let created_obj_id2 = effects.created()[1].0.0;
-    let created_obj1 = res
-        .authority_state
-        .get_object(&created_obj_id1)
-        .await
-        .unwrap();
-    let created_obj2 = res
-        .authority_state
-        .get_object(&created_obj_id2)
-        .await
-        .unwrap();
+    let created_obj1 = res.authority_state.get_object(&created_obj_id1).unwrap();
+    let created_obj2 = res.authority_state.get_object(&created_obj_id2).unwrap();
     let addr1 = effects.created()[0].1.get_owner_address()?;
     let addr2 = effects.created()[1].1.get_owner_address()?;
     let coin_val1 = *recipient_amount_map
@@ -276,7 +255,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
         sender
     );
     let gas_used = effects.gas_cost_summary().net_gas_usage() as u64;
-    let gas_object = res.authority_state.get_object(&object_id1).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id1).unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
         5002000 - 500 - 1500 - gas_used,
@@ -345,7 +324,7 @@ async fn test_pay_all_sui_success_one_input_coin() -> anyhow::Result<()> {
     );
 
     let gas_used = effects.gas_cost_summary().gas_used();
-    let gas_object = res.authority_state.get_object(&object_id).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id).unwrap();
     assert_eq!(GasCoin::try_from(&gas_object)?.value(), 3000000 - gas_used,);
     Ok(())
 }
@@ -380,7 +359,7 @@ async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     );
 
     let gas_used = effects.gas_cost_summary().gas_used();
-    let gas_object = res.authority_state.get_object(&object_id1).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id1).unwrap();
     assert_eq!(GasCoin::try_from(&gas_object)?.value(), 3002000 - gas_used,);
     Ok(())
 }
@@ -404,11 +383,9 @@ async fn execute_pay_sui(
         .iter()
         .map(|coin_obj| coin_obj.compute_object_reference())
         .collect();
-    let handles: Vec<_> = input_coin_objects
-        .into_iter()
-        .map(|obj| authority_state.insert_genesis_object(obj))
-        .collect();
-    join_all(handles).await;
+    for obj in input_coin_objects {
+        authority_state.insert_genesis_object(obj);
+    }
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
     let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -62,7 +62,7 @@ impl TestRunner {
         for _ in 0..20 {
             let gas_object_id = ObjectID::random();
             let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-            authority_state.insert_genesis_object(gas_object).await;
+            authority_state.insert_genesis_object(gas_object);
             gas_object_ids.push(gas_object_id);
         }
 

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -223,7 +223,6 @@ async fn test_submit_transaction_already_executed() {
     test_context
         .state
         .try_execute_immediately(&verified_transaction, ExecutionEnv::new(), &epoch_store)
-        .await
         .unwrap();
 
     // Submit the same transaction that has already been executed.
@@ -388,13 +387,12 @@ async fn test_submit_batched_transactions_with_already_executed() {
     test_context
         .state
         .try_execute_immediately(&verified_tx1, ExecutionEnv::new(), &epoch_store)
-        .await
         .unwrap();
 
     // Create 2nd transaction (not executed)
     let gas_object2 = Object::with_owner_for_testing(test_context.sender);
     let gas_object_ref2 = gas_object2.compute_object_reference();
-    test_context.state.insert_genesis_object(gas_object2).await;
+    test_context.state.insert_genesis_object(gas_object2);
 
     let tx_data2 = TestTransactionBuilder::new(
         test_context.sender,
@@ -501,13 +499,12 @@ async fn test_submit_soft_bundle_transactions_with_already_executed() {
     test_context
         .state
         .try_execute_immediately(&verified_tx1, ExecutionEnv::new(), &epoch_store)
-        .await
         .unwrap();
 
     // Create 2nd transaction (not executed)
     let gas_object2 = Object::with_owner_for_testing(test_context.sender);
     let gas_object_ref2 = gas_object2.compute_object_reference();
-    test_context.state.insert_genesis_object(gas_object2).await;
+    test_context.state.insert_genesis_object(gas_object2);
 
     let tx_data2 = TestTransactionBuilder::new(
         test_context.sender,
@@ -574,7 +571,6 @@ async fn test_submit_oversized_transaction() {
     let gas_object = test_context
         .state
         .get_object(&test_context.gas_object_ref.0)
-        .await
         .unwrap();
     let full_object_ref = gas_object.compute_full_object_reference();
     let recipient = dbg_addr(2);

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -480,12 +480,12 @@ async fn do_transaction_test_impl(
         })
         .collect();
     let authority_state = init_state_with_ids(init_state_input).await;
-    authority_state.insert_genesis_object(input_object).await;
+    authority_state.insert_genesis_object(input_object);
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&input_object_id).await.unwrap();
+    let object = authority_state.get_object(&input_object_id).unwrap();
     let mut gas_objects = Vec::new();
     for id in gas_object_ids {
-        gas_objects.push(authority_state.get_object(&id).await.unwrap());
+        gas_objects.push(authority_state.get_object(&id).unwrap());
     }
 
     // Execute the test with two transactions, one transfer and one move call.
@@ -917,14 +917,13 @@ async fn do_zklogin_transaction_test(
 
 async fn check_locks(authority_state: Arc<AuthorityState>, object_ids: Vec<ObjectID>) {
     for object_id in object_ids {
-        let object = authority_state.get_object(&object_id).await.unwrap();
+        let object = authority_state.get_object(&object_id).unwrap();
         assert!(
             authority_state
                 .get_transaction_lock(
                     &object.compute_object_reference(),
                     &authority_state.epoch_store_for_testing()
                 )
-                .await
                 .unwrap()
                 .is_none()
         );
@@ -1052,8 +1051,8 @@ async fn init_zklogin_transfer(
     zklogin: &ZkLoginInputs,
 ) -> sui_types::message_envelope::Envelope<SenderSignedData, sui_types::crypto::EmptySignInfo> {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let full_object_ref = object.compute_full_object_reference();
     let gas_object_ref = gas_object.compute_object_reference();
     let gas_budget = rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER;
@@ -1094,8 +1093,8 @@ async fn sign_with_zklogin_inside_multisig(
     multisig_pk: MultiSigPublicKey,
 ) -> sui_types::message_envelope::Envelope<SenderSignedData, sui_types::crypto::EmptySignInfo> {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let full_object_ref = object.compute_full_object_reference();
     let gas_object_ref = gas_object.compute_object_reference();
     let gas_budget = rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER;
@@ -1238,8 +1237,8 @@ async fn zk_multisig_test() {
     });
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let data = TransactionData::new_transfer(
         recipient,
@@ -1392,7 +1391,7 @@ async fn test_shared_object_v2_denied() {
         .await;
 
     // Insert genesis objects
-    authority.insert_genesis_objects(&gas_objects).await;
+    authority.insert_genesis_objects(&gas_objects);
 
     // Publish the object_basics package
     let (authority, package) = publish_object_basics(authority).await;
@@ -1417,7 +1416,7 @@ async fn test_shared_object_v2_denied() {
 
         effects.status().unwrap();
         let shared_object_id = effects.created()[0].0.0;
-        authority.get_object(&shared_object_id).await.unwrap()
+        authority.get_object(&shared_object_id).unwrap()
     };
 
     let initial_shared_version = shared_object.version();

--- a/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
@@ -87,7 +87,7 @@ impl TestRunner {
         for _ in 0..num {
             let gas_object_id = ObjectID::random();
             let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-            authority_state.insert_genesis_object(gas_object).await;
+            authority_state.insert_genesis_object(gas_object);
             gas_object_ids.push(gas_object_id);
         }
 

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -113,7 +113,6 @@ async fn test_wait_for_effects_position_mismatch() {
         epoch_store.set_consensus_tx_status(tx_position2, ConsensusTxStatus::Finalized);
         state_clone
             .try_execute_immediately(&transaction, ExecutionEnv::new(), &epoch_store)
-            .await
             .unwrap()
             .0
     });
@@ -311,7 +310,6 @@ async fn test_wait_for_effects_finalized() {
         epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Finalized);
         state_clone
             .try_execute_immediately(&transaction, ExecutionEnv::new(), &epoch_store)
-            .await
             .unwrap()
             .0
     });

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -2599,9 +2599,7 @@ async fn publish_and_mint_trusted_coin(test_env: &mut TestEnv, sender: SuiAddres
                     .cluster
                     .fullnode_handle
                     .sui_node
-                    .with_async(
-                        |node| async move { node.state().get_object(&obj_ref.0).await.unwrap() },
-                    )
+                    .with_async(|node| async move { node.state().get_object(&obj_ref.0).unwrap() })
                     .await;
                 if object.type_().unwrap().name().as_str() == "TreasuryCap" {
                     treasury_cap = Some(obj_ref);

--- a/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
@@ -90,7 +90,7 @@ async fn load_event_stream_head_by_object_id(
     state: &sui_core::authority::AuthorityState,
     object_id: ObjectID,
 ) -> Option<EventStreamHead> {
-    let obj = state.get_object(&object_id).await?;
+    let obj = state.get_object(&object_id)?;
     let mo = obj.data.try_as_move()?;
     let field = mo.to_rust::<Field<ar::AccumulatorKey, EventStreamHead>>()?;
     Some(field.value)

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -305,7 +305,7 @@ impl StateRead for AuthorityState {
     }
 
     async fn get_object(&self, object_id: &ObjectID) -> StateReadResult<Option<Object>> {
-        Ok(self.get_object(object_id).await)
+        Ok(self.get_object(object_id))
     }
 
     fn get_past_object_read(
@@ -442,9 +442,7 @@ impl StateRead for AuthorityState {
     }
 
     async fn get_staked_sui(&self, owner: SuiAddress) -> StateReadResult<Vec<StakedSui>> {
-        Ok(self
-            .get_move_objects(owner, MoveObjectType::staked_sui())
-            .await?)
+        Ok(self.get_move_objects(owner, MoveObjectType::staked_sui())?)
     }
     fn get_system_state(&self) -> StateReadResult<SuiSystemState> {
         Ok(self

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -803,10 +803,9 @@ impl SuiNode {
                         sui_types::executable_transaction::CertificateProof::Checkpoint(0, 0),
                     ),
                 );
+            let _enter = span.enter();
             state
                 .try_execute_immediately(&transaction, ExecutionEnv::new(), &epoch_store)
-                .instrument(span)
-                .await
                 .unwrap();
         }
 

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -116,7 +116,6 @@ impl SingleValidator {
         let effects = self
             .get_validator()
             .try_execute_immediately(&executable, ExecutionEnv::new(), &self.epoch_store)
-            .await
             .unwrap()
             .0;
         assert!(effects.status().is_ok());
@@ -147,7 +146,6 @@ impl SingleValidator {
                         ExecutionEnv::new().with_assigned_versions(assigned_versions.clone()),
                         &self.epoch_store,
                     )
-                    .await
                     .unwrap()
                     .0
             }

--- a/crates/test-cluster/src/addr_balance_test_env.rs
+++ b/crates/test-cluster/src/addr_balance_test_env.rs
@@ -631,9 +631,7 @@ impl TestEnv {
                     .cluster
                     .fullnode_handle
                     .sui_node
-                    .with_async(
-                        |node| async move { node.state().get_object(&obj_ref.0).await.unwrap() },
-                    )
+                    .with_async(|node| async move { node.state().get_object(&obj_ref.0).unwrap() })
                     .await;
                 if object.type_().unwrap().name().as_str() == "TreasuryCap" {
                     treasury_cap = Some(obj_ref);

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -266,7 +266,7 @@ impl TestCluster {
     pub async fn get_object_from_fullnode_store(&self, object_id: &ObjectID) -> Option<Object> {
         self.fullnode_handle
             .sui_node
-            .with_async(|node| async { node.state().get_object(object_id).await })
+            .with_async(|node| async { node.state().get_object(object_id) })
             .await
     }
 

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -110,11 +110,11 @@ impl Executor {
     }
 
     pub fn add_object(&mut self, object: Object) {
-        self.rt.block_on(self.state.insert_genesis_object(object));
+        self.state.insert_genesis_object(object);
     }
 
     pub fn add_objects(&mut self, objects: &[Object]) {
-        self.rt.block_on(self.state.insert_genesis_objects(objects));
+        self.state.insert_genesis_objects(objects);
     }
 
     pub fn execute_transaction(&mut self, txn: Transaction) -> ExecutionResult {

--- a/crates/transaction-fuzzer/tests/pt_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/pt_fuzz.rs
@@ -49,13 +49,7 @@ fn publish_coin_factory(
         .created()
         .into_iter()
         .find(|(obj_ref, _)| {
-            if let Some(stag) = exec
-                .rt
-                .block_on(exec.state.get_object(&obj_ref.0))
-                .unwrap()
-                .data
-                .struct_tag()
-            {
+            if let Some(stag) = exec.state.get_object(&obj_ref.0).unwrap().data.struct_tag() {
                 stag.name.as_str().eq("TreasuryCap")
             } else {
                 false
@@ -105,13 +99,7 @@ pub fn run_pt_success(
         .mutated()
         .into_iter()
         .find(|(obj_ref, _)| {
-            if let Some(stag) = exec
-                .rt
-                .block_on(exec.state.get_object(&obj_ref.0))
-                .unwrap()
-                .data
-                .struct_tag()
-            {
+            if let Some(stag) = exec.state.get_object(&obj_ref.0).unwrap().data.struct_tag() {
                 stag.name.as_str().eq("TreasuryCap")
             } else {
                 false


### PR DESCRIPTION
## Summary

Several `AuthorityState` methods were declared `async` despite containing no `await` expressions. An `async fn` with no awaits produces a future that, when polled, runs the entire function synchronously without yielding — making the `async` keyword purely cosmetic overhead (allocating a future state machine, generating larger LLVM IR, etc.). This PR makes them honest `fn`s.

Methods changed:
- `try_execute_immediately` — the main execution entry point (~155 lines, all sync)
- `get_object` / `get_objects` / `get_object_or_tombstone`
- `get_move_objects`
- `insert_genesis_object` / `insert_genesis_objects` (also simplifies from `join_all` to a plain loop)
- `get_transaction_lock`
- `get_sui_system_package_object_ref`

Notable callsite adjustments:
- `sui-node`: genesis tx call used `.instrument(span).await` which requires a Future; replaced with a span guard
- `sui-json-rpc`: `StateRead` and `ObjectProvider` traits remain async (those interface boundaries are unchanged); only direct `AuthorityState` call sites are updated
- `pay_sui_tests`: `join_all` collecting `()` values replaced with a plain loop

## Test plan

- [ ] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-core -p sui-json-rpc`
- [ ] `cargo xclippy` on changed crates — clean