### PR TITLE
Resilience against crashes during execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6060,9 +6060,9 @@ checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"

--- a/crates/mysten-common/src/random.rs
+++ b/crates/mysten-common/src/random.rs
@@ -3,6 +3,18 @@
 
 use crate::in_antithesis;
 
+/// Return `true` with probability `chance` where the decision depends only on `value`.
+///
+/// Seeds an RNG with the value bytes so independent processes always reach the same
+/// decision for the same input.
+pub fn content_addressed_probability(value: &[u8], chance: f32) -> bool {
+    use rand::{Rng, SeedableRng};
+    let mut seed = [0u8; 32];
+    let len = value.len().min(32);
+    seed[..len].copy_from_slice(&value[..len]);
+    rand::rngs::SmallRng::from_seed(seed).r#gen::<f32>() < chance
+}
+
 /// Get a random number generator.
 ///
 /// If we are running in antithesis mode, use the antithesis RNG.

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -878,6 +878,14 @@ async fn run_bench_worker(
                     err,
                     transaction.digest()
                 );
+                #[cfg(msim)]
+                if sui_core::crash_recovery::crash_recovery_probability().is_some()
+                    && sui_core::crash_recovery::should_poison_transaction(
+                        transaction.data().transaction_data(),
+                    )
+                {
+                    return NextOp::Failure { payload };
+                }
                 match payload.get_failure_type() {
                     Some(ExpectedFailureType::NoFailure) => {
                         panic!(

--- a/crates/sui-benchmark/src/workloads/addr_bal_deposit.rs
+++ b/crates/sui-benchmark/src/workloads/addr_bal_deposit.rs
@@ -204,7 +204,13 @@ impl Workload<dyn Payload> for AddrBalDepositWorkload {
                     vec![coin_balance, recipient_arg],
                 );
             }
-            let tx = tx_builder.ensure_unique().build_and_sign(keypair.as_ref());
+            // Seeding transactions do not opt in to crash injection (they carry no crash-opt-in
+            // marker), so they can never be poisoned.
+            let tx_data = tx_builder.ensure_unique().build();
+            let tx = sui_types::transaction::Transaction::from_data_and_signer(
+                tx_data,
+                vec![keypair.as_ref()],
+            );
             let proxy_ref = execution_proxy.clone();
             futures.push(async move {
                 let result = proxy_ref.execute_transaction_block(tx).await;

--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -11,8 +11,8 @@ pub use operations::{
     AddressBalanceDeposit, AddressBalanceOverdraw, AddressBalanceWithdraw, AuthenticatedEventEmit,
     CoinReservationWithdraw, INVALID_ALIAS_TX, ImmutableObjectRead, ObjectBalanceDeposit,
     ObjectBalanceOverdraw, ObjectBalanceWithdraw, OperationDescriptor, RandomnessRead,
-    SharedCounterIncrement, SharedCounterRead, TestCoinAddressDeposit, TestCoinAddressWithdraw,
-    TestCoinMint, TestCoinObjectWithdraw,
+    RequestCrash, SharedCounterIncrement, SharedCounterRead, TestCoinAddressDeposit,
+    TestCoinAddressWithdraw, TestCoinMint, TestCoinObjectWithdraw,
 };
 use rand::seq::SliceRandom;
 
@@ -319,6 +319,9 @@ impl CompositeWorkloadConfig {
         probabilities.insert(AuthenticatedEventEmit::NAME, 0.1);
         probabilities.insert(ImmutableObjectRead::NAME, 0.2);
         probabilities.insert(CoinReservationWithdraw::NAME, 0.1);
+        // Every composite transaction opts in to crash injection; whether it is actually poisoned
+        // is then decided (content-addressed) at the configured crash probability.
+        probabilities.insert(RequestCrash::NAME, 1.0);
         Self {
             probabilities,
             alias_tx_probability: 0.3,
@@ -343,8 +346,13 @@ impl CompositeWorkloadConfig {
             .map(|desc| (desc.factory)())
             .collect();
 
-        if ops.is_empty()
-            && let Some(desc) = ALL_OPERATIONS.first()
+        // Ensure at least one command-producing operation. RequestCrash only attaches an unused
+        // marker argument and produces no command, so a transaction containing only it would be an
+        // empty (command-less) PTB.
+        if ops.iter().all(|op| op.name() == RequestCrash::NAME)
+            && let Some(desc) = ALL_OPERATIONS
+                .iter()
+                .find(|desc| desc.name != RequestCrash::NAME)
         {
             ops.push((desc.factory)());
         }

--- a/crates/sui-benchmark/src/workloads/composite/operations.rs
+++ b/crates/sui-benchmark/src/workloads/composite/operations.rs
@@ -45,6 +45,7 @@ pub struct OperationDescriptor {
 
 pub const ALL_OPERATIONS: &[OperationDescriptor] = &[
     SharedCounterIncrement::DESCRIPTOR,
+    RequestCrash::DESCRIPTOR,
     SharedCounterRead::DESCRIPTOR,
     RandomnessRead::DESCRIPTOR,
     AddressBalanceDeposit::DESCRIPTOR,
@@ -151,6 +152,42 @@ impl Operation for SharedCounterIncrement {
                 })],
             )
             .unwrap();
+    }
+}
+
+/// Opt the composite transaction in to crash injection by attaching an unused marker argument.
+/// Only transactions carrying this marker are eligible to be poisoned (see
+/// `sui_core::crash_recovery`), so a transaction's poison status is intrinsic to its contents and
+/// consistent across re-executions. Produces no command, so it must not be the only operation.
+pub struct RequestCrash;
+
+impl RequestCrash {
+    pub const NAME: &'static str = "request_crash";
+    pub const DESCRIPTOR: OperationDescriptor = OperationDescriptor {
+        name: Self::NAME,
+        factory: || Box::new(RequestCrash),
+    };
+}
+
+impl Operation for RequestCrash {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn resource_requests(&self) -> Vec<ResourceRequest> {
+        vec![]
+    }
+
+    fn apply(
+        &self,
+        builder: &mut ProgrammableTransactionBuilder,
+        _resources: &OperationResources,
+        _account_state: &AccountState,
+    ) {
+        builder.pure_bytes(
+            sui_core::crash_recovery::CRASH_OPT_IN_MARKER.to_vec(),
+            /* force_separate */ true,
+        );
     }
 }
 

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -509,7 +509,25 @@ mod test {
         // quorum, empirically ~6% per-validator skip rate produces ~5% DKG failure per epoch.
         register_fail_point_if("rb-dkg", || thread_rng().gen_bool(0.06));
 
-        test_simulated_load(test_cluster, 120).await;
+        // Only transactions that opt in (by carrying the crash-opt-in marker arg, attached by the
+        // composite workload) are eligible to be poisoned, so setup/gas transactions are never
+        // crashed and a transaction's poison status is consistent for the whole run. The crash
+        // probability can therefore be enabled before load generation begins.
+        const CRASH_PROB: f32 = 0.02;
+        test_simulated_load_with_test_config(
+            test_cluster,
+            120,
+            SimulatedLoadConfig::default(),
+            None,
+            None,
+            Some(|_cluster: Arc<TestCluster>| {
+                register_fail_point_if("crash-with-tx-logging", || true);
+                sui_core::crash_recovery::set_crash_recovery_probability(CRASH_PROB as f64);
+                std::future::ready(())
+            }),
+            true,
+        )
+        .await;
     }
 
     #[sim_test(config = "test_config()")]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -805,6 +805,11 @@ pub struct ExecutionEnv {
     /// Transactions that must finish before this transaction can be executed.
     /// Used to schedule barrier transactions after non-exclusive writes.
     pub barrier_dependencies: Vec<TransactionDigest>,
+    /// Set when executing from a source (e.g. a certified checkpoint) whose effects show the
+    /// transaction failed with `InternalExecutionError` (a crash-recovered poison transaction).
+    /// Forces the same early error on re-execution so the node reproduces the effects without
+    /// running the real logic that would crash the process again.
+    pub internal_execution_error: bool,
 }
 
 impl Default for ExecutionEnv {
@@ -814,6 +819,7 @@ impl Default for ExecutionEnv {
             expected_effects_digest: None,
             funds_withdraw_status: FundsWithdrawStatus::MaybeSufficient,
             barrier_dependencies: Default::default(),
+            internal_execution_error: false,
         }
     }
 }
@@ -838,6 +844,11 @@ impl ExecutionEnv {
 
     pub fn with_insufficient_funds(mut self) -> Self {
         self.funds_withdraw_status = FundsWithdrawStatus::Insufficient;
+        self
+    }
+
+    pub fn with_internal_execution_error(mut self) -> Self {
+        self.internal_execution_error = true;
         self
     }
 
@@ -1472,6 +1483,8 @@ impl AuthorityState {
         let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
 
         let tx_digest = certificate.digest();
+        let _crash_guard =
+            crate::crash_recovery::register_executing_transaction(*tx_digest, self.name);
 
         if let Some(fork_recovery) = &self.fork_recovery_state
             && let Some(override_digest) = fork_recovery.get_transaction_override(tx_digest)
@@ -1987,11 +2000,38 @@ impl AuthorityState {
             self.config.certificate_deny_config.certificate_deny_set(),
             &execution_env.funds_withdraw_status,
         );
+        // Crash-recovery: a transaction that previously crashed the node is re-executed with an
+        // early error instead of running its real (crashing) logic. It still assigns versions,
+        // executes (as a deterministic failure), advances shared-object versions, and is
+        // checkpointed like any other transaction, so consensus-committed state stays a pure
+        // function of the commit. Two triggers: the local crashed-set (validator re-executing after
+        // its own crash) and the ExecutionEnv flag (executing from a certified checkpoint whose
+        // effects are InternalExecutionError, so the node never runs the crashing logic). Prepended
+        // so the effect status is InternalExecutionError regardless of any other early error.
+        let early_execution_error = if epoch_store.is_crashed_transaction(&tx_digest)
+            || execution_env.internal_execution_error
+        {
+            let mut errors = vec![ExecutionErrorKind::InternalExecutionError];
+            if let Some(existing) = early_execution_error {
+                errors.extend(existing);
+            }
+            NonEmpty::from_vec(errors)
+        } else {
+            early_execution_error
+        };
         let accumulator_version = execution_env.assigned_versions.accumulator_version;
         let execution_params = match early_execution_error {
             None => ExecutionOrEarlyError::ok(accumulator_version),
             Some(errors) => ExecutionOrEarlyError::failed(errors, accumulator_version),
         };
+
+        // Inject the simulated crash only when the transaction actually executes (no early error),
+        // mirroring the execution engine's early-exit-on-early-error. A crash-recovered tx takes the
+        // early-error path above (InternalExecutionError) and must not re-crash. The upstream
+        // effects-cache check ensures this only fires on the first execution attempt.
+        if execution_params.is_ok() && !transaction_data.kind().is_system_tx() {
+            crate::crash_recovery::maybe_crash_for_testing(transaction_data);
+        }
 
         // Skip on early error: the tx will fail anyway and rewriting may fail if the accumulator
         // was deleted.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -346,6 +346,12 @@ pub struct AuthorityPerEpochStore {
     parent_path: PathBuf,
     db_options: Option<Options>,
 
+    /// Transactions that caused a process panic in a previous run (loaded from the crash log at
+    /// startup). They are dropped at execution time and filtered from checkpoint contents and
+    /// settlement, but otherwise flow through scheduling identically to normal transactions so
+    /// their effect on neighbors is reproducible across the crash boundary.
+    crashed_transactions: HashSet<TransactionDigest>,
+
     /// In-memory cache of the content from the reconfig_state db table.
     reconfig_state_mem: RwLock<ReconfigState>,
     consensus_notify_read: NotifyRead<SequencedConsensusTransactionKey, ()>,
@@ -1010,6 +1016,7 @@ impl AuthorityPerEpochStore {
         previous_epoch_last_checkpoint: CheckpointSequenceNumber,
         submitted_transaction_cache_metrics: Arc<SubmittedTransactionCacheMetrics>,
         fullnode_sync_mode: Option<FullNodeSyncMode>,
+        crashed_transactions: HashSet<TransactionDigest>,
     ) -> SuiResult<Arc<Self>> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -1180,6 +1187,7 @@ impl AuthorityPerEpochStore {
             )),
             parent_path: parent_path.to_path_buf(),
             db_options,
+            crashed_transactions,
             reconfig_state_mem: RwLock::new(reconfig_state),
             epoch_alive_token,
             epoch_alive: tokio::sync::RwLock::new(true),
@@ -1351,6 +1359,11 @@ impl AuthorityPerEpochStore {
         self.parent_path.clone()
     }
 
+    /// Returns true if `digest` caused a process panic in a previous run and must be dropped.
+    pub fn is_crashed_transaction(&self, digest: &TransactionDigest) -> bool {
+        self.crashed_transactions.contains(digest)
+    }
+
     /// Returns `&Arc<EpochStartConfiguration>`
     /// User can treat this `Arc` as `&EpochStartConfiguration`, or clone the Arc to pass as owned object
     pub fn epoch_start_config(&self) -> &Arc<EpochStartConfiguration> {
@@ -1414,6 +1427,9 @@ impl AuthorityPerEpochStore {
             epoch_last_checkpoint,
             self.submitted_transaction_cache.metrics(),
             fullnode_sync_mode,
+            // The crash log is loaded once at process startup; a crash restarts the process and
+            // reloads it, so the set never grows mid-process and can be carried across epochs.
+            self.crashed_transactions.clone(),
         )
     }
 

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -403,6 +403,7 @@ impl SharedObjVerManager {
             } else {
                 None
             };
+
         let txn_cancelled = cancellation_info.is_some();
 
         let mut input_object_keys = assignable.non_shared_input_object_keys();
@@ -413,8 +414,6 @@ impl SharedObjVerManager {
         input_object_keys.extend(receiving_object_keys);
 
         if txn_cancelled {
-            // For cancelled transaction due to congestion, assign special versions to all shared objects.
-            // Note that new lamport version does not depend on any shared objects.
             for SharedInputObject {
                 id,
                 initial_shared_version,

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -329,6 +329,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             0,
             Arc::new(SubmittedTransactionCacheMetrics::new(&registry)),
             None,
+            std::collections::HashSet::new(),
         )
         .expect("failed to create authority per epoch store");
 

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -959,6 +959,17 @@ impl CheckpointExecutor {
                             env = env.with_insufficient_funds();
                         }
 
+                        // Crash-recovered (poison) transactions are recorded with an
+                        // InternalExecutionError. Reproduce that early error here so the node never
+                        // runs the real logic (which would crash the process again on re-execution).
+                        if let &ExecutionStatus::Failure(ExecutionFailure {
+                            error: ExecutionErrorKind::InternalExecutionError,
+                            ..
+                        }) = effects.status()
+                        {
+                            env = env.with_internal_execution_error();
+                        }
+
                         Some((tx_digest, (txn.clone(), env)))
                     }
                 },

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1738,7 +1738,6 @@ impl CheckpointBuilder {
             contents_digest = ?contents.digest(),
             "writing checkpoint",
         );
-
         if let Some(previously_computed_summary) = self
             .store
             .tables

--- a/crates/sui-core/src/crash_recovery.rs
+++ b/crates/sui-core/src/crash_recovery.rs
@@ -1,0 +1,470 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Crash-recovery support: detect which transaction was executing when the process panicked.
+//!
+//! # How it works
+//!
+//! 1. At process startup, `install_panic_hook` chains a closure into the existing panic hook.
+//!    When a panic fires, the hook reads a thread-local slot.  If that slot holds a transaction
+//!    digest it appends the digest (as hex) to a small log file on disk.
+//!
+//! 2. At the start of `try_execute_immediately`, the caller registers the transaction digest with
+//!    `register_executing_transaction`.  The returned `ExecutingTransactionGuard` clears the slot
+//!    on drop, so the registration is always scoped to the execution of that single transaction.
+//!
+//!    The guard is deliberately `!Sync`.  `try_execute_immediately` is now a synchronous function,
+//!    but this marker prevents any future change from accidentally moving the guard (and therefore
+//!    the registration) across threads inside an async context, which would corrupt TLS.
+//!
+//! 3. On the next startup, `load_crashed_transactions` reads the log file and returns the set of
+//!    digests that were active during a past crash.  The consensus handler uses this set to drop
+//!    those transactions before they reach execution again.
+//!
+//! # Why TLS is correct here
+//!
+//! Rust's `panic` hook runs on the thread that panicked, so `with` on the TLS slot correctly sees
+//! the digest that was registered by that thread's call to `try_execute_immediately`.  Threads that
+//! were not executing a transaction at the time of the panic simply see an empty slot and are
+//! ignored.
+//!
+//! # Drop guard vs. panic hook
+//!
+//! The drop guard does NOT write the crash log.  In production builds, `panic = "abort"` means
+//! drop is never called during a panic, so only the hook can do it.  In simtest builds the hook
+//! also runs synchronously (it fires inside the `catch_unwind` scope that simulates the crash),
+//! so the hook is always the right place to write.
+
+use std::{
+    cell::Cell,
+    collections::{HashMap, HashSet},
+    fs::{self, OpenOptions},
+    io::{BufRead, BufReader, Write},
+    marker::PhantomData,
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
+
+use sui_types::{
+    base_types::AuthorityName, digests::TransactionDigest, transaction::TransactionData,
+};
+use tracing::{error, info, warn};
+
+macro_rules! git_revision {
+    () => {
+        match option_env!("GIT_REVISION") {
+            Some(r) => r,
+            None => "unknown",
+        }
+    };
+}
+
+const GIT_REVISION: &str = git_revision!();
+
+static FILE_WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+// ---------------------------------------------------------------------------
+// Simtest-only: catch_unwind panic marker
+// ---------------------------------------------------------------------------
+
+/// Panic message used by the crash-simulation fail point in simtests.
+///
+/// The panic hook identifies intentional crash-simulation panics by checking for this exact
+/// payload.  `kill_current_node` panics with a private `PanicWrapper` type, so plain `&str`
+/// downcasting cleanly discriminates the two kinds of panic.
+#[cfg(msim)]
+pub const CRASH_SIM_PANIC_MSG: &str = "crash-simulation";
+
+// ---------------------------------------------------------------------------
+// Deterministic crash decision (available in all test configurations)
+// ---------------------------------------------------------------------------
+
+static CRASH_RECOVERY_PROBABILITY_1E6: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// Set the fraction of user transactions that should be treated as poison.
+/// A poison transaction triggers a crash-recovery test cycle: the node panics
+/// while executing it, writes the digest to the crash log, and on restart drops
+/// the transaction so it cannot crash the node again.
+///
+/// Has no effect in release builds because `should_poison_transaction` is only
+/// called when `in_test_configuration()` is true.
+pub fn set_crash_recovery_probability(prob: f64) {
+    CRASH_RECOVERY_PROBABILITY_1E6.store(
+        (prob.clamp(0.0, 1.0) * 1_000_000.0) as u32,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+}
+
+/// Returns the crash probability: the explicitly set value if any, otherwise a
+/// default of 0.2 % in Antithesis (where explicit setup is not always possible),
+/// or `None` everywhere else.
+pub fn crash_recovery_probability() -> Option<f64> {
+    let v = CRASH_RECOVERY_PROBABILITY_1E6.load(std::sync::atomic::Ordering::Relaxed);
+    if v != 0 {
+        Some(v as f64 / 1_000_000.0)
+    } else if mysten_common::in_antithesis() {
+        Some(0.002)
+    } else {
+        None
+    }
+}
+
+/// Marker pure-argument bytes (`0xdeadbeef`) that a transaction must carry to opt in to crash
+/// injection. Only transactions that attach this unused argument are eligible to be poisoned, so
+/// system and setup transactions are never crashed and a transaction's poison status is intrinsic
+/// to its contents (hence consistent across re-executions).
+pub const CRASH_OPT_IN_MARKER: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
+
+/// Returns `true` if `tx_data` carries the crash-opt-in marker argument.
+fn has_crash_opt_in_marker(tx_data: &TransactionData) -> bool {
+    use sui_types::transaction::{CallArg, TransactionDataAPI as _, TransactionKind};
+    matches!(
+        tx_data.kind(),
+        TransactionKind::ProgrammableTransaction(pt)
+            if pt.inputs.iter().any(|input| matches!(
+                input,
+                CallArg::Pure(bytes) if bytes.as_slice() == CRASH_OPT_IN_MARKER
+            ))
+    )
+}
+
+/// Return `true` if `tx_data` should be treated as a poison transaction.
+///
+/// Returns `false` unless a crash probability has been set via `set_crash_recovery_probability`
+/// AND the transaction opts in via the [`CRASH_OPT_IN_MARKER`] argument. The remaining decision is
+/// content-addressed so that independent validator processes always agree on which transactions are
+/// poison. Under msim, getrandom is intercepted and made deterministic, so this is equally
+/// reproducible there.
+pub fn should_poison_transaction(tx_data: &TransactionData) -> bool {
+    let Some(prob) = crash_recovery_probability() else {
+        return false;
+    };
+    if !has_crash_opt_in_marker(tx_data) {
+        return false;
+    }
+    let digest = tx_data.digest();
+    mysten_common::random::content_addressed_probability(digest.as_ref(), prob as f32)
+}
+
+/// Trigger a crash-recovery cycle for `digest` if it is in the poison set.
+///
+/// In simtests: uses a fail point so the test harness controls when crashes fire; the
+/// panic is caught and re-raised via `kill_current_node` so the sim can restart the node.
+/// In other test configurations (debug builds, Antithesis): panics directly; the panic
+/// hook writes the digest to the crash log and the process terminates.
+/// In release builds: no-op (the `not(msim)` branch is compiled out by
+/// `in_test_configuration()` always returning false, and the msim branch is not compiled).
+pub fn maybe_crash_for_testing(tx_data: &TransactionData) {
+    #[cfg(msim)]
+    {
+        sui_macros::fail_point_if!("crash-with-tx-logging", || {
+            if should_poison_transaction(tx_data) {
+                // Use catch_unwind to trigger the panic hook without crashing the test process.
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    std::panic::panic_any(CRASH_SIM_PANIC_MSG);
+                }));
+                sui_simulator::task::kill_current_node(Some(std::time::Duration::from_millis(100)));
+            }
+        });
+    }
+    #[cfg(not(msim))]
+    if mysten_common::in_test_configuration() && should_poison_transaction(tx_data) {
+        panic!("crash-recovery: transaction {}", tx_data.digest());
+    }
+}
+
+/// File name within the node's db_path where panicking-transaction digests are persisted.
+const PANIC_TX_LOG_FILE: &str = "panic-tx.log";
+
+// ---------------------------------------------------------------------------
+// Global registry: AuthorityName → db_path
+// ---------------------------------------------------------------------------
+//
+// The panic hook needs to write to a specific log file. Rather than carrying a PathBuf through
+// TLS (which would require heap allocation on every transaction), we keep a small process-wide
+// map from AuthorityName to db_path that is populated once at startup by `install_panic_hook`.
+
+static NODE_DB_PATHS: OnceLock<Mutex<HashMap<AuthorityName, PathBuf>>> = OnceLock::new();
+
+fn node_db_paths() -> &'static Mutex<HashMap<AuthorityName, PathBuf>> {
+    NODE_DB_PATHS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn get_db_path(authority_name: &AuthorityName) -> Option<PathBuf> {
+    node_db_paths().lock().ok()?.get(authority_name).cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Thread-local slot
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// The authority and digest of the transaction currently executing on this thread, if any.
+    ///
+    /// We use `Cell<Option<(AuthorityName, TransactionDigest)>>` so that the panic hook (which
+    /// takes `&PanicInfo`) can read it without needing `&mut` access or a `RefCell` borrow.
+    /// Both `AuthorityName` and `TransactionDigest` are `Copy`, so `Cell` is appropriate.
+    ///
+    /// Storing the authority name alongside the digest lets each validator's panic hook
+    /// identify — purely from TLS — whether it is responsible for writing the crash log,
+    /// without relying on any external node-identity mechanism.
+    static EXECUTING_TX: Cell<Option<(AuthorityName, TransactionDigest)>> =
+        const { Cell::new(None) };
+}
+
+// ---------------------------------------------------------------------------
+// Scope guard
+// ---------------------------------------------------------------------------
+
+/// RAII guard that registers a transaction digest in thread-local storage for the duration of its
+/// lifetime and removes it on drop.
+///
+/// The `PhantomData<*mut ()>` makes the guard `!Send + !Sync`, ensuring it is never moved to a
+/// different thread (which would corrupt TLS) or shared across threads.
+pub struct ExecutingTransactionGuard {
+    _not_send_sync: PhantomData<*mut ()>,
+}
+
+impl ExecutingTransactionGuard {
+    fn new(digest: TransactionDigest, authority_name: AuthorityName) -> Self {
+        EXECUTING_TX.with(|slot| slot.set(Some((authority_name, digest))));
+        Self {
+            _not_send_sync: PhantomData,
+        }
+    }
+}
+
+impl Drop for ExecutingTransactionGuard {
+    fn drop(&mut self) {
+        EXECUTING_TX.with(|slot| slot.set(None));
+    }
+}
+
+/// Register `digest` as the transaction currently executing on this thread.
+///
+/// Returns a guard whose `Drop` implementation removes the registration. The registration lives
+/// exactly as long as the guard, which should be kept in a local variable at the call site.
+///
+/// `authority_name` identifies the node. It is used to look up the crash-log path from the
+/// registry populated by `install_panic_hook`, and to ensure each validator's panic hook writes
+/// only to its own log.
+///
+/// ```ignore
+/// let _guard = register_executing_transaction(digest, authority_name);
+/// // ... execute the transaction ...
+/// // guard is dropped here, clearing the TLS slot
+/// ```
+pub fn register_executing_transaction(
+    digest: TransactionDigest,
+    authority_name: AuthorityName,
+) -> ExecutingTransactionGuard {
+    ExecutingTransactionGuard::new(digest, authority_name)
+}
+
+// ---------------------------------------------------------------------------
+// Panic hook
+// ---------------------------------------------------------------------------
+
+/// Install a panic hook that appends the active transaction digest (if any) to the crash log.
+///
+/// This chains onto whatever panic hook is already installed (typically the tracing hook set up by
+/// `telemetry-subscribers`), so existing behaviour is preserved.
+///
+/// `authority_name` is this node's public key identity; it is used as the key in
+/// `NODE_DB_PATHS` and to gate the hook so that each validator only claims panics that
+/// originated in its own execution context.
+///
+/// `db_path` is the node's base database directory; the log file is written at
+/// `{db_path}/panic-tx.log`.
+pub fn install_panic_hook(authority_name: AuthorityName, db_path: PathBuf) {
+    // Register the authority → db_path mapping so the hook can locate the log file.
+    node_db_paths()
+        .lock()
+        .expect("NODE_DB_PATHS poisoned")
+        .insert(authority_name, db_path);
+
+    // In simtests, all simulated nodes share the same OS process and panic hook chain. Each
+    // node installs its own hook, prepending to the chain. When any panic fires, all hooks run
+    // in reverse-install order.
+    //
+    // Each hook captures `authority_name` at install time and compares it to the authority name
+    // stored in TLS at panic time. Because `register_executing_transaction` writes the executing
+    // node's authority name into TLS, each hook correctly claims only panics that originated in
+    // its own node's execution context.
+    //
+    // In simtests, two distinct panic kinds flow through the hook chain:
+    //   1. `panic!("{}", CRASH_SIM_PANIC_MSG)` inside a `catch_unwind`: the intended crash
+    //      simulation. The payload is a plain `&str` and we should write the crash log.
+    //   2. `kill_current_node(...)`: simulates a node going down. It panics with a private
+    //      `PanicWrapper` struct, so `downcast_ref::<&str>()` returns `None`. We should NOT
+    //      write the crash log for these — the node is being killed for an unrelated reason and
+    //      the other validators have already committed the transaction.
+    //
+    // In non-sim builds any panic is a genuine crash and we always write.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Write the crash log BEFORE calling the previous hook. Some previous hooks call
+        // `process::exit` (e.g. the telemetry hook when crash_on_panic=true), and we must
+        // not lose the digest in that race.
+        //
+        // We also clear the TLS slot after writing so that (in unwind builds) any drop impls
+        // that run later see an empty slot.
+        let entry = EXECUTING_TX.with(|slot| slot.get());
+        if let Some((tls_authority, digest)) = entry
+            && tls_authority == authority_name
+        {
+            // In simtests, only write for intentional crash-simulation panics. Random node
+            // kills from unrelated fail points panic with a PanicWrapper (not a &str), so
+            // this check naturally excludes them.
+            #[cfg(msim)]
+            if info.payload().downcast_ref::<&str>().copied() != Some(CRASH_SIM_PANIC_MSG) {
+                prev_hook(info);
+                return;
+            }
+
+            EXECUTING_TX.with(|slot| slot.set(None));
+            if let Some(db_path) = get_db_path(&authority_name) {
+                let log_path = db_path.join(PANIC_TX_LOG_FILE);
+                match append_digest_to_log(&log_path, digest) {
+                    Ok(()) => {
+                        // Use eprintln rather than tracing: the subscriber may be in a broken
+                        // state during a panic.
+                        eprintln!(
+                            "[crash-recovery] Panic while executing transaction {digest}; \
+                             recorded to {}",
+                            log_path.display()
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "[crash-recovery] Failed to write crashed transaction {digest} to \
+                             {}: {e}",
+                            log_path.display()
+                        );
+                    }
+                }
+            }
+        }
+
+        if mysten_common::in_antithesis() {
+            eprintln!("antithesis: exiting with code 137");
+            std::process::exit(137);
+        }
+
+        prev_hook(info);
+    }));
+}
+
+fn append_digest_to_log(path: &Path, digest: TransactionDigest) -> std::io::Result<()> {
+    let _guard = FILE_WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(file, "{} {}", GIT_REVISION, digest)?;
+    file.flush()
+}
+
+// ---------------------------------------------------------------------------
+// Startup: read crashed transactions
+// ---------------------------------------------------------------------------
+
+/// Read the panic log and return the set of transaction digests that were active during a past
+/// crash.  Returns an empty set if the log file does not exist.
+///
+/// Lines whose git revision does not match the current binary are skipped and removed from the
+/// log (the file is rewritten with only matching-revision lines).  This prevents stale entries
+/// from a different binary version from poisoning new runs.
+///
+/// `db_path` should be the same path passed to `install_panic_hook`.
+pub fn load_crashed_transactions(db_path: &Path) -> HashSet<TransactionDigest> {
+    const LINE_LIMIT: usize = 1024 * 1024;
+
+    let log_path = db_path.join(PANIC_TX_LOG_FILE);
+    let file = match fs::File::open(&log_path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return HashSet::new();
+        }
+        Err(e) => {
+            error!(
+                "Failed to open crash-recovery log {}: {e}",
+                log_path.display()
+            );
+            return HashSet::new();
+        }
+        Ok(f) => f,
+    };
+
+    let mut digests = HashSet::new();
+    let mut kept_lines: Vec<String> = Vec::new();
+    let mut any_skipped = false;
+
+    for line in BufReader::new(file).lines().take(LINE_LIMIT) {
+        match line {
+            Err(e) => {
+                warn!("Error reading crash-recovery log: {e}");
+            }
+            Ok(s) => {
+                let s = s.trim().to_owned();
+                if s.is_empty() {
+                    continue;
+                }
+                // Expected format: "<git_revision> <tx_digest>".
+                // Old single-token lines (bare digest) are treated as non-matching.
+                let mut parts = s.splitn(2, ' ');
+                let (rev, digest_str) = match (parts.next(), parts.next()) {
+                    (Some(r), Some(d)) => (r, d),
+                    _ => {
+                        warn!("Crash-recovery log contains unrecognised entry {s:?}; skipping");
+                        any_skipped = true;
+                        continue;
+                    }
+                };
+
+                if rev != GIT_REVISION {
+                    info!("Crash-recovery: skipping entry from different binary revision {rev:?}");
+                    any_skipped = true;
+                    continue;
+                }
+
+                match digest_str.parse::<TransactionDigest>() {
+                    Ok(d) => {
+                        info!(
+                            "Crash-recovery: previously-crashing transaction {d} will be \
+                             re-executed as an InternalExecutionError"
+                        );
+                        digests.insert(d);
+                        kept_lines.push(s);
+                    }
+                    Err(e) => {
+                        warn!("Crash-recovery log contains unparseable digest {digest_str:?}: {e}");
+                        any_skipped = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if any_skipped {
+        let _guard = FILE_WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        match OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(&log_path)
+        {
+            Ok(mut f) => {
+                for line in &kept_lines {
+                    if let Err(e) = writeln!(f, "{line}") {
+                        warn!("Failed to rewrite crash-recovery log: {e}");
+                        break;
+                    }
+                }
+            }
+            Err(e) => warn!(
+                "Failed to rewrite crash-recovery log {}: {e}",
+                log_path.display()
+            ),
+        }
+    }
+
+    digests
+}

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod consensus_manager;
 pub mod consensus_throughput_calculator;
 pub(crate) mod consensus_types;
 pub mod consensus_validator;
+pub mod crash_recovery;
 pub mod db_checkpoint_handler;
 pub mod epoch;
 pub mod execution_cache;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -244,7 +244,8 @@ pub use simulator::set_jwk_injector;
 use simulator::*;
 use sui_core::authority::authority_store_pruner::PrunerWatermarks;
 use sui_core::{
-    consensus_handler::ConsensusHandlerInitializer, safe_client::SafeClientMetricsBase,
+    consensus_handler::ConsensusHandlerInitializer, crash_recovery,
+    safe_client::SafeClientMetricsBase,
 };
 
 const DEFAULT_GRPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
@@ -498,6 +499,11 @@ impl SuiNode {
         #[cfg(not(msim))]
         mysten_metrics::thread_stall_monitor::start_thread_stall_monitor();
 
+        // Install the crash-recovery panic hook and load any transactions that caused a crash in
+        // a previous run. These are installed early so the hook is active for the rest of startup.
+        crash_recovery::install_panic_hook(config.protocol_public_key(), config.db_path.clone());
+        let crashed_transactions = crash_recovery::load_crashed_transactions(&config.db_path);
+
         let genesis = config.genesis()?.clone();
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
@@ -623,6 +629,7 @@ impl SuiNode {
                 &registry_service.default_registry(),
             )),
             config.fullnode_sync_mode,
+            crashed_transactions,
         )?;
 
         info!("created epoch store");

--- a/crates/sui-replay-2/src/replay_txn.rs
+++ b/crates/sui-replay-2/src/replay_txn.rs
@@ -737,6 +737,7 @@ fn is_early_execution_error(status: &ExecutionStatus) -> bool {
         ExecutionStatus::Failure(ExecutionFailure { error, .. }) => matches!(
             error,
             ExecutionErrorKind::CertificateDenied
+                | ExecutionErrorKind::InternalExecutionError
                 | ExecutionErrorKind::InputObjectDeleted
                 | ExecutionErrorKind::ExecutionCancelledDueToSharedObjectCongestion { .. }
                 | ExecutionErrorKind::ExecutionCancelledDueToRandomnessUnavailable

--- a/crates/sui-surfer/src/surfer_state.rs
+++ b/crates/sui-surfer/src/surfer_state.rs
@@ -22,7 +22,7 @@ use sui_types::transaction::{CallArg, ObjectArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
 use sui_types::{Identifier, SUI_FRAMEWORK_ADDRESS};
 use test_cluster::TestCluster;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 type Type = normalized::Type<normalized::ArcIdentifier>;
 
@@ -174,6 +174,13 @@ impl SurferState {
         )
         .unwrap();
         let tx = self.cluster.wallet.sign_transaction(&tx_data).await;
+        // Bound retries so that permanently-unexecutable transactions (e.g. those
+        // dropped by crash-recovery on every validator) don't consume the whole
+        // test duration.  Three attempts covers a 20-second validator restart with
+        // margin; if all three fail we record a failure and let the surfer pick a
+        // new transaction.
+        const MAX_TX_RETRIES: u32 = 3;
+        let mut retry_count = 0u32;
         let response = loop {
             debug!("Executing transaction {:?}", tx.digest());
             match self
@@ -184,6 +191,22 @@ impl SurferState {
             {
                 Ok(effects) => break effects,
                 Err(e) => {
+                    retry_count += 1;
+                    if retry_count >= MAX_TX_RETRIES {
+                        warn!(
+                            "Giving up on transaction {:?} after {} retries: {e:?}",
+                            tx.digest(),
+                            retry_count
+                        );
+                        self.stats.record_transaction(
+                            use_shared_object,
+                            false,
+                            package,
+                            module,
+                            function,
+                        );
+                        return;
+                    }
                     error!("Error executing transaction {:?}: {e:?}", tx.digest());
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 }

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -298,6 +298,12 @@ pub enum ExecutionErrorKind {
 
     #[error("Non-exclusive write input object {id} has been modified")]
     NonExclusiveWriteInputObjectModified { id: ObjectID },
+
+    // An internal (test/antithesis-only) failure used by crash-recovery: a transaction that
+    // previously crashed the node is re-executed with this early error instead of running its real
+    // logic, so it produces deterministic effects and is checkpointed like any other transaction.
+    #[error("Internal execution error")]
+    InternalExecutionError,
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
 }

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -1323,6 +1323,8 @@ impl From<crate::execution_status::ExecutionErrorKind> for ExecutionError {
                 ExecutionErrorKind::WrittenObjectsTooLarge
             }
             E::CertificateDenied => ExecutionErrorKind::CertificateDenied,
+            // Test/antithesis-only; no dedicated proto kind, map to the generic InvariantViolation.
+            E::InternalExecutionError => ExecutionErrorKind::InvariantViolation,
             E::SuiMoveVerificationTimedout => ExecutionErrorKind::SuiMoveVerificationTimedout,
             E::SharedObjectOperationNotAllowed => {
                 ExecutionErrorKind::ConsensusObjectOperationNotAllowed

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -933,6 +933,8 @@ impl From<crate::execution_status::ExecutionErrorKind> for ExecutionError {
             crate::execution_status::ExecutionErrorKind::PackageUpgradeError { upgrade_error } => Self::PackageUpgradeError { kind: upgrade_error.into() },
             crate::execution_status::ExecutionErrorKind::WrittenObjectsTooLarge { current_size, max_size } => Self::WrittenObjectsTooLarge { object_size: current_size, max_object_size:max_size },
             crate::execution_status::ExecutionErrorKind::CertificateDenied => Self::CertificateDenied,
+            // Test/antithesis-only; no dedicated SDK kind, map to the generic InvariantViolation.
+            crate::execution_status::ExecutionErrorKind::InternalExecutionError => Self::InvariantViolation,
             crate::execution_status::ExecutionErrorKind::SuiMoveVerificationTimedout => Self::SuiMoveVerificationTimedout,
             crate::execution_status::ExecutionErrorKind::SharedObjectOperationNotAllowed => Self::ConsensusObjectOperationNotAllowed,
             crate::execution_status::ExecutionErrorKind::InputObjectDeleted => Self::InputObjectDeleted,

--- a/crates/sui-types/tests/snapshots/format__sui.yaml.snap
+++ b/crates/sui-types/tests/snapshots/format__sui.yaml.snap
@@ -666,6 +666,8 @@ ExecutionErrorKind:
         STRUCT:
           - id:
               TYPENAME: ObjectID
+    42:
+      InternalExecutionError: UNIT
 ExecutionFailure:
   STRUCT:
     - error:

--- a/crates/sui-types/tests/staged/exec_failure_status.yaml
+++ b/crates/sui-types/tests/staged/exec_failure_status.yaml
@@ -41,3 +41,4 @@
 39: InvalidLinkage
 40: InsufficientFundsForWithdraw
 41: NonExclusiveWriteInputObjectModified
+42: InternalExecutionError


### PR DESCRIPTION
## Description

Certain transactions can deterministically panic a node during execution; without recovery the node crash-loops on every restart. This adds crash-recovery (test/antithesis-only, opt-in via a content-addressed poison marker; inert in release): a panic hook records the executing transaction's digest, and on restart the node re-executes it with a new terminal `InternalExecutionError` early error instead of running the logic that crashes.

A crashed transaction is **not** dropped — it is still assigned versions, executed (as a deterministic failure that advances its shared-object versions), and checkpointed like any other transaction. This keeps version assignment, the `ConsensusCommitPrologue` version-assignment commitment, and checkpoint contents a pure function of the consensus commit, so a node's pre-crash build and post-restart rebuild agree. (An earlier drop-based approach forked checkpoints and stalled the builder because the node-local crashed set leaked into consensus-committed state.) Fullnodes and lagging nodes reproduce the effect from the certified checkpoint without re-running the crashing logic.

## Test plan

Covered by `test_simulated_load_reconfig_with_crashes_and_delays` (sui-benchmark simtest), which injects deterministic crashes under load with reconfiguration. Verified on the seeds that previously forked / hung the checkpoint builder / hit the accumulator assertion, plus a 60-seed search with no failures.

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
