### PR TITLE
[move][move-decompiler] Pull a trailing dispatch-writer out of a labeled loop [3/8]

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/refinement/extract_dispatch_writer.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/extract_dispatch_writer.rs
@@ -187,6 +187,14 @@ fn try_extract(exp: Exp) -> Result<Exp, Exp> {
     if items[..k].iter().any(|p| contains_break_for(p, label)) {
         return Err(Exp::Loop(Some(label), Box::new(Exp::Seq(items))));
     }
+    // A `Continue(Some(label))` buried in the soon-to-be-extracted suffix would target a
+    // loop we're about to remove. `all_paths_terminate` only checks tail positions, so an
+    // early Continue in a Seq prefix passes the tail check and would dangle once extracted.
+    // Bail rather than try to rewrite it; the dispatch-writer shape this fires on always
+    // writes-then-breaks and doesn't construct such suffixes in practice.
+    if items[k..].iter().any(|s| contains_continue_for(s, label)) {
+        return Err(Exp::Loop(Some(label), Box::new(Exp::Seq(items))));
+    }
 
     let suffix_items: Vec<Exp> = items.split_off(k);
     items.push(Exp::Break(Some(label)));
@@ -207,6 +215,16 @@ fn try_extract(exp: Exp) -> Result<Exp, Exp> {
 /// True iff every leaf evaluation path of `exp` terminates (Break(label), Return, or
 /// Abort). A path that falls through, continues, or breaks to a different label doesn't
 /// count.
+///
+/// Conservative on a few shapes:
+/// - `Loop` / `While` return `false` unconditionally, even when their body unconditionally
+///   returns/aborts. Recognizing that would require a recursive structural analysis that
+///   detected "no escaping break path"; not worth the complexity until the corpus exercises
+///   it.
+/// - `Switch` / `Match` / `MatchLit` rely on the arm list being exhaustive over the
+///   scrutinee. Move's enum dispatch is exhaustive at the type level, so post-structuring
+///   shapes meet this. If a future refinement drops an arm during folding, this check is
+///   over-optimistic — flag the change with a regression fixture.
 fn all_paths_terminate(exp: &Exp, label: Label) -> bool {
     use Exp as E;
     match exp {
@@ -280,6 +298,66 @@ fn contains_break_for(exp: &Exp, label: Label) -> bool {
         }
         E::Break(None)
         | E::Continue(_)
+        | E::Declare(_)
+        | E::Value(_)
+        | E::Variable(_)
+        | E::Constant(_) => false,
+    }
+}
+
+/// True iff `exp` syntactically contains `Continue(Some(label))`. Mirrors
+/// `contains_break_for`; used to bail extraction when the suffix would dangle a continue
+/// at the now-removed loop's label.
+fn contains_continue_for(exp: &Exp, label: Label) -> bool {
+    use Exp as E;
+    match exp {
+        E::Continue(Some(l)) => *l == label,
+        E::Seq(items) | E::Return(items) | E::Call(_, items) => {
+            items.iter().any(|i| contains_continue_for(i, label))
+        }
+        E::IfElse(c, t, alt) => {
+            contains_continue_for(c, label)
+                || contains_continue_for(t, label)
+                || alt
+                    .as_ref()
+                    .as_ref()
+                    .is_some_and(|a| contains_continue_for(a, label))
+        }
+        E::Switch(c, _, arms) => {
+            contains_continue_for(c, label)
+                || arms.iter().any(|(_, b)| contains_continue_for(b, label))
+        }
+        E::Match(c, _, arms) => {
+            contains_continue_for(c, label)
+                || arms.iter().any(|(_, _, b)| contains_continue_for(b, label))
+        }
+        E::MatchLit(c, arms) => {
+            contains_continue_for(c, label)
+                || arms.iter().any(|(_, b)| contains_continue_for(b, label))
+        }
+        E::Loop(_, b) | E::Block(_, b) => contains_continue_for(b, label),
+        E::While(_, c, b) => contains_continue_for(c, label) || contains_continue_for(b, label),
+        E::Primitive { args, .. } | E::Data { args, .. } => {
+            args.iter().any(|a| contains_continue_for(a, label))
+        }
+        E::Assign(_, e)
+        | E::LetBind(_, e)
+        | E::Abort(e)
+        | E::Borrow(_, e)
+        | E::Unpack(_, _, e)
+        | E::UnpackVariant(_, _, _, e)
+        | E::VecUnpack(_, e) => contains_continue_for(e, label),
+        E::Unstructured(nodes) => {
+            use crate::ast::UnstructuredNode;
+            nodes.iter().any(|n| match n {
+                UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                    contains_continue_for(body, label)
+                }
+                UnstructuredNode::Goto(_) => false,
+            })
+        }
+        E::Continue(None)
+        | E::Break(_)
         | E::Declare(_)
         | E::Value(_)
         | E::Variable(_)

--- a/external-crates/move/crates/move-decompiler/src/refinement/extract_dispatch_writer.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/extract_dispatch_writer.rs
@@ -18,7 +18,7 @@
 //     match (sel) { ... }
 //
 // The if/else nest at the loop's tail is the **dispatch-writer**: every leaf path is
-// guaranteed to set `sel` and `break`. That's a property we can exploit — the entire
+// guaranteed to set `sel` and `break`. That's a property we can exploit - the entire
 // conditional structurally belongs OUTSIDE the loop, because:
 //
 //   1. None of its leaves continue the loop. Every path exits.
@@ -27,7 +27,7 @@
 //      to the extracted dispatch-writer, which sets `sel` (without the now-stale `break`).
 //
 // **Detection.** A trailing slice `items[k..n]` of the loop body's `Seq` qualifies if
-// every leaf-evaluation path of every item terminates (Break(L), Return, or Abort) — never
+// every leaf-evaluation path of every item terminates (Break(L), Return, or Abort) - never
 // falls through, never continues. Then `items[k..n]` is reached only via fall-through from
 // the prefix.
 //
@@ -56,7 +56,7 @@
 //     let sel = if (...) { K } else { ... };
 //     if (sel <= 0) { ... }; if (sel <= 1) { ... }; ...; last_body
 //
-// — close to what the original Move source looked like before the bytecode optimizer
+// - close to what the original Move source looked like before the bytecode optimizer
 // fused the post-loop code into the search loop.
 
 use crate::ast::{Exp, Label};
@@ -224,7 +224,7 @@ fn try_extract(exp: Exp) -> Result<Exp, Exp> {
 /// - `Switch` / `Match` / `MatchLit` rely on the arm list being exhaustive over the
 ///   scrutinee. Move's enum dispatch is exhaustive at the type level, so post-structuring
 ///   shapes meet this. If a future refinement drops an arm during folding, this check is
-///   over-optimistic — flag the change with a regression fixture.
+///   over-optimistic - flag the change with a regression fixture.
 fn all_paths_terminate(exp: &Exp, label: Label) -> bool {
     use Exp as E;
     match exp {
@@ -249,7 +249,7 @@ fn all_paths_terminate(exp: &Exp, label: Label) -> bool {
 }
 
 /// True iff `exp` syntactically contains `Break(Some(label))`. Descends through nested
-/// constructs — a labeled break from inside an inner loop still exits OUR loop.
+/// constructs - a labeled break from inside an inner loop still exits OUR loop.
 fn contains_break_for(exp: &Exp, label: Label) -> bool {
     use Exp as E;
     match exp {

--- a/external-crates/move/crates/move-decompiler/src/refinement/extract_dispatch_writer.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/extract_dispatch_writer.rs
@@ -1,0 +1,364 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// -------------------------------------------------------------------------------------------------
+// Dispatch-writer extraction from a fused loop body
+// -------------------------------------------------------------------------------------------------
+//
+// When `structure_loop`'s multi-succ dispatch synthesizes a `match (sel)` after a loop,
+// the loop body ends up with a conditional that writes `sel` and `break`s at every leaf:
+//
+//     loop {
+//       iter_check
+//       if (cond_1) { ... ; sel = 0; break }
+//       else if (cond_2) { sel = 1; break }
+//       ...
+//       else { sel = K; break }
+//     }
+//     match (sel) { ... }
+//
+// The if/else nest at the loop's tail is the **dispatch-writer**: every leaf path is
+// guaranteed to set `sel` and `break`. That's a property we can exploit — the entire
+// conditional structurally belongs OUTSIDE the loop, because:
+//
+//   1. None of its leaves continue the loop. Every path exits.
+//   2. Pulling it past the loop and dropping the `break`s gives equivalent semantics:
+//      the prefix exits via an inserted explicit `break`, then control naturally flows
+//      to the extracted dispatch-writer, which sets `sel` (without the now-stale `break`).
+//
+// **Detection.** A trailing slice `items[k..n]` of the loop body's `Seq` qualifies if
+// every leaf-evaluation path of every item terminates (Break(L), Return, or Abort) — never
+// falls through, never continues. Then `items[k..n]` is reached only via fall-through from
+// the prefix.
+//
+// **Soundness check.** The prefix `items[0..k]` must contain no `Break(L)`. Such a break
+// would otherwise be re-routed: in the original it exited to "after the loop" =
+// POST_LOOP_CODE; after extraction the suffix sits between the loop and POST_LOOP_CODE, so
+// the break would now execute the suffix on its way out.
+//
+// **Rewrite.**
+//   - Take `items.split_off(k)` as the extracted suffix.
+//   - Append `Break(L)` to the (shortened) `items` so fall-through paths in the prefix
+//     that previously reached the suffix now exit the loop instead of re-iterating.
+//   - In the extracted suffix, replace every `Break(L)` with an empty `Seq` (the loop no
+//     longer encloses the suffix; the break has nothing to target). Other breaks/continues
+//     targeting OUTER scopes are preserved.
+//   - Wrap as `Seq[Loop(L, modified_body), suffix]`.
+//
+// After this runs, the loop's body looks like a normal single-exit `while`-equivalent
+// (existing `introduce_while` will then collapse `loop { if (c) { ... continue } else { break } }`
+// into `while (c) { ... }`), and the extracted dispatch-writer's `Assign(sel, K)` sites
+// are visible to `fuse_let` + `hoist_arm_assignments`, which collapse them into a single
+// `let sel = if (...) { K } else { ... }` expression. Combined with the cascade
+// compression (`compress_dispatch_cascade.rs`), the final output reads as
+//
+//     while (...) { search-body }
+//     let sel = if (...) { K } else { ... };
+//     if (sel <= 0) { ... }; if (sel <= 1) { ... }; ...; last_body
+//
+// — close to what the original Move source looked like before the bytecode optimizer
+// fused the post-loop code into the search loop.
+
+use crate::ast::{Exp, Label};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    let mut pass = Extract { changed: false };
+    pass.walk(exp);
+    pass.changed
+}
+
+struct Extract {
+    changed: bool,
+}
+
+impl Extract {
+    fn walk(&mut self, exp: &mut Exp) {
+        use Exp as E;
+        // Recurse into children first (post-order), then attempt extraction at THIS node if
+        // it's a `Loop`. The post-order means nested loops get their tails pulled out
+        // before we look at this loop's body.
+        match exp {
+            E::Loop(_, body) | E::Block(_, body) => self.walk(body),
+            E::While(_, c, b) => {
+                self.walk(c);
+                self.walk(b);
+            }
+            E::Seq(items) | E::Return(items) | E::Call(_, items) => {
+                for i in items.iter_mut() {
+                    self.walk(i);
+                }
+            }
+            E::IfElse(c, t, alt) => {
+                self.walk(c);
+                self.walk(t);
+                if let Some(a) = alt.as_mut().as_mut() {
+                    self.walk(a);
+                }
+            }
+            E::Switch(c, _, arms) => {
+                self.walk(c);
+                for (_, b) in arms.iter_mut() {
+                    self.walk(b);
+                }
+            }
+            E::Match(c, _, arms) => {
+                self.walk(c);
+                for (_, _, b) in arms.iter_mut() {
+                    self.walk(b);
+                }
+            }
+            E::MatchLit(s, arms) => {
+                self.walk(s);
+                for (_, b) in arms.iter_mut() {
+                    self.walk(b);
+                }
+            }
+            E::Primitive { args, .. } | E::Data { args, .. } => {
+                for a in args.iter_mut() {
+                    self.walk(a);
+                }
+            }
+            E::Assign(_, e)
+            | E::LetBind(_, e)
+            | E::Abort(e)
+            | E::Borrow(_, e)
+            | E::Unpack(_, _, e)
+            | E::UnpackVariant(_, _, _, e)
+            | E::VecUnpack(_, e) => self.walk(e),
+            E::Unstructured(nodes) => {
+                use crate::ast::UnstructuredNode;
+                for n in nodes.iter_mut() {
+                    match n {
+                        UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                            self.walk(body);
+                        }
+                        UnstructuredNode::Goto(_) => {}
+                    }
+                }
+            }
+            E::Break(_)
+            | E::Continue(_)
+            | E::Declare(_)
+            | E::Value(_)
+            | E::Variable(_)
+            | E::Constant(_) => {}
+        }
+        // After children are refined, attempt the extraction if this is a labeled loop.
+        if matches!(exp, Exp::Loop(Some(_), _)) {
+            let placeholder = Exp::Seq(vec![]);
+            let taken = std::mem::replace(exp, placeholder);
+            match try_extract(taken) {
+                Ok(new_exp) => {
+                    *exp = new_exp;
+                    self.changed = true;
+                }
+                Err(original) => {
+                    *exp = original;
+                }
+            }
+        }
+    }
+}
+
+/// Attempt extraction. On success returns `Ok(Seq[Loop(label, prefix_with_break),
+/// suffix])`. On failure returns `Err(original_loop)` so the caller can restore it. The
+/// failure modes are: non-Seq body, no qualifying trailing slice, or prefix contains
+/// `Break(label)`.
+fn try_extract(exp: Exp) -> Result<Exp, Exp> {
+    let Exp::Loop(label_opt, body) = exp else {
+        return Err(exp);
+    };
+    let Some(label) = label_opt else {
+        return Err(Exp::Loop(label_opt, body));
+    };
+    let Exp::Seq(mut items) = *body else {
+        return Err(Exp::Loop(Some(label), body));
+    };
+    if items.len() < 2 {
+        return Err(Exp::Loop(Some(label), Box::new(Exp::Seq(items))));
+    }
+    let mut k = items.len();
+    while k > 0 && all_paths_terminate(&items[k - 1], label) {
+        k -= 1;
+    }
+    if k == items.len() {
+        return Err(Exp::Loop(Some(label), Box::new(Exp::Seq(items))));
+    }
+    if items[..k].iter().any(|p| contains_break_for(p, label)) {
+        return Err(Exp::Loop(Some(label), Box::new(Exp::Seq(items))));
+    }
+
+    let suffix_items: Vec<Exp> = items.split_off(k);
+    items.push(Exp::Break(Some(label)));
+
+    let mut suffix = if suffix_items.len() == 1 {
+        suffix_items.into_iter().next().unwrap()
+    } else {
+        Exp::Seq(suffix_items)
+    };
+    strip_break_for(&mut suffix, label);
+
+    Ok(Exp::Seq(vec![
+        Exp::Loop(Some(label), Box::new(Exp::Seq(items))),
+        suffix,
+    ]))
+}
+
+/// True iff every leaf evaluation path of `exp` terminates (Break(label), Return, or
+/// Abort). A path that falls through, continues, or breaks to a different label doesn't
+/// count.
+fn all_paths_terminate(exp: &Exp, label: Label) -> bool {
+    use Exp as E;
+    match exp {
+        E::Break(Some(l)) if *l == label => true,
+        E::Return(_) | E::Abort(_) => true,
+        E::Seq(items) => items
+            .last()
+            .map(|last| all_paths_terminate(last, label))
+            .unwrap_or(false),
+        E::IfElse(_, conseq, alt) => match alt.as_ref().as_ref() {
+            Some(a) => all_paths_terminate(conseq, label) && all_paths_terminate(a, label),
+            None => false,
+        },
+        E::Switch(_, _, arms) => arms.iter().all(|(_, b)| all_paths_terminate(b, label)),
+        E::Match(_, _, arms) => arms.iter().all(|(_, _, b)| all_paths_terminate(b, label)),
+        E::MatchLit(_, arms) => arms.iter().all(|(_, b)| all_paths_terminate(b, label)),
+        // Everything else either falls through (Assign, Call, Primitive, ...) or has its
+        // own loop scope that doesn't represent "this loop's exit" (Loop, While).
+        // Unlabeled Break inside a nested loop targets that loop, not ours.
+        _ => false,
+    }
+}
+
+/// True iff `exp` syntactically contains `Break(Some(label))`. Descends through nested
+/// constructs — a labeled break from inside an inner loop still exits OUR loop.
+fn contains_break_for(exp: &Exp, label: Label) -> bool {
+    use Exp as E;
+    match exp {
+        E::Break(Some(l)) => *l == label,
+        E::Seq(items) | E::Return(items) | E::Call(_, items) => {
+            items.iter().any(|i| contains_break_for(i, label))
+        }
+        E::IfElse(c, t, alt) => {
+            contains_break_for(c, label)
+                || contains_break_for(t, label)
+                || alt
+                    .as_ref()
+                    .as_ref()
+                    .is_some_and(|a| contains_break_for(a, label))
+        }
+        E::Switch(c, _, arms) => {
+            contains_break_for(c, label) || arms.iter().any(|(_, b)| contains_break_for(b, label))
+        }
+        E::Match(c, _, arms) => {
+            contains_break_for(c, label)
+                || arms.iter().any(|(_, _, b)| contains_break_for(b, label))
+        }
+        E::MatchLit(c, arms) => {
+            contains_break_for(c, label) || arms.iter().any(|(_, b)| contains_break_for(b, label))
+        }
+        E::Loop(_, b) | E::Block(_, b) => contains_break_for(b, label),
+        E::While(_, c, b) => contains_break_for(c, label) || contains_break_for(b, label),
+        E::Primitive { args, .. } | E::Data { args, .. } => {
+            args.iter().any(|a| contains_break_for(a, label))
+        }
+        E::Assign(_, e)
+        | E::LetBind(_, e)
+        | E::Abort(e)
+        | E::Borrow(_, e)
+        | E::Unpack(_, _, e)
+        | E::UnpackVariant(_, _, _, e)
+        | E::VecUnpack(_, e) => contains_break_for(e, label),
+        E::Unstructured(nodes) => {
+            use crate::ast::UnstructuredNode;
+            nodes.iter().any(|n| match n {
+                UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                    contains_break_for(body, label)
+                }
+                UnstructuredNode::Goto(_) => false,
+            })
+        }
+        E::Break(None)
+        | E::Continue(_)
+        | E::Declare(_)
+        | E::Value(_)
+        | E::Variable(_)
+        | E::Constant(_) => false,
+    }
+}
+
+/// Replace each `Break(Some(label))` in `exp` with an empty `Seq` (a no-op that
+/// `flatten_seq` will drop). Used on the extracted suffix to neutralize breaks that
+/// targeted the loop we just pulled out of.
+fn strip_break_for(exp: &mut Exp, label: Label) {
+    use Exp as E;
+    match exp {
+        E::Break(Some(l)) if *l == label => {
+            *exp = E::Seq(vec![]);
+        }
+        E::Seq(items) | E::Return(items) | E::Call(_, items) => {
+            for i in items.iter_mut() {
+                strip_break_for(i, label);
+            }
+        }
+        E::IfElse(c, t, alt) => {
+            strip_break_for(c, label);
+            strip_break_for(t, label);
+            if let Some(a) = alt.as_mut().as_mut() {
+                strip_break_for(a, label);
+            }
+        }
+        E::Switch(c, _, arms) => {
+            strip_break_for(c, label);
+            for (_, b) in arms.iter_mut() {
+                strip_break_for(b, label);
+            }
+        }
+        E::Match(c, _, arms) => {
+            strip_break_for(c, label);
+            for (_, _, b) in arms.iter_mut() {
+                strip_break_for(b, label);
+            }
+        }
+        E::MatchLit(c, arms) => {
+            strip_break_for(c, label);
+            for (_, b) in arms.iter_mut() {
+                strip_break_for(b, label);
+            }
+        }
+        E::Loop(_, b) | E::Block(_, b) => strip_break_for(b, label),
+        E::While(_, c, b) => {
+            strip_break_for(c, label);
+            strip_break_for(b, label);
+        }
+        E::Primitive { args, .. } | E::Data { args, .. } => {
+            for a in args.iter_mut() {
+                strip_break_for(a, label);
+            }
+        }
+        E::Assign(_, e)
+        | E::LetBind(_, e)
+        | E::Abort(e)
+        | E::Borrow(_, e)
+        | E::Unpack(_, _, e)
+        | E::UnpackVariant(_, _, _, e)
+        | E::VecUnpack(_, e) => strip_break_for(e, label),
+        E::Unstructured(nodes) => {
+            use crate::ast::UnstructuredNode;
+            for n in nodes.iter_mut() {
+                match n {
+                    UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                        strip_break_for(body, label);
+                    }
+                    UnstructuredNode::Goto(_) => {}
+                }
+            }
+        }
+        E::Break(_)
+        | E::Continue(_)
+        | E::Declare(_)
+        | E::Value(_)
+        | E::Variable(_)
+        | E::Constant(_) => {}
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -7,6 +7,7 @@ mod bool_if_simplify;
 mod collapse_let_usage;
 mod collect_uses;
 mod dedupe_freeze;
+mod extract_dispatch_writer;
 mod flatten_seq;
 mod fuse_let;
 mod hoist_arm_assignments;
@@ -38,6 +39,7 @@ pub use liveness::collect_local_names;
 pub type Refinement = fn(&mut Exp) -> bool;
 
 const REFINEMENTS: &[Refinement] = &[
+    extract_dispatch_writer::refine,
     flatten_seq::refine,
     fuse_let::refine,
     hoist_arm_assignments::refine,

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/ART20.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/ART20.mv.snap
@@ -302,11 +302,11 @@ public entry fun batch_burn_art20(l0: vector<NFT>, l1: &mut CollectionCap, l2: v
                 *(&mut l6.balance) = xf_ART20::safe_sub(*(&l6.balance), 1u64);
                 l8 = true;
             };
-            assert!(l8, C6);
-            xf_ART20::burn_single_art20(l15, l1, freeze(l3));
-            l11 = l11 + 1u64;
             break
-        }
+        };
+        assert!(l8, C6);
+        xf_ART20::burn_single_art20(l15, l1, freeze(l3));
+        l11 = l11 + 1u64;
     };
     while (&l2.len() > 0u64) {
         let l7 = vector::remove(&mut l2, 0u64);
@@ -379,14 +379,14 @@ public entry fun batch_burn_art20_by_asset_ids(l0: &mut CollectionCap, l1: vecto
                         *(&mut l11.balance) = xf_ART20::safe_sub(*(&l11.balance), 1u64);
                         l12 = true;
                     };
-                    assert!(l12, C6);
-                    *(&mut l0.current_supply) = xf_ART20::safe_sub(*(&l0.current_supply), 1u64);
-                    event::emit(BurnEvent { owner: l22, id: object::uid_to_inner(&(&l20).id) });
-                    let NFT { id: reg_147, artinals_id: reg_148, creator: reg_149, name: reg_150, description: reg_151, uri: reg_152, logo_uri: reg_153, asset_id: reg_154, max_supply: reg_155, collection_id: reg_156, category: reg_157 } = l20;
-                    object::delete(reg_147 : 0x2::object::UID);
-                    l14 = true;
                     break
-                }
+                };
+                assert!(l12, C6);
+                *(&mut l0.current_supply) = xf_ART20::safe_sub(*(&l0.current_supply), 1u64);
+                event::emit(BurnEvent { owner: l22, id: object::uid_to_inner(&(&l20).id) });
+                let NFT { id: reg_147, artinals_id: reg_148, creator: reg_149, name: reg_150, description: reg_151, uri: reg_152, logo_uri: reg_153, asset_id: reg_154, max_supply: reg_155, collection_id: reg_156, category: reg_157 } = l20;
+                object::delete(reg_147 : 0x2::object::UID);
+                l14 = true;
             } else {
                 (&mut l24).push_back(l20)
             }
@@ -742,7 +742,7 @@ public entry fun burn_art20(l0: NFT, l1: &mut CollectionCap, l2: vector<UserBala
     let l8 = false;
     let l10 = vector[];
     loop {
-        if (!(!(vector::is_empty(&l7)))) {
+        if (vector::is_empty(&l7)) {
             assert!(l8, C6);
             break
         };
@@ -1226,11 +1226,10 @@ public entry fun mint_additional_art20(l0: &mut CollectionCap, l1: u64, l2: &mut
                 *(&mut l8.balance) = *(&l8.balance) + l1;
                 l10 = true;
             };
-            if (!(l10)) {
-                transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14);
-                break
-            };
             break
+        };
+        if (!(l10)) {
+            transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14)
         }
     };
     /* block 132 */;
@@ -1397,9 +1396,9 @@ public entry fun set_collection_value_source(l0: &mut CollectionCap, l1: vector<
                 };
                 l10 = false;
             };
