### PR TITLE
fix(sui-core): allow epoch to advance by more than one in submit_tx retry

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -8,7 +8,7 @@ use fastcrypto::traits::KeyPair;
 use futures::{TryFutureExt, future};
 use itertools::Itertools as _;
 use mysten_common::ZipDebugEqIteratorExt;
-use mysten_common::{assert_reachable, debug_fatal};
+use mysten_common::assert_reachable;
 use mysten_metrics::spawn_monitored_task;
 use prometheus::{
     Gauge, Histogram, HistogramVec, IntCounter, IntCounterVec, Registry,
@@ -573,19 +573,15 @@ impl ValidatorService {
                             "ValidatorHaltedAtEpochEnd. Will retry after validator reconfigures"
                         );
 
-                        if let Ok(Ok(new_epoch)) =
+                        if let Ok(Ok(_new_epoch)) =
                             timeout(Duration::from_secs(15), state.wait_for_epoch(next_epoch)).await
                         {
                             assert_reachable!("retry submission at epoch end");
-                            if new_epoch == next_epoch {
-                                continue;
-                            }
-
-                            debug_fatal!(
-                                "expected epoch {} after reconfiguration. got {}",
-                                next_epoch,
-                                new_epoch
-                            );
+                            // wait_for_epoch guarantees _new_epoch >= next_epoch, so any
+                            // returned epoch is a valid signal that reconfiguration completed.
+                            // Under crashes/delays the epoch can advance by more than one, so
+                            // checking for strict equality was a false invariant.
+                            continue;
                         }
                     }
                     return Err(err.into());

--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -387,6 +387,9 @@ parser.add_argument('--watchdog-timeout-ms', type=int, default=120000,
 parser.add_argument('--log-dir', type=str, default=None,
                     help='Directory for per-job log files plus failures.ndjson. '
                          'When set, per-job stdout+stderr is captured to disk instead of memory.')
+parser.add_argument('--error-regex', type=str, default=None,
+                    help='Regex to match against test output; exit early and report the repro command '
+                         'when a failing seed whose output matches the pattern is found.')
 args = parser.parse_args()
 
 if args.no_build and args.package:
@@ -396,10 +399,31 @@ if not args.test and not args.package:
     print("Error: must supply at least one --test or --package", file=sys.stderr)
     sys.exit(2)
 
+error_re = re.compile(args.error_regex) if args.error_regex else None
+
 # Cap on per-process wall time. Without this, a hung test process would block
 # the whole sweep forever; matches `simtestnightly`'s nextest slow-timeout
 # (period=30m, terminate-after=3 = 90 minutes).
 PROCESS_TIMEOUT_SECS = 90 * 60
+
+def _report_error_match_found(seed, job, log_path):
+    """Print repro info for a seed matching --error-regex and kill the process group."""
+    c = Colors
+    if is_tty and progress_tracker:
+        with print_lock:
+            sys.stdout.write("\033[2K\033[A\033[2K\r")
+            sys.stdout.flush()
+    binary_name = job["binary_name"]
+    test = job["test"]
+    print(f"\n{c.GREEN}{c.BOLD}[MATCH] --error-regex matched: seed={seed}{c.RESET}")
+    print(f"  binary: {binary_name}")
+    print(f"  test:   {test}")
+    print(f"\nRepro command:")
+    print(f"  MSIM_TEST_SEED={seed} RUST_LOG=sui=debug,info cargo simtest --test {binary_name} -E 'test(={test})' -- --no-capture")
+    if log_path:
+        print(f"  log:    {log_path}")
+    sys.stdout.flush()
+    os.killpg(0, signal.SIGKILL)
 
 def run_command(job):
     cmd = job["cmd"]
@@ -469,6 +493,19 @@ def run_command(job):
                 safe_print(f"stdout:\n=========================={captured_stdout.decode('utf-8', errors='replace')}\n==========================")
                 if captured_stderr:
                     safe_print(f"stderr:\n=========================={captured_stderr.decode('utf-8', errors='replace')}\n==========================")
+
+            if error_re is not None:
+                if log_path:
+                    try:
+                        with open(log_path, "rb") as f:
+                            output_text = f.read().decode("utf-8", errors="replace")
+                    except OSError:
+                        output_text = ""
+                else:
+                    output_text = (captured_stdout or b"").decode("utf-8", errors="replace")
+                    output_text += (captured_stderr or b"").decode("utf-8", errors="replace")
+                if error_re.search(output_text):
+                    _report_error_match_found(seed, job, log_path)
         else:
             if not is_tty:
                 safe_print(f"-- seed passed {seed}")
@@ -556,7 +593,7 @@ if __name__ == "__main__":
     if args.log_dir:
         os.makedirs(args.log_dir, exist_ok=True)
 
-    rust_log = "error" if (args.no_capture or args.log_dir) else "off"
+    rust_log = "error" if (args.no_capture or args.log_dir or args.error_regex) else "off"
 
     # SIMTEST_STATIC_INIT_MOVE is normally exported by cargo-simtest at runtime;
     # since we invoke test binaries directly, we have to set it ourselves.


### PR DESCRIPTION
## Summary

When a transaction receives `ValidatorHaltedAtEpochEnd`, `authority_server.rs` records `next_epoch = current_epoch + 1`, then calls `wait_for_epoch(next_epoch)` and retries. The previous code panicked (via `debug_fatal!`) if the returned epoch wasn't exactly `next_epoch`.

This was a false invariant. `wait_for_epoch` returns the current epoch as soon as it is `>= target_epoch`, so the returned value can be higher than `next_epoch` — this happens legitimately under crashes and delays, where the network can reconfigure multiple times before the retry loop wakes up. The panic surfaced as a flaky `test_simulated_load_reconfig_with_crashes_and_delays` failure.

Fix: drop the strict equality check and always retry after a successful `wait_for_epoch` return. Any epoch `>= next_epoch` is a valid signal that reconfiguration completed.

Also includes a small improvement to `scripts/simtest/seed-search.py`: new `--error-regex` flag that matches test output against a regex and exits early with the repro command when a matching failing seed is found, making targeted seed searches much faster.

## Test plan
- [ ] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-core` passes
- [ ] `cargo xclippy -D warnings` on `sui-core` passes
- [ ] Run `scripts/simtest/seed-search.py --test simtest test::test_simulated_load_reconfig_with_crashes_and_delays --exact --error-regex "expected epoch.*after reconfiguration"` — should find no matching seeds with this fix applied