### PR TITLE
fix(ci): derive release cache_family from the .0 minor branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,10 @@ jobs:
         run: |
           sui_tag="${{ env.TAG_NAME }}"
           sui_version=$(echo "${sui_tag}" | sed -e 's|^refs/tags/||' -e 's/^mainnet-v//' -e 's/^testnet-v//' -e 's/^devnet-v//')
-          echo "cache_family=releases/sui-v${sui_version}-release" >> "$GITHUB_OUTPUT"
+          # Release branches are cut per minor version at patch .0; patches (e.g. v1.73.1)
+          # land as commits on that branch, so bucket the cache by the .0 branch that exists.
+          release_branch_version=$(echo "${sui_version}" | awk -F. '{print $1"."$2".0"}')
+          echo "cache_family=releases/sui-v${release_branch_version}-release" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch Tagging of images in DockerHub, in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
@@ -289,7 +292,10 @@ jobs:
         run: |
           sui_tag="${{ env.TAG_NAME }}"
           sui_version=$(echo "${sui_tag}" | sed -e 's|^refs/tags/||' -e 's/^mainnet-v//' -e 's/^testnet-v//' -e 's/^devnet-v//')
-          echo "cache_family=releases/sui-v${sui_version}-release" >> "$GITHUB_OUTPUT"
+          # Release branches are cut per minor version at patch .0; patches (e.g. v1.73.1)
+          # land as commits on that branch, so bucket the cache by the .0 branch that exists.
+          release_branch_version=$(echo "${sui_version}" | awk -F. '{print $1"."$2".0"}')
+          echo "cache_family=releases/sui-v${release_branch_version}-release" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch ensure-sui-binaries in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1


### PR DESCRIPTION
## Problem
The two **Derive cache_family from release tag** steps in `release.yml` build the branch name from the full release version:
```bash
sui_version=...   # e.g. 1.73.1 (from tag testnet-v1.73.1)
echo "cache_family=releases/sui-v${sui_version}-release"   # → releases/sui-v1.73.1-release ❌
```
That branch **does not exist** — sui cuts one release branch per **minor** version at patch `.0` (`releases/sui-v1.73.0-release`), and patches (1.73.1, 1.73.2, …) land as commits *on that branch*. The bad name is dispatched to `MystenLabs/sui-operations` (`tag-docker-images` and `ensure-sui-binaries`) as the **mp3 `cache_family`**.

**Observed:** v1.73.1 release builds (`sui-bridge-indexer-alt`, `sui-bridge-indexer`, `sui-checkpoint-blob-indexer` at `ff1fe0ec`) carried `cache_family: releases/sui-v1.73.1-release`. Because that bucket doesn't correspond to a real branch, patch-release builds don't share the warm `/cargo-target` cache of the actual release branch — they start cold.

## Fix
Force the patch component to `0` so the family points at the branch that exists:
```bash
release_branch_version=$(echo "${sui_version}" | awk -F. '{print $1"."$2".0"}')
echo "cache_family=releases/sui-v${release_branch_version}-release"   # 1.73.1 → releases/sui-v1.73.0-release ✅
```
Applied to both steps (DockerHub tag dispatch + S3 binaries dispatch). `1.73.0` → `1.73.0` (unchanged), `1.74.2` → `1.74.0`.

## Test
- `1.73.1 → 1.73.0`, `1.73.0 → 1.73.0`, `1.74.2 → 1.74.0` verified locally.
- `actionlint` clean on the changed steps.

## Note
`MystenLabs/sui-operations` `continuous-release.yml` has the same *class* of latent bug (it derives the branch from main's version with the patch carried through), currently masked because main is `1.74.0`. Worth a companion fix there for robustness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)