### PR TITLE
[graphql] Thread `alpha_ledger_grpc_reader` to optionally support bitmap stream apis with backward compatibility 1/n

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15589,6 +15589,7 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "bcs",
+ "bytes",
  "clap",
  "diesel",
  "diesel-async",

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -336,6 +336,10 @@ pub async fn start_rpc(
         .ledger_grpc_reader(Some("graphql_ledger_grpc"), registry)
         .await?;
 
+    let alpha_ledger_grpc_reader = kv_args
+        .alpha_ledger_grpc_reader(Some("graphql_alpha_ledger_grpc"), registry)
+        .await?;
+
     let pg_reader =
         PgReader::new(Some("graphql_db"), database_url.clone(), db_args, registry).await?;
 
@@ -430,6 +434,10 @@ pub async fn start_rpc(
         .data(pg_loader)
         .data(kv_loader)
         .data(package_store);
+
+    if let Some(reader) = alpha_ledger_grpc_reader {
+        rpc = rpc.data(reader);
+    }
 
     if let Some(fullnode_client) = fullnode_client {
         rpc = rpc.data(fullnode_client);

--- a/crates/sui-indexer-alt-reader/Cargo.toml
+++ b/crates/sui-indexer-alt-reader/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 async-graphql = { workspace = true, features = ["dataloader"] }
 async-trait.workspace = true
 bcs.workspace = true
+bytes.workspace = true
 clap.workspace = true
 diesel.workspace = true
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -8,7 +8,7 @@ use futures::Stream;
 use futures::StreamExt;
 use prometheus::Registry;
 use sui_rpc::proto::sui::rpc::v2alpha as grpc_alpha;
-use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient as V2alphaLedgerServiceClient;
+use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient;
 use tonic::transport::Channel;
 use tonic::transport::ClientTlsConfig;
 use tonic::transport::Uri;
@@ -24,7 +24,7 @@ const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 /// A reader backed by the gRPC LedgerService's v2alpha experimental query APIs.
 #[derive(Clone)]
 pub struct AlphaLedgerGrpcReader {
-    client: V2alphaLedgerServiceClient<GrpcMetricsService<Channel>>,
+    client: LedgerServiceClient<GrpcMetricsService<Channel>>,
     timeout: Option<Duration>,
 }
 
@@ -77,7 +77,7 @@ impl AlphaLedgerGrpcReader {
         let max_decoding_message_size = args
             .ledger_grpc_max_decoding_message_size
             .unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE);
-        let client = V2alphaLedgerServiceClient::new(layered.clone())
+        let client = LedgerServiceClient::new(layered.clone())
             .max_decoding_message_size(max_decoding_message_size);
 
         Ok(Self { client, timeout })

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -144,7 +144,7 @@ impl<I> StreamPage<I> {
     /// Fold one frame into the page. `first_cursor` is set once to the first cursor-bearing frame.
     /// `last_cursor` continuously tracks the latest cursor-bearing frame.
     ///
-    /// Returns `true` when the frame is the terminal `QueryEnd`.
+    /// Returns `true` when the frame is `QueryEnd`.
     fn apply(&mut self, frame: FrameKind<I>) -> bool {
         match frame {
             FrameKind::Item { item, cursor } => {
@@ -350,13 +350,13 @@ mod tests {
     }
 
     #[test]
-    fn apply_signals_terminal_only_on_end_frame() {
+    fn apply_signals_stop_only_on_end_frame() {
         // The bool returned by `apply` is the drain loop's stop signal: `true` means "stop
-        // draining," `false` means "keep going." Only the terminal `End` frame should signal stop.
+        // draining," `false` means "keep going." Only the `End` frame should signal stop.
         let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
         assert!(!page.apply(item_response(b"c1").into()));
         assert!(!page.apply(watermark_response(b"w1").into()));
-        // Outer message with no oneof set → `FrameKind::Unknown` → also non-terminal.
+        // Outer message with no oneof set → `FrameKind::Unknown` → continue.
         assert!(!page.apply(grpc_alpha::ListTransactionsResponse::default().into()));
         assert!(page.apply(end_response(grpc_alpha::QueryEndReason::LedgerTip).into()));
     }
@@ -387,7 +387,7 @@ mod tests {
             assert!(page.has_more(), "expected has_more for {reason:?}");
         }
 
-        // `end_reason == None` covers both the deadline cut-short case (no terminal frame
+        // `end_reason == None` covers both the deadline cut-short case (no end frame
         // received) and any unrecognized / future-added variant — defaulting to "may have more"
         // avoids silent truncation.
         let page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -71,9 +71,8 @@ impl AlphaLedgerGrpcReader {
             GrpcMetricsLayer::new(prefix.unwrap_or("ledger_grpc"), registry).layer(channel);
 
         let timeout = args.statement_timeout();
-        let max_decoding_message_size = args.max_decoding_message_size();
         let client = LedgerServiceClient::new(layered.clone())
-            .max_decoding_message_size(max_decoding_message_size);
+            .max_decoding_message_size(args.ledger_grpc_max_decoding_message_size);
 
         Ok(Self { client, timeout })
     }

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -10,6 +10,7 @@ use bytes::Bytes;
 use futures::Stream;
 use futures::StreamExt;
 use prometheus::Registry;
+use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_rpc::proto::sui::rpc::v2alpha as proto;
 use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient;
 use tonic::transport::Channel;
@@ -29,21 +30,26 @@ pub struct AlphaLedgerGrpcReader {
     timeout: Option<Duration>,
 }
 
+/// A single item from a list stream and the resume cursor the server emitted alongside it.
+#[derive(Debug, Clone)]
+pub struct PageItem<T> {
+    pub payload: T,
+    pub cursor: Bytes,
+}
+
 /// A page drained from a single gRPC list stream.
 #[derive(Debug, Clone)]
-pub struct StreamPage<I> {
+pub struct StreamPage<T> {
     /// Items that matched the filters, in stream order.
-    pub items: Vec<I>,
-    /// First cursor value observed across item and standalone watermark frames.
-    pub first_cursor: Option<Bytes>,
-    /// Latest cursor value observed, advances as new cursor-bearing frames arrive.
-    pub last_cursor: Option<Bytes>,
+    pub items: Vec<PageItem<T>>,
+    first_wm_cursor: Option<Bytes>,
+    last_wm_cursor: Option<Bytes>,
     pub end_reason: Option<proto::QueryEndReason>,
 }
 
 #[derive(Debug)]
-enum FrameKind<I> {
-    Item { item: I, cursor: Option<Bytes> },
+enum FrameKind<T> {
+    Item { payload: T, cursor: Bytes },
     Watermark { cursor: Option<Bytes> },
     End { reason: i32 },
     Unknown,
@@ -80,7 +86,7 @@ impl AlphaLedgerGrpcReader {
     pub async fn list_transactions(
         &self,
         request: proto::ListTransactionsRequest,
-    ) -> anyhow::Result<StreamPage<proto::TransactionItem>> {
+    ) -> anyhow::Result<StreamPage<ExecutedTransaction>> {
         let mut client = self.client.clone();
         let stream = client
             .list_transactions(self.request(request))
@@ -101,7 +107,7 @@ impl AlphaLedgerGrpcReader {
     }
 }
 
-impl<I> StreamPage<I> {
+impl<T> StreamPage<T> {
     /// Whether further data may exist in the direction of pagination.
     ///
     /// `false` iff one of:
@@ -115,51 +121,52 @@ impl<I> StreamPage<I> {
             None => true,
             Some(R::Unspecified | R::ItemLimit | R::ScanLimit) => true,
             Some(R::LedgerTip | R::CheckpointBound) => false,
-            Some(R::CursorBound) => self.last_cursor.is_some(),
+            Some(R::CursorBound) => self.last_cursor().is_some(),
             // `QueryEndReason` is non exhaustive — conservatively `true` if a
             // future variant slips past `apply()`'s `unwrap_or(Unspecified)`.
             Some(_) => true,
         }
     }
 
-    /// The latest cursor observed in the direction of pagination.
-    pub fn next_cursor(&self) -> Option<&Bytes> {
-        self.last_cursor.as_ref()
+    /// The page's starting cursor: the standalone-watermark cursor if one preceded any items,
+    /// otherwise the first item's own cursor.
+    pub fn first_cursor(&self) -> Option<&Bytes> {
+        self.first_wm_cursor
+            .as_ref()
+            .or_else(|| self.items.first().map(|item| &item.cursor))
     }
 
-    /// Fold one frame into the page. `first_cursor` is set once to the first cursor-bearing frame.
-    /// `last_cursor` continuously tracks the latest cursor-bearing frame.
+    /// The page's resume cursor: a standalone-watermark cursor emitted after the last item if one
+    /// exists, otherwise the last item's own cursor.
+    pub fn last_cursor(&self) -> Option<&Bytes> {
+        self.last_wm_cursor
+            .as_ref()
+            .or_else(|| self.items.last().map(|item| &item.cursor))
+    }
+
+    /// Fold one frame into the page.
     ///
     /// Returns `true` when the frame is `QueryEnd`.
-    fn apply(&mut self, frame: FrameKind<I>) -> bool {
+    fn apply(&mut self, frame: FrameKind<T>) -> bool {
         match frame {
-            FrameKind::Item { item, cursor } => {
-                if cursor.is_some() {
-                    if self.first_cursor.is_none() {
-                        self.first_cursor = cursor.clone();
-                    }
-                    self.last_cursor = cursor;
-                }
-                self.items.push(item);
+            FrameKind::Item { payload, cursor } => {
+                self.last_wm_cursor = None;
+                self.items.push(PageItem { payload, cursor });
             }
             FrameKind::Watermark { cursor } => {
-                if cursor.is_some() {
-                    if self.first_cursor.is_none() {
-                        self.first_cursor = cursor.clone();
-                    }
-                    self.last_cursor = cursor;
+                self.last_wm_cursor = cursor.clone();
+                if self.items.is_empty() && self.first_wm_cursor.is_none() {
+                    self.first_wm_cursor = cursor.clone();
                 }
             }
             FrameKind::End { reason } => {
                 // Fold an unknown reason into `Unspecified` so `None` remains unambiguous shorthand
                 // for "no End frame received" (i.e. the deadline cut the stream short).
-                self.end_reason = match proto::QueryEndReason::try_from(reason) {
-                    Ok(decoded) => Some(decoded),
-                    Err(_) => {
-                        warn!(reason, "unknown QueryEndReason",);
-                        Some(proto::QueryEndReason::Unspecified)
-                    }
-                };
+                self.end_reason =
+                    Some(proto::QueryEndReason::try_from(reason).unwrap_or_else(|_| {
+                        warn!(reason, "unknown QueryEndReason");
+                        proto::QueryEndReason::Unspecified
+                    }));
                 return true;
             }
             FrameKind::Unknown => {
@@ -170,44 +177,52 @@ impl<I> StreamPage<I> {
     }
 }
 
-impl<I> Default for StreamPage<I> {
+impl<T> Default for StreamPage<T> {
     fn default() -> Self {
         Self {
             items: Vec::new(),
-            first_cursor: None,
-            last_cursor: None,
+            first_wm_cursor: None,
+            last_wm_cursor: None,
             end_reason: None,
         }
     }
 }
 
-impl From<proto::ListTransactionsResponse> for FrameKind<proto::TransactionItem> {
-    fn from(response: proto::ListTransactionsResponse) -> Self {
+impl TryFrom<proto::ListTransactionsResponse> for FrameKind<ExecutedTransaction> {
+    type Error = anyhow::Error;
+
+    fn try_from(response: proto::ListTransactionsResponse) -> anyhow::Result<Self> {
         use proto::list_transactions_response::Response;
 
         let Some(response) = response.response else {
-            return FrameKind::Unknown;
+            return Ok(FrameKind::Unknown);
         };
-        match response {
+        Ok(match response {
             Response::Item(item) => {
-                let cursor = item.watermark.as_ref().and_then(|w| w.cursor.clone());
-                FrameKind::Item { item, cursor }
+                let cursor = item
+                    .watermark
+                    .and_then(|w| w.cursor)
+                    .context("Item frame missing watermark.cursor")?;
+                let payload = item
+                    .transaction
+                    .context("Item frame missing transaction payload")?;
+                FrameKind::Item { payload, cursor }
             }
             Response::Watermark(watermark) => FrameKind::Watermark {
                 cursor: watermark.cursor,
             },
             Response::End(end) => FrameKind::End { reason: end.reason },
             _ => FrameKind::Unknown,
-        }
+        })
     }
 }
 
-async fn drain_list_stream<R, I, S>(
+async fn drain_list_stream<R, T, S>(
     rpc_name: &'static str,
     stream: S,
-) -> anyhow::Result<StreamPage<I>>
+) -> anyhow::Result<StreamPage<T>>
 where
-    R: Into<FrameKind<I>>,
+    R: TryInto<FrameKind<T>, Error = anyhow::Error>,
     S: Stream<Item = Result<R, tonic::Status>>,
 {
     futures::pin_mut!(stream);
@@ -215,8 +230,11 @@ where
     while let Some(result) = stream.next().await {
         match result {
             Ok(response) => {
+                let frame = response
+                    .try_into()
+                    .with_context(|| format!("{rpc_name}: malformed frame"))?;
                 // Process and break on receiving `QueryEnd`.
-                if page.apply(response.into()) {
+                if page.apply(frame) {
                     break;
                 }
             }
@@ -242,10 +260,11 @@ where
         }
     }
 
-    // Exited via `break` or via `None`. If `has_more() promises further data, the cursor to resume
-    // from must be present.`
+    // Exited via `break` or via `None`. If `has_more()` promises further data, the cursor to resume
+    // from must be present — either a standalone watermark advanced past the last item, or the last
+    // item's own cursor.
     ensure!(
-        !page.has_more() || page.last_cursor.is_some(),
+        !page.has_more() || page.last_cursor().is_some(),
         "{rpc_name}: server reported more results but did not provide resume cursor — cannot continue",
     );
 
@@ -256,11 +275,13 @@ where
 mod tests {
     use super::*;
 
+    /// Well-formed `Item` frame with both `transaction` payload and a cursor-bearing watermark.
     fn item_response(cursor: &[u8]) -> proto::ListTransactionsResponse {
         let mut watermark = proto::Watermark::default();
         watermark.cursor = Some(Bytes::copy_from_slice(cursor));
         let mut item = proto::TransactionItem::default();
         item.watermark = Some(watermark);
+        item.transaction = Some(ExecutedTransaction::default());
         let mut response = proto::ListTransactionsResponse::default();
         response.response = Some(proto::list_transactions_response::Response::Item(item));
         response
@@ -284,14 +305,14 @@ mod tests {
         response
     }
 
-    /// Drain a mocked stream. The turbofish pins `I = TransactionItem` for `drain_list_stream`
-    /// since the `R: Into<FrameKind<I>>` bound alone doesn't let Rust infer `I` (Rust doesn't
-    /// search `Into` impls for a unique match, and the return type doesn't propagate backward
-    /// to inner generic calls).
+    fn frame(r: proto::ListTransactionsResponse) -> FrameKind<ExecutedTransaction> {
+        r.try_into().expect("test fixture should be well-formed")
+    }
+
     async fn drain_iter(
         responses: Vec<Result<proto::ListTransactionsResponse, tonic::Status>>,
-    ) -> anyhow::Result<StreamPage<proto::TransactionItem>> {
-        drain_list_stream::<_, proto::TransactionItem, _>(
+    ) -> anyhow::Result<StreamPage<ExecutedTransaction>> {
+        drain_list_stream::<_, ExecutedTransaction, _>(
             "ListTransactions",
             futures::stream::iter(responses),
         )
@@ -300,31 +321,40 @@ mod tests {
 
     #[test]
     fn drains_items_tracking_latest_cursor_and_end_reason() {
-        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-        page.apply(item_response(b"c1").into());
-        page.apply(watermark_response(b"c2").into());
-        page.apply(item_response(b"c3").into());
-        page.apply(end_response(proto::QueryEndReason::ItemLimit).into());
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(item_response(b"c1")));
+        page.apply(frame(watermark_response(b"w2")));
+        page.apply(frame(item_response(b"c3")));
+        page.apply(frame(end_response(proto::QueryEndReason::ItemLimit)));
 
         assert_eq!(page.items.len(), 2);
-        // `first_cursor` latches on the first cursor-bearing frame (the item at `c1`) and stays
-        // there. `last_cursor` advances on every cursor-bearing frame — item OR standalone watermark
-        // — so it went `c1` → `c2` (the watermark between items) → `c3` (the last item).
-        assert_eq!(page.first_cursor.as_deref(), Some(b"c1".as_ref()));
-        assert_eq!(page.last_cursor.as_deref(), Some(b"c3".as_ref()));
+        // Per-item cursors are preserved on `PageItem` — that's the whole point of the
+        // payload/cursor split. The standalone watermark at `c2` does not produce a `PageItem`.
+        assert_eq!(page.items[0].cursor.as_ref(), b"c1".as_ref());
+        assert_eq!(page.items[1].cursor.as_ref(), b"c3".as_ref());
+        assert_eq!(
+            page.first_cursor().map(|c| c.as_ref()),
+            Some(b"c1".as_ref())
+        );
+        assert_eq!(page.last_cursor().map(|c| c.as_ref()), Some(b"c3".as_ref()));
         assert_eq!(page.end_reason, Some(proto::QueryEndReason::ItemLimit));
+        // w2 watermark was briefly set on last_wm_cursor, but got wiped from subsequent item.
+        assert!(page.last_wm_cursor.is_none());
     }
 
     #[test]
     fn standalone_watermark_advances_cursor_without_items() {
-        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-        page.apply(watermark_response(b"w1").into());
-        page.apply(watermark_response(b"w2").into());
-        page.apply(end_response(proto::QueryEndReason::LedgerTip).into());
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(watermark_response(b"w1")));
+        page.apply(frame(watermark_response(b"w2")));
+        page.apply(frame(end_response(proto::QueryEndReason::LedgerTip)));
 
         assert!(page.items.is_empty());
-        assert_eq!(page.first_cursor.as_deref(), Some(b"w1".as_ref()));
-        assert_eq!(page.last_cursor.as_deref(), Some(b"w2".as_ref()));
+        assert_eq!(
+            page.first_cursor().map(|c| c.as_ref()),
+            Some(b"w1".as_ref())
+        );
+        assert_eq!(page.last_cursor().map(|c| c.as_ref()), Some(b"w2".as_ref()));
         assert_eq!(page.end_reason, Some(proto::QueryEndReason::LedgerTip));
     }
 
@@ -332,26 +362,60 @@ mod tests {
     fn apply_signals_stop_only_on_end_frame() {
         // The bool returned by `apply` is the drain loop's stop signal: `true` means "stop
         // draining," `false` means "keep going." Only the `End` frame should signal stop.
-        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-        assert!(!page.apply(item_response(b"c1").into()));
-        assert!(!page.apply(watermark_response(b"w1").into()));
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        assert!(!page.apply(frame(item_response(b"c1"))));
+        assert!(!page.apply(frame(watermark_response(b"w1"))));
         // Outer message with no oneof set → `FrameKind::Unknown` → continue.
-        assert!(!page.apply(proto::ListTransactionsResponse::default().into()));
-        assert!(page.apply(end_response(proto::QueryEndReason::LedgerTip).into()));
+        assert!(!page.apply(frame(proto::ListTransactionsResponse::default())));
+        assert!(page.apply(frame(end_response(proto::QueryEndReason::LedgerTip))));
     }
 
     #[test]
-    fn first_cursor_latches_on_first_frame_and_does_not_update() {
-        // Multiple cursor-bearing frames: `first_cursor` should remain at the first one,
-        // `last_cursor` should track the latest.
-        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-        page.apply(watermark_response(b"w1").into());
-        page.apply(item_response(b"c2").into());
-        page.apply(watermark_response(b"w3").into());
-        page.apply(item_response(b"c4").into());
+    fn first_wm_cursor_set_to_first_pre_item_watermark() {
+        // `first_wm_cursor` is set when watermark frame observed before items.
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(watermark_response(b"w1")));
+        page.apply(frame(item_response(b"c2")));
+        page.apply(frame(watermark_response(b"w3")));
+        page.apply(frame(item_response(b"c4")));
 
-        assert_eq!(page.first_cursor.as_deref(), Some(b"w1".as_ref()));
-        assert_eq!(page.last_cursor.as_deref(), Some(b"c4".as_ref()));
+        assert_eq!(
+            page.first_cursor().map(|c| c.as_ref()),
+            Some(b"w1".as_ref())
+        );
+        assert_eq!(page.last_cursor().map(|c| c.as_ref()), Some(b"c4".as_ref()));
+    }
+
+    #[test]
+    fn first_wm_cursor_not_set_after_items() {
+        // `first_wm_cursor` is never set once at least one item exists on the page.
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(item_response(b"c2")));
+        page.apply(frame(watermark_response(b"w3")));
+        page.apply(frame(item_response(b"c4")));
+        page.apply(frame(watermark_response(b"w1")));
+
+        assert_eq!(
+            page.first_cursor().map(|c| c.as_ref()),
+            Some(b"c2".as_ref())
+        );
+        assert!(page.first_wm_cursor.is_none());
+    }
+
+    #[test]
+    fn trailing_watermark_advances_past_last_item() {
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(item_response(b"c1")));
+        page.apply(frame(watermark_response(b"w2")));
+
+        // The trailing watermark's cursor wins over the item's — it represents
+        // server progress past the last delivered item.
+        assert_eq!(page.last_cursor().map(|c| c.as_ref()), Some(b"w2".as_ref()));
+        // first_cursor falls back to the item, since no watermark preceded it.
+        assert_eq!(
+            page.first_cursor().map(|c| c.as_ref()),
+            Some(b"c1".as_ref())
+        );
     }
 
     #[test]
@@ -361,15 +425,15 @@ mod tests {
             proto::QueryEndReason::ItemLimit,
             proto::QueryEndReason::ScanLimit,
         ] {
-            let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-            page.apply(end_response(reason).into());
+            let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+            page.apply(frame(end_response(reason)));
             assert!(page.has_more(), "expected has_more for {reason:?}");
         }
 
         // `end_reason == None` covers both the deadline cut-short case (no end frame
         // received) and any unrecognized / future-added variant — defaulting to "may have more"
         // avoids silent truncation.
-        let page: StreamPage<proto::TransactionItem> = StreamPage::default();
+        let page: StreamPage<ExecutedTransaction> = StreamPage::default();
         assert!(page.has_more());
     }
 
@@ -383,19 +447,19 @@ mod tests {
             proto::QueryEndReason::LedgerTip,
             proto::QueryEndReason::CursorBound,
         ] {
-            let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-            page.apply(end_response(reason).into());
+            let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+            page.apply(frame(end_response(reason)));
             assert!(!page.has_more(), "expected !has_more for {reason:?}");
         }
     }
 
     #[test]
     fn has_more_true_on_cursor_bound_with_tracked_cursor() {
-        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-        page.apply(item_response(b"c1").into());
-        page.apply(end_response(proto::QueryEndReason::CursorBound).into());
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(item_response(b"c1")));
+        page.apply(frame(end_response(proto::QueryEndReason::CursorBound)));
 
-        assert_eq!(page.last_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert_eq!(page.last_cursor().map(|c| c.as_ref()), Some(b"c1".as_ref()));
         assert!(
             page.has_more(),
             "CursorBound with tracked cursor should not be terminal"
@@ -409,8 +473,8 @@ mod tests {
         let mut response = proto::ListTransactionsResponse::default();
         response.response = Some(proto::list_transactions_response::Response::End(end));
 
-        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-        page.apply(response.into());
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(response));
         assert_eq!(page.end_reason, Some(proto::QueryEndReason::Unspecified));
     }
 
@@ -420,12 +484,28 @@ mod tests {
         // warn but leave items / cursors / end_reason untouched.
         let response = proto::ListTransactionsResponse::default();
 
-        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
-        page.apply(response.into());
+        let mut page: StreamPage<ExecutedTransaction> = StreamPage::default();
+        page.apply(frame(response));
         assert!(page.items.is_empty());
-        assert_eq!(page.first_cursor, None);
-        assert_eq!(page.last_cursor, None);
+        assert_eq!(page.first_cursor(), None);
+        assert_eq!(page.last_cursor(), None);
         assert_eq!(page.end_reason, None);
+    }
+
+    #[test]
+    fn try_from_item_without_transaction_errors() {
+        // An Item frame without a `transaction` payload violates the protocol contract —
+        // the conversion must fail loudly rather than silently dropping the slot. The
+        // cursor on the watermark would otherwise be a tempting but lossy fallback.
+        let mut watermark = proto::Watermark::default();
+        watermark.cursor = Some(Bytes::copy_from_slice(b"c1"));
+        let mut item = proto::TransactionItem::default();
+        item.watermark = Some(watermark);
+        let mut response = proto::ListTransactionsResponse::default();
+        response.response = Some(proto::list_transactions_response::Response::Item(item));
+
+        let result: anyhow::Result<FrameKind<ExecutedTransaction>> = response.try_into();
+        assert!(result.is_err(), "missing transaction payload should error");
     }
 
     #[tokio::test]
@@ -439,7 +519,7 @@ mod tests {
         .expect("partial progress should be preserved");
 
         assert_eq!(page.items.len(), 2);
-        assert_eq!(page.last_cursor.as_deref(), Some(b"c2".as_ref()));
+        assert_eq!(page.last_cursor().map(|c| c.as_ref()), Some(b"c2".as_ref()));
         assert_eq!(page.end_reason, None);
         assert!(page.has_more());
     }
@@ -472,6 +552,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drain_errors_on_malformed_item_frame() {
+        // A malformed Item frame (no `transaction` payload) reaches `drain_list_stream` via
+        // `try_into`, which propagates the error out — partial work is discarded because the
+        // cursor state is no longer trustworthy.
+        let mut watermark = proto::Watermark::default();
+        watermark.cursor = Some(Bytes::copy_from_slice(b"c1"));
+        let mut item = proto::TransactionItem::default();
+        item.watermark = Some(watermark);
+        let mut malformed = proto::ListTransactionsResponse::default();
+        malformed.response = Some(proto::list_transactions_response::Response::Item(item));
+
+        drain_iter(vec![Ok(item_response(b"c0")), Ok(malformed)])
+            .await
+            .expect_err("malformed Item frame should error the drain");
+    }
+
+    #[tokio::test]
     async fn drain_returns_page_on_half_close_after_progress() {
         // Server emitted one item, then half-closed without an End frame. The page is still
         // valid and resumable from the item's watermark.
@@ -480,7 +577,7 @@ mod tests {
             .expect("partial-progress half-close should succeed");
 
         assert_eq!(page.items.len(), 1);
-        assert_eq!(page.last_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert_eq!(page.last_cursor().map(|c| c.as_ref()), Some(b"c1".as_ref()));
         assert_eq!(page.end_reason, None);
     }
 }

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -124,19 +124,18 @@ impl<I> StreamPage<I> {
         )
     }
 
-    /// The cursor to continue paginating, or `None` if the requested range has been exhausted and
-    /// no further pagination is possible.
-    ///
-    /// Invariant: `has_more()` ⇒ `end_cursor.is_some()`. Enforced at the page boundary by
-    /// `drain_list_stream` (returns `data_loss` on violation) and preserved by any caller that
-    /// re-synthesizes a `StreamPage` from a previously-validated one's `end_reason` +
-    /// `end_cursor` fields together.
+    /// The latest cursor seen for resuming pagination. If more items are expected, e.g.
+    /// `has_more()` is true, `next_cursor` must yield a cursor.
     pub fn next_cursor(&self) -> Option<&Bytes> {
-        self.has_more().then(|| {
-            self.end_cursor
-                .as_ref()
-                .expect("invariant: has_more implies end_cursor is Some")
-        })
+        if self.has_more() {
+            Some(
+                self.end_cursor
+                    .as_ref()
+                    .expect("invariant: has_more implies end_cursor is Some"),
+            )
+        } else {
+            self.end_cursor.as_ref()
+        }
     }
 
     /// Fold one frame into the page. `start_cursor` latches on the first cursor seen; `end_cursor`

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -31,19 +31,15 @@ pub struct AlphaLedgerGrpcReader {
     timeout: Option<Duration>,
 }
 
-/// A page drained from a stream consisting of the items in stream order, the cursors of the first
-/// and latest frames the stream emitted, and why the stream stopped.
-///
-/// `start_cursor` is the cursor of the first frame seen.
-///
-/// `end_cursor` may be beyond the last item in the collected page.
-///
-/// `end_reason` is `None` only when the stream terminated before a `QueryEnd` was received.
+/// A page drained from a single gRPC list stream.
 #[derive(Debug, Clone)]
 pub struct StreamPage<I> {
+    /// Items that matched the filters, in stream order.
     pub items: Vec<I>,
-    pub start_cursor: Option<Bytes>,
-    pub end_cursor: Option<Bytes>,
+    /// First cursor recorded from an item or watermark.
+    pub first_cursor: Option<Bytes>,
+    /// Last cursor recorded from an item or watermark.
+    pub last_cursor: Option<Bytes>,
     pub end_reason: Option<grpc_alpha::QueryEndReason>,
 }
 
@@ -86,9 +82,6 @@ impl AlphaLedgerGrpcReader {
         Ok(Self { client, timeout })
     }
 
-    /// Consumes the stream returned from a `list_transactions` request until server timeout or
-    /// other terminal condition is met. The caller is responsible for resuming the next page from
-    /// the `end_cursor` if there are more results to yield after the current page.
     pub async fn list_transactions(
         &self,
         request: grpc_alpha::ListTransactionsRequest,
@@ -114,57 +107,61 @@ impl AlphaLedgerGrpcReader {
 }
 
 impl<I> StreamPage<I> {
-    /// Whether the caller can continue paginating from `next_cursor()`.
+    /// Whether further data may exist in the direction of pagination.
+    ///
+    /// `false` iff one of:
+    /// - `reason ∈ {LedgerTip, CheckpointBound}` — authoritative range terminals.
+    /// - `reason = CursorBound` AND no cursor was emitted - the server did not do any scanning and
+    ///   short-circuited. Typically implies that the cursors for the request fell outside the
+    ///   available range.
     pub fn has_more(&self) -> bool {
         use grpc_alpha::QueryEndReason as R;
         match self.end_reason {
             None => true,
             Some(R::Unspecified | R::ItemLimit | R::ScanLimit) => true,
             Some(R::LedgerTip | R::CheckpointBound) => false,
-            // Terminal only when no cursor was reported from gRPC, such as when the client's
-            // cursors fall outside the available range of the server. Otherwise, additional data
-            // may exist past the client's cursors until a terminal bound.
-            Some(R::CursorBound) => self.end_cursor.is_some(),
-            // `QueryEndReason` is non exhaustive.
+            Some(R::CursorBound) => self.last_cursor.is_some(),
+            // `QueryEndReason` is non exhaustive — conservatively `true` if a
+            // future variant slips past `apply()`'s `unwrap_or(Unspecified)`.
             Some(_) => true,
         }
     }
 
-    /// The latest cursor observed in the direction of pagination. A cursor is expected to exist if
+    /// The latest cursor observed in the direction of pagination. Expect `Some` whenever
     /// `has_more()` is true.
     pub fn next_cursor(&self) -> Option<&Bytes> {
         if self.has_more() {
             Some(
-                self.end_cursor
+                self.last_cursor
                     .as_ref()
-                    .expect("invariant: has_more implies end_cursor is Some"),
+                    .expect("invariant: has_more implies last_cursor is Some"),
             )
         } else {
-            self.end_cursor.as_ref()
+            self.last_cursor.as_ref()
         }
     }
 
-    /// Fold one frame into the page. Sets `start_cursor` to the first cursor seen; `end_cursor`
-    /// tracks the latest.
+    /// Fold one frame into the page. `first_cursor` is set once to the first cursor-bearing frame.
+    /// `last_cursor` continuously tracks the latest cursor-bearing frame.
     ///
     /// Returns `true` when the frame is the terminal `QueryEnd`.
     fn apply(&mut self, frame: FrameKind<I>) -> bool {
         match frame {
             FrameKind::Item { item, cursor } => {
                 if cursor.is_some() {
-                    if self.start_cursor.is_none() {
-                        self.start_cursor = cursor.clone();
+                    if self.first_cursor.is_none() {
+                        self.first_cursor = cursor.clone();
                     }
-                    self.end_cursor = cursor;
+                    self.last_cursor = cursor;
                 }
                 self.items.push(item);
             }
             FrameKind::Watermark { cursor } => {
                 if cursor.is_some() {
-                    if self.start_cursor.is_none() {
-                        self.start_cursor = cursor.clone();
+                    if self.first_cursor.is_none() {
+                        self.first_cursor = cursor.clone();
                     }
-                    self.end_cursor = cursor;
+                    self.last_cursor = cursor;
                 }
             }
             FrameKind::End { reason } => {
@@ -194,8 +191,8 @@ impl<I> Default for StreamPage<I> {
     fn default() -> Self {
         Self {
             items: Vec::new(),
-            start_cursor: None,
-            end_cursor: None,
+            first_cursor: None,
+            last_cursor: None,
             end_reason: None,
         }
     }
@@ -254,7 +251,7 @@ where
                 ) =>
             {
                 ensure!(
-                    !page.items.is_empty() || page.end_cursor.is_some(),
+                    !page.items.is_empty() || page.last_cursor.is_some(),
                     "{rpc_name} stream {:?} with no progress: {}",
                     status.code(),
                     status.message(),
@@ -267,10 +264,10 @@ where
         }
     }
 
-    // Either there's no more to paginate, or we must have a cursor to resume from
+    // If `has_more() promises further data, the cursor to resume from must be present.`
     ensure!(
-        !page.has_more() || page.end_cursor.is_some(),
-        "{rpc_name}: server reported more results but did not advance cursor — cannot resume",
+        !page.has_more() || page.last_cursor.is_some(),
+        "{rpc_name}: server reported more results but did not provide resume cursor — cannot continue",
     );
 
     Ok(page)
@@ -331,11 +328,11 @@ mod tests {
         page.apply(end_response(grpc_alpha::QueryEndReason::ItemLimit).into());
 
         assert_eq!(page.items.len(), 2);
-        // `start_cursor` latches on the first cursor-bearing frame (the item at `c1`) and stays
-        // there. `end_cursor` advances on every cursor-bearing frame — item OR standalone watermark
+        // `first_cursor` latches on the first cursor-bearing frame (the item at `c1`) and stays
+        // there. `last_cursor` advances on every cursor-bearing frame — item OR standalone watermark
         // — so it went `c1` → `c2` (the watermark between items) → `c3` (the last item).
-        assert_eq!(page.start_cursor.as_deref(), Some(b"c1".as_ref()));
-        assert_eq!(page.end_cursor.as_deref(), Some(b"c3".as_ref()));
+        assert_eq!(page.first_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert_eq!(page.last_cursor.as_deref(), Some(b"c3".as_ref()));
         assert_eq!(page.end_reason, Some(grpc_alpha::QueryEndReason::ItemLimit));
     }
 
@@ -347,8 +344,8 @@ mod tests {
         page.apply(end_response(grpc_alpha::QueryEndReason::LedgerTip).into());
 
         assert!(page.items.is_empty());
-        assert_eq!(page.start_cursor.as_deref(), Some(b"w1".as_ref()));
-        assert_eq!(page.end_cursor.as_deref(), Some(b"w2".as_ref()));
+        assert_eq!(page.first_cursor.as_deref(), Some(b"w1".as_ref()));
+        assert_eq!(page.last_cursor.as_deref(), Some(b"w2".as_ref()));
         assert_eq!(page.end_reason, Some(grpc_alpha::QueryEndReason::LedgerTip));
     }
 
@@ -365,17 +362,17 @@ mod tests {
     }
 
     #[test]
-    fn start_cursor_latches_on_first_frame_and_does_not_update() {
-        // Multiple cursor-bearing frames: `start_cursor` should remain at the first one,
-        // `end_cursor` should track the latest.
+    fn first_cursor_latches_on_first_frame_and_does_not_update() {
+        // Multiple cursor-bearing frames: `first_cursor` should remain at the first one,
+        // `last_cursor` should track the latest.
         let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
         page.apply(watermark_response(b"w1").into());
         page.apply(item_response(b"c2").into());
         page.apply(watermark_response(b"w3").into());
         page.apply(item_response(b"c4").into());
 
-        assert_eq!(page.start_cursor.as_deref(), Some(b"w1".as_ref()));
-        assert_eq!(page.end_cursor.as_deref(), Some(b"c4".as_ref()));
+        assert_eq!(page.first_cursor.as_deref(), Some(b"w1".as_ref()));
+        assert_eq!(page.last_cursor.as_deref(), Some(b"c4".as_ref()));
     }
 
     #[test]
@@ -419,7 +416,7 @@ mod tests {
         page.apply(item_response(b"c1").into());
         page.apply(end_response(grpc_alpha::QueryEndReason::CursorBound).into());
 
-        assert_eq!(page.end_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert_eq!(page.last_cursor.as_deref(), Some(b"c1".as_ref()));
         assert!(
             page.has_more(),
             "CursorBound with tracked cursor should not be terminal"
@@ -450,8 +447,8 @@ mod tests {
         let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
         page.apply(response.into());
         assert!(page.items.is_empty());
-        assert_eq!(page.start_cursor, None);
-        assert_eq!(page.end_cursor, None);
+        assert_eq!(page.first_cursor, None);
+        assert_eq!(page.last_cursor, None);
         assert_eq!(page.end_reason, None);
     }
 
@@ -466,7 +463,7 @@ mod tests {
         .expect("partial progress should be preserved");
 
         assert_eq!(page.items.len(), 2);
-        assert_eq!(page.end_cursor.as_deref(), Some(b"c2".as_ref()));
+        assert_eq!(page.last_cursor.as_deref(), Some(b"c2".as_ref()));
         assert_eq!(page.end_reason, None);
         assert!(page.has_more());
     }
@@ -507,7 +504,7 @@ mod tests {
             .expect("partial-progress half-close should succeed");
 
         assert_eq!(page.items.len(), 1);
-        assert_eq!(page.end_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert_eq!(page.last_cursor.as_deref(), Some(b"c1".as_ref()));
         assert_eq!(page.end_reason, None);
     }
 }

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -4,6 +4,8 @@
 use std::time::Duration;
 
 use anyhow::Context;
+use anyhow::bail;
+use anyhow::ensure;
 use bytes::Bytes;
 use futures::Stream;
 use futures::StreamExt;
@@ -112,20 +114,24 @@ impl AlphaLedgerGrpcReader {
 }
 
 impl<I> StreamPage<I> {
-    /// True while the server has not exhausted the requested range.
+    /// Whether the caller can continue paginating from `next_cursor()`.
     pub fn has_more(&self) -> bool {
-        !matches!(
-            self.end_reason,
-            Some(
-                grpc_alpha::QueryEndReason::CheckpointBound
-                    | grpc_alpha::QueryEndReason::CursorBound
-                    | grpc_alpha::QueryEndReason::LedgerTip
-            )
-        )
+        use grpc_alpha::QueryEndReason as R;
+        match self.end_reason {
+            None => true,
+            Some(R::Unspecified | R::ItemLimit | R::ScanLimit) => true,
+            Some(R::LedgerTip | R::CheckpointBound) => false,
+            // Terminal only when no cursor was reported from gRPC, such as when the client's
+            // cursors fall outside the available range of the server. Otherwise, additional data
+            // may exist past the client's cursors until a terminal bound.
+            Some(R::CursorBound) => self.end_cursor.is_some(),
+            // `QueryEndReason` is non exhaustive.
+            Some(_) => true,
+        }
     }
 
-    /// The latest cursor seen for resuming pagination. If more items are expected, e.g.
-    /// `has_more()` is true, `next_cursor` must yield a cursor.
+    /// The latest cursor observed in the direction of pagination. A cursor is expected to exist if
+    /// `has_more()` is true.
     pub fn next_cursor(&self) -> Option<&Bytes> {
         if self.has_more() {
             Some(
@@ -138,7 +144,7 @@ impl<I> StreamPage<I> {
         }
     }
 
-    /// Fold one frame into the page. `start_cursor` latches on the first cursor seen; `end_cursor`
+    /// Fold one frame into the page. Sets `start_cursor` to the first cursor seen; `end_cursor`
     /// tracks the latest.
     ///
     /// Returns `true` when the frame is the terminal `QueryEnd`.
@@ -234,7 +240,8 @@ where
                     break;
                 }
             }
-            // We expect the server to yield an `End` frame before reaching this branch.
+            // Server closed the stream before sending an `End` frame. Fall-through to the post-loop
+            // check.
             None => break,
             // `DeadlineExceeded`: server-side `grpc-timeout` header fired.
             // `Cancelled`: client-side channel timeout fired (or upstream cancel).
@@ -246,31 +253,25 @@ where
                     tonic::Code::DeadlineExceeded | tonic::Code::Cancelled
                 ) =>
             {
-                if page.items.is_empty() && page.end_cursor.is_none() {
-                    return Err(anyhow::anyhow!(
-                        "{rpc_name} stream {:?} with no progress: {}",
-                        status.code(),
-                        status.message()
-                    ));
-                }
+                ensure!(
+                    !page.items.is_empty() || page.end_cursor.is_some(),
+                    "{rpc_name} stream {:?} with no progress: {}",
+                    status.code(),
+                    status.message(),
+                );
                 break;
             }
             Some(Err(status)) => {
-                return Err(anyhow::anyhow!(
-                    "{rpc_name} stream error: {}",
-                    status.message()
-                ));
+                bail!("{rpc_name} stream error: {}", status.message());
             }
         }
     }
 
-    // Pagination is considered unresumable if there is more server-side work, but no valid cursor
-    // was yielded (either from a standalone `Watermark` or the last `Item`'s watermark.)
-    if page.has_more() && page.end_cursor.is_none() {
-        return Err(anyhow::anyhow!(
-            "{rpc_name}: server reported more results but did not advance cursor — cannot resume"
-        ));
-    }
+    // Either there's no more to paginate, or we must have a cursor to resume from
+    ensure!(
+        !page.has_more() || page.end_cursor.is_some(),
+        "{rpc_name}: server reported more results but did not advance cursor — cannot resume",
+    );
 
     Ok(page)
 }
@@ -397,16 +398,32 @@ mod tests {
     }
 
     #[test]
-    fn has_more_false_when_range_exhausted() {
+    fn has_more_false_on_authoritative_terminals() {
+        // `LedgerTip` and `CheckpointBound` are unconditional terminals — no data past tip /
+        // outside the client's cp scope. `CursorBound` with no tracked cursor is the
+        // short-circuit case (range collapsed at request resolution).
         for reason in [
             grpc_alpha::QueryEndReason::CheckpointBound,
-            grpc_alpha::QueryEndReason::CursorBound,
             grpc_alpha::QueryEndReason::LedgerTip,
+            grpc_alpha::QueryEndReason::CursorBound,
         ] {
             let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
             page.apply(end_response(reason).into());
             assert!(!page.has_more(), "expected !has_more for {reason:?}");
         }
+    }
+
+    #[test]
+    fn has_more_true_on_cursor_bound_with_tracked_cursor() {
+        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        page.apply(item_response(b"c1").into());
+        page.apply(end_response(grpc_alpha::QueryEndReason::CursorBound).into());
+
+        assert_eq!(page.end_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert!(
+            page.has_more(),
+            "CursorBound with tracked cursor should not be terminal"
+        );
     }
 
     #[test]

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -1,0 +1,496 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::Stream;
+use futures::StreamExt;
+use prometheus::Registry;
+use sui_rpc::proto::sui::rpc::v2alpha as grpc_alpha;
+use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient as V2alphaLedgerServiceClient;
+use tonic::transport::Channel;
+use tonic::transport::ClientTlsConfig;
+use tonic::transport::Uri;
+use tower::Layer;
+use tracing::warn;
+
+use crate::ledger_grpc_reader::LedgerGrpcArgs;
+use crate::metrics::GrpcMetricsLayer;
+use crate::metrics::GrpcMetricsService;
+
+const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+
+/// A reader backed by the gRPC LedgerService's v2alpha experimental query APIs.
+#[derive(Clone)]
+pub struct AlphaLedgerGrpcReader {
+    client: V2alphaLedgerServiceClient<GrpcMetricsService<Channel>>,
+    timeout: Option<Duration>,
+}
+
+/// A page drained from a stream consisting of the items in stream order, the cursors of the first
+/// and latest frames the stream emitted, and why the stream stopped.
+///
+/// `start_cursor` is the cursor of the first frame seen.
+///
+/// `end_cursor` may be beyond the last item in the collected page.
+///
+/// `end_reason` is `None` only when the stream terminated before a `QueryEnd` was received.
+#[derive(Debug, Clone)]
+pub struct StreamPage<I> {
+    pub items: Vec<I>,
+    pub start_cursor: Option<Bytes>,
+    pub end_cursor: Option<Bytes>,
+    pub end_reason: Option<grpc_alpha::QueryEndReason>,
+}
+
+#[derive(Debug)]
+enum FrameKind<I> {
+    Item { item: I, cursor: Option<Bytes> },
+    Watermark { cursor: Option<Bytes> },
+    End { reason: i32 },
+    Unknown,
+}
+
+impl AlphaLedgerGrpcReader {
+    pub async fn new(
+        uri: Uri,
+        args: LedgerGrpcArgs,
+        prefix: Option<&str>,
+        registry: &Registry,
+    ) -> anyhow::Result<Self> {
+        let mut endpoint = Channel::builder(uri.clone());
+        if let Some(timeout) = args.statement_timeout() {
+            endpoint = endpoint.timeout(timeout);
+        }
+
+        if uri.scheme_str() == Some("https") {
+            let tls_config = ClientTlsConfig::new().with_native_roots();
+            endpoint = endpoint.tls_config(tls_config)?;
+        }
+
+        let channel = endpoint.connect_lazy();
+        let layered =
+            GrpcMetricsLayer::new(prefix.unwrap_or("ledger_grpc"), registry).layer(channel);
+
+        let timeout = args.statement_timeout();
+        let max_decoding_message_size = args
+            .ledger_grpc_max_decoding_message_size
+            .unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE);
+        let client = V2alphaLedgerServiceClient::new(layered.clone())
+            .max_decoding_message_size(max_decoding_message_size);
+
+        Ok(Self { client, timeout })
+    }
+
+    /// Consumes the stream returned from a `list_transactions` request until server timeout or
+    /// other terminal condition is met. The caller is responsible for resuming the next page from
+    /// the `end_cursor` if there are more results to yield after the current page.
+    pub async fn list_transactions(
+        &self,
+        request: grpc_alpha::ListTransactionsRequest,
+    ) -> anyhow::Result<StreamPage<grpc_alpha::TransactionItem>> {
+        let mut client = self.client.clone();
+        let stream = client
+            .list_transactions(self.request(request))
+            .await
+            .map_err(|s| anyhow::anyhow!("ListTransactions stream open failed: {}", s.message()))?
+            .into_inner();
+
+        drain_list_stream("ListTransactions", stream).await
+    }
+
+    /// Create a gRPC request, optionally with the grpc-timeout header if configured.
+    fn request<T>(&self, input: T) -> tonic::Request<T> {
+        let mut request = tonic::Request::new(input);
+        if let Some(timeout) = self.timeout {
+            request.set_timeout(timeout);
+        }
+        request
+    }
+}
+
+impl<I> StreamPage<I> {
+    /// True while the server has not exhausted the requested range.
+    pub fn has_more(&self) -> bool {
+        !matches!(
+            self.end_reason,
+            Some(
+                grpc_alpha::QueryEndReason::CheckpointBound
+                    | grpc_alpha::QueryEndReason::CursorBound
+                    | grpc_alpha::QueryEndReason::LedgerTip
+            )
+        )
+    }
+
+    /// The cursor to continue paginating, or `None` if the requested range has been exhausted and
+    /// no further pagination is possible.
+    ///
+    /// Invariant: `has_more()` ⇒ `end_cursor.is_some()`. Enforced at the page boundary by
+    /// `drain_list_stream` (returns `data_loss` on violation) and preserved by any caller that
+    /// re-synthesizes a `StreamPage` from a previously-validated one's `end_reason` +
+    /// `end_cursor` fields together.
+    pub fn next_cursor(&self) -> Option<&Bytes> {
+        self.has_more().then(|| {
+            self.end_cursor
+                .as_ref()
+                .expect("invariant: has_more implies end_cursor is Some")
+        })
+    }
+
+    /// Fold one frame into the page. `start_cursor` latches on the first cursor seen; `end_cursor`
+    /// tracks the latest.
+    ///
+    /// Returns `true` when the frame is the terminal `QueryEnd`.
+    fn apply(&mut self, frame: FrameKind<I>) -> bool {
+        match frame {
+            FrameKind::Item { item, cursor } => {
+                if cursor.is_some() {
+                    if self.start_cursor.is_none() {
+                        self.start_cursor = cursor.clone();
+                    }
+                    self.end_cursor = cursor;
+                }
+                self.items.push(item);
+            }
+            FrameKind::Watermark { cursor } => {
+                if cursor.is_some() {
+                    if self.start_cursor.is_none() {
+                        self.start_cursor = cursor.clone();
+                    }
+                    self.end_cursor = cursor;
+                }
+            }
+            FrameKind::End { reason } => {
+                // Fold an unknown reason into `Unspecified` so `None` remains unambiguous shorthand
+                // for "no End frame received" (i.e. the deadline cut the stream short).
+                self.end_reason = match grpc_alpha::QueryEndReason::try_from(reason) {
+                    Ok(decoded) => Some(decoded),
+                    Err(_) => {
+                        warn!(
+                            reason_int = reason,
+                            "list stream: server sent unknown QueryEndReason",
+                        );
+                        Some(grpc_alpha::QueryEndReason::Unspecified)
+                    }
+                };
+                return true;
+            }
+            FrameKind::Unknown => {
+                warn!("list stream: server sent empty or unrecognized Frame");
+            }
+        }
+        false
+    }
+}
+
+impl<I> Default for StreamPage<I> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            start_cursor: None,
+            end_cursor: None,
+            end_reason: None,
+        }
+    }
+}
+
+impl From<grpc_alpha::ListTransactionsResponse> for FrameKind<grpc_alpha::TransactionItem> {
+    fn from(response: grpc_alpha::ListTransactionsResponse) -> Self {
+        use grpc_alpha::list_transactions_response::Response;
+
+        let Some(response) = response.response else {
+            return FrameKind::Unknown;
+        };
+        match response {
+            Response::Item(item) => {
+                let cursor = item.watermark.as_ref().and_then(|w| w.cursor.clone());
+                FrameKind::Item { item, cursor }
+            }
+            Response::Watermark(watermark) => FrameKind::Watermark {
+                cursor: watermark.cursor,
+            },
+            Response::End(end) => FrameKind::End { reason: end.reason },
+            _ => FrameKind::Unknown,
+        }
+    }
+}
+
+async fn drain_list_stream<R, I, S>(
+    rpc_name: &'static str,
+    stream: S,
+) -> anyhow::Result<StreamPage<I>>
+where
+    R: Into<FrameKind<I>>,
+    S: Stream<Item = Result<R, tonic::Status>>,
+{
+    futures::pin_mut!(stream);
+    let mut page = StreamPage::default();
+    loop {
+        match stream.next().await {
+            Some(Ok(response)) => {
+                // Process and break on receiving `QueryEnd`.
+                if page.apply(response.into()) {
+                    break;
+                }
+            }
+            // We expect the server to yield an `End` frame before reaching this branch.
+            None => break,
+            // `DeadlineExceeded`: server-side `grpc-timeout` header fired.
+            // `Cancelled`: client-side channel timeout fired (or upstream cancel).
+            // Both are timeout-shaped — preserve partial work if any progress was made;
+            // propagate as error only if zero progress, so the caller can reshape.
+            Some(Err(status))
+                if matches!(
+                    status.code(),
+                    tonic::Code::DeadlineExceeded | tonic::Code::Cancelled
+                ) =>
+            {
+                if page.items.is_empty() && page.end_cursor.is_none() {
+                    return Err(anyhow::anyhow!(
+                        "{rpc_name} stream {:?} with no progress: {}",
+                        status.code(),
+                        status.message()
+                    ));
+                }
+                break;
+            }
+            Some(Err(status)) => {
+                return Err(anyhow::anyhow!(
+                    "{rpc_name} stream error: {}",
+                    status.message()
+                ));
+            }
+        }
+    }
+
+    // Pagination is considered unresumable if there is more server-side work, but no valid cursor
+    // was yielded (either from a standalone `Watermark` or the last `Item`'s watermark.)
+    if page.has_more() && page.end_cursor.is_none() {
+        return Err(anyhow::anyhow!(
+            "{rpc_name}: server reported more results but did not advance cursor — cannot resume"
+        ));
+    }
+
+    Ok(page)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item_response(cursor: &[u8]) -> grpc_alpha::ListTransactionsResponse {
+        let mut watermark = grpc_alpha::Watermark::default();
+        watermark.cursor = Some(Bytes::copy_from_slice(cursor));
+        let mut item = grpc_alpha::TransactionItem::default();
+        item.watermark = Some(watermark);
+        let mut response = grpc_alpha::ListTransactionsResponse::default();
+        response.response = Some(grpc_alpha::list_transactions_response::Response::Item(item));
+        response
+    }
+
+    fn watermark_response(cursor: &[u8]) -> grpc_alpha::ListTransactionsResponse {
+        let mut watermark = grpc_alpha::Watermark::default();
+        watermark.cursor = Some(Bytes::copy_from_slice(cursor));
+        let mut response = grpc_alpha::ListTransactionsResponse::default();
+        response.response = Some(grpc_alpha::list_transactions_response::Response::Watermark(
+            watermark,
+        ));
+        response
+    }
+
+    fn end_response(reason: grpc_alpha::QueryEndReason) -> grpc_alpha::ListTransactionsResponse {
+        let mut end = grpc_alpha::QueryEnd::default();
+        end.reason = reason as i32;
+        let mut response = grpc_alpha::ListTransactionsResponse::default();
+        response.response = Some(grpc_alpha::list_transactions_response::Response::End(end));
+        response
+    }
+
+    /// Drain a mocked stream. The turbofish pins `I = TransactionItem` for `drain_list_stream`
+    /// since the `R: Into<FrameKind<I>>` bound alone doesn't let Rust infer `I` (Rust doesn't
+    /// search `Into` impls for a unique match, and the return type doesn't propagate backward
+    /// to inner generic calls).
+    async fn drain_iter(
+        responses: Vec<Result<grpc_alpha::ListTransactionsResponse, tonic::Status>>,
+    ) -> anyhow::Result<StreamPage<grpc_alpha::TransactionItem>> {
+        drain_list_stream::<_, grpc_alpha::TransactionItem, _>(
+            "ListTransactions",
+            futures::stream::iter(responses),
+        )
+        .await
+    }
+
+    #[test]
+    fn drains_items_tracking_latest_cursor_and_end_reason() {
+        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        page.apply(item_response(b"c1").into());
+        page.apply(watermark_response(b"c2").into());
+        page.apply(item_response(b"c3").into());
+        page.apply(end_response(grpc_alpha::QueryEndReason::ItemLimit).into());
+
+        assert_eq!(page.items.len(), 2);
+        // `start_cursor` latches on the first cursor-bearing frame (the item at `c1`) and stays
+        // there. `end_cursor` advances on every cursor-bearing frame — item OR standalone watermark
+        // — so it went `c1` → `c2` (the watermark between items) → `c3` (the last item).
+        assert_eq!(page.start_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert_eq!(page.end_cursor.as_deref(), Some(b"c3".as_ref()));
+        assert_eq!(page.end_reason, Some(grpc_alpha::QueryEndReason::ItemLimit));
+    }
+
+    #[test]
+    fn standalone_watermark_advances_cursor_without_items() {
+        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        page.apply(watermark_response(b"w1").into());
+        page.apply(watermark_response(b"w2").into());
+        page.apply(end_response(grpc_alpha::QueryEndReason::LedgerTip).into());
+
+        assert!(page.items.is_empty());
+        assert_eq!(page.start_cursor.as_deref(), Some(b"w1".as_ref()));
+        assert_eq!(page.end_cursor.as_deref(), Some(b"w2".as_ref()));
+        assert_eq!(page.end_reason, Some(grpc_alpha::QueryEndReason::LedgerTip));
+    }
+
+    #[test]
+    fn apply_signals_terminal_only_on_end_frame() {
+        // The bool returned by `apply` is the drain loop's stop signal: `true` means "stop
+        // draining," `false` means "keep going." Only the terminal `End` frame should signal stop.
+        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        assert!(!page.apply(item_response(b"c1").into()));
+        assert!(!page.apply(watermark_response(b"w1").into()));
+        // Outer message with no oneof set → `FrameKind::Unknown` → also non-terminal.
+        assert!(!page.apply(grpc_alpha::ListTransactionsResponse::default().into()));
+        assert!(page.apply(end_response(grpc_alpha::QueryEndReason::LedgerTip).into()));
+    }
+
+    #[test]
+    fn start_cursor_latches_on_first_frame_and_does_not_update() {
+        // Multiple cursor-bearing frames: `start_cursor` should remain at the first one,
+        // `end_cursor` should track the latest.
+        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        page.apply(watermark_response(b"w1").into());
+        page.apply(item_response(b"c2").into());
+        page.apply(watermark_response(b"w3").into());
+        page.apply(item_response(b"c4").into());
+
+        assert_eq!(page.start_cursor.as_deref(), Some(b"w1".as_ref()));
+        assert_eq!(page.end_cursor.as_deref(), Some(b"c4".as_ref()));
+    }
+
+    #[test]
+    fn has_more_true_when_truncated_or_timed_out() {
+        // ITEM_LIMIT and SCAN_LIMIT both signal "we stopped short, resume here".
+        for reason in [
+            grpc_alpha::QueryEndReason::ItemLimit,
+            grpc_alpha::QueryEndReason::ScanLimit,
+        ] {
+            let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+            page.apply(end_response(reason).into());
+            assert!(page.has_more(), "expected has_more for {reason:?}");
+        }
+
+        // `end_reason == None` covers both the deadline cut-short case (no terminal frame
+        // received) and any unrecognized / future-added variant — defaulting to "may have more"
+        // avoids silent truncation.
+        let page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        assert!(page.has_more());
+    }
+
+    #[test]
+    fn has_more_false_when_range_exhausted() {
+        for reason in [
+            grpc_alpha::QueryEndReason::CheckpointBound,
+            grpc_alpha::QueryEndReason::CursorBound,
+            grpc_alpha::QueryEndReason::LedgerTip,
+        ] {
+            let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+            page.apply(end_response(reason).into());
+            assert!(!page.has_more(), "expected !has_more for {reason:?}");
+        }
+    }
+
+    #[test]
+    fn apply_end_with_unknown_reason_folds_to_unspecified() {
+        let mut end = grpc_alpha::QueryEnd::default();
+        end.reason = i32::MAX;
+        let mut response = grpc_alpha::ListTransactionsResponse::default();
+        response.response = Some(grpc_alpha::list_transactions_response::Response::End(end));
+
+        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        page.apply(response.into());
+        assert_eq!(
+            page.end_reason,
+            Some(grpc_alpha::QueryEndReason::Unspecified)
+        );
+    }
+
+    #[test]
+    fn apply_unknown_frame_does_not_mutate_page() {
+        // Outer message with no oneof set — classifies to `FrameKind::Unknown`. `apply` should
+        // warn but leave items / cursors / end_reason untouched.
+        let response = grpc_alpha::ListTransactionsResponse::default();
+
+        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        page.apply(response.into());
+        assert!(page.items.is_empty());
+        assert_eq!(page.start_cursor, None);
+        assert_eq!(page.end_cursor, None);
+        assert_eq!(page.end_reason, None);
+    }
+
+    #[tokio::test]
+    async fn drain_preserves_partial_progress_on_timeout() {
+        let page = drain_iter(vec![
+            Ok(item_response(b"c1")),
+            Ok(item_response(b"c2")),
+            Err(tonic::Status::cancelled("client channel timeout")),
+        ])
+        .await
+        .expect("partial progress should be preserved");
+
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.end_cursor.as_deref(), Some(b"c2".as_ref()));
+        assert_eq!(page.end_reason, None);
+        assert!(page.has_more());
+    }
+
+    #[tokio::test]
+    async fn drain_errors_on_zero_progress_timeout() {
+        drain_iter(vec![Err(tonic::Status::deadline_exceeded("server budget"))])
+            .await
+            .expect_err("zero-progress timeout should error");
+    }
+
+    #[tokio::test]
+    async fn drain_errors_on_zero_progress_half_close() {
+        drain_iter(vec![])
+            .await
+            .expect_err("zero-progress half-close should error");
+    }
+
+    #[tokio::test]
+    async fn drain_propagates_non_timeout_status() {
+        // A real upstream failure (not a timeout) — propagate as an error rather than
+        // pretending the partial page is usable. Even with one item already collected, the
+        // catch-all `Some(Err(status))` arm errors out.
+        drain_iter(vec![
+            Ok(item_response(b"c1")),
+            Err(tonic::Status::internal("upstream blew up")),
+        ])
+        .await
+        .expect_err("non-timeout status should propagate as error");
+    }
+
+    #[tokio::test]
+    async fn drain_returns_page_on_half_close_after_progress() {
+        // Server emitted one item, then half-closed without an End frame. The page is still
+        // valid and resumable from the item's watermark.
+        let page = drain_iter(vec![Ok(item_response(b"c1"))])
+            .await
+            .expect("partial-progress half-close should succeed");
+
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.end_cursor.as_deref(), Some(b"c1".as_ref()));
+        assert_eq!(page.end_reason, None);
+    }
+}

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use futures::Stream;
 use futures::StreamExt;
 use prometheus::Registry;
-use sui_rpc::proto::sui::rpc::v2alpha as grpc_alpha;
+use sui_rpc::proto::sui::rpc::v2alpha as proto;
 use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient;
 use tonic::transport::Channel;
 use tonic::transport::ClientTlsConfig;
@@ -21,8 +21,6 @@ use tracing::warn;
 use crate::ledger_grpc_reader::LedgerGrpcArgs;
 use crate::metrics::GrpcMetricsLayer;
 use crate::metrics::GrpcMetricsService;
-
-const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 
 /// A reader backed by the gRPC LedgerService's v2alpha experimental query APIs.
 #[derive(Clone)]
@@ -36,11 +34,11 @@ pub struct AlphaLedgerGrpcReader {
 pub struct StreamPage<I> {
     /// Items that matched the filters, in stream order.
     pub items: Vec<I>,
-    /// First cursor recorded from an item or watermark.
+    /// First cursor value observed across item and standalone watermark frames.
     pub first_cursor: Option<Bytes>,
-    /// Last cursor recorded from an item or watermark.
+    /// Latest cursor value observed, advances as new cursor-bearing frames arrive.
     pub last_cursor: Option<Bytes>,
-    pub end_reason: Option<grpc_alpha::QueryEndReason>,
+    pub end_reason: Option<proto::QueryEndReason>,
 }
 
 #[derive(Debug)]
@@ -73,9 +71,7 @@ impl AlphaLedgerGrpcReader {
             GrpcMetricsLayer::new(prefix.unwrap_or("ledger_grpc"), registry).layer(channel);
 
         let timeout = args.statement_timeout();
-        let max_decoding_message_size = args
-            .ledger_grpc_max_decoding_message_size
-            .unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE);
+        let max_decoding_message_size = args.max_decoding_message_size();
         let client = LedgerServiceClient::new(layered.clone())
             .max_decoding_message_size(max_decoding_message_size);
 
@@ -84,8 +80,8 @@ impl AlphaLedgerGrpcReader {
 
     pub async fn list_transactions(
         &self,
-        request: grpc_alpha::ListTransactionsRequest,
-    ) -> anyhow::Result<StreamPage<grpc_alpha::TransactionItem>> {
+        request: proto::ListTransactionsRequest,
+    ) -> anyhow::Result<StreamPage<proto::TransactionItem>> {
         let mut client = self.client.clone();
         let stream = client
             .list_transactions(self.request(request))
@@ -115,7 +111,7 @@ impl<I> StreamPage<I> {
     ///   short-circuited. Typically implies that the cursors for the request fell outside the
     ///   available range.
     pub fn has_more(&self) -> bool {
-        use grpc_alpha::QueryEndReason as R;
+        use proto::QueryEndReason as R;
         match self.end_reason {
             None => true,
             Some(R::Unspecified | R::ItemLimit | R::ScanLimit) => true,
@@ -127,18 +123,9 @@ impl<I> StreamPage<I> {
         }
     }
 
-    /// The latest cursor observed in the direction of pagination. Expect `Some` whenever
-    /// `has_more()` is true.
+    /// The latest cursor observed in the direction of pagination.
     pub fn next_cursor(&self) -> Option<&Bytes> {
-        if self.has_more() {
-            Some(
-                self.last_cursor
-                    .as_ref()
-                    .expect("invariant: has_more implies last_cursor is Some"),
-            )
-        } else {
-            self.last_cursor.as_ref()
-        }
+        self.last_cursor.as_ref()
     }
 
     /// Fold one frame into the page. `first_cursor` is set once to the first cursor-bearing frame.
@@ -167,20 +154,17 @@ impl<I> StreamPage<I> {
             FrameKind::End { reason } => {
                 // Fold an unknown reason into `Unspecified` so `None` remains unambiguous shorthand
                 // for "no End frame received" (i.e. the deadline cut the stream short).
-                self.end_reason = match grpc_alpha::QueryEndReason::try_from(reason) {
+                self.end_reason = match proto::QueryEndReason::try_from(reason) {
                     Ok(decoded) => Some(decoded),
                     Err(_) => {
-                        warn!(
-                            reason_int = reason,
-                            "list stream: server sent unknown QueryEndReason",
-                        );
-                        Some(grpc_alpha::QueryEndReason::Unspecified)
+                        warn!(reason, "unknown QueryEndReason",);
+                        Some(proto::QueryEndReason::Unspecified)
                     }
                 };
                 return true;
             }
             FrameKind::Unknown => {
-                warn!("list stream: server sent empty or unrecognized Frame");
+                warn!("unknown Frame");
             }
         }
         false
@@ -198,9 +182,9 @@ impl<I> Default for StreamPage<I> {
     }
 }
 
-impl From<grpc_alpha::ListTransactionsResponse> for FrameKind<grpc_alpha::TransactionItem> {
-    fn from(response: grpc_alpha::ListTransactionsResponse) -> Self {
-        use grpc_alpha::list_transactions_response::Response;
+impl From<proto::ListTransactionsResponse> for FrameKind<proto::TransactionItem> {
+    fn from(response: proto::ListTransactionsResponse) -> Self {
+        use proto::list_transactions_response::Response;
 
         let Some(response) = response.response else {
             return FrameKind::Unknown;
@@ -229,42 +213,38 @@ where
 {
     futures::pin_mut!(stream);
     let mut page = StreamPage::default();
-    loop {
-        match stream.next().await {
-            Some(Ok(response)) => {
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(response) => {
                 // Process and break on receiving `QueryEnd`.
                 if page.apply(response.into()) {
                     break;
                 }
             }
-            // Server closed the stream before sending an `End` frame. Fall-through to the post-loop
-            // check.
-            None => break,
-            // `DeadlineExceeded`: server-side `grpc-timeout` header fired.
-            // `Cancelled`: client-side channel timeout fired (or upstream cancel).
-            // Both are timeout-shaped — preserve partial work if any progress was made;
-            // propagate as error only if zero progress, so the caller can reshape.
-            Some(Err(status))
+            // `DeadlineExceeded`: server-side `grpc-timeout` header fired. `Cancelled`: client-side
+            // channel timeout fired (or upstream cancel). In either case, preserve partial work if
+            // any progress was made.
+            Err(status)
                 if matches!(
                     status.code(),
                     tonic::Code::DeadlineExceeded | tonic::Code::Cancelled
                 ) =>
             {
-                ensure!(
-                    !page.items.is_empty() || page.last_cursor.is_some(),
-                    "{rpc_name} stream {:?} with no progress: {}",
-                    status.code(),
-                    status.message(),
-                );
                 break;
             }
-            Some(Err(status)) => {
-                bail!("{rpc_name} stream error: {}", status.message());
+            // Consider other errors as the request failed, safest to discard partial work.
+            Err(status) => {
+                bail!(
+                    "{rpc_name}: stream error {:?}: {}",
+                    status.code(),
+                    status.message()
+                );
             }
         }
     }
 
-    // If `has_more() promises further data, the cursor to resume from must be present.`
+    // Exited via `break` or via `None`. If `has_more() promises further data, the cursor to resume
+    // from must be present.`
     ensure!(
         !page.has_more() || page.last_cursor.is_some(),
         "{rpc_name}: server reported more results but did not provide resume cursor — cannot continue",
@@ -277,31 +257,31 @@ where
 mod tests {
     use super::*;
 
-    fn item_response(cursor: &[u8]) -> grpc_alpha::ListTransactionsResponse {
-        let mut watermark = grpc_alpha::Watermark::default();
+    fn item_response(cursor: &[u8]) -> proto::ListTransactionsResponse {
+        let mut watermark = proto::Watermark::default();
         watermark.cursor = Some(Bytes::copy_from_slice(cursor));
-        let mut item = grpc_alpha::TransactionItem::default();
+        let mut item = proto::TransactionItem::default();
         item.watermark = Some(watermark);
-        let mut response = grpc_alpha::ListTransactionsResponse::default();
-        response.response = Some(grpc_alpha::list_transactions_response::Response::Item(item));
+        let mut response = proto::ListTransactionsResponse::default();
+        response.response = Some(proto::list_transactions_response::Response::Item(item));
         response
     }
 
-    fn watermark_response(cursor: &[u8]) -> grpc_alpha::ListTransactionsResponse {
-        let mut watermark = grpc_alpha::Watermark::default();
+    fn watermark_response(cursor: &[u8]) -> proto::ListTransactionsResponse {
+        let mut watermark = proto::Watermark::default();
         watermark.cursor = Some(Bytes::copy_from_slice(cursor));
-        let mut response = grpc_alpha::ListTransactionsResponse::default();
-        response.response = Some(grpc_alpha::list_transactions_response::Response::Watermark(
+        let mut response = proto::ListTransactionsResponse::default();
+        response.response = Some(proto::list_transactions_response::Response::Watermark(
             watermark,
         ));
         response
     }
 
-    fn end_response(reason: grpc_alpha::QueryEndReason) -> grpc_alpha::ListTransactionsResponse {
-        let mut end = grpc_alpha::QueryEnd::default();
+    fn end_response(reason: proto::QueryEndReason) -> proto::ListTransactionsResponse {
+        let mut end = proto::QueryEnd::default();
         end.reason = reason as i32;
-        let mut response = grpc_alpha::ListTransactionsResponse::default();
-        response.response = Some(grpc_alpha::list_transactions_response::Response::End(end));
+        let mut response = proto::ListTransactionsResponse::default();
+        response.response = Some(proto::list_transactions_response::Response::End(end));
         response
     }
 
@@ -310,9 +290,9 @@ mod tests {
     /// search `Into` impls for a unique match, and the return type doesn't propagate backward
     /// to inner generic calls).
     async fn drain_iter(
-        responses: Vec<Result<grpc_alpha::ListTransactionsResponse, tonic::Status>>,
-    ) -> anyhow::Result<StreamPage<grpc_alpha::TransactionItem>> {
-        drain_list_stream::<_, grpc_alpha::TransactionItem, _>(
+        responses: Vec<Result<proto::ListTransactionsResponse, tonic::Status>>,
+    ) -> anyhow::Result<StreamPage<proto::TransactionItem>> {
+        drain_list_stream::<_, proto::TransactionItem, _>(
             "ListTransactions",
             futures::stream::iter(responses),
         )
@@ -321,11 +301,11 @@ mod tests {
 
     #[test]
     fn drains_items_tracking_latest_cursor_and_end_reason() {
-        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
         page.apply(item_response(b"c1").into());
         page.apply(watermark_response(b"c2").into());
         page.apply(item_response(b"c3").into());
-        page.apply(end_response(grpc_alpha::QueryEndReason::ItemLimit).into());
+        page.apply(end_response(proto::QueryEndReason::ItemLimit).into());
 
         assert_eq!(page.items.len(), 2);
         // `first_cursor` latches on the first cursor-bearing frame (the item at `c1`) and stays
@@ -333,39 +313,39 @@ mod tests {
         // — so it went `c1` → `c2` (the watermark between items) → `c3` (the last item).
         assert_eq!(page.first_cursor.as_deref(), Some(b"c1".as_ref()));
         assert_eq!(page.last_cursor.as_deref(), Some(b"c3".as_ref()));
-        assert_eq!(page.end_reason, Some(grpc_alpha::QueryEndReason::ItemLimit));
+        assert_eq!(page.end_reason, Some(proto::QueryEndReason::ItemLimit));
     }
 
     #[test]
     fn standalone_watermark_advances_cursor_without_items() {
-        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
         page.apply(watermark_response(b"w1").into());
         page.apply(watermark_response(b"w2").into());
-        page.apply(end_response(grpc_alpha::QueryEndReason::LedgerTip).into());
+        page.apply(end_response(proto::QueryEndReason::LedgerTip).into());
 
         assert!(page.items.is_empty());
         assert_eq!(page.first_cursor.as_deref(), Some(b"w1".as_ref()));
         assert_eq!(page.last_cursor.as_deref(), Some(b"w2".as_ref()));
-        assert_eq!(page.end_reason, Some(grpc_alpha::QueryEndReason::LedgerTip));
+        assert_eq!(page.end_reason, Some(proto::QueryEndReason::LedgerTip));
     }
 
     #[test]
     fn apply_signals_stop_only_on_end_frame() {
         // The bool returned by `apply` is the drain loop's stop signal: `true` means "stop
         // draining," `false` means "keep going." Only the `End` frame should signal stop.
-        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
         assert!(!page.apply(item_response(b"c1").into()));
         assert!(!page.apply(watermark_response(b"w1").into()));
         // Outer message with no oneof set → `FrameKind::Unknown` → continue.
-        assert!(!page.apply(grpc_alpha::ListTransactionsResponse::default().into()));
-        assert!(page.apply(end_response(grpc_alpha::QueryEndReason::LedgerTip).into()));
+        assert!(!page.apply(proto::ListTransactionsResponse::default().into()));
+        assert!(page.apply(end_response(proto::QueryEndReason::LedgerTip).into()));
     }
 
     #[test]
     fn first_cursor_latches_on_first_frame_and_does_not_update() {
         // Multiple cursor-bearing frames: `first_cursor` should remain at the first one,
         // `last_cursor` should track the latest.
-        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
         page.apply(watermark_response(b"w1").into());
         page.apply(item_response(b"c2").into());
         page.apply(watermark_response(b"w3").into());
@@ -379,10 +359,10 @@ mod tests {
     fn has_more_true_when_truncated_or_timed_out() {
         // ITEM_LIMIT and SCAN_LIMIT both signal "we stopped short, resume here".
         for reason in [
-            grpc_alpha::QueryEndReason::ItemLimit,
-            grpc_alpha::QueryEndReason::ScanLimit,
+            proto::QueryEndReason::ItemLimit,
+            proto::QueryEndReason::ScanLimit,
         ] {
-            let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+            let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
             page.apply(end_response(reason).into());
             assert!(page.has_more(), "expected has_more for {reason:?}");
         }
@@ -390,7 +370,7 @@ mod tests {
         // `end_reason == None` covers both the deadline cut-short case (no end frame
         // received) and any unrecognized / future-added variant — defaulting to "may have more"
         // avoids silent truncation.
-        let page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let page: StreamPage<proto::TransactionItem> = StreamPage::default();
         assert!(page.has_more());
     }
 
@@ -400,11 +380,11 @@ mod tests {
         // outside the client's cp scope. `CursorBound` with no tracked cursor is the
         // short-circuit case (range collapsed at request resolution).
         for reason in [
-            grpc_alpha::QueryEndReason::CheckpointBound,
-            grpc_alpha::QueryEndReason::LedgerTip,
-            grpc_alpha::QueryEndReason::CursorBound,
+            proto::QueryEndReason::CheckpointBound,
+            proto::QueryEndReason::LedgerTip,
+            proto::QueryEndReason::CursorBound,
         ] {
-            let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+            let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
             page.apply(end_response(reason).into());
             assert!(!page.has_more(), "expected !has_more for {reason:?}");
         }
@@ -412,9 +392,9 @@ mod tests {
 
     #[test]
     fn has_more_true_on_cursor_bound_with_tracked_cursor() {
-        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
         page.apply(item_response(b"c1").into());
-        page.apply(end_response(grpc_alpha::QueryEndReason::CursorBound).into());
+        page.apply(end_response(proto::QueryEndReason::CursorBound).into());
 
         assert_eq!(page.last_cursor.as_deref(), Some(b"c1".as_ref()));
         assert!(
@@ -425,26 +405,23 @@ mod tests {
 
     #[test]
     fn apply_end_with_unknown_reason_folds_to_unspecified() {
-        let mut end = grpc_alpha::QueryEnd::default();
+        let mut end = proto::QueryEnd::default();
         end.reason = i32::MAX;
-        let mut response = grpc_alpha::ListTransactionsResponse::default();
-        response.response = Some(grpc_alpha::list_transactions_response::Response::End(end));
+        let mut response = proto::ListTransactionsResponse::default();
+        response.response = Some(proto::list_transactions_response::Response::End(end));
 
-        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
         page.apply(response.into());
-        assert_eq!(
-            page.end_reason,
-            Some(grpc_alpha::QueryEndReason::Unspecified)
-        );
+        assert_eq!(page.end_reason, Some(proto::QueryEndReason::Unspecified));
     }
 
     #[test]
     fn apply_unknown_frame_does_not_mutate_page() {
         // Outer message with no oneof set — classifies to `FrameKind::Unknown`. `apply` should
         // warn but leave items / cursors / end_reason untouched.
-        let response = grpc_alpha::ListTransactionsResponse::default();
+        let response = proto::ListTransactionsResponse::default();
 
-        let mut page: StreamPage<grpc_alpha::TransactionItem> = StreamPage::default();
+        let mut page: StreamPage<proto::TransactionItem> = StreamPage::default();
         page.apply(response.into());
         assert!(page.items.is_empty());
         assert_eq!(page.first_cursor, None);

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -3,6 +3,7 @@
 
 use std::time::Duration;
 
+use anyhow::Context;
 use bytes::Bytes;
 use futures::Stream;
 use futures::StreamExt;
@@ -94,7 +95,7 @@ impl AlphaLedgerGrpcReader {
         let stream = client
             .list_transactions(self.request(request))
             .await
-            .map_err(|s| anyhow::anyhow!("ListTransactions stream open failed: {}", s.message()))?
+            .context("ListTransactions stream open failed")?
             .into_inner();
 
         drain_list_stream("ListTransactions", stream).await

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -226,10 +226,10 @@ impl KvArgs {
     }
 
     fn ledger_grpc_args(&self) -> LedgerGrpcArgs {
-        LedgerGrpcArgs {
-            ledger_grpc_statement_timeout_ms: self.kv_statement_timeout_ms,
-            ledger_grpc_max_decoding_message_size: self.kv_max_decoding_message_size,
-        }
+        LedgerGrpcArgs::new(
+            self.kv_statement_timeout_ms,
+            self.kv_max_decoding_message_size,
+        )
     }
 }
 

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -86,7 +86,7 @@ pub struct KvArgs {
     /// Whether the configured ledger gRPC service also has alpha experimental query APIs enabled
     /// (e.g. bitmap-backed transaction pagination). When unset, treated as `false`.
     #[arg(long)]
-    pub enable_experimental_query_apis: Option<bool>,
+    pub experimental_query_apis: Option<bool>,
 
     /// Time spent waiting for a request to the kv store to complete, in milliseconds.
     #[arg(long, alias = "bigtable-statement-timeout-ms")]
@@ -190,14 +190,14 @@ impl KvArgs {
     }
 
     /// Construct a v2alpha streaming reader when the operator has opted in via
-    /// `enable_experimental_query_apis` AND a ledger gRPC URL is configured. Returns `None`
+    /// `experimental_query_apis` AND a ledger gRPC URL is configured. Returns `None`
     /// otherwise. Reuses the same channel settings as the v2 `ledger_grpc_reader`.
     pub async fn alpha_ledger_grpc_reader(
         &self,
         prefix: Option<&str>,
         registry: &Registry,
     ) -> anyhow::Result<Option<AlphaLedgerGrpcReader>> {
-        if !self.enable_experimental_query_apis.unwrap_or(false) {
+        if !self.experimental_query_apis.unwrap_or(false) {
             return Ok(None);
         }
         let Some(ledger_grpc_url) = self.ledger_grpc_url.as_ref() else {

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -30,6 +30,7 @@ use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
 use tonic::transport::Uri;
 
+use crate::alpha_ledger_grpc_reader::AlphaLedgerGrpcReader;
 use crate::bigtable_reader::BigtableArgs;
 use crate::bigtable_reader::BigtableReader;
 use crate::checkpoints::CheckpointDigestKey;
@@ -81,6 +82,11 @@ pub struct KvArgs {
     /// gRPC endpoint URL for the ledger service (e.g., archive.mainnet.sui.io)
     #[arg(long, group = "kv_source")]
     pub ledger_grpc_url: Option<Uri>,
+
+    /// Whether the configured ledger gRPC service also has alpha experimental query APIs enabled
+    /// (e.g. bitmap-backed transaction pagination). When unset, treated as `false`.
+    #[arg(long)]
+    pub enable_experimental_query_apis: Option<bool>,
 
     /// Time spent waiting for a request to the kv store to complete, in milliseconds.
     #[arg(long, alias = "bigtable-statement-timeout-ms")]
@@ -174,6 +180,32 @@ impl KvArgs {
 
         Ok(Some(
             LedgerGrpcReader::new(
+                ledger_grpc_url.clone(),
+                self.ledger_grpc_args(),
+                prefix,
+                registry,
+            )
+            .await?,
+        ))
+    }
+
+    /// Construct a v2alpha streaming reader when the operator has opted in via
+    /// `enable_experimental_query_apis` AND a ledger gRPC URL is configured. Returns `None`
+    /// otherwise. Reuses the same channel settings as the v2 `ledger_grpc_reader`.
+    pub async fn alpha_ledger_grpc_reader(
+        &self,
+        prefix: Option<&str>,
+        registry: &Registry,
+    ) -> anyhow::Result<Option<AlphaLedgerGrpcReader>> {
+        if !self.enable_experimental_query_apis.unwrap_or(false) {
+            return Ok(None);
+        }
+        let Some(ledger_grpc_url) = self.ledger_grpc_url.as_ref() else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            AlphaLedgerGrpcReader::new(
                 ledger_grpc_url.clone(),
                 self.ledger_grpc_args(),
                 prefix,

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -21,8 +21,6 @@ use tower::Layer;
 use crate::metrics::GrpcMetricsLayer;
 use crate::metrics::GrpcMetricsService;
 
-const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
-
 #[derive(clap::Args, Debug, Clone)]
 pub struct LedgerGrpcArgs {
     /// Timeout for gRPC statements to the ledger service, in milliseconds.
@@ -30,8 +28,8 @@ pub struct LedgerGrpcArgs {
     pub ledger_grpc_statement_timeout_ms: Option<u64>,
 
     /// Maximum gRPC decoding message size for Ledger service responses, in bytes.
-    #[arg(long)]
-    pub ledger_grpc_max_decoding_message_size: Option<usize>,
+    #[arg(long, default_value_t = 32 * 1024 * 1024)]
+    pub ledger_grpc_max_decoding_message_size: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -56,14 +54,21 @@ pub struct LedgerGrpcReader {
 }
 
 impl LedgerGrpcArgs {
+    pub fn new(
+        statement_timeout_ms: Option<u64>,
+        max_decoding_message_size: Option<usize>,
+    ) -> Self {
+        let defaults = Self::default();
+        Self {
+            ledger_grpc_statement_timeout_ms: statement_timeout_ms,
+            ledger_grpc_max_decoding_message_size: max_decoding_message_size
+                .unwrap_or(defaults.ledger_grpc_max_decoding_message_size),
+        }
+    }
+
     pub fn statement_timeout(&self) -> Option<std::time::Duration> {
         self.ledger_grpc_statement_timeout_ms
             .map(Duration::from_millis)
-    }
-
-    pub fn max_decoding_message_size(&self) -> usize {
-        self.ledger_grpc_max_decoding_message_size
-            .unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE)
     }
 }
 
@@ -89,11 +94,8 @@ impl LedgerGrpcReader {
             GrpcMetricsLayer::new(prefix.unwrap_or("ledger_grpc"), registry).layer(channel);
 
         let timeout = args.statement_timeout();
-        let max_decoding_message_size = args
-            .ledger_grpc_max_decoding_message_size
-            .unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE);
-        let client =
-            LedgerServiceClient::new(layered).max_decoding_message_size(max_decoding_message_size);
+        let client = LedgerServiceClient::new(layered)
+            .max_decoding_message_size(args.ledger_grpc_max_decoding_message_size);
 
         Ok(Self { client, timeout })
     }
@@ -207,7 +209,7 @@ impl Default for LedgerGrpcArgs {
     fn default() -> Self {
         Self {
             ledger_grpc_statement_timeout_ms: None,
-            ledger_grpc_max_decoding_message_size: Some(DEFAULT_MAX_DECODING_MESSAGE_SIZE),
+            ledger_grpc_max_decoding_message_size: 32 * 1024 * 1024,
         }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -23,7 +23,7 @@ use crate::metrics::GrpcMetricsService;
 
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 
-#[derive(clap::Args, Debug, Clone, Default)]
+#[derive(clap::Args, Debug, Clone)]
 pub struct LedgerGrpcArgs {
     /// Timeout for gRPC statements to the ledger service, in milliseconds.
     #[arg(long)]
@@ -59,6 +59,11 @@ impl LedgerGrpcArgs {
     pub fn statement_timeout(&self) -> Option<std::time::Duration> {
         self.ledger_grpc_statement_timeout_ms
             .map(Duration::from_millis)
+    }
+
+    pub fn max_decoding_message_size(&self) -> usize {
+        self.ledger_grpc_max_decoding_message_size
+            .unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE)
     }
 }
 
@@ -195,5 +200,14 @@ impl LedgerGrpcReader {
             request.set_timeout(timeout);
         }
         request
+    }
+}
+
+impl Default for LedgerGrpcArgs {
+    fn default() -> Self {
+        Self {
+            ledger_grpc_statement_timeout_ms: None,
+            ledger_grpc_max_decoding_message_size: Some(DEFAULT_MAX_DECODING_MESSAGE_SIZE),
+        }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/lib.rs
+++ b/crates/sui-indexer-alt-reader/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod alpha_ledger_grpc_reader;
 pub mod bigtable_reader;
 pub mod checkpoints;
 pub mod consistent_reader;


### PR DESCRIPTION
## Description 
New ledger grpc reader for alpha bitmap streaming apis to be used by graphql. Supports draining a stream from a single grpc request. 

Setup is through KvArgs controlled by a new `Option<bool>` flag, and reuses the same config for ledger service. This alpha ledger service gets added to graphql context if instantiated.

## Test plan 

Tests in new `alpha_ledger_grpc_reader.rs` file


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
