### PR TITLE
Split latest account amount reads

### DIFF
--- a/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
+++ b/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
@@ -230,13 +230,15 @@ Together these two checks guarantee that the eager scheduler never schedules wit
 a version that some component (in-memory or on-disk) has already moved past, regardless of
 which path delivered the settlement.
 
-### 3.1.1 Why a latest-state read is sufficient here
+### 3.1.1 Why a root-consistent read is sufficient here
 
 This is a place where the address-funds scheduler is intentionally asking a weaker question than
 the object-funds checker asks later in the pipeline.
 
-For an untracked account, `get_latest_account_amount` returns both the latest visible balance and
-the version that balance came from. The scheduler uses that pair for two purposes only:
+For an untracked account, `get_consistent_latest_account_amount_and_version` returns a balance and
+the root accumulator version that balance is consistent with. The balance may be older than the
+latest account object amount if the account object has advanced ahead of the root. The scheduler
+uses that pair for two purposes only:
 
 1. **Staleness detection.** If storage already says "this account is at version > V", then the
    scheduler knows the request for version V is stale and returns `SkipSchedule`.

--- a/crates/sui-core/src/accumulators/design_docs/data_model.md
+++ b/crates/sui-core/src/accumulators/design_docs/data_model.md
@@ -206,12 +206,14 @@ scheduler's point of view, this lifecycle is mostly invisible — it sees deposi
 as `funds_changes: BTreeMap<AccumulatorObjId, i128>` deltas — but it is reflected in the
 storage-version reads:
 
-- For an account that doesn't exist yet, `get_latest_account_amount` returns
+- For an account that doesn't exist yet, `get_consistent_latest_account_amount_and_version` returns
   `(0, current_root_version)`.
 - After deletion, the same call returns `(0, current_root_version)`.
-- Between creation and deletion, it returns `(balance, account_object_version)`.
+- Between creation and deletion, it returns `(balance_at_or_before_root, current_root_version)`.
+  If the account object has advanced ahead of the root, this may be older than the latest account
+  object amount.
 
-This shape — "balance plus the version it was read at" — is what lets the scheduler detect when
+This shape — "balance plus the root version it is consistent with" — is what lets the scheduler detect when
 storage has advanced past a request even without an in-process settlement notification (see
 [`address_funds_scheduling.md`](./address_funds_scheduling.md) §3).
 

