### PR TITLE
ci(sccache): warm-cache via GitHub OIDC instead of static AWS keys

### DIFF
--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -22,6 +22,9 @@ jobs:
   warm-cache:
     name: Warm sccache (${{ matrix.os }})
     timeout-minutes: 240
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token to assume the sccache role
     strategy:
       matrix:
         os:
@@ -54,8 +57,10 @@ jobs:
 
       - uses: ./.github/actions/setup-sccache
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # OIDC on main (scheduled run / dispatch from main). The role trusts only
+          # the protected branches, so an off-ref workflow_dispatch passes an empty
+          # role and setup-sccache falls back to a local cache instead of failing.
+          role-to-assume: ${{ github.ref == 'refs/heads/main' && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
           key-prefix: ${{ matrix.os }}
 
       - name: Register cargo problem matcher
@@ -150,11 +155,20 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs: [warm-cache]
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token to read bucket stats for the report
     steps:
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      # Read-only bucket stats via the same role (it has s3:ListBucket). Gated to
+      # main so an off-ref dispatch skips cred config; the report below then shows
+      # zeros instead of failing.
+      - name: Configure AWS credentials (OIDC)
+        if: github.ref == 'refs/heads/main'
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::011083325127:role/sui-sccache-rw-github
+          role-session-name: sui-sccache-summary-${{ github.run_id }}-${{ github.run_attempt }}
+          allowed-account-ids: '011083325127'
           aws-region: us-west-2
 
       - name: Generate cache report


### PR DESCRIPTION
## What

**Phase 1** of migrating `MystenLabs/sui` CI off long-lived AWS keys → GitHub OIDC (enabler landed in #26922). Flips the lowest-risk caller — `sccache-warmup.yml` — to assume the **already-provisioned** `sui-sccache-rw-github` role via OIDC. No new AWS resources.

Both AWS auth sites converted; the workflow no longer references `secrets.AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`:

| Job | Before | After |
|---|---|---|
| `warm-cache` | `setup-sccache` w/ static keys (RW cache) | `role-to-assume: …/sui-sccache-rw-github` via OIDC |
| `cache-summary` | `configure-aws-credentials` w/ static keys (`aws s3 ls`) | same role via OIDC (read-only `ListBucket`) |

## Hardening applied
- **Job-level `id-token: write`** on the two AWS-touching jobs only — not workflow level (`report-failure` stays default).
- **Trusted-ref gating** — `role-to-assume` is passed only on `refs/heads/main`. The role trusts just the four protected branches, so an off-ref `workflow_dispatch` passes an empty role and `setup-sccache` falls back to a **local** cache instead of failing the AssumeRole. `cache-summary` gates its cred step the same way and the report degrades to zeros.
- `allowed-account-ids: 011083325127` is pinned in the action (both cred paths) + here for the summary step; `role-session-name` carries run/attempt for CloudTrail.

The role (`arn:aws:iam::011083325127:role/sui-sccache-rw-github`, policy `sui-sccache-rw`) is RW to `mystenlabs-sccache` only, `aud` pinned, subjects = `main`/`devnet`/`testnet`/`mainnet`, no wildcard.

## Test plan
- [ ] Merge, then `workflow_dispatch` from **main**.
- [ ] `warm-cache`: `Configure AWS credentials (OIDC)` step runs (no static-key step), sccache shows S3 hits/puts, build green on all three matrix OSes.
- [ ] `cache-summary`: report posts real object/byte counts.
- [ ] CloudTrail: `AssumeRoleWithWebIdentity` events for `sui-sccache-rw-github` with session name `sui-sccache-*-<run_id>-<attempt>`.
- [ ] (Negative) `workflow_dispatch` from a throwaway branch → no AssumeRole failure; build proceeds on local cache; summary shows zeros.

Once green for a cycle → **Phase 2** (`nightly.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)