### PR TITLE
Unanchored Negation

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
@@ -648,7 +648,7 @@ fn tx_missing_include_filter(addr: SuiAddress) -> TransactionFilter {
     filter
 }
 
-fn ev_missing_include_filter(addr: SuiAddress) -> EventFilter {
+fn ev_not_sender_only_filter(addr: SuiAddress) -> EventFilter {
     let mut term = EventTerm::default();
     term.literals = vec![ev_not_sender_literal(addr)];
     let mut filter = EventFilter::default();
@@ -1533,6 +1533,87 @@ async fn test_list_events_combinators() {
 }
 
 #[sim_test]
+async fn test_list_events_unanchored_negation() {
+    let cluster = new_cluster().await;
+    let sender_a = cluster.get_address_0();
+    let sender_b = cluster.get_address_1();
+
+    let (pkg, _) = publish_package(&cluster, sender_a, emit_test_event_pkg_path()).await;
+    let tx_a = call_move(
+        &cluster,
+        sender_a,
+        pkg,
+        "emit_test_event",
+        "emit_test_event",
+    )
+    .await;
+    let tx_b = call_move(
+        &cluster,
+        sender_b,
+        pkg,
+        "emit_test_event",
+        "emit_test_event",
+    )
+    .await;
+    let digest_a = tx_digest(&tx_a);
+    let digest_b = tx_digest(&tx_b);
+
+    let mut client = new_ledger_client(&cluster).await;
+
+    // Single-term exclude-only filter: `NOT sender = B` must return A's event
+    // (and any other event whose sender is not B), validating that the
+    // synthesized EventExtant include actually anchors the term so the driver
+    // walks the event space rather than rejecting the filter.
+    let mut req = ListEventsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.filter = Some(ev_not_sender_only_filter(sender_b));
+    req.options = Some(query_options(100));
+    let resp = list_events_result(&mut client, req).await;
+    let digests = event_digest_set(&resp);
+    assert!(
+        digests.contains(&digest_a),
+        "A event should match unanchored NOT(Sender=B)"
+    );
+    assert!(
+        !digests.contains(&digest_b),
+        "B event should be excluded by unanchored NOT(Sender=B)"
+    );
+    assert!(resp.end);
+
+    // Symmetric case: `NOT sender = A` returns B's event.
+    let mut req = ListEventsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.filter = Some(ev_not_sender_only_filter(sender_a));
+    req.options = Some(query_options(100));
+    let resp = list_events_result(&mut client, req).await;
+    let digests = event_digest_set(&resp);
+    assert!(
+        digests.contains(&digest_b),
+        "B event should match unanchored NOT(Sender=A)"
+    );
+    assert!(
+        !digests.contains(&digest_a),
+        "A event should be excluded by unanchored NOT(Sender=A)"
+    );
+
+    // DNF with two unanchored terms `NOT sender = A OR NOT sender = B` —
+    // every emitted event satisfies at least one branch, so both digests
+    // come back. Exercises the dedup path: the synthetic EventExtant leaf
+    // is shared across both terms and must only be scanned once.
+    let mut req = ListEventsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.filter = Some(ev_or(vec![
+        vec![ev_not_sender_literal(sender_a)],
+        vec![ev_not_sender_literal(sender_b)],
+    ]));
+    req.options = Some(query_options(100));
+    let resp = list_events_result(&mut client, req).await;
+    let digests = event_digest_set(&resp);
+    assert!(digests.contains(&digest_a));
+    assert!(digests.contains(&digest_b));
+}
+
+#[sim_test]
 async fn test_list_filter_edge_cases_and_limit_caps() {
     let cluster = new_cluster().await;
     let sender = cluster.get_address_0();
@@ -1681,14 +1762,6 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(EventFilter::default());
-    req.options = Some(query_options(10));
-    expect_invalid_list_events(&mut client, req).await;
-
-    let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
-    req.start_checkpoint = Some(0);
-    req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
-    req.filter = Some(ev_missing_include_filter(sender));
     req.options = Some(query_options(10));
     expect_invalid_list_events(&mut client, req).await;
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
@@ -640,7 +640,7 @@ fn ev_or(terms: Vec<Vec<EventLiteral>>) -> EventFilter {
     ev_filter_terms(terms)
 }
 
-fn tx_missing_include_filter(addr: SuiAddress) -> TransactionFilter {
+fn tx_not_sender_only_filter(addr: SuiAddress) -> TransactionFilter {
     let mut term = TransactionTerm::default();
     term.literals = vec![tx_not_sender_literal(addr)];
     let mut filter = TransactionFilter::default();
@@ -1614,6 +1614,161 @@ async fn test_list_events_unanchored_negation() {
 }
 
 #[sim_test]
+async fn test_list_transactions_unanchored_negation() {
+    let cluster = new_cluster().await;
+    let sender_a = cluster.get_address_0();
+    let sender_b = cluster.get_address_1();
+
+    let tx_a = transfer_self(&cluster, sender_a).await;
+    let tx_b = transfer_self(&cluster, sender_b).await;
+    let digest_a = tx_digest(&tx_a);
+    let digest_b = tx_digest(&tx_b);
+    let (start, end) = checkpoint_range(&[&tx_a, &tx_b]);
+
+    let mut client = new_ledger_client(&cluster).await;
+
+    // Single-term exclude-only filter: `NOT sender = B` must return A's tx
+    // and every other tx in range (including system transactions), validating
+    // that the synthesized TxUniverse include anchors the term so the driver
+    // walks the dense tx space rather than rejecting the filter.
+    let mut req = ListTransactionsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["digest"]));
+    req.start_checkpoint = Some(start);
+    req.end_checkpoint = Some(end);
+    req.filter = Some(tx_not_sender_only_filter(sender_b));
+    req.options = Some(query_options(100));
+    let resp = list_transactions_result(&mut client, req).await;
+    assert_transaction_cursors(&resp);
+    let digests = transaction_digest_set(&resp);
+    assert!(
+        digests.contains(&digest_a),
+        "A tx should match unanchored NOT(Sender=B)"
+    );
+    assert!(
+        !digests.contains(&digest_b),
+        "B tx should be excluded by unanchored NOT(Sender=B)"
+    );
+    assert!(
+        resp.transactions.len() >= 2,
+        "complement includes system transactions in range"
+    );
+    assert!(resp.end);
+    let full_complement = digests;
+
+    // Symmetric case: `NOT sender = A` returns B's tx.
+    let mut req = ListTransactionsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["digest"]));
+    req.start_checkpoint = Some(start);
+    req.end_checkpoint = Some(end);
+    req.filter = Some(tx_not_sender_only_filter(sender_a));
+    req.options = Some(query_options(100));
+    let resp = list_transactions_result(&mut client, req).await;
+    let digests = transaction_digest_set(&resp);
+    assert!(
+        digests.contains(&digest_b),
+        "B tx should match unanchored NOT(Sender=A)"
+    );
+    assert!(
+        !digests.contains(&digest_a),
+        "A tx should be excluded by unanchored NOT(Sender=A)"
+    );
+
+    // DNF with two unanchored terms `NOT sender = A OR NOT sender = B` —
+    // every tx satisfies at least one branch, so both digests return.
+    // Confirms a multi-term exclude-only DNF survives the full stack.
+    let mut req = ListTransactionsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["digest"]));
+    req.start_checkpoint = Some(start);
+    req.end_checkpoint = Some(end);
+    req.filter = Some(tx_or(vec![
+        vec![tx_not_sender_literal(sender_a)],
+        vec![tx_not_sender_literal(sender_b)],
+    ]));
+    req.options = Some(query_options(100));
+    let resp = list_transactions_result(&mut client, req).await;
+    let digests = transaction_digest_set(&resp);
+    assert!(digests.contains(&digest_a));
+    assert!(digests.contains(&digest_b));
+
+    // Pagination across the dense complement: small pages with cursor resume
+    // must cover exactly the single-shot result with no overlap.
+    let mut paged: HashSet<String> = HashSet::new();
+    let mut after: Option<Bytes> = None;
+    loop {
+        let mut req = ListTransactionsRequest::default();
+        req.read_mask = Some(FieldMask::from_paths(["digest"]));
+        req.start_checkpoint = Some(start);
+        req.end_checkpoint = Some(end);
+        req.filter = Some(tx_not_sender_only_filter(sender_b));
+        req.options = Some(query_options_maybe_after(2, after.clone()));
+        let resp = list_transactions_result(&mut client, req).await;
+        for digest in transaction_digest_set(&resp) {
+            assert!(paged.insert(digest), "pages must not overlap");
+        }
+        if resp.end_reason != Some(QueryEndReason::ItemLimit) {
+            break;
+        }
+        after = Some(transaction_end_cursor(
+            &resp,
+            "item-limited page should carry an end cursor",
+        ));
+    }
+    assert_eq!(
+        paged, full_complement,
+        "paged union must equal the single-shot complement"
+    );
+}
+
+#[sim_test]
+async fn test_list_checkpoints_unanchored_negation() {
+    let cluster = new_cluster().await;
+    let sender_a = cluster.get_address_0();
+    let sender_b = cluster.get_address_1();
+
+    let tx_a = transfer_self(&cluster, sender_a).await;
+    let tx_b = transfer_self(&cluster, sender_b).await;
+    let cp_a = tx_checkpoint(&tx_a);
+    let cp_b = tx_checkpoint(&tx_b);
+    let (start, end) = checkpoint_range(&[&tx_a, &tx_b]);
+
+    let mut client = new_ledger_client(&cluster).await;
+
+    // Checkpoint filters reuse the tx filter machinery: a checkpoint matches
+    // when it contains at least one matching tx. `NOT sender = A` matches the
+    // system transactions in every checkpoint, so the unanchored filter must
+    // return the same checkpoint set as an unfiltered scan of the range —
+    // pinning the dense complement through the tx→checkpoint mapping.
+    let mut req = ListCheckpointsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["sequence_number"]));
+    req.start_checkpoint = Some(start);
+    req.end_checkpoint = Some(end);
+    req.options = Some(query_options(100));
+    let unfiltered: Vec<u64> = list_checkpoints_result(&mut client, req)
+        .await
+        .checkpoints
+        .iter()
+        .map(checkpoint_sequence)
+        .collect();
+
+    let mut req = ListCheckpointsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["sequence_number"]));
+    req.start_checkpoint = Some(start);
+    req.end_checkpoint = Some(end);
+    req.filter = Some(tx_not_sender_only_filter(sender_a));
+    req.options = Some(query_options(100));
+    let resp = list_checkpoints_result(&mut client, req).await;
+    assert_checkpoint_cursors(&resp);
+    let filtered: Vec<u64> = resp.checkpoints.iter().map(checkpoint_sequence).collect();
+    assert_eq!(
+        filtered, unfiltered,
+        "every checkpoint contains a non-A system tx, so the complement covers the range"
+    );
+    assert!(filtered.contains(&cp_a));
+    assert!(filtered.contains(&cp_b));
+    assert!(resp.end);
+}
+
+#[sim_test]
 async fn test_list_filter_edge_cases_and_limit_caps() {
     let cluster = new_cluster().await;
     let sender = cluster.get_address_0();
@@ -1749,14 +1904,6 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     req.options = Some(query_options(10));
     expect_invalid_list_transactions(&mut client, req).await;
 
-    let mut req = ListTransactionsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["digest"]));
-    req.start_checkpoint = Some(0);
-    req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
-    req.filter = Some(tx_missing_include_filter(sender));
-    req.options = Some(query_options(10));
-    expect_invalid_list_transactions(&mut client, req).await;
-
     let mut req = ListEventsRequest::default();
     req.read_mask = Some(FieldMask::from_paths(["event_type"]));
     req.start_checkpoint = Some(0);
