### PR TITLE
Fix rpc-index coin-balance double-count after an unclean restart

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -121,6 +121,20 @@ pub struct AuthorityPerpetualTables {
     /// A singleton table that stores latest pruned checkpoint. Used to keep objects pruner progress
     pub(crate) pruned_checkpoint: DBMap<(), CheckpointSequenceNumber>,
 
+    /// A singleton table recording the highest checkpoint whose transaction
+    /// outputs (objects, effects, etc.) are durably committed to this store.
+    /// It is written in the *same* atomic batch as those outputs (see
+    /// `AuthorityStore::build_db_batch` and the checkpoint executor), so it is
+    /// always consistent with the live object set even after an unclean stop.
+    ///
+    /// This differs from the checkpoint store's `highest_executed` watermark,
+    /// which is bumped in a separate write after the outputs are committed: an
+    /// abrupt stop can leave the object writes durable while `highest_executed`
+    /// still lags. Consumers that read the live object set directly (e.g. the
+    /// embedded rpc-store's bulk restore) use this watermark instead, so they
+    /// never observe objects beyond the checkpoint they think they are at.
+    pub(crate) highest_committed_checkpoint: DBMap<(), CheckpointSequenceNumber>,
+
     /// Expected total amount of SUI in the network. This is expected to remain constant
     /// throughout the lifetime of the network. We check it at the end of each epoch if
     /// expensive checks are enabled. We cannot use 10B today because in tests we often
@@ -359,6 +373,10 @@ impl AuthorityPerpetualTables {
             ),
             (
                 "pruned_checkpoint".to_string(),
+                ThConfig::new(0, 1, KeyType::uniform(1)),
+            ),
+            (
+                "highest_committed_checkpoint".to_string(),
                 ThConfig::new(0, 1, KeyType::uniform(1)),
             ),
             (
@@ -611,6 +629,27 @@ impl AuthorityPerpetualTables {
         checkpoint_number: CheckpointSequenceNumber,
     ) -> SuiResult {
         wb.insert_batch(&self.pruned_checkpoint, [((), checkpoint_number)])?;
+        Ok(())
+    }
+
+    pub fn get_highest_committed_checkpoint(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
+        self.highest_committed_checkpoint.get(&())
+    }
+
+    /// Stage the highest-committed-checkpoint watermark into `wb`. Must be
+    /// called on the same batch that commits the checkpoint's transaction
+    /// outputs so the watermark and the outputs land atomically.
+    pub fn set_highest_committed_checkpoint(
+        &self,
+        wb: &mut DBBatch,
+        checkpoint_number: CheckpointSequenceNumber,
+    ) -> SuiResult {
+        wb.insert_batch(
+            &self.highest_committed_checkpoint,
+            [((), checkpoint_number)],
+        )?;
         Ok(())
     }
 

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -404,10 +404,19 @@ impl CheckpointExecutor {
 
         let seq = ckpt_state.data.checkpoint.sequence_number;
 
-        let batch = self
+        let mut batch = self
             .state
             .get_cache_commit()
             .build_db_batch(self.epoch_store.epoch(), &ckpt_state.data.tx_digests);
+
+        // Stamp the highest-committed-checkpoint watermark into the same batch
+        // as the outputs, so it lands atomically with the object writes. This
+        // gives consumers that read the live object set directly (the embedded
+        // rpc-store restore) a watermark that never lags the durable objects,
+        // unlike the separately-bumped `highest_executed` watermark below.
+        self.state
+            .get_cache_commit()
+            .set_highest_committed_checkpoint_in_batch(&mut batch, seq);
 
         finish_stage!(pipeline_handle, BuildDbBatch);
 

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -156,6 +156,18 @@ pub trait ExecutionCacheCommit: Send + Sync {
     /// Build a DBBatch containing the given transaction outputs.
     fn build_db_batch(&self, epoch: EpochId, digests: &[TransactionDigest]) -> Batch;
 
+    /// Stage the highest-committed-checkpoint watermark into `batch` so it is
+    /// written atomically with that checkpoint's transaction outputs. Called by
+    /// CheckpointExecutor between [`Self::build_db_batch`] and
+    /// [`Self::commit_transaction_outputs`]. Unlike the checkpoint store's
+    /// separately-bumped `highest_executed` watermark, this stays consistent
+    /// with the durable object set across an unclean stop.
+    fn set_highest_committed_checkpoint_in_batch(
+        &self,
+        batch: &mut Batch,
+        checkpoint: CheckpointSequenceNumber,
+    );
+
     /// Durably commit the outputs of the given transactions to the database.
     /// Will be called by CheckpointExecutor to ensure that transaction outputs are
     /// written durably before marking a checkpoint as finalized.

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -1458,6 +1458,17 @@ impl ExecutionCacheCommit for WritebackCache {
         self.build_db_batch(epoch, digests)
     }
 
+    fn set_highest_committed_checkpoint_in_batch(
+        &self,
+        batch: &mut Batch,
+        checkpoint: CheckpointSequenceNumber,
+    ) {
+        self.store
+            .perpetual_tables
+            .set_highest_committed_checkpoint(&mut batch.1, checkpoint)
+            .expect("db error");
+    }
+
     fn commit_transaction_outputs(
         &self,
         epoch: EpochId,

--- a/crates/sui-core/src/rpc_index.rs
+++ b/crates/sui-core/src/rpc_index.rs
@@ -903,8 +903,37 @@ impl IndexStoreTables {
     ) -> Result<(), StorageError> {
         info!("Initializing RPC indexes");
 
-        let highest_executed_checkpint =
-            checkpoint_store.get_highest_executed_checkpoint_seq_number()?;
+        // The restore target: the highest checkpoint whose transaction outputs
+        // (objects, effects) are durably committed to the perpetual store. The
+        // live-object indexing below reads the live object set directly, and the
+        // historical backfill covers `[lowest, restore_target]`, so this is the
+        // checkpoint the rebuilt index reflects. We stamp `Watermark::Indexed`
+        // here, and `commit_update_for_checkpoint` then only applies the next
+        // contiguous checkpoint (`watermark + 1`), dropping forward updates at
+        // or below the watermark. That is what stops the checkpoint executor --
+        // which resumes from the possibly-lagging `highest_executed` -- from
+        // re-applying checkpoints the restore already captured.
+        //
+        // We use the perpetual store's `highest_committed` watermark (written
+        // atomically with the objects) rather than the checkpoint store's
+        // `highest_executed` (bumped in a separate write afterward). An unclean
+        // stop can leave the object writes durable while `highest_executed`
+        // still lags, so the live object set can reflect a checkpoint beyond
+        // `highest_executed`; using `highest_committed` keeps the restore target
+        // (and therefore the drop floor) consistent with the set we actually
+        // read, so the executor's re-application of `(highest_executed,
+        // highest_committed]` is dropped rather than double-counted.
+        //
+        // Fall back to `highest_executed` for a database written before the
+        // atomic `highest_committed` watermark existed: it has no stamp yet, so
+        // this preserves the prior restore target until the next committed
+        // checkpoint stamps the consistent one. In normal operation
+        // `highest_committed` is written before `highest_executed` is bumped, so
+        // it is never absent while the executed watermark is present.
+        let restore_target = authority_store
+            .perpetual_tables
+            .get_highest_committed_checkpoint()?
+            .or(checkpoint_store.get_highest_executed_checkpoint_seq_number()?);
         let lowest_available_checkpoint = checkpoint_store
             .get_highest_pruned_checkpoint_seq_number()?
             .map(|c| c.saturating_add(1))
@@ -919,9 +948,8 @@ impl IndexStoreTables {
         let lowest_available_checkpoint =
             lowest_available_checkpoint.max(lowest_available_checkpoint_objects);
 
-        let checkpoint_range = highest_executed_checkpint.map(|highest_executed_checkpint| {
-            lowest_available_checkpoint..=highest_executed_checkpint
-        });
+        let checkpoint_range =
+            restore_target.map(|restore_target| lowest_available_checkpoint..=restore_target);
 
         if let Some(checkpoint_range) = checkpoint_range.clone() {
             self.index_existing_checkpoints(authority_store, checkpoint_store, checkpoint_range)?;
@@ -942,7 +970,7 @@ impl IndexStoreTables {
         // Only index live objects if genesis checkpoint has been executed.
         // If genesis hasn't been executed yet, the objects will be properly indexed
         // as checkpoints are processed through the normal checkpoint execution path.
-        if highest_executed_checkpint.is_some() {
+        if restore_target.is_some() {
             let coin_index = Mutex::new(HashMap::new());
 
             let make_live_object_indexer = RpcParLiveObjectSetIndexer {
@@ -959,10 +987,17 @@ impl IndexStoreTables {
             self.coin.multi_insert(coin_index.into_inner().unwrap())?;
         }
 
-        self.watermark.insert(
-            &Watermark::Indexed,
-            &highest_executed_checkpint.unwrap_or(0),
-        )?;
+        // Stamp the watermark at the restore target so forward indexing resumes
+        // (and the drop floor in `commit_update_for_checkpoint` sits) exactly at
+        // the checkpoint the rebuilt index reflects. When `restore_target` is
+        // `None` -- a fresh node with nothing committed yet -- leave the
+        // watermark absent rather than stamping 0: nothing has been indexed, so
+        // genesis must still be applied by forward indexing (`watermark + 1`
+        // starts at 0), not dropped as already-covered.
+        if let Some(restore_target) = restore_target {
+            self.watermark
+                .insert(&Watermark::Indexed, &restore_target)?;
+        }
 
         // Write the schema version and the feature settings in one batch so the
         // two can never be persisted independently.
@@ -2043,6 +2078,20 @@ impl RpcIndexStore {
     /// - Callers of this function must ensure that it is called for each checkpoint in sequential
     ///   order. This will panic if the provided checkpoint does not match the expected next
     ///   checkpoint to commit.
+    ///
+    /// Forward updates are gated on `Watermark::Indexed`, the source of truth for
+    /// index coverage: only the next contiguous checkpoint (`watermark + 1`, or 0
+    /// when nothing is indexed yet) is written, and its batch advances the
+    /// watermark. A checkpoint at or below the watermark is already reflected in
+    /// the index, so its batch is dropped rather than re-applied -- this is what
+    /// prevents double-counting after a bulk restore. The restore stamps the
+    /// watermark at the checkpoint the live object set reflects
+    /// (`highest_committed`), but the checkpoint executor resumes from the
+    /// separately-bumped `highest_executed`, which can lag; without this drop it
+    /// would re-apply the `(highest_executed, highest_committed]` checkpoints the
+    /// restore already captured, double-counting additive indexes like balances.
+    /// A checkpoint above `watermark + 1` is a gap that would leave a hole in the
+    /// index, so it panics.
     #[tracing::instrument(skip(self))]
     pub fn commit_update_for_checkpoint(&self, checkpoint: u64) -> Result<(), StorageError> {
         let next_batch = self.pending_updates.lock().unwrap().pop_first();
@@ -2052,6 +2101,23 @@ impl RpcIndexStore {
         assert_eq!(
             checkpoint, next_sequence_number,
             "commit_update_for_checkpoint must be called in order"
+        );
+
+        let indexed = self.tables.watermark.get(&Watermark::Indexed)?;
+        let expected_next = indexed.map_or(0, |w| w + 1);
+        if checkpoint < expected_next {
+            // Already covered (by the bulk restore or a prior commit). Dropping
+            // the batch avoids re-applying its additive index updates.
+            debug!(
+                checkpoint,
+                expected_next, "dropping already-indexed checkpoint update"
+            );
+            return Ok(());
+        }
+        assert_eq!(
+            checkpoint, expected_next,
+            "rpc-index forward update is not contiguous: expected checkpoint {expected_next}, \
+             got {checkpoint}"
         );
 
         Ok(batch.write()?)

--- a/crates/sui-e2e-tests/tests/rpc/main.rs
+++ b/crates/sui-e2e-tests/tests/rpc/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod client;
+mod rpc_index_restore;
 mod v2;
 
 async fn transfer_coin(context: &sui_sdk::wallet_context::WalletContext) -> sui_sdk_types::Digest {

--- a/crates/sui-e2e-tests/tests/rpc/rpc_index_restore.rs
+++ b/crates/sui-e2e-tests/tests/rpc/rpc_index_restore.rs
@@ -1,0 +1,347 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rebuild behavior of the legacy `rpc-index` index backend (`enable_indexing`).
+//!
+//! A node that ran without indexing and is restarted with it on rebuilds the
+//! `rpc-index` from the perpetual store: `RpcIndexStore::init` bulk-loads the
+//! live object set (the `balance` index) and backfills the historical
+//! checkpoint indexes (the `transaction_bitmap`), then the checkpoint executor
+//! resumes forward indexing from `highest_executed`.
+//!
+//! The bulk restore reads the live object set, which the perpetual store writes
+//! atomically with the `highest_committed` watermark. The checkpoint store's
+//! `highest_executed` watermark is bumped in a *separate* write afterward, so an
+//! unclean stop can leave the live set reflecting a checkpoint that
+//! `highest_executed` does not yet count. If the restore stamps its watermark at
+//! the lagging `highest_executed`, the executor re-applies the checkpoints in
+//! `(highest_executed, highest_committed]` that the live set already captured,
+//! double-counting additive indexes -- a recipient's coin balance shows up at
+//! twice its value. This test exercises that path: it asserts the recipient's
+//! balance is reported exactly once after the rebuild.
+//!
+//! The unit under test is a fullnode spawned into the swarm separately from the
+//! cluster's primary fullnode. The cluster's wallet executes transactions
+//! against the primary (which stays up the whole time); the dedicated node
+//! follows by state sync and is restarted with a mutated `NodeConfig.rpc`
+//! between runs. Its `db_path` is stable across restarts, so each restart sees
+//! the previous run's perpetual store and exercises the real rebuild path.
+//!
+//! Restart correctness note: the swarm node holds only a `Weak` reference to the
+//! running `SuiNode`, so a stop releases the node's RocksDB locks only if no
+//! strong handle outlives it. These helpers therefore never retain a
+//! `SuiNodeHandle` across a restart -- reads fetch a transient handle and drop
+//! it immediately.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use prost_types::FieldMask;
+use rand::rngs::OsRng;
+use sui_config::RpcConfig;
+use sui_macros::sim_test;
+use sui_node::SuiNode;
+use sui_rpc::Client;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::GetBalanceRequest;
+use sui_rpc::proto::sui::rpc::v2alpha::ListTransactionsRequest;
+use sui_rpc::proto::sui::rpc::v2alpha::QueryOptions;
+use sui_rpc::proto::sui::rpc::v2alpha::SenderFilter;
+use sui_rpc::proto::sui::rpc::v2alpha::TransactionFilter;
+use sui_rpc::proto::sui::rpc::v2alpha::TransactionLiteral;
+use sui_rpc::proto::sui::rpc::v2alpha::TransactionPredicate;
+use sui_rpc::proto::sui::rpc::v2alpha::TransactionTerm;
+use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient;
+use sui_rpc::proto::sui::rpc::v2alpha::list_transactions_response;
+use sui_rpc::proto::sui::rpc::v2alpha::transaction_literal;
+use sui_rpc::proto::sui::rpc::v2alpha::transaction_predicate;
+use sui_test_transaction_builder::make_transfer_sui_transaction;
+use sui_types::base_types::AuthorityName;
+use sui_types::base_types::SuiAddress;
+use sui_types::base_types::TransactionDigest;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::transaction::TransactionDataAPI;
+use test_cluster::TestCluster;
+use test_cluster::TestClusterBuilder;
+
+const SUI_COIN_TYPE: &str =
+    "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI";
+
+/// How long to wait for the dedicated fullnode to sync and index a target
+/// checkpoint. A rebuild reloads the live object set and backfills the history
+/// indexes from genesis, so this is generous.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// An rpc config that builds the legacy `rpc-index` with the ledger-history
+/// (bitmap) indexes enabled.
+fn legacy_indexing_config() -> RpcConfig {
+    RpcConfig {
+        enable_indexing: Some(true),
+        ledger_history_indexing: Some(true),
+        ..Default::default()
+    }
+}
+
+/// An rpc config that builds no index at all.
+fn no_indexing_config() -> RpcConfig {
+    RpcConfig {
+        enable_indexing: Some(false),
+        ..Default::default()
+    }
+}
+
+/// Spawn a dedicated fullnode into the swarm with `rpc`, returning its (stable)
+/// name and rpc url. The handle `spawn_new_node` returns is dropped immediately
+/// so the node keeps no external strong reference and a later
+/// [`restart_fullnode`] can release its DB locks on stop.
+async fn spawn_fullnode(cluster: &mut TestCluster, rpc: RpcConfig) -> (AuthorityName, String) {
+    let config = cluster
+        .fullnode_config_builder()
+        .with_rpc_config(rpc)
+        .build(&mut OsRng, cluster.swarm.config());
+    let name = config.protocol_public_key();
+    let rpc_url = format!("http://{}", config.json_rpc_address);
+    cluster.swarm.spawn_new_node(config).await;
+    (name, rpc_url)
+}
+
+/// Stop the fullnode `name`, swap in `rpc` (the `db_path` is unchanged), and
+/// restart it. The stop releases the previous run's RocksDB locks because no
+/// strong `SuiNodeHandle` is held across the call.
+async fn restart_fullnode(cluster: &TestCluster, name: &AuthorityName, rpc: RpcConfig) {
+    let node = cluster.swarm.node(name).unwrap();
+    node.stop();
+    node.config().rpc = Some(rpc);
+    // Under simulation, stopping a node only schedules its teardown via
+    // `delete_node`; the old node's RocksDB handles (and on-disk file locks)
+    // are released asynchronously. Restarting immediately races the previous
+    // instance for the same `db_path` and panics opening it. Give the simulator
+    // time to finish the teardown. A real runtime joins the node's thread on
+    // stop, so the handles are already released there.
+    if cfg!(msim) {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+    node.start().await.unwrap();
+}
+
+/// Run `f` against the dedicated fullnode through a transient handle that is
+/// dropped before returning (see the module note on restart safety).
+fn with_node<T>(cluster: &TestCluster, name: &AuthorityName, f: impl FnOnce(&SuiNode) -> T) -> T {
+    let handle = cluster.swarm.node(name).unwrap().get_node_handle().unwrap();
+    handle.with(f)
+}
+
+fn has_rpc_index(cluster: &TestCluster, name: &AuthorityName) -> bool {
+    with_node(cluster, name, |node| node.state().rpc_index.is_some())
+}
+
+/// The highest checkpoint the dedicated node's `rpc-index` has indexed, or
+/// `None` if the node has no index.
+fn highest_indexed(cluster: &TestCluster, name: &AuthorityName) -> Option<u64> {
+    with_node(cluster, name, |node| {
+        node.state().rpc_index.as_ref().and_then(|index| {
+            index
+                .get_highest_indexed_checkpoint_seq_number()
+                .ok()
+                .flatten()
+        })
+    })
+}
+
+/// Block until the dedicated fullnode's `rpc-index` has indexed through
+/// `target`. Panics on timeout with the last-observed watermark.
+async fn wait_for_indexed(cluster: &TestCluster, name: &AuthorityName, target: u64) {
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let indexed = highest_indexed(cluster, name);
+        if indexed.is_some_and(|c| c >= target) {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for rpc-index to index checkpoint {target} \
+                 (indexed={indexed:?})"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// A transfer executed against the cluster, with the facts a test asserts on
+/// afterward.
+struct Transfer {
+    /// The transaction's sender (whichever account funded the gas).
+    sender: SuiAddress,
+    /// A fresh address with no prior coins, so its post-transfer SUI balance is
+    /// exactly `amount`.
+    receiver: SuiAddress,
+    amount: u64,
+    digest: TransactionDigest,
+}
+
+/// Transfer `amount` MIST of SUI to a fresh address through the cluster's
+/// primary fullnode and wait for the transaction to land in an executed
+/// checkpoint.
+async fn transfer_to_fresh_address(cluster: &TestCluster, amount: u64) -> Transfer {
+    let receiver = SuiAddress::random_for_testing_only();
+    let txn = make_transfer_sui_transaction(&cluster.wallet, Some(receiver), Some(amount)).await;
+    let executed = cluster.execute_transaction(txn).await;
+    let transfer = Transfer {
+        sender: executed.transaction.sender(),
+        receiver,
+        amount,
+        digest: *executed.effects.transaction_digest(),
+    };
+    cluster.wait_for_tx_settlement(&[transfer.digest]).await;
+    transfer
+}
+
+/// Push the chain a few checkpoints beyond the current tip and return the new
+/// tip. Used after a rebuild so the dedicated node's forward indexing has to
+/// process (and, on buggy code, re-apply) the checkpoints the restore already
+/// covered before the test reads the index. Each transfer settles in its own
+/// checkpoint, so the returned tip is strictly above the rebuild's restore
+/// watermark.
+async fn advance_chain_past_rebuild(cluster: &TestCluster) -> u64 {
+    for _ in 0..3 {
+        transfer_to_fresh_address(cluster, 1_000_000).await;
+    }
+    chain_tip(cluster)
+}
+
+/// The chain tip as seen by the cluster's primary fullnode -- an upper bound on
+/// the checkpoints the dedicated node must sync and index.
+fn chain_tip(cluster: &TestCluster) -> u64 {
+    cluster.fullnode_handle.sui_node.with(|node| {
+        node.state()
+            .get_checkpoint_store()
+            .get_highest_executed_checkpoint_seq_number()
+            .unwrap()
+            .unwrap_or(0)
+    })
+}
+
+/// The total SUI balance the `rpc-index` reports for `owner`.
+async fn sui_balance(rpc_url: &str, owner: SuiAddress) -> u64 {
+    let mut client = Client::new(rpc_url.to_owned()).unwrap();
+    let mut request = GetBalanceRequest::default();
+    request.owner = Some(owner.to_string());
+    request.coin_type = Some(SUI_COIN_TYPE.to_string());
+    client
+        .state_client()
+        .get_balance(request)
+        .await
+        .unwrap()
+        .into_inner()
+        .balance
+        .unwrap()
+        .balance
+        .unwrap()
+}
+
+/// A `ListTransactions` filter matching a single sender.
+fn sender_filter(sender: SuiAddress) -> TransactionFilter {
+    let mut sender_filter = SenderFilter::default();
+    sender_filter.address = Some(sender.to_string());
+    let mut predicate = TransactionPredicate::default();
+    predicate.predicate = Some(transaction_predicate::Predicate::Sender(sender_filter));
+    let mut literal = TransactionLiteral::default();
+    literal.polarity = Some(transaction_literal::Polarity::Include(predicate));
+    let mut term = TransactionTerm::default();
+    term.literals = vec![literal];
+    let mut filter = TransactionFilter::default();
+    filter.terms = vec![term];
+    filter
+}
+
+/// The set of transaction digests the ledger-history `ListTransactions` API
+/// returns for `sender`, scanning the whole indexed range.
+async fn list_transaction_digests_by_sender(rpc_url: &str, sender: SuiAddress) -> HashSet<String> {
+    let mut client = LedgerServiceClient::connect(rpc_url.to_owned())
+        .await
+        .unwrap();
+    let mut options = QueryOptions::default();
+    options.limit_items = Some(500);
+    let mut request = ListTransactionsRequest::default();
+    request.read_mask = Some(FieldMask::from_paths(["digest"]));
+    request.filter = Some(sender_filter(sender));
+    request.options = Some(options);
+    let mut stream = client
+        .list_transactions(request)
+        .await
+        .unwrap()
+        .into_inner();
+    let mut digests = HashSet::new();
+    while let Some(response) = stream.message().await.unwrap() {
+        if let Some(list_transactions_response::Response::Item(item)) = response.response
+            && let Some(digest) = item.transaction.and_then(|tx| tx.digest)
+        {
+            digests.insert(digest);
+        }
+    }
+    digests
+}
+
+/// Assert both index surfaces reflect `transfer`: the `balance` index reports
+/// the recipient's exact balance (the double-count regression shows up here as
+/// twice `amount`), and the `transaction_bitmap` index returns the transfer
+/// under a sender filter.
+async fn assert_transfer_indexed(rpc_url: &str, transfer: &Transfer) {
+    assert_eq!(
+        sui_balance(rpc_url, transfer.receiver).await,
+        transfer.amount,
+        "GetBalance should report the recipient's exact SUI balance",
+    );
+    let digests = list_transaction_digests_by_sender(rpc_url, transfer.sender).await;
+    assert!(
+        digests.contains(&transfer.digest.to_string()),
+        "ListTransactions(sender={}) should include {}",
+        transfer.sender,
+        transfer.digest,
+    );
+}
+
+/// Enabling the legacy `rpc-index` on a node that ran unindexed rebuilds the
+/// indexes from the perpetual store and reports the pre-enable transfer's
+/// balance exactly once -- it must not double-count the live object set against
+/// the executor's forward indexing of the checkpoints the restore already
+/// captured.
+#[sim_test]
+async fn enabling_legacy_index_rebuilds_without_double_counting() {
+    let mut cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .disable_fullnode_pruning()
+        .build()
+        .await;
+    let (name, rpc_url) = spawn_fullnode(&mut cluster, no_indexing_config()).await;
+    assert!(
+        !has_rpc_index(&cluster, &name),
+        "indexing is off, so the node should build no rpc-index",
+    );
+
+    // Run a transfer while the node is unindexed.
+    let transfer = transfer_to_fresh_address(&cluster, 7_000_000).await;
+
+    // Turn on indexing and restart. With no prior rpc-index database the store
+    // rebuilds from the perpetual store (bulk-loading the live object set and
+    // backfilling the history indexes).
+    restart_fullnode(&cluster, &name, legacy_indexing_config()).await;
+    assert!(
+        has_rpc_index(&cluster, &name),
+        "indexing is on, so the node should build the rpc-index",
+    );
+
+    // Advance the chain past the rebuild point and wait for the node's forward
+    // indexing to catch up beyond it. The double-count happens when the executor
+    // re-applies a checkpoint that was committed (in the live object set the
+    // restore loaded) but not yet executed when the node stopped; the executor
+    // resumes from `highest_executed` and re-indexes it. We must read *after*
+    // that re-application, not while the index still sits at the freshly stamped
+    // restore watermark -- otherwise the bug is masked by reading too early.
+    let target = advance_chain_past_rebuild(&cluster).await;
+    wait_for_indexed(&cluster, &name, target).await;
+
+    // The pre-enable transfer is visible through both index surfaces, and the
+    // balance is reported exactly once (not double-counted).
+    assert_transfer_indexed(&rpc_url, &transfer).await;
+}


### PR DESCRIPTION
## Description 

Summary

  A fullnode's rpc-index could report a coin balance at twice its true value after an unclean restart. The root cause is a watermark
  consistency gap in checkpoint execution; the fix records a crash-consistent watermark and uses it to gate the rpc-index restore and
  forward indexing. This is intermittently reproducible across an unclean fullnode restart, and is consensus-safe (no protocol or
  on-disk-format change beyond an additive, self-populating column family).

  Background

  The checkpoint executor commits a checkpoint's transaction outputs (objects, effects) to the perpetual store and then bumps the
  checkpoint store's highest_executed watermark in a separate write (there is even a fail_point!("crash") between the two). An abrupt
  stop in that window leaves the object writes durable while highest_executed still lags — so the perpetual store's live object set is
  momentarily ahead of the executed watermark.

  The rpc-index rebuild reads the live object set directly and stamps its watermark at a "restore target." When that target was
  highest_executed but the live set already reflected a later in-flight checkpoint, the restore captured that checkpoint's objects, and
  then the checkpoint executor — which also resumes from highest_executed — re-applied the same checkpoint through forward indexing.
  Additive indexes (coin balances) got counted twice.

  What's in this PR

  1. core: record a highest-committed-checkpoint watermark atomic with outputs
  Adds a highest_committed_checkpoint singleton column family to AuthorityPerpetualTables, written in the same atomic batch as the
  checkpoint's outputs via a new ExecutionCacheCommit::set_highest_committed_checkpoint_in_batch hook the executor calls between
  building and committing the batch. The watermark is therefore always consistent with the durable object set, even after a crash. It is
  always >= highest_executed.

  2. core: stop rpc-index double-counting checkpoints after a rebuild
  - RpcIndexStore::init uses highest_committed as the restore target (falling back to highest_executed for databases written before the
  watermark existed), so the stamped watermark matches the checkpoint the live set actually reflects. A fresh node stamps no watermark,
  so genesis is still indexed by forward indexing rather than dropped.
  - commit_update_for_checkpoint now gates forward updates on Watermark::Indexed: it commits only the next contiguous checkpoint
  (watermark + 1), drops a batch for a checkpoint at or below the watermark (already covered), and panics on a gap. This is what
  actually prevents the re-application, and it also closes the normal-operation crash window where a running indexed node stops between
  the forward commit and the highest_executed bump.
  - Adds the enabling_legacy_index_rebuilds_without_double_counting e2e test.

  ▎ Note: the watermark change alone is necessary but not sufficient for the legacy rpc-index. Unlike the embedded store (whose tip
  ▎ indexer gates on its own cohort watermark), legacy forward indexing is driven by the executor from highest_executed; the
  ▎ commit_update_for_checkpoint drop is what stops the re-application.

  Testing

  The new e2e test runs a transfer with indexing off, restarts the node with indexing on, advances the chain past the rebuild point so
  forward indexing re-processes the restored checkpoints before the test reads (reading too early masks the bug), and asserts the
  recipient's balance is reported exactly once.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
