### PR TITLE
ci(sccache): nightly build via GitHub OIDC instead of static AWS keys

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,12 +31,17 @@ jobs:
   release:
     name: Build Release Binaries
     runs-on: [ubuntu-ghcloud]
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token to assume the sccache role
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - uses: ./.github/actions/setup-sccache
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # OIDC on main (scheduled / dispatch from main). The role trusts only the
+          # protected branches, so an off-ref workflow_dispatch passes an empty role
+          # and setup-sccache falls back to a local cache instead of failing.
+          role-to-assume: ${{ github.ref == 'refs/heads/main' && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
           key-prefix: ubuntu-ghcloud
       - name: Register cargo problem matcher
         run: echo "::add-matcher::.github/matchers/cargo.json"


### PR DESCRIPTION
**Phase 2** of migrating `MystenLabs/sui` CI off static AWS keys → GitHub OIDC. Same mechanical change as the validated warmup flip (#26923), applied to `nightly.yml`'s `release` build job. Uses the already-provisioned `sui-sccache-rw-github` role — no new AWS resources.

- `setup-sccache` now passes `role-to-assume` (OIDC) instead of `secrets.AWS_ACCESS_KEY_ID`/`SECRET`.
- **Job-level `id-token: write`** on the build job only.
- **Trusted-ref gating** — role passed only on `refs/heads/main`; an off-ref `workflow_dispatch` gets an empty role and `setup-sccache` falls back to a local cache instead of failing AssumeRole. `allowed-account-ids` + `role-session-name` are pinned in the action.

### Validation context
Phase 1 (#26923) was confirmed working: CloudTrail logged a successful `AssumeRoleWithWebIdentity` for `sui-sccache-rw-github` (session `sui-sccache-<run_id>-1`) and `setup-sccache` came up on S3. nightly runs on `main` (schedule/dispatch), so the same trust applies.

### Test plan
- [ ] Merge, then `workflow_dispatch` from **main**; confirm the OIDC cred step runs (no static-key step), sccache shows S3 hits, build green.
- [ ] CloudTrail shows `AssumeRoleWithWebIdentity` for `sui-sccache-rw-github`.

Next: **Phase 3** — the remaining trusted `setup-sccache` callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)