@@ -1783,14 +1930,6 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(TransactionFilter::default());
-    req.options = Some(query_options(10));
-    expect_invalid_list_checkpoints(&mut client, req).await;
-
-    let mut req = ListCheckpointsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["sequence_number"]));
-    req.start_checkpoint = Some(0);
-    req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
-    req.filter = Some(tx_missing_include_filter(sender));
     req.options = Some(query_options(10));
     expect_invalid_list_checkpoints(&mut client, req).await;
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -677,7 +677,7 @@ fn ev_or(terms: Vec<Vec<EventLiteral>>) -> EventFilter {
     ev_filter_terms(terms)
 }
 
-fn tx_missing_include_filter(addr: SuiAddress) -> TransactionFilter {
+fn tx_not_sender_only_filter(addr: SuiAddress) -> TransactionFilter {
     let mut term = TransactionTerm::default();
     term.literals = vec![tx_not_sender_literal(addr)];
     let mut filter = TransactionFilter::default();
@@ -685,7 +685,7 @@ fn tx_missing_include_filter(addr: SuiAddress) -> TransactionFilter {
     filter
 }
 
-fn ev_missing_include_filter(addr: SuiAddress) -> EventFilter {
+fn ev_not_sender_only_filter(addr: SuiAddress) -> EventFilter {
     let mut term = EventTerm::default();
     term.literals = vec![ev_not_sender_literal(addr)];
     let mut filter = EventFilter::default();
@@ -2012,6 +2012,68 @@ async fn test_list_transactions_combinator_or_not() {
 }
 
 #[tokio::test]
+async fn test_list_transactions_unanchored_negation() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+    let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+
+    let (digest_a, _) = transfer_self(&mut cluster, sender_a, &kp_a, gas_a).await;
+    let (digest_b, _) = transfer_self(&mut cluster, sender_b, &kp_b, gas_b).await;
+
+    cluster.create_checkpoint().await;
+
+    let mut client = KvLedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+
+    // Exclude-only term: `NOT sender = B` anchors on the scan-time-synthesized
+    // TxUniverse leaf and returns the dense complement — A's tx plus every
+    // other tx in range (funding transfers, genesis).
+    let mut req = ListTransactionsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["digest"]));
+    req.filter = Some(tx_not_sender_only_filter(sender_b));
+    req.options = Some(query_options(100));
+    let resp = list_transactions_result(&mut client, req).await;
+    let digests: Vec<String> = resp
+        .transactions
+        .iter()
+        .filter_map(|t| t.transaction.as_ref().and_then(|tx| tx.digest.clone()))
+        .collect();
+    assert!(
+        digests.contains(&digest_a.to_string()),
+        "A's tx should match unanchored Not(Sender=B)"
+    );
+    assert!(
+        !digests.contains(&digest_b.to_string()),
+        "B's tx should be excluded by unanchored Not(Sender=B)"
+    );
+    assert!(
+        digests.len() >= 2,
+        "complement includes funding/genesis transactions"
+    );
+
+    // Symmetric case: `NOT sender = A` returns B's tx.
+    let mut req = ListTransactionsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["digest"]));
+    req.filter = Some(tx_not_sender_only_filter(sender_a));
+    req.options = Some(query_options(100));
+    let resp = list_transactions_result(&mut client, req).await;
+    let digests: Vec<String> = resp
+        .transactions
+        .iter()
+        .filter_map(|t| t.transaction.as_ref().and_then(|tx| tx.digest.clone()))
+        .collect();
+    assert!(
+        digests.contains(&digest_b.to_string()),
+        "B's tx should match unanchored Not(Sender=A)"
+    );
+    assert!(
+        !digests.contains(&digest_a.to_string()),
+        "A's tx should be excluded by unanchored Not(Sender=A)"
+    );
+}
+
+#[tokio::test]
 async fn test_list_transactions_recipient_and_affected_object() {
     let mut cluster = FullCluster::new().await.unwrap();
     let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
@@ -2308,6 +2370,90 @@ async fn test_list_events_combinator_or_not() {
     assert!(
         !digests.contains(&digest_b.to_string()),
         "B's event should be excluded by Not(Sender=B)"
+    );
+}
+
+#[tokio::test]
+async fn test_list_events_unanchored_negation() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+    let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+
+    let (pkg, gas_a) = publish_package(
+        &mut cluster,
+        sender_a,
+        &kp_a,
+        gas_a,
+        emit_test_event_pkg_path(),
+    )
+    .await;
+
+    let (digest_a, _) = call_move(
+        &mut cluster,
+        sender_a,
+        &kp_a,
+        gas_a,
+        pkg,
+        "emit_test_event",
+        "emit_test_event",
+    )
+    .await;
+    let (digest_b, _) = call_move(
+        &mut cluster,
+        sender_b,
+        &kp_b,
+        gas_b,
+        pkg,
+        "emit_test_event",
+        "emit_test_event",
+    )
+    .await;
+
+    cluster.create_checkpoint().await;
+
+    let mut client = KvLedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+
+    // Exclude-only term: `NOT sender = B` anchors on the stored EventExtant
+    // marker and returns every event whose sender is not B.
+    let mut req = ListEventsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.filter = Some(ev_not_sender_only_filter(sender_b));
+    req.options = Some(query_options(100));
+    let resp = list_events_result(&mut client, req).await;
+    let digests: Vec<String> = resp
+        .events
+        .iter()
+        .filter_map(|e| e.transaction_digest.clone())
+        .collect();
+    assert!(
+        digests.contains(&digest_a.to_string()),
+        "A's event should match unanchored Not(Sender=B)"
+    );
+    assert!(
+        !digests.contains(&digest_b.to_string()),
+        "B's event should be excluded by unanchored Not(Sender=B)"
+    );
+
+    // Symmetric case: `NOT sender = A` returns B's event.
+    let mut req = ListEventsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.filter = Some(ev_not_sender_only_filter(sender_a));
+    req.options = Some(query_options(100));
+    let resp = list_events_result(&mut client, req).await;
+    let digests: Vec<String> = resp
+        .events
+        .iter()
+        .filter_map(|e| e.transaction_digest.clone())
+        .collect();
+    assert!(
+        digests.contains(&digest_b.to_string()),
+        "B's event should match unanchored Not(Sender=A)"
+    );
+    assert!(
+        !digests.contains(&digest_a.to_string()),
+        "A's event should be excluded by unanchored Not(Sender=A)"
     );
 }
 