-            assert!(l10, C16);
             break
-        }
+        };
+        assert!(l10, C16)
     } else {
         assert!(string::length(&l9) == 64u64, C17);
         unstructured {
@@ -1477,15 +1476,15 @@ public entry fun transfer_art20(l0: vector<NFT>, l1: vector<address>, l2: &Colle
                 *(&mut l9.balance) = xf_ART20::safe_sub(*(&l9.balance), 1u64);
                 l11 = true;
             };
-            assert!(l11, C6);
-            (&mut l23).push_back(object::uid_to_inner(&(&l21).id));
-            (&mut l7).push_back(1u64);
-            event::emit(TransferEvent { from: l20, to: l17, id: object::uid_to_inner(&(&l21).id), royalty: 0u64, asset_id: *(&(&l21).asset_id) });
-            transfer::transfer(l21, l17);
-            transfer::transfer(l18, l17);
-            l14 = l14 + 1u64;
             break
-        }
+        };
+        assert!(l11, C6);
+        (&mut l23).push_back(object::uid_to_inner(&(&l21).id));
+        (&mut l7).push_back(1u64);
+        event::emit(TransferEvent { from: l20, to: l17, id: object::uid_to_inner(&(&l21).id), royalty: 0u64, asset_id: *(&(&l21).asset_id) });
+        transfer::transfer(l21, l17);
+        transfer::transfer(l18, l17);
+        l14 = l14 + 1u64;
     };
     while (&l3.len() > 0u64) {
         let l10 = vector::remove(&mut l3, 0u64);
@@ -1544,7 +1543,6 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
             };
             l17 = l17 + 1u64;
         };
-        let __c191;
         match (__dispatch_81) {
             0 => {
                 loop {
@@ -1557,21 +1555,19 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
                         *(&mut l12.balance) = xf_ART20::safe_sub(*(&l12.balance), 1u64);
                         l13 = true;
                     };
-                    assert!(l13, C6);
-                    (&mut l26).push_back(l21);
-                    (&mut l9).push_back(1u64);
-                    transfer::transfer(vector::remove(&mut l1, l17), l4);
-                    l15 = true;
                     break
                 };
-                __c191 = l15;
-                assert!(__c191, C15);
+                assert!(l13, C6);
+                (&mut l26).push_back(l21);
+                (&mut l9).push_back(1u64);
+                transfer::transfer(vector::remove(&mut l1, l17), l4);
+                l15 = true;
+                assert!(l15, C15);
                 l16 = l16 + 1u64;
                 continue
             },
             1 => {
-                __c191 = l15;
-                assert!(__c191, C15);
+                assert!(l15, C15);
                 l16 = l16 + 1u64;
                 continue
             }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/ART20.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/ART20.mv.snap
@@ -302,9 +302,10 @@ public entry fun batch_burn_art20(l0: vector<NFT>, l1: &mut CollectionCap, l2: v
                 *(&mut l6.balance) = xf_ART20::safe_sub(*(&l6.balance), 1u64);
                 l8 = true;
             };
+            let __c144 = l8;
             break
         };
-        assert!(l8, C6);
+        assert!(__c144, C6);
         xf_ART20::burn_single_art20(l15, l1, freeze(l3));
         l11 = l11 + 1u64;
     };
@@ -379,9 +380,10 @@ public entry fun batch_burn_art20_by_asset_ids(l0: &mut CollectionCap, l1: vecto
                         *(&mut l11.balance) = xf_ART20::safe_sub(*(&l11.balance), 1u64);
                         l12 = true;
                     };
+                    let __c201 = l12;
                     break
                 };
-                assert!(l12, C6);
+                assert!(__c201, C6);
                 *(&mut l0.current_supply) = xf_ART20::safe_sub(*(&l0.current_supply), 1u64);
                 event::emit(BurnEvent { owner: l22, id: object::uid_to_inner(&(&l20).id) });
                 let NFT { id: reg_147, artinals_id: reg_148, creator: reg_149, name: reg_150, description: reg_151, uri: reg_152, logo_uri: reg_153, asset_id: reg_154, max_supply: reg_155, collection_id: reg_156, category: reg_157 } = l20;
@@ -742,7 +744,7 @@ public entry fun burn_art20(l0: NFT, l1: &mut CollectionCap, l2: vector<UserBala
     let l8 = false;
     let l10 = vector[];
     loop {
-        if (vector::is_empty(&l7)) {
+        if (!(!(vector::is_empty(&l7)))) {
             assert!(l8, C6);
             break
         };
@@ -1226,9 +1228,10 @@ public entry fun mint_additional_art20(l0: &mut CollectionCap, l1: u64, l2: &mut
                 *(&mut l8.balance) = *(&l8.balance) + l1;
                 l10 = true;
             };
+            let __c122 = !(l10);
             break
         };
-        if (!(l10)) {
+        if (__c122) {
             transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14)
         }
     };
@@ -1396,9 +1399,10 @@ public entry fun set_collection_value_source(l0: &mut CollectionCap, l1: vector<
                 };
                 l10 = false;
             };
+            let __c84 = l10;
             break
         };
-        assert!(l10, C16)
+        assert!(__c84, C16)
     } else {
         assert!(string::length(&l9) == 64u64, C17);
         unstructured {
@@ -1476,9 +1480,10 @@ public entry fun transfer_art20(l0: vector<NFT>, l1: vector<address>, l2: &Colle
                 *(&mut l9.balance) = xf_ART20::safe_sub(*(&l9.balance), 1u64);
                 l11 = true;
             };
+            let __c186 = l11;
             break
         };
-        assert!(l11, C6);
+        assert!(__c186, C6);
         (&mut l23).push_back(object::uid_to_inner(&(&l21).id));
         (&mut l7).push_back(1u64);
         event::emit(TransferEvent { from: l20, to: l17, id: object::uid_to_inner(&(&l21).id), royalty: 0u64, asset_id: *(&(&l21).asset_id) });
@@ -1543,6 +1548,7 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
             };
             l17 = l17 + 1u64;
         };
