### PR TITLE
Custom `TransactionConnection` to support partially-filled results from bitmap streaming 2/n

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -63,6 +63,7 @@ use crate::api::types::signature_verify::SignatureVerifyResult;
 use crate::api::types::simulation_result::SimulationResult;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::transaction_effects::TransactionEffects;
@@ -718,7 +719,7 @@ impl Query {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         Some(
             async {
                 let scope = self.scope(ctx)?;

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -40,6 +40,7 @@ use crate::api::types::object_filter::ObjectFilter;
 use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::transaction_effects::EffectsContents;
@@ -491,7 +492,7 @@ impl Address {
         before: Option<CTransaction>,
         relation: Option<AddressTransactionRelationship>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         Some(
             async {
                 let pagination: &PaginationConfig = ctx.data()?;
@@ -515,7 +516,7 @@ impl Address {
 
                 // Intersect with user-provided filter
                 let Some(filter) = filter.unwrap_or_default().intersect(address_filter) else {
-                    return Ok(Connection::new(false, false));
+                    return Ok(Connection::new(false, false).into());
                 };
 
                 Transaction::paginate(ctx, self.scope.clone(), page, filter).await

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -30,6 +30,7 @@ use crate::api::types::epoch::Epoch;
 use crate::api::types::gas::GasCostSummary;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::validator_aggregated_signature::ValidatorAggregatedSignature;
@@ -221,7 +222,7 @@ impl CheckpointContents {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         async {
             let Some((summary, _, _)) = &self.contents else {
                 return Ok(None);
@@ -235,7 +236,7 @@ impl CheckpointContents {
                 at_checkpoint: Some(UInt53::from(summary.sequence_number)),
                 ..Default::default()
             }) else {
-                return Ok(Some(Connection::new(false, false)));
+                return Ok(Some(Connection::new(false, false).into()));
             };
 
             if let Some(streamed) = &self.streamed_data {

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -50,6 +50,7 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::error::RpcError;
 use crate::error::upcast;
@@ -425,7 +426,7 @@ impl CoinMetadata {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -49,6 +49,7 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::config::Limits;
 use crate::error::RpcError;
@@ -415,7 +416,7 @@ impl DynamicField {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -47,6 +47,7 @@ use crate::api::types::object::Object;
 use crate::api::types::protocol_configs::ProtocolConfigs;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::validator_set::ValidatorSet;
@@ -425,7 +426,7 @@ impl Epoch {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         async {
             let (Some(start), end) = try_join!(self.start(ctx), self.end(ctx))? else {
                 return Ok(None);
@@ -451,7 +452,7 @@ impl Epoch {
                 before_checkpoint: Some(UInt53::from(cp_hi)),
                 ..Default::default()
             }) else {
-                return Ok(Some(Connection::new(false, false)));
+                return Ok(Some(Connection::new(false, false).into()));
             };
 
             Ok(Some(

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -40,6 +40,7 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::error::RpcError;
 use crate::pagination::Page;
@@ -487,7 +488,7 @@ impl MoveObject {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -57,6 +57,7 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::type_origin::TypeOrigin;
 use crate::error::RpcError;
@@ -548,7 +549,7 @@ impl MovePackage {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         self.super_
             .received_transactions(ctx, first, after, last, before, filter)
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -67,6 +67,7 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::owner::Owner;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
@@ -150,7 +151,7 @@ use crate::task::watermark::Watermarks;
         arg(name = "last", ty = "Option<u64>"),
         arg(name = "before", ty = "Option<CTransaction>"),
         arg(name = "filter", ty = "Option<TransactionFilter>"),
-        ty = "Option<Result<Connection<String, Transaction>, RpcError>>",
+        ty = "Option<Result<TransactionConnection, RpcError>>",
         desc = "The transactions that sent objects to this object."
     )
 )]
@@ -644,7 +645,7 @@ impl Object {
         last: Option<u64>,
         before: Option<CTransaction>,
         filter: Option<TransactionFilter>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         let result = async {
             let pagination: &PaginationConfig = ctx.data()?;
             let limits = pagination.limits("IObject", "receivedTransactions");
@@ -658,7 +659,7 @@ impl Object {
 
             // Intersect with user-provided filter
             let Some(filter) = filter.unwrap_or_default().intersect(address_filter) else {
-                return Ok(Connection::new(false, false));
+                return Ok(Connection::new(false, false).into());
             };
 
             Transaction::paginate(ctx, self.super_.scope.clone(), page, filter).await

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -75,24 +75,6 @@ pub(crate) struct TransactionConnection {
     pub page_info: PageInfo,
 }
 
-#[Object]
-impl TransactionConnection {
-    /// Information to aid in pagination.
-    async fn page_info(&self) -> &PageInfo {
-        &self.page_info
-    }
-
-    /// A list of edges.
-    async fn edges(&self) -> &[Edge<String, Transaction, EmptyFields>] {
-        &self.edges
-    }
-
-    /// A list of nodes.
-    async fn nodes(&self) -> Vec<&Transaction> {
-        self.edges.iter().map(|e| &e.node).collect()
-    }
-}
-
 /// Description of a transaction, the unit of activity on Sui.
 #[Object]
 impl Transaction {
@@ -132,6 +114,24 @@ impl Transaction {
     #[graphql(flatten)]
     async fn contents(&self, ctx: &Context<'_>) -> Result<TransactionContents, RpcError> {
         self.contents.fetch(ctx, self.digest).await
+    }
+}
+
+#[Object]
+impl TransactionConnection {
+    /// Information to aid in pagination.
+    async fn page_info(&self) -> &PageInfo {
+        &self.page_info
+    }
+
+    /// A list of edges.
+    async fn edges(&self) -> &[Edge<String, Transaction, EmptyFields>] {
+        &self.edges
+    }
+
+    /// A list of nodes.
+    async fn nodes(&self) -> Vec<&Transaction> {
+        self.edges.iter().map(|e| &e.node).collect()
     }
 }
 
@@ -336,7 +336,7 @@ impl Transaction {
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 
         let Some(query) = filter.tx_bounds(ctx, &scope, reader_lo, &page).await? else {
-            return Ok(Connection::new(false, false).into());
+            return Ok(TransactionConnection::empty());
         };
 
         let TransactionFilter {
@@ -427,6 +427,20 @@ impl TransactionContents {
             scope: self.scope.clone(),
             contents: Some(Arc::new(transaction)),
         })
+    }
+}
+
+impl TransactionConnection {
+    pub fn empty() -> Self {
+        Self {
+            edges: vec![],
+            page_info: PageInfo {
+                has_next_page: false,
+                has_previous_page: false,
+                start_cursor: None,
+                end_cursor: None,
+            },
+        }
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -431,7 +431,7 @@ impl TransactionContents {
 }
 
 impl TransactionConnection {
-    pub fn empty() -> Self {
+    fn empty() -> Self {
         Self {
             edges: vec![],
             page_info: PageInfo {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -435,8 +435,8 @@ impl TransactionConnection {
         Self {
             edges: vec![],
             page_info: PageInfo {
-                has_next_page: false,
                 has_previous_page: false,
+                has_next_page: false,
                 start_cursor: None,
                 end_cursor: None,
             },

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -8,6 +8,9 @@ use anyhow::Context as _;
 use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
+use async_graphql::connection::Edge;
+use async_graphql::connection::EmptyFields;
+use async_graphql::connection::PageInfo;
 use async_graphql::dataloader::DataLoader;
 use diesel::QueryableByName;
 use diesel::sql_types::BigInt;
@@ -66,6 +69,29 @@ pub(crate) struct TransactionContents {
 }
 
 pub(crate) type CTransaction = JsonCursor<u64>;
+
+pub(crate) struct TransactionConnection {
+    pub edges: Vec<Edge<String, Transaction, EmptyFields>>,
+    pub page_info: PageInfo,
+}
+
+#[Object]
+impl TransactionConnection {
+    /// Information to aid in pagination.
+    async fn page_info(&self) -> &PageInfo {
+        &self.page_info
+    }
+
+    /// A list of edges.
+    async fn edges(&self) -> &[Edge<String, Transaction, EmptyFields>] {
+        &self.edges
+    }
+
+    /// A list of nodes.
+    async fn nodes(&self) -> Vec<&Transaction> {
+        self.edges.iter().map(|e| &e.node).collect()
+    }
+}
 
 /// Description of a transaction, the unit of activity on Sui.
 #[Object]
@@ -253,7 +279,7 @@ impl Transaction {
         transactions: &[ProcessedTransaction],
         page: &Page<CTransaction>,
         filter: TransactionFilter,
-    ) -> Result<Connection<String, Transaction>, RpcError> {
+    ) -> Result<TransactionConnection, RpcError> {
         let after = page.after().map(|c| **c);
         let before = page.before().map(|c| **c);
 
@@ -270,6 +296,7 @@ impl Transaction {
             |tx| JsonCursor::new(tx.tx_sequence_number),
             |tx| Transaction::with_contents(scope.clone(), tx.contents.clone()),
         )
+        .map(Into::into)
     }
 
     /// Load the transaction from the store, and return it fully inflated (with contents already
@@ -299,7 +326,7 @@ impl Transaction {
         scope: Scope,
         page: Page<CTransaction>,
         filter: TransactionFilter,
-    ) -> Result<Connection<String, Transaction>, RpcError> {
+    ) -> Result<TransactionConnection, RpcError> {
         let watermarks: &Arc<Watermarks> = ctx.data()?;
         let available_range_key = AvailableRangeKey {
             type_: "Query".to_string(),
@@ -309,7 +336,7 @@ impl Transaction {
         let reader_lo = available_range_key.reader_lo(watermarks)?;
 
         let Some(query) = filter.tx_bounds(ctx, &scope, reader_lo, &page).await? else {
-            return Ok(Connection::new(false, false));
+            return Ok(Connection::new(false, false).into());
         };
 
         let TransactionFilter {
@@ -342,6 +369,7 @@ impl Transaction {
             |(s, _)| JsonCursor::new(*s),
             |(_, d)| Ok(Self::with_digest(scope.clone(), d)),
         )
+        .map(Into::into)
     }
 }
 
@@ -415,6 +443,25 @@ impl From<TransactionEffects> for Transaction {
         Self {
             digest: fx.digest,
             contents: TransactionContents { scope, contents },
+        }
+    }
+}
+
+impl From<Connection<String, Transaction>> for TransactionConnection {
+    /// Convert a stock async-graphql `Connection` (as produced by the PG path's
+    /// `Page::paginate_results`) into the custom shape. Cursors are derived from edges, matching
+    /// stock semantics.
+    fn from(conn: Connection<String, Transaction>) -> Self {
+        let start_cursor = conn.edges.first().map(|e| e.cursor.clone());
+        let end_cursor = conn.edges.last().map(|e| e.cursor.clone());
+        Self {
+            edges: conn.edges,
+            page_info: PageInfo {
+                has_previous_page: conn.has_previous_page,
+                has_next_page: conn.has_next_page,
+                start_cursor,
+                end_cursor,
+            },
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -42,6 +42,7 @@ use crate::api::types::execution_error::ExecutionError;
 use crate::api::types::gas_effects::GasEffects;
 use crate::api::types::object_change::ObjectChange;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::TransactionContents;
 use crate::api::types::unchanged_consensus_object::UnchangedConsensusObject;
 use crate::error::RpcError;
@@ -469,7 +470,7 @@ impl EffectsContents {
         after: Option<CDependency>,
         last: Option<u64>,
         before: Option<CDependency>,
-    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         let content = self.contents.as_ref()?;
 
         Some(
@@ -486,6 +487,7 @@ impl EffectsContents {
                         dependencies[i],
                     ))
                 })
+                .map(Into::into)
             }
             .await,
         )


### PR DESCRIPTION
## Description 

Once we switch the backend from postgres to bitmap streams, we can return partially-filled pages (where previously we would timeout.) In order to do so, we need to define custom connections instead of using async-graphql's stock `Connection` (which derives cursors from `items`).

PR stack:
https://github.com/MystenLabs/sui/pull/26894

## Test plan 

Existing tests should pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