@@ -2735,27 +2881,11 @@ async fn test_list_filter_edge_cases() {
     req.options = Some(query_options(10));
     expect_invalid_list_transactions(&mut client, req).await;
 
-    let mut req = ListTransactionsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["digest"]));
-    req.start_checkpoint = Some(0);
-    req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
-    req.filter = Some(tx_missing_include_filter(sender));
-    req.options = Some(query_options(10));
-    expect_invalid_list_transactions(&mut client, req).await;
-
     let mut req = ListEventsRequest::default();
     req.read_mask = Some(FieldMask::from_paths(["event_type"]));
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(EventFilter::default());
-    req.options = Some(query_options(10));
-    expect_invalid_list_events(&mut client, req).await;
-
-    let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
-    req.start_checkpoint = Some(0);
-    req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
-    req.filter = Some(ev_missing_include_filter(sender));
     req.options = Some(query_options(10));
     expect_invalid_list_events(&mut client, req).await;
 
@@ -2782,14 +2912,6 @@ async fn test_list_filter_edge_cases() {
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(TransactionFilter::default());
-    req.options = Some(query_options(10));
-    expect_invalid_list_checkpoints(&mut client, req).await;
-
-    let mut req = ListCheckpointsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["sequence_number"]));
-    req.start_checkpoint = Some(0);
-    req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
-    req.filter = Some(tx_missing_include_filter(sender));
     req.options = Some(query_options(10));
     expect_invalid_list_checkpoints(&mut client, req).await;
 }
@@ -2951,6 +3073,47 @@ async fn test_list_checkpoints_combinator_or() {
     assert!(
         !seqs.contains(&cp_c),
         "OR filter should exclude checkpoint for C"
+    );
+}
+
+#[tokio::test]
+async fn test_list_checkpoints_unanchored_negation() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    let (sender_a, kp_a, gas_a) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+    let (sender_b, kp_b, gas_b) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+
+    transfer_in_own_checkpoint(&mut cluster, sender_a, &kp_a, gas_a).await;
+    let cp_a = cluster.latest_checkpoint().await.unwrap().unwrap();
+    transfer_in_own_checkpoint(&mut cluster, sender_b, &kp_b, gas_b).await;
+    let cp_b = cluster.latest_checkpoint().await.unwrap().unwrap();
+
+    let mut client = KvLedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+
+    // Exclude-only term with two excludes: `NOT sender = B AND NOT sender = 0x0`.
+    // cp_b contains only B's transfer plus the system settlement/barrier txs
+    // (sender 0x0), so excluding both empties its complement and the whole
+    // checkpoint drops out — checkpoint-level negation is observable here.
+    // cp_a still matches via A's transfer and the funding transfers.
+    let mut req = ListCheckpointsRequest::default();
+    req.read_mask = Some(FieldMask::from_paths(["sequence_number"]));
+    req.filter = Some(tx_filter(vec![
+        tx_not_sender_literal(sender_b),
+        tx_not_sender_literal(SuiAddress::ZERO),
+    ]));
+    req.options = Some(query_options(100));
+    let resp = list_checkpoints_result(&mut client, req).await;
+    assert_checkpoint_cursors(&resp);
+    let seqs: std::collections::HashSet<u64> =
+        resp.checkpoints.iter().map(checkpoint_sequence).collect();
+    assert!(
+        seqs.contains(&cp_a),
+        "checkpoint with A's tx should match the unanchored complement, got {seqs:?}"
+    );
+    assert!(
+        !seqs.contains(&cp_b),
+        "checkpoint containing only B's and system txs should be excluded, got {seqs:?}"
     );
 }
 

--- a/crates/sui-inverted-index/src/bitmap_query/iter.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/iter.rs
@@ -510,4 +510,159 @@ mod tests {
             "final watermark must reach the range terminus"
         );
     }