+        let __c191;
         match (__dispatch_81) {
             0 => {
                 loop {
@@ -1555,19 +1561,22 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
                         *(&mut l12.balance) = xf_ART20::safe_sub(*(&l12.balance), 1u64);
                         l13 = true;
                     };
+                    let __c163 = l13;
                     break
                 };
-                assert!(l13, C6);
+                assert!(__c163, C6);
                 (&mut l26).push_back(l21);
                 (&mut l9).push_back(1u64);
                 transfer::transfer(vector::remove(&mut l1, l17), l4);
                 l15 = true;
-                assert!(l15, C15);
+                __c191 = l15;
+                assert!(__c191, C15);
                 l16 = l16 + 1u64;
                 continue
             },
             1 => {
-                assert!(l15, C15);
+                __c191 = l15;
+                assert!(__c191, C15);
                 l16 = l16 + 1u64;
                 continue
             }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/bet_manager.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/bet_manager.mv.snap
@@ -1721,9 +1721,10 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l28 = l28 + 1u64;
                 continue
             };
+            let __c282 = l22;
             break
         };
-        assert!(l22, C0)
+        assert!(__c282, C0)
     } else {
         unstructured {
             goto 'label_289;
@@ -1749,9 +1750,10 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l29 = l29 + 1u64;
                 continue
             };
+            let __c357 = l23;
             break
         };
-        assert!(l23, C0)
+        assert!(__c357, C0)
     } else {
         unstructured {
             goto 'label_364;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/bet_manager.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/bet_manager.mv.snap
@@ -1721,9 +1721,9 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l28 = l28 + 1u64;
                 continue
             };
-            assert!(l22, C0);
             break
-        }
+        };
+        assert!(l22, C0)
     } else {
         unstructured {
             goto 'label_289;
@@ -1749,9 +1749,9 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l29 = l29 + 1u64;
                 continue
             };
-            assert!(l23, C0);
             break
-        }
+        };
+        assert!(l23, C0)
     } else {
         unstructured {
             goto 'label_364;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/demo.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/demo.mv.snap
@@ -590,9 +590,10 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
+        let __c132 = l8;
         break
     };
-    assert!(l8, C29)
+    assert!(__c132, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1632,9 +1633,10 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c115 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c115, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1907,9 +1909,10 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
+        let __c109 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c109, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2326,9 +2329,10 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c120 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c120, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/demo.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/demo.mv.snap
@@ -590,10 +590,9 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
-        assert!(l8, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l8, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1633,10 +1632,9 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1909,10 +1907,9 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2329,10 +2326,9 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/format.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/format.mv.snap
@@ -143,7 +143,11 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                     (&mut l9).push_back(l11);
                     let l4 = false;
                     let l7 = l6 + 2u64;
-                    while (!(l4) && l12 > l7) {
+                    loop {
+                        let l3 = !(l4) && l12 > l7;
+                        break
+                    };
+                    if (l3) {
                         let l8 = *(&l0[l7]);
                         if (l8 == 125u8) {
                             l4 = true;
@@ -151,6 +155,7 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                             (&mut l9).push_back(l8)
                         };
                         l7 = l7 + 1u64;
+                        continue 'loop_75
                     };
                     if (x2_format::append_format_piece(&mut l10, &l9, l13, l1)) {
                         l13 = l13 + 1u64;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/format.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/format.mv.snap
@@ -143,11 +143,7 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                     (&mut l9).push_back(l11);
                     let l4 = false;
                     let l7 = l6 + 2u64;
-                    loop {
-                        let l3 = !(l4) && l12 > l7;
-                        break
-                    };
-                    if (l3) {
+                    while (!(l4) && l12 > l7) {
                         let l8 = *(&l0[l7]);
                         if (l8 == 125u8) {
                             l4 = true;
@@ -155,7 +151,6 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                             (&mut l9).push_back(l8)
                         };
                         l7 = l7 + 1u64;
-                        continue 'loop_75
                     };
                     if (x2_format::append_format_piece(&mut l10, &l9, l13, l1)) {
                         l13 = l13 + 1u64;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/gauge.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/gauge.mv.snap
@@ -278,11 +278,10 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
                     continue
                 }
             };
-            if (l8 >= l18.len()) {
-                (table::borrow_mut(&mut l2.stakes, l13)).push_back(l11);
-                break
-            };
             break
+        };
+        if (l8 >= l18.len()) {
+            (table::borrow_mut(&mut l2.stakes, l13)).push_back(l11)
         }
     };
     /* block 192 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/gauge.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/gauge.mv.snap
@@ -278,9 +278,10 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
                     continue
                 }
             };
+            let __c181 = l8 >= l18.len();
             break
         };
-        if (l8 >= l18.len()) {
+        if (__c181) {
             (table::borrow_mut(&mut l2.stakes, l13)).push_back(l11)
         }
     };

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/marketplace.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/marketplace.mv.snap
@@ -452,9 +452,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 l32 = *(&(&vector::remove(l34, l39)).last_points_claimed_at);
             };
+            let __c165 = freeze(l34).len() == 0u64;
             break
         };
-        if (freeze(l34).len() == 0u64) {
+        if (__c165) {
             
         }
     } else {
@@ -484,9 +485,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 let l22 = vector::remove(l35, l40);
             };
+            let __c329 = freeze(l35).len() == 0u64;
             break
         };
-        if (freeze(l35).len() == 0u64) {
+        if (__c329) {
             std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7))
         }
     } else {
@@ -704,9 +706,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 l29 = *(&(&vector::remove(l31, l36)).last_points_claimed_at);
             };
+            let __c138 = freeze(l31).len() == 0u64;
             break
         };
-        if (freeze(l31).len() == 0u64) {
+        if (__c138) {
             
         }
     } else {
@@ -731,9 +734,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 let l18 = vector::remove(l32, l37);
             };
+            let __c236 = freeze(l32).len() == 0u64;
             break
         };
-        if (freeze(l32).len() == 0u64) {
+        if (__c236) {
             std::vector::destroy_empty(linked_table::remove(&mut l33.collection_bids, l6))
         }
     } else {
@@ -1157,9 +1161,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 };
                 let l22 = vector::remove(l20, l30);
             };
+            let __c155 = freeze(l20).len() == 0u64;
             break
         };
-        if (freeze(l20).len() == 0u64) {
+        if (__c155) {
             std::vector::destroy_empty(linked_table::remove(&mut l28.collection_bids, l27))
         }
     };
@@ -1185,9 +1190,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 l26 = *(&(&l23).bid_price);
                 l34 = *(&(&l23).last_points_claimed_at);
             };
+            let __c269 = freeze(l25).len() == 0u64;
             break
         };
-        if (freeze(l25).len() == 0u64) {
+        if (__c269) {
             
         }
     } else {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/marketplace.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/marketplace.mv.snap
@@ -452,10 +452,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 l32 = *(&(&vector::remove(l34, l39)).last_points_claimed_at);
             };
-            if (freeze(l34).len() == 0u64) {
-                break
-            };
             break
+        };
+        if (freeze(l34).len() == 0u64) {
+            
         }
     } else {
         assert!(linked_table::contains(&l29.bids, l5), C17);
@@ -484,11 +484,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 let l22 = vector::remove(l35, l40);
             };
-            if (freeze(l35).len() == 0u64) {
-                std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7));
-                break
-            };
             break
+        };
+        if (freeze(l35).len() == 0u64) {
+            std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7))
         }
     } else {
         assert!(object::uid_to_inner(&(&linked_table::remove(&mut (linked_table::borrow_mut(&mut l36.bids, l5)).bids, l7)).id) == l6, C26);
@@ -705,10 +704,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 l29 = *(&(&vector::remove(l31, l36)).last_points_claimed_at);
             };
-            if (freeze(l31).len() == 0u64) {
-                break
-            };
             break
+        };
+        if (freeze(l31).len() == 0u64) {
+            
         }
     } else {
         assert!(linked_table::contains(&l26.bids, l5), C17);
@@ -732,11 +731,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 let l18 = vector::remove(l32, l37);
             };
-            if (freeze(l32).len() == 0u64) {
-                std::vector::destroy_empty(linked_table::remove(&mut l33.collection_bids, l6));
-                break
-            };
             break
+        };
+        if (freeze(l32).len() == 0u64) {
+            std::vector::destroy_empty(linked_table::remove(&mut l33.collection_bids, l6))
         }
     } else {
         assert!(linked_table::contains(&l33.bids, l5), C17);
@@ -1159,11 +1157,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 };
                 let l22 = vector::remove(l20, l30);
             };
-            if (freeze(l20).len() == 0u64) {
-                std::vector::destroy_empty(linked_table::remove(&mut l28.collection_bids, l27));
-                break
-            };
             break
+        };
+        if (freeze(l20).len() == 0u64) {
+            std::vector::destroy_empty(linked_table::remove(&mut l28.collection_bids, l27))
         }
     };
     /* block 166 */;
@@ -1188,10 +1185,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 l26 = *(&(&l23).bid_price);
                 l34 = *(&(&l23).last_points_claimed_at);
             };
-            if (freeze(l25).len() == 0u64) {
-                break
-            };
             break
+        };
+        if (freeze(l25).len() == 0u64) {
+            
         }
     } else {
         let l36 = *(option::borrow(&l1));

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/orlim.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/orlim.mv.snap
@@ -317,9 +317,10 @@ public fun cancel_order_by_object(l0: &mut OrderManager, l1: OrderReceipt, l2: &
                 continue
             }
         };
+        let __c104 = option::is_some(&(&l16).oco_group_id);
         break
     };
