### PR TITLE
fix(mysten-network): apply connect_timeout to lazy gRPC channels

### DIFF
--- a/.claude/skills/simtest-debug/SKILL.md
+++ b/.claude/skills/simtest-debug/SKILL.md
@@ -72,6 +72,8 @@ If only a test name was provided, find a repro as follows:
 - run `./scripts/simtest/seed-search.py --test <test_target_name> <test_name> --exact`. This program will search for a seed that fails.
 - Once you have a seed that fails, the repro will be `MSIM_TEST_SEED=<seed> cargo simtest --test <test_target> -E 'test(=<test_name>)'`
 
+**IMPORTANT**: Do NOT use `-p <package>` in the repro command. The seed-search script runs the test binary directly without `-p`, and adding `-p` changes the execution context in a way that breaks determinism and may cause the failure to not reproduce.
+
 ### 3. Run the test.
 
 Run the repro command. If `RUST_LOG=...` is missing, add `RUST_LOG=sui=debug,info`. if `--no-capture` is missing, add it.

--- a/crates/mysten-network/src/client.rs
+++ b/crates/mysten-network/src/client.rs
@@ -121,27 +121,27 @@ impl MyEndpoint {
             disable_caching_resolver
         });
 
+        let connect_timeout = self.endpoint.get_connect_timeout();
+
         if disable_caching_resolver {
             let mut http = HttpConnector::new();
             http.enforce_http(false);
             http.set_nodelay(true);
             http.set_keepalive(None);
-            http.set_connect_timeout(None);
+            http.set_connect_timeout(connect_timeout);
 
-            Channel::new(
-                hyper_rustls::HttpsConnectorBuilder::new()
-                    .with_tls_config(self.tls_config)
-                    .https_only()
-                    .enable_http2()
-                    .wrap_connector(http),
-                self.endpoint,
-            )
+            let https = hyper_rustls::HttpsConnectorBuilder::new()
+                .with_tls_config(self.tls_config)
+                .https_only()
+                .enable_http2()
+                .wrap_connector(http);
+            Channel::new(https, self.endpoint)
         } else {
             let mut http = HttpConnector::new_with_resolver(CachingResolver::new());
             http.enforce_http(false);
             http.set_nodelay(true);
             http.set_keepalive(None);
-            http.set_connect_timeout(None);
+            http.set_connect_timeout(connect_timeout);
 
             let https = hyper_rustls::HttpsConnectorBuilder::new()
                 .with_tls_config(self.tls_config)


### PR DESCRIPTION
## Summary

- `MyEndpoint::connect_lazy()` was creating `HttpConnector` instances with `set_connect_timeout(None)`, ignoring any `connect_timeout` configured on the endpoint
- When the endpoint's configured timeout exists (e.g. from `network_config.connect_timeout`), it was never propagated to the underlying HTTP connector
- In environments where TCP SYNs to unreachable hosts are silently dropped (e.g. msim simulation, or real network partitions), tonic's `Reconnect` layer would stay in `State::Connecting` indefinitely with no timeout, blocking all gRPC calls on that channel forever
- Fixed by reading `self.endpoint.get_connect_timeout()` and passing it to `http.set_connect_timeout(connect_timeout)` in both the caching and non-caching resolver paths

## Root cause

`NetworkAuthorityClient::connect_lazy` (used for all validator gRPC channels) calls `mysten_network::client::connect_lazy`, which builds channels via `MyEndpoint::connect_lazy`. That method constructed `HttpConnector::new()` / `HttpConnector::new_with_resolver(...)` but never called `set_connect_timeout`, leaving it as `None`. The endpoint's connect timeout setting was passed to `Channel::new` but tonic's `Channel::new` does not apply it to the provided connector — only `Endpoint::connect_with_connector_lazy` does, and that path has other incompatibilities with our custom hyper_rustls TLS setup.

## Test plan

- Verified the specific failing simtest seed now passes: `MSIM_TEST_SEED=1780842577433 cargo simtest --test discovery_tests -E 'test(=test::test_removed_validator_disconnected_after_reconfig)'`
- Ran seed-search across 40 seeds post-fix: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)