### PR TITLE
docs: remove testnet-only notices from PAS documentation

### DIFF
--- a/docs/content/onchain-finance/pas/integrating-pas.mdx
+++ b/docs/content/onchain-finance/pas/integrating-pas.mdx
@@ -5,12 +5,6 @@ description: Learn how to integrate with the PAS standard.
 keywords: [ approval, witness, policy, currency policy, pas template, approval logic, pas approval, permissioned assets, integrate with pas ]
 ---
 
-:::caution
-
-Permissioned Asset Standard is currently available on Testnet. It is not yet live on Mainnet.
-
-:::
-
 To integrate with the Permissioned Assets Standard (PAS), you must:
 
 1. Define your approval witness using `public struct MyApproval() has drop;`.

--- a/docs/content/onchain-finance/pas/pas-architecture.mdx
+++ b/docs/content/onchain-finance/pas/pas-architecture.mdx
@@ -4,12 +4,6 @@ description: Learn how the Permissioned Asset Standard (PAS) enforces restricted
 keywords: [ PAS, Permissioned Asset Standard, Account, Policy, Request, approval, permissioned assets, closed-loop ]
 ---
 
-:::caution
-
-Permissioned Asset Standard is currently available on Testnet. It is not yet live on Mainnet.
-
-:::
-
 On Sui, any object with the `store` ability can be freely transferred by its owner. `Balance` and `Coin` both have `store`, meaning if you hold them, you can send them anywhere on the network with no restrictions.
 
 This works well for general-purpose assets, but creates a problem for regulated assets that need transfer controls, compliance checks, or issuer oversight.

--- a/docs/content/onchain-finance/pas/querying-assets.mdx
+++ b/docs/content/onchain-finance/pas/querying-assets.mdx
@@ -43,7 +43,7 @@ The following example shows how to query both regular and PAS-managed balances:
 ```tsx
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { pas } from '@mysten/pas';
-const client = new SuiGrpcClient({ network: 'testnet' }).$extend(pas());
+const client = new SuiGrpcClient({ network: 'mainnet' }).$extend(pas());
 const walletAddress = '0xAlice';
 // Regular balances — query the wallet address directly
 const regularBalances = await client.core.getAllBalances({

--- a/docs/content/onchain-finance/types-of-assets.mdx
+++ b/docs/content/onchain-finance/types-of-assets.mdx
@@ -82,12 +82,6 @@ Use the Currency standard if you are:
 
 ## Permissioned assets
 
-:::caution
-
-Permissioned Asset Standard is currently available on Testnet. It is not yet live on Mainnet.
-
-:::
-
 The Permissioned Asset Standard (PAS) enables asset ownership through Account objects. Account objects can hold assets and enforce transfer controls and compliance checks. Accounts can only hold one asset, independent of its types, and the asset can only move between Accounts through hot potato requests that must be approved and resolved in the same programmable transaction block (PTB).
 
 PAS uses Sui [Address Balances](/onchain-finance/asset-custody/address-balances/using-address-balances). PAS balances are managed by PAS on behalf of the wallet address. They are held in a derived Account object, however, transfers always target the wallet address, not the Account address.


### PR DESCRIPTION
## Summary
- Removes the `:::caution` banners from three PAS pages that stated "Permissioned Asset Standard is currently available on Testnet. It is not yet live on Mainnet."
- Updates the code example in `querying-assets.mdx` from `network: 'testnet'` to `network: 'mainnet'`

## Test plan
- [ ] Verify `types-of-assets.mdx`, `integrating-pas.mdx`, and `pas-architecture.mdx` no longer show the testnet-only caution banner
- [ ] Verify the code example in `querying-assets.mdx` uses `mainnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)