-    let __dispatch_81 = if (option::is_some(&(&l16).oco_group_id)) {
+    let __dispatch_81 = if (__c104) {
         l14 = *(option::borrow(&(&l16).oco_group_id));
         if (table::contains(&l0.oco_groups, l14)) {
             let l13 = table::borrow_mut(&mut l0.oco_groups, l14);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/orlim.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/orlim.mv.snap
@@ -307,7 +307,6 @@ public fun cancel_order_by_object(l0: &mut OrderManager, l1: OrderReceipt, l2: &
     let l18 = coin::zero(l3);
     let l8 = 0u64;
     let l10 = &l0.active_orders.len();
-    let __dispatch_81;
     let (l11, l12, l14, l5, l9);
     loop {
         if (l8 < l10) {
@@ -318,40 +317,40 @@ public fun cancel_order_by_object(l0: &mut OrderManager, l1: OrderReceipt, l2: &
                 continue
             }
         };
-        if (option::is_some(&(&l16).oco_group_id)) {
-            l14 = *(option::borrow(&(&l16).oco_group_id));
-            if (table::contains(&l0.oco_groups, l14)) {
-                let l13 = table::borrow_mut(&mut l0.oco_groups, l14);
-                if (*(&l13.is_active)) {
-                    l11 = if (*(&l13.order1_id) == l17) {
-                        *(&l13.order2_id)
-                    } else {
-                        *(&l13.order1_id)
-                    };
-                    if (table::contains(&l0.receipts, l11)) {
-                        l12 = table::remove(&mut l0.receipts, l11);
-                        if (*(&(&l12).is_active)) {
-                            *(&mut (&mut l12).is_active) = false;
-                            *(&mut (&mut l12).cancelled_at) = option::some(l7);
-                            l9 = 0u64;
-                            l5 = &l0.active_orders.len();
-                            __dispatch_81 = 0u32;
-                            break
-                        };
-                        __dispatch_81 = 1u32;
-                        break
-                    };
-                    __dispatch_81 = 2u32;
-                    break
-                };
-                __dispatch_81 = 2u32;
-                break
-            };
-            __dispatch_81 = 3u32;
-            break
-        };
-        __dispatch_81 = 3u32;
         break
+    };
+    let __dispatch_81 = if (option::is_some(&(&l16).oco_group_id)) {
+        l14 = *(option::borrow(&(&l16).oco_group_id));
+        if (table::contains(&l0.oco_groups, l14)) {
+            let l13 = table::borrow_mut(&mut l0.oco_groups, l14);
+            if (*(&l13.is_active)) {
+                l11 = if (*(&l13.order1_id) == l17) {
+                    *(&l13.order2_id)
+                } else {
+                    *(&l13.order1_id)
+                };
+                if (table::contains(&l0.receipts, l11)) {
+                    l12 = table::remove(&mut l0.receipts, l11);
+                    if (*(&(&l12).is_active)) {
+                        *(&mut (&mut l12).is_active) = false;
+                        *(&mut (&mut l12).cancelled_at) = option::some(l7);
+                        l9 = 0u64;
+                        l5 = &l0.active_orders.len();
+                        0u32
+                    } else {
+                        1u32
+                    }
+                } else {
+                    2u32
+                }
+            } else {
+                2u32
+            }
+        } else {
+            3u32
+        }
+    } else {
+        3u32
     };
     let (l15, reg_174 : 0x2::object::UID);
     match (__dispatch_81) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/format.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/format.move
@@ -140,7 +140,11 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                     (&mut l9).push_back(l11);
                     let l4 = false;
                     let l7 = l6 + 2u64;
-                    while (!(l4) && l12 > l7) {
+                    loop {
+                        let l3 = !(l4) && l12 > l7;
+                        break
+                    };
+                    if (l3) {
                         let l8 = *(&l0[l7]);
                         if (l8 == 125u8) {
                             l4 = true;
@@ -148,6 +152,7 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                             (&mut l9).push_back(l8)
                         };
                         l7 = l7 + 1u64;
+                        continue 'loop_75
                     };
                     if (x2_format::append_format_piece(&mut l10, &l9, l13, l1)) {
                         l13 = l13 + 1u64;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/format.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/format.move
@@ -140,11 +140,7 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                     (&mut l9).push_back(l11);
                     let l4 = false;
                     let l7 = l6 + 2u64;
-                    loop {
-                        let l3 = !(l4) && l12 > l7;
-                        break
-                    };
-                    if (l3) {
+                    while (!(l4) && l12 > l7) {
                         let l8 = *(&l0[l7]);
                         if (l8 == 125u8) {
                             l4 = true;
@@ -152,7 +148,6 @@ public fun format(l0: &vector<u8>, l1: &vector<u8>): vector<u8> {
                             (&mut l9).push_back(l8)
                         };
                         l7 = l7 + 1u64;
-                        continue 'loop_75
                     };
                     if (x2_format::append_format_piece(&mut l10, &l9, l13, l1)) {
                         l13 = l13 + 1u64;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x043c56e72265ab93219e928b742bc6465a83c70481e2846964d8e6bc3459cd06/verse.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x043c56e72265ab93219e928b742bc6465a83c70481e2846964d8e6bc3459cd06/verse.move
@@ -587,9 +587,10 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
+        let __c132 = l8;
         break
     };
-    assert!(l8, C29)
+    assert!(__c132, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1629,9 +1630,10 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c115 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c115, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1904,9 +1906,10 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
+        let __c109 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c109, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2323,9 +2326,10 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c120 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c120, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x043c56e72265ab93219e928b742bc6465a83c70481e2846964d8e6bc3459cd06/verse.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x043c56e72265ab93219e928b742bc6465a83c70481e2846964d8e6bc3459cd06/verse.move
@@ -587,10 +587,9 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
-        assert!(l8, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l8, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1630,10 +1629,9 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1906,10 +1904,9 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2326,10 +2323,9 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x2c6b186d1bb437e09132af796714340d431c7dfaa83cddfd4b9bd785204be743/bet_manager.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x2c6b186d1bb437e09132af796714340d431c7dfaa83cddfd4b9bd785204be743/bet_manager.move
@@ -1718,9 +1718,9 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l28 = l28 + 1u64;
                 continue
             };
-            assert!(l22, C0);
             break
-        }
+        };
+        assert!(l22, C0)
     } else {
         unstructured {
             goto 'label_289;
@@ -1746,9 +1746,9 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l29 = l29 + 1u64;
                 continue
             };
-            assert!(l23, C0);
             break
-        }
+        };
+        assert!(l23, C0)
     } else {
         unstructured {
             goto 'label_364;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x2c6b186d1bb437e09132af796714340d431c7dfaa83cddfd4b9bd785204be743/bet_manager.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x2c6b186d1bb437e09132af796714340d431c7dfaa83cddfd4b9bd785204be743/bet_manager.move
@@ -1718,9 +1718,10 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l28 = l28 + 1u64;
                 continue
             };
+            let __c282 = l22;
             break
         };
-        assert!(l22, C0)
+        assert!(__c282, C0)
     } else {
         unstructured {
             goto 'label_289;
@@ -1746,9 +1747,10 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
                 l29 = l29 + 1u64;
                 continue
             };
+            let __c357 = l23;
             break
         };
-        assert!(l23, C0)
+        assert!(__c357, C0)
     } else {
         unstructured {
             goto 'label_364;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4a68c41bfa2b908ce449e411d0e16718839a62780df0fee568bc027ee2d14ebb/safu.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4a68c41bfa2b908ce449e411d0e16718839a62780df0fee568bc027ee2d14ebb/safu.move
@@ -554,16 +554,17 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 continue
             }
         };
+        let __c110 = l22 == l25;
         break
     };
-    let __dispatch_58 = if (l22 == l25) {
+    let __dispatch_58 = if (__c110) {
         l29 = C25;
         l24 = 0u64;
         0u32
     } else {
         1u32
     };
-    let (l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
+    let (__c142, __c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
     match (__dispatch_58) {
         0 => {
             while (l24 < &l36.reward_tokens.len()) {
@@ -577,7 +578,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            if (*(&(&l30.share)[C8]) < l7) {
+            __c142 = *(&(&l30.share)[C8]) < l7;
+            if (__c142) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -594,7 +596,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            if (*(&(&l30.share)[C9]) < l8) {
+            __c252 = *(&(&l30.share)[C9]) < l8;
+            if (__c252) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -612,13 +615,16 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            if (l9 > 0u64) {
+            __c319 = l9 > 0u64;
+            if (__c319) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                if (reg_309) {
-                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
+                __c375 = reg_309;
+                if (__c375) {
+                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
+                    if (__c385) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -650,8 +656,10 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
-            if (l19 >= *(&(&l36.config)[C8])) {
+            __c464 = l19 + l21 + l23 + l28 > 0u64;
+            assert!(__c464, C8);
+            __c508 = l19 >= *(&(&l36.config)[C8]);
+            if (__c508) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -663,9 +671,12 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            assert!(l18, C10);
-            assert!(l19 >= *(&(&l36.config)[C9]), C11);
-            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
+            __c529 = l18;
+            assert!(__c529, C10);
+            __c538 = l19 >= *(&(&l36.config)[C9]);
+            assert!(__c538, C11);
+            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
+            assert!(__c553, C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -677,7 +688,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            if (*(&(&l30.share)[C8]) < l7) {
+            __c142 = *(&(&l30.share)[C8]) < l7;
+            if (__c142) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -694,7 +706,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            if (*(&(&l30.share)[C9]) < l8) {
+            __c252 = *(&(&l30.share)[C9]) < l8;
+            if (__c252) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -712,13 +725,16 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            if (l9 > 0u64) {
+            __c319 = l9 > 0u64;
+            if (__c319) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                if (reg_309) {
-                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
+                __c375 = reg_309;
+                if (__c375) {
+                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
+                    if (__c385) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -750,8 +766,10 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
-            if (l19 >= *(&(&l36.config)[C8])) {
+            __c464 = l19 + l21 + l23 + l28 > 0u64;
+            assert!(__c464, C8);
+            __c508 = l19 >= *(&(&l36.config)[C8]);
+            if (__c508) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -763,9 +781,12 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            assert!(l18, C10);
-            assert!(l19 >= *(&(&l36.config)[C9]), C11);
-            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
+            __c529 = l18;
+            assert!(__c529, C10);
+            __c538 = l19 >= *(&(&l36.config)[C9]);
+            assert!(__c538, C11);
+            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
+            assert!(__c553, C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -965,9 +986,10 @@ public fun snapshot(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l2: &mu
                 continue
             }
         };
+        let __c110 = l10 == l11;
         break
     };
-    if (l10 == l11) {
+    if (__c110) {
         dynamic_field::add(&mut l4.id, ascii::string(C6), l17)
     } else {
         let l13 = big_vector::borrow_mut(&mut l19.share, l10);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4a68c41bfa2b908ce449e411d0e16718839a62780df0fee568bc027ee2d14ebb/safu.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4a68c41bfa2b908ce449e411d0e16718839a62780df0fee568bc027ee2d14ebb/safu.move
@@ -540,7 +540,6 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
     let l32 = 0u64;
     let l31 = big_vector::borrow_slice(&l36.share, l32);
     let l22 = 0u64;
-    let __dispatch_58;
     let (l24, l29);
     loop {
         if (l22 < l25) {
@@ -555,16 +554,16 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 continue
             }
         };
-        if (l22 == l25) {
-            l29 = C25;
-            l24 = 0u64;
-            __dispatch_58 = 0u32;
-            break
-        };
-        __dispatch_58 = 1u32;
         break
     };
-    let (__c142, __c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
+    let __dispatch_58 = if (l22 == l25) {
+        l29 = C25;
+        l24 = 0u64;
+        0u32
+    } else {
+        1u32
+    };
+    let (l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
     match (__dispatch_58) {
         0 => {
             while (l24 < &l36.reward_tokens.len()) {
@@ -578,8 +577,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            __c142 = *(&(&l30.share)[C8]) < l7;
-            if (__c142) {
+            if (*(&(&l30.share)[C8]) < l7) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -596,8 +594,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            __c252 = *(&(&l30.share)[C9]) < l8;
-            if (__c252) {
+            if (*(&(&l30.share)[C9]) < l8) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -615,16 +612,13 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            __c319 = l9 > 0u64;
-            if (__c319) {
+            if (l9 > 0u64) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                __c375 = reg_309;
-                if (__c375) {
-                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
-                    if (__c385) {
+                if (reg_309) {
+                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -656,10 +650,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            __c464 = l19 + l21 + l23 + l28 > 0u64;
-            assert!(__c464, C8);
-            __c508 = l19 >= *(&(&l36.config)[C8]);
-            if (__c508) {
+            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
+            if (l19 >= *(&(&l36.config)[C8])) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -671,12 +663,9 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            __c529 = l18;
-            assert!(__c529, C10);
-            __c538 = l19 >= *(&(&l36.config)[C9]);
-            assert!(__c538, C11);
-            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
-            assert!(__c553, C9);
+            assert!(l18, C10);
+            assert!(l19 >= *(&(&l36.config)[C9]), C11);
+            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -688,8 +677,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            __c142 = *(&(&l30.share)[C8]) < l7;
-            if (__c142) {
+            if (*(&(&l30.share)[C8]) < l7) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -706,8 +694,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            __c252 = *(&(&l30.share)[C9]) < l8;
-            if (__c252) {
+            if (*(&(&l30.share)[C9]) < l8) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -725,16 +712,13 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            __c319 = l9 > 0u64;
-            if (__c319) {
+            if (l9 > 0u64) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                __c375 = reg_309;
-                if (__c375) {
-                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
-                    if (__c385) {
+                if (reg_309) {
+                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -766,10 +750,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            __c464 = l19 + l21 + l23 + l28 > 0u64;
-            assert!(__c464, C8);
-            __c508 = l19 >= *(&(&l36.config)[C8]);
-            if (__c508) {
+            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
+            if (l19 >= *(&(&l36.config)[C8])) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -781,12 +763,9 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            __c529 = l18;
-            assert!(__c529, C10);
-            __c538 = l19 >= *(&(&l36.config)[C9]);
-            assert!(__c538, C11);
-            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
-            assert!(__c553, C9);
+            assert!(l18, C10);
+            assert!(l19 >= *(&(&l36.config)[C9]), C11);
+            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -986,17 +965,17 @@ public fun snapshot(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l2: &mu
                 continue
             }
         };
-        if (l10 == l11) {
-            dynamic_field::add(&mut l4.id, ascii::string(C6), l17);
-            return
-        };
+        break
+    };
+    if (l10 == l11) {
+        dynamic_field::add(&mut l4.id, ascii::string(C6), l17)
+    } else {
         let l13 = big_vector::borrow_mut(&mut l19.share, l10);
         let l12 = *(&(&l13.u64_padding)[C7])as u256 * l9 - *(&(&l13.u64_padding)[C8])as u256 * *(&(&l19.config)[C12])as u256 / 3600000u256 / 10000u256as u64;
         *(&mut (&mut l13.u64_padding)[C8]) = l9;
         *(&mut (&mut l13.u64_padding)[C7]) = *(&(&l13.share)[C7]) + *(&(&l13.share)[C10])as u128 * *(&(&l19.info)[C13])as u128 / 10000u128as u64;
         event::emit(UserEvent { action: ascii::string(C42), log: vector[l5, *(&(&l19.info)[C8]), l12], bcs_padding: C21 });
-        dynamic_field::add(&mut l4.id, ascii::string(C6), l17);
-        return
+        dynamic_field::add(&mut l4.id, ascii::string(C6), l17)
     }
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4b0f4ee1a40ce37ec81c987cc4e76a665419e74b863319492fc7d26f708b835a/tails_staking.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4b0f4ee1a40ce37ec81c987cc4e76a665419e74b863319492fc7d26f708b835a/tails_staking.move
@@ -721,29 +721,29 @@ fun stake_tails_(l0: &mut TailsStakingRegistry, l1: Tails, l2: address) {
             big_vector::push_back(&mut l0.staking_infos, StakingInfo { user: l2, tails: C14, profits: l6, u64_padding: C25 })
         };
         let l11 = big_vector::borrow_mut(&mut l0.staking_infos, l4);
-        assert!(&l11.tails.len() < *(&(&l0.config)[C1]), C11);
-        (&mut l11.tails).push_back(typus_nft::tails_number(&l1));
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C19))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C19))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C20))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C20))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C21))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C21))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C22))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C22))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C23))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C23))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C24))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C24))
-        };
-        object_table::add(&mut l0.tails, object::id_address(&l1), l1);
-        return
-    }
+        break
+    };
+    assert!(&l11.tails.len() < *(&(&l0.config)[C1]), C11);
+    (&mut l11.tails).push_back(typus_nft::tails_number(&l1));
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C19))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C19))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C20))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C20))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C21))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C21))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C22))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C22))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C23))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C23))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C24))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C24))
+    };
+    object_table::add(&mut l0.tails, object::id_address(&l1), l1)
 }
 
 public fun transfer_tails(l0: &mut Version, l1: &TailsStakingRegistry, l2: &mut Kiosk, l3: &KioskOwnerCap, l4: address, l5: Coin<SUI>, l6: address, l7: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4b0f4ee1a40ce37ec81c987cc4e76a665419e74b863319492fc7d26f708b835a/tails_staking.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4b0f4ee1a40ce37ec81c987cc4e76a665419e74b863319492fc7d26f708b835a/tails_staking.move
@@ -721,9 +721,10 @@ fun stake_tails_(l0: &mut TailsStakingRegistry, l1: Tails, l2: address) {
             big_vector::push_back(&mut l0.staking_infos, StakingInfo { user: l2, tails: C14, profits: l6, u64_padding: C25 })
         };
         let l11 = big_vector::borrow_mut(&mut l0.staking_infos, l4);
+        let __c127 = &l11.tails.len() < *(&(&l0.config)[C1]);
         break
     };
