### PR TITLE
fix(sui-benchmark): prevent duplicate tx digests in benchmark workloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17093,6 +17093,7 @@ version = "0.1.0"
 dependencies = [
  "bcs",
  "move-core-types",
+ "rand 0.8.5",
  "shared-crypto",
  "sui-genesis-builder",
  "sui-move-build",

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -66,6 +66,7 @@ pub async fn publish_basics_package(
         let transaction = TestTransactionBuilder::new(sender, current_gas, gas_price)
             .publish_examples("basics")
             .await
+            .ensure_unique()
             .build_and_sign(keypair);
         tracing::info!(
             "Publishing basics package with tx digest {:?} (attempt {})",

--- a/crates/sui-benchmark/src/workloads/addr_bal_deposit.rs
+++ b/crates/sui-benchmark/src/workloads/addr_bal_deposit.rs
@@ -204,7 +204,7 @@ impl Workload<dyn Payload> for AddrBalDepositWorkload {
                     vec![coin_balance, recipient_arg],
                 );
             }
-            let tx = tx_builder.build_and_sign(keypair.as_ref());
+            let tx = tx_builder.ensure_unique().build_and_sign(keypair.as_ref());
             let proxy_ref = execution_proxy.clone();
             futures.push(async move {
                 let result = proxy_ref.execute_transaction_block(tx).await;
@@ -346,7 +346,9 @@ impl Payload for AddrBalDepositPayload {
             }
         }
 
-        let tx = tx_builder.build_and_sign(self.keypair.as_ref());
+        let tx = tx_builder
+            .ensure_unique()
+            .build_and_sign(self.keypair.as_ref());
         self.metrics.lock().unwrap().sent += 1;
         vec![tx]
     }

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -250,6 +250,7 @@ impl AdversarialTestPayload {
                     .publish_with_data(PublishData::CompiledPackage(
                         self.max_package_published_compiled.clone(),
                     ))
+                    .ensure_unique()
                     .build_and_sign(account.key())
             }
             _ => self.state.move_call_pt(
@@ -477,6 +478,7 @@ impl Workload<dyn Payload> for AdversarialWorkload {
         let transaction = TestTransactionBuilder::new(gas.1, gas.0, reference_gas_price)
             .publish_async(path)
             .await
+            .ensure_unique()
             .build_and_sign(gas.2.as_ref());
 
         let execution_result = execution_proxy.execute_transaction_block(transaction).await;

--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -632,7 +632,7 @@ impl CompositePayload {
             }
         }
 
-        (tx_builder.build_and_sign(keypair), op_set)
+        (tx_builder.ensure_unique().build_and_sign(keypair), op_set)
     }
 
     fn generate_alias_transaction(
@@ -664,6 +664,7 @@ impl CompositePayload {
                             CallArg::Pure(bcs::to_bytes(&alias_state.alias_address).unwrap()),
                         ],
                     )
+                    .ensure_unique()
                     .build_and_sign(keypair);
                 alias_state.cycle_state = AliasRevokeCycleState::RemovePending { tx_digest: None };
                 (
@@ -675,6 +676,7 @@ impl CompositePayload {
             AliasRevokeCycleState::Active { .. } => {
                 let data = TestTransactionBuilder::new(sender, gas, rgp)
                     .transfer_sui(None, sender)
+                    .ensure_unique()
                     .build();
                 let tx = Transaction::from_data_and_signer(
                     data,
@@ -689,6 +691,7 @@ impl CompositePayload {
             AliasRevokeCycleState::Revoked => {
                 let data = TestTransactionBuilder::new(sender, gas, rgp)
                     .transfer_sui(None, sender)
+                    .ensure_unique()
                     .build();
                 let tx = Transaction::from_data_and_signer(
                     data,
@@ -717,6 +720,7 @@ impl CompositePayload {
                             CallArg::Pure(bcs::to_bytes(&alias_state.alias_address).unwrap()),
                         ],
                     )
+                    .ensure_unique()
                     .build_and_sign(keypair);
                 alias_state.cycle_state = AliasRevokeCycleState::AddPending { tx_digest: None };
                 (
@@ -1355,6 +1359,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
         let transaction = TestTransactionBuilder::new(head.1, head.0, gas_price)
             .publish_async(path)
             .await
+            .ensure_unique()
             .build_and_sign(head.2.as_ref());
         let execution_result = execution_proxy.execute_transaction_block(transaction).await;
         let effects = execution_result.expect("Package publish should succeed");
@@ -1389,6 +1394,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
         for (gas, sender, keypair) in tail.iter() {
             let transaction = TestTransactionBuilder::new(*sender, *gas, gas_price)
                 .call_counter_create(self.package_id.unwrap())
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
             let proxy_ref = execution_proxy.clone();
             futures.push(async move {
@@ -1483,7 +1489,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                         vec![coin_balance, recipient_arg],
                     );
                 }
-                let tx = tx_builder.build_and_sign(keypair.as_ref());
+                let tx = tx_builder.ensure_unique().build_and_sign(keypair.as_ref());
 
                 let proxy_ref = execution_proxy.clone();
                 futures.push(async move {
@@ -1506,6 +1512,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
             let gas = &mut multi_gas[0];
             let tx = TestTransactionBuilder::new(*sender, *gas, gas_price)
                 .move_call(self.package_id.unwrap(), "balance_pool", "create", vec![])
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
 
             let execution_result = execution_proxy.execute_transaction_block(tx).await;
@@ -1563,7 +1570,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                     vec![pool_arg, coin_balance],
                 );
             }
-            let tx = tx_builder.build_and_sign(keypair.as_ref());
+            let tx = tx_builder.ensure_unique().build_and_sign(keypair.as_ref());
 
             let execution_result = execution_proxy.execute_transaction_block(tx).await;
             let effects = execution_result.expect("Balance pool seed should succeed");
@@ -1582,6 +1589,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                         "create_cap",
                         vec![cap_ref.into()],
                     )
+                    .ensure_unique()
                     .build_and_sign(keypair.as_ref());
 
                 let execution_result = execution_proxy.execute_transaction_block(tx).await;
@@ -1621,7 +1629,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                     vec![value_arg],
                 );
             }
-            let tx = tx_builder.build_and_sign(keypair.as_ref());
+            let tx = tx_builder.ensure_unique().build_and_sign(keypair.as_ref());
 
             let execution_result = execution_proxy.execute_transaction_block(tx).await;
             let effects = execution_result.expect("Immutable object creation should succeed");
@@ -1685,7 +1693,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                             vec![balance, recipient_arg],
                         );
                     }
-                    let tx = tx_builder.build_and_sign(keypair.as_ref());
+                    let tx = tx_builder.ensure_unique().build_and_sign(keypair.as_ref());
 
                     let execution_result = execution_proxy.execute_transaction_block(tx).await;
                     let effects = execution_result.expect("TEST_COIN seed deposit should succeed");
@@ -1737,6 +1745,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                             mutability: SharedObjectMutability::Mutable,
                         })],
                     )
+                    .ensure_unique()
                     .build_and_sign(keypair.as_ref());
 
                 let execution_result = execution_proxy.execute_transaction_block(enable_tx).await;
@@ -1797,7 +1806,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                         .collect();
                     builder.transfer_args(*sender, new_coin_args);
                 }