+
+    /// An unanchored term (`NOT x`, anchored on the synthesized universe leaf)
+    /// emits the complement at exclude-occupied buckets, full bitmaps at gap
+    /// buckets, and keeps emitting full buckets after the exclude leaf EOFs.
+    #[test]
+    fn unanchored_term_emits_complement_over_gaps_and_past_exclude_eof() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([(
+                test_key(b"x"),
+                vec![(0, vec![1, 2]), (2, vec![5])],
+            )])),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include_universe(), exclude(b"x")]).unwrap(),
+        ])
+        .unwrap();
+
+        let items: Vec<(u64, RoaringBitmap)> = eval_bitmap_query_bucket_iter(
+            source,
+            query,
+            0..(4 * BUCKET_SIZE),
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+        )
+        .filter_map(|r| match r.unwrap() {
+            Watermarked::Item(it) => Some(it),
+            Watermarked::Watermark(_) => None,
+        })
+        .collect();
+
+        let complement = |bits: &[u32]| {
+            let mut bm = full_bucket();
+            for &b in bits {
+                bm.remove(b);
+            }
+            bm
+        };
+        let expected = vec![
+            (0, complement(&[1, 2])),
+            (1, full_bucket()),
+            (2, complement(&[5])),
+            (3, full_bucket()),
+        ];
+        assert_eq!(items, expected);
+    }
+
+    /// Iter/stream parity for a mixed DNF with an unanchored term, in both
+    /// directions — the universe leaf forces dense bucket coverage while the
+    /// anchored term stays sparse.
+    #[tokio::test]
+    async fn eval_bitmap_query_bucket_iter_matches_stream_for_unanchored_terms() {
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::from([
+                (test_key(b"a"), vec![(1, vec![7])]),
+                (test_key(b"x"), vec![(0, vec![1, 2]), (3, vec![5])]),
+            ])),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include(b"a")]).unwrap(),
+            BitmapTerm::new(vec![include_universe(), exclude(b"x")]).unwrap(),
+        ])
+        .unwrap();
+
+        for direction in [ScanDirection::Ascending, ScanDirection::Descending] {
+            let stream_out: Vec<_> = eval_bitmap_query_bucket_stream(
+                source.clone(),
+                query.clone(),
+                0..(5 * BUCKET_SIZE),
+                BUCKET_SIZE,
+                direction,
+                BitmapScanBudget::new(1_000_000),
+            )
+            .collect()
+            .await;
+            let iter_out: Vec<_> = eval_bitmap_query_bucket_iter(
+                source.clone(),
+                query.clone(),
+                0..(5 * BUCKET_SIZE),
+                BUCKET_SIZE,
+                direction,
+            )
+            .collect();
+
+            assert_eq!(
+                collect_marked(stream_out),
+                collect_marked(iter_out),
+                "iter and stream diverged on unanchored terms for {direction:?}"
+            );
+        }
+    }
+
+    /// Budget exhaustion mid-dense-scan surfaces `BitmapScanLimitExceeded`
+    /// after a floor watermark, and resuming from that watermark covers the
+    /// remaining buckets exactly once.
+    #[tokio::test]
+    async fn unanchored_budget_exhaustion_resumes_at_watermark() {
+        use crate::bitmap_query::BitmapScanLimitExceeded;
+        use crate::bitmap_query::error_contains;
+
+        let source = TestBucketSource {
+            buckets: Arc::new(BTreeMap::new()),
+        };
+        let query = BitmapQuery::new(vec![
+            BitmapTerm::new(vec![include_universe(), exclude(b"x")]).unwrap(),
+        ])
+        .unwrap();
+
+        let first: Vec<_> = eval_bitmap_query_bucket_stream(
+            source.clone(),
+            query.clone(),
+            0..(10 * BUCKET_SIZE),
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            BitmapScanBudget::new(3),
+        )
+        .collect()
+        .await;
+
+        let mut covered: Vec<u64> = Vec::new();
+        let mut last_watermark = 0;
+        let mut limit_hit = false;
+        for item in first {
+            match item {
+                Ok(Watermarked::Item((bucket, bitmap))) => {
+                    assert_eq!(bitmap, full_bucket());
+                    covered.push(bucket);
+                }
+                Ok(Watermarked::Watermark(p)) => last_watermark = p,
+                Err(e) => {
+                    assert!(error_contains::<BitmapScanLimitExceeded>(&e).is_some());
+                    limit_hit = true;
+                }
+            }
+        }
+        assert!(limit_hit, "3-bucket budget cannot cover 10 dense buckets");
+        assert_eq!(covered, vec![0, 1, 2]);
+        assert_eq!(last_watermark, 3 * BUCKET_SIZE);
+
+        let resumed: Vec<_> = eval_bitmap_query_bucket_stream(
+            source,
+            query,
+            last_watermark..(10 * BUCKET_SIZE),
+            BUCKET_SIZE,
+            ScanDirection::Ascending,
+            BitmapScanBudget::new(1_000_000),
+        )
+        .collect()
+        .await;
+        for item in resumed {
+            if let Watermarked::Item((bucket, _)) = item.unwrap() {
+                covered.push(bucket);
+            }
+        }
+        assert_eq!(covered, (0..10).collect::<Vec<_>>());
+    }
 }

--- a/crates/sui-inverted-index/src/bitmap_query/mod.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/mod.rs
@@ -260,7 +260,7 @@ impl BitmapLiteral {
         Ok(Self::Exclude(BitmapKey::new(dimension_key)?))
     }
 
-    pub(crate) fn key_bytes(&self) -> &[u8] {
+    pub fn key_bytes(&self) -> &[u8] {
         match self {
             BitmapLiteral::Include(k) | BitmapLiteral::Exclude(k) => k.as_bytes(),
         }
@@ -295,6 +295,10 @@ impl BitmapQuery {
             .collect::<HashSet<_>>()
             .len()
     }
+
+    pub fn terms(&self) -> &[BitmapTerm] {
+        &self.terms
+    }
 }
 
 impl BitmapTerm {
@@ -306,6 +310,10 @@ impl BitmapTerm {
             bail!("bitmap query term must contain at least one include literal");
         }
         Ok(Self { literals })
+    }
+
+    pub fn literals(&self) -> &[BitmapLiteral] {
+        &self.literals
     }
 }
 

--- a/crates/sui-inverted-index/src/bitmap_query/mod.rs
+++ b/crates/sui-inverted-index/src/bitmap_query/mod.rs
@@ -12,12 +12,13 @@
 //! Queries are intentionally restricted to anchored DNF: every term must contain
 //! at least one positive literal. Positive literals give the evaluator concrete
 //! bitmap streams to scan and intersect; negative literals only shrink those
-//! candidate streams. Supporting negative-only terms such as `NOT sender = A`
-//! would require scanning an external universe for the requested range and
-//! subtracting from it, which defeats the index's selective streaming behavior
-//! and makes pagination depend on a full-range scan. Requiring DNF at the API
-//! boundary also keeps this evaluator as a set of ordered stream merge-joins
-//! instead of a recursive expression engine or a query normalizer.
+//! candidate streams. Negative-only terms such as `NOT sender = A` are
+//! supported by anchoring them upstream on a universe include — a stored
+//! existence marker in event-space (`EventExtant`), a scan-time-synthesized
+//! dense leaf in tx-space (`TxUniverse`, see [`dense_universe_buckets`]) — so
+//! the evaluator itself stays a set of ordered stream merge-joins with no
+//! complement-specific code path. The full-range scan such a term implies is
+//! inherent to negation and is bounded by the per-request bucket budget.
 //!
 //! Backends provide one ordered `(bucket_id, RoaringBitmap)` stream or iterator
 //! per dimension key. The merge-join machinery here is storage-agnostic:
