### PR TITLE
ci(sccache): bridge.yml dual-pass OIDC (Phase 3 pilot)

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -47,6 +47,10 @@ env:
   RUST_LOG: error
   # RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
+  # sccache RW role on trusted refs only (protected branches + release branches);
+  # empty elsewhere → setup-sccache falls back to static keys (same-repo PRs) or a
+  # local cache (forks). Keep in sync with the sui-sccache-rw-github trust policy.
+  SCCACHE_ROLE: ${{ (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
 
 jobs:
   diff:
@@ -78,12 +82,18 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ ubuntu-ghcloud ]
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          # Dual-pass: OIDC on trusted refs (SCCACHE_ROLE non-empty); static-key
+          # fallback on same-repo PRs / untrusted refs until Phase 4 sets PR cache.
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -101,6 +111,9 @@ jobs:
       # non-deterministic `test` job.
       SUI_SKIP_SIMTESTS: 1
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     strategy:
       matrix:
         os:
@@ -110,6 +123,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - uses: ./.github/actions/setup-sccache
         with:
+          # Dual-pass: OIDC on trusted refs (SCCACHE_ROLE non-empty); static-key
+          # fallback on same-repo PRs / untrusted refs until Phase 4 sets PR cache.
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -47,10 +47,13 @@ env:
   RUST_LOG: error
   # RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
-  # sccache RW role on trusted refs only (protected branches + release branches);
-  # empty elsewhere → setup-sccache falls back to static keys (same-repo PRs) or a
-  # local cache (forks). Keep in sync with the sui-sccache-rw-github trust policy.
-  SCCACHE_ROLE: ${{ (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
+  # sccache RW role on trusted refs only (protected branches + release branches),
+  # AND only when not building an override ref: a workflow_dispatch with a non-empty
+  # sui_repo_ref checks out arbitrary code, so it must NOT hold the RW cache even
+  # though github.ref (and the OIDC sub) is main. Empty elsewhere → setup-sccache
+  # falls back to static keys (same-repo PRs) or a local cache (forks / overrides).
+  # Keep in sync with the sui-sccache-rw-github trust policy.
+  SCCACHE_ROLE: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.sui_repo_ref == '') && (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
 
 jobs:
   diff:


### PR DESCRIPTION
**Phase 3 pilot** — first of the mixed-trigger `setup-sccache` callers, flipped with the **dual-pass** mechanic from [`AWS_OIDC_MIGRATION_INVENTORY.md`](https://github.com/MystenLabs/sui/blob/main/.github/AWS_OIDC_MIGRATION_INVENTORY.md). `bridge.yml` is the pilot because it's small (2 sccache jobs) **and** has `workflow_dispatch` for immediate post-merge OIDC validation. `rust.yml` (11) + `external.yml` (2) follow once this validates.

### Mechanic
- New **workflow-level `SCCACHE_ROLE`**: resolves to `arn:…:role/sui-sccache-rw-github` on **trusted refs** (`main`/`devnet`/`testnet`/`mainnet` + `releases/sui-*-release`), empty elsewhere. Kept in sync with the role's trust policy.
- Both sccache jobs (`clippy`, `test`) pass **`role-to-assume: ${{ env.SCCACHE_ROLE }}` *and* keep the static keys**. `setup-sccache` prefers the role when set:
  | Context | Behavior |
  |---|---|
  | trusted `push` / dispatch-from-`main` | **OIDC RW** (no static keys) |
  | same-repo PR (empty role) | static-key fallback = **unchanged** |
  | fork PR | no creds → local cache |
- **Job-level `id-token: write`** on the two sccache jobs only (`diff`/`rustfmt` keep the default — risk-scanned: no job here uses the token for anything but checkout).

### Dependencies already in place
- Role #1 trust extended to `releases/sui-*-release` (2026-06-08) so release-branch CI gets cache.
- The PR path stays on static keys until **Phase 4** (A/B/C decision); static keys are deleted in **Phase 7**.

### Test plan
> **Correction:** `bridge.yml`'s `clippy`/`test` are gated on
> `needs.diff.outputs.isRust == 'true'`. This PR touches only a workflow file, so the
> diff detector reports no Rust change and **both sccache jobs skip** — the new path is
> **NOT exercised pre-merge** (the green checks here do not cover it).

Validation is therefore **post-merge**:
- [ ] `workflow_dispatch` from **main**, no `sui_repo_ref` → `SCCACHE_ROLE` = ARN → OIDC; CloudTrail `AssumeRoleWithWebIdentity` for `sui-sccache-rw-github`; sccache S3 hits.
- [ ] (negative — validates the override guard) `workflow_dispatch` from **main** **with** `sui_repo_ref=<feature>` → `SCCACHE_ROLE` empty → **no** assume; build uses static-key/local cache.
- [ ] Next real Rust PR → `clippy`/`test` run on `pull_request` → static-key fallback (same-repo PR behavior unchanged).
- [ ] Next `push` to `main` → OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