-                let tx = tx_builder.build_and_sign(keypair.as_ref());
+                let tx = tx_builder.ensure_unique().build_and_sign(keypair.as_ref());
                 let proxy_ref = execution_proxy.clone();
                 futures.push(async move {
                     let execution_result = proxy_ref.execute_transaction_block(tx).await;

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -67,6 +67,7 @@ impl Payload for DelegationTestPayload {
                     .reference_gas_price,
             )
             .call_staking(coin, self.validator)
+            .ensure_unique()
             .build_and_sign(self.keypair.as_ref()),
             None => make_transfer_sui_transaction(
                 self.gas,

--- a/crates/sui-benchmark/src/workloads/party.rs
+++ b/crates/sui-benchmark/src/workloads/party.rs
@@ -137,7 +137,7 @@ impl PartyTestPayload {
             );
         }
 
-        tx_builder.build_and_sign(account.key())
+        tx_builder.ensure_unique().build_and_sign(account.key())
     }
 }
 
@@ -252,6 +252,7 @@ impl Workload<dyn Payload> for PartyWorkload {
             TestTransactionBuilder::new(first_gas.1, first_gas.0, reference_gas_price)
                 .publish_async(path)
                 .await
+                .ensure_unique()
                 .build_and_sign(first_gas.2.as_ref());
         let execution_result = execution_proxy.execute_transaction_block(transaction).await;
         let effects = execution_result.unwrap();
@@ -282,6 +283,7 @@ impl Workload<dyn Payload> for PartyWorkload {
         for (gas, sender, keypair) in &self.payload_gas[..self.payload_gas.len() / 2] {
             let transaction = TestTransactionBuilder::new(*sender, *gas, reference_gas_price)
                 .move_call(self.package_id, "party", "create_party", vec![])
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
             let state = state.clone();
             let system_state_observer = system_state_observer.clone();
@@ -327,6 +329,7 @@ impl Workload<dyn Payload> for PartyWorkload {
         for (gas, sender, keypair) in &self.payload_gas[self.payload_gas.len() / 2..] {
             let transaction = TestTransactionBuilder::new(*sender, *gas, reference_gas_price)
                 .move_call(self.package_id, "party", "create_fastpath", vec![])
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
             let state = state.clone();
             let system_state_observer = system_state_observer.clone();

--- a/crates/sui-benchmark/src/workloads/randomized_transaction.rs
+++ b/crates/sui-benchmark/src/workloads/randomized_transaction.rs
@@ -333,7 +333,9 @@ impl Payload for RandomizedTransactionPayload {
                 }
             }
 
-            let signed_tx = tx_builder.build_and_sign(self.gas_objects[i].2.as_ref());
+            let signed_tx = tx_builder
+                .ensure_unique()
+                .build_and_sign(self.gas_objects[i].2.as_ref());
             transactions.push(signed_tx);
         }
 
@@ -607,6 +609,7 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
             for (gas, sender, keypair) in counter_gas.iter() {
                 let transaction = TestTransactionBuilder::new(*sender, *gas, gas_price)
                     .call_counter_create(self.basics_package_id.unwrap())
+                    .ensure_unique()
                     .build_and_sign(keypair.as_ref());
                 let proxy_ref = execution_proxy.clone();
                 futures.push(async move {
@@ -633,6 +636,7 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
                         CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
                     ],
                 )
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
             let execution_result = execution_proxy.execute_transaction_block(transaction).await;
             let effects = execution_result.expect("Failed to create immutable object");
@@ -648,6 +652,7 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
                     "freeze_object",
                     vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(created_obj))],
                 )
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
             let execution_result = execution_proxy.execute_transaction_block(transaction).await;
             let effects = execution_result.expect("Failed to freeze object");
@@ -680,6 +685,7 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
                             CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
                         ],
                     )