-    assert!(&l11.tails.len() < *(&(&l0.config)[C1]), C11);
+    assert!(__c127, C11);
     (&mut l11.tails).push_back(typus_nft::tails_number(&l1));
     if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C19))) {
         typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C19))

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
@@ -54,16 +54,10 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    let __c0 = l16 > l13;
-    let __c25 = l16 - l13 >= l18;
-    let __c35 = l13 - l16 >= l18;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        let __c44 = l16 > l13;
-        let __c59 = l16 - l13 >= l18;
-        let __c68 = l13 - l16 >= l18;
-        __c44 && __c59 || __c68 && !(__c44)
+        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -77,22 +71,14 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    let __c0 = l19 > l16;
-    let __c25 = l19 - l16 >= l21;
-    let __c35 = l16 - l19 >= l21;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        let __c44 = l19 > l16;
-        let __c59 = l19 - l16 >= l21;
-        let __c68 = l16 - l19 >= l21;
-        __c44 && __c59 || __c68 && !(__c44)
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        let __c77 = l19 > l16;
-        let __c92 = l19 - l16 >= l21;
-        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -107,29 +93,18 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    let __c0 = l22 > l19;
-    let __c25 = l22 - l19 >= l24;
-    let __c35 = l19 - l22 >= l24;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        let __c44 = l22 > l19;
-        let __c59 = l22 - l19 >= l24;
-        let __c68 = l19 - l22 >= l24;
-        __c44 && __c59 || __c68 && !(__c44)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        let __c77 = l22 > l19;
-        let __c92 = l22 - l19 >= l24;
-        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        let __c110 = l22 > l19;
-        let __c125 = l22 - l19 >= l24;
-        let __c134 = l19 - l22 >= l24;
-        __c110 && __c125 || __c134 && !(__c110)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -145,36 +120,22 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    let __c0 = l25 > l22;
-    let __c25 = l25 - l22 >= l27;
-    let __c35 = l22 - l25 >= l27;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        let __c44 = l25 > l22;
-        let __c59 = l25 - l22 >= l27;
-        let __c68 = l22 - l25 >= l27;
-        __c44 && __c59 || __c68 && !(__c44)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        let __c77 = l25 > l22;
-        let __c92 = l25 - l22 >= l27;
-        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        let __c110 = l25 > l22;
-        let __c125 = l25 - l22 >= l27;
-        let __c134 = l22 - l25 >= l27;
-        __c110 && __c125 || __c134 && !(__c110)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        let __c143 = l25 > l22;
-        let __c158 = l25 - l22 >= l27;
-        let __c167 = l22 - l25 >= l27;
-        __c143 && __c158 || __c167 && !(__c143)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -191,43 +152,26 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    let __c0 = l28 > l25;
-    let __c25 = l28 - l25 >= l30;
-    let __c35 = l25 - l28 >= l30;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        let __c44 = l28 > l25;
-        let __c59 = l28 - l25 >= l30;
-        let __c68 = l25 - l28 >= l30;
-        __c44 && __c59 || __c68 && !(__c44)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        let __c77 = l28 > l25;
-        let __c92 = l28 - l25 >= l30;
-        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        let __c110 = l28 > l25;
-        let __c125 = l28 - l25 >= l30;
-        let __c134 = l25 - l28 >= l30;
-        __c110 && __c125 || __c134 && !(__c110)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        let __c143 = l28 > l25;
-        let __c158 = l28 - l25 >= l30;
-        let __c167 = l25 - l28 >= l30;
-        __c143 && __c158 || __c167 && !(__c143)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        let __c176 = l28 > l25;
-        let __c191 = l28 - l25 >= l30;
-        let __c200 = l25 - l28 >= l30;
-        __c176 && __c191 || __c200 && !(__c176)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -245,50 +189,30 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    let __c0 = l31 > l28;
-    let __c25 = l31 - l28 >= l33;
-    let __c35 = l28 - l31 >= l33;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        let __c44 = l31 > l28;
-        let __c59 = l31 - l28 >= l33;
-        let __c68 = l28 - l31 >= l33;
-        __c44 && __c59 || __c68 && !(__c44)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        let __c77 = l31 > l28;
-        let __c92 = l31 - l28 >= l33;
-        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        let __c110 = l31 > l28;
-        let __c125 = l31 - l28 >= l33;
-        let __c134 = l28 - l31 >= l33;
-        __c110 && __c125 || __c134 && !(__c110)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        let __c143 = l31 > l28;
-        let __c158 = l31 - l28 >= l33;
-        let __c167 = l28 - l31 >= l33;
-        __c143 && __c158 || __c167 && !(__c143)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        let __c176 = l31 > l28;
-        let __c191 = l31 - l28 >= l33;
-        let __c200 = l28 - l31 >= l33;
-        __c176 && __c191 || __c200 && !(__c176)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        let __c209 = l31 > l28;
-        let __c224 = l31 - l28 >= l33;
-        let __c233 = l28 - l31 >= l33;
-        __c209 && __c224 || __c233 && !(__c209)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -307,57 +231,34 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    let __c0 = l34 > l31;
-    let __c25 = l34 - l31 >= l36;
-    let __c35 = l31 - l34 >= l36;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        let __c44 = l34 > l31;
-        let __c59 = l34 - l31 >= l36;
-        let __c68 = l31 - l34 >= l36;
-        __c44 && __c59 || __c68 && !(__c44)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        let __c77 = l34 > l31;
-        let __c92 = l34 - l31 >= l36;
-        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        let __c110 = l34 > l31;
-        let __c125 = l34 - l31 >= l36;
-        let __c134 = l31 - l34 >= l36;
-        __c110 && __c125 || __c134 && !(__c110)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        let __c143 = l34 > l31;
-        let __c158 = l34 - l31 >= l36;
-        let __c167 = l31 - l34 >= l36;
-        __c143 && __c158 || __c167 && !(__c143)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        let __c176 = l34 > l31;
-        let __c191 = l34 - l31 >= l36;
-        let __c200 = l31 - l34 >= l36;
-        __c176 && __c191 || __c200 && !(__c176)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        let __c209 = l34 > l31;
-        let __c224 = l34 - l31 >= l36;
-        let __c233 = l31 - l34 >= l36;
-        __c209 && __c224 || __c233 && !(__c209)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        let __c242 = l34 > l31;
-        let __c257 = l34 - l31 >= l36;
-        let __c266 = l31 - l34 >= l36;
-        __c242 && __c257 || __c266 && !(__c242)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -378,36 +279,30 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l10 = clock::timestamp_ms(l7) / 1000u64;
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
-    let __dispatch_15;
     let l16;
-    loop {
-        if (l12 < l14) {
-            let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
-            let l17 = option::get_with_default(&(&l3)[l12], l11);
-            if (l15 > l10) {
-                if (l15 - l10 >= l17) {
-                    l13 = false;
-                }
-            } else {
-                if (l10 - l15 < l17) {
-                    l13 = false;
-                }
-            };
-            l12 = l12 + 1u64;
-            continue
+    while (l12 < l14) {
+        let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
+        let l17 = option::get_with_default(&(&l3)[l12], l11);
+        if (l15 > l10) {
+            if (l15 - l10 >= l17) {
+                l13 = false;
+            }
+        } else {
+            if (l10 - l15 < l17) {
+                l13 = false;
+            }
         };
-        if (l13) {
-            l12 = 0u64;
-            __dispatch_15 = 0u32;
-            break
-        };
+        l12 = l12 + 1u64;
+    };
+    match (if (l13) {
+        l12 = 0u64;
+        0u32
+    } else {
         let l18 = vaa::parse_and_verify(l4, l5, l7);
         l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
         l12 = 0u64;
-        __dispatch_15 = 1u32;
-        break
-    };
-    match (__dispatch_15) {
+        1u32
+    }) {
         0 => {
             while (l12 < l14) {
                 transfer::public_share_object((&mut l2).pop_back());

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
@@ -54,10 +54,16 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
+    let __c0 = l16 > l13;
+    let __c25 = l16 - l13 >= l18;
+    let __c35 = l13 - l16 >= l18;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
+        let __c44 = l16 > l13;
+        let __c59 = l16 - l13 >= l18;
+        let __c68 = l13 - l16 >= l18;
+        __c44 && __c59 || __c68 && !(__c44)
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -71,14 +77,22 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
+    let __c0 = l19 > l16;
+    let __c25 = l19 - l16 >= l21;
+    let __c35 = l16 - l19 >= l21;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c44 = l19 > l16;
+        let __c59 = l19 - l16 >= l21;
+        let __c68 = l16 - l19 >= l21;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c77 = l19 > l16;
+        let __c92 = l19 - l16 >= l21;
+        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -93,18 +107,29 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
+    let __c0 = l22 > l19;
+    let __c25 = l22 - l19 >= l24;
+    let __c35 = l19 - l22 >= l24;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c44 = l22 > l19;
+        let __c59 = l22 - l19 >= l24;
+        let __c68 = l19 - l22 >= l24;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c77 = l22 > l19;
+        let __c92 = l22 - l19 >= l24;
+        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c110 = l22 > l19;
+        let __c125 = l22 - l19 >= l24;
+        let __c134 = l19 - l22 >= l24;
+        __c110 && __c125 || __c134 && !(__c110)
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -120,22 +145,36 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
+    let __c0 = l25 > l22;
+    let __c25 = l25 - l22 >= l27;
+    let __c35 = l22 - l25 >= l27;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c44 = l25 > l22;
+        let __c59 = l25 - l22 >= l27;
+        let __c68 = l22 - l25 >= l27;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c77 = l25 > l22;
+        let __c92 = l25 - l22 >= l27;
+        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c110 = l25 > l22;
+        let __c125 = l25 - l22 >= l27;
+        let __c134 = l22 - l25 >= l27;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c143 = l25 > l22;
+        let __c158 = l25 - l22 >= l27;
+        let __c167 = l22 - l25 >= l27;
+        __c143 && __c158 || __c167 && !(__c143)
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -152,26 +191,43 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
+    let __c0 = l28 > l25;
+    let __c25 = l28 - l25 >= l30;
+    let __c35 = l25 - l28 >= l30;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c44 = l28 > l25;
+        let __c59 = l28 - l25 >= l30;
+        let __c68 = l25 - l28 >= l30;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c77 = l28 > l25;
+        let __c92 = l28 - l25 >= l30;
+        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c110 = l28 > l25;
+        let __c125 = l28 - l25 >= l30;
+        let __c134 = l25 - l28 >= l30;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c143 = l28 > l25;
+        let __c158 = l28 - l25 >= l30;
+        let __c167 = l25 - l28 >= l30;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c176 = l28 > l25;
+        let __c191 = l28 - l25 >= l30;
+        let __c200 = l25 - l28 >= l30;
+        __c176 && __c191 || __c200 && !(__c176)
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -189,30 +245,50 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
+    let __c0 = l31 > l28;
+    let __c25 = l31 - l28 >= l33;
+    let __c35 = l28 - l31 >= l33;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c44 = l31 > l28;
+        let __c59 = l31 - l28 >= l33;
+        let __c68 = l28 - l31 >= l33;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c77 = l31 > l28;
+        let __c92 = l31 - l28 >= l33;
+        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c110 = l31 > l28;
+        let __c125 = l31 - l28 >= l33;
+        let __c134 = l28 - l31 >= l33;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c143 = l31 > l28;
+        let __c158 = l31 - l28 >= l33;
+        let __c167 = l28 - l31 >= l33;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c176 = l31 > l28;
+        let __c191 = l31 - l28 >= l33;
+        let __c200 = l28 - l31 >= l33;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c209 = l31 > l28;
+        let __c224 = l31 - l28 >= l33;
+        let __c233 = l28 - l31 >= l33;
+        __c209 && __c224 || __c233 && !(__c209)
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -231,34 +307,57 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
+    let __c0 = l34 > l31;
+    let __c25 = l34 - l31 >= l36;
+    let __c35 = l31 - l34 >= l36;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c44 = l34 > l31;
+        let __c59 = l34 - l31 >= l36;
+        let __c68 = l31 - l34 >= l36;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c77 = l34 > l31;
+        let __c92 = l34 - l31 >= l36;
+        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c110 = l34 > l31;
+        let __c125 = l34 - l31 >= l36;
+        let __c134 = l31 - l34 >= l36;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c143 = l34 > l31;
+        let __c158 = l34 - l31 >= l36;
+        let __c167 = l31 - l34 >= l36;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c176 = l34 > l31;
+        let __c191 = l34 - l31 >= l36;
+        let __c200 = l31 - l34 >= l36;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c209 = l34 > l31;
+        let __c224 = l34 - l31 >= l36;
+        let __c233 = l31 - l34 >= l36;
+        __c209 && __c224 || __c233 && !(__c209)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c242 = l34 > l31;
+        let __c257 = l34 - l31 >= l36;
+        let __c266 = l31 - l34 >= l36;
+        __c242 && __c257 || __c266 && !(__c242)
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -280,7 +379,11 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
     let l16;
-    while (l12 < l14) {
+    loop {
+        if (l12 >= l14) {
+            let __c61 = l13;
+            break
+        };
         let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
         let l17 = option::get_with_default(&(&l3)[l12], l11);
         if (l15 > l10) {
@@ -294,7 +397,7 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
         };
         l12 = l12 + 1u64;
     };
-    match (if (l13) {
+    match (if (__c61) {
         l12 = 0u64;
         0u32
     } else {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5059e676e3cd64696547e0617a0a7e9dbfe2e7090d4ec3c2c396650d21960045/orlim.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5059e676e3cd64696547e0617a0a7e9dbfe2e7090d4ec3c2c396650d21960045/orlim.move
@@ -314,9 +314,10 @@ public fun cancel_order_by_object(l0: &mut OrderManager, l1: OrderReceipt, l2: &
                 continue
             }
         };
+        let __c104 = option::is_some(&(&l16).oco_group_id);
         break
     };
-    let __dispatch_81 = if (option::is_some(&(&l16).oco_group_id)) {
+    let __dispatch_81 = if (__c104) {
         l14 = *(option::borrow(&(&l16).oco_group_id));
         if (table::contains(&l0.oco_groups, l14)) {
             let l13 = table::borrow_mut(&mut l0.oco_groups, l14);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5059e676e3cd64696547e0617a0a7e9dbfe2e7090d4ec3c2c396650d21960045/orlim.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5059e676e3cd64696547e0617a0a7e9dbfe2e7090d4ec3c2c396650d21960045/orlim.move
@@ -304,7 +304,6 @@ public fun cancel_order_by_object(l0: &mut OrderManager, l1: OrderReceipt, l2: &
     let l18 = coin::zero(l3);
     let l8 = 0u64;
     let l10 = &l0.active_orders.len();
-    let __dispatch_81;
     let (l11, l12, l14, l5, l9);
     loop {
         if (l8 < l10) {
@@ -315,40 +314,40 @@ public fun cancel_order_by_object(l0: &mut OrderManager, l1: OrderReceipt, l2: &
                 continue
             }
         };
-        if (option::is_some(&(&l16).oco_group_id)) {
-            l14 = *(option::borrow(&(&l16).oco_group_id));
-            if (table::contains(&l0.oco_groups, l14)) {
-                let l13 = table::borrow_mut(&mut l0.oco_groups, l14);
-                if (*(&l13.is_active)) {
-                    l11 = if (*(&l13.order1_id) == l17) {
-                        *(&l13.order2_id)
-                    } else {
-                        *(&l13.order1_id)
-                    };
-                    if (table::contains(&l0.receipts, l11)) {
-                        l12 = table::remove(&mut l0.receipts, l11);
-                        if (*(&(&l12).is_active)) {
-                            *(&mut (&mut l12).is_active) = false;
-                            *(&mut (&mut l12).cancelled_at) = option::some(l7);
-                            l9 = 0u64;
-                            l5 = &l0.active_orders.len();
-                            __dispatch_81 = 0u32;
-                            break
-                        };
-                        __dispatch_81 = 1u32;
-                        break
-                    };
-                    __dispatch_81 = 2u32;
-                    break
-                };
-                __dispatch_81 = 2u32;
-                break
-            };
-            __dispatch_81 = 3u32;
-            break
-        };
-        __dispatch_81 = 3u32;
         break
+    };
+    let __dispatch_81 = if (option::is_some(&(&l16).oco_group_id)) {
+        l14 = *(option::borrow(&(&l16).oco_group_id));
+        if (table::contains(&l0.oco_groups, l14)) {
+            let l13 = table::borrow_mut(&mut l0.oco_groups, l14);
+            if (*(&l13.is_active)) {
+                l11 = if (*(&l13.order1_id) == l17) {
+                    *(&l13.order2_id)
+                } else {
+                    *(&l13.order1_id)
+                };
+                if (table::contains(&l0.receipts, l11)) {
+                    l12 = table::remove(&mut l0.receipts, l11);
+                    if (*(&(&l12).is_active)) {
+                        *(&mut (&mut l12).is_active) = false;
+                        *(&mut (&mut l12).cancelled_at) = option::some(l7);
+                        l9 = 0u64;
+                        l5 = &l0.active_orders.len();
+                        0u32
+                    } else {
+                        1u32
+                    }
+                } else {
+                    2u32
+                }
+            } else {
+                2u32
+            }
+        } else {
+            3u32
+        }
+    } else {
+        3u32
     };
     let (l15, reg_174 : 0x2::object::UID);
     match (__dispatch_81) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x97e21376b9fe82f849b32ae42fd7499f89c947ca922dd19e3ee2350dd9cfe726/gauge.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x97e21376b9fe82f849b32ae42fd7499f89c947ca922dd19e3ee2350dd9cfe726/gauge.move
@@ -275,11 +275,10 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
                     continue
                 }
             };
-            if (l8 >= l18.len()) {
-                (table::borrow_mut(&mut l2.stakes, l13)).push_back(l11);
-                break
-            };
             break
+        };
+        if (l8 >= l18.len()) {
+            (table::borrow_mut(&mut l2.stakes, l13)).push_back(l11)
         }
     };
     /* block 192 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x97e21376b9fe82f849b32ae42fd7499f89c947ca922dd19e3ee2350dd9cfe726/gauge.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x97e21376b9fe82f849b32ae42fd7499f89c947ca922dd19e3ee2350dd9cfe726/gauge.move
@@ -275,9 +275,10 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
                     continue
                 }
             };
+            let __c181 = l8 >= l18.len();
             break
         };
-        if (l8 >= l18.len()) {
+        if (__c181) {
             (table::borrow_mut(&mut l2.stakes, l13)).push_back(l11)
         }
     };

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xa32574713e612fa6d9eb439723cb7d69f06ae55117d8c9a028330cea98c5f391/marketplace.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xa32574713e612fa6d9eb439723cb7d69f06ae55117d8c9a028330cea98c5f391/marketplace.move
@@ -449,10 +449,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 l32 = *(&(&vector::remove(l34, l39)).last_points_claimed_at);
             };
-            if (freeze(l34).len() == 0u64) {
-                break
-            };
             break
+        };
+        if (freeze(l34).len() == 0u64) {
+            
         }
     } else {
         assert!(linked_table::contains(&l29.bids, l5), C17);
@@ -481,11 +481,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 let l22 = vector::remove(l35, l40);
             };
-            if (freeze(l35).len() == 0u64) {
-                std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7));
-                break
-            };
             break
+        };
+        if (freeze(l35).len() == 0u64) {
+            std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7))
         }
     } else {
         assert!(object::uid_to_inner(&(&linked_table::remove(&mut (linked_table::borrow_mut(&mut l36.bids, l5)).bids, l7)).id) == l6, C26);
@@ -702,10 +701,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 l29 = *(&(&vector::remove(l31, l36)).last_points_claimed_at);
             };
-            if (freeze(l31).len() == 0u64) {
-                break
-            };
             break
+        };
+        if (freeze(l31).len() == 0u64) {
+            
         }
     } else {
         assert!(linked_table::contains(&l26.bids, l5), C17);
@@ -729,11 +728,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 let l18 = vector::remove(l32, l37);
             };
-            if (freeze(l32).len() == 0u64) {
-                std::vector::destroy_empty(linked_table::remove(&mut l33.collection_bids, l6));
-                break
-            };
             break
+        };
+        if (freeze(l32).len() == 0u64) {
+            std::vector::destroy_empty(linked_table::remove(&mut l33.collection_bids, l6))
         }
     } else {
         assert!(linked_table::contains(&l33.bids, l5), C17);
@@ -1156,11 +1154,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 };
                 let l22 = vector::remove(l20, l30);
             };
-            if (freeze(l20).len() == 0u64) {
-                std::vector::destroy_empty(linked_table::remove(&mut l28.collection_bids, l27));
-                break
-            };
             break
+        };
+        if (freeze(l20).len() == 0u64) {
+            std::vector::destroy_empty(linked_table::remove(&mut l28.collection_bids, l27))
         }
     };
     /* block 166 */;
@@ -1185,10 +1182,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 l26 = *(&(&l23).bid_price);
                 l34 = *(&(&l23).last_points_claimed_at);
             };
-            if (freeze(l25).len() == 0u64) {
-                break
-            };
             break
+        };
+        if (freeze(l25).len() == 0u64) {
+            
         }
     } else {
         let l36 = *(option::borrow(&l1));

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xa32574713e612fa6d9eb439723cb7d69f06ae55117d8c9a028330cea98c5f391/marketplace.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xa32574713e612fa6d9eb439723cb7d69f06ae55117d8c9a028330cea98c5f391/marketplace.move
@@ -449,9 +449,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 l32 = *(&(&vector::remove(l34, l39)).last_points_claimed_at);
             };
+            let __c165 = freeze(l34).len() == 0u64;
             break
         };
-        if (freeze(l34).len() == 0u64) {
+        if (__c165) {
             
         }
     } else {
@@ -481,9 +482,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
                 };
                 let l22 = vector::remove(l35, l40);
             };
+            let __c329 = freeze(l35).len() == 0u64;
             break
         };
-        if (freeze(l35).len() == 0u64) {
+        if (__c329) {
             std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7))
         }
     } else {
@@ -701,9 +703,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 l29 = *(&(&vector::remove(l31, l36)).last_points_claimed_at);
             };
