### PR TITLE
docs(oidc): per-call-site setup-sccache caller inventory + classification

### DIFF
--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -1,0 +1,107 @@
+<!--
+Copyright (c) Mysten Labs, Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AWS OIDC migration — `setup-sccache` caller inventory
+
+Companion to [`AWS_OIDC_ROLES.md`](./AWS_OIDC_ROLES.md). Classifies every
+`setup-sccache` call site so the static-key → OIDC migration can be sequenced per
+**call site and per event/ref**, not per file. Mixed-trigger workflows
+(`push` + `pull_request`) are split across both: a single job is "trusted" on a
+protected-branch push and "untrusted" on a PR.
+
+The RW cache role is `arn:aws:iam::011083325127:role/sui-sccache-rw-github`. Its
+trust today = **only** these subjects (aud pinned, no wildcard):
+`repo:MystenLabs/sui:ref:refs/heads/{main,devnet,testnet,mainnet}`.
+
+## Status
+
+| Workflow             | Call sites | Triggers                                     | Auth today  | Phase |
+| -------------------- | ---------- | -------------------------------------------- | ----------- | ----- |
+| `sccache-warmup.yml` | 2          | schedule, workflow_dispatch                  | **OIDC ✅** | 1 ✅  |
+| `nightly.yml`        | 1          | schedule, workflow_dispatch (disabled)       | **OIDC ✅** | 2 ✅  |
+| `rust.yml`           | 11         | push, pull_request, workflow_dispatch        | static keys | 3/4   |
+| `external.yml`       | 2          | push, pull_request                           | static keys | 3/4   |
+| `bridge.yml`         | 2          | push, pull_request, workflow_dispatch        | static keys | 3/4   |
+| `release.yml`        | 1          | release, workflow_dispatch                   | static keys | 5     |
+
+## How each event/ref classifies
+
+The decision is the OIDC `sub` of the run, which depends on the event + ref:
+
+| Event              | Ref                                  | `sub`                          | Assume RW role #1 today? | Plan                                  |
+| ------------------ | ------------------------------------ | ------------------------------ | ------------------------ | ------------------------------------- |
+| `push`             | `main`/`devnet`/`testnet`/`mainnet`  | `…:ref:refs/heads/<b>`         | **YES**                  | OIDC RW (trusted)                     |
+| `push`             | `releases/sui-*-release`             | `…:ref:refs/heads/releases/…`  | **NO — trust gap**       | add ref to role trust → OIDC RW       |
+| `push`             | `extensions` (external.yml only)     | `…:ref:refs/heads/extensions`  | **NO — trust gap**       | add ref to role trust, or local cache |
+| `workflow_dispatch`| `main`                               | `…:ref:refs/heads/main`        | **YES**                  | OIDC RW                               |
+| `workflow_dispatch`| feature branch                       | `…:ref:refs/heads/<feat>`      | **NO**                   | local-cache fallback (expected)       |
+| `pull_request`     | any (same-repo **and** fork)         | `…:pull_request`               | **NO — by design**       | **blocked on A/B/C** (see roles doc)  |
+
+## Per-call-site map
+
+### `rust.yml` — 11 sites (`push`[main,devnet,testnet,mainnet,releases/sui-*-release] + `pull_request` + `workflow_dispatch`)
+
+`test` (L97), `test-tidehunter` (L146), `test-extra` (L211), `benchmark-smoke`
+(L276), `windows-build` (L334), `windows-cli-tests` (L361), `simtest` (L386),
+`simtest-mainnet` (L422), `move-test` (L458), `clippy` (L554), `sui-excution-cut`
+(L635). Prefixes: `ubuntu-ghcloud` (×9), `windows-ghcloud` (×2).
+
+### `external.yml` — 2 sites (`push`[main,extensions,devnet] + `pull_request`)
+
+`external-crates-test` (L66), `clippy` (L107). Prefix `ubuntu-ghcloud`.
+Note `extensions` push is a trust gap.
+
+### `bridge.yml` — 2 sites (`push`[main,devnet,testnet,mainnet,releases/sui-*-release] + `pull_request` + `workflow_dispatch`)
+
+`clippy` (L85), `test` (L111). Prefix `ubuntu-ghcloud`.
+
+### `release.yml` — 1 site — **Phase 5, special**
+
+`release-build` (L155), prefix `${{ matrix.os }}`. Triggers on `release: created`
+(tag) + `workflow_dispatch`. **Two reasons it is not part of the Phase-3 batch:**
+1. It also writes to `s3://sui-releases` via the **separate** `release-s3` role in
+   the **same job**, and `configure-aws-credentials` overwrites cred env vars — the
+   job must re-assume the right role before each S3 op (see roles doc §"Credential
+   sequencing"). The `release` GitHub Environment for that role now exists.
+2. Its sccache run is on a **release tag** (`*-v*`), which is **not** in role #1's
+   trust — a separate gap from the release-branch one.
+
+## Trust-policy gaps blocking the "trusted" path
+
+Before a trusted-ref flip can actually use the cache (rather than silently
+dropping to local) on these refs, add the subject(s) to role #1's trust:
+
+1. **`releases/sui-*-release` branches** — needed by `rust.yml`, `bridge.yml` push CI.
+2. **`extensions` branch** — needed by `external.yml` push CI (decide if worth it).
+3. **`*-v*` tags** — needed by `release.yml` sccache (Phase 5).
+
+Until added, those refs fall back to local cache (no breakage, just no shared cache).
+
+## Recommended Phase-3 mechanic for mixed-trigger callers
+
+`setup-sccache` prefers `role-to-assume` when set and falls back to static keys
+when only those are set. That lets a single call site be flipped **without
+changing PR behavior**, by passing **both**:
+
+```yaml
+- uses: ./.github/actions/setup-sccache
+  with:
+    # trusted refs → OIDC RW; empty elsewhere
+    role-to-assume: ${{ contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
+    # retained so same-repo PRs keep today's RW cache until Phase 4 decides A/B/C
+    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    key-prefix: ...
+```
+
+- **Trusted push / dispatch-from-main** → OIDC RW (no static keys used).
+- **`pull_request`** → empty role → static-key fallback = **unchanged behavior**.
+- **Phase 4** then resolves the PR path per A/B/C (RO role, no-cache, or fork split).
+- **Phase 7** removes the static-key inputs once no event path needs them.
+
+**Decision required to finish the mixed callers (Phase 4):** pick PR-cache option
+**A** (all PRs → RO role), **B** (no PR cache), or **C** (same-repo RO, fork none)
+— see `AWS_OIDC_ROLES.md` §"PR read-only cache". The Phase-3 dual-pass above is the
+same regardless; A/B/C only changes the Phase-4 follow-up and when static keys die.

--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -12,8 +12,10 @@ Companion to [`AWS_OIDC_ROLES.md`](./AWS_OIDC_ROLES.md). Classifies every
 protected-branch push and "untrusted" on a PR.
 
 The RW cache role is `arn:aws:iam::011083325127:role/sui-sccache-rw-github`. Its
-trust today = **only** these subjects (aud pinned, no wildcard):
-`repo:MystenLabs/sui:ref:refs/heads/{main,devnet,testnet,mainnet}`.
+trust (aud pinned, no wildcard) = these subjects:
+`repo:MystenLabs/sui:ref:refs/heads/{main,devnet,testnet,mainnet}` **plus**
+`repo:MystenLabs/sui:ref:refs/heads/releases/sui-*-release` (added 2026-06-08).
+Keep any new `SCCACHE_ROLE` gate in sync with this exact set.
 
 ## Status
 
@@ -35,9 +37,18 @@ The decision is the OIDC `sub` of the run, which depends on the event + ref:
 | `push`             | `main`/`devnet`/`testnet`/`mainnet`  | `…:ref:refs/heads/<b>`         | **YES**                  | OIDC RW (trusted)                     |
 | `push`             | `releases/sui-*-release`             | `…:ref:refs/heads/releases/…`  | **YES** (added 2026-06-08) | OIDC RW (trusted)                   |
 | `push`             | `extensions` (external.yml only)     | `…:ref:refs/heads/extensions`  | **NO — excluded**        | branch is 404; local-cache fallback   |
-| `workflow_dispatch`| `main`                               | `…:ref:refs/heads/main`        | **YES**                  | OIDC RW                               |
+| `workflow_dispatch`| `main`, **no** `sui_repo_ref`        | `…:ref:refs/heads/main`        | **YES**                  | OIDC RW                               |
+| `workflow_dispatch`| `main` + `sui_repo_ref=<feature>`    | `…:ref:refs/heads/main`        | sub matches, but **gate OFF** | builds the override ref (untrusted code) → must NOT hold RW; gate requires `sui_repo_ref==''` → static/local |
 | `workflow_dispatch`| feature branch                       | `…:ref:refs/heads/<feat>`      | **NO**                   | local-cache fallback (expected)       |
 | `pull_request`     | any (same-repo **and** fork)         | `…:pull_request`               | **NO — by design**       | **blocked on A/B/C** (see roles doc)  |
+
+> **Checkout-ref caveat (rust.yml / bridge.yml).** The OIDC `sub` (and thus role
+> assumability) is decided by `github.ref` — but these workflows check out
+> `${{ github.event.inputs.sui_repo_ref || github.ref }}`. So a `workflow_dispatch`
+> from `main` with `sui_repo_ref` set to a feature ref has a **trusted `sub`** while
+> **building untrusted code**. The `SCCACHE_ROLE` gate must therefore also require
+> `sui_repo_ref` to be empty, or that build would populate the RW cache from
+> arbitrary code. `external.yml` has no such input, so it is unaffected.
 
 ## Per-call-site map
 
@@ -96,18 +107,37 @@ to local cache):
 
 `setup-sccache` prefers `role-to-assume` when set and falls back to static keys
 when only those are set. That lets a single call site be flipped **without