+                    .ensure_unique()
                     .build_and_sign(keypair.as_ref());
                 let proxy_ref = execution_proxy.clone();
                 futures.push(async move {

--- a/crates/sui-benchmark/src/workloads/randomness.rs
+++ b/crates/sui-benchmark/src/workloads/randomness.rs
@@ -89,7 +89,9 @@ impl Payload for RandomnessTestPayload {
                 .unwrap();
         }
 
-        tx_builder.build_and_sign(self.gas.2.as_ref())
+        tx_builder
+            .ensure_unique()
+            .build_and_sign(self.gas.2.as_ref())
     }
     fn get_failure_type(&self) -> Option<ExpectedFailureType> {
         None
@@ -235,6 +237,7 @@ impl Workload<dyn Payload> for RandomnessWorkload {
         if self.counter_id.is_none() {
             let transaction = TestTransactionBuilder::new(counter_gas.1, counter_gas.0, gas_price)
                 .call_counter_create(self.basics_package_id.unwrap())
+                .ensure_unique()
                 .build_and_sign(counter_gas.2.as_ref());
             let (obj_ref, owner) = execution_proxy
                 .execute_transaction_block(transaction)

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -70,6 +70,7 @@ impl Payload for SharedCounterTestPayload {
                 self.counter_id,
                 self.counter_initial_shared_version,
             )
+            .ensure_unique()
             .build_and_sign(self.gas.2.as_ref())
     }
     fn get_failure_type(&self) -> Option<ExpectedFailureType> {
@@ -231,6 +232,7 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
         for (gas, sender, keypair) in tail.iter() {
             let transaction = TestTransactionBuilder::new(*sender, *gas, gas_price)
                 .call_counter_create(self.basics_package_id.unwrap())
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
             let proxy_ref = execution_proxy.clone();
             futures.push(async move {

--- a/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
+++ b/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
@@ -116,6 +116,7 @@ impl Payload for SharedCounterDeletionTestPayload {
             }
             _ => panic!("Invalid transaction selector"),
         }
+        .ensure_unique()
         .build_and_sign(self.gas.2.as_ref())
     }
     fn get_failure_type(&self) -> Option<ExpectedFailureType> {
@@ -272,6 +273,7 @@ impl Workload<dyn Payload> for SharedCounterDeletionWorkload {
         for (gas, sender, keypair) in tail.iter() {
             let transaction = TestTransactionBuilder::new(*sender, *gas, gas_price)
                 .call_counter_create(self.basics_package_id.unwrap())
+                .ensure_unique()
                 .build_and_sign(keypair.as_ref());
             let proxy_ref = execution_proxy.clone();
             futures.push(async move {

--- a/crates/sui-benchmark/src/workloads/slow.rs
+++ b/crates/sui-benchmark/src/workloads/slow.rs
@@ -99,7 +99,7 @@ impl SlowTestPayload {
                 .unwrap();
         }
 
-        tx_builder.build_and_sign(account.key())
+        tx_builder.ensure_unique().build_and_sign(account.key())
     }
 }
 
@@ -217,6 +217,7 @@ impl Workload<dyn Payload> for SlowWorkload {
         let transaction = TestTransactionBuilder::new(gas.1, gas.0, reference_gas_price)
             .publish_async(path)
             .await
+            .ensure_unique()
             .build_and_sign(gas.2.as_ref());
         let execution_result = execution_proxy.execute_transaction_block(transaction).await;
         let effects = execution_result.unwrap();

--- a/crates/sui-test-transaction-builder/Cargo.toml
+++ b/crates/sui-test-transaction-builder/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 
 [dependencies]
 bcs.workspace = true
+rand.workspace = true
 
 shared-crypto.workspace = true
 sui-genesis-builder.workspace = true

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -3,6 +3,7 @@
 
 use move_core_types::ident_str;
 use move_core_types::u256::U256;
+use rand::Rng;
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::path::PathBuf;
 use sui_genesis_builder::validator_info::GenesisValidatorMetadata;
@@ -677,6 +678,15 @@ impl TestTransactionBuilder {
 
     pub fn build_and_sign(self, signer: &dyn Signer<Signature>) -> Transaction {
         Transaction::from_data_and_signer(self.build(), vec![signer])
+    }
+
+    // ensure that transaction is unique
+    pub fn ensure_unique(mut self) -> Self {
+        let nonce: u64 = rand::thread_rng().r#gen();
+        self.ptb_builder
+            .force_separate_pure(nonce)
+            .expect("nonce serialization is infallible");
+        self
     }
 
     pub fn build_and_sign_multisig(


### PR DESCRIPTION
## Summary

- Adds `TestTransactionBuilder::ensure_unique() -> Self` — a chainable method that injects a random `u64` unused pure input (via `force_separate_pure`) so every subsequent `build()` / `build_and_sign()` produces a unique digest even when all logical inputs are identical
- `build()` itself is unchanged, so tests that intentionally build duplicate transactions are unaffected
- All 38 sui-benchmark call sites now call `.ensure_unique()` before building

## Root cause

In the alias-revocation benchmark workload (`composite/mod.rs`), both the `Active` and `Revoked` states build structurally identical transactions — `transfer_sui(None, sender)` signed by the alias keypair. When a bundle submission fails with a transport error during rolling restarts, the workload marks the transaction failed and does not update gas tracking. However the transaction may have already reached consensus and committed.

Later, the `Revoked` state fires with the same stale gas object version and produces the exact same digest. The validator returns "already executed" with the cached success result, tripping the `debug_fatal!` assertion that the post-revocation tx must fail.

## Test plan

- Verified the specific failing seed passes: `MSIM_TEST_SEED=1780854396117 cargo simtest --test simtest -E 'test(=test::test_simulated_load_rolling_restarts_all_validators)'`
- Ran post-fix seed search across 200 seeds with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)