### PR TITLE
docs: add Codex to the developer tools catalog

### DIFF
--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -778,6 +778,14 @@ Indexers, data APIs, and analytics services for querying on-chain state.
 />
 
 <ToolCard
+  name="Codex"
+  description="GraphQL API for real-time token prices, charts, transactions, and wallet data on Sui. Supports live-streamed subscriptions and webhooks."
+  docs="https://docs.codex.io/"
+  website="https://www.codex.io/"
+  community
+/>
+
+<ToolCard
   name="Indexer.xyz (TradePort)"
   description="Toolkit for accessing NFT data and integrating trading functionality on Sui."
   docs="https://tradeport.xyz/docs"


### PR DESCRIPTION
## Description

Adds [Codex](https://www.codex.io/) to the **Data and indexing** section of the Developer Tools page (`docs/content/getting-started/tooling.mdx`).

Codex provides a GraphQL API for real-time token prices, charts, transactions, and wallet data on Sui, with support for live-streamed subscriptions and webhooks. Sui is a supported network ([docs.codex.io/networks](https://docs.codex.io/networks)).

The entry follows the existing `ToolCard` format and is tagged as a Community tool.

## Test plan

Docs-only change; verified the card matches the existing component props. Will check the Vercel preview once it builds.

---

## Release notes

Docs-only change — release notes not required.