### PR TITLE
fix(ci): trigger-builds cache_family falls back to main when branch not cut

### DIFF
--- a/.github/workflows/trigger-builds.yml
+++ b/.github/workflows/trigger-builds.yml
@@ -31,7 +31,24 @@ jobs:
         shell: bash
         run: |
           sui_version=$(awk '/^\[workspace\.package\]/{found=1} found && /^version =/{gsub(/[" ]/,"",$3); print $3; exit}' Cargo.toml)
-          echo "cache_family=releases/sui-v${sui_version}-release" >> "$GITHUB_OUTPUT"
+          # Bucket the cargo-target cache by the branch the build originates from.
+          # Release branches are cut at the minor version (patch .0); normalize to
+          # that. If that branch doesn't exist yet (e.g. the devnet branch tracks
+          # main before the cut), the build is off main, so bucket by main instead
+          # of a non-existent releases/sui-v<version>-release.
+          release_branch="releases/sui-v$(echo "${sui_version}" | awk -F. '{print $1"."$2".0"}')-release"
+          # git ls-remote --exit-code: 0 = ref found, 2 = remote reached but ref
+          # absent, anything else = couldn't reach the remote. Only treat a genuine
+          # "absent" (2) as the pre-cut/main case; fail loudly on a lookup error so a
+          # transient GitHub/network blip can't silently mis-bucket the cache.
+          rc=0
+          git ls-remote --exit-code --heads https://github.com/MystenLabs/sui.git "${release_branch}" >/dev/null 2>&1 || rc=$?
+          case "${rc}" in
+            0) cache_family="${release_branch}" ;;
+            2) cache_family="main" ;;
+            *) echo "::error::git ls-remote for ${release_branch} failed (exit ${rc}) — refusing to guess cache_family"; exit 1 ;;
+          esac
+          echo "cache_family=${cache_family}" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch Tagging of images in DockerHub, in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1


### PR DESCRIPTION
## Problem
`trigger-builds.yml` fires on pushes to the `devnet`/`testnet`/`mainnet` branches and derived the mp3 **`cache_family`** straight from the raw Cargo.toml version:
```bash
echo "cache_family=releases/sui-v${sui_version}-release"
```

**Observed:** a devnet release (force-push of the v1.74.0 main commit `5c392a5a6a94` to the `devnet` branch) produced builds (e.g. `sui-bridge-indexer` #37833, `sui-checkpoint-blob-indexer` #37835) with `cache_family: releases/sui-v1.74.0-release` — **a branch that doesn't exist**, since 1.74.0 is still on `main` (not branch-cut).

Two bugs in that one line:
1. **Branch-not-cut:** on a **devnet** push the version is main's (1.74.0) and `releases/sui-v1.74.0-release` doesn't exist yet. The build is off `main`, so the family should be **`main`** — instead it buckets the `/cargo-target` cache under a non-existent branch key that nothing else shares, so devnet images compile **cold every release**.
2. **Patch leak:** the raw version means a **testnet/mainnet** push at patch ≥ 1 (e.g. 1.73.1) emits `releases/sui-v1.73.1-release`, which also doesn't exist (branches are cut at `.0`). Same class of bug fixed in `release.yml` (#26895) and sui-operations `continuous-release.yml` — `trigger-builds.yml` was missed.

## Fix
Normalize the patch to `.0`, and use that release branch as the cache family **only if it actually exists**; otherwise the build is off `main`, so bucket by `main`:
```bash
release_branch="releases/sui-v$(echo "${sui_version}" | awk -F. '{print $1"."$2".0"}')-release"
if git ls-remote --exit-code --heads https://github.com/MystenLabs/sui.git "${release_branch}" >/dev/null 2>&1; then
  cache_family="${release_branch}"
else
  cache_family="main"
fi
```

Resulting behavior:
- **devnet** (1.74.0, branch not cut) → **`main`** ✅ (shares the warm main cargo-target bucket)
- **testnet/mainnet** (1.73.x, branch exists) → **`releases/sui-v1.73.0-release`** ✅ (`.0`-normalized, real branch)
- patch-leak gone: 1.73.1 → `releases/sui-v1.73.0-release`

## Impact
Cache efficiency only — not a correctness issue. Today devnet builds miss the warm `main` cache; after this they share it.

## Test
- `awk` normalization verified: `1.74.0→1.74.0`, `1.73.1→1.73.0`, `1.73.0→1.73.0`.
- `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update (per review):** hardened the `git ls-remote` check so only a genuine *absent* result maps to `main`. It now keys on the exit code — `0` (found) → release branch, `2` (reached remote, ref absent) → `main`, anything else (couldn't reach the remote, e.g. exit 128) → **fail loudly** rather than silently mis-bucketing the cache on a transient GitHub/network blip.