+            let __c138 = freeze(l31).len() == 0u64;
             break
         };
-        if (freeze(l31).len() == 0u64) {
+        if (__c138) {
             
         }
     } else {
@@ -728,9 +731,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
                 };
                 let l18 = vector::remove(l32, l37);
             };
+            let __c236 = freeze(l32).len() == 0u64;
             break
         };
-        if (freeze(l32).len() == 0u64) {
+        if (__c236) {
             std::vector::destroy_empty(linked_table::remove(&mut l33.collection_bids, l6))
         }
     } else {
@@ -1154,9 +1158,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 };
                 let l22 = vector::remove(l20, l30);
             };
+            let __c155 = freeze(l20).len() == 0u64;
             break
         };
-        if (freeze(l20).len() == 0u64) {
+        if (__c155) {
             std::vector::destroy_empty(linked_table::remove(&mut l28.collection_bids, l27))
         }
     };
@@ -1182,9 +1187,10 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
                 l26 = *(&(&l23).bid_price);
                 l34 = *(&(&l23).last_points_claimed_at);
             };
+            let __c269 = freeze(l25).len() == 0u64;
             break
         };
-        if (freeze(l25).len() == 0u64) {
+        if (__c269) {
             
         }
     } else {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xaeb83a6f7faeb742ecd0b72fce593a9364b962c56f1a419a3d6296355720a9a1/sui20.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xaeb83a6f7faeb742ecd0b72fce593a9364b962c56f1a419a3d6296355720a9a1/sui20.move
@@ -250,14 +250,15 @@ public fun mint(l0: &mut Global, l1: &Clock, l2: String, l3: u64, l4: Coin<SUI>,
                 vector::insert(&mut l7.users, l15, l8)
             };
             let l11 = &l7.users.len();
-            if (l11 == l10 && l10 < C0) {
-                (&mut l7.users).push_back(l15);
-                break
-            };
-            if (l11 > C0) {
-                break
-            };
+            let l6 = l11 == l10 && l10 < C0;
             break
+        };
+        if (l6) {
+            (&mut l7.users).push_back(l15)
+        } else {
+            if (l11 > C0) {
+                
+            }
         }
     } else {
         unstructured {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb247a3071c9a70a0ecc96c1841acf389147609e007f343f7ddf00acab769752c/demo.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb247a3071c9a70a0ecc96c1841acf389147609e007f343f7ddf00acab769752c/demo.move
@@ -587,9 +587,10 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
+        let __c132 = l8;
         break
     };
-    assert!(l8, C29)
+    assert!(__c132, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1629,9 +1630,10 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c115 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c115, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1904,9 +1906,10 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
+        let __c109 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c109, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2323,9 +2326,10 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c120 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c120, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb247a3071c9a70a0ecc96c1841acf389147609e007f343f7ddf00acab769752c/demo.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb247a3071c9a70a0ecc96c1841acf389147609e007f343f7ddf00acab769752c/demo.move
@@ -587,10 +587,9 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
-        assert!(l8, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l8, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1630,10 +1629,9 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1906,10 +1904,9 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2326,10 +2323,9 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xffec77bdbb001fb7d9770bfdee1d3d1e5f48598d77c6ba793d8452e166ccb0d4/ART20.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xffec77bdbb001fb7d9770bfdee1d3d1e5f48598d77c6ba793d8452e166ccb0d4/ART20.move
@@ -299,9 +299,10 @@ public entry fun batch_burn_art20(l0: vector<NFT>, l1: &mut CollectionCap, l2: v
                 *(&mut l6.balance) = xf_ART20::safe_sub(*(&l6.balance), 1u64);
                 l8 = true;
             };
+            let __c144 = l8;
             break
         };
-        assert!(l8, C6);
+        assert!(__c144, C6);
         xf_ART20::burn_single_art20(l15, l1, freeze(l3));
         l11 = l11 + 1u64;
     };
@@ -376,9 +377,10 @@ public entry fun batch_burn_art20_by_asset_ids(l0: &mut CollectionCap, l1: vecto
                         *(&mut l11.balance) = xf_ART20::safe_sub(*(&l11.balance), 1u64);
                         l12 = true;
                     };
+                    let __c201 = l12;
                     break
                 };
-                assert!(l12, C6);
+                assert!(__c201, C6);
                 *(&mut l0.current_supply) = xf_ART20::safe_sub(*(&l0.current_supply), 1u64);
                 event::emit(BurnEvent { owner: l22, id: object::uid_to_inner(&(&l20).id) });
                 let NFT { id: reg_147, artinals_id: reg_148, creator: reg_149, name: reg_150, description: reg_151, uri: reg_152, logo_uri: reg_153, asset_id: reg_154, max_supply: reg_155, collection_id: reg_156, category: reg_157 } = l20;
@@ -739,7 +741,7 @@ public entry fun burn_art20(l0: NFT, l1: &mut CollectionCap, l2: vector<UserBala
     let l8 = false;
     let l10 = vector[];
     loop {
-        if (vector::is_empty(&l7)) {
+        if (!(!(vector::is_empty(&l7)))) {
             assert!(l8, C6);
             break
         };
@@ -1223,9 +1225,10 @@ public entry fun mint_additional_art20(l0: &mut CollectionCap, l1: u64, l2: &mut
                 *(&mut l8.balance) = *(&l8.balance) + l1;
                 l10 = true;
             };
+            let __c122 = !(l10);
             break
         };
-        if (!(l10)) {
+        if (__c122) {
             transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14)
         }
     };
@@ -1393,9 +1396,10 @@ public entry fun set_collection_value_source(l0: &mut CollectionCap, l1: vector<
                 };
                 l10 = false;
             };
+            let __c84 = l10;
             break
         };
-        assert!(l10, C16)
+        assert!(__c84, C16)
     } else {
         assert!(string::length(&l9) == 64u64, C17);
         unstructured {
@@ -1473,9 +1477,10 @@ public entry fun transfer_art20(l0: vector<NFT>, l1: vector<address>, l2: &Colle
                 *(&mut l9.balance) = xf_ART20::safe_sub(*(&l9.balance), 1u64);
                 l11 = true;
             };
+            let __c186 = l11;
             break
         };
-        assert!(l11, C6);
+        assert!(__c186, C6);
         (&mut l23).push_back(object::uid_to_inner(&(&l21).id));
         (&mut l7).push_back(1u64);
         event::emit(TransferEvent { from: l20, to: l17, id: object::uid_to_inner(&(&l21).id), royalty: 0u64, asset_id: *(&(&l21).asset_id) });
@@ -1540,6 +1545,7 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
             };
             l17 = l17 + 1u64;
         };
+        let __c191;
         match (__dispatch_81) {
             0 => {
                 loop {
@@ -1552,19 +1558,22 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
                         *(&mut l12.balance) = xf_ART20::safe_sub(*(&l12.balance), 1u64);
                         l13 = true;
                     };
+                    let __c163 = l13;
                     break
                 };
-                assert!(l13, C6);
+                assert!(__c163, C6);
                 (&mut l26).push_back(l21);
                 (&mut l9).push_back(1u64);
                 transfer::transfer(vector::remove(&mut l1, l17), l4);
                 l15 = true;
-                assert!(l15, C15);
+                __c191 = l15;
+                assert!(__c191, C15);
                 l16 = l16 + 1u64;
                 continue
             },
             1 => {
-                assert!(l15, C15);
+                __c191 = l15;
+                assert!(__c191, C15);
                 l16 = l16 + 1u64;
                 continue
             }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xffec77bdbb001fb7d9770bfdee1d3d1e5f48598d77c6ba793d8452e166ccb0d4/ART20.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xffec77bdbb001fb7d9770bfdee1d3d1e5f48598d77c6ba793d8452e166ccb0d4/ART20.move
@@ -299,11 +299,11 @@ public entry fun batch_burn_art20(l0: vector<NFT>, l1: &mut CollectionCap, l2: v
                 *(&mut l6.balance) = xf_ART20::safe_sub(*(&l6.balance), 1u64);
                 l8 = true;
             };
-            assert!(l8, C6);
-            xf_ART20::burn_single_art20(l15, l1, freeze(l3));
-            l11 = l11 + 1u64;
             break
-        }
+        };
+        assert!(l8, C6);
+        xf_ART20::burn_single_art20(l15, l1, freeze(l3));
+        l11 = l11 + 1u64;
     };
     while (&l2.len() > 0u64) {
         let l7 = vector::remove(&mut l2, 0u64);
@@ -376,14 +376,14 @@ public entry fun batch_burn_art20_by_asset_ids(l0: &mut CollectionCap, l1: vecto
                         *(&mut l11.balance) = xf_ART20::safe_sub(*(&l11.balance), 1u64);
                         l12 = true;
                     };
-                    assert!(l12, C6);
-                    *(&mut l0.current_supply) = xf_ART20::safe_sub(*(&l0.current_supply), 1u64);
-                    event::emit(BurnEvent { owner: l22, id: object::uid_to_inner(&(&l20).id) });
-                    let NFT { id: reg_147, artinals_id: reg_148, creator: reg_149, name: reg_150, description: reg_151, uri: reg_152, logo_uri: reg_153, asset_id: reg_154, max_supply: reg_155, collection_id: reg_156, category: reg_157 } = l20;
-                    object::delete(reg_147 : 0x2::object::UID);
-                    l14 = true;
                     break
-                }
+                };
+                assert!(l12, C6);
+                *(&mut l0.current_supply) = xf_ART20::safe_sub(*(&l0.current_supply), 1u64);
+                event::emit(BurnEvent { owner: l22, id: object::uid_to_inner(&(&l20).id) });
+                let NFT { id: reg_147, artinals_id: reg_148, creator: reg_149, name: reg_150, description: reg_151, uri: reg_152, logo_uri: reg_153, asset_id: reg_154, max_supply: reg_155, collection_id: reg_156, category: reg_157 } = l20;
+                object::delete(reg_147 : 0x2::object::UID);
+                l14 = true;
             } else {
                 (&mut l24).push_back(l20)
             }
@@ -739,7 +739,7 @@ public entry fun burn_art20(l0: NFT, l1: &mut CollectionCap, l2: vector<UserBala
     let l8 = false;
     let l10 = vector[];
     loop {
-        if (!(!(vector::is_empty(&l7)))) {
+        if (vector::is_empty(&l7)) {
             assert!(l8, C6);
             break
         };
@@ -1223,11 +1223,10 @@ public entry fun mint_additional_art20(l0: &mut CollectionCap, l1: u64, l2: &mut
                 *(&mut l8.balance) = *(&l8.balance) + l1;
                 l10 = true;
             };
-            if (!(l10)) {
-                transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14);
-                break
-            };
             break
+        };
+        if (!(l10)) {
+            transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14)
         }
     };
     /* block 132 */;
@@ -1394,9 +1393,9 @@ public entry fun set_collection_value_source(l0: &mut CollectionCap, l1: vector<
                 };
                 l10 = false;
             };
-            assert!(l10, C16);
             break
-        }
+        };
+        assert!(l10, C16)
     } else {
         assert!(string::length(&l9) == 64u64, C17);
         unstructured {
@@ -1474,15 +1473,15 @@ public entry fun transfer_art20(l0: vector<NFT>, l1: vector<address>, l2: &Colle
                 *(&mut l9.balance) = xf_ART20::safe_sub(*(&l9.balance), 1u64);
                 l11 = true;
             };
-            assert!(l11, C6);
-            (&mut l23).push_back(object::uid_to_inner(&(&l21).id));
-            (&mut l7).push_back(1u64);
-            event::emit(TransferEvent { from: l20, to: l17, id: object::uid_to_inner(&(&l21).id), royalty: 0u64, asset_id: *(&(&l21).asset_id) });
-            transfer::transfer(l21, l17);
-            transfer::transfer(l18, l17);
-            l14 = l14 + 1u64;
             break
-        }
+        };
+        assert!(l11, C6);
+        (&mut l23).push_back(object::uid_to_inner(&(&l21).id));
+        (&mut l7).push_back(1u64);
+        event::emit(TransferEvent { from: l20, to: l17, id: object::uid_to_inner(&(&l21).id), royalty: 0u64, asset_id: *(&(&l21).asset_id) });
+        transfer::transfer(l21, l17);
+        transfer::transfer(l18, l17);
+        l14 = l14 + 1u64;
     };
     while (&l3.len() > 0u64) {
         let l10 = vector::remove(&mut l3, 0u64);
@@ -1541,7 +1540,6 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
             };
             l17 = l17 + 1u64;
         };