@@ -158,6 +159,36 @@ impl ScanDirection {
     pub fn is_ascending(self) -> bool {
         matches!(self, Self::Ascending)
     }
+}
+
+/// Synthesized bucket sequence for the dense tx-seq universe: one full bitmap
+/// per bucket touched by `range`, in scan-direction order. Backends return this
+/// for the query-only `IndexDimension::TxUniverse` key instead of reading
+/// storage — the tx-seq namespace is dense, so the universe is computable.
+///
+/// Bitmaps carry all `[0, bucket_size)` relative bits even in edge buckets;
+/// trimming against the requested range happens at the flatten step, same as
+/// for stored buckets.
+pub fn dense_universe_buckets(
+    range: Range<u64>,
+    bucket_size: u64,
+    direction: ScanDirection,
+) -> impl Iterator<Item = (u64, RoaringBitmap)> + Send + 'static {
+    let bits = u32::try_from(bucket_size).expect("bucket size fits in u32");
+    let mut buckets = if range.is_empty() {
+        0..0
+    } else {
+        (range.start / bucket_size)..(range.end - 1) / bucket_size + 1
+    };
+    std::iter::from_fn(move || {
+        let bucket = match direction {
+            ScanDirection::Ascending => buckets.next(),
+            ScanDirection::Descending => buckets.next_back(),
+        }?;
+        let mut bitmap = RoaringBitmap::new();
+        bitmap.insert_range(0..bits);
+        Some((bucket, bitmap))
+    })
 }
 
 /// Storage backend that can scan one bitmap dimension key over a member range.
@@ -546,10 +577,10 @@ pub(crate) mod test_utils {
         fn scan_bucket_stream(
             &self,
             dimension_key: Vec<u8>,
-            _range: Range<u64>,
+            range: Range<u64>,
             direction: ScanDirection,
         ) -> BucketStream {
-            stream::iter(self.bucket_items(&dimension_key, direction)).boxed()
+            stream::iter(self.bucket_items(&dimension_key, range, direction)).boxed()
         }
     }
 
@@ -559,10 +590,11 @@ pub(crate) mod test_utils {
         fn scan_bucket_iter(
             &self,
             dimension_key: Vec<u8>,
-            _range: Range<u64>,
+            range: Range<u64>,
             direction: ScanDirection,
         ) -> Self::Iter {
-            self.bucket_items(&dimension_key, direction).into_iter()
+            self.bucket_items(&dimension_key, range, direction)
+                .into_iter()
         }
     }
 