--- a/crates/sui-core/src/accumulators/funds_read.rs
+++ b/crates/sui-core/src/accumulators/funds_read.rs
@@ -12,10 +12,20 @@ use sui_types::{
 };
 
 pub trait AccountFundsRead: Send + Sync {
-    /// Gets latest amount in account together with the version of the accumulator root object.
-    /// If the account does not exist, returns the current root accumulator version.
+    /// Gets the latest amount in an account. If the account does not exist, returns 0.
+    /// This does an unsequenced read and does not guarantee consistency with the root accumulator
+    /// version.
+    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> u128;
+
+    /// Gets the account amount at a version consistent with a stable accumulator root version.
+    /// If the account object has advanced ahead of that root version, this returns the amount
+    /// at or before the root version instead of the latest account object amount. If the account
+    /// does not exist at that root version, returns 0 for the amount.
     /// It guarantees no data race between the read of the account object and the root accumulator version.
-    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> (u128, SequenceNumber);
+    fn get_consistent_latest_account_amount_and_version(
+        &self,
+        account_id: &AccumulatorObjId,
+    ) -> (u128, SequenceNumber);
 
     /// Read the amount at a precise version. Care must be taken to only call this function if we
     /// can guarantee that objects behind this version have not yet been pruned.
@@ -33,7 +43,7 @@ pub trait AccountFundsRead: Send + Sync {
         requested_amounts: &BTreeMap<AccumulatorObjId, (u64, TypeTag)>,
     ) -> SuiResult {
         for (object_id, (requested_amount, _type_tag)) in requested_amounts {
-            let (actual_amount, _) = self.get_latest_account_amount(object_id);
+            let actual_amount = self.get_latest_account_amount(object_id);
 
             if actual_amount < *requested_amount as u128 {
                 return Err(SuiErrorKind::UserInputError {
@@ -61,7 +71,7 @@ pub trait AccountFundsRead: Send + Sync {
         min_amounts: &BTreeMap<TypeTag, u64>,
     ) -> SuiResult {
         for (object_id, (requested_amount, type_tag)) in requested_amounts {
-            let (actual_amount, _) = self.get_latest_account_amount(object_id);
+            let actual_amount = self.get_latest_account_amount(object_id);
             let remaining = actual_amount.saturating_sub(*requested_amount as u128);
             if remaining == 0 {
                 continue;

--- a/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
@@ -128,8 +128,7 @@ impl TestEnv {
             AccumulatorValue::get_field_id(self.vault_obj.into(), &Balance::type_tag(type_tag))
                 .unwrap();
         let balance_read = self.authority.get_account_funds_read();
-        let (balance, _version) = balance_read.get_latest_account_amount(&account_id);
-        balance
+        balance_read.get_latest_account_amount(&account_id)
     }
 }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2563,7 +2563,7 @@ impl AuthorityState {
                 .iter()
                 .filter(|(id, _)| !address_funds.contains(id))
                 .any(|(id, max_withdraw)| {
-                    let (balance, _) = self.get_account_funds_read().get_latest_account_amount(id);
+                    let balance = self.get_account_funds_read().get_latest_account_amount(id);
                     balance < *max_withdraw
                 });
 

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -1173,12 +1173,11 @@ async fn test_transaction_cache_race() {
 // Regression test for the race described in Mark's original report: an account at
 // version V is deleted by a settlement tx that writes a tombstone at V+1, but the
 // barrier tx that bumps the root from V to V+1 has not yet run. In that window a
-// reader observes (live object at V, tombstone at V+1, root at V). Before the MVCC
-// fix, `get_latest_account_amount` would read the latest account (the tombstone),
-// fall through to re-read the root (still V), and return (0, V) — even though the
-// correct balance at V was non-zero.
+// reader observes (live object at V, tombstone at V+1, root at V). The consistent
+// read must cap the account read at the root version instead of reading the latest
+// account tombstone.
 #[tokio::test]
-async fn test_get_latest_account_amount_race_with_pending_settlement() {
+async fn test_get_consistent_latest_account_amount_race_with_pending_settlement() {
     use crate::accumulators::funds_read::AccountFundsRead;
     use sui_types::{
         SUI_ACCUMULATOR_ROOT_OBJECT_ID, accumulator_root::AccumulatorValue, balance::Balance,
@@ -1230,11 +1229,15 @@ async fn test_get_latest_account_amount_race_with_pending_settlement() {
     // V to V+1.
     cache.write_object_entry(account_id.inner(), v.next(), ObjectEntry::Deleted);
 
-    // The read must observe the pre-settlement balance at V: settlement must appear
-    // atomic to readers. Before the fix this returned (0, V) because the latest
-    // account read produced None (the tombstone at V+1) while the root had not
-    // advanced past V.
-    let (balance, version) = AccountFundsRead::get_latest_account_amount(&*cache, &account_id);
+    assert_eq!(
+        AccountFundsRead::get_latest_account_amount(&*cache, &account_id),
+        0
+    );
+
+    // The consistent read must observe the pre-settlement balance at V: settlement
+    // must appear atomic to readers that need the root version paired with the amount.
+    let (balance, version) =
+        AccountFundsRead::get_consistent_latest_account_amount_and_version(&*cache, &account_id);
     assert_eq!(version, v);
     assert_eq!(balance, expected_balance as u128);
 }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -1382,8 +1382,23 @@ impl WritebackCache {
     }
 }
 
+fn account_amount_from_object(account_obj: &Object) -> u128 {
+    let (_, AccumulatorValue::U128(value)) =
+        account_obj.data.try_as_move().unwrap().try_into().unwrap();
+    value.value
+}
+
 impl AccountFundsRead for WritebackCache {
-    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> (u128, SequenceNumber) {
+    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> u128 {
+        ObjectCacheRead::get_object(self, account_id.inner())
+            .map(|account_obj| account_amount_from_object(&account_obj))
+            .unwrap_or(0)
+    }
+
+    fn get_consistent_latest_account_amount_and_version(
+        &self,
+        account_id: &AccumulatorObjId,
+    ) -> (u128, SequenceNumber) {
         // Settlement is not atomic. A settlement transaction writes the accumulator
         // objects at version V+1 first, and then a later barrier transaction bumps the
         // root from V to V+1. A reader that observes the state in between sees
@@ -1397,8 +1412,9 @@ impl AccountFundsRead for WritebackCache {
         //    By construction of the settlement/barrier ordering, every account object's
         //    version is <= the root version after the corresponding barrier runs, so
         //    capping at the captured root strips away any newer-settlement writes that
-        //    have raced ahead of the barrier — we get the balance consistent with the
-        //    root version we captured.
+        //    have raced ahead of the barrier. The returned amount is the balance at or
+        //    before the captured root version, even if the account object has a newer
+        //    latest version by the time this method returns.
         //
         // 2. Root-version stability check (pre == post). `get_account_amount_at_version`
         //    is only safe to call when the target version has not been pruned. Pruning
@@ -1413,6 +1429,7 @@ impl AccountFundsRead for WritebackCache {
                 .version();
         let mut loop_iter = 0;
         loop {
+            loop_iter += 1;
             // Safe because of (1) and (2) above: the stability check below bounds the
             // lifetime of `pre_root_version` to a window in which no pruning happens.
             let value = self.get_account_amount_at_version(account_id, pre_root_version);
@@ -1421,6 +1438,12 @@ impl AccountFundsRead for WritebackCache {
                     .unwrap()
                     .version();
             if pre_root_version == post_root_version {
+                if loop_iter > 3 {
+                    debug_fatal!(
+                        "Root version stabilized after {} iterations during MVCC read",
+                        loop_iter
+                    );
+                }
                 return (value, pre_root_version);
             }
             debug!(
@@ -1428,10 +1451,6 @@ impl AccountFundsRead for WritebackCache {
                 pre_root_version, post_root_version
             );
             pre_root_version = post_root_version;
-            loop_iter += 1;
-            if loop_iter >= 3 {
-                debug_fatal!("Unable to get a stable version after 3 iterations");
-            }
         }
     }
 
@@ -1441,13 +1460,9 @@ impl AccountFundsRead for WritebackCache {
         version: SequenceNumber,
     ) -> u128 {
         let account_obj = self.find_object_lt_or_eq_version(*account_id.inner(), version);
-        if let Some(account_obj) = account_obj {
-            let (_, AccumulatorValue::U128(value)) =
-                account_obj.data.try_as_move().unwrap().try_into().unwrap();
-            value.value
-        } else {
-            0
-        }
+        account_obj
+            .map(|account_obj| account_amount_from_object(&account_obj))
+            .unwrap_or(0)
     }
 }
 

--- a/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/eager_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/eager_scheduler/mod.rs
@@ -87,7 +87,9 @@ impl FundsWithdrawSchedulerTrait for EagerFundsWithdrawScheduler {
         let mut init_balances = BTreeMap::new();
         for account_id in untracked_accounts {
             // TODO: We can warm up the cache prior to holding the lock.
-            let (balance, version) = self.funds_read.get_latest_account_amount(account_id);
+            let (balance, version) = self
+                .funds_read
+                .get_consistent_latest_account_amount_and_version(account_id);
             if version > reservations.accumulator_version {
                 return reservations.notify_skip_schedule();
             }

--- a/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/naive_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/naive_scheduler.rs
@@ -51,7 +51,8 @@ impl NaiveFundsWithdrawScheduler {
         let all_accounts = reservations.all_accounts();
         for account_id in all_accounts {
             // TODO: We can warm up the cache prior to holding the lock.
-            let (balance, version) = funds_read.get_latest_account_amount(&account_id);
+            let (balance, version) =
+                funds_read.get_consistent_latest_account_amount_and_version(&account_id);
             if version > reservations.accumulator_version {
                 return reservations.notify_skip_schedule();
             }

--- a/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/mock_funds_read.rs
+++ b/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/mock_funds_read.rs
@@ -62,7 +62,7 @@ impl MockFundsRead {
         let new_accumulator_version = cur_version.next();
         assert_eq!(new_accumulator_version, next_accumulator_version);
         for (account_id, balance_change) in funds_changes {
-            let balance = self.inner.read().get_latest_account_amount(&account_id).0;
+            let balance = self.inner.read().get_latest_account_amount(&account_id);
             let new_balance = balance as i128 + balance_change;
             assert!(new_balance >= 0);
             let new_entry = if new_balance == 0 {
@@ -88,15 +88,25 @@ impl MockFundsRead {
 }
 
 impl MockFundsReadInner {
-    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> (u128, SequenceNumber) {
+    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> u128 {
         let account_amounts = self.amounts.get(account_id);
         match account_amounts {
             Some(amounts) => {
-                let (version, amount) = amounts.iter().last().unwrap();
-                (amount.unwrap_or(0), *version)
+                let (_, amount) = amounts.iter().last().unwrap();
+                amount.unwrap_or(0)
             }
-            None => (0, self.cur_version),
+            None => 0,
         }
+    }
+
+    fn get_consistent_latest_account_amount_and_version(
+        &self,
+        account_id: &AccumulatorObjId,
+    ) -> (u128, SequenceNumber) {
+        (
+            self.get_account_amount_at_version(account_id, self.cur_version),
+            self.cur_version,
+        )
     }
 
     fn get_account_amount_at_version(
@@ -106,19 +116,28 @@ impl MockFundsReadInner {
     ) -> u128 {
         let account_amounts = self.amounts.get(account_id);
         match account_amounts {
-            Some(amounts) => {
-                let (_, amount) = amounts.range(..=version).last().unwrap();
-                amount.unwrap_or(0)
-            }
+            Some(amounts) => amounts
+                .range(..=version)
+                .last()
+                .and_then(|(_, amount)| *amount)
+                .unwrap_or(0),
             None => 0,
         }
     }
 }
 
 impl AccountFundsRead for MockFundsRead {
-    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> (u128, SequenceNumber) {
+    fn get_latest_account_amount(&self, account_id: &AccumulatorObjId) -> u128 {
         let inner = self.inner.read();
         inner.get_latest_account_amount(account_id)
+    }
+
+    fn get_consistent_latest_account_amount_and_version(
+        &self,
+        account_id: &AccumulatorObjId,
+    ) -> (u128, SequenceNumber) {
+        let inner = self.inner.read();
+        inner.get_consistent_latest_account_amount_and_version(account_id)
     }
 
     fn get_account_amount_at_version(


### PR DESCRIPTION
## Summary
- split the account funds read API into a simple latest amount read and a consistent amount/root-version read
- keep schedulers on the consistent read while signing/non-deterministic checks use the simpler latest amount
- update writeback cache tests/docs and mock funds reads for the new semantics

## Test Plan
- `writeback_cache_tests::test_get_consistent_latest_account_amount_race_with_pending_settlement`
  (renamed/extended from the previous test): reproduces the MVCC settlement race where an account live at
  version V is deleted by a settlement tx that writes a tombstone at V+1, while the barrier tx that bumps the
  accumulator root from V to V+1 has not yet run. In that window it asserts the two read paths now diverge as
  intended:
  - the unsequenced `get_latest_account_amount` observes the tombstone and returns `0`;
  - `get_consistent_latest_account_amount_and_version` caps the account read at the root version V and returns
    the pre-settlement non-zero balance paired with version V, so settlement still appears atomic to readers
    that need a root-consistent amount.
- `object_funds_checker::integration_tests`: the `ObjectFundsChecker` test env now drives the new
  `get_latest_account_amount` (amount-only) signature, exercising the funds-availability checks against the
  simpler latest-amount read path end to end.
- `funds_withdraw_scheduler::mock_funds_read`: the mock implements both new trait methods, so the eager and
  naive scheduler tests continue to exercise the consistent read path used by schedulers.