-        let __c191;
         match (__dispatch_81) {
             0 => {
                 loop {
@@ -1554,21 +1552,19 @@ public entry fun transfer_art20_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>
                         *(&mut l12.balance) = xf_ART20::safe_sub(*(&l12.balance), 1u64);
                         l13 = true;
                     };
-                    assert!(l13, C6);
-                    (&mut l26).push_back(l21);
-                    (&mut l9).push_back(1u64);
-                    transfer::transfer(vector::remove(&mut l1, l17), l4);
-                    l15 = true;
                     break
                 };
-                __c191 = l15;
-                assert!(__c191, C15);
+                assert!(l13, C6);
+                (&mut l26).push_back(l21);
+                (&mut l9).push_back(1u64);
+                transfer::transfer(vector::remove(&mut l1, l17), l4);
+                l15 = true;
+                assert!(l15, C15);
                 l16 = l16 + 1u64;
                 continue
             },
             1 => {
-                __c191 = l15;
-                assert!(__c191, C15);
+                assert!(l15, C15);
                 l16 = l16 + 1u64;
                 continue
             }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
@@ -57,10 +57,16 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
+    let __c0 = l16 > l13;
+    let __c25 = l16 - l13 >= l18;
+    let __c35 = l13 - l16 >= l18;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
+        let __c44 = l16 > l13;
+        let __c59 = l16 - l13 >= l18;
+        let __c68 = l13 - l16 >= l18;
+        __c44 && __c59 || __c68 && !(__c44)
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -74,14 +80,22 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
+    let __c0 = l19 > l16;
+    let __c25 = l19 - l16 >= l21;
+    let __c35 = l16 - l19 >= l21;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c44 = l19 > l16;
+        let __c59 = l19 - l16 >= l21;
+        let __c68 = l16 - l19 >= l21;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c77 = l19 > l16;
+        let __c92 = l19 - l16 >= l21;
+        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -96,18 +110,29 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
+    let __c0 = l22 > l19;
+    let __c25 = l22 - l19 >= l24;
+    let __c35 = l19 - l22 >= l24;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c44 = l22 > l19;
+        let __c59 = l22 - l19 >= l24;
+        let __c68 = l19 - l22 >= l24;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c77 = l22 > l19;
+        let __c92 = l22 - l19 >= l24;
+        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c110 = l22 > l19;
+        let __c125 = l22 - l19 >= l24;
+        let __c134 = l19 - l22 >= l24;
+        __c110 && __c125 || __c134 && !(__c110)
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -123,22 +148,36 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
+    let __c0 = l25 > l22;
+    let __c25 = l25 - l22 >= l27;
+    let __c35 = l22 - l25 >= l27;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c44 = l25 > l22;
+        let __c59 = l25 - l22 >= l27;
+        let __c68 = l22 - l25 >= l27;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c77 = l25 > l22;
+        let __c92 = l25 - l22 >= l27;
+        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c110 = l25 > l22;
+        let __c125 = l25 - l22 >= l27;
+        let __c134 = l22 - l25 >= l27;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c143 = l25 > l22;
+        let __c158 = l25 - l22 >= l27;
+        let __c167 = l22 - l25 >= l27;
+        __c143 && __c158 || __c167 && !(__c143)
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -155,26 +194,43 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
+    let __c0 = l28 > l25;
+    let __c25 = l28 - l25 >= l30;
+    let __c35 = l25 - l28 >= l30;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c44 = l28 > l25;
+        let __c59 = l28 - l25 >= l30;
+        let __c68 = l25 - l28 >= l30;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c77 = l28 > l25;
+        let __c92 = l28 - l25 >= l30;
+        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c110 = l28 > l25;
+        let __c125 = l28 - l25 >= l30;
+        let __c134 = l25 - l28 >= l30;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c143 = l28 > l25;
+        let __c158 = l28 - l25 >= l30;
+        let __c167 = l25 - l28 >= l30;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c176 = l28 > l25;
+        let __c191 = l28 - l25 >= l30;
+        let __c200 = l25 - l28 >= l30;
+        __c176 && __c191 || __c200 && !(__c176)
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -192,30 +248,50 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
+    let __c0 = l31 > l28;
+    let __c25 = l31 - l28 >= l33;
+    let __c35 = l28 - l31 >= l33;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c44 = l31 > l28;
+        let __c59 = l31 - l28 >= l33;
+        let __c68 = l28 - l31 >= l33;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c77 = l31 > l28;
+        let __c92 = l31 - l28 >= l33;
+        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c110 = l31 > l28;
+        let __c125 = l31 - l28 >= l33;
+        let __c134 = l28 - l31 >= l33;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c143 = l31 > l28;
+        let __c158 = l31 - l28 >= l33;
+        let __c167 = l28 - l31 >= l33;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c176 = l31 > l28;
+        let __c191 = l31 - l28 >= l33;
+        let __c200 = l28 - l31 >= l33;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c209 = l31 > l28;
+        let __c224 = l31 - l28 >= l33;
+        let __c233 = l28 - l31 >= l33;
+        __c209 && __c224 || __c233 && !(__c209)
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -234,34 +310,57 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
+    let __c0 = l34 > l31;
+    let __c25 = l34 - l31 >= l36;
+    let __c35 = l31 - l34 >= l36;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c44 = l34 > l31;
+        let __c59 = l34 - l31 >= l36;
+        let __c68 = l31 - l34 >= l36;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c77 = l34 > l31;
+        let __c92 = l34 - l31 >= l36;
+        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c110 = l34 > l31;
+        let __c125 = l34 - l31 >= l36;
+        let __c134 = l31 - l34 >= l36;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c143 = l34 > l31;
+        let __c158 = l34 - l31 >= l36;
+        let __c167 = l31 - l34 >= l36;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c176 = l34 > l31;
+        let __c191 = l34 - l31 >= l36;
+        let __c200 = l31 - l34 >= l36;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c209 = l34 > l31;
+        let __c224 = l34 - l31 >= l36;
+        let __c233 = l31 - l34 >= l36;
+        __c209 && __c224 || __c233 && !(__c209)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c242 = l34 > l31;
+        let __c257 = l34 - l31 >= l36;
+        let __c266 = l31 - l34 >= l36;
+        __c242 && __c257 || __c266 && !(__c242)
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -283,7 +382,11 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
     let l16;