@@ -570,8 +602,16 @@ pub(crate) mod test_utils {
         pub(crate) fn bucket_items(
             &self,
             dimension_key: &[u8],
+            range: Range<u64>,
             direction: ScanDirection,
         ) -> Vec<BucketItem> {
+            // Mirror the real backends: the tx-universe key is synthesized at
+            // scan time, never read from stored buckets.
+            if dimension_key == universe_key() {
+                return dense_universe_buckets(range, BUCKET_SIZE, direction)
+                    .map(Ok)
+                    .collect();
+            }
             let mut buckets = self.buckets.get(dimension_key).cloned().unwrap_or_default();
             if matches!(direction, ScanDirection::Descending) {
                 buckets.reverse();
@@ -595,8 +635,27 @@ pub(crate) mod test_utils {
         crate::dimensions::encode_dimension_key(crate::dimensions::IndexDimension::Sender, value)
     }
 
+    pub(crate) fn universe_key() -> Vec<u8> {
+        crate::dimensions::encode_dimension_key(
+            crate::dimensions::IndexDimension::TxUniverse,
+            crate::dimensions::TX_UNIVERSE_VALUE,
+        )
+    }
+
     pub(crate) fn include(value: &[u8]) -> BitmapLiteral {
         BitmapLiteral::include(test_key(value)).unwrap()
+    }
+
+    pub(crate) fn include_universe() -> BitmapLiteral {
+        BitmapLiteral::include(universe_key()).unwrap()
+    }
+
+    /// Full `[0, BUCKET_SIZE)` bitmap — what the synthesized universe leaf
+    /// yields per bucket.
+    pub(crate) fn full_bucket() -> RoaringBitmap {
+        let mut bm = RoaringBitmap::new();
+        bm.insert_range(0..BUCKET_SIZE as u32);
+        bm
     }
 
     /// A `TestBucketSource` that records how many times `scan_bucket_*` is
@@ -635,7 +694,17 @@ pub(crate) mod test_utils {
                 .or_insert(0) += 1;
         }
 
-        fn bucket_items(&self, dimension_key: &[u8], direction: ScanDirection) -> Vec<BucketItem> {
+        fn bucket_items(
+            &self,
+            dimension_key: &[u8],
+            range: Range<u64>,
+            direction: ScanDirection,
+        ) -> Vec<BucketItem> {
+            if dimension_key == universe_key() {
+                return dense_universe_buckets(range, BUCKET_SIZE, direction)
+                    .map(Ok)
+                    .collect();
+            }
             let mut buckets = self.buckets.get(dimension_key).cloned().unwrap_or_default();
             if matches!(direction, ScanDirection::Descending) {
                 buckets.reverse();
@@ -651,11 +720,11 @@ pub(crate) mod test_utils {
         fn scan_bucket_stream(
             &self,
             dimension_key: Vec<u8>,
-            _range: Range<u64>,
+            range: Range<u64>,
             direction: ScanDirection,
         ) -> BucketStream {
             self.record(&dimension_key);
-            stream::iter(self.bucket_items(&dimension_key, direction)).boxed()
+            stream::iter(self.bucket_items(&dimension_key, range, direction)).boxed()
         }
     }
 
@@ -665,11 +734,12 @@ pub(crate) mod test_utils {
         fn scan_bucket_iter(
             &self,
             dimension_key: Vec<u8>,
-            _range: Range<u64>,
+            range: Range<u64>,
             direction: ScanDirection,
         ) -> Self::Iter {
             self.record(&dimension_key);
-            self.bucket_items(&dimension_key, direction).into_iter()
+            self.bucket_items(&dimension_key, range, direction)
+                .into_iter()
         }
     }
 
@@ -694,6 +764,38 @@ mod tests {
         );
         assert!(BitmapLiteral::include(vec![0xff, 0x00]).is_err());
         assert!(BitmapTerm::new(vec![exclude(b"neg")]).is_err());
+    }
+
+    #[test]
+    fn dense_universe_buckets_covers_range_in_direction_order() {
+        use super::test_utils::BUCKET_SIZE;
+
+        // Partial edge buckets still yield full bitmaps — trimming happens at
+        // the flatten step.
+        let asc: Vec<u64> =
+            dense_universe_buckets(150_000..350_001, BUCKET_SIZE, ScanDirection::Ascending)
+                .map(|(bucket, bitmap)| {
+                    assert_eq!(bitmap.len(), BUCKET_SIZE);
+                    bucket
+                })
+                .collect();
+        assert_eq!(asc, vec![1, 2, 3]);
+
+        let desc: Vec<u64> =
+            dense_universe_buckets(150_000..350_001, BUCKET_SIZE, ScanDirection::Descending)
+                .map(|(bucket, _)| bucket)
+                .collect();
+        assert_eq!(desc, vec![3, 2, 1]);
+
+        let single: Vec<u64> = dense_universe_buckets(5..6, BUCKET_SIZE, ScanDirection::Ascending)
+            .map(|(bucket, _)| bucket)
+            .collect();
+        assert_eq!(single, vec![0]);
+
+        assert_eq!(
+            dense_universe_buckets(7..7, BUCKET_SIZE, ScanDirection::Ascending).count(),
+            0
+        );
     }
 
     #[test]

--- a/crates/sui-inverted-index/src/dimensions.rs
+++ b/crates/sui-inverted-index/src/dimensions.rs
@@ -57,6 +57,14 @@ pub enum IndexDimension {
     /// event maps to the same singleton key; it carries a single placeholder
     /// value byte so the encoded key keeps the standard `[tag, value...]` shape.
     EventExtant = 0x08,
+    /// Internal query-only universe marker for tx-space unanchored negation
+    /// (not user-queryable, never persisted): the tx-seq namespace is dense —
+    /// every integer up to the indexed tip is a real transaction — so backends
+    /// synthesize full buckets for this key at scan time instead of reading
+    /// storage. The filter layer anchors exclude-only tx terms with an include
+    /// on this key, resolving `NOT D` as `range \ D` without an extra
+    /// evaluator code path. No write path emits this dimension.
+    TxUniverse = 0x09,
 }
 
 impl IndexDimension {
@@ -74,6 +82,7 @@ impl IndexDimension {
             tag if tag == Self::EventType.tag_byte() => Some(Self::EventType),
             tag if tag == Self::EventStreamHead.tag_byte() => Some(Self::EventStreamHead),
             tag if tag == Self::EventExtant.tag_byte() => Some(Self::EventExtant),
+            tag if tag == Self::TxUniverse.tag_byte() => Some(Self::TxUniverse),
             _ => None,
         }
     }
@@ -88,6 +97,13 @@ const COMPOUND_VALUE_SEPARATOR: u8 = 0x00;
 /// bytes) without a per-tag carve-out. The marker is a singleton — one row per
 /// bucket, not per event — so the extra byte costs ~1 byte per bucket-row.
 pub const EVENT_EXTANT_VALUE: &[u8] = &[0x00];
+
+/// Singleton value for the internal [`IndexDimension::TxUniverse`] marker.
+/// Like [`EVENT_EXTANT_VALUE`], it is a single placeholder byte so the encoded
+/// key has the standard `[tag, value...]` shape and passes `BitmapKey::new`'s
+/// length invariant. The key never reaches storage — backends recognize the
+/// tag at scan time and synthesize full buckets over the requested range.
+pub const TX_UNIVERSE_VALUE: &[u8] = &[0x00];
 
 /// Visit all tx-space dimensions for a transaction.
 ///

--- a/crates/sui-inverted-index/src/dimensions.rs
+++ b/crates/sui-inverted-index/src/dimensions.rs
@@ -87,7 +87,7 @@ const COMPOUND_VALUE_SEPARATOR: u8 = 0x00;
 /// `BitmapKey::new`'s length invariant (dimension keys must be at least two
 /// bytes) without a per-tag carve-out. The marker is a singleton — one row per
 /// bucket, not per event — so the extra byte costs ~1 byte per bucket-row.
-const EVENT_EXTANT_VALUE: &[u8] = &[0x00];
+pub const EVENT_EXTANT_VALUE: &[u8] = &[0x00];
 
 /// Visit all tx-space dimensions for a transaction.
 ///

--- a/crates/sui-inverted-index/src/mod.rs
+++ b/crates/sui-inverted-index/src/mod.rs
@@ -19,6 +19,7 @@ pub use bitmap_query::ScanDirection;
 pub use bitmap_query::Watermarked;
 pub use bitmap_query::WatermarkedBucketStream;
 pub use bitmap_query::buckets_with_watermarks;
+pub use bitmap_query::dense_universe_buckets;
 pub use bitmap_query::error_contains;
 pub use bitmap_query::eval_bitmap_query_bucket_iter;
 pub use bitmap_query::eval_bitmap_query_stream;

--- a/crates/sui-kvstore/src/bigtable/client/bitmap_query.rs
+++ b/crates/sui-kvstore/src/bigtable/client/bitmap_query.rs
@@ -17,7 +17,9 @@ use futures::StreamExt;
 use roaring::RoaringBitmap;
 use sui_inverted_index::BitmapBucketSource;
 use sui_inverted_index::BucketStream;
+use sui_inverted_index::IndexDimension;
 use sui_inverted_index::ScanDirection;
+use sui_inverted_index::dense_universe_buckets;
 
 use super::BigTableClient;
 
@@ -89,6 +91,18 @@ impl BitmapBucketSource for BigTableBitmapSource {
         range: Range<u64>,
         direction: ScanDirection,
     ) -> BucketStream {
+        // The tx universe is dense (every tx_seq in range is real), so it is
+        // synthesized here rather than stored; see `IndexDimension::TxUniverse`.
+        // Gated on the tx table: the key is only ever produced by the tx filter
+        // layer, and in event-space a dense universe would be semantically wrong.
+        if self.spec.table_name == transaction_bitmap_index::NAME
+            && dimension_key.first() == Some(&IndexDimension::TxUniverse.tag_byte())
+        {
+            return futures::stream::iter(
+                dense_universe_buckets(range, self.spec.bucket_size, direction).map(Ok),
+            )
+            .boxed();
+        }
         scan_bucket_stream(
             self.client.clone(),
             dimension_key,

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/bitmap_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/bitmap_scan.rs
@@ -8,8 +8,10 @@ use std::rc::Rc;
 use roaring::RoaringBitmap;
 use sui_inverted_index::BitmapBucketIteratorSource;
 use sui_inverted_index::BitmapQuery;
+use sui_inverted_index::IndexDimension;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::Watermarked;
+use sui_inverted_index::dense_universe_buckets;
 use sui_inverted_index::eval_bitmap_query_bucket_iter;
 use sui_types::storage::LedgerBitmapBucketIterator;
 use tokio_util::sync::CancellationToken;
@@ -360,10 +362,18 @@ impl<'a> BitmapBucketIteratorSource<'a> for RpcIndexesBitmapSource<'a> {
     }
 }
 
+/// Inner bucket source: a stored RocksDB scan, or the synthesized dense
+/// tx-universe sequence — `IndexDimension::TxUniverse` is query-only and
+/// never reaches storage.
+enum BitmapBucketIter<'a> {
+    Stored(LedgerBitmapBucketIterator<'a>),
+    Universe(Box<dyn Iterator<Item = (u64, RoaringBitmap)> + Send + 'a>),
+}
+
 struct RpcIndexesBitmapIterator<'a> {
     scan_budget: BitmapScanBudget,
     cancel: CancellationToken,
-    iter: Option<LedgerBitmapBucketIterator<'a>>,
+    iter: Option<BitmapBucketIter<'a>>,
     finished: bool,
     initial_error: Option<anyhow::Error>,
     /// This leaf has not yet charged a bucket. Its first bucket is reserved
@@ -389,6 +399,25 @@ impl<'a> RpcIndexesBitmapIterator<'a> {
                 cancel,
                 iter: None,
                 finished: true,
+                initial_error: None,
+                first: true,
+            };
+        }
+
+        // The tx universe is dense (every tx_seq in range is real), so it is
+        // synthesized rather than read from storage. Gated on the tx kind: the
+        // key is only ever produced by the tx filter layer, and in event-space
+        // a dense universe would be semantically wrong.
+        if kind == LedgerBitmapKind::Transaction
+            && dimension_key.first() == Some(&IndexDimension::TxUniverse.tag_byte())
+        {
+            return Self {
+                scan_budget,
+                cancel,
+                finished: false,
+                iter: Some(BitmapBucketIter::Universe(Box::new(
+                    dense_universe_buckets(range, bucket_size, direction),
+                ))),
                 initial_error: None,
                 first: true,
             };
@@ -421,7 +450,7 @@ impl<'a> RpcIndexesBitmapIterator<'a> {
             });
 
         let (iter, initial_error) = match iter {
-            Ok(iter) => (Some(iter), None),
+            Ok(iter) => (Some(BitmapBucketIter::Stored(iter)), None),
             Err(e) => (None, Some(e)),
         };
         Self {
@@ -444,7 +473,15 @@ impl<'a> RpcIndexesBitmapIterator<'a> {
             return None;
         };
 
-        match iter.next() {
+        let next = match iter {
+            BitmapBucketIter::Stored(iter) => match iter.next() {
+                Some(Ok(bucket)) => Some(Ok((bucket.bucket_id, bucket.bitmap))),
+                Some(Err(e)) => Some(Err(anyhow::anyhow!(e.to_string()))),
+                None => None,
+            },
+            BitmapBucketIter::Universe(iter) => iter.next().map(Ok),
+        };
+        match next {
             Some(Ok(bucket)) => {
                 if self.first {
                     // Reserved: a leaf's first bucket is always allowed so it
@@ -459,7 +496,7 @@ impl<'a> RpcIndexesBitmapIterator<'a> {
                     self.finished = true;
                     return Some(Err(e));
                 }
-                Some(Ok((bucket.bucket_id, bucket.bitmap)))
+                Some(Ok(bucket))
             }
             None => {
                 self.finished = true;
@@ -467,7 +504,7 @@ impl<'a> RpcIndexesBitmapIterator<'a> {
             }
             Some(Err(e)) => {
                 self.finished = true;
-                Some(Err(anyhow::anyhow!(e.to_string())))
+                Some(Err(e))
             }
         }
     }

--- a/crates/sui-rpc-api/src/ledger_history/filter.rs
+++ b/crates/sui-rpc-api/src/ledger_history/filter.rs
@@ -4,6 +4,7 @@
 use sui_inverted_index::BitmapLiteral;
 use sui_inverted_index::BitmapQuery;
 use sui_inverted_index::BitmapTerm;
+use sui_inverted_index::EVENT_EXTANT_VALUE;
 use sui_inverted_index::IndexDimension;
 use sui_inverted_index::emit_module_value;
 use sui_inverted_index::encode_dimension_key;
@@ -148,22 +149,31 @@ fn transaction_term_to_query(term: &TransactionTerm) -> Result<BitmapTerm, RpcEr
 }
 
 fn event_term_to_query(term: &EventTerm) -> Result<BitmapTerm, RpcError> {
-    if !term
+    let has_include = term
         .literals
         .iter()
-        .any(|literal| matches!(literal.polarity, Some(event_literal::Polarity::Include(_))))
-    {
-        return Err(FieldViolation::new("filter.terms.literals")
-            .with_description("at least one included literal is required")
-            .with_reason(ErrorReason::FieldMissing)
-            .into());
-    }
+        .any(|literal| matches!(literal.polarity, Some(event_literal::Polarity::Include(_))));
 
-    let literals = term
-        .literals
-        .iter()
-        .map(|p| convert_event_literal(p, "filter.terms.literals"))
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut literals = Vec::with_capacity(term.literals.len() + usize::from(!has_include));
+    // Unanchored negation: a term with only excludes resolves as
+    // `EventExtant \ union(excludes)`. The synthetic include anchors the
+    // term on the existence marker so the merge-join driver's floor advances
+    // through every bucket that contains a real event. `expect` is sound: the
+    // key bytes are a workspace-constant `[EventExtant.tag_byte(), 0x00]`, so
+    // `BitmapKey::new`'s validation can only fail under a source change
+    // that test suites would catch.
+    if !has_include {
+        literals.push(
+            BitmapLiteral::include(encode_dimension_key(
+                IndexDimension::EventExtant,
+                EVENT_EXTANT_VALUE,
+            ))
+            .expect("EventExtant universe key is statically valid"),
+        );
+    }
+    for p in &term.literals {
+        literals.push(convert_event_literal(p, "filter.terms.literals")?);
+    }
 
     BitmapTerm::new(literals).map_err(|e| {
         FieldViolation::new("filter.terms")
@@ -530,5 +540,124 @@ mod tests {
             key,
             encode_dimension_key(IndexDimension::EventStreamHead, &bytes)
         );
+    }
+
+    fn ev_sender_literal(byte: u8, exclude: bool) -> EventLiteral {
+        let address = SuiAddress::from_bytes([byte; 32])
+            .expect("valid address bytes")
+            .to_string();
+        let mut sender = SenderFilter::default();
+        sender.address = Some(address);
+
+        let mut predicate = EventPredicate::default();
+        predicate.predicate = Some(event_predicate::Predicate::Sender(sender));
+
+        let mut literal = EventLiteral::default();
+        literal.polarity = Some(if exclude {
+            event_literal::Polarity::Exclude(predicate)
+        } else {
+            event_literal::Polarity::Include(predicate)
+        });
+        literal
+    }
+
+    fn ev_term(literals: Vec<EventLiteral>) -> EventTerm {
+        let mut term = EventTerm::default();
+        term.literals = literals;
+        term
+    }
+
+    fn ev_filter_with_terms(terms: Vec<EventTerm>) -> EventFilter {
+        let mut filter = EventFilter::default();
+        filter.terms = terms;
+        filter
+    }
+
+    fn universe_key() -> Vec<u8> {
+        encode_dimension_key(IndexDimension::EventExtant, EVENT_EXTANT_VALUE)
+    }
+
+    #[test]
+    fn event_filter_exclude_only_term_synthesizes_event_extant_include() {
+        let filter = ev_filter_with_terms(vec![ev_term(vec![ev_sender_literal(1, true)])]);
+        let query =
+            event_filter_to_query(&filter, TEST_MAX_LITERALS).expect("unanchored term is valid");
+
+        let term = &query.terms()[0];
+        let literals = term.literals();
+        assert_eq!(literals.len(), 2, "synthetic include + user exclude");
+        assert!(
+            matches!(literals[0], BitmapLiteral::Include(_)),
+            "synthetic universe include is prepended"
+        );
+        assert_eq!(literals[0].key_bytes(), universe_key().as_slice());
+        assert!(matches!(literals[1], BitmapLiteral::Exclude(_)));
+    }
+
+    #[test]
+    fn event_filter_multiple_unanchored_terms_each_get_universe_include() {
+        let filter = ev_filter_with_terms(vec![
+            ev_term(vec![ev_sender_literal(1, true)]),
+            ev_term(vec![ev_sender_literal(2, true)]),
+        ]);
+        let query =
+            event_filter_to_query(&filter, TEST_MAX_LITERALS).expect("unanchored terms are valid");
+
+        for term in query.terms() {
+            assert_eq!(term.literals()[0].key_bytes(), universe_key().as_slice());
+        }
+    }
+
+    #[test]
+    fn event_filter_mixed_dnf_only_synthesizes_when_needed() {
+        let filter = ev_filter_with_terms(vec![
+            ev_term(vec![ev_sender_literal(1, false)]),
+            ev_term(vec![ev_sender_literal(2, true)]),
+        ]);
+        let query = event_filter_to_query(&filter, TEST_MAX_LITERALS).expect("mixed DNF is valid");
+
+        let terms = query.terms();
+        assert_ne!(
+            terms[0].literals()[0].key_bytes(),
+            universe_key().as_slice(),
+            "anchored term gets no synthetic include"
+        );
+        assert_eq!(
+            terms[1].literals()[0].key_bytes(),
+            universe_key().as_slice(),
+            "unanchored term gets the synthetic include"
+        );
+    }
+
+    #[test]
+    fn event_filter_unanchored_term_does_not_count_against_fanout() {
+        // Two unanchored terms with one exclude each = 2 user-provided literals;
+        // synthetic includes are not counted, so we stay under the cap.
+        let filter = ev_filter_with_terms(vec![
+            ev_term(vec![ev_sender_literal(1, true)]),
+            ev_term(vec![ev_sender_literal(2, true)]),
+        ]);
+        assert!(event_filter_to_query(&filter, 2).is_ok());
+    }
+
+    #[test]
+    fn transaction_filter_exclude_only_term_still_rejected() {
+        // Pin PR 3's gate: tx-side unanchored negation is not yet supported.
+        let mut sender = SenderFilter::default();
+        sender.address = Some(SuiAddress::from_bytes([1; 32]).unwrap().to_string());
+        let mut predicate = TransactionPredicate::default();
+        predicate.predicate = Some(transaction_predicate::Predicate::Sender(sender));
+        let mut literal = TransactionLiteral::default();
+        literal.polarity = Some(transaction_literal::Polarity::Exclude(predicate));
+
+        let mut term = TransactionTerm::default();
+        term.literals = vec![literal];
+        let mut filter = TransactionFilter::default();
+        filter.terms = vec![term];
+
+        let error = transaction_filter_to_query(&filter, TEST_MAX_LITERALS)
+            .expect_err("tx unanchored negation should still be rejected")
+            .into_status_proto();
+        assert!(error.message.contains("at least one included literal"));
     }
 }

--- a/crates/sui-rpc-api/src/ledger_history/filter.rs
+++ b/crates/sui-rpc-api/src/ledger_history/filter.rs
@@ -6,6 +6,7 @@ use sui_inverted_index::BitmapQuery;
 use sui_inverted_index::BitmapTerm;
 use sui_inverted_index::EVENT_EXTANT_VALUE;
 use sui_inverted_index::IndexDimension;
+use sui_inverted_index::TX_UNIVERSE_VALUE;
 use sui_inverted_index::emit_module_value;
 use sui_inverted_index::encode_dimension_key;
 use sui_inverted_index::event_type_value;
@@ -122,23 +123,32 @@ fn validate_literal_fanout(
 }
 
 fn transaction_term_to_query(term: &TransactionTerm) -> Result<BitmapTerm, RpcError> {
-    if !term.literals.iter().any(|literal| {
+    let has_include = term.literals.iter().any(|literal| {
         matches!(
             literal.polarity,
             Some(transaction_literal::Polarity::Include(_))
         )
-    }) {
-        return Err(FieldViolation::new("filter.terms.literals")
-            .with_description("at least one included literal is required")
-            .with_reason(ErrorReason::FieldMissing)
-            .into());
-    }
+    });
 
-    let literals = term
-        .literals
-        .iter()
-        .map(|p| convert_transaction_literal(p, "filter.terms.literals"))
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut literals = Vec::with_capacity(term.literals.len() + usize::from(!has_include));
+    // Unanchored negation: a term with only excludes resolves as
+    // `range \ union(excludes)`. The tx-seq namespace is dense, so the
+    // universe needs no stored marker — backends synthesize full buckets for
+    // the `TxUniverse` key at scan time. The synthetic include anchors the
+    // term so the merge-join driver's floor advances through every bucket in
+    // range. `expect` is sound for the same reason as the event-side synthesis.
+    if !has_include {
+        literals.push(
+            BitmapLiteral::include(encode_dimension_key(
+                IndexDimension::TxUniverse,
+                TX_UNIVERSE_VALUE,
+            ))
+            .expect("TxUniverse key is statically valid"),
+        );
+    }
+    for p in &term.literals {
+        literals.push(convert_transaction_literal(p, "filter.terms.literals")?);
+    }
 
     BitmapTerm::new(literals).map_err(|e| {
         FieldViolation::new("filter.terms")
@@ -478,6 +488,10 @@ mod tests {
     const TEST_MAX_LITERALS: usize = 10;
 
     fn sender_literal(byte: u8) -> TransactionLiteral {
+        tx_sender_literal(byte, false)
+    }
+
+    fn tx_sender_literal(byte: u8, exclude: bool) -> TransactionLiteral {
         let address = SuiAddress::from_bytes([byte; 32])
             .expect("valid address bytes")
             .to_string();
@@ -488,8 +502,28 @@ mod tests {
         predicate.predicate = Some(transaction_predicate::Predicate::Sender(sender));
 
         let mut literal = TransactionLiteral::default();
-        literal.polarity = Some(transaction_literal::Polarity::Include(predicate));
+        literal.polarity = Some(if exclude {
+            transaction_literal::Polarity::Exclude(predicate)
+        } else {
+            transaction_literal::Polarity::Include(predicate)
+        });
         literal
+    }
+
+    fn tx_term(literals: Vec<TransactionLiteral>) -> TransactionTerm {
+        let mut term = TransactionTerm::default();
+        term.literals = literals;
+        term
+    }
+
+    fn tx_filter_with_terms(terms: Vec<TransactionTerm>) -> TransactionFilter {
+        let mut filter = TransactionFilter::default();
+        filter.terms = terms;
+        filter
+    }
+
+    fn tx_universe_key() -> Vec<u8> {
+        encode_dimension_key(IndexDimension::TxUniverse, TX_UNIVERSE_VALUE)
     }
 
     #[test]
@@ -641,23 +675,30 @@ mod tests {
     }
 
     #[test]
-    fn transaction_filter_exclude_only_term_still_rejected() {
-        // Pin PR 3's gate: tx-side unanchored negation is not yet supported.
-        let mut sender = SenderFilter::default();
-        sender.address = Some(SuiAddress::from_bytes([1; 32]).unwrap().to_string());
-        let mut predicate = TransactionPredicate::default();
-        predicate.predicate = Some(transaction_predicate::Predicate::Sender(sender));
-        let mut literal = TransactionLiteral::default();
-        literal.polarity = Some(transaction_literal::Polarity::Exclude(predicate));
+    fn transaction_filter_exclude_only_term_synthesizes_tx_universe_include() {
+        let filter = tx_filter_with_terms(vec![tx_term(vec![tx_sender_literal(1, true)])]);
+        let query = transaction_filter_to_query(&filter, TEST_MAX_LITERALS)
+            .expect("unanchored term is valid");
 
-        let mut term = TransactionTerm::default();
-        term.literals = vec![literal];
-        let mut filter = TransactionFilter::default();
-        filter.terms = vec![term];
+        let term = &query.terms()[0];
+        let literals = term.literals();
+        assert_eq!(literals.len(), 2, "synthetic include + user exclude");
+        assert!(
+            matches!(literals[0], BitmapLiteral::Include(_)),
+            "synthetic universe include is prepended"
+        );
+        assert_eq!(literals[0].key_bytes(), tx_universe_key().as_slice());
+        assert!(matches!(literals[1], BitmapLiteral::Exclude(_)));
+    }
 
-        let error = transaction_filter_to_query(&filter, TEST_MAX_LITERALS)
-            .expect_err("tx unanchored negation should still be rejected")
-            .into_status_proto();
-        assert!(error.message.contains("at least one included literal"));
+    #[test]
+    fn transaction_filter_unanchored_term_does_not_count_against_fanout() {
+        // Two unanchored terms with one exclude each = 2 user-provided literals;
+        // synthetic includes are not counted, so we stay under the cap.
+        let filter = tx_filter_with_terms(vec![
+            tx_term(vec![tx_sender_literal(1, true)]),
+            tx_term(vec![tx_sender_literal(2, true)]),
+        ]);
+        assert!(transaction_filter_to_query(&filter, 2).is_ok());
     }
 }


### PR DESCRIPTION
## Description

Adding support for "unanchored negation" by 'and'-ing the negated queries to bitmaps that contain a positive bit for every transaction/event. For events, they are stored in the DB, for txns, they can be synthesized without actually hitting a DB, since it's just every integer from 0 to chain tip.

## Test plan

Unit tests