-changing PR behavior**, by passing **both**:
+changing PR behavior**. Compute the role once at the **workflow level** (a
+workflow-level `env` value may reference the `github` context — actionlint-confirmed)
+and reference it from each sccache job. As implemented + validated in `bridge.yml`
+(PR #26927):
 
 ```yaml
-- uses: ./.github/actions/setup-sccache
-  with:
-    # trusted refs → OIDC RW; empty elsewhere
-    role-to-assume: ${{ contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
-    # retained so same-repo PRs keep today's RW cache until Phase 4 decides A/B/C
-    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    key-prefix: ...
+env:
+  # OIDC RW role only when BOTH: (1) the ref/sub is trusted, AND (2) we are not a
+  # workflow_dispatch building an override ref (sui_repo_ref). Keep the ref set in
+  # sync with the role trust. Drop the sui_repo_ref clause for workflows lacking
+  # that input (e.g. external.yml).
+  SCCACHE_ROLE: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.sui_repo_ref == '') && (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
+
+jobs:
+  <sccache-job>:
+    permissions:
+      contents: read
+      id-token: write # only the sccache jobs, not the whole workflow
+    steps:
+      - uses: ./.github/actions/setup-sccache
+        with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }} # OIDC on trusted refs; empty elsewhere
+          # retained so same-repo PRs keep today's RW cache until Phase 4 decides A/B/C
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          key-prefix: ...
 ```
+
+The `sui_repo_ref` guard is **conservative** for jobs that ignore that input
+(e.g. `bridge.yml`'s `test` checks out the default ref) — they fall back to
+static/local on an override dispatch rather than OIDC. That is the safe direction.
 
 - **Trusted push / dispatch-from-main** → OIDC RW (no static keys used).
 - **`pull_request`** → empty role → static-key fallback = **unchanged behavior**.

--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -33,8 +33,8 @@ The decision is the OIDC `sub` of the run, which depends on the event + ref:
 | Event              | Ref                                  | `sub`                          | Assume RW role #1 today? | Plan                                  |
 | ------------------ | ------------------------------------ | ------------------------------ | ------------------------ | ------------------------------------- |
 | `push`             | `main`/`devnet`/`testnet`/`mainnet`  | `…:ref:refs/heads/<b>`         | **YES**                  | OIDC RW (trusted)                     |
-| `push`             | `releases/sui-*-release`             | `…:ref:refs/heads/releases/…`  | **NO — trust gap**       | add ref to role trust → OIDC RW       |
-| `push`             | `extensions` (external.yml only)     | `…:ref:refs/heads/extensions`  | **NO — trust gap**       | add ref to role trust, or local cache |
+| `push`             | `releases/sui-*-release`             | `…:ref:refs/heads/releases/…`  | **YES** (added 2026-06-08) | OIDC RW (trusted)                   |
+| `push`             | `extensions` (external.yml only)     | `…:ref:refs/heads/extensions`  | **NO — excluded**        | branch is 404; local-cache fallback   |
 | `workflow_dispatch`| `main`                               | `…:ref:refs/heads/main`        | **YES**                  | OIDC RW                               |
 | `workflow_dispatch`| feature branch                       | `…:ref:refs/heads/<feat>`      | **NO**                   | local-cache fallback (expected)       |
 | `pull_request`     | any (same-repo **and** fork)         | `…:pull_request`               | **NO — by design**       | **blocked on A/B/C** (see roles doc)  |
@@ -51,7 +51,7 @@ The decision is the OIDC `sub` of the run, which depends on the event + ref:
 ### `external.yml` — 2 sites (`push`[main,extensions,devnet] + `pull_request`)
 
 `external-crates-test` (L66), `clippy` (L107). Prefix `ubuntu-ghcloud`.
-Note `extensions` push is a trust gap.
+Note `extensions` push is **not** trusted (branch is 404 → excluded) → local cache.
 
 ### `bridge.yml` — 2 sites (`push`[main,devnet,testnet,mainnet,releases/sui-*-release] + `pull_request` + `workflow_dispatch`)
 
@@ -65,19 +65,32 @@ Note `extensions` push is a trust gap.
    the **same job**, and `configure-aws-credentials` overwrites cred env vars — the
    job must re-assume the right role before each S3 op (see roles doc §"Credential
    sequencing"). The `release` GitHub Environment for that role now exists.
-2. Its sccache run is on a **release tag** (`*-v*`), which is **not** in role #1's
-   trust — a separate gap from the release-branch one.
+2. **Environment-sub subtlety (not a tag-trust gap).** Once `release-build` declares
+   `environment: release` (required for the `release-s3` role), **every** OIDC assume
+   in that job — the sccache one included — presents
+   `sub=repo:MystenLabs/sui:environment:release`, **not** a tag/branch ref. So adding
+   `*-v*` tag trust to role #1 would do **nothing** for the sccache step. To give it
+   OIDC, pick one in Phase 5:
+   - **(a)** role #1 **also** trusts `repo:MystenLabs/sui:environment:release`; or
+   - **(b)** restructure `release.yml` so the sccache **build** runs in a job
+     *without* `environment: release` (gets a branch/tag sub role #1 trusts) and only
+     the S3 upload/download runs in a job *with* `environment: release`.
 
-## Trust-policy gaps blocking the "trusted" path
+## Trust-policy gaps — status
 
-Before a trusted-ref flip can actually use the cache (rather than silently
-dropping to local) on these refs, add the subject(s) to role #1's trust:
+Whether role #1 trusts each ref a trusted-ref flip needs (else it silently drops
+to local cache):
 
-1. **`releases/sui-*-release` branches** — needed by `rust.yml`, `bridge.yml` push CI.
-2. **`extensions` branch** — needed by `external.yml` push CI (decide if worth it).
-3. **`*-v*` tags** — needed by `release.yml` sccache (Phase 5).
-
-Until added, those refs fall back to local cache (no breakage, just no shared cache).
+1. **`releases/sui-*-release` branches** — **ADDED 2026-06-08** (StringLike; 4 exact
+   branches preserved, `aud` pinned). Covers `rust.yml` + `bridge.yml` protected
+   release-branch push CI.
+2. **`extensions` branch** — **excluded.** The branch returns 404 (not active), so
+   trusting it now is unused attack surface. Add only if it is confirmed active again;
+   until then `external.yml` `extensions` pushes fall back to local cache.
+3. **`release.yml` sccache** — **not a tag-trust gap.** Because `release-build` will
+   declare `environment: release`, its OIDC sub is `environment:release`, not a tag
+   ref — adding `*-v*` tag trust would not help. See the `release.yml` section above
+   for the two Phase-5 options.
 
 ## Recommended Phase-3 mechanic for mixed-trigger callers
 

--- a/.github/AWS_OIDC_ROLES.md
+++ b/.github/AWS_OIDC_ROLES.md
@@ -15,6 +15,9 @@ resulting role ARNs via a `role-to-assume` input.
 > OIDC mints short-lived, request-scoped credentials with a trust policy that
 > pins exactly which repo/branch/tag/environment may assume the role.
 
+> **Caller migration status + per-call-site classification:** see
+> [`AWS_OIDC_MIGRATION_INVENTORY.md`](./AWS_OIDC_MIGRATION_INVENTORY.md).
+
 ## One-time: the GitHub OIDC identity provider
 
 Create (once per account) the IAM OIDC provider:


### PR DESCRIPTION
Companion to `AWS_OIDC_ROLES.md` — the inventory/classification step before flipping the remaining `setup-sccache` callers. Makes the per-call-site, per-event/ref split explicit (mixed-trigger workflows are trusted on protected-branch push, untrusted on PR — so it's not a clean "these files now, those later").

### Contents
- **Status table** — warmup + nightly are OIDC ✅; remaining static-key callers: `rust.yml` (11), `external.yml` (2), `bridge.yml` (2), `release.yml` (1).
- **Event/ref → `sub` → "can assume RW role #1 today?" matrix** — the core decision table.
- **Per-call-site map** (job, line, key-prefix) for all 16 remaining sites.
- **Trust-policy gaps** that silently drop to local cache until fixed: `releases/sui-*-release` + `extensions` branches, `*-v*` tags.
- **Phase-3 dual-pass mechanic** — pass a trusted-ref-gated `role-to-assume` **and** keep the static keys, so trusted refs move to OIDC immediately while same-repo PR behavior is unchanged until Phase 4. A/B/C only changes the Phase-4 follow-up and when static keys can be deleted.
- `release.yml` documented as **Phase 5** (credential sequencing + tag-trust gap); the `release` GitHub Environment for its role now exists.

Doc-only — no workflow/behavior change. Decision still needed to finish the mixed callers: PR-cache option **A/B/C**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)