-    while (l12 < l14) {
+    loop {
+        if (l12 >= l14) {
+            let __c61 = l13;
+            break
+        };
         let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
         let l17 = option::get_with_default(&(&l3)[l12], l11);
         if (l15 > l10) {
@@ -297,7 +400,7 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
         };
         l12 = l12 + 1u64;
     };
-    match (if (l13) {
+    match (if (__c61) {
         l12 = 0u64;
         0u32
     } else {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
@@ -57,16 +57,10 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    let __c0 = l16 > l13;
-    let __c25 = l16 - l13 >= l18;
-    let __c35 = l13 - l16 >= l18;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        let __c44 = l16 > l13;
-        let __c59 = l16 - l13 >= l18;
-        let __c68 = l13 - l16 >= l18;
-        __c44 && __c59 || __c68 && !(__c44)
+        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -80,22 +74,14 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    let __c0 = l19 > l16;
-    let __c25 = l19 - l16 >= l21;
-    let __c35 = l16 - l19 >= l21;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        let __c44 = l19 > l16;
-        let __c59 = l19 - l16 >= l21;
-        let __c68 = l16 - l19 >= l21;
-        __c44 && __c59 || __c68 && !(__c44)
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        let __c77 = l19 > l16;
-        let __c92 = l19 - l16 >= l21;
-        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -110,29 +96,18 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    let __c0 = l22 > l19;
-    let __c25 = l22 - l19 >= l24;
-    let __c35 = l19 - l22 >= l24;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        let __c44 = l22 > l19;
-        let __c59 = l22 - l19 >= l24;
-        let __c68 = l19 - l22 >= l24;
-        __c44 && __c59 || __c68 && !(__c44)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        let __c77 = l22 > l19;
-        let __c92 = l22 - l19 >= l24;
-        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        let __c110 = l22 > l19;
-        let __c125 = l22 - l19 >= l24;
-        let __c134 = l19 - l22 >= l24;
-        __c110 && __c125 || __c134 && !(__c110)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -148,36 +123,22 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    let __c0 = l25 > l22;
-    let __c25 = l25 - l22 >= l27;
-    let __c35 = l22 - l25 >= l27;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        let __c44 = l25 > l22;
-        let __c59 = l25 - l22 >= l27;
-        let __c68 = l22 - l25 >= l27;
-        __c44 && __c59 || __c68 && !(__c44)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        let __c77 = l25 > l22;
-        let __c92 = l25 - l22 >= l27;
-        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        let __c110 = l25 > l22;
-        let __c125 = l25 - l22 >= l27;
-        let __c134 = l22 - l25 >= l27;
-        __c110 && __c125 || __c134 && !(__c110)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        let __c143 = l25 > l22;
-        let __c158 = l25 - l22 >= l27;
-        let __c167 = l22 - l25 >= l27;
-        __c143 && __c158 || __c167 && !(__c143)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -194,43 +155,26 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    let __c0 = l28 > l25;
-    let __c25 = l28 - l25 >= l30;
-    let __c35 = l25 - l28 >= l30;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        let __c44 = l28 > l25;
-        let __c59 = l28 - l25 >= l30;
-        let __c68 = l25 - l28 >= l30;
-        __c44 && __c59 || __c68 && !(__c44)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        let __c77 = l28 > l25;
-        let __c92 = l28 - l25 >= l30;
-        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        let __c110 = l28 > l25;
-        let __c125 = l28 - l25 >= l30;
-        let __c134 = l25 - l28 >= l30;
-        __c110 && __c125 || __c134 && !(__c110)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        let __c143 = l28 > l25;
-        let __c158 = l28 - l25 >= l30;
-        let __c167 = l25 - l28 >= l30;
-        __c143 && __c158 || __c167 && !(__c143)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        let __c176 = l28 > l25;
-        let __c191 = l28 - l25 >= l30;
-        let __c200 = l25 - l28 >= l30;
-        __c176 && __c191 || __c200 && !(__c176)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -248,50 +192,30 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    let __c0 = l31 > l28;
-    let __c25 = l31 - l28 >= l33;
-    let __c35 = l28 - l31 >= l33;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        let __c44 = l31 > l28;
-        let __c59 = l31 - l28 >= l33;
-        let __c68 = l28 - l31 >= l33;
-        __c44 && __c59 || __c68 && !(__c44)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        let __c77 = l31 > l28;
-        let __c92 = l31 - l28 >= l33;
-        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        let __c110 = l31 > l28;
-        let __c125 = l31 - l28 >= l33;
-        let __c134 = l28 - l31 >= l33;
-        __c110 && __c125 || __c134 && !(__c110)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        let __c143 = l31 > l28;
-        let __c158 = l31 - l28 >= l33;
-        let __c167 = l28 - l31 >= l33;
-        __c143 && __c158 || __c167 && !(__c143)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        let __c176 = l31 > l28;
-        let __c191 = l31 - l28 >= l33;
-        let __c200 = l28 - l31 >= l33;
-        __c176 && __c191 || __c200 && !(__c176)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        let __c209 = l31 > l28;
-        let __c224 = l31 - l28 >= l33;
-        let __c233 = l28 - l31 >= l33;
-        __c209 && __c224 || __c233 && !(__c209)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -310,57 +234,34 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    let __c0 = l34 > l31;
-    let __c25 = l34 - l31 >= l36;
-    let __c35 = l31 - l34 >= l36;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        let __c44 = l34 > l31;
-        let __c59 = l34 - l31 >= l36;
-        let __c68 = l31 - l34 >= l36;
-        __c44 && __c59 || __c68 && !(__c44)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        let __c77 = l34 > l31;
-        let __c92 = l34 - l31 >= l36;
-        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        let __c110 = l34 > l31;
-        let __c125 = l34 - l31 >= l36;
-        let __c134 = l31 - l34 >= l36;
-        __c110 && __c125 || __c134 && !(__c110)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        let __c143 = l34 > l31;
-        let __c158 = l34 - l31 >= l36;
-        let __c167 = l31 - l34 >= l36;
-        __c143 && __c158 || __c167 && !(__c143)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        let __c176 = l34 > l31;
-        let __c191 = l34 - l31 >= l36;
-        let __c200 = l31 - l34 >= l36;
-        __c176 && __c191 || __c200 && !(__c176)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        let __c209 = l34 > l31;
-        let __c224 = l34 - l31 >= l36;
-        let __c233 = l31 - l34 >= l36;
-        __c209 && __c224 || __c233 && !(__c209)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        let __c242 = l34 > l31;
-        let __c257 = l34 - l31 >= l36;
-        let __c266 = l31 - l34 >= l36;
-        __c242 && __c257 || __c266 && !(__c242)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -381,36 +282,30 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l10 = clock::timestamp_ms(l7) / 1000u64;
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
-    let __dispatch_15;
     let l16;
-    loop {
-        if (l12 < l14) {
-            let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
-            let l17 = option::get_with_default(&(&l3)[l12], l11);
-            if (l15 > l10) {
-                if (l15 - l10 >= l17) {
-                    l13 = false;
-                }
-            } else {
-                if (l10 - l15 < l17) {
-                    l13 = false;
-                }
-            };
-            l12 = l12 + 1u64;
-            continue
+    while (l12 < l14) {
+        let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
+        let l17 = option::get_with_default(&(&l3)[l12], l11);
+        if (l15 > l10) {
+            if (l15 - l10 >= l17) {
+                l13 = false;
+            }
+        } else {
+            if (l10 - l15 < l17) {
+                l13 = false;
+            }
         };
-        if (l13) {
-            l12 = 0u64;
-            __dispatch_15 = 0u32;
-            break
-        };
+        l12 = l12 + 1u64;
+    };
+    match (if (l13) {
+        l12 = 0u64;
+        0u32
+    } else {
         let l18 = vaa::parse_and_verify(l4, l5, l7);
         l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
         l12 = 0u64;
-        __dispatch_15 = 1u32;
-        break
-    };
-    match (__dispatch_15) {
+        1u32
+    }) {
         0 => {
             while (l12 < l14) {
                 transfer::public_share_object((&mut l2).pop_back());

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/safu.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/safu.mv.snap
@@ -557,16 +557,17 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 continue
             }
         };
+        let __c110 = l22 == l25;
         break
     };
-    let __dispatch_58 = if (l22 == l25) {
+    let __dispatch_58 = if (__c110) {
         l29 = C25;
         l24 = 0u64;
         0u32
     } else {
         1u32
     };
-    let (l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
+    let (__c142, __c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
     match (__dispatch_58) {
         0 => {
             while (l24 < &l36.reward_tokens.len()) {
@@ -580,7 +581,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            if (*(&(&l30.share)[C8]) < l7) {
+            __c142 = *(&(&l30.share)[C8]) < l7;
+            if (__c142) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -597,7 +599,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            if (*(&(&l30.share)[C9]) < l8) {
+            __c252 = *(&(&l30.share)[C9]) < l8;
+            if (__c252) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -615,13 +618,16 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            if (l9 > 0u64) {
+            __c319 = l9 > 0u64;
+            if (__c319) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                if (reg_309) {
-                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
+                __c375 = reg_309;
+                if (__c375) {
+                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
+                    if (__c385) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -653,8 +659,10 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
-            if (l19 >= *(&(&l36.config)[C8])) {
+            __c464 = l19 + l21 + l23 + l28 > 0u64;
+            assert!(__c464, C8);
+            __c508 = l19 >= *(&(&l36.config)[C8]);
+            if (__c508) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -666,9 +674,12 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            assert!(l18, C10);
-            assert!(l19 >= *(&(&l36.config)[C9]), C11);
-            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
+            __c529 = l18;
+            assert!(__c529, C10);
+            __c538 = l19 >= *(&(&l36.config)[C9]);
+            assert!(__c538, C11);
+            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
+            assert!(__c553, C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -680,7 +691,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            if (*(&(&l30.share)[C8]) < l7) {
+            __c142 = *(&(&l30.share)[C8]) < l7;
+            if (__c142) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -697,7 +709,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            if (*(&(&l30.share)[C9]) < l8) {
+            __c252 = *(&(&l30.share)[C9]) < l8;
+            if (__c252) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -715,13 +728,16 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            if (l9 > 0u64) {
+            __c319 = l9 > 0u64;
+            if (__c319) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                if (reg_309) {
-                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
+                __c375 = reg_309;
+                if (__c375) {
+                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
+                    if (__c385) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -753,8 +769,10 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
-            if (l19 >= *(&(&l36.config)[C8])) {
+            __c464 = l19 + l21 + l23 + l28 > 0u64;
+            assert!(__c464, C8);
+            __c508 = l19 >= *(&(&l36.config)[C8]);
+            if (__c508) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -766,9 +784,12 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            assert!(l18, C10);
-            assert!(l19 >= *(&(&l36.config)[C9]), C11);
-            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
+            __c529 = l18;
+            assert!(__c529, C10);
+            __c538 = l19 >= *(&(&l36.config)[C9]);
+            assert!(__c538, C11);
+            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
+            assert!(__c553, C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -968,9 +989,10 @@ public fun snapshot(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l2: &mu
                 continue
             }
         };
+        let __c110 = l10 == l11;
         break
     };
-    if (l10 == l11) {
+    if (__c110) {
         dynamic_field::add(&mut l4.id, ascii::string(C6), l17)
     } else {
         let l13 = big_vector::borrow_mut(&mut l19.share, l10);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/safu.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/safu.mv.snap
@@ -543,7 +543,6 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
     let l32 = 0u64;
     let l31 = big_vector::borrow_slice(&l36.share, l32);
     let l22 = 0u64;
-    let __dispatch_58;
     let (l24, l29);
     loop {
         if (l22 < l25) {
@@ -558,16 +557,16 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 continue
             }
         };
-        if (l22 == l25) {
-            l29 = C25;
-            l24 = 0u64;
-            __dispatch_58 = 0u32;
-            break
-        };
-        __dispatch_58 = 1u32;
         break
     };
-    let (__c142, __c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
+    let __dispatch_58 = if (l22 == l25) {
+        l29 = C25;
+        l24 = 0u64;
+        0u32
+    } else {
+        1u32
+    };
+    let (l13, l14, l15, l16, l17, l18, l19, l21, l23, l26, l27, l28, l30, reg_309, reg_310);
     match (__dispatch_58) {
         0 => {
             while (l24 < &l36.reward_tokens.len()) {
@@ -581,8 +580,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            __c142 = *(&(&l30.share)[C8]) < l7;
-            if (__c142) {
+            if (*(&(&l30.share)[C8]) < l7) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -599,8 +597,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            __c252 = *(&(&l30.share)[C9]) < l8;
-            if (__c252) {
+            if (*(&(&l30.share)[C9]) < l8) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -618,16 +615,13 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            __c319 = l9 > 0u64;
-            if (__c319) {
+            if (l9 > 0u64) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                __c375 = reg_309;
-                if (__c375) {
-                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
-                    if (__c385) {
+                if (reg_309) {
+                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -659,10 +653,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            __c464 = l19 + l21 + l23 + l28 > 0u64;
-            assert!(__c464, C8);
-            __c508 = l19 >= *(&(&l36.config)[C8]);
-            if (__c508) {
+            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
+            if (l19 >= *(&(&l36.config)[C8])) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -674,12 +666,9 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            __c529 = l18;
-            assert!(__c529, C10);
-            __c538 = l19 >= *(&(&l36.config)[C9]);
-            assert!(__c538, C11);
-            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
-            assert!(__c553, C9);
+            assert!(l18, C10);
+            assert!(l19 >= *(&(&l36.config)[C9]), C11);
+            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -691,8 +680,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             l19 = balance::value(&l6);
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-            __c142 = *(&(&l30.share)[C8]) < l7;
-            if (__c142) {
+            if (*(&(&l30.share)[C8]) < l7) {
                 l13 = *(&(&l30.share)[C8]);
                 unstructured {
                     goto 'label_252;
@@ -709,8 +697,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l36.share_supply)[C7]) = *(&(&l36.share_supply)[C7]) + l21;
             *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
             *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
-            __c252 = *(&(&l30.share)[C9]) < l8;
-            if (__c252) {
+            if (*(&(&l30.share)[C9]) < l8) {
                 l14 = *(&(&l30.share)[C9]);
                 unstructured {
                     goto 'label_319;
@@ -728,16 +715,13 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             *(&mut (&mut l30.share)[C9]) = *(&(&l30.share)[C9]) - l23;
             *(&mut (&mut l36.share_supply)[C9]) = *(&(&l36.share_supply)[C9]) - l23;
             l28 = 0u64;
-            __c319 = l9 > 0u64;
-            if (__c319) {
+            if (l9 > 0u64) {
                 l16 = &l36.reward_tokens;
                 l15 = type_name::get();
                 (reg_309, reg_310) = vector::index_of(l16, &l15);
                 l27 = reg_310;
-                __c375 = reg_309;
-                if (__c375) {
-                    __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
-                    if (__c385) {
+                if (reg_309) {
+                    if (*(&(&l30.share)[l27 + 5u64]) < l9) {
                         l17 = *(&(&l30.share)[l27 + 5u64]);
                         unstructured {
                             goto 'label_406;
@@ -769,10 +753,8 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
             };
             /* block 464 */;
             *(&mut (&mut l30.u64_padding)[C7]) = *(&(&l30.share)[C7]) + *(&(&l30.share)[C10])as u128 * *(&(&l36.info)[C13])as u128 / 10000u128as u64;
-            __c464 = l19 + l21 + l23 + l28 > 0u64;
-            assert!(__c464, C8);
-            __c508 = l19 >= *(&(&l36.config)[C8]);
-            if (__c508) {
+            assert!(l19 + l21 + l23 + l28 > 0u64, C8);
+            if (l19 >= *(&(&l36.config)[C8])) {
                 l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
                 unstructured {
                     goto 'label_529;
@@ -784,12 +766,9 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
                 }
             };
             /* block 529 */;
-            __c529 = l18;
-            assert!(__c529, C10);
-            __c538 = l19 >= *(&(&l36.config)[C9]);
-            assert!(__c538, C11);
-            __c553 = *(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]);
-            assert!(__c553, C9);
+            assert!(l18, C10);
+            assert!(l19 >= *(&(&l36.config)[C9]), C11);
+            assert!(*(&(&l36.share_supply)[C10]) + *(&(&l36.share_supply)[C7]) <= *(&(&l36.config)[C7]), C9);
             event::emit(UserEvent { action: ascii::string(C39), log: vector[l5, *(&(&l36.info)[C8]), l19, l21, l23, l28, l26], bcs_padding: C21 });
             dynamic_field::add(&mut l4.id, ascii::string(C6), l34);
             return
@@ -989,17 +968,17 @@ public fun snapshot(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l2: &mu
                 continue
             }
         };
-        if (l10 == l11) {
-            dynamic_field::add(&mut l4.id, ascii::string(C6), l17);
-            return
-        };
+        break
+    };
+    if (l10 == l11) {
+        dynamic_field::add(&mut l4.id, ascii::string(C6), l17)
+    } else {
         let l13 = big_vector::borrow_mut(&mut l19.share, l10);
         let l12 = *(&(&l13.u64_padding)[C7])as u256 * l9 - *(&(&l13.u64_padding)[C8])as u256 * *(&(&l19.config)[C12])as u256 / 3600000u256 / 10000u256as u64;
         *(&mut (&mut l13.u64_padding)[C8]) = l9;
         *(&mut (&mut l13.u64_padding)[C7]) = *(&(&l13.share)[C7]) + *(&(&l13.share)[C10])as u128 * *(&(&l19.info)[C13])as u128 / 10000u128as u64;
         event::emit(UserEvent { action: ascii::string(C42), log: vector[l5, *(&(&l19.info)[C8]), l12], bcs_padding: C21 });
-        dynamic_field::add(&mut l4.id, ascii::string(C6), l17);
-        return
+        dynamic_field::add(&mut l4.id, ascii::string(C6), l17)
     }
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/sui20.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/sui20.mv.snap
@@ -253,14 +253,15 @@ public fun mint(l0: &mut Global, l1: &Clock, l2: String, l3: u64, l4: Coin<SUI>,
                 vector::insert(&mut l7.users, l15, l8)
             };
             let l11 = &l7.users.len();
-            if (l11 == l10 && l10 < C0) {
-                (&mut l7.users).push_back(l15);
-                break
-            };
-            if (l11 > C0) {
-                break
-            };
+            let l6 = l11 == l10 && l10 < C0;
             break
+        };
+        if (l6) {
+            (&mut l7.users).push_back(l15)
+        } else {
+            if (l11 > C0) {
+                
+            }
         }
     } else {
         unstructured {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/tails_staking.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/tails_staking.mv.snap
@@ -724,29 +724,29 @@ fun stake_tails_(l0: &mut TailsStakingRegistry, l1: Tails, l2: address) {
             big_vector::push_back(&mut l0.staking_infos, StakingInfo { user: l2, tails: C14, profits: l6, u64_padding: C25 })
         };
         let l11 = big_vector::borrow_mut(&mut l0.staking_infos, l4);
-        assert!(&l11.tails.len() < *(&(&l0.config)[C1]), C11);
-        (&mut l11.tails).push_back(typus_nft::tails_number(&l1));
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C19))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C19))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C20))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C20))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C21))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C21))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C22))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C22))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C23))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C23))
-        };
-        if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C24))) {
-            typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C24))
-        };
-        object_table::add(&mut l0.tails, object::id_address(&l1), l1);
-        return
-    }
+        break
+    };
+    assert!(&l11.tails.len() < *(&(&l0.config)[C1]), C11);
+    (&mut l11.tails).push_back(typus_nft::tails_number(&l1));
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C19))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C19))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C20))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C20))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C21))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C21))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C22))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C22))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C23))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C23))
+    };
+    if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C24))) {
+        typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C24))
+    };
+    object_table::add(&mut l0.tails, object::id_address(&l1), l1)
 }
 
 public fun transfer_tails(l0: &mut Version, l1: &TailsStakingRegistry, l2: &mut Kiosk, l3: &KioskOwnerCap, l4: address, l5: Coin<SUI>, l6: address, l7: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/tails_staking.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/tails_staking.mv.snap
@@ -724,9 +724,10 @@ fun stake_tails_(l0: &mut TailsStakingRegistry, l1: Tails, l2: address) {
             big_vector::push_back(&mut l0.staking_infos, StakingInfo { user: l2, tails: C14, profits: l6, u64_padding: C25 })
         };
         let l11 = big_vector::borrow_mut(&mut l0.staking_infos, l4);
+        let __c127 = &l11.tails.len() < *(&(&l0.config)[C1]);
         break
     };
-    assert!(&l11.tails.len() < *(&(&l0.config)[C1]), C11);
+    assert!(__c127, C11);
     (&mut l11.tails).push_back(typus_nft::tails_number(&l1));
     if (typus_nft::contains_u64_padding(&l0.tails_manager_cap, &l1, string::utf8(C19))) {
         typus_nft::remove_u64_padding(&l0.tails_manager_cap, &mut l1, string::utf8(C19))

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/verse.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/verse.mv.snap
@@ -590,9 +590,10 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
+        let __c132 = l8;
         break
     };
-    assert!(l8, C29)
+    assert!(__c132, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1632,9 +1633,10 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c115 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c115, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1907,9 +1909,10 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
+        let __c109 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c109, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2326,9 +2329,10 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
+        let __c120 = l9;
         break
     };
-    assert!(l9, C29)
+    assert!(__c120, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/verse.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/verse.mv.snap
@@ -590,10 +590,9 @@ public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l8 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l12, slot_number: l1, old_collections: l11, new_collections: *(&l6.allowed_collections), is_open_to_all: *(&l6.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l7 })
         };
-        assert!(l8, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l8, C29)
 }
 
 public entry fun add_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1633,10 +1632,9 @@ public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: *(&l7.is_open_to_all), updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l1: &Clock, l2: &mut TxContext) {
@@ -1909,10 +1907,9 @@ public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: 
             l9 = true;
             event::emit(SlotCollectionsUpdated { pool_id: l13, slot_number: l1, old_collections: l12, new_collections: *(&l7.allowed_collections), is_open_to_all: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u64, l3: String, l4: &Clock, l5: &mut TxContext) {
@@ -2329,10 +2326,9 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
             l9 = true;
             event::emit(SlotMultiplierUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, old_multiplier: l12, new_multiplier: l2, updated_by: tx_context::sender(freeze(l4)), update_time: l8 })
         };
-        assert!(l9, C29);
-        break;
-        return
-    }
+        break
+    };
+    assert!(l9, C29)
 }
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {


### PR DESCRIPTION
## Description

New refinement `extract_dispatch_writer` that pulls a fused dispatch-writer suffix out of a labeled loop body. When `structure_loop`'s multi-succ dispatch synthesizes a `match (sel)` after a loop, the trailing if/else nest in the body writes `sel` and breaks at every leaf — semantically it belongs OUTSIDE the loop. Detection takes the longest trailing slice of the loop body whose every leaf-evaluation path terminates (Break(L) / Return / Abort), bails if the prefix contains its own Break(L) (which would re-route through the now-extracted suffix), and bails if the suffix would dangle a Continue(L) once extracted. Rewrite inserts a `Break(L)` at the loop body's new tail so prefix paths still exit cleanly, neutralizes each Break(L) in the extracted suffix, and emits `Seq[Loop(L, prefix + Break(L)), suffix]`. After this fires the loop is a normal single-exit shape that `introduce_while` / `fuse_let` / `hoist_arm_assignments` can fold into a clean `while`, with the now-sibling `Assign(sel, K)` sites visible to the next two PRs' cascade-compression and inline refinements.

## Test Plan

`cargo nextest run` from `external-crates/move/crates/move-decompiler` — corpus snapshots regenerate (loops with multi-succ dispatch are visibly cleaner); 100 tests pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
