### PR TITLE
Introduce gas_v3.rs for v15+ SuiGasStatus

### DIFF
--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -384,6 +384,47 @@ async fn test_oog_computation_oog_storage_final_one_coin() -> SuiResult {
     .await
 }
 
+// Regression test for the full-budget OOG fallback charging the budget exactly.
+//
+// When computation OOGs and even input-only storage doesn't fit, the pipeline
+// forces `computation_cost = gas_budget` (`force_computation_cost_to_budget`).
+// A previous version derived the cost from the meter as
+// `(gas_budget / user_gas_price) * effective_gas_price`, which floors away
+// `gas_budget % user_gas_price` MIST and undercharged the sender. Here the
+// budget is deliberately NOT a multiple of the gas price, so any reintroduction
+// of that integer-division floor makes `computation_cost != BUDGET` and fails.
+#[tokio::test]
+async fn test_oog_full_budget_charge_exact_when_budget_indivisible_by_price() -> SuiResult {
+    const GAS_PRICE: u64 = 1000;
+    const MAX_UNIT_BUDGET: u64 = 5_000_000;
+    // Add a remainder so BUDGET % GAS_PRICE == 777 (not a clean multiple).
+    const BUDGET: u64 = MAX_UNIT_BUDGET * GAS_PRICE + 777;
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "loopy",
+        vec![],
+        BUDGET,
+        GAS_PRICE,
+        1,
+        |summary, initial_value, final_value| {
+            // Deepest fallback: storage is zeroed, computation absorbs the full budget.
+            assert_eq!(summary.storage_cost, 0);
+            assert_eq!(summary.storage_rebate, 0);
+            assert_eq!(summary.non_refundable_storage_fee, 0);
+            // The exact-charge guarantee: the full budget is charged, with no MIST
+            // lost to integer-division flooring of (budget / price) * price.
+            assert_eq!(summary.computation_cost, BUDGET);
+            let gas_used = summary.net_gas_usage() as u64;
+            assert_eq!(gas_used, BUDGET);
+            assert_eq!(initial_value - gas_used, final_value);
+            Ok(())
+        },
+    )
+    .await
+}
+
 // - computation ok, OOG for storage, minimal storage ok
 #[tokio::test]
 async fn test_computation_ok_oog_storage_minimal_ok_one_coin() -> SuiResult {

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -358,6 +358,8 @@ const MAINNET_USDB: &str =
 //              Update gas prices for range proofs and ristretto group operations.
 //              Enable Ristretto255 group operations and bulletproofs verification on testnet.
 //              Enable timestamp_based_epoch_close on mainnet.
+//              Step-by-step gas-charging pipeline (gas_model v15). Replaces the
+//              monolithic charge_gas with discrete steps
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -5027,6 +5029,8 @@ impl ProtocolConfig {
                     }
 
                     cfg.feature_flags.timestamp_based_epoch_close = true;
+
+                    cfg.gas_model_version = Some(15);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_127.snap
@@ -252,7 +252,7 @@ obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
 max_ptb_value_size: 1048576
-gas_model_version: 14
+gas_model_version: 15
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
@@ -254,7 +254,7 @@ obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
 max_ptb_value_size: 1048576
-gas_model_version: 14
+gas_model_version: 15
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_127.snap
@@ -256,7 +256,7 @@ obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
 max_ptb_value_size: 1048576
-gas_model_version: 14
+gas_model_version: 15
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-replay/src/displays/gas_status_displays.rs
+++ b/crates/sui-replay/src/displays/gas_status_displays.rs
@@ -3,8 +3,9 @@
 
 use crate::displays::Pretty;
 use std::fmt::{Display, Formatter};
-use sui_types::gas::SuiGasStatus;
-use sui_types::gas_model::gas_v2::SuiGasStatus as GasStatusV2;
+use sui_types::base_types::ObjectID;
+use sui_types::gas::{SuiGasStatus, SuiGasStatusAPI};
+use sui_types::gas_model::gas_v2::PerObjectStorage;
 use tabled::{
     builder::Builder as TableBuilder,
     settings::{Style as TableStyle, style::HorizontalLine},
@@ -13,20 +14,19 @@ use tabled::{
 impl Display for Pretty<'_, SuiGasStatus> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(sui_gas_status) = self;
-        match sui_gas_status {
-            SuiGasStatus::V2(s) => {
-                display_info(f, s)?;
-                per_object_storage_table(f, s)?;
-            }
-        };
+        display_info(f, *sui_gas_status)?;
+        per_object_storage_table(f, sui_gas_status.per_object_storage())?;
         Ok(())
     }
 }
 
-fn per_object_storage_table(f: &mut Formatter, sui_gas_status: &GasStatusV2) -> std::fmt::Result {
+fn per_object_storage_table(
+    f: &mut Formatter,
+    per_object_storage: &[(ObjectID, PerObjectStorage)],
+) -> std::fmt::Result {
     let mut builder = TableBuilder::default();
     builder.push_record(vec!["Object ID", "Bytes", "Old Rebate", "New Rebate"]);
-    for (object_id, per_obj_storage) in sui_gas_status.per_object_storage() {
+    for (object_id, per_obj_storage) in per_object_storage {
         builder.push_record(vec![
             object_id.to_string(),
             per_obj_storage.new_size.to_string(),
@@ -43,31 +43,29 @@ fn per_object_storage_table(f: &mut Formatter, sui_gas_status: &GasStatusV2) -> 
     write!(f, "\n{}\n", table)
 }
 
-fn display_info(f: &mut Formatter<'_>, sui_gas_status: &GasStatusV2) -> std::fmt::Result {
+fn display_info(f: &mut Formatter<'_>, sui_gas_status: &dyn SuiGasStatusAPI) -> std::fmt::Result {
+    let move_gas_status = sui_gas_status.move_gas_status();
     let mut builder = TableBuilder::default();
     builder.push_record(vec!["Gas Info".to_string()]);
     builder.push_record(vec![format!(
         "Reference Gas Price: {}",
         sui_gas_status.reference_gas_price()
     )]);
-    builder.push_record(vec![format!(
-        "Gas Price: {}",
-        sui_gas_status.gas_status.gas_price()
-    )]);
+    builder.push_record(vec![format!("Gas Price: {}", move_gas_status.gas_price())]);
 
     builder.push_record(vec![format!(
         "Max Gas Stack Height: {}",
-        sui_gas_status.gas_status.stack_height_high_water_mark()
+        move_gas_status.stack_height_high_water_mark()
     )]);
 
     builder.push_record(vec![format!(
         "Max Gas Stack Size: {}",
-        sui_gas_status.gas_status.stack_size_high_water_mark()
+        move_gas_status.stack_size_high_water_mark()
     )]);
 
     builder.push_record(vec![format!(
         "Number of Bytecode Instructions Executed: {}",
-        sui_gas_status.gas_status.instructions_executed()
+        move_gas_status.instructions_executed()
     )]);
 
     let mut table = builder.build();

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -14,6 +14,7 @@ mod checked {
     use sui_types::base_types::{ObjectID, ObjectRef};
     use sui_types::error::{SuiResult, UserInputError, UserInputResult};
     use sui_types::executable_transaction::VerifiedExecutableTransaction;
+    use sui_types::gas::SuiGasStatusAPI;
     use sui_types::metrics::BytecodeVerifierMetrics;
     use sui_types::object::ObjectPermission;
     use sui_types::transaction::{

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -12,11 +12,15 @@ pub mod checked {
 
     use crate::gas::GasUsageReport;
     use crate::gas_model::gas_predicates::check_for_gas_price_too_high;
+    use crate::gas_model::gas_v2::PerObjectStorage;
     use crate::{
         ObjectID,
         effects::{TransactionEffects, TransactionEffectsAPI},
         error::{ExecutionError, SuiResult, UserInputError, UserInputResult},
-        gas_model::{gas_v2::SuiGasStatus as SuiGasStatusV2, tables::GasStatus},
+        gas_model::{
+            gas_v2::SuiGasStatus as SuiGasStatusV2, gas_v3::SuiGasStatus as SuiGasStatusV3,
+            tables::GasStatus,
+        },
         object::Object,
         sui_serde::{BigInt, Readable},
         transaction::ObjectReadResult,
@@ -54,15 +58,31 @@ pub mod checked {
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
         fn adjust_computation_on_out_of_gas(&mut self);
         fn gas_usage_report(&self) -> GasUsageReport;
+        fn check_gas_balance(
+            &self,
+            gas_objs: &[&ObjectReadResult],
+            gas_budget: u64,
+            available_address_balance_gas: u64,
+        ) -> UserInputResult;
+        fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult;
+        fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)>;
     }
 
     /// Version aware enum for gas status.
+    ///
+    /// `V2` carries the legacy gas model (used by every executor for `gas_model_version < 15`,
+    /// including replay of old-protocol transactions). `V3` is the v15+ pipeline — same
+    /// invariants as V2 minus the dead branches that legacy versions still need
+    /// (`Option<u64>` abort cap, `GasRoundingMode::Bucketize`/`Stepped`, the
+    /// non-multiplier `base_tx_cost_fixed` arm). The dispatch picks V3 when
+    /// `protocol_config.gas_model_version() >= 15`, V2 otherwise.
     #[enum_dispatch(SuiGasStatusAPI)]
     #[derive(Debug)]
     pub enum SuiGasStatus {
         // V1 does not exists any longer as it was a pre mainnet version.
         // So we start the enum from V2
         V2(SuiGasStatusV2),
+        V3(SuiGasStatusV3),
     }
 
     impl SuiGasStatus {
@@ -92,41 +112,30 @@ pub mod checked {
                 .into());
             }
 
-            Ok(Self::V2(SuiGasStatusV2::new_with_budget(
-                gas_budget,
-                gas_price,
-                reference_gas_price,
-                config,
-            )))
+            // Dispatch by gas model version: v15+ uses the clean gas_v3 pipeline;
+            // everything older keeps the legacy gas_v2 path so replay determinism holds.
+            if config.gas_model_version() >= 15 {
+                Ok(Self::V3(SuiGasStatusV3::new_with_budget(
+                    gas_budget,
+                    gas_price,
+                    reference_gas_price,
+                    config,
+                )))
+            } else {
+                Ok(Self::V2(SuiGasStatusV2::new_with_budget(
+                    gas_budget,
+                    gas_price,
+                    reference_gas_price,
+                    config,
+                )))
+            }
         }
 
         pub fn new_unmetered() -> Self {
-            Self::V2(SuiGasStatusV2::new_unmetered())
-        }
-
-        pub fn check_gas_balance(
-            &self,
-            gas_objs: &[&ObjectReadResult],
-            gas_budget: u64,
-            available_address_balance_gas: u64,
-        ) -> UserInputResult {
-            match self {
-                Self::V2(status) => {
-                    status.check_gas_balance(gas_objs, gas_budget, available_address_balance_gas)
-                }
-            }
-        }
-
-        pub fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult {
-            match self {
-                Self::V2(status) => status.check_gas_objects(gas_objs),
-            }
-        }
-
-        pub fn gas_price(&self) -> u64 {
-            match self {
-                Self::V2(status) => status.gas_price(),
-            }
+            // Unmetered txs (system, dev-inspect, dry-run) never trigger metering, so the
+            // pipeline choice doesn't matter for their semantics — pick gas_v3 to match the
+            // current execution layer.
+            Self::V3(SuiGasStatusV3::new_unmetered())
         }
     }
 

--- a/crates/sui-types/src/gas_model/gas_predicates.rs
+++ b/crates/sui-types/src/gas_model/gas_predicates.rs
@@ -85,3 +85,7 @@ pub fn native_function_threshold_exceeded(gas_model_version: u64, num_native_cal
 pub fn refresh_gas_payment_location(gas_model_version: u64) -> bool {
     gas_model_version >= 13
 }
+
+pub fn use_step_gas_charging(gas_model_version: u64) -> bool {
+    gas_model_version >= 15
+}

--- a/crates/sui-types/src/gas_model/gas_v3.rs
+++ b/crates/sui-types/src/gas_model/gas_v3.rs
@@ -8,7 +8,7 @@ pub use checked::*;
 mod checked {
     use crate::error::{UserInputError, UserInputResult};
     use crate::gas::{self, GasCostSummary, GasUsageReport, SuiGasStatusAPI};
-    use crate::gas_model::gas_predicates::{cost_table_for_version, txn_base_cost_as_multiplier};
+    use crate::gas_model::gas_predicates::cost_table_for_version;
     use crate::gas_model::units_types::CostTable;
     use crate::transaction::ObjectReadResult;
     use crate::{
@@ -18,57 +18,7 @@ mod checked {
         gas_model::tables::{GasStatus, ZERO_COST_SCHEDULE},
     };
     use move_core_types::vm_status::StatusCode;
-    use serde::{Deserialize, Serialize};
     use sui_protocol_config::*;
-
-    /// A bucket defines a range of units that will be priced the same.
-    /// After execution a call to `GasStatus::bucketize` will round the computation
-    /// cost to `cost` for the bucket ([`min`, `max`]) the gas used falls into.
-    #[allow(dead_code)]
-    pub(crate) struct ComputationBucket {
-        min: u64,
-        max: u64,
-        cost: u64,
-    }
-
-    impl ComputationBucket {
-        fn new(min: u64, max: u64, cost: u64) -> Self {
-            ComputationBucket { min, max, cost }
-        }
-
-        fn simple(min: u64, max: u64) -> Self {
-            Self::new(min, max, max)
-        }
-    }
-
-    fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
-        for bucket in table {
-            if bucket.max >= computation_cost {
-                return bucket.cost;
-            }
-        }
-        match table.last() {
-            // maybe not a literal here could be better?
-            None => 5_000_000,
-            Some(bucket) => bucket.cost,
-        }
-    }
-
-    // define the bucket table for computation charging
-    // If versioning defines multiple functions and
-    fn computation_bucket(max_bucket_cost: u64) -> Vec<ComputationBucket> {
-        assert!(max_bucket_cost >= 5_000_000);
-        vec![
-            ComputationBucket::simple(0, 1_000),
-            ComputationBucket::simple(1_000, 5_000),
-            ComputationBucket::simple(5_000, 10_000),
-            ComputationBucket::simple(10_000, 20_000),
-            ComputationBucket::simple(20_000, 50_000),
-            ComputationBucket::simple(50_000, 200_000),
-            ComputationBucket::simple(200_000, 1_000_000),
-            ComputationBucket::simple(1_000_000, max_bucket_cost),
-        ]
-    }
 
     /// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
     /// will be burned, then re-minted + added to the storage fund at the next epoch change
@@ -101,10 +51,10 @@ mod checked {
         storage_per_byte_cost: u64,
         /// Execution cost table to be used.
         pub execution_cost_table: CostTable,
-        /// Computation buckets to cost transaction in price groups
-        computation_bucket: Vec<ComputationBucket>,
-        /// Max gas price for aborted transactions.
-        max_gas_price_rgp_factor_for_aborted_transactions: Option<u64>,
+        /// RGP-multiplier cap on the effective gas price for aborted transactions.
+        /// gas_v3 only runs at gas_model >= 15 (protocol v127+), where this field is always
+        /// `Some(_)` in the protocol config — stored as a plain `u64` here.
+        max_gas_price_rgp_factor_for_aborted_transactions: u64,
     }
 
     impl std::fmt::Debug for SuiCostTable {
@@ -118,11 +68,10 @@ mod checked {
         pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
             // gas_price here is the Reference Gas Price, however we may decide
             // to change it to be the price passed in the transaction
-            let min_transaction_cost = if txn_base_cost_as_multiplier(c) {
-                c.base_tx_cost_fixed() * gas_price
-            } else {
-                c.base_tx_cost_fixed()
-            };
+            //
+            // `txn_base_cost_as_multiplier` is on at every protocol version this gas_v3 runs at
+            // (v127+), so the base cost is always scaled by gas_price.
+            let min_transaction_cost = c.base_tx_cost_fixed() * gas_price;
             Self {
                 min_transaction_cost,
                 max_gas_budget: c.max_tx_gas(),
@@ -130,9 +79,8 @@ mod checked {
                 object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
                 storage_per_byte_cost: c.obj_data_cost_refundable(),
                 execution_cost_table: cost_table_for_version(c.gas_model_version()),
-                computation_bucket: computation_bucket(c.max_gas_computation_bucket()),
                 max_gas_price_rgp_factor_for_aborted_transactions: c
-                    .max_gas_price_rgp_factor_for_aborted_transactions_as_option(),
+                    .max_gas_price_rgp_factor_for_aborted_transactions(),
             }
         }
 
@@ -144,38 +92,17 @@ mod checked {
                 object_read_per_byte_cost: 0,
                 storage_per_byte_cost: 0,
                 execution_cost_table: ZERO_COST_SCHEDULE.clone(),
-                // should not matter
-                computation_bucket: computation_bucket(5_000_000),
-                max_gas_price_rgp_factor_for_aborted_transactions: None,
+                // Unmetered txs never enter `bucketize_computation`, so this value is never
+                // observed; 0 is fine as a placeholder.
+                max_gas_price_rgp_factor_for_aborted_transactions: 0,
             }
         }
     }
 
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct PerObjectStorage {
-        /// storage_cost is the total storage gas to charge. This is computed
-        /// at the end of execution while determining storage charges.
-        /// It tracks `storage_bytes * obj_data_cost_refundable` as
-        /// described in `storage_gas_price`
-        /// It has been multiplied by the storage gas price. This is the new storage rebate.
-        pub storage_cost: u64,
-        /// storage_rebate is the storage rebate (in Sui) for in this object.
-        /// This is computed at the end of execution while determining storage charges.
-        /// The value is in Sui.
-        pub storage_rebate: u64,
-        /// The object size post-transaction in bytes
-        pub new_size: u64,
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    enum GasRoundingMode {
-        /// Bucketize the computation cost according to predefined buckets.
-        Bucketize,
-        /// Rounding value to round up gas charges.
-        Stepped(u64),
-        /// Round by keeping just over half digits
-        KeepHalfDigits,
-    }
+    // gas_v3 reuses the shared `PerObjectStorage` from gas_v2 — it is a pure data type with
+    // no behavioural difference between the two pipelines, and is exposed through
+    // `GasUsageReport.per_object_storage` to callers like sui-replay.
+    pub use crate::gas_model::gas_v2::PerObjectStorage;
 
     #[allow(dead_code)]
     #[derive(Debug)]
@@ -187,18 +114,19 @@ mod checked {
         // Gas budget for this gas status instance.
         // Typically the gas budget as defined in the `TransactionData::GasData`
         gas_budget: u64,
-        // Computation cost after execution. This is the result of the gas used by the `GasStatus`
-        // properly bucketized.
-        // Starts at 0 and it is assigned in `bucketize_computation`.
-        computation_cost: u64,
         // Whether to charge or go unmetered
         charge: bool,
-        // Gas price for computation.
-        // This is a multiplier on the final charge as related to the RGP (reference gas price).
-        // Checked at signing: `gas_price >= reference_gas_price`
-        // and then conceptually
-        // `final_computation_cost = total_computation_cost * gas_price / reference_gas_price`
-        gas_price: u64,
+        // The price `summary()` uses to convert raw gas units into MIST. Starts
+        // equal to `user_gas_price`; lowered to the abort-tx cap by
+        // `bucketize_computation` when the result is a Move abort and the
+        // protocol config sets `max_gas_price_rgp_factor_for_aborted_transactions`.
+        effective_gas_price: u64,
+        // The gas price the user signed for. Checked at signing
+        // (`user_gas_price >= reference_gas_price`). Used as the upper bound
+        // for the abort cap, as the initial value of `effective_gas_price`,
+        // and exposed via the `gas_price()` accessor for TxContext / RPC /
+        // telemetry.
+        user_gas_price: u64,
         // RGP as defined in the protocol config.
         reference_gas_price: u64,
         // Gas price for storage. This is a multiplier on the final charge
@@ -217,8 +145,15 @@ mod checked {
         /// Amount of storage rebate accumulated when we are running in unmetered mode (i.e. system transaction).
         /// This allows us to track how much storage rebate we need to retain in system transactions.
         unmetered_storage_rebate: u64,
-        /// Rounding mode for gas charges.
-        gas_rounding_mode: GasRoundingMode,
+        /// When true, `uncapped_computation_cost` and `derived_computation_cost`
+        /// short-circuit to `gas_budget` instead of deriving from the Move VM
+        /// meter. Set by `adjust_computation_on_out_of_gas` on the err-path
+        /// fallback (legacy storage-OOG handler, step-pipeline
+        /// `set_computation_to_budget`) so the gas summary reports the budget
+        /// exactly — meter-derived math is `(budget / user_gas_price) ×
+        /// effective_gas_price` and loses up to `budget % user_gas_price`
+        /// MIST to integer-division floor.
+        force_computation_cost_to_budget: bool,
     }
 
     impl SuiGasStatus {
@@ -226,31 +161,25 @@ mod checked {
             move_gas_status: GasStatus,
             gas_budget: u64,
             charge: bool,
-            gas_price: u64,
+            user_gas_price: u64,
             reference_gas_price: u64,
             storage_gas_price: u64,
             rebate_rate: u64,
-            gas_rounding_mode: GasRoundingMode,
             cost_table: SuiCostTable,
         ) -> SuiGasStatus {
-            let gas_rounding_mode = match gas_rounding_mode {
-                GasRoundingMode::Bucketize => GasRoundingMode::Bucketize,
-                GasRoundingMode::Stepped(val) => GasRoundingMode::Stepped(val.max(1)),
-                GasRoundingMode::KeepHalfDigits => GasRoundingMode::KeepHalfDigits,
-            };
             SuiGasStatus {
                 gas_status: move_gas_status,
                 gas_budget,
                 charge,
-                computation_cost: 0,
-                gas_price,
+                effective_gas_price: user_gas_price,
+                user_gas_price,
                 reference_gas_price,
                 storage_gas_price,
                 per_object_storage: Vec::new(),
                 rebate_rate,
                 unmetered_storage_rebate: 0,
-                gas_rounding_mode,
                 cost_table,
+                force_computation_cost_to_budget: false,
             }
         }
 
@@ -260,6 +189,9 @@ mod checked {
             reference_gas_price: u64,
             config: &ProtocolConfig,
         ) -> SuiGasStatus {
+            // `gas_rounding_halve_digits` is on at every protocol version this gas_v3 runs at
+            // (v127+), so rounding is always `half_digits_rounding` in `uncapped_computation_cost`.
+            // No enum, no per-version branch.
             let storage_gas_price = config.storage_gas_price();
             let max_computation_budget = config.max_gas_computation_bucket() * gas_price;
             let computation_budget = if gas_budget > max_computation_budget {
@@ -268,13 +200,6 @@ mod checked {
                 gas_budget
             };
             let sui_cost_table = SuiCostTable::new(config, gas_price);
-            let gas_rounding_mode = if config.gas_rounding_halve_digits() {
-                GasRoundingMode::KeepHalfDigits
-            } else if let Some(step) = config.gas_rounding_step_as_option() {
-                GasRoundingMode::Stepped(step)
-            } else {
-                GasRoundingMode::Bucketize
-            };
             Self::new(
                 GasStatus::new(
                     sui_cost_table.execution_cost_table.clone(),
@@ -288,7 +213,6 @@ mod checked {
                 reference_gas_price,
                 storage_gas_price,
                 config.storage_rebate_rate(),
-                gas_rounding_mode,
                 sui_cost_table,
             )
         }
@@ -302,13 +226,58 @@ mod checked {
                 0,
                 0,
                 0,
-                GasRoundingMode::Bucketize,
                 SuiCostTable::unmetered(),
             )
         }
 
         pub fn reference_gas_price(&self) -> u64 {
             self.reference_gas_price
+        }
+
+        /// Current computation cost in MIST derived from the Move VM meter:
+        ///   `gas_used_pre_gas_price() × effective_gas_price`,
+        /// capped so that `computation_cost + storage_cost - sender_rebate ≤ gas_budget`.
+        ///
+        /// `effective_gas_price` starts equal to the user's `user_gas_price`
+        /// and is lowered to the abort-tx cap by `bucketize_computation` when a
+        /// Move abort is detected and the protocol config defines such a cap.
+        ///
+        /// The budget cap accounts for storage so the gas coin can always pay
+        /// `net_gas_usage()` — if both computation and storage are attempted (e.g.
+        /// storage OOG'd after a Move abort), the meter-derived computation is
+        /// reduced to leave room for the accumulated net storage cost. Storage
+        /// charges stick, computation absorbs whatever the budget can still afford.
+        /// The bucketed, abort-discounted MIST cost of the computation accumulated
+        /// in the Move VM meter so far. NO budget cap applied — callers that need
+        /// the cap (`summary()`) should use `derived_computation_cost`; callers
+        /// that need the "true" value to gate further charging (`bucketize_computation`,
+        /// `charge_storage_and_rebate`) should use this one.
+        ///
+        /// The abort discount, if applicable, is folded in via
+        /// `effective_gas_price` — `bucketize_computation` lowers that field when
+        /// the result is a Move abort and the protocol config defines an abort cap.
+        fn uncapped_computation_cost(&self) -> u64 {
+            if self.force_computation_cost_to_budget {
+                return self.gas_budget;
+            }
+            let raw_units = self.gas_status.gas_used_pre_gas_price();
+            let bucketed_units = half_digits_rounding(raw_units);
+            bucketed_units.saturating_mul(self.effective_gas_price)
+        }
+
+        /// Computation cost reported to the user via `summary()`. Caps so that
+        /// `computation_cost + storage_cost - sender_rebate ≤ gas_budget` — when
+        /// both computation and storage are attempted (e.g. storage OOG'd after
+        /// computation succeeded), the meter-derived computation is reduced to
+        /// leave room for the accumulated net storage cost. Storage charges
+        /// stick, computation absorbs whatever the budget can still afford.
+        fn derived_computation_cost(&self) -> u64 {
+            let uncapped = self.uncapped_computation_cost();
+            let storage_rebate = self.storage_rebate();
+            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+            let net_storage = self.storage_cost().saturating_sub(sender_rebate);
+            let max_computation = self.gas_budget.saturating_sub(net_storage);
+            uncapped.min(max_computation)
         }
 
         // Gas data is consistent
@@ -370,64 +339,39 @@ mod checked {
         }
 
         fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
-            let gas_used = self.gas_status.gas_used_pre_gas_price();
-            let effective_gas_price = if self
-                .cost_table
-                .max_gas_price_rgp_factor_for_aborted_transactions
-                .is_some()
-                && aborted.unwrap_or(false)
-            {
-                // For aborts, cap at max but don't exceed user's price
-                // This minimizes the risk of competing for priority execution in the case that the txn may be aborted.
-                let max_gas_price_for_aborted_txns = self
+            // Bucketize fixes the price `summary()` will use for the rest of the
+            // pipeline — normally the user's `gas_price`, but lowered to the
+            // abort-tx cap if this call reports a Move abort and the protocol
+            // config defines such a cap. After that, it signals OOG if the
+            // bucketed-and-priced computation alone exceeds the budget. The
+            // bucketing math itself lives in `uncapped_computation_cost`, which
+            // `summary()` calls on demand through `derived_computation_cost`.
+            self.effective_gas_price = if aborted.unwrap_or(false) {
+                let cap = self
                     .cost_table
                     .max_gas_price_rgp_factor_for_aborted_transactions
-                    .unwrap()
                     * self.reference_gas_price;
-                self.gas_price.min(max_gas_price_for_aborted_txns)
+                self.user_gas_price.min(cap)
             } else {
-                // For all other cases, use the user's gas price
-                self.gas_price
+                self.user_gas_price
             };
-            let gas_used = match self.gas_rounding_mode {
-                GasRoundingMode::KeepHalfDigits => {
-                    half_digits_rounding(gas_used) * effective_gas_price
-                }
-                GasRoundingMode::Stepped(gas_rounding) => {
-                    if gas_used > 0 && gas_used % gas_rounding == 0 {
-                        gas_used * effective_gas_price
-                    } else {
-                        ((gas_used / gas_rounding) + 1) * gas_rounding * effective_gas_price
-                    }
-                }
-                GasRoundingMode::Bucketize => {
-                    let bucket_cost =
-                        get_bucket_cost(&self.cost_table.computation_bucket, gas_used);
-                    // charge extra on top of `computation_cost` to make the total computation
-                    // cost a bucket value
-                    bucket_cost * effective_gas_price
-                }
-            };
-            if self.gas_budget <= gas_used {
-                self.computation_cost = self.gas_budget;
-                Err(ExecutionErrorKind::InsufficientGas.into())
-            } else {
-                self.computation_cost = gas_used;
-                Ok(())
+            if self.uncapped_computation_cost() >= self.gas_budget {
+                return Err(ExecutionErrorKind::InsufficientGas.into());
             }
+            Ok(())
         }
 
-        /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
-        /// We use initial budget, combined with remaining gas and storage cost to derive
-        /// computation cost.
+        /// Returns the gas cost summary derived directly from the Move VM meter state.
+        /// `computation_cost = gas_used × effective_gas_price` (capped at
+        /// `gas_budget − net_storage`). The effective price equals
+        /// `user_gas_price` until `bucketize_computation` lowers it for a Move abort.
         fn summary(&self) -> GasCostSummary {
-            // compute storage rebate, both rebate and non refundable fee
             let storage_rebate = self.storage_rebate();
             let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
             assert!(sender_rebate <= storage_rebate);
             let non_refundable_storage_fee = storage_rebate - sender_rebate;
             GasCostSummary {
-                computation_cost: self.computation_cost,
+                computation_cost: self.derived_computation_cost(),
                 storage_cost: self.storage_cost(),
                 storage_rebate: sender_rebate,
                 non_refundable_storage_fee,
@@ -439,7 +383,7 @@ mod checked {
         }
 
         fn gas_price(&self) -> u64 {
-            self.gas_price
+            self.user_gas_price
         }
 
         fn reference_gas_price(&self) -> u64 {
@@ -524,22 +468,25 @@ mod checked {
             storage_cost
         }
 
+        /// Verify the accumulated `per_object_storage` fits in the remaining
+        /// budget (`gas_budget − net_computation`). If the rebates already
+        /// cover the cost, succeed unconditionally; otherwise compare net
+        /// storage against the *uncapped* computation cost so the check
+        /// reflects what the meter actually accumulated rather than the
+        /// summary's capped report (the cap would otherwise always make
+        /// storage appear to fit).
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
             let storage_rebate = self.storage_rebate();
             let storage_cost = self.storage_cost();
             let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
             assert!(sender_rebate <= storage_rebate);
             if sender_rebate >= storage_cost {
-                // there is more rebate than cost, when deducting gas we are adding
-                // to whatever is the current amount charged so we are `Ok`
                 Ok(())
             } else {
-                let gas_left = self.gas_budget - self.computation_cost;
-                // we have to charge for storage and may go out of gas, check
+                let gas_left = self
+                    .gas_budget
+                    .saturating_sub(self.uncapped_computation_cost());
                 if gas_left < storage_cost - sender_rebate {
-                    // Running out of gas would cause the temporary store to reset
-                    // and zero storage and rebate.
-                    // The remaining_gas will be 0 and we will charge all in computation
                     Err(ExecutionErrorKind::InsufficientGas.into())
                 } else {
                     Ok(())
@@ -547,9 +494,17 @@ mod checked {
             }
         }
 
+        /// Force `summary()` to report `computation_cost == gas_budget` by
+        /// dropping the accumulated `per_object_storage` and flipping
+        /// `force_computation_cost_to_budget`. Setting the flag bypasses the
+        /// meter math entirely; deriving from `gas_used_pre_gas_price() ×
+        /// effective_gas_price` would otherwise lose up to `budget %
+        /// user_gas_price` MIST. Callers: `set_computation_to_budget` on the
+        /// err-path fallback when even input-only storage doesn't fit the
+        /// budget, and the legacy storage-OOG handler.
         fn adjust_computation_on_out_of_gas(&mut self) {
             self.per_object_storage = Vec::new();
-            self.computation_cost = self.gas_budget;
+            self.force_computation_cost_to_budget = true;
         }
 
         fn gas_usage_report(&self) -> GasUsageReport {

--- a/crates/sui-types/src/gas_model/mod.rs
+++ b/crates/sui-types/src/gas_model/mod.rs
@@ -3,5 +3,6 @@
 
 pub mod gas_predicates;
 pub mod gas_v2;
+pub mod gas_v3;
 pub mod tables;
 pub mod units_types;

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -14,8 +14,8 @@ mod checked {
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::runtime::MoveRuntime;
     use mysten_common::{assert_reachable, debug_fatal, in_test_configuration};
-    use std::collections::BTreeMap;
-    use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::{cell::RefCell, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
     use sui_types::balance::{
         BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
@@ -24,6 +24,7 @@ mod checked {
     use sui_types::coin_reservation::ParsedDigest;
     use sui_types::execution_params::ExecutionOrEarlyError;
     use sui_types::gas_coin::GAS;
+    use sui_types::gas_model::gas_predicates::use_step_gas_charging;
     use sui_types::messages_checkpoint::CheckpointTimestamp;
     use sui_types::metrics::ExecutionMetrics;
     use sui_types::object::OBJECT_START_VERSION;
@@ -63,7 +64,7 @@ mod checked {
     };
     use sui_types::effects::TransactionEffects;
     use sui_types::error::{ExecutionError, ExecutionErrorTrait};
-    use sui_types::execution::{ExecutionTiming, ResultWithTimings};
+    use sui_types::execution::{ExecutionTiming, ResultWithTimings, SharedInput};
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
@@ -88,97 +89,107 @@ mod checked {
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     };
 
-    // MAGIC CONSTANTS -- these are all mainnet-only hardcoded constants and should not be changed
-    // (but can be removed in future execution cuts).
+    /// Output of transaction execution: the inner store carrying all written
+    /// objects, the final gas status, the effects, per-command timings, and the
+    /// mode-specific execution result.
+    type ExecutionOutput<Mode> = (
+        InnerTemporaryStore,
+        SuiGasStatus,
+        TransactionEffects,
+        Vec<ExecutionTiming>,
+        Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
+    );
 
-    /// Mainnet recovery point: the fix replays for transactions at/above this accumulator root
-    /// version and keeps the old behavior below it. A compiled constant (not a protocol flag)
-    /// because it had to take effect mid-epoch during recovery, when the network can't reconfigure.
-    const ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION: SequenceNumber =
-        SequenceNumber::from_u64(692949576);
-
-    /// Mainnet settlement version at/above which an `InsufficientFundsForWithdraw` transaction
-    /// short-circuits execution entirely (zero-gas effects, mutable-input version bumps only),
-    /// superseding the address-balance gas-payment pruning hotfix. A compiled constant, not a
-    /// protocol flag, because it must take effect mid-epoch during recovery when the network cannot
-    /// reconfigure. Only consulted when an accumulator version is assigned (mainnet committed
-    /// execution); everywhere else the short-circuit is protocol gated (see
-    /// `should_short_circuit_insufficient_funds`).
-    ///
-    /// Value is the mainnet accumulator root version where the new binary was activated on the network.
-    const ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION: SequenceNumber =
-        SequenceNumber::from_u64(693531074);
-
-    /// Whether the *head* early error is `InsufficientFundsForWithdraw`. Used to gate the first
-    /// address-balance gas-payment pruning hotfix: the head error is the one surfaced as the
-    /// failure status, so keying off it (rather than any occurrence) keeps the pruning bit-for-bit
-    /// with the original single-error hotfix.
-    fn head_error_is_insufficient_funds_for_withdraw(
+    /// Whether `InsufficientFundsForWithdraw` appears anywhere in the early-error list.
+    /// `get_early_execution_error` always appends IFFW last (priority 5), so when a
+    /// higher-priority error (CertificateDenied / InputObjectDeleted / ExecutionCancelled-*)
+    /// is also present, IFFW lands in `errors[1..]`. Both the v15+ short-circuit and the
+    /// legacy protocol-gated hotfix predicates must catch it regardless of position, or
+    /// `GasCharger::new` would proceed to call `smash_gas` on the unbacked
+    /// coin-reservation entry — the underflow path #26865 pins.
+    fn any_error_is_insufficient_funds_for_withdraw(
         execution_params: &ExecutionOrEarlyError,
     ) -> bool {
         execution_params.early_errors().is_some_and(|errors| {
-            matches!(
-                errors.head,
-                ExecutionErrorKind::InsufficientFundsForWithdraw
-            )
-        })
-    }
-
-    /// Whether to prune the address-balance leg of gas smashing for an IFFW transaction. This is
-    /// the mainnet-only accumulator backfill that replays the pre-flag incident hotfix below the
-    /// short-circuit rollout point; once `early_exit_on_iffw` is set the short-circuit handles IFFW
-    /// upstream, so reaching here implies the flag is off (asserted below).
-    fn should_filter_address_balance_gas_smash(
-        execution_params: &ExecutionOrEarlyError,
-        protocol_config: &ProtocolConfig,
-    ) -> bool {
-        if !head_error_is_insufficient_funds_for_withdraw(execution_params) {
-            return false;
-        }
-        debug_assert!(
-            !protocol_config.early_exit_on_iffw(),
-            "Should not reach gas smashing filtering address balances if IFFW early exit is enabled"
-        );
-        // In test/debug builds, always apply the fix unconditionally to match the behaviour of
-        // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
-        in_test_configuration()
-            || protocol_config.early_exit_on_iffw()
-            || execution_params
-                .accumulator_version()
-                .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION)
-    }
-
-    /// Whether to short-circuit an IFFW transaction. When an accumulator version is assigned
-    /// (mainnet committed execution) it gates on the settlement-version rollout point; otherwise
-    /// (every other chain and non-committed paths, where no accumulator version is assigned) the
-    /// short-circuit applies based on `early_exit_on_iffw`.
-    fn should_short_circuit_insufficient_funds(
-        execution_params: &ExecutionOrEarlyError,
-        protocol_config: &ProtocolConfig,
-    ) -> bool {
-        // If no IFWWs, then does not apply
-        if !execution_params.early_errors().is_some_and(|errors| {
             errors
                 .iter()
                 .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw))
-        }) {
+        })
+    }
+
+    /// Whether the v15+ pipeline must short-circuit an IFFW transaction.
+    /// Short-circuit is required only when the gas payment carries
+    /// coin-reservation entries: smashing those emits accumulator events against
+    /// declared amounts that may not be backed by the actual address balance.
+    /// Every other payment shape is safe to run through the normal pipeline:
+    /// all-real-coin payments are fully backed (the failed transaction is charged
+    /// normally), and pure address-balance payments are protected by the
+    /// IFFW+AddressBalance guard in `GasCharger::charge` (zero summary, no debit).
+    ///
+    /// Fallback: if this narrower gate proves problematic, replace the call site
+    /// with `any_error_is_insufficient_funds_for_withdraw(&execution_params)` to
+    /// restore the unconditional short-circuit.
+    fn should_short_circuit_insufficient_funds(
+        execution_params: &ExecutionOrEarlyError,
+        gas_data: &GasData,
+    ) -> bool {
+        if !any_error_is_insufficient_funds_for_withdraw(execution_params) {
             return false;
         }
-
-        // In test/debug builds, always short-circuit unconditionally to match the behaviour of
-        // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
-        if in_test_configuration() {
-            return true;
-        }
-
-        // otherwise gate by accumulator version (if present) or protocol flag
-        protocol_config.early_exit_on_iffw()
-            || execution_params
-                .accumulator_version()
-                .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION)
+        gas_data
+            .payment
+            .iter()
+            .any(|entry| ParsedDigest::try_from(entry.2).is_ok())
     }
 
     fn payment_kind(
+        gas_data: &GasData,
+        transaction_kind: &TransactionKind,
+        protocol_config: &ProtocolConfig,
+        transaction_signer: SuiAddress,
+    ) -> PaymentKind {
+        if gas_data.is_unmetered() || transaction_kind.is_system_tx() {
+            PaymentKind::unmetered()
+        } else if protocol_config.enable_gasless()
+            && is_gasless_transaction(gas_data, transaction_kind)
+        {
+            // Capture the PTB's withdrawal reservations now so they ride on the gasless
+            // payment metadata instead of being threaded through the charging pipeline.
+            let sponsor = (gas_data.owner != transaction_signer).then_some(gas_data.owner);
+            let reservations =
+                compute_gasless_reservations(transaction_kind, transaction_signer, sponsor)
+                    .unwrap_or_default();
+            PaymentKind::gasless(reservations)
+        } else if gas_data.payment.is_empty() {
+            PaymentKind::smash(vec![PaymentMethod::AddressBalance(
+                gas_data.owner,
+                gas_data.budget,
+            )])
+            .expect("unable to create a payment kind with a single address balance")
+        } else {
+            let payment_methods = gas_data
+                .payment
+                .iter()
+                .map(|entry| {
+                    if let Ok(parsed) = ParsedDigest::try_from(entry.2) {
+                        PaymentMethod::AddressBalance(gas_data.owner, parsed.reservation_amount())
+                    } else {
+                        PaymentMethod::Coin(*entry)
+                    }
+                })
+                .collect();
+            PaymentKind::smash(payment_methods).expect(
+                "unable to create a payment kind from payment methods. \
+                 Should not be possible wit ha non-empty vector",
+            )
+        }
+    }
+
+    /// Legacy (gas_model < 15) payment classification. Frozen copy of `payment_kind` whose gasless
+    /// arm carries no reservations (the legacy executor computes its own `withdrawal_reservations`
+    /// local and never reads the charger's gasless metadata). Kept separate so `mod legacy` is
+    /// independent of the v15 reservation logic.
+    fn legacy_payment_kind(
         gas_data: &GasData,
         transaction_kind: &TransactionKind,
         protocol_config: &ProtocolConfig,
@@ -188,7 +199,7 @@ mod checked {
         } else if protocol_config.enable_gasless()
             && is_gasless_transaction(gas_data, transaction_kind)
         {
-            PaymentKind::gasless()
+            PaymentKind::gasless(BTreeMap::new())
         } else if gas_data.payment.is_empty() {
             PaymentKind::smash(vec![PaymentMethod::AddressBalance(
                 gas_data.owner,
@@ -262,12 +273,11 @@ mod checked {
         reservations
     }
 
-    #[allow(clippy::type_complexity)]
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
         input_objects: CheckedInputObjects,
-        mut gas_data: GasData,
+        gas_data: GasData,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         rewritten_inputs: Option<Vec<bool>>,
@@ -281,22 +291,14 @@ mod checked {
         enable_expensive_checks: bool,
         execution_params: ExecutionOrEarlyError,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<Mode::ExecutionResults, Mode::Error>,
-    ) {
+    ) -> ExecutionOutput<Mode> {
+        //
+        // setup, common to current and legacy execution
+        //
         let input_objects = input_objects.into_inner();
-        let mutable_inputs = if enable_expensive_checks {
-            input_objects.all_mutable_inputs().keys().copied().collect()
-        } else {
-            HashSet::new()
-        };
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
-        let mut transaction_dependencies = input_objects.transaction_dependencies();
+        let transaction_dependencies = input_objects.transaction_dependencies();
 
         let mut temporary_store = TemporaryStore::new(
             store,
@@ -307,115 +309,123 @@ mod checked {
             *epoch_id,
         );
 
-        // Short-circuit on InsufficientFundsForWithdraw: the transaction is guaranteed to fail
-        // and has nothing to execute, so skip the executor pipeline. Bump versions of mutable
-        // inputs (so locks advance) and emit effects with a zero gas cost summary. On mainnet
-        // committed execution this is gated on the settlement-version rollout point (below it we
-        // fall through to the address-balance gas-payment pruning hotfix instead); everywhere else
-        // it applies based on `early_exit_on_iffw`.
-        if should_short_circuit_insufficient_funds(&execution_params, protocol_config) {
-            assert_reachable!("IFFW short-circuit fired");
-            temporary_store.ensure_active_inputs_mutated();
-            transaction_dependencies.remove(&TransactionDigest::genesis_marker());
-
-            let execution_error: Mode::Error =
-                ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw).into();
-            let status = ExecutionStatus::new_failure(execution_error.to_execution_failure());
-            let mut gas_meter = GasCharger::new(
-                transaction_digest,
-                PaymentKind::gasless(),
-                gas_status,
+        //
+        // dispatch: fork immediately into the current pipeline or the frozen legacy
+        // one; each fork is self-contained through to effects
+        //
+        if use_step_gas_charging(protocol_config.gas_model_version()) {
+            // New model: the inner fork runs execution + the consistency check and hands back an
+            // `Outcome`. This level owns the TemporaryStore lifecycle and builds the effects (the
+            // single terminal): `Proceed` builds them from the charged state; `BumpOnly` installs a
+            // gasless charger, drops writes, bumps the inputs, charges nothing, and reports the error.
+            match execute_transaction_inner::<Mode>(
+                store,
                 &mut temporary_store,
+                gas_data,
+                gas_status,
+                transaction_kind,
+                rewritten_inputs,
+                transaction_signer,
+                transaction_digest,
+                move_vm,
+                epoch_id,
+                epoch_timestamp_ms,
                 protocol_config,
-            );
-
-            let (inner, effects) = temporary_store.into_effects(
-                shared_object_refs,
-                &transaction_digest,
-                transaction_dependencies,
-                GasCostSummary::default(),
-                status,
-                &mut gas_meter,
-                *epoch_id,
-            );
-
-            return (
-                inner,
-                gas_meter.into_gas_status(),
-                effects,
-                vec![],
-                Err(execution_error),
-            );
-        }
-
-        let sponsor = {
-            let gas_owner = gas_data.owner;
-            if gas_owner == transaction_signer {
-                None
-            } else {
-                Some(gas_owner)
+                metrics.clone(),
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+            ) {
+                Outcome::Proceed {
+                    gas_charger,
+                    gas_cost_summary,
+                    execution_result,
+                    timings,
+                } => build_effects::<Mode>(
+                    temporary_store,
+                    gas_charger,
+                    gas_cost_summary,
+                    execution_result,
+                    shared_object_refs,
+                    transaction_dependencies,
+                    timings,
+                    transaction_digest,
+                    *epoch_id,
+                    metrics,
+                    move_vm,
+                ),
+                Outcome::BumpOnly { gas_status, error } => {
+                    // One gasless-charger construction for every bail (IFFW + consistency failure).
+                    let gas_charger = GasCharger::new(
+                        transaction_digest,
+                        PaymentKind::gasless(BTreeMap::new()),
+                        gas_status,
+                        &mut temporary_store,
+                        protocol_config,
+                    );
+                    let gas_cost_summary = bump_inputs_only(&mut temporary_store);
+                    build_effects::<Mode>(
+                        temporary_store,
+                        gas_charger,
+                        gas_cost_summary,
+                        Err(error),
+                        shared_object_refs,
+                        transaction_dependencies,
+                        vec![],
+                        transaction_digest,
+                        *epoch_id,
+                        metrics,
+                        move_vm,
+                    )
+                }
             }
-        };
-        let gas_price = gas_status.gas_price();
-        let rgp = gas_status.reference_gas_price();
-
-        // On an IFFW abort, drop the address-balance gas payments (keeping real coins) so the
-        // pruned list flows into `payment_kind`/`compute_input_reservations` with no special
-        // handling. See `should_filter_address_balance_gas_smash` for when this applies.
-        if should_filter_address_balance_gas_smash(&execution_params, protocol_config)
-            && gas_data.payment.len() > 1
-            && ParsedDigest::try_from(gas_data.payment[0].2).is_err()
-        {
-            gas_data
-                .payment
-                .retain(|entry| ParsedDigest::try_from(entry.2).is_err());
+        } else {
+            // TODO: remove all `legacy` code on the next execution version cut
+            legacy::execute_transaction_inner::<Mode>(
+                store,
+                temporary_store,
+                gas_data,
+                gas_status,
+                transaction_kind,
+                rewritten_inputs,
+                transaction_signer,
+                transaction_digest,
+                move_vm,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+                shared_object_refs,
+                transaction_dependencies,
+            )
         }
+    }
 
-        let mut gas_charger = GasCharger::new(
-            transaction_digest,
-            payment_kind(&gas_data, &transaction_kind, protocol_config),
-            gas_status,
-            &mut temporary_store,
-            protocol_config,
-        );
-
-        let tx_ctx = TxContext::new_from_components(
-            &transaction_signer,
-            &transaction_digest,
-            epoch_id,
-            epoch_timestamp_ms,
-            rgp,
-            gas_price,
-            gas_data.budget,
-            sponsor,
-            protocol_config,
-        );
-        let tx_ctx = Rc::new(RefCell::new(tx_ctx));
-
-        let is_gasless = protocol_config.enable_gasless()
-            && is_gasless_transaction(&gas_data, &transaction_kind);
-        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
-
-        let input_reservations =
-            compute_input_reservations(&transaction_kind, &gas_data, transaction_signer);
-
-        let (gas_cost_summary, execution_result, timings) = execute_transaction::<Mode>(
-            store,
-            &mut temporary_store,
-            transaction_kind,
-            rewritten_inputs,
-            &mut gas_charger,
-            tx_ctx,
-            move_vm,
-            protocol_config,
-            metrics.clone(),
-            enable_expensive_checks,
-            execution_params,
-            trace_builder_opt,
-            is_gasless,
-            &input_reservations,
-        );
-
+    /// Teardown shared by the current and legacy execution forks: map the result
+    /// to a status, bump-clean the dependencies, run the expensive ownership
+    /// checks, build the effects, and report VM telemetry.
+    #[allow(clippy::too_many_arguments)]
+    fn finish_transaction_to_effects<Mode: ExecutionMode>(
+        temporary_store: TemporaryStore<'_>,
+        mut gas_charger: GasCharger,
+        shared_object_refs: Vec<SharedInput>,
+        mut transaction_dependencies: BTreeSet<TransactionDigest>,
+        sponsor: Option<SuiAddress>,
+        is_epoch_change: bool,
+        input_reservations: BTreeMap<(SuiAddress, TypeTag), u64>,
+        gas_cost_summary: GasCostSummary,
+        execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+        timings: Vec<ExecutionTiming>,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        epoch_id: EpochId,
+        enable_expensive_checks: bool,
+        metrics: Arc<ExecutionMetrics>,
+        move_vm: &Arc<MoveRuntime>,
+    ) -> ExecutionOutput<Mode> {
         let status = if let Err(error) = &execution_result {
             ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
@@ -443,7 +453,6 @@ mod checked {
                     &transaction_signer,
                     &sponsor,
                     &gas_charger,
-                    &mutable_inputs,
                     &input_reservations,
                     is_epoch_change,
                 )
@@ -457,68 +466,13 @@ mod checked {
             gas_cost_summary,
             status,
             &mut gas_charger,
-            *epoch_id,
+            epoch_id,
         );
 
         // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
         // spun-up each time.
         if !Mode::TRACK_EXECUTION {
-            metrics.vm_telemetry_metrics.try_update(|vm_metrics| {
-                let t = move_vm.get_telemetry_report();
-                vm_metrics
-                    .move_vm_package_cache_count
-                    .set(t.package_cache_count as i64);
-                vm_metrics
-                    .move_vm_total_arena_size_bytes
-                    .set(t.total_arena_size as i64);
-                vm_metrics.move_vm_module_count.set(t.module_count as i64);
-                vm_metrics
-                    .move_vm_function_count
-                    .set(t.function_count as i64);
-                vm_metrics.move_vm_type_count.set(t.type_count as i64);
-                vm_metrics.move_vm_interner_size.set(t.interner_size as i64);
-                vm_metrics
-                    .move_vm_vtable_cache_count
-                    .set(t.vtable_cache_count as i64);
-                vm_metrics
-                    .move_vm_vtable_cache_hits
-                    .set(t.vtable_cache_hits as i64);
-                vm_metrics
-                    .move_vm_vtable_cache_misses
-                    .set(t.vtable_cache_misses as i64);
-                vm_metrics
-                    .move_vm_load_time_ms
-                    .set(t.total_load_time as i64);
-                vm_metrics.move_vm_load_count.set(t.load_count as i64);
-                vm_metrics
-                    .move_vm_validation_time_ms
-                    .set(t.total_validation_time as i64);
-                vm_metrics
-                    .move_vm_validation_count
-                    .set(t.validation_count as i64);
-                vm_metrics.move_vm_jit_time_ms.set(t.total_jit_time as i64);
-                vm_metrics.move_vm_jit_count.set(t.jit_count as i64);
-                vm_metrics
-                    .move_vm_execution_time_ms
-                    .set(t.total_execution_time as i64);
-                vm_metrics
-                    .move_vm_execution_count
-                    .set(t.execution_count as i64);
-                vm_metrics
-                    .move_vm_interpreter_time_ms
-                    .set(t.total_interpreter_time as i64);
-                vm_metrics
-                    .move_vm_interpreter_count
-                    .set(t.interpreter_count as i64);
-                vm_metrics
-                    .move_vm_max_callstack_size
-                    .set(t.max_callstack_size as i64);
-                vm_metrics
-                    .move_vm_max_valuestack_size
-                    .set(t.max_valuestack_size as i64);
-                vm_metrics.move_vm_total_time_ms.set(t.total_time as i64);
-                vm_metrics.move_vm_total_count.set(t.total_count as i64);
-            });
+            update_vm_telemetry_metrics(&metrics, move_vm);
         }
 
         (
@@ -528,6 +482,194 @@ mod checked {
             timings,
             execution_result,
         )
+    }
+
+    /// Check the post-execution consistency invariants (the new path's outer layer, stage 1): SUI
+    /// conservation and the expensive ownership invariants. `Ok(())` → the charge stands and we build
+    /// effects normally; `Err(error)` → an invariant was violated unrecoverably (no panic, no
+    /// recovery, no bump here) and the caller bails to the no-op (`bump_inputs_only`) reporting that
+    /// error.
+    #[allow(clippy::too_many_arguments)]
+    fn check_consistency<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &GasCharger,
+        gas_cost_summary: &GasCostSummary,
+        move_vm: &Arc<MoveRuntime>,
+        enable_expensive_checks: bool,
+        is_genesis_tx: bool,
+        advance_epoch_gas_summary: Option<(u64, u64)>,
+        input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
+        transaction_signer: SuiAddress,
+        sponsor: Option<SuiAddress>,
+        is_epoch_change: bool,
+        transaction_digest: TransactionDigest,
+    ) -> Result<(), Mode::Error> {
+        // Conservation: verify SUI is conserved against the charged summary; on failure bail to the
+        // no-op reporting the conservation error.
+        // FIXME: we cannot fail the transaction if this is an epoch change transaction.
+        run_conservation_checks::<Mode>(
+            temporary_store,
+            gas_charger,
+            transaction_digest,
+            move_vm,
+            enable_expensive_checks,
+            gas_cost_summary,
+            is_genesis_tx,
+            advance_epoch_gas_summary,
+            input_reservations,
+        )?;
+
+        if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
+            if let Err(err) = temporary_store.check_ownership_invariants(
+                &transaction_signer,
+                &sponsor,
+                gas_charger,
+                input_reservations,
+                is_epoch_change,
+            ) {
+                // Post-execution ownership invariants are violated — a real bug that should never
+                // fire. Rather than crash the validator, bail to the no-op (the caller drops
+                // everything, bumps the inputs, charges nothing) reporting an invariant violation: a
+                // deterministic, conserving no-op. Alert loudly (with the underlying `SuiError`) so
+                // the violation is visible. The reported status is `InvariantViolation` — the
+                // `SuiError` from ownership checking is not an `ExecutionError`, and an internal
+                // invariant breach is exactly what that status is for.
+                #[skip_checked_arithmetic]
+                tracing::error!(
+                    tx_digest = ?transaction_digest,
+                    error = %err,
+                    "ownership invariants violated; falling back to the no-op exit (State 2): \
+                     dropping all writes and charging nothing",
+                );
+                return Err(
+                    ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation).into(),
+                );
+            }
+        } // else, in dev inspect mode and anything goes--don't check
+
+        Ok(())
+    }
+
+    /// Build the transaction effects from the final state (the new path's outer layer, stage 2):
+    /// derive the status, trim the genesis dependency marker, assemble the effects, and report VM
+    /// telemetry. The charge and consistency checks already ran in `check_consistency`.
+    #[allow(clippy::too_many_arguments)]
+    fn build_effects<Mode: ExecutionMode>(
+        temporary_store: TemporaryStore<'_>,
+        mut gas_charger: GasCharger,
+        gas_cost_summary: GasCostSummary,
+        execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+        shared_object_refs: Vec<SharedInput>,
+        mut transaction_dependencies: BTreeSet<TransactionDigest>,
+        timings: Vec<ExecutionTiming>,
+        transaction_digest: TransactionDigest,
+        epoch_id: EpochId,
+        metrics: Arc<ExecutionMetrics>,
+        move_vm: &Arc<MoveRuntime>,
+    ) -> ExecutionOutput<Mode> {
+        let status = if let Err(error) = &execution_result {
+            ExecutionStatus::new_failure(error.to_execution_failure())
+        } else {
+            ExecutionStatus::Success
+        };
+
+        #[skip_checked_arithmetic]
+        trace!(
+            tx_digest = ?transaction_digest,
+            computation_gas_cost = gas_cost_summary.computation_cost,
+            storage_gas_cost = gas_cost_summary.storage_cost,
+            storage_gas_rebate = gas_cost_summary.storage_rebate,
+            "Finished execution of transaction with status {:?}",
+            status
+        );
+
+        // Genesis writes a special digest to indicate that an object was created during
+        // genesis and not written by any normal transaction - remove that from the
+        // dependencies
+        transaction_dependencies.remove(&TransactionDigest::genesis_marker());
+
+        let (inner, effects) = temporary_store.into_effects(
+            shared_object_refs,
+            &transaction_digest,
+            transaction_dependencies,
+            gas_cost_summary,
+            status,
+            &mut gas_charger,
+            epoch_id,
+        );
+
+        // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
+        // spun-up each time.
+        if !Mode::TRACK_EXECUTION {
+            update_vm_telemetry_metrics(&metrics, move_vm);
+        }
+
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            timings,
+            execution_result,
+        )
+    }
+
+    fn update_vm_telemetry_metrics(metrics: &ExecutionMetrics, move_vm: &MoveRuntime) {
+        metrics.vm_telemetry_metrics.try_update(|vm_metrics| {
+            let t = move_vm.get_telemetry_report();
+            vm_metrics
+                .move_vm_package_cache_count
+                .set(t.package_cache_count as i64);
+            vm_metrics
+                .move_vm_total_arena_size_bytes
+                .set(t.total_arena_size as i64);
+            vm_metrics.move_vm_module_count.set(t.module_count as i64);
+            vm_metrics
+                .move_vm_function_count
+                .set(t.function_count as i64);
+            vm_metrics.move_vm_type_count.set(t.type_count as i64);
+            vm_metrics.move_vm_interner_size.set(t.interner_size as i64);
+            vm_metrics
+                .move_vm_vtable_cache_count
+                .set(t.vtable_cache_count as i64);
+            vm_metrics
+                .move_vm_vtable_cache_hits
+                .set(t.vtable_cache_hits as i64);
+            vm_metrics
+                .move_vm_vtable_cache_misses
+                .set(t.vtable_cache_misses as i64);
+            vm_metrics
+                .move_vm_load_time_ms
+                .set(t.total_load_time as i64);
+            vm_metrics.move_vm_load_count.set(t.load_count as i64);
+            vm_metrics
+                .move_vm_validation_time_ms
+                .set(t.total_validation_time as i64);
+            vm_metrics
+                .move_vm_validation_count
+                .set(t.validation_count as i64);
+            vm_metrics.move_vm_jit_time_ms.set(t.total_jit_time as i64);
+            vm_metrics.move_vm_jit_count.set(t.jit_count as i64);
+            vm_metrics
+                .move_vm_execution_time_ms
+                .set(t.total_execution_time as i64);
+            vm_metrics
+                .move_vm_execution_count
+                .set(t.execution_count as i64);
+            vm_metrics
+                .move_vm_interpreter_time_ms
+                .set(t.total_interpreter_time as i64);
+            vm_metrics
+                .move_vm_interpreter_count
+                .set(t.interpreter_count as i64);
+            vm_metrics
+                .move_vm_max_callstack_size
+                .set(t.max_callstack_size as i64);
+            vm_metrics
+                .move_vm_max_valuestack_size
+                .set(t.max_valuestack_size as i64);
+            vm_metrics.move_vm_total_time_ms.set(t.total_time as i64);
+            vm_metrics.move_vm_total_count.set(t.total_count as i64);
+        });
     }
 
     pub fn execute_genesis_state_update(
@@ -566,7 +708,181 @@ mod checked {
         Ok(temporary_store.into_inner(BTreeMap::new()))
     }
 
+    /// What the new-model `execute_transaction_inner` hands back to `execute_transaction_to_effects`
+    /// to turn into effects (the single `build_effects` terminal handles both cases).
+    enum Outcome<Mode: ExecutionMode> {
+        /// Execution and all post-checks passed; build effects from this charged state.
+        Proceed {
+            gas_charger: GasCharger,
+            gas_cost_summary: GasCostSummary,
+            execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+            timings: Vec<ExecutionTiming>,
+        },
+        /// Bail to a version-bump-only no-op reporting `error`: the top level installs a gasless
+        /// charger, drops writes, bumps the mutable inputs, and charges nothing. `gas_status` (which
+        /// `SuiGasStatus` cannot clone) is carried out so that single gasless charger can be built up
+        /// the stack — for IFFW it is the untouched input status, for a consistency failure it is the
+        /// post-execution status recovered from the real charger.
+        BumpOnly {
+            gas_status: SuiGasStatus,
+            error: Mode::Error,
+        },
+    }
+
+    /// Execution fork for `gas_model_version >= 15`: IFFW short-circuit, gas
+    /// charger construction, the step-by-step gas-charging pipeline, and the
+    /// consistency check. Entered from `execute_transaction_to_effects` right
+    /// after the common setup; returns an `Outcome` for the top level to finalize.
     #[instrument(name = "tx_execute", level = "debug", skip_all)]
+    fn execute_transaction_inner<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_data: GasData,
+        gas_status: SuiGasStatus,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        move_vm: &Arc<MoveRuntime>,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        enable_expensive_checks: bool,
+        execution_params: ExecutionOrEarlyError,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> Outcome<Mode> {
+        // ── Exit route ①: pre-execution bail (IFFW) ───────────────────────────────────────────
+        // IFFW is short-circuited only when the gas payment carries coin-reservation entries
+        // (smashing those is unsafe); other payment shapes run the normal pipeline and surface the
+        // IFFW failure through it. We never run the VM; bail with `BumpOnly` carrying the untouched
+        // input `gas_status` — the top level builds the gasless charger, bumps the inputs, and
+        // charges nothing. (Legacy keeps the frozen `respond_with_iffw_short_circuit`.)
+        if should_short_circuit_insufficient_funds(&execution_params, &gas_data) {
+            assert_reachable!("IFFW short-circuit fired");
+            let iffw: Mode::Error =
+                ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw).into();
+            return Outcome::BumpOnly {
+                gas_status,
+                error: iffw,
+            };
+        }
+
+        // ── Exit route ②: execute → check_consistency → Proceed | BumpOnly ────────────────────
+        let sponsor = {
+            let gas_owner = gas_data.owner;
+            if gas_owner == transaction_signer {
+                None
+            } else {
+                Some(gas_owner)
+            }
+        };
+        let gas_price = gas_status.gas_price();
+        let rgp = gas_status.reference_gas_price();
+        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
+        // Captured before `transaction_kind` is moved into `execute_transaction`; consumed by the
+        // conservation step in `check_consistency`.
+        let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
+        let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+
+        let tx_ctx = TxContext::new_from_components(
+            &transaction_signer,
+            &transaction_digest,
+            epoch_id,
+            epoch_timestamp_ms,
+            rgp,
+            gas_price,
+            gas_data.budget,
+            sponsor,
+            protocol_config,
+        );
+        let tx_ctx = Rc::new(RefCell::new(tx_ctx));
+
+        let input_reservations =
+            compute_input_reservations(&transaction_kind, &gas_data, transaction_signer);
+
+        let mut gas_charger = GasCharger::new(
+            transaction_digest,
+            payment_kind(
+                &gas_data,
+                &transaction_kind,
+                protocol_config,
+                transaction_signer,
+            ),
+            gas_status,
+            temporary_store,
+            protocol_config,
+        );
+        // Execution: run the PTB and apply the gas charge (with its internal State-1 resets).
+        let (gas_cost_summary, execution_result, timings) = execute_transaction::<Mode>(
+            store,
+            temporary_store,
+            transaction_kind,
+            rewritten_inputs,
+            &mut gas_charger,
+            tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics,
+            execution_params,
+            trace_builder_opt,
+        );
+
+        // Check the post-execution consistency invariants (conservation + ownership). On violation we
+        // bail with `BumpOnly` carrying that check's own error and the `gas_status` recovered from the
+        // real charger (so the top level can build the single gasless charger); otherwise we proceed
+        // to build effects from the charged state.
+        match check_consistency::<Mode>(
+            temporary_store,
+            &gas_charger,
+            &gas_cost_summary,
+            move_vm,
+            enable_expensive_checks,
+            is_genesis_tx,
+            advance_epoch_gas_summary,
+            &input_reservations,
+            transaction_signer,
+            sponsor,
+            is_epoch_change,
+            transaction_digest,
+        ) {
+            Ok(()) => Outcome::Proceed {
+                gas_charger,
+                gas_cost_summary,
+                execution_result,
+                timings,
+            },
+            Err(error) => Outcome::BumpOnly {
+                gas_status: gas_charger.into_gas_status(),
+                error,
+            },
+        }
+    }
+
+    /// Gas-charging pipeline for `gas_model_version >= 15`. Reads top-to-bottom
+    /// as explicit steps on the running `Result`. Each step that returns
+    /// `Result<(), ExecutionError>` is folded in via `and_then`; the chain
+    /// short-circuits on the first `Err`.
+    ///
+    ///   1. `charge_input_objects`    — charge `storage_read` for every input object.
+    ///   2. early-error gate          — if `execution_params` carries early errors,
+    ///                                  fail with the head (highest-priority) error
+    ///                                  without running the VM; otherwise
+    ///      `execute_ptb`             — run the PTB; bucketize computation at the
+    ///                                  tail regardless of inner Ok/Err.
+    ///   3. `charge_storage`          — collect per-object storage cost and rebate,
+    ///                                  verify they fit in the remaining budget.
+    ///   4. `check_effects`           — meter + written-objects limits + accumulator
+    ///                                  representability. Always runs (metrics fire on err too).
+    ///   5. `reset_writes` (on Err).  — rewind execution writes and recompute
+    ///                                  storage against the rewound state so the
+    ///                                  charges in step 6 match what's actually
+    ///                                  persisted.
+    ///   6. `charge`                  — deduct `net_gas_usage` from the gas coin /
+    ///                                  emit the address-balance accumulator event.
+    ///
+    /// Conservation and effects-building are NOT part of this pipeline — they live one level up in
+    /// `finalize_to_effects`, which consumes the `(cost_summary, result)` this returns.
     fn execute_transaction<Mode: ExecutionMode>(
         store: &dyn BackingStore,
         temporary_store: &mut TemporaryStore<'_>,
@@ -577,213 +893,757 @@ mod checked {
         move_vm: &Arc<MoveRuntime>,
         protocol_config: &ProtocolConfig,
         metrics: Arc<ExecutionMetrics>,
-        enable_expensive_checks: bool,
         execution_params: ExecutionOrEarlyError,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-        is_gasless: bool,
-        input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
     ) -> (
         GasCostSummary,
         Result<Mode::ExecutionResults, Mode::Error>,
         Vec<ExecutionTiming>,
     ) {
-        // At this point no charges have been applied yet
         debug_assert!(
             gas_charger.no_charges(),
             "No gas charges must be applied yet"
         );
 
-        let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
-        let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
-        let digest = tx_ctx.borrow().digest();
-        let withdrawal_reservations =
-            if is_gasless && protocol_config.gasless_verify_remaining_balance() {
-                gasless_withdrawal_reservations(&transaction_kind, &tx_ctx.borrow())
-            } else {
-                None
-            };
+        let mut timings: Vec<ExecutionTiming> = vec![];
 
-        // We must charge object read here during transaction execution, because if this fails
-        // we must still ensure an effect is committed and all objects versions incremented
-        let result = gas_charger.charge_input_objects(temporary_store);
+        // Steps 1–3: charge inputs → early-error gate / execute PTB (with
+        // computation rounding at its tail) → charge storage. Each step is
+        // Ok-only via `and_then`; any earlier Err short-circuits the chain.
+        let result = gas_charger
+            .charge_input_objects(temporary_store)
+            .map_err(Into::into)
+            // Early errors (deny / cancel / deleted input / IFFW that was not
+            // short-circuited) consume the transaction without running the VM:
+            // the head (highest-priority) error becomes the failure. Skipping
+            // `execute_ptb` also skips computation rounding — nothing executed,
+            // so there is no abort price to freeze and nothing to round; the
+            // input charges already on the meter are billed as-is.
+            .and_then(|()| match execution_params.into_early_errors() {
+                Some(early_execution_errors) => {
+                    Err(ExecutionError::new(early_execution_errors.head, None).into())
+                }
+                None => execute_ptb::<Mode>(
+                    store,
+                    temporary_store,
+                    transaction_kind,
+                    rewritten_inputs,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                    trace_builder_opt,
+                    &mut timings,
+                ),
+            })
+            .and_then(|v| {
+                gas_charger
+                    .charge_storage(temporary_store)
+                    .map_err(Into::into)
+                    .map(|_| v)
+            });
 
-        let result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> =
-            result.map_err(|e| (e.into(), vec![])).and_then(
-                |()| -> ResultWithTimings<Mode::ExecutionResults, Mode::Error> {
-                    let mut execution_result: ResultWithTimings<
-                        Mode::ExecutionResults,
-                        Mode::Error,
-                    > = match execution_params.into_early_errors() {
-                        Some(early_execution_errors) => {
-                            Err((Mode::Error::from_kind(early_execution_errors.head), vec![]))
-                        }
-                        None => execution_loop::<Mode>(
-                            store,
-                            temporary_store,
-                            transaction_kind,
-                            rewritten_inputs,
-                            tx_ctx,
-                            move_vm,
-                            gas_charger,
-                            protocol_config,
-                            metrics.clone(),
-                            trace_builder_opt,
-                        ),
-                    };
-
-                    let meter_check = check_meter_limit::<Mode>(
-                        temporary_store,
-                        gas_charger,
-                        protocol_config,
-                        metrics.clone(),
-                    );
-                    if let Err(e) = meter_check {
-                        execution_result = Err((e, vec![]));
-                    }
-
-                    if execution_result.is_ok() {
-                        let gas_check = check_written_objects_limit::<Mode>(
-                            temporary_store,
-                            gas_charger,
-                            protocol_config,
-                            metrics,
-                        );
-                        if let Err(e) = gas_check {
-                            execution_result = Err((e, vec![]));
-                        }
-                    }
-
-                    execution_result
-                },
-            );
-
-        let (mut result, timings) = match result {
-            Ok((r, t)) => (Ok(r), t),
-            Err((e, t)) => (Err(e), t),
+        // Step 4: effects-validity checks (meter limit, written-objects limit, accumulator
+        // representability). Always run (so their metrics fire on the err path too); their
+        // errors stick only if `result` was previously Ok.
+        let checks = check_effects::<Mode>(temporary_store, gas_charger, protocol_config, metrics);
+        let result = match (result, checks) {
+            (Err(e), _) => Err(e),     // execution error wins
+            (Ok(_), Err(e)) => Err(e), // else a failed effects check
+            (Ok(v), Ok(())) => Ok(v),
         };
-        if is_gasless
-            && result.is_ok()
-            && let Err(msg) = temporary_store
-                .check_gasless_execution_requirements(withdrawal_reservations.as_ref())
-        {
-            result = Err(Mode::Error::new_with_source(
-                ExecutionErrorKind::InsufficientGas,
-                msg,
-            ));
+
+        if result.is_err() {
+            // on error all writes (changes) are dropped and the state goes back
+            // to the beginning (after transaction loads).
+            // Effectively we are canceling all side effects of the transaction
+            reset_writes(gas_charger, temporary_store);
         }
 
-        // Reject transactions whose per-key accumulator totals are not representable *before*
-        // charging gas. For SUI this bounds each per-key gross Merge/Split total to the total supply;
-        // for other balances it bounds them to u64. Doing so here means the rejected PTB-emitted
-        // accumulator events are dropped during the gas reset on the error path (only the bounded gas
-        // events remain). Bounding SUI to the supply (which is ~8.4B SUI below u64::MAX) leaves enough
-        // headroom that the gas-smash deposit / gas-charge events emitted *after* this point cannot
-        // push any per-key total past u64::MAX, so the fold in AccumulatorWriteV1::merge cannot
-        // overflow even though those gas events are not re-checked here.
-        //
-        // Ungated: this only ever turns a would-be arithmetic failure into a deterministic abort,
-        // which produces no committed effects and so cannot diverge from any previously-committed
-        // result, and it applies uniformly across protocol versions.
-        if result.is_ok()
-            && let Err(e) = temporary_store.check_accumulator_amounts_representable()
-        {
-            result = Err(e.into());
-        }
+        // `charge` also parks any unmetered (system-tx) storage rebate into 0x5 (its
+        // `Unmetered` arm) — a conservation step, not a metered charge.
+        let cost_summary = gas_charger.charge(temporary_store, &result);
 
-        let cost_summary = gas_charger.charge_gas(temporary_store, protocol_config, &mut result);
-        // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
-        // information provided to check_sui_conserved, because we mint rewards, and burn
-        // the rebates. We also need to pass in the unmetered_storage_rebate because storage
-        // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
-        // We could probably clean up the code a bit.
-        // Put all the storage rebate accumulated in the system transaction
-        // to the 0x5 object so that it's not lost.
-        temporary_store.conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
-
-        if let Err(e) = run_conservation_checks::<Mode>(
-            temporary_store,
-            gas_charger,
-            digest,
-            move_vm,
-            protocol_config,
-            enable_expensive_checks,
-            &cost_summary,
-            is_genesis_tx,
-            advance_epoch_gas_summary,
-            input_reservations,
-        ) {
-            // FIXME: we cannot fail the transaction if this is an epoch change transaction.
-            result = Err(e);
-        }
-
+        // Conservation + effects-building happen one level up in `finalize_to_effects`.
         (cost_summary, result, timings)
     }
 
+    /// Execute the programmable transaction, then bucketize computation gas at the
+    /// tail via `round_computation`. Timings from `execution_loop` are written into
+    /// `timings_out` regardless of inner Ok/Err.
+    ///
+    /// Called from inside the v15+ pipeline's `and_then` chain, so this only runs
+    /// after `charge_input_objects` succeeded and the early-error gate passed —
+    /// meaning input objects have been charged and the VM is actually going to run.
+    fn execute_ptb<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        tx_ctx: Rc<RefCell<TxContext>>,
+        move_vm: &Arc<MoveRuntime>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        timings_out: &mut Vec<ExecutionTiming>,
+    ) -> Result<Mode::ExecutionResults, Mode::Error> {
+        let result = match execution_loop::<Mode>(
+            store,
+            temporary_store,
+            transaction_kind,
+            rewritten_inputs,
+            tx_ctx,
+            move_vm,
+            gas_charger,
+            protocol_config,
+            metrics,
+            trace_builder_opt,
+        ) {
+            Ok((v, t)) => {
+                *timings_out = t;
+                Ok(v)
+            }
+            Err((e, t)) => {
+                *timings_out = t;
+                Err(e)
+            }
+        };
+        gas_charger.round_computation(result)
+    }
+
+    /// Err-path handler for the v15+ pipeline. Rewinds to a state consistent
+    /// with "only the input objects were touched": drops execution writes,
+    /// re-smashes gas, re-touches mutable inputs, then recomputes storage
+    /// charges against the rewound store. After this returns, the cost
+    /// summary reports what is actually persisted — the storage charges
+    /// match the input-only mutations (including rebates owed back from
+    /// previously-stored objects), not the writes execution attempted.
+    ///
+    /// If even input-only storage doesn't fit the remaining budget, falls
+    /// back to "computation = full budget, storage = rebates from deleted
+    /// inputs only."
+    fn reset_writes(gas_charger: &mut GasCharger, temporary_store: &mut TemporaryStore<'_>) {
+        gas_charger.reset(temporary_store);
+        gas_charger
+            .charge_storage(temporary_store)
+            .unwrap_or_else(|_| {
+                // Deepest fallback: even input-only storage doesn't fit the
+                // remaining budget. Reset again (which re-bumps the mutable
+                // inputs), charge the full budget for computation, and collect
+                // only the input-object rebates.
+                gas_charger.reset(temporary_store);
+                gas_charger.set_computation_to_budget();
+                temporary_store.collect_rebate(gas_charger);
+            });
+    }
+
+    /// State 2 — the minimal valid exit from execution. Drop every write (PTB outputs, events, the
+    /// gas smash, and any applied charge), bump ONLY the mutable inputs, and charge nothing.
+    /// Touches no value, so it conserves SUI trivially and can never itself fail conservation.
+    /// Used by the IFFW short-circuit and as the conservation last-resort (in place of a panic).
+    /// Returns the (zero) cost summary to record.
+    fn bump_inputs_only(temporary_store: &mut TemporaryStore<'_>) -> GasCostSummary {
+        temporary_store.drop_writes();
+        temporary_store.ensure_active_inputs_mutated();
+        GasCostSummary::default()
+    }
+
+    /// Run the effects-validity checks: meter limit, written-objects limit, and per-key
+    /// accumulator-amount representability. The first two are invoked unconditionally so their
+    /// metrics fire even when the transaction is already failing; all three outcomes are then
+    /// combined with `Result::and` (`meter` first, then `written`, then `representable`, so an
+    /// earlier error wins). The caller folds the returned `Result<(), _>` into the running
+    /// transaction result, which keeps precedence over these.
+    ///
+    /// The representability check runs here, before `charge` adds the gas accumulator events and
+    /// before `reset_writes` — so it sees only the PTB-emitted accumulator events. On the err
+    /// path `reset_writes` later drops those events, leaving only the bounded gas events, so the
+    /// downstream merge fold and conservation sums cannot overflow. The check is `&self` and
+    /// panic-safe (each running total early-returns once it crosses its limit), so running it
+    /// unconditionally alongside the limit checks is harmless even when the tx is already failing.
+    fn check_effects<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+    ) -> Result<(), Mode::Error> {
+        let meter = check_meter_limit::<Mode>(
+            temporary_store,
+            gas_charger,
+            protocol_config,
+            metrics.clone(),
+        );
+        let written = check_written_objects_limit::<Mode>(
+            temporary_store,
+            gas_charger,
+            protocol_config,
+            metrics,
+        );
+        let representable = temporary_store
+            .check_accumulator_amounts_representable()
+            .map_err(Into::into);
+        meter.and(written).and(representable)
+    }
+
+    /// v15+ pipeline's conservation check. Runs `check_conservation` once; on failure, logs loudly
+    /// and returns `Err` with the conservation error so the caller bails to State 2
+    /// (`bump_inputs_only`): a deterministic no-op that conserves trivially — no panic.
+    ///
+    /// No recovery is attempted: by the time this runs, `reset_writes` has already aligned the
+    /// storage charges with the actually-persisted (input-only) state, so a conservation failure
+    /// here is a genuine invariant violation, not a recoverable accounting drift — there is no
+    /// partial reset that would balance it. Consequently, no v15+ path recomputes charges after
+    /// they were set. Conservation is a system invariant: if SUI doesn't balance we can't surface
+    /// that as a normal err, so we fall back to the no-op State 2.
     #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
     fn run_conservation_checks<Mode: ExecutionMode>(
         temporary_store: &mut TemporaryStore<'_>,
-        gas_charger: &mut GasCharger,
+        gas_charger: &GasCharger,
         tx_digest: TransactionDigest,
         move_vm: &Arc<MoveRuntime>,
-        protocol_config: &ProtocolConfig,
         enable_expensive_checks: bool,
         cost_summary: &GasCostSummary,
         is_genesis_tx: bool,
         advance_epoch_gas_summary: Option<(u64, u64)>,
         input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
     ) -> Result<(), Mode::Error> {
-        let simple_conservation_checks = protocol_config.simple_conservation_checks();
-        let mut result: Result<(), Mode::Error> = Ok(());
-        if !is_genesis_tx && !Mode::skip_conservation_checks() {
-            let run_checks = |store: &TemporaryStore<'_>| -> Result<(), ExecutionError> {
-                store
-                    .check_sui_conserved(simple_conservation_checks, cost_summary)
-                    .and_then(|()| {
-                        if enable_expensive_checks {
-                            let mut layout_resolver = TypeLayoutResolver::new(
-                                move_vm,
-                                store.protocol_config(),
-                                Box::new(store),
-                            );
-                            store.check_sui_conserved_expensive(
-                                cost_summary,
-                                advance_epoch_gas_summary,
-                                &mut layout_resolver,
-                            )
-                        } else {
-                            Ok(())
-                        }
-                    })
-                    .and_then(|()| {
-                        store.check_address_balance_changes(
-                            store.protocol_config(),
-                            input_reservations,
-                        )
-                    })
-            };
+        if is_genesis_tx || Mode::skip_conservation_checks() {
+            return Ok(());
+        }
 
-            if let Err(conservation_err) = run_checks(temporary_store) {
-                // conservation violated. try to avoid panic by dumping all writes, charging for gas,
-                // re-checking conservation, and surfacing an aborted transaction with an invariant
-                // violation if all of that works.
-                result = Err(conservation_err.into());
-                gas_charger.reset(temporary_store);
-                gas_charger.charge_gas(temporary_store, protocol_config, &mut result);
-                if let Err(recovery_err) = run_checks(temporary_store) {
-                    // if we still fail, it's a problem with gas charging that happens even in the
-                    // "aborted" case — no other option but panic. We will create or destroy SUI
-                    // otherwise (or admit an unauthorized accumulator Split).
-                    panic!(
-                        "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
-                        tx_digest,
-                        recovery_err,
-                        gas_charger.summary()
-                    )
-                }
+        // `simple_conservation_checks` has been on for every chain since protocol v113,
+        // well below anything this pipeline runs at, so we pass `true` directly.
+        if let Err(conservation_err) = check_conservation(
+            temporary_store,
+            move_vm,
+            enable_expensive_checks,
+            cost_summary,
+            advance_epoch_gas_summary,
+            input_reservations,
+        ) {
+            // `reset_writes` has already aligned charges with the persisted state, so a conservation
+            // failure here is a genuine invariant violation, not a recoverable drift — there is no
+            // partial reset that would balance it. Fall back to State 2 (the caller drops all writes,
+            // bumps the inputs, charges nothing): deterministic, conserves trivially, no panic. Alert
+            // loudly so the (should-never-happen) violation is visible.
+            #[skip_checked_arithmetic]
+            tracing::error!(
+                tx_digest = ?tx_digest,
+                conservation_error = %conservation_err,
+                gas_status = %gas_charger.summary(),
+                "SUI conservation check failed; falling back to the no-op exit (State 2): \
+                 dropping all writes and charging nothing",
+            );
+            return Err(conservation_err.into());
+        }
+
+        Ok(())
+    }
+
+    /// Run SUI conservation against `cost_summary`: the cheap check always,
+    /// the expensive check if requested, and the address-balance check. Returns
+    /// the first failure; otherwise `Ok(())`.
+    fn check_conservation(
+        temporary_store: &mut TemporaryStore<'_>,
+        move_vm: &Arc<MoveRuntime>,
+        enable_expensive_checks: bool,
+        cost_summary: &GasCostSummary,
+        advance_epoch_gas_summary: Option<(u64, u64)>,
+        input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
+    ) -> Result<(), ExecutionError> {
+        // `simple_conservation_checks` has been on for every chain since v113;
+        // this new-pipeline `check_conservation` only runs at v127+ so the bool
+        // is hardcoded here instead of plumbed through.
+        temporary_store.check_sui_conserved(true, cost_summary)?;
+        if enable_expensive_checks {
+            let mut layout_resolver = TypeLayoutResolver::new(
+                move_vm,
+                temporary_store.protocol_config(),
+                Box::new(&*temporary_store),
+            );
+            temporary_store.check_sui_conserved_expensive(
+                cost_summary,
+                advance_epoch_gas_summary,
+                &mut layout_resolver,
+            )?;
+        }
+        temporary_store
+            .check_address_balance_changes(temporary_store.protocol_config(), input_reservations)?;
+        Ok(())
+    }
+
+    /// Pre-refactor gas-charging entry point — kept here for replay determinism on
+    /// `gas_model_version < 15`. Verbatim copy of the body that lived directly at
+    /// `mod checked`-level before the refactor (with `charge_gas` calls renamed to
+    /// `legacy_charge_gas` to match `gas_charger`'s `mod legacy`). Will be removed when
+    /// execution_version bumps past 4.
+    mod legacy {
+        use super::*;
+
+        // MAGIC CONSTANTS -- these are all mainnet-only hardcoded constants and should not be
+        // changed (but can be removed in future execution cuts).
+
+        /// Mainnet recovery point: the fix replays for transactions at/above this accumulator root
+        /// version and keeps the old behavior below it. A compiled constant (not a protocol flag)
+        /// because it had to take effect mid-epoch during recovery, when the network can't reconfigure.
+        pub(super) const ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION: SequenceNumber =
+            SequenceNumber::from_u64(692949576);
+
+        /// Mainnet settlement version at/above which an `InsufficientFundsForWithdraw` transaction
+        /// short-circuits execution entirely (zero-gas effects, mutable-input version bumps only),
+        /// superseding the address-balance gas-payment pruning hotfix. A compiled constant, not a
+        /// protocol flag, because it must take effect mid-epoch during recovery when the network
+        /// cannot reconfigure. Only consulted when an accumulator version is assigned (mainnet
+        /// committed execution); everywhere else the short-circuit is protocol gated (see
+        /// `should_short_circuit_insufficient_funds`).
+        ///
+        /// Value is the mainnet accumulator root version where the new binary was activated on the network.
+        pub(super) const ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION:
+            SequenceNumber = SequenceNumber::from_u64(693531074);
+
+        /// Whether to prune the address-balance leg of gas smashing for an IFFW transaction. This is
+        /// the mainnet-only accumulator backfill that replays the pre-flag incident hotfix below the
+        /// short-circuit rollout point; once `early_exit_on_iffw` is set the short-circuit handles IFFW
+        /// upstream, so reaching here implies the flag is off (asserted below).
+        pub(super) fn should_filter_address_balance_gas_smash(
+            execution_params: &ExecutionOrEarlyError,
+            protocol_config: &ProtocolConfig,
+        ) -> bool {
+            if !any_error_is_insufficient_funds_for_withdraw(execution_params) {
+                return false;
             }
-        } // else, we're in the genesis transaction which mints the SUI supply, and hence does not satisfy SUI conservation, or
-        // we're in the non-production dev inspect mode which allows us to violate conservation
-        result
+            debug_assert!(
+                !protocol_config.early_exit_on_iffw(),
+                "Should not reach gas smashing filtering address balances if IFFW early exit is enabled"
+            );
+            // In test/debug builds, always apply the fix unconditionally to match the behaviour of
+            // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
+            in_test_configuration()
+                || protocol_config.early_exit_on_iffw()
+                || execution_params
+                    .accumulator_version()
+                    .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION)
+        }
+
+        /// Whether to short-circuit an IFFW transaction. When an accumulator version is assigned
+        /// (mainnet committed execution) it gates on the settlement-version rollout point; otherwise
+        /// (every other chain and non-committed paths, where no accumulator version is assigned) the
+        /// short-circuit applies based on `early_exit_on_iffw`.
+        pub(super) fn should_short_circuit_insufficient_funds(
+            execution_params: &ExecutionOrEarlyError,
+            protocol_config: &ProtocolConfig,
+        ) -> bool {
+            // If no IFWWs, then does not apply
+            if !execution_params.early_errors().is_some_and(|errors| {
+                errors
+                    .iter()
+                    .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw))
+            }) {
+                return false;
+            }
+
+            // In test/debug builds, always short-circuit unconditionally to match the behaviour of
+            // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
+            if in_test_configuration() {
+                return true;
+            }
+
+            // otherwise gate by accumulator version (if present) or protocol flag
+            protocol_config.early_exit_on_iffw()
+                || execution_params.accumulator_version().is_some_and(|v| {
+                    v >= ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION
+                })
+        }
+
+        /// Build the legacy pipeline's IFFW short-circuit response: bump versions of mutable inputs,
+        /// emit effects with a zero gas cost summary, and return an `InsufficientFundsForWithdraw`
+        /// failure. (The new v15+ pipeline produces the same response inline via its `BumpOnly`
+        /// outcome + `build_effects`; this copy is kept frozen for the legacy path.)
+        fn respond_with_iffw_short_circuit<Mode: ExecutionMode>(
+            mut temporary_store: TemporaryStore<'_>,
+            shared_object_refs: Vec<SharedInput>,
+            mut transaction_dependencies: BTreeSet<TransactionDigest>,
+            transaction_digest: TransactionDigest,
+            gas_status: SuiGasStatus,
+            protocol_config: &ProtocolConfig,
+            epoch_id: EpochId,
+        ) -> ExecutionOutput<Mode> {
+            assert_reachable!("IFFW short-circuit fired");
+            // State 2: bump the mutable inputs, charge nothing. The store is clean here (no pipeline
+            // ran), so `drop_writes` inside is a no-op — bit-identical to the prior bare bump.
+            let gas_cost_summary = bump_inputs_only(&mut temporary_store);
+            transaction_dependencies.remove(&TransactionDigest::genesis_marker());
+
+            let execution_error: Mode::Error =
+                ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw).into();
+            let status = ExecutionStatus::new_failure(execution_error.to_execution_failure());
+            let mut gas_meter = GasCharger::new(
+                transaction_digest,
+                // No real payment in the short-circuit; this charger only computes effects with a
+                // default gas summary and never reaches `charge_storage`, so reservations are empty.
+                PaymentKind::gasless(BTreeMap::new()),
+                gas_status,
+                &mut temporary_store,
+                protocol_config,
+            );
+
+            let (inner, effects) = temporary_store.into_effects(
+                shared_object_refs,
+                &transaction_digest,
+                transaction_dependencies,
+                gas_cost_summary,
+                status,
+                &mut gas_meter,
+                epoch_id,
+            );
+
+            (
+                inner,
+                gas_meter.into_gas_status(),
+                effects,
+                vec![],
+                Err(execution_error),
+            )
+        }
+
+        /// Execution fork for `gas_model_version < 15`, frozen at `origin/main`'s
+        /// behavior: protocol-gated IFFW short-circuit, AB-gas-smash hotfix prune,
+        /// gas charger construction, the monolithic `charge_gas` body, and the
+        /// shared teardown. Entered from `execute_transaction_to_effects` right
+        /// after the common setup; self-contained through to effects.
+        #[instrument(name = "tx_execute_legacy", level = "debug", skip_all)]
+        pub(super) fn execute_transaction_inner<Mode: ExecutionMode>(
+            store: &dyn BackingStore,
+            mut temporary_store: TemporaryStore<'_>,
+            mut gas_data: GasData,
+            gas_status: SuiGasStatus,
+            transaction_kind: TransactionKind,
+            rewritten_inputs: Option<Vec<bool>>,
+            transaction_signer: SuiAddress,
+            transaction_digest: TransactionDigest,
+            move_vm: &Arc<MoveRuntime>,
+            epoch_id: &EpochId,
+            epoch_timestamp_ms: u64,
+            protocol_config: &ProtocolConfig,
+            metrics: Arc<ExecutionMetrics>,
+            enable_expensive_checks: bool,
+            execution_params: ExecutionOrEarlyError,
+            trace_builder_opt: &mut Option<MoveTraceBuilder>,
+            shared_object_refs: Vec<SharedInput>,
+            transaction_dependencies: BTreeSet<TransactionDigest>,
+        ) -> ExecutionOutput<Mode> {
+            // Protocol-gated IFFW short-circuit (mainnet-replay concern).
+            if should_short_circuit_insufficient_funds(&execution_params, protocol_config) {
+                return respond_with_iffw_short_circuit::<Mode>(
+                    temporary_store,
+                    shared_object_refs,
+                    transaction_dependencies,
+                    transaction_digest,
+                    gas_status,
+                    protocol_config,
+                    *epoch_id,
+                );
+            }
+            // On an IFFW abort, drop the address-balance gas payments (keeping real coins) so
+            // the pruned list flows into `payment_kind`/`compute_input_reservations` with no
+            // special handling. See `should_filter_address_balance_gas_smash`.
+            if should_filter_address_balance_gas_smash(&execution_params, protocol_config)
+                && gas_data.payment.len() > 1
+                && ParsedDigest::try_from(gas_data.payment[0].2).is_err()
+            {
+                gas_data
+                    .payment
+                    .retain(|entry| ParsedDigest::try_from(entry.2).is_err());
+            }
+
+            let sponsor = {
+                let gas_owner = gas_data.owner;
+                if gas_owner == transaction_signer {
+                    None
+                } else {
+                    Some(gas_owner)
+                }
+            };
+            let gas_price = gas_status.gas_price();
+            let rgp = gas_status.reference_gas_price();
+
+            let mut gas_charger = GasCharger::new(
+                transaction_digest,
+                legacy_payment_kind(&gas_data, &transaction_kind, protocol_config),
+                gas_status,
+                &mut temporary_store,
+                protocol_config,
+            );
+
+            let tx_ctx = TxContext::new_from_components(
+                &transaction_signer,
+                &transaction_digest,
+                epoch_id,
+                epoch_timestamp_ms,
+                rgp,
+                gas_price,
+                gas_data.budget,
+                sponsor,
+                protocol_config,
+            );
+            let tx_ctx = Rc::new(RefCell::new(tx_ctx));
+
+            // `enable_gasless` has been on for every chain since protocol v119, well below
+            // anything this execution version handles (gas_model 13+ = protocol v123+), so we
+            // don't gate on the flag any more.
+            let is_gasless = is_gasless_transaction(&gas_data, &transaction_kind);
+            let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
+
+            let input_reservations =
+                compute_input_reservations(&transaction_kind, &gas_data, transaction_signer);
+
+            let (gas_cost_summary, execution_result, timings) = execute_transaction::<Mode>(
+                store,
+                &mut temporary_store,
+                transaction_kind,
+                rewritten_inputs,
+                &mut gas_charger,
+                tx_ctx,
+                move_vm,
+                protocol_config,
+                metrics.clone(),
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+                is_gasless,
+                &input_reservations,
+            );
+
+            finish_transaction_to_effects::<Mode>(
+                temporary_store,
+                gas_charger,
+                shared_object_refs,
+                transaction_dependencies,
+                sponsor,
+                is_epoch_change,
+                input_reservations,
+                gas_cost_summary,
+                execution_result,
+                timings,
+                transaction_signer,
+                transaction_digest,
+                *epoch_id,
+                enable_expensive_checks,
+                metrics,
+                move_vm,
+            )
+        }
+
+        fn execute_transaction<Mode: ExecutionMode>(
+            store: &dyn BackingStore,
+            temporary_store: &mut TemporaryStore<'_>,
+            transaction_kind: TransactionKind,
+            rewritten_inputs: Option<Vec<bool>>,
+            gas_charger: &mut GasCharger,
+            tx_ctx: Rc<RefCell<TxContext>>,
+            move_vm: &Arc<MoveRuntime>,
+            protocol_config: &ProtocolConfig,
+            metrics: Arc<ExecutionMetrics>,
+            enable_expensive_checks: bool,
+            execution_params: ExecutionOrEarlyError,
+            trace_builder_opt: &mut Option<MoveTraceBuilder>,
+            is_gasless: bool,
+            input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
+        ) -> (
+            GasCostSummary,
+            Result<Mode::ExecutionResults, Mode::Error>,
+            Vec<ExecutionTiming>,
+        ) {
+            // At this point no charges have been applied yet
+            debug_assert!(
+                gas_charger.no_charges(),
+                "No gas charges must be applied yet"
+            );
+
+            let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
+            let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+            let digest = tx_ctx.borrow().digest();
+            let withdrawal_reservations =
+                if is_gasless && protocol_config.gasless_verify_remaining_balance() {
+                    gasless_withdrawal_reservations(&transaction_kind, &tx_ctx.borrow())
+                } else {
+                    None
+                };
+
+            // We must charge object read here during transaction execution, because if this fails
+            // we must still ensure an effect is committed and all objects versions incremented
+            let result = gas_charger.charge_input_objects_legacy(temporary_store);
+
+            let result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> =
+                result.map_err(|e| (e.into(), vec![])).and_then(
+                    |()| -> ResultWithTimings<Mode::ExecutionResults, Mode::Error> {
+                        let mut execution_result: ResultWithTimings<
+                            Mode::ExecutionResults,
+                            Mode::Error,
+                        > = match execution_params.into_early_errors() {
+                            Some(early_execution_errors) => {
+                                Err((Mode::Error::from_kind(early_execution_errors.head), vec![]))
+                            }
+                            None => execution_loop::<Mode>(
+                                store,
+                                temporary_store,
+                                transaction_kind,
+                                rewritten_inputs,
+                                tx_ctx,
+                                move_vm,
+                                gas_charger,
+                                protocol_config,
+                                metrics.clone(),
+                                trace_builder_opt,
+                            ),
+                        };
+
+                        let meter_check = check_meter_limit::<Mode>(
+                            temporary_store,
+                            gas_charger,
+                            protocol_config,
+                            metrics.clone(),
+                        );
+                        if let Err(e) = meter_check {
+                            execution_result = Err((e, vec![]));
+                        }
+
+                        if execution_result.is_ok() {
+                            let gas_check = check_written_objects_limit::<Mode>(
+                                temporary_store,
+                                gas_charger,
+                                protocol_config,
+                                metrics,
+                            );
+                            if let Err(e) = gas_check {
+                                execution_result = Err((e, vec![]));
+                            }
+                        }
+
+                        execution_result
+                    },
+                );
+
+            let (mut result, timings) = match result {
+                Ok((r, t)) => (Ok(r), t),
+                Err((e, t)) => (Err(e), t),
+            };
+            if is_gasless
+                && result.is_ok()
+                && let Err(msg) = temporary_store
+                    .check_gasless_execution_requirements(withdrawal_reservations.as_ref())
+            {
+                result = Err(Mode::Error::new_with_source(
+                    ExecutionErrorKind::InsufficientGas,
+                    msg,
+                ));
+            }
+
+            // Reject transactions whose per-key accumulator totals are not representable, before
+            // charging gas (see the v15+ pipeline for the rationale).
+            if result.is_ok()
+                && let Err(e) = temporary_store.check_accumulator_amounts_representable()
+            {
+                result = Err(e.into());
+            }
+
+            let cost_summary = gas_charger.legacy_charge_gas(temporary_store, &mut result);
+            // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
+            // information provided to check_sui_conserved, because we mint rewards, and burn
+            // the rebates. We also need to pass in the unmetered_storage_rebate because storage
+            // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
+            // We could probably clean up the code a bit.
+            // Put all the storage rebate accumulated in the system transaction
+            // to the 0x5 object so that it's not lost.
+            temporary_store
+                .conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
+
+            if let Err(e) = run_conservation_checks::<Mode>(
+                temporary_store,
+                gas_charger,
+                digest,
+                move_vm,
+                protocol_config.simple_conservation_checks(),
+                enable_expensive_checks,
+                &cost_summary,
+                is_genesis_tx,
+                advance_epoch_gas_summary,
+                input_reservations,
+            ) {
+                // FIXME: we cannot fail the transaction if this is an epoch change transaction.
+                result = Err(e);
+            }
+
+            (cost_summary, result, timings)
+        }
+
+        #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
+        fn run_conservation_checks<Mode: ExecutionMode>(
+            temporary_store: &mut TemporaryStore<'_>,
+            gas_charger: &mut GasCharger,
+            tx_digest: TransactionDigest,
+            move_vm: &Arc<MoveRuntime>,
+            simple_conservation_checks: bool,
+            enable_expensive_checks: bool,
+            cost_summary: &GasCostSummary,
+            is_genesis_tx: bool,
+            advance_epoch_gas_summary: Option<(u64, u64)>,
+            input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
+        ) -> Result<(), Mode::Error> {
+            let mut result: Result<(), Mode::Error> = Ok(());
+            if !is_genesis_tx && !Mode::skip_conservation_checks() {
+                let run_checks = |store: &TemporaryStore<'_>| -> Result<(), ExecutionError> {
+                    store
+                        .check_sui_conserved(simple_conservation_checks, cost_summary)
+                        .and_then(|()| {
+                            if enable_expensive_checks {
+                                let mut layout_resolver = TypeLayoutResolver::new(
+                                    move_vm,
+                                    store.protocol_config(),
+                                    Box::new(store),
+                                );
+                                store.check_sui_conserved_expensive(
+                                    cost_summary,
+                                    advance_epoch_gas_summary,
+                                    &mut layout_resolver,
+                                )
+                            } else {
+                                Ok(())
+                            }
+                        })
+                        .and_then(|()| {
+                            store.check_address_balance_changes(
+                                store.protocol_config(),
+                                input_reservations,
+                            )
+                        })
+                };
+
+                if let Err(conservation_err) = run_checks(temporary_store) {
+                    // conservation violated. try to avoid panic by dumping all writes, charging for gas,
+                    // re-checking conservation, and surfacing an aborted transaction with an invariant
+                    // violation if all of that works.
+                    result = Err(conservation_err.into());
+                    gas_charger.reset(temporary_store);
+                    gas_charger.legacy_charge_gas(temporary_store, &mut result);
+                    if let Err(recovery_err) = run_checks(temporary_store) {
+                        // if we still fail, it's a problem with gas charging that happens even in the
+                        // "aborted" case — no other option but panic. We will create or destroy SUI
+                        // otherwise (or admit an unauthorized accumulator Split).
+                        panic!(
+                            "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
+                            tx_digest,
+                            recovery_err,
+                            gas_charger.summary()
+                        )
+                    }
+                }
+            } // else, we're in the genesis transaction which mints the SUI supply, and hence does not satisfy SUI conservation, or
+            // we're in the non-production dev inspect mode which allows us to violate conservation
+            result
+        }
     }
 
     #[instrument(name = "check_meter_limit", level = "debug", skip_all)]
@@ -867,6 +1727,45 @@ mod checked {
         Ok(())
     }
 
+    /// v15+ gasless reservation computation: parks the PTB's `FundsWithdrawal` reservations on the
+    /// gasless payment metadata. Takes `sender`/`sponsor` directly (the v15 `payment_kind` has no
+    /// `TxContext` yet at charger-construction time). Kept separate from the legacy
+    /// `gasless_withdrawal_reservations` so `mod legacy` stays frozen.
+    fn compute_gasless_reservations(
+        transaction_kind: &TransactionKind,
+        sender: SuiAddress,
+        sponsor: Option<SuiAddress>,
+    ) -> Option<BTreeMap<(SuiAddress, TypeTag), u64>> {
+        let TransactionKind::ProgrammableTransaction(pt) = transaction_kind else {
+            debug_fatal!("Gasless transaction must be a ProgrammableTransaction");
+            return None;
+        };
+        let mut reservations = BTreeMap::<(SuiAddress, TypeTag), u64>::new();
+        for input in &pt.inputs {
+            let CallArg::FundsWithdrawal(fw) = input else {
+                continue;
+            };
+            let Some(coin_type) = fw.type_arg.get_balance_type_param() else {
+                debug_fatal!("expected Balance type for withdrawal");
+                continue;
+            };
+            let owner = match fw.withdraw_from {
+                WithdrawFrom::Sender => sender,
+                WithdrawFrom::Sponsor => {
+                    debug_fatal!("WithdrawFrom::Sponsor is not expected in gasless transactions");
+                    sponsor.unwrap_or(sender)
+                }
+            };
+            let Reservation::MaxAmountU64(amount) = fw.reservation;
+            let entry = reservations.entry((owner, coin_type)).or_insert(0);
+            *entry = entry.saturating_add(amount);
+        }
+        Some(reservations)
+    }
+
+    /// Legacy (gas_model < 15) gasless reservation computation. Frozen copy that derives
+    /// `sender`/`sponsor` from `TxContext` internally — used only by `mod legacy`, kept bit-for-bit
+    /// so the legacy executor is unaffected by v15 gasless changes.
     fn gasless_withdrawal_reservations(
         transaction_kind: &TransactionKind,
         tx_ctx: &TxContext,
@@ -1853,7 +2752,7 @@ mod checked {
 
     #[cfg(test)]
     mod address_balance_smash_gate_tests {
-        use super::{
+        use super::legacy::{
             ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION,
             should_filter_address_balance_gas_smash,
         };
@@ -1936,7 +2835,7 @@ mod checked {
 
     #[cfg(test)]
     mod address_balance_smash_short_circuit_tests {
-        use super::{
+        use super::legacy::{
             ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION,
             should_short_circuit_insufficient_funds,
         };

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -11,14 +11,16 @@ pub mod checked {
     use crate::temporary_store::TemporaryStore;
     use either::Either;
     use indexmap::IndexMap;
+    use move_core_types::language_storage::TypeTag;
     use mysten_common::assert_reachable;
+    use std::collections::BTreeMap;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::deny_list_v2::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS;
     use sui_types::digests::TransactionDigest;
     use sui_types::error::ExecutionErrorTrait;
     use sui_types::gas::{GasCostSummary, SuiGasStatus, deduct_gas};
     use sui_types::gas_model::gas_predicates::{
-        charge_upgrades, dont_charge_budget_on_storage_oog, refresh_gas_payment_location,
+        dont_charge_budget_on_storage_oog, refresh_gas_payment_location,
     };
     use sui_types::{
         accumulator_event::AccumulatorEvent,
@@ -50,16 +52,26 @@ pub mod checked {
     #[derive(Debug)]
     enum PaymentMetadata {
         Unmetered,
-        Gasless,
+        Gasless(GaslessMetadata),
         /// Contains the list of payments (coins and address balances) and additional metadata
         Smash(SmashMetadata),
+    }
+
+    /// Payment-source metadata for a gasless (metered-but-free) transaction.
+    /// Holds the per-`(owner, token type)` withdrawal reservations declared by the PTB's
+    /// `FundsWithdrawal` inputs, the only extra state `check_gasless_execution_requirements`
+    /// needs. Constant for the transaction's lifetime, so it lives here rather than being
+    /// threaded through the charging pipeline.
+    #[derive(Debug)]
+    struct GaslessMetadata {
+        withdrawal_reservations: BTreeMap<(SuiAddress, TypeTag), u64>,
     }
 
     /// State produced by smashing multiple gas payment sources into one.
     /// Tracks the combined balance (`total_smashed`), the target location where the
     /// smashed value lives, and the original payment methods for bookkeeping.
     /// Note that the target location (`gas_charge_location`) may differ from the first payment
-    /// method in the list if it has ben overridden during execution.
+    /// method in the list if it has been overridden during execution.
     #[derive(Debug)]
     struct SmashMetadata {
         /// The location to charge gas from at the end of execution. Starts with the primary
@@ -86,13 +98,15 @@ pub mod checked {
     #[derive(Debug)]
     enum PaymentKind_ {
         Unmetered,
-        Gasless,
+        /// Carries the PTB's per-`(owner, token type)` withdrawal reservations, stored into
+        /// `GaslessMetadata` at construction.
+        Gasless(BTreeMap<(SuiAddress, TypeTag), u64>),
         /// A non-empty map of gas coins or address balance withdrawals, keyed by location.
         /// The first entry is the smash target; all others are smashed into it.
         Smash(IndexMap<PaymentLocation, PaymentMethod>),
     }
 
-    /// A single source of SUI used to pay for gas: either an coin object or a withdrawal
+    /// A single source of SUI used to pay for gas: either a coin object or a withdrawal
     /// reservation from an address balance.
     #[derive(Debug)]
     pub enum PaymentMethod {
@@ -132,7 +146,11 @@ pub mod checked {
             let gas_model_version = protocol_config.gas_model_version();
             let payment = match payment_kind.0 {
                 PaymentKind_::Unmetered => PaymentMetadata::Unmetered,
-                PaymentKind_::Gasless => PaymentMetadata::Gasless,
+                PaymentKind_::Gasless(withdrawal_reservations) => {
+                    PaymentMetadata::Gasless(GaslessMetadata {
+                        withdrawal_reservations,
+                    })
+                }
                 PaymentKind_::Smash(mut payment_methods) => {
                     let (_, smash_target) = payment_methods.shift_remove_index(0).unwrap();
                     let mut metadata = SmashMetadata {
@@ -167,7 +185,7 @@ pub mod checked {
         //       Explore way to remove it.
         pub(crate) fn used_coins(&self) -> impl Iterator<Item = &'_ ObjectRef> {
             match &self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => {
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => {
                     Either::Left(std::iter::empty())
                 }
                 PaymentMetadata::Smash(metadata) => Either::Right(metadata.used_coins()),
@@ -195,7 +213,7 @@ pub mod checked {
         /// is used.
         pub fn gas_payment_amount(&self) -> Option<GasPayment> {
             match &self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => None,
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => None,
                 PaymentMetadata::Smash(metadata) => Some(GasPayment {
                     location: metadata.smash_target.location(),
                     amount: metadata.total_smashed,
@@ -205,7 +223,7 @@ pub mod checked {
 
         pub(crate) fn gas_payment_location(&self) -> Option<PaymentLocation> {
             match &self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => None,
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => None,
                 PaymentMetadata::Smash(metadata) => Some(metadata.gas_charge_location),
             }
         }
@@ -226,6 +244,14 @@ pub mod checked {
 
         pub fn is_unmetered(&self) -> bool {
             self.gas_status.is_unmetered()
+        }
+
+        pub fn gas_model_version(&self) -> u64 {
+            self.gas_model_version
+        }
+
+        pub fn set_computation_to_budget(&mut self) {
+            self.gas_status.adjust_computation_on_out_of_gas();
         }
 
         pub fn move_gas_status(&self) -> &GasStatus {
@@ -253,7 +279,7 @@ pub mod checked {
         // are correct.
         fn smash_gas(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             match &mut self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => (),
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => (),
                 PaymentMetadata::Smash(smash_metadata) => {
                     smash_metadata.smash_gas(&self.tx_digest, temporary_store);
                 }
@@ -283,29 +309,27 @@ pub mod checked {
         }
 
         pub fn charge_upgrade_package(&mut self, size: usize) -> Result<(), ExecutionError> {
-            if charge_upgrades(self.gas_model_version) {
-                self.gas_status.charge_publish_package(size)
-            } else {
-                Ok(())
-            }
+            // `charge_upgrades` is on for gas_model >= 7; this execution version's lowest
+            // target is gas_model 13, so the predicate is always true and we charge directly.
+            self.gas_status.charge_publish_package(size)
         }
 
+        /// Iterate the transaction's inputs and charge `storage_read` for each
+        /// (system packages excepted). Charges go straight into the Move VM meter;
+        /// `summary()` derives `computation_cost` from the meter live, so after
+        /// this returns (Ok or Err) the running summary already reflects the
+        /// input charges.
         pub fn charge_input_objects(
             &mut self,
             temporary_store: &TemporaryStore<'_>,
         ) -> Result<(), ExecutionError> {
-            let objects = temporary_store.objects();
-            // TODO: Charge input object count.
-            let _object_count = objects.len();
-            // Charge bytes read
-            let total_size = temporary_store
+            temporary_store
                 .objects()
                 .iter()
                 // don't charge for loading Sui Framework or Move stdlib
                 .filter(|(id, _)| !is_system_package(**id))
                 .map(|(_, obj)| obj.object_size_for_gas_metering())
-                .sum();
-            self.gas_status.charge_storage_read(total_size)
+                .try_for_each(|size| self.gas_status.charge_storage_read(size))
         }
 
         pub fn charge_coin_transfers(
@@ -326,130 +350,185 @@ pub mod checked {
             self.gas_status.charge_storage_read(owner_cost)
         }
 
-        /// Resets any mutations, deletions, and events recorded in the store, as well as any storage costs and
-        /// rebates, then Re-runs gas smashing. Effects on store are now as if we were about to begin execution
+        /// Resets the temporary store and gas tracking to a clean post-input state:
+        /// drops all writes, clears storage costs/rebates, re-smashes gas, and re-touches
+        /// all mutable input objects for version bumping. After this returns, the store
+        /// contains gas coin + active input objects (no execution outputs), and the gas
+        /// status's storage_cost / storage_rebate are zeroed.
+        /// Restore the temporary store and gas state to the post-input shape:
+        /// drop all execution writes, clear `per_object_storage`, re-apply the
+        /// gas-coin smash (since `drop_writes` cleared it), and re-touch
+        /// mutable inputs so their versions still bump even on the err path.
+        /// Used by both the legacy storage-OOG fallback and the v15+ err-path
+        /// handler in execution_engine.
         pub fn reset(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             temporary_store.drop_writes();
             self.gas_status.reset_storage_cost_and_rebate();
             self.smash_gas(temporary_store);
+            temporary_store.ensure_active_inputs_mutated();
         }
 
-        /// Entry point for gas charging.
-        /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of
-        /// mutated objects
-        /// 2. Deduct computation gas costs and storage costs, credit storage rebates.
-        /// The happy path of this function follows (1) + (2) and is fairly simple.
-        /// Most of the complexity is in the unhappy paths:
-        /// - if execution aborted before calling this function, we have to dump all writes +
-        ///   re-smash gas, then charge for storage
-        /// - if we run out of gas while charging for storage, we have to dump all writes +
-        ///   re-smash gas, then charge for storage again
-        pub fn charge_gas<T, E: ExecutionErrorTrait>(
+        /// Called at the tail of `execute_ptb` (so after `charge_input_objects`
+        /// succeeded). Inspects `result` for a Move abort, then delegates to
+        /// `bucketize_computation` which fixes the effective gas price on
+        /// `SuiGasStatus` (lowered to the abort-tx cap on a Move abort) and
+        /// signals OOG if the bucketed-and-priced computation alone exceeds
+        /// the budget. Merges any rounding failure with `result` using
+        /// earliest-error-wins:
+        ///   - `Ok(v)` + round Ok    → `Ok(v)`
+        ///   - `Ok(v)` + round Err   → `Err(round_err)`
+        ///   - `Err(e)` + round any  → `Err(e)` (round error discarded)
+        ///
+        /// Runs regardless of whether `execution_loop` returned Ok or Err so
+        /// the abort flag is captured. Skipped (returns the input `result`
+        /// unchanged) for unmetered transactions.
+        pub fn round_computation<T, E: ExecutionErrorTrait>(
             &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            protocol_config: &ProtocolConfig,
-            execution_result: &mut Result<T, E>,
-        ) -> GasCostSummary {
-            // at this point, we have done *all* charging for computation,
-            // but have not yet set the storage rebate or storage gas units
+            result: Result<T, E>,
+        ) -> Result<T, E> {
             debug_assert!(self.gas_status.storage_rebate() == 0);
             debug_assert!(self.gas_status.storage_gas_units() == 0);
 
-            if !matches!(&self.payment, PaymentMetadata::Unmetered) {
-                // bucketize computation cost
-                let is_move_abort = execution_result
-                    .as_ref()
-                    .err()
-                    .map(|err| {
-                        matches!(
-                            err.kind(),
-                            sui_types::execution_status::ExecutionErrorKind::MoveAbort(_, _)
-                        )
-                    })
-                    .unwrap_or(false);
-                // bucketize computation cost
-                if let Err(err) = self.gas_status.bucketize_computation(Some(is_move_abort))
-                    && execution_result.is_ok()
-                {
-                    *execution_result = Err(err.into());
-                }
-
-                // On error we need to dump writes, deletes, etc before charging storage gas
-                if execution_result.is_err() {
-                    self.reset(temporary_store);
-                }
-            }
-
-            // compute and collect storage charges
-            temporary_store.ensure_active_inputs_mutated();
-            temporary_store.collect_storage_and_rebate(self);
-
             if matches!(&self.payment, PaymentMetadata::Unmetered) {
-                return GasCostSummary::default();
+                return result;
             }
-            let gas_payment_location = self.gas_payment_location();
-            if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
-                #[skip_checked_arithmetic]
-                trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+            let is_move_abort = matches!(
+                result.as_ref().err().map(|e| e.kind()),
+                Some(sui_types::execution_status::ExecutionErrorKind::MoveAbort(
+                    ..
+                ))
+            );
+            let round_res = self.gas_status.bucketize_computation(Some(is_move_abort));
+            match result {
+                Ok(v) => round_res.map(|_| v).map_err(Into::into),
+                Err(e) => Err(e),
             }
+        }
 
-            if execution_result
-                .as_ref()
-                .err()
-                .map(|err| {
-                    matches!(
-                        err.kind(),
-                        sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
-                    )
-                })
-                .unwrap_or(false)
-                && matches!(gas_payment_location, Some(PaymentLocation::AddressBalance(_))) {
-                    debug_assert!(!protocol_config.early_exit_on_iffw(), "Should have not reached charge gas in this case with IFFW");
-                    // If we don't have enough balance to withdraw, don't charge for gas
-                    // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
-                    return GasCostSummary::default();
-            }
-
-            self.compute_storage_and_rebate(temporary_store, execution_result);
-
-            let gas_payment_location = if refresh_gas_payment_location(self.gas_model_version) {
-                self.gas_payment_location()
-            } else {
-                gas_payment_location
-            };
-
-            let cost_summary = self.gas_status.summary();
-
-            let Some(gas_payment_location) = gas_payment_location else {
-                // Gasless: sender pays nothing.
-                assert!(
-                    matches!(self.payment, PaymentMetadata::Gasless),
-                    "Only gasless transactions should reach this point without a payment location"
-                );
-                if execution_result.is_err() {
-                    return GasCostSummary::default();
+        /// Collect storage costs and rebates against the current `temporary_store`
+        /// writes, populate `per_object_storage`, then verify the storage fits in
+        /// the remaining budget. For gasless transactions, validates execution
+        /// requirements first (must run before `ensure_active_inputs_mutated`
+        /// would add objects to written_objects). Returns Ok if storage fits,
+        /// Err(InsufficientGas) otherwise. Does NOT retry or reset on failure
+        /// (the caller handles that) and does NOT apply payment (`charge` does).
+        pub fn charge_storage(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+        ) -> Result<(), ExecutionError> {
+            match &self.payment {
+                PaymentMetadata::Unmetered => {
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self);
+                    Ok(())
                 }
-                // Any storage rebate from destroyed input coins is absorbed as
-                // network fees, not returned to sender.
-                let storage_cost = cost_summary.storage_cost;
-                assert!(
-                    storage_cost == 0,
-                    "Gasless transaction must not incur storage cost, got {storage_cost}"
-                );
-                let sender_rebate = cost_summary.storage_rebate;
-                return GasCostSummary {
-                    computation_cost: sender_rebate,
-                    storage_cost: 0,
-                    storage_rebate: sender_rebate,
-                    non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
-                };
-            };
+                PaymentMetadata::Gasless(meta) => {
+                    if let Err(msg) = temporary_store
+                        .check_gasless_execution_requirements(Some(&meta.withdrawal_reservations))
+                    {
+                        return Err(ExecutionError::new_with_source(
+                            sui_types::execution_status::ExecutionErrorKind::InsufficientGas,
+                            msg,
+                        ));
+                    }
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self);
+                    Ok(())
+                }
+                PaymentMetadata::Smash(_) => {
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self);
+                    self.gas_status.charge_storage_and_rebate()
+                }
+            }
+        }
 
+        /// Apply the final gas charge derived from the current `SuiGasStatus`.
+        /// Behaviour by payment kind:
+        ///   - `Unmetered`: parks any unmetered (system-tx) storage rebate into
+        ///     0x5 for conservation, then returns a default (zero) summary, no payment.
+        ///   - `Gasless` on err: returns a default summary (no charge).
+        ///   - `Gasless` on Ok: net cost is the absorbed storage rebate.
+        ///   - `Smash`: deducts `net_gas_usage` from the gas coin or emits an
+        ///     `AccumulatorEvent` against the payer's address balance.
+        ///
+        /// Reads `metadata.gas_charge_location` directly at apply time — no
+        /// snapshot is taken before the err-path rewind. This is the structural
+        /// fix for SUIPR-753: `reset_writes` (in execution_engine) runs before
+        /// `charge`, so any override installed during execution (e.g. by
+        /// `coin::send_funds`) is undone on the err path before we read here.
+        pub fn charge<T, E: ExecutionErrorTrait>(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            execution_result: &Result<T, E>,
+        ) -> GasCostSummary {
+            match &self.payment {
+                PaymentMetadata::Unmetered => {
+                    // Park any unmetered (system-tx) storage rebate into 0x5 so SUI is not
+                    // dropped. Only unmetered payment ever accumulates this; runs once here on
+                    // the final settled store.
+                    let unmetered_storage_rebate = self.gas_status.unmetered_storage_rebate();
+                    temporary_store.conserve_unmetered_storage_rebate(unmetered_storage_rebate);
+                    GasCostSummary::default()
+                }
+                PaymentMetadata::Gasless(_) => {
+                    if execution_result.is_err() {
+                        return GasCostSummary::default();
+                    }
+                    let cost_summary = self.gas_status.summary();
+                    let storage_cost = cost_summary.storage_cost;
+                    assert!(
+                        storage_cost == 0,
+                        "Gasless transaction must not incur storage cost, got {storage_cost}"
+                    );
+                    let sender_rebate = cost_summary.storage_rebate;
+                    GasCostSummary {
+                        computation_cost: sender_rebate,
+                        storage_cost: 0,
+                        storage_rebate: sender_rebate,
+                        non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
+                    }
+                }
+                PaymentMetadata::Smash(metadata) => {
+                    if execution_result
+                        .as_ref()
+                        .err()
+                        .map(|err| {
+                            matches!(
+                                err.kind(),
+                                sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
+                            )
+                        })
+                        .unwrap_or(false)
+                        && matches!(
+                            metadata.gas_charge_location,
+                            PaymentLocation::AddressBalance(_)
+                        )
+                    {
+                        return GasCostSummary::default();
+                    }
+                    if let PaymentLocation::Coin(_) = metadata.gas_charge_location {
+                        #[skip_checked_arithmetic]
+                        trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+                    }
+                    let cost_summary = self.gas_status.summary();
+                    self.apply_payment(temporary_store, cost_summary, metadata.gas_charge_location)
+                }
+            }
+        }
+
+        /// Apply the gas charge to the payment source.
+        /// For coin payments, deducts net gas usage from the gas coin.
+        /// For address balance payments, emits an accumulator event.
+        fn apply_payment(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            cost_summary: GasCostSummary,
+            gas_payment_location: PaymentLocation,
+        ) -> GasCostSummary {
             let net_change = cost_summary.net_gas_usage();
-
             match gas_payment_location {
                 PaymentLocation::AddressBalance(payer_address) => {
-                    // TODO tracing?
                     if net_change != 0 {
                         let balance_type = sui_types::balance::Balance::type_tag(
                             sui_types::gas_coin::GAS::type_tag(),
@@ -475,60 +554,207 @@ pub mod checked {
             cost_summary
         }
 
-        /// Calculate total gas cost considering storage and rebate.
-        ///
-        /// First, we net computation, storage, and rebate to determine total gas to charge.
-        ///
-        /// If we exceed gas_budget, we set execution_result to InsufficientGas, failing the tx.
-        /// If we have InsufficientGas, we determine how much gas to charge for the failed tx:
-        ///
-        /// v1: we set computation_cost = gas_budget, so we charge net (gas_budget - storage_rebates)
-        /// v2: we charge (computation + storage costs for input objects - storage_rebates)
-        ///     if the gas balance is still insufficient, we fall back to set computation_cost = gas_budget
-        ///     so we charge net (gas_budget - storage_rebates)
-        fn compute_storage_and_rebate<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) {
-            if dont_charge_budget_on_storage_oog(self.gas_model_version) {
-                self.handle_storage_and_rebate_v2(temporary_store, execution_result)
-            } else {
-                self.handle_storage_and_rebate_v1(temporary_store, execution_result)
-            }
-        }
+        // === legacy methods below — see `mod legacy` for the full bodies ===
+    }
 
-        fn handle_storage_and_rebate_v1<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) {
-            if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                self.reset(temporary_store);
-                self.gas_status.adjust_computation_on_out_of_gas();
-                temporary_store.ensure_active_inputs_mutated();
-                temporary_store.collect_rebate(self);
-                if execution_result.is_ok() {
-                    *execution_result = Err(err.into());
+    /// Pre-refactor gas charging: a single monolithic `charge_gas` plus the storage-OOG
+    /// retry helpers. Kept here so transactions executed at `gas_model_version < 15`
+    /// (i.e. before the v15+ pipeline activates) replay bit-for-bit identically to
+    /// what `origin/main` produces today, including the SUIPR-753 surgical fix gated on
+    /// `refresh_gas_payment_location`. Will be removed when execution_version bumps past 4.
+    mod legacy {
+        use super::*;
+
+        impl super::GasCharger {
+            /// Pre-v15 input charging: sum all input sizes and charge
+            /// `storage_read` once. Bit-for-bit identical to origin/main for
+            /// replay determinism; goes away when execution_version > 4.
+            pub fn charge_input_objects_legacy(
+                &mut self,
+                temporary_store: &TemporaryStore<'_>,
+            ) -> Result<(), ExecutionError> {
+                let objects = temporary_store.objects();
+                // TODO: Charge input object count.
+                let _object_count = objects.len();
+                // Charge bytes read
+                let total_size = temporary_store
+                    .objects()
+                    .iter()
+                    // don't charge for loading Sui Framework or Move stdlib
+                    .filter(|(id, _)| !is_system_package(**id))
+                    .map(|(_, obj)| obj.object_size_for_gas_metering())
+                    .sum();
+                self.gas_status.charge_storage_read(total_size)
+            }
+
+            /// Entry point for legacy gas charging.
+            /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field
+            /// of mutated objects
+            /// 2. Deduct computation gas costs and storage costs, credit storage rebates.
+            /// The happy path of this function follows (1) + (2) and is fairly simple.
+            /// Most of the complexity is in the unhappy paths:
+            /// - if execution aborted before calling this function, we have to dump all writes +
+            ///   re-smash gas, then charge for storage
+            /// - if we run out of gas while charging for storage, we have to dump all writes +
+            ///   re-smash gas, then charge for storage again
+            pub(crate) fn legacy_charge_gas<T, E: ExecutionErrorTrait>(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+                execution_result: &mut Result<T, E>,
+            ) -> GasCostSummary {
+                // at this point, we have done *all* charging for computation,
+                // but have not yet set the storage rebate or storage gas units
+                debug_assert!(self.gas_status.storage_rebate() == 0);
+                debug_assert!(self.gas_status.storage_gas_units() == 0);
+
+                if !matches!(&self.payment, PaymentMetadata::Unmetered) {
+                    // bucketize computation cost
+                    let is_move_abort = execution_result
+                        .as_ref()
+                        .err()
+                        .map(|err| {
+                            matches!(
+                                err.kind(),
+                                sui_types::execution_status::ExecutionErrorKind::MoveAbort(_, _)
+                            )
+                        })
+                        .unwrap_or(false);
+                    // bucketize computation cost
+                    if let Err(err) = self.gas_status.bucketize_computation(Some(is_move_abort))
+                        && execution_result.is_ok()
+                    {
+                        *execution_result = Err(err.into());
+                    }
+
+                    // On error we need to dump writes, deletes, etc before charging storage gas
+                    if execution_result.is_err() {
+                        self.reset(temporary_store);
+                    }
                 }
-            }
-        }
 
-        fn handle_storage_and_rebate_v2<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) {
-            if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                // we run out of gas charging storage, reset and try charging for storage again.
-                // Input objects are touched and so they have a storage cost
-                // Attempt to charge just for computation + input object storage costs - storage_rebate
-                self.reset(temporary_store);
+                // compute and collect storage charges
                 temporary_store.ensure_active_inputs_mutated();
                 temporary_store.collect_storage_and_rebate(self);
+
+                if matches!(&self.payment, PaymentMetadata::Unmetered) {
+                    return GasCostSummary::default();
+                }
+                let gas_payment_location = self.gas_payment_location();
+                if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
+                    #[skip_checked_arithmetic]
+                    trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+                }
+
+                if execution_result
+                .as_ref()
+                .err()
+                .map(|err| {
+                    matches!(
+                        err.kind(),
+                        sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
+                    )
+                })
+                .unwrap_or(false)
+                && matches!(gas_payment_location, Some(PaymentLocation::AddressBalance(_))) {
+                    // If we don't have enough balance to withdraw, don't charge for gas
+                    // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
+                    return GasCostSummary::default();
+            }
+
+                self.compute_storage_and_rebate(temporary_store, execution_result);
+
+                let gas_payment_location = if refresh_gas_payment_location(self.gas_model_version) {
+                    self.gas_payment_location()
+                } else {
+                    gas_payment_location
+                };
+
+                let cost_summary = self.gas_status.summary();
+
+                let Some(gas_payment_location) = gas_payment_location else {
+                    // Gasless: sender pays nothing.
+                    assert!(
+                        matches!(self.payment, PaymentMetadata::Gasless(_)),
+                        "Only gasless transactions should reach this point without a payment location"
+                    );
+                    if execution_result.is_err() {
+                        return GasCostSummary::default();
+                    }
+                    // Any storage rebate from destroyed input coins is absorbed as
+                    // network fees, not returned to sender.
+                    let storage_cost = cost_summary.storage_cost;
+                    assert!(
+                        storage_cost == 0,
+                        "Gasless transaction must not incur storage cost, got {storage_cost}"
+                    );
+                    let sender_rebate = cost_summary.storage_rebate;
+                    return GasCostSummary {
+                        computation_cost: sender_rebate,
+                        storage_cost: 0,
+                        storage_rebate: sender_rebate,
+                        non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
+                    };
+                };
+
+                let net_change = cost_summary.net_gas_usage();
+
+                match gas_payment_location {
+                    PaymentLocation::AddressBalance(payer_address) => {
+                        // TODO tracing?
+                        if net_change != 0 {
+                            let balance_type = sui_types::balance::Balance::type_tag(
+                                sui_types::gas_coin::GAS::type_tag(),
+                            );
+                            let event = AccumulatorEvent::from_balance_change(
+                                payer_address,
+                                balance_type,
+                                net_change.checked_neg().unwrap(),
+                            )
+                            .expect("Failed to create accumulator event for gas charging");
+                            temporary_store.add_accumulator_event(event);
+                        }
+                    }
+                    PaymentLocation::Coin(gas_object_id) => {
+                        let mut gas_object =
+                            temporary_store.read_object(&gas_object_id).unwrap().clone();
+                        deduct_gas(&mut gas_object, net_change);
+                        #[skip_checked_arithmetic]
+                        trace!(net_change, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+                        temporary_store.mutate_new_or_input_object(gas_object);
+                    }
+                }
+                cost_summary
+            }
+
+            /// Calculate total gas cost considering storage and rebate.
+            ///
+            /// First, we net computation, storage, and rebate to determine total gas to charge.
+            ///
+            /// If we exceed gas_budget, we set execution_result to InsufficientGas, failing the tx.
+            /// If we have InsufficientGas, we determine how much gas to charge for the failed tx:
+            ///
+            /// v1: we set computation_cost = gas_budget, so we charge net (gas_budget - storage_rebates)
+            /// v2: we charge (computation + storage costs for input objects - storage_rebates)
+            ///     if the gas balance is still insufficient, we fall back to set computation_cost = gas_budget
+            ///     so we charge net (gas_budget - storage_rebates)
+            fn compute_storage_and_rebate<T, E: ExecutionErrorTrait>(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+                execution_result: &mut Result<T, E>,
+            ) {
+                if dont_charge_budget_on_storage_oog(self.gas_model_version) {
+                    self.handle_storage_and_rebate_v2(temporary_store, execution_result)
+                } else {
+                    self.handle_storage_and_rebate_v1(temporary_store, execution_result)
+                }
+            }
+
+            fn handle_storage_and_rebate_v1<T, E: ExecutionErrorTrait>(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+                execution_result: &mut Result<T, E>,
+            ) {
                 if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                    // we run out of gas attempting to charge for the input objects exclusively,
-                    // deal with this edge case by not charging for storage: we charge (gas_budget - rebates).
                     self.reset(temporary_store);
                     self.gas_status.adjust_computation_on_out_of_gas();
                     temporary_store.ensure_active_inputs_mutated();
@@ -536,8 +762,34 @@ pub mod checked {
                     if execution_result.is_ok() {
                         *execution_result = Err(err.into());
                     }
-                } else if execution_result.is_ok() {
-                    *execution_result = Err(err.into());
+                }
+            }
+
+            fn handle_storage_and_rebate_v2<T, E: ExecutionErrorTrait>(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+                execution_result: &mut Result<T, E>,
+            ) {
+                if let Err(err) = self.gas_status.charge_storage_and_rebate() {
+                    // we run out of gas charging storage, reset and try charging for storage again.
+                    // Input objects are touched and so they have a storage cost
+                    // Attempt to charge just for computation + input object storage costs - storage_rebate
+                    self.reset(temporary_store);
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self);
+                    if let Err(err) = self.gas_status.charge_storage_and_rebate() {
+                        // we run out of gas attempting to charge for the input objects exclusively,
+                        // deal with this edge case by not charging for storage: we charge (gas_budget - rebates).
+                        self.reset(temporary_store);
+                        self.gas_status.adjust_computation_on_out_of_gas();
+                        temporary_store.ensure_active_inputs_mutated();
+                        temporary_store.collect_rebate(self);
+                        if execution_result.is_ok() {
+                            *execution_result = Err(err.into());
+                        }
+                    } else if execution_result.is_ok() {
+                        *execution_result = Err(err.into());
+                    }
                 }
             }
         }
@@ -686,8 +938,8 @@ pub mod checked {
             Self(PaymentKind_::Unmetered)
         }
 
-        pub fn gasless() -> Self {
-            Self(PaymentKind_::Gasless)
+        pub fn gasless(withdrawal_reservations: BTreeMap<(SuiAddress, TypeTag), u64>) -> Self {
+            Self(PaymentKind_::Gasless(withdrawal_reservations))
         }
 
         pub fn smash(payment_methods: Vec<PaymentMethod>) -> Option<Self> {

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -833,7 +833,6 @@ impl TemporaryStore<'_> {
         sender: &SuiAddress,
         sponsor: &Option<SuiAddress>,
         gas_charger: &GasCharger,
-        mutable_inputs: &HashSet<ObjectID>,
         input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
         is_epoch_change: bool,
     ) -> SuiResult<()> {
@@ -892,7 +891,8 @@ impl TemporaryStore<'_> {
             .filter(|id| {
                 // remove any non-mutable inputs. This will remove deleted or readonly shared
                 // objects
-                mutable_inputs.contains(id)
+                self.mutable_input_refs.contains_key(id)
+                    || self.non_exclusive_input_original_versions.contains_key(id)
             })
             .copied()
             // Add any object IDs generated in the object runtime during execution to the


### PR DESCRIPTION
## Summary
- New `crates/sui-types/src/gas_model/gas_v3.rs` as a clean alternative to `gas_v2.rs`, dispatched to whenever `gas_model_version >= 15` via the version-aware `SuiGasStatus` enum (`enum_dispatch(SuiGasStatusAPI)`). Old executors keep `gas_v2` untouched, so old-protocol replay is unaffected.
- `per_object_storage()` lifted onto `SuiGasStatusAPI` so `sui-replay`'s display can drive either variant via the trait object. `gas_v2.rs` change is a single additive trait-method body; semantics unchanged.

## Cleanups introduced in V3 only
V3 drops the dead branches V2 still carries for backwards compatibility:
- `ComputationBucket` struct + helpers — V3 hardcodes `half_digits_rounding`.
- `GasRoundingMode` enum, field, and per-config selection.
- `max_gas_price_rgp_factor_for_aborted_transactions: Option<u64>` → `u64` (always `Some(_)` at v127+).
- `SuiCostTable::new`'s non-multiplier base-cost arm (`txn_base_cost_as_multiplier` is true at every v127+ version).

`PerObjectStorage` is shared (`gas_v3` re-exports `gas_v2`'s definition; pure data type, zero behavior).

## Why two SuiGasStatus types
The cross-executor `sui_types::gas::SuiGasStatus` is reached from every execution layer (v0..v3 *and* latest) for old-protocol replay. We can't change `gas_v2.rs` semantics without regressing those layers. `gas_v3.rs` lets us land all the cleanups for v15+ semantics behind the existing version-aware dispatch — no per-executor duplication needed.

## Test plan
- New regression test `test_oog_full_budget_charge_exact_when_budget_indivisible_by_price`: pins the `force_computation_cost_to_budget` precision fix using a budget deliberately not a multiple of the gas price — the pre-existing OOG test used a clean multiple and never tripped the rounding loss.
- Version-dispatch coverage falls out of the existing suites: old-protocol-pinned transactional tests exercise gas_v2 + the legacy path unchanged; v127+ tests exercise gas_v3 + the step pipeline.
- Replaying mainnet transactions from epoch 1100 onward shows no change in effects.
