### PR TITLE
fix(sui-core): allow epoch to advance by >1 in submit_tx ValidatorHaltedAtEpochEnd retry

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -577,12 +577,12 @@ impl ValidatorService {
                             timeout(Duration::from_secs(15), state.wait_for_epoch(next_epoch)).await
                         {
                             assert_reachable!("retry submission at epoch end");
-                            if new_epoch == next_epoch {
+                            if new_epoch >= next_epoch {
                                 continue;
                             }
-
+                            // wait_for_epoch guarantees >= target; < would indicate a bug there.
                             debug_fatal!(
-                                "expected epoch {} after reconfiguration. got {}",
+                                "wait_for_epoch returned early: expected >= {}, got {}",
                                 next_epoch,
                                 new_epoch
                             );


### PR DESCRIPTION
When a transaction hits `ValidatorHaltedAtEpochEnd`, `authority_server.rs` waits for `next_epoch = current_epoch + 1` before retrying. The previous code called `debug_fatal!` if the returned epoch wasn't exactly `next_epoch`.

`wait_for_epoch` returns the current epoch as soon as it reaches `>= target_epoch`, so the epoch can legitimately be higher than `next_epoch` — this happens under crashes and delays where the network reconfigures multiple times before the retry wakes up. The strict equality check was a false invariant that caused flaky panics in `test_simulated_load_reconfig_with_crashes_and_delays`.

Fix: drop the check and always retry after a successful `wait_for_epoch` return.