### PR TITLE
[move][move-decompiler] Strip tail gotos and rewrite forward gotos as labeled breaks [7/8]

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
+++ b/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
@@ -18,8 +18,16 @@ use indexmap::IndexMap;
 // Render Context
 // -------------------------------------------------------------------------------------------------
 
+#[derive(Clone)]
 struct Context {
     constant_table: IndexMap<*const Constant<Symbol>, String>,
+    /// Set of `Block(N)` ids targeted by any surviving `Goto(N)` or `Break(Some(N))` in the
+    /// currently-rendering function's body. Populated per-function in [`function`] from
+    /// [`crate::translate::collect_goto_targets`]. When a `Block(N)` has its id in this set,
+    /// we render it as a labeled scope (`'label_N: { body }`) instead of the inline
+    /// `/* block N */ body` form, and `Break(Some(N))` / `Continue(Some(N))` render as
+    /// `'label_N` instead of `'loop_N`. Module-level value is empty.
+    goto_targets: std::collections::HashSet<u64>,
 }
 
 impl Context {
@@ -63,7 +71,10 @@ pub fn module<S: SourceKind>(
             .map(|(k, (name, _))| (*k, name.clone()))
             .collect();
 
-        Context { constant_table }
+        Context {
+            constant_table,
+            goto_targets: std::collections::HashSet::new(),
+        }
     };
 
     let crate::ast::Module {
@@ -198,6 +209,17 @@ pub fn module<S: SourceKind>(
 fn function(context: &Context, fun: &Function) -> Doc {
     let header = fun_header_doc(fun);
     let code = &fun.code;
+
+    // Build a per-function context populated with the set of `Block(N)` ids targeted by
+    // surviving gotos (and labeled-block breaks). Block / Break / Continue rendering use
+    // this to switch between the inline `/* block N */` comment form (untargeted) and the
+    // labeled-scope `'label_N: { ... }` / `break 'label_N` form (targeted).
+    let context = {
+        let mut fn_ctx = context.clone();
+        fn_ctx.goto_targets = crate::translate::collect_goto_targets(code);
+        fn_ctx
+    };
+    let context = &context;
 
     // Notice for input blocks the structurer received but never emitted. Prepending it
     // inside the function braces puts the warning right above the recovered source so a
@@ -612,6 +634,11 @@ fn exp(context: &Context, exp: &Exp) -> Doc {
 
     fn push_stmt(context: &Context, e: &Exp, out: &mut Vec<Doc>) {
         match e {
+            Exp::Block(id, body) if context.goto_targets.contains(id) => {
+                // A goto in this function targets `id`. Render the Block as a labeled
+                // scope so the goto resolves: `'label_id: { body }`.
+                out.push(D::text(format!("'label_{id}:")).concat_space(e_block(context, body)));
+            }
             Exp::Block(id, body) => {
                 out.push(D::text(format!("/* block {id} */")));
                 match &**body {
@@ -632,10 +659,16 @@ fn exp(context: &Context, exp: &Exp) -> Doc {
     fn recur(context: &Context, e: &Exp) -> Doc {
         match e {
             Exp::Break(label) => match label {
+                Some(l) if context.goto_targets.contains(l) => {
+                    D::text(format!("break 'label_{}", l))
+                }
                 Some(l) => D::text(format!("break 'loop_{}", l)),
                 None => D::text("break"),
             },
             Exp::Continue(label) => match label {
+                Some(l) if context.goto_targets.contains(l) => {
+                    D::text(format!("continue 'label_{}", l))
+                }
                 Some(l) => D::text(format!("continue 'loop_{}", l)),
                 None => D::text("continue"),
             },
@@ -811,9 +844,13 @@ fn exp(context: &Context, exp: &Exp) -> Doc {
             Exp::Unstructured(nodes) => {
                 D::text("unstructured").concat_space(unstructured_block(context, nodes))
             }
-            // Expression-position Block: emit an inline `/* block N */` comment and recur
-            // into the body. Statement-position rendering goes through `stmts` / `push_stmt`,
-            // which keeps the comment on its own line above the inlined body items.
+            // Expression-position Block: when targeted by a goto, render as a labeled scope
+            // (`'label_N: { body }`) so the goto resolves; otherwise emit an inline
+            // `/* block N */` comment and recur into the body. Statement-position rendering
+            // goes through `stmts` / `push_stmt`, which has its own labeled/comment fork.
+            Exp::Block(id, body) if context.goto_targets.contains(id) => {
+                D::text(format!("'label_{id}:")).concat_space(e_block(context, body))
+            }
             Exp::Block(id, body) => {
                 D::text(format!("/* block {id} */")).concat_space(recur(context, body))
             }
@@ -821,11 +858,16 @@ fn exp(context: &Context, exp: &Exp) -> Doc {
     }
 
     fn e_block(context: &Context, e: &Exp) -> Doc {
-        // Peel `Block` wrappers, collecting `/* block N */` comments to lead the brace-block,
-        // then delegate the inner shape (Seq -> stmts; single Exp -> statement).
+        // Peel `Block` wrappers, collecting headers to lead the brace-block. For a Block(N)
+        // that's NOT a goto target we emit a `/* block N */` comment. For a targeted Block
+        // we don't peel - labeled scopes need to remain wrappers - so we stop peeling and
+        // let the caller render via `Block(id) if targeted` arms above.
         let mut headers: Vec<Doc> = Vec::new();
         let mut inner = e;
         while let Exp::Block(id, body) = inner {
+            if context.goto_targets.contains(id) {
+                break;
+            }
             headers.push(D::text(format!("/* block {id} */")));
             inner = body;
         }

--- a/external-crates/move/crates/move-decompiler/src/refinement/elide_tail_goto_to_block.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/elide_tail_goto_to_block.rs
@@ -5,11 +5,9 @@
 // Tail-goto-to-immediate-block elision
 // -------------------------------------------------------------------------------------------------
 //
-// The dom-tree acyclic structurer used to elide tail `Jump`s targeting orphan-hoisted
-// siblings via `convergence_ok` + `elide_tail_jump_to`; `-1.4` deleted that machinery
-// because reaching covers most acyclic shapes goto-free. For the shapes reaching doesn't
-// fold the dom-tree path now surfaces those tail jumps as `Unstructured(Goto)` in the
-// output. The dominant pattern is:
+// The reaching-condition acyclic structurer covers most goto-free shapes; for the rest, the
+// dom-tree path surfaces tail jumps as `Unstructured(Goto)` in the output. The dominant
+// residual pattern is:
 //
 //     if (cond) {
 //         body_t;

--- a/external-crates/move/crates/move-decompiler/src/refinement/elide_tail_goto_to_block.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/elide_tail_goto_to_block.rs
@@ -1,0 +1,200 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// -------------------------------------------------------------------------------------------------
+// Tail-goto-to-immediate-block elision
+// -------------------------------------------------------------------------------------------------
+//
+// The dom-tree acyclic structurer used to elide tail `Jump`s targeting orphan-hoisted
+// siblings via `convergence_ok` + `elide_tail_jump_to`; `-1.4` deleted that machinery
+// because reaching covers most acyclic shapes goto-free. For the shapes reaching doesn't
+// fold the dom-tree path now surfaces those tail jumps as `Unstructured(Goto)` in the
+// output. The dominant pattern is:
+//
+//     if (cond) {
+//         body_t;
+//         unstructured { goto 'label_N; }
+//     } else {
+//         body_e;
+//         unstructured { goto 'label_N; }
+//     };
+//     /* block N */;  // <- Exp::Block(N, ...)
+//     post_action
+//
+// Fall-through from the if-else's natural exit lands at the immediately-following
+// `Block(N, _)`, which is what the gotos target. So the gotos are redundant: stripping
+// them changes nothing semantically and renders cleanly:
+//
+//     if (cond) { body_t } else { body_e };
+//     /* block N */;
+//     post_action
+//
+// This refinement does exactly that. It looks at every `Seq` and, for each adjacent pair
+// `(items[i], items[i+1])` where `items[i+1]` is `Block(N, _)`, walks the tail positions
+// of `items[i]` (last item of a `Seq`, both arms of `IfElse`, every arm of `Switch`/
+// `Match`/`MatchLit`) and pops any `Unstructured(…, Goto(N))` it finds. Empty
+// `Unstructured` after the pop becomes an empty `Seq` (later refinements drop it).
+//
+// Conservative: only strips when `Block(N, _)` is the *immediately* next sibling. A goto
+// to a later sibling would skip everything between, which is a different execution path,
+// so we leave those for the labeled-break fallback (when/if `-3`'s deletion path is taken).
+
+use crate::ast::{Exp, UnstructuredNode};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    let mut changed = false;
+    walk(exp, &mut changed);
+    changed
+}
+
+fn walk(exp: &mut Exp, changed: &mut bool) {
+    use Exp as E;
+    match exp {
+        E::Seq(items) => {
+            for item in items.iter_mut() {
+                walk(item, changed);
+            }
+            for i in 0..items.len().saturating_sub(1) {
+                // Look past any side-effect-free declarations (`hoist_declarations` often
+                // floats a bare `let l;` between the if-else and the labeled block whose body
+                // uses it) to find the eligible `Block(N, _)`. Statements like `Declare(_)`
+                // don't change control flow, so the goto's natural fall-through still lands
+                // on `Block(N)` after we skip them.
+                let mut j = i + 1;
+                while j < items.len() && matches!(&items[j], E::Declare(_)) {
+                    j += 1;
+                }
+                let target = match items.get(j) {
+                    Some(E::Block(n, _)) => *n,
+                    _ => continue,
+                };
+                if strip_tail_goto_to(&mut items[i], target) {
+                    *changed = true;
+                }
+            }
+        }
+        E::Loop(_, body) | E::Block(_, body) => walk(body, changed),
+        E::While(_, c, b) => {
+            walk(c, changed);
+            walk(b, changed);
+        }
+        E::IfElse(c, t, alt) => {
+            walk(c, changed);
+            walk(t, changed);
+            if let Some(a) = alt.as_mut().as_mut() {
+                walk(a, changed);
+            }
+        }
+        E::Switch(c, _, arms) => {
+            walk(c, changed);
+            for (_, b) in arms.iter_mut() {
+                walk(b, changed);
+            }
+        }
+        E::Match(c, _, arms) => {
+            walk(c, changed);
+            for (_, _, b) in arms.iter_mut() {
+                walk(b, changed);
+            }
+        }
+        E::MatchLit(s, arms) => {
+            walk(s, changed);
+            for (_, b) in arms.iter_mut() {
+                walk(b, changed);
+            }
+        }
+        E::Return(items) | E::Call(_, items) => {
+            for item in items.iter_mut() {
+                walk(item, changed);
+            }
+        }
+        E::Primitive { args, .. } | E::Data { args, .. } => {
+            for a in args.iter_mut() {
+                walk(a, changed);
+            }
+        }
+        E::Assign(_, e)
+        | E::LetBind(_, e)
+        | E::Abort(e)
+        | E::Borrow(_, e)
+        | E::Unpack(_, _, e)
+        | E::UnpackVariant(_, _, _, e)
+        | E::VecUnpack(_, e) => walk(e, changed),
+        E::Unstructured(nodes) => {
+            for n in nodes.iter_mut() {
+                match n {
+                    UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                        walk(body, changed);
+                    }
+                    UnstructuredNode::Goto(_) => {}
+                }
+            }
+        }
+        E::Break(_)
+        | E::Continue(_)
+        | E::Declare(_)
+        | E::Value(_)
+        | E::Variable(_)
+        | E::Constant(_) => {}
+    }
+}
+
+/// Pop a trailing `Unstructured(Goto(target))` from `exp`'s tail positions. Returns `true`
+/// if anything was popped. Drops empty `Unstructured` so flatten/refinements can clean up.
+fn strip_tail_goto_to(exp: &mut Exp, target: u64) -> bool {
+    use Exp as E;
+    match exp {
+        E::Unstructured(nodes) => {
+            if matches!(nodes.last(), Some(UnstructuredNode::Goto(n)) if *n == target) {
+                nodes.pop();
+                if nodes.is_empty() {
+                    *exp = E::Seq(vec![]);
+                }
+                true
+            } else {
+                false
+            }
+        }
+        E::Seq(items) => {
+            let Some(last) = items.last_mut() else {
+                return false;
+            };
+            let popped = strip_tail_goto_to(last, target);
+            if popped && matches!(items.last(), Some(E::Seq(v)) if v.is_empty()) {
+                items.pop();
+            }
+            popped
+        }
+        E::IfElse(_, t, alt) => {
+            let ct = strip_tail_goto_to(t, target);
+            let ce = alt
+                .as_mut()
+                .as_mut()
+                .is_some_and(|a| strip_tail_goto_to(a, target));
+            ct || ce
+        }
+        E::Switch(_, _, arms) => {
+            let mut popped = false;
+            for (_, body) in arms.iter_mut() {
+                popped |= strip_tail_goto_to(body, target);
+            }
+            popped
+        }
+        E::Match(_, _, arms) => {
+            let mut popped = false;
+            for (_, _, body) in arms.iter_mut() {
+                popped |= strip_tail_goto_to(body, target);
+            }
+            popped
+        }
+        E::MatchLit(_, arms) => {
+            let mut popped = false;
+            for (_, body) in arms.iter_mut() {
+                popped |= strip_tail_goto_to(body, target);
+            }
+            popped
+        }
+        E::Block(_, body) => strip_tail_goto_to(body, target),
+        _ => false,
+    }
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/elide_tail_goto_to_block.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/elide_tail_goto_to_block.rs
@@ -30,7 +30,7 @@
 // This refinement does exactly that. It looks at every `Seq` and, for each adjacent pair
 // `(items[i], items[i+1])` where `items[i+1]` is `Block(N, _)`, walks the tail positions
 // of `items[i]` (last item of a `Seq`, both arms of `IfElse`, every arm of `Switch`/
-// `Match`/`MatchLit`) and pops any `Unstructured(…, Goto(N))` it finds. Empty
+// `Match`/`MatchLit`) and pops any `Unstructured(..., Goto(N))` it finds. Empty
 // `Unstructured` after the pop becomes an empty `Seq` (later refinements drop it).
 //
 // Conservative: only strips when `Block(N, _)` is the *immediately* next sibling. A goto

--- a/external-crates/move/crates/move-decompiler/src/refinement/goto_to_break.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/goto_to_break.rs
@@ -1,0 +1,103 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Rewrite forward `goto`s into labeled-block `break`s.
+//
+// After structuring, a forward control-flow edge the structurer couldn't lower to a
+// structured break/continue survives as `Unstructured(Goto(N))`, with `Block(N, body)`
+// (the goto's landing point) appearing LATER in the same `Seq`:
+//
+//   Seq[ ...prefix containing Unstructured(Goto(N))...,
+//        Block(N, body),
+//        ...suffix... ]
+//
+// Move's labeled blocks express exactly this: wrap the prefix in a `'label_N: { ... }`
+// block, turn each `goto 'label_N` into `break 'label_N`, and move the landing body out to
+// follow the block:
+//
+//   Seq[ Block(N, prefix_with_breaks), body..., suffix... ]
+//
+// Soundness: only fires when EVERY `Goto(N)` lives before the `Block(N)` (a forward jump).
+// A backward `Goto(N)` (target earlier than the goto) is a loop the structurer didn't
+// recover; labeled blocks can't express it, so we leave it as a goto. We also require the
+// block body itself to contain no `Goto(N)` (that would be a self-loop, again backward).
+//
+// The `Goto -> Break(Some(N))` rewrite produces a first-class `Break`; the pretty-printer
+// renders `Break(Some(N))` as `break 'label_N` when `N` is a block id (vs `break 'loop_N`
+// for loops). `Block(N)` continues to render as `'label_N: { ... }` because it's still
+// referenced (now by a break rather than a goto).
+
+use crate::{
+    ast::Exp,
+    refinement::{
+        Refine,
+        utils::{contains_goto, rewrite_gotos_as_breaks},
+    },
+};
+
+pub fn refine(exp: &mut Exp) -> bool {
+    let mut pass = GotoToBreak { changed: false };
+    pass.refine(exp);
+    pass.changed
+}
+
+struct GotoToBreak {
+    changed: bool,
+}
+
+impl Refine for GotoToBreak {
+    fn refine_custom(&mut self, exp: &mut Exp) -> bool {
+        if let Exp::Seq(items) = exp
+            && try_wrap(items)
+        {
+            self.changed = true;
+            return true;
+        }
+        false
+    }
+}
+
+fn try_wrap(items: &mut Vec<Exp>) -> bool {
+    for j in 0..items.len() {
+        let Exp::Block(n, body) = &items[j] else {
+            continue;
+        };
+        let n = *n;
+        // The block body must not jump to its own label (that would be a backward/self
+        // loop, not expressible as a forward break).
+        if contains_goto(body, n) {
+            continue;
+        }
+        // Earliest prefix item that jumps to `n`.
+        let Some(k) = (0..j).find(|&i| contains_goto(&items[i], n)) else {
+            continue;
+        };
+        // Forward-only: nothing after the block may jump to `n`.
+        if (j + 1..items.len()).any(|i| contains_goto(&items[i], n)) {
+            continue;
+        }
+
+        // Pull out items[k..=j]; the last is the Block, the rest is the prefix to wrap.
+        let mut removed: Vec<Exp> = items.splice(k..=j, std::iter::empty()).collect();
+        let block = removed.pop().unwrap();
+        let body_n = match block {
+            Exp::Block(_, b) => *b,
+            _ => unreachable!(),
+        };
+        // Rewrite gotos-to-`n` in the prefix into breaks-to-`n`.
+        for item in &mut removed {
+            rewrite_gotos_as_breaks(item, n);
+        }
+        let new_block = Exp::Block(n, Box::new(Exp::Seq(removed)));
+
+        // Splice back: the wrapped block, then the landing body's items, at position k.
+        let mut insert = vec![new_block];
+        match body_n {
+            Exp::Seq(v) => insert.extend(v),
+            other => insert.push(other),
+        }
+        items.splice(k..k, insert);
+        return true;
+    }
+    false
+}

--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -8,9 +8,11 @@ mod collapse_let_usage;
 mod collect_uses;
 mod compress_dispatch_cascade;
 mod dedupe_freeze;
+mod elide_tail_goto_to_block;
 mod extract_dispatch_writer;
 mod flatten_seq;
 mod fuse_let;
+mod goto_to_break;
 mod hoist_arm_assignments;
 mod hoist_dual_continue;
 mod hoist_shared_landing;
@@ -68,6 +70,8 @@ const REFINEMENTS: &[Refinement] = &[
     recover_flag::refine,
     recover_asserts::refine,
     hoist_shared_landing::refine,
+    elide_tail_goto_to_block::refine,
+    goto_to_break::refine,
     strip_loop_labels::refine,
     swap_continue_break::refine,
     swap_continue_break_else::refine,

--- a/external-crates/move/crates/move-decompiler/src/refinement/recover_flag.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/recover_flag.rs
@@ -1,21 +1,21 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Flag elimination + `||`-fold. Recovers `if (stale_a || stale_b || …) { X }` from the
+//! Flag elimination + `||`-fold. Recovers `if (stale_a || stale_b || ...) { X }` from the
 //! structured form the reaching-condition structurer leaves:
 //!
 //! ```text
 //!   let f = true;
 //!   <setup_a>
-//!   if (cond_a) { f = false } else { <setup_b>; if (cond_b) { f = false } else { … } };
+//!   if (cond_a) { f = false } else { <setup_b>; if (cond_b) { f = false } else { ... } };
 //!   if (f) { T } else { E }
 //! ```
 //!
 //! `f` is a flag set `false` exactly on the "stale" paths and read once at the trailing
-//! `if (f)`, so its final value is `¬(cond_a ∨ cond_b ∨ …)` and the test becomes
-//! `if (cond_a ∨ cond_b ∨ …) { E } else { T }`. Each later condition's setup (reused
+//! `if (f)`, so its final value is `!(cond_a || cond_b || ...)` and the test becomes
+//! `if (cond_a || cond_b || ...) { E } else { T }`. Each later condition's setup (reused
 //! per-feed locals like `get_price_unsafe`) rides into its `||` operand as a block
-//! expression, preserving the original short-circuit — a later feed's price is only fetched
+//! expression, preserving the original short-circuit - a later feed's price is only fetched
 //! when the earlier ones are fresh. The flag's declaration and assignments drop out.
 
 use move_core_types::runtime_value::MoveValue as Value;
@@ -53,7 +53,7 @@ fn try_recover(items: &mut Vec<Exp>) -> bool {
             continue;
         };
 
-        // Pull the test apart: `f` false ⇒ run the else; `f` true ⇒ run the then.
+        // Pull the test apart: `f` false => run the else; `f` true => run the then.
         let Exp::IfElse(_, then_t, else_t) = items[test_idx].clone() else {
             continue;
         };

--- a/external-crates/move/crates/move-decompiler/src/refinement/recover_flag.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/recover_flag.rs
@@ -1,21 +1,21 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Flag elimination + `||`-fold. Recovers `if (stale_a || stale_b || ...) { X }` from the
+//! Flag elimination + `||`-fold. Recovers `if (stale_a || stale_b || …) { X }` from the
 //! structured form the reaching-condition structurer leaves:
 //!
 //! ```text
 //!   let f = true;
 //!   <setup_a>
-//!   if (cond_a) { f = false } else { <setup_b>; if (cond_b) { f = false } else { ... } };
+//!   if (cond_a) { f = false } else { <setup_b>; if (cond_b) { f = false } else { … } };
 //!   if (f) { T } else { E }
 //! ```
 //!
 //! `f` is a flag set `false` exactly on the "stale" paths and read once at the trailing
-//! `if (f)`, so its final value is `!(cond_a || cond_b || ...)` and the test becomes
-//! `if (cond_a || cond_b || ...) { E } else { T }`. Each later condition's setup (reused
+//! `if (f)`, so its final value is `¬(cond_a ∨ cond_b ∨ …)` and the test becomes
+//! `if (cond_a ∨ cond_b ∨ …) { E } else { T }`. Each later condition's setup (reused
 //! per-feed locals like `get_price_unsafe`) rides into its `||` operand as a block
-//! expression, preserving the original short-circuit - a later feed's price is only fetched
+//! expression, preserving the original short-circuit — a later feed's price is only fetched
 //! when the earlier ones are fresh. The flag's declaration and assignments drop out.
 
 use move_core_types::runtime_value::MoveValue as Value;
@@ -53,7 +53,7 @@ fn try_recover(items: &mut Vec<Exp>) -> bool {
             continue;
         };
 
-        // Pull the test apart: `f` false => run the else; `f` true => run the then.
+        // Pull the test apart: `f` false ⇒ run the else; `f` true ⇒ run the then.
         let Exp::IfElse(_, then_t, else_t) = items[test_idx].clone() else {
             continue;
         };

--- a/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/utils.rs
@@ -313,6 +313,26 @@ pub(super) fn walk_children_mut(exp: &mut Exp, f: &mut impl FnMut(&mut Exp)) {
     }
 }
 
+/// True if `exp` syntactically contains an `Unstructured(Goto(n))`. Walks through nested
+/// `Unstructured` bodies and through arbitrary AST children.
+pub(super) fn contains_goto(exp: &Exp, n: Label) -> bool {
+    if let Exp::Unstructured(nodes) = exp {
+        return nodes.iter().any(|node| match node {
+            UnstructuredNode::Goto(l) => *l == n,
+            UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                contains_goto(body, n)
+            }
+        });
+    }
+    let mut found = false;
+    walk_children(exp, &mut |c| {
+        if contains_goto(c, n) {
+            found = true;
+        }
+    });
+    found
+}
+
 /// Replace every `Unstructured(Goto(target))` reachable in `exp` with `Break(Some(target))`.
 /// A single-goto `Unstructured` collapses to a bare `Break`; a goto among other unstructured
 /// nodes becomes an `Unstructured(Statement(Break))` in place.

--- a/external-crates/move/crates/move-decompiler/src/translate.rs
+++ b/external-crates/move/crates/move-decompiler/src/translate.rs
@@ -409,7 +409,7 @@ fn extract_input(block: &SB::BasicBlock, next_block_label: Option<SB::Label>) ->
 
 /// Collect every label that a surviving `Unstructured(Goto(_))` targets. Block markers
 /// whose ID is in this set are kept (for cross-referencing); the rest are stripped.
-fn collect_goto_targets(exp: &Exp) -> HashSet<u64> {
+pub(crate) fn collect_goto_targets(exp: &Exp) -> HashSet<u64> {
     let mut out = HashSet::new();
     collect_goto_targets_into(exp, &mut out);
     out

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/ART20.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/ART20.mv.snap
@@ -241,20 +241,9 @@ const C42: vector<u8> = vector[104u8, 116u8, 116u8, 112u8, 115u8, 58u8, 47u8, 47
 // -- functions -- 
 
 public entry fun add_to_deny_list(l0: &mut CollectionCap, l1: vector<address>, l2: &mut TxContext) {
-    let l3;
     let l9 = tx_context::sender(freeze(l2));
     let l5 = &l1.len();
-    if (l5 > 0u64) {
-        l3 = l5 <= C29;
-        unstructured {
-            goto 'label_18;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_18;
-        }
-    };
+    let l3 = l5 > 0u64 && l5 <= C29;
     /* block 18 */;
     assert!(l3, C11);
     assert!(l9 == *(&l0.creator), C1);
@@ -323,21 +312,10 @@ public entry fun batch_burn_art20(l0: vector<NFT>, l1: &mut CollectionCap, l2: v
 }
 
 public entry fun batch_burn_art20_by_asset_ids(l0: &mut CollectionCap, l1: vector<NFT>, l2: vector<UserBalance>, l3: vector<u64>, l4: &mut TxContext) {
-    let l5;
     let l22 = tx_context::sender(freeze(l4));
     let l13 = xf_ART20::get_collection_cap_id(freeze(l0));
     let l8 = &l3.len();
-    if (l8 > 0u64) {
-        l5 = l8 <= C29;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_22;
-        }
-    };
+    let l5 = l8 > 0u64 && l8 <= C29;
     /* block 22 */;
     assert!(l5, C11);
     assert!(*(&l0.current_supply) >= l8, C4);
@@ -424,18 +402,7 @@ public entry fun batch_update_art20_image_uri_by_asset_ids(l0: &CollectionCap, l
     xf_ART20::check_deny_list_restrictions(l0, l17);
     let l7 = &l2.len();
     assert!(l7 == &l3.len(), C0);
-    let l5;
-    if (l7 > 0u64) {
-        l5 = l7 <= C29;
-        unstructured {
-            goto 'label_45;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_45;
-        }
-    };
+    let l5 = l7 > 0u64 && l7 <= C29;
     /* block 45 */;
     assert!(l5, C11);
     let l11 = 0u64;
@@ -490,47 +457,19 @@ public entry fun batch_update_metadata(l0: &CollectionCap, l1: vector<NFT>, l2: 
     let l10 = tx_context::sender(freeze(l6));
     let l8 = xf_ART20::get_collection_cap_id(l0);
     if (option::is_some(&l2)) {
-        assert!(string::length(option::borrow(&l2)) <= 128u64, C10);
-        unstructured {
-            goto 'label_24;
-        }
-    } else {
-        unstructured {
-            goto 'label_24;
-        }
+        assert!(string::length(option::borrow(&l2)) <= 128u64, C10)
     };
     /* block 24 */;
     if (option::is_some(&l3)) {
-        assert!(string::length(option::borrow(&l3)) <= 1000u64, C10);
-        unstructured {
-            goto 'label_38;
-        }
-    } else {
-        unstructured {
-            goto 'label_38;
-        }
+        assert!(string::length(option::borrow(&l3)) <= 1000u64, C10)
     };
     /* block 38 */;
     if (option::is_some(&l4)) {
-        assert!(option::borrow(&l4).len() <= 256u64, C10);
-        unstructured {
-            goto 'label_52;
-        }
-    } else {
-        unstructured {
-            goto 'label_52;
-        }
+        assert!(option::borrow(&l4).len() <= 256u64, C10)
     };
     /* block 52 */;
     if (option::is_some(&l5)) {
-        assert!(option::borrow(&l5).len() <= 256u64, C10);
-        unstructured {
-            goto 'label_66;
-        }
-    } else {
-        unstructured {
-            goto 'label_66;
-        }
+        assert!(option::borrow(&l5).len() <= 256u64, C10)
     };
     /* block 66 */;
     let l9 = 0u64;
@@ -561,21 +500,10 @@ public entry fun batch_update_metadata(l0: &CollectionCap, l1: vector<NFT>, l2: 
 }
 
 public entry fun batch_update_metadata_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>, l2: vector<u64>, l3: Option<String>, l4: Option<String>, l5: Option<vector<u8>>, l6: Option<vector<u8>>, l7: &mut TxContext) {
-    let l8;
     let l22 = tx_context::sender(freeze(l7));
     let l14 = xf_ART20::get_collection_cap_id(l0);
     let l10 = &l2.len();
-    if (l10 > 0u64) {
-        l8 = l10 <= C29;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
+    let l8 = l10 > 0u64 && l10 <= C29;
     /* block 21 */;
     assert!(l8, C11);
     if (option::is_some(&l3)) {
@@ -583,14 +511,7 @@ public entry fun batch_update_metadata_by_asset_ids(l0: &CollectionCap, l1: vect
         assert!(string::length(l19) <= 128u64, C10);
         let l12 = string::as_bytes(l19);
         assert!(l12.len() <= 512u64, C10);
-        assert!(l12.len() > 0u64, C10);
-        unstructured {
-            goto 'label_79;
-        }
-    } else {
-        unstructured {
-            goto 'label_79;
-        }
+        assert!(l12.len() > 0u64, C10)
     };
     /* block 79 */;
     if (option::is_some(&l4)) {
@@ -598,40 +519,19 @@ public entry fun batch_update_metadata_by_asset_ids(l0: &CollectionCap, l1: vect
         assert!(string::length(l15) <= 1000u64, C10);
         let l13 = string::as_bytes(l15);
         assert!(l13.len() <= 4000u64, C10);
-        assert!(l13.len() > 0u64, C10);
-        unstructured {
-            goto 'label_128;
-        }
-    } else {
-        unstructured {
-            goto 'label_128;
-        }
+        assert!(l13.len() > 0u64, C10)
     };
     /* block 128 */;
     if (option::is_some(&l5)) {
         let l24 = option::borrow(&l5);
         assert!(l24.len() <= 256u64, C10);
-        assert!(l24.len() > 0u64, C10);
-        unstructured {
-            goto 'label_160;
-        }
-    } else {
-        unstructured {
-            goto 'label_160;
-        }
+        assert!(l24.len() > 0u64, C10)
     };
     /* block 160 */;
     if (option::is_some(&l6)) {
         let l18 = option::borrow(&l6);
         assert!(l18.len() <= 256u64, C10);
-        assert!(l18.len() > 0u64, C10);
-        unstructured {
-            goto 'label_192;
-        }
-    } else {
-        unstructured {
-            goto 'label_192;
-        }
+        assert!(l18.len() > 0u64, C10)
     };
     let (l17, l21);
     /* block 192 */;
@@ -688,18 +588,7 @@ public entry fun batch_update_token_logo_uri(l0: vector<NFT>, l1: vector<vector<
     let l9 = &l0.len();
     assert!(*(&l2.is_mutable), C2);
     assert!(l9 == &l1.len(), C0);
-    let l4;
-    if (l9 > 0u64) {
-        l4 = l9 <= C29;
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        l4 = false;
-        unstructured {
-            goto 'label_40;
-        }
-    };
+    let l4 = l9 > 0u64 && l9 <= C29;
     /* block 40 */;
     assert!(l4, C11);
     xf_ART20::check_deny_list_restrictions(l2, l10);
@@ -842,14 +731,7 @@ public fun drop_collection_cap(l0: CollectionCap, l1: &mut TxContext) {
     let CollectionCap { id: reg_15, max_supply: reg_16, current_supply: reg_17, creator: reg_18, name: reg_19, description: reg_20, uri: reg_21, logo_uri: reg_22, is_mutable: reg_23, is_mintable: reg_24, has_deny_list_authority: reg_25, value_source: reg_26, is_api_source: reg_27 } = l0;
     let l2 = reg_15 : 0x2::object::UID;
     if (dynamic_field::exists_(&l2, DenyListKey { dummy_field: false })) {
-        table::drop(dynamic_field::remove(&mut l2, DenyListKey { dummy_field: false }));
-        unstructured {
-            goto 'label_45;
-        }
-    } else {
-        unstructured {
-            goto 'label_45;
-        }
+        table::drop(dynamic_field::remove(&mut l2, DenyListKey { dummy_field: false }))
     };
     /* block 45 */;
     object::delete(l2)
@@ -904,7 +786,6 @@ public fun get_collection_current_supply(l0: &CollectionCap): u64 {
 }
 
 public fun get_collection_details(l0: &CollectionCap): ( ID, address, String, String, Url, Url, u64, u64, bool, bool, u64) {
-    let l1;
     let l3 = xf_ART20::get_collection_cap_id(l0);
     let l2 = *(&l0.creator);
     let l11 = *(&l0.name);
@@ -915,16 +796,10 @@ public fun get_collection_details(l0: &CollectionCap): ( ID, address, String, St
     let l6 = *(&l0.max_supply);
     let l5 = *(&l0.is_mutable);
     let l4 = *(&l0.has_deny_list_authority);
-    if (xf_ART20::has_deny_list(l0)) {
-        l1 = xf_ART20::deny_list_size(l0);
-        unstructured {
-            goto 'label_50;
-        }
+    let l1 = if (xf_ART20::has_deny_list(l0)) {
+        xf_ART20::deny_list_size(l0)
     } else {
-        l1 = 0u64;
-        unstructured {
-            goto 'label_50;
-        }
+        0u64
     };
     /* block 50 */;
     return (l3, l2, l11, l10, l9, l8, l7, l6, l5, l4, l1)
@@ -1027,20 +902,13 @@ public fun get_holder_info(l0: &vector<NFT>, l1: &CollectionCap, l2: &vector<Use
         };
         l11 = l11 + 1u64;
     };
-    let l4;
     let l10 = xf_ART20::has_deny_list(l1);
     let l8 = xf_ART20::has_deny_list_authority(l1);
     let l12 = xf_ART20::is_denied(l1, l3);
-    if (l10) {
-        l4 = xf_ART20::deny_list_size(l1);
-        unstructured {
-            goto 'label_57;
-        }
+    let l4 = if (l10) {
+        xf_ART20::deny_list_size(l1)
     } else {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_57;
-        }
+        0u64
     };
     let (l13, l16, l17, l18, l19, l20, l21, l5, l9);
     /* block 57 */;
@@ -1194,27 +1062,13 @@ public fun is_denied(l0: &CollectionCap, l1: address): bool {
 public entry fun mint_additional_art20(l0: &mut CollectionCap, l1: u64, l2: &mut TokenIdCounter, l3: vector<UserBalance>, l4: &Clock, l5: &mut TxContext) {
     assert!(*(&l0.is_mutable), C21);
     assert!(tx_context::sender(freeze(l5)) == *(&l0.creator), C1);
-    let l6;
-    if (*(&l0.max_supply) == 0u64) {
-        l6 = true;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = *(&l0.current_supply) + l1 <= *(&l0.max_supply);
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = *(&l0.max_supply) == 0u64 || *(&l0.current_supply) + l1 <= *(&l0.max_supply);
     /* block 53 */;
     assert!(l6, C13);
     let l11 = object::uid_to_inner(&l0.id);
     let l14 = tx_context::sender(freeze(l5));
     if (vector::is_empty(&l3)) {
-        transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14);
-        unstructured {
-            goto 'label_132;
-        }
+        transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14)
     } else {
         let l10 = false;
         let l12 = 0u64;
@@ -1270,41 +1124,17 @@ public entry fun mint_art20<T0>(l0: vector<u8>, l1: vector<u8>, l2: u64, l3: u64
         assert!(type_name::get() == *(&l11.fee_coin_type), C20);
         if (l20 > *(&l11.fee_amount)) {
             let l21 = l20 - *(&l11.fee_amount);
-            transfer::public_transfer(coin::split(&mut l12, l21, l14), tx_context::sender(freeze(l14)));
-            unstructured {
-                goto 'label_129;
-            }
-        } else {
-            unstructured {
-                goto 'label_129;
-            }
+            transfer::public_transfer(coin::split(&mut l12, l21, l14), tx_context::sender(freeze(l14)))
         };
         /* block 129 */;
-        transfer::public_transfer(l12, *(&l11.fee_collector));
-        unstructured {
-            goto 'label_142;
-        }
+        transfer::public_transfer(l12, *(&l11.fee_collector))
     } else {
-        transfer::public_transfer(l12, tx_context::sender(freeze(l14)));
-        unstructured {
-            goto 'label_142;
-        }
+        transfer::public_transfer(l12, tx_context::sender(freeze(l14)))
     };
     /* block 142 */;
     assert!(l3 <= C28, C13);
     assert!(l2 <= C28, C13);
-    let l15;
-    if (l3 == 0u64) {
-        l15 = true;
-        unstructured {
-            goto 'label_179;
-        }
-    } else {
-        l15 = l2 <= l3;
-        unstructured {
-            goto 'label_179;
-        }
-    };
+    let l15 = l3 == 0u64 || l2 <= l3;
     /* block 179 */;
     assert!(l15, C19);
     assert!(*(&l10.last_id) <= C27 - l2, C12);
@@ -1334,20 +1164,9 @@ public entry fun mint_art20<T0>(l0: vector<u8>, l1: vector<u8>, l2: u64, l3: u64
 }
 
 public entry fun remove_from_deny_list(l0: &mut CollectionCap, l1: vector<address>, l2: &mut TxContext) {
-    let l3;
     let l9 = tx_context::sender(freeze(l2));
     let l5 = &l1.len();
-    if (l5 > 0u64) {
-        l3 = l5 <= C29;
-        unstructured {
-            goto 'label_18;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_18;
-        }
-    };
+    let l3 = l5 > 0u64 && l5 <= C29;
     /* block 18 */;
     assert!(l3, C11);
     assert!(l9 == *(&l0.creator), C1);
@@ -1404,22 +1223,13 @@ public entry fun set_collection_value_source(l0: &mut CollectionCap, l1: vector<
         };
         assert!(__c84, C16)
     } else {
-        assert!(string::length(&l9) == 64u64, C17);
-        unstructured {
-            goto 'label_105;
-        }
+        assert!(string::length(&l9) == 64u64, C17)
     };
     /* block 105 */;
     if (option::is_none(&l0.value_source)) {
-        *(&mut l0.value_source) = option::some(l9);
-        unstructured {
-            goto 'label_120;
-        }
+        *(&mut l0.value_source) = option::some(l9)
     } else {
-        *(option::borrow_mut(&mut l0.value_source)) = l9;
-        unstructured {
-            goto 'label_120;
-        }
+        *(option::borrow_mut(&mut l0.value_source)) = l9
     };
     /* block 120 */;
     *(&mut l0.is_api_source) = l2;
@@ -1709,14 +1519,7 @@ public entry fun update_metadata_by_asset_id(l0: &CollectionCap, l1: vector<NFT>
         assert!(string::length(l15) <= 128u64, C10);
         let l16 = string::as_bytes(l15);
         assert!(l16.len() <= 512u64, C10);
-        assert!(l16.len() > 0u64, C10);
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        unstructured {
-            goto 'label_50;
-        }
+        assert!(l16.len() > 0u64, C10)
     };
     /* block 50 */;
     if (option::is_some(&l4)) {
@@ -1724,40 +1527,19 @@ public entry fun update_metadata_by_asset_id(l0: &CollectionCap, l1: vector<NFT>
         assert!(string::length(l12) <= 1000u64, C10);
         let l11 = string::as_bytes(l12);
         assert!(l11.len() <= 4000u64, C10);
-        assert!(l11.len() > 0u64, C10);
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        unstructured {
-            goto 'label_93;
-        }
+        assert!(l11.len() > 0u64, C10)
     };
     /* block 93 */;
     if (option::is_some(&l5)) {
         let l20 = option::borrow(&l5);
         assert!(l20.len() <= 256u64, C10);
-        assert!(l20.len() > 0u64, C10);
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        unstructured {
-            goto 'label_121;
-        }
+        assert!(l20.len() > 0u64, C10)
     };
     /* block 121 */;
     if (option::is_some(&l6)) {
         let l14 = option::borrow(&l6);
         assert!(l14.len() <= 256u64, C10);
-        assert!(l14.len() > 0u64, C10);
-        unstructured {
-            goto 'label_149;
-        }
-    } else {
-        unstructured {
-            goto 'label_149;
-        }
+        assert!(l14.len() > 0u64, C10)
     };
     let (l13, l19);
     /* block 149 */;
@@ -1803,53 +1585,25 @@ public entry fun update_metadata_by_object(l0: &mut NFT, l1: &CollectionCap, l2:
     if (option::is_some(&l2)) {
         let l9 = option::extract(&mut l2);
         assert!(string::length(&l9) <= 128u64, C10);
-        *(&mut l0.name) = l9;
-        unstructured {
-            goto 'label_60;
-        }
-    } else {
-        unstructured {
-            goto 'label_60;
-        }
+        *(&mut l0.name) = l9
     };
     /* block 60 */;
     if (option::is_some(&l3)) {
         let l7 = option::extract(&mut l3);
         assert!(string::length(&l7) <= 1000u64, C10);
-        *(&mut l0.description) = l7;
-        unstructured {
-            goto 'label_80;
-        }
-    } else {
-        unstructured {
-            goto 'label_80;
-        }
+        *(&mut l0.description) = l7
     };
     /* block 80 */;
     if (option::is_some(&l4)) {
         let l10 = option::extract(&mut l4);
         assert!(&l10.len() <= 256u64, C10);
-        *(&mut l0.uri) = url::new_unsafe_from_bytes(l10);
-        unstructured {
-            goto 'label_101;
-        }
-    } else {
-        unstructured {
-            goto 'label_101;
-        }
+        *(&mut l0.uri) = url::new_unsafe_from_bytes(l10)
     };
     /* block 101 */;
     if (option::is_some(&l5)) {
         let l8 = option::extract(&mut l5);
         assert!(&l8.len() <= 256u64, C10);
-        *(&mut l0.logo_uri) = url::new_unsafe_from_bytes(l8);
-        unstructured {
-            goto 'label_122;
-        }
-    } else {
-        unstructured {
-            goto 'label_122;
-        }
+        *(&mut l0.logo_uri) = url::new_unsafe_from_bytes(l8)
     };
     /* block 122 */;
     event::emit(MetadataUpdateEvent { id: object::uid_to_inner(&l0.id), new_name: *(&l0.name), new_description: *(&l0.description) })

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/acbdd009a143591b1.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/acbdd009a143591b1.mv.snap
@@ -58,17 +58,12 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
         let l29 = l10;
         let l28 = l11;
         let l39 = l12;
-        let l33 = l13;
-        let l34 = l14;
         let l51 = a2ec4300f6df080d1::a558d3d4811fa675d(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28);
         let l52 = a2ec4300f6df080d1::ac4104d3c58483259(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28, l51);
+        /* block 440 */;
         if (a10868438248226c1::ad3e462cd25333e7f(l51, l39) > l52) {
-            a2ec4300f6df080d1::a5eefc623c389ac57(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l33, l34);
-            unstructured {
-                goto 'label_440;
-            }
+            a2ec4300f6df080d1::a5eefc623c389ac57(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l13, l14)
         } else {
-            let l19;
             let l38 = a2ec4300f6df080d1::a99ab6d0cf8644a81(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28);
             let l54 = a2ec4300f6df080d1::aa8fecb213cfb45e1(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28);
             let l37 = i32::div(l38, l54);
@@ -80,79 +75,39 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
             let l46 = a10868438248226c1::ab78d0325509532d4(l25, freeze(l27));
             let l58 = l47;
             let l64 = a783956f993d811bc::ae2894da560e9dfaf(l25);
-            if (l58 < l64) {
-                l19 = l58;
-                unstructured {
-                    goto 'label_187;
-                }
+            let l19 = if (l58 < l64) {
+                l58
             } else {
-                l19 = l64;
-                unstructured {
-                    goto 'label_187;
-                }
+                l64
             };
             let l20;
             /* block 187 */;
             l47 = l19;
             let l59 = l46;
             let l65 = a783956f993d811bc::a8f57f404176c397b(l25);
-            if (l59 < l65) {
-                l20 = l59;
-                unstructured {
-                    goto 'label_203;
-                }
+            l20 = if (l59 < l65) {
+                l59
             } else {
-                l20 = l65;
-                unstructured {
-                    goto 'label_203;
-                }
+                l65
             };
             let (l21, l36);
             /* block 203 */;
             l46 = l20;
             l36 = a2ec4300f6df080d1::a1d4c92881210dfd5(l40, l24);
-            if (ad9e4d11aecc532fa::a86e56d31feeb19a6(&l36) == l26) {
-                l21 = ad9e4d11aecc532fa::a21b8c64204576499(&l36) == l23;
-                unstructured {
-                    goto 'label_222;
-                }
-            } else {
-                l21 = false;
-                unstructured {
-                    goto 'label_222;
-                }
-            };
+            l21 = ad9e4d11aecc532fa::a86e56d31feeb19a6(&l36) == l26 && ad9e4d11aecc532fa::a21b8c64204576499(&l36) == l23;
             /* block 222 */;
             if (l21) {
-                let l22;
                 let l53 = a10868438248226c1::aa2c4ceebf26949f7(l25, l46, l47, l39);
                 let l35 = a10868438248226c1::aa2c4ceebf26949f7(l25, ad9e4d11aecc532fa::ae18556b7140949ca(&l36), ad9e4d11aecc532fa::a888b107d980228f4(&l36), l39);
                 let l60 = l53;
                 let l66 = l35;
-                if (l60 > l66) {
-                    l22 = l60 - l66;
-                    unstructured {
-                        goto 'label_255;
-                    }
-                } else {
-                    l22 = l66 - l60;
-                    unstructured {
-                        goto 'label_255;
-                    }
-                };
                 /* block 255 */;
-                if (l22 < l53 / 2u64) {
-                    unstructured {
-                        goto 'label_440;
-                    }
+                if (if (l60 > l66) {
+                    l60 - l66
                 } else {
-                    unstructured {
-                        goto 'label_292;
-                    }
-                }
-            } else {
-                unstructured {
-                    goto 'label_292;
+                    l66 - l60
+                } < l53 / 2u64) {
+                    break 'loop_440
                 }
             };
             let l16;
@@ -161,16 +116,10 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
             let l43 = a2ec4300f6df080d1::a7235c62aa5b27437(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28, l26, l23, l46, true);
             let l61 = l44;
             let l67 = l43;
-            if (l61 < l67) {
-                l16 = l61;
-                unstructured {
-                    goto 'label_337;
-                }
+            l16 = if (l61 < l67) {
+                l61
             } else {
-                l16 = l67;
-                unstructured {
-                    goto 'label_337;
-                }
+                l67
             };
             let l17;
             /* block 337 */;
@@ -178,66 +127,36 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
             let l48 = a2ec4300f6df080d1::a8fa7d5a111cd2750(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28) * a783956f993d811bc::afa416ea5d7b9d0f7(l25);
             let l62 = l41;
             let l68 = l48;
-            if (l62 < l68) {
-                l17 = l62;
-                unstructured {
-                    goto 'label_367;
-                }
+            l17 = if (l62 < l68) {
+                l62
             } else {
-                l17 = l68;
-                unstructured {
-                    goto 'label_367;
-                }
+                l68
             };
             let (l18, l42);
             /* block 367 */;
             l42 = l17;
             let l63 = l42;
             let l69 = ad9e4d11aecc532fa::afb1904d62fe08653(&l36);
-            if (l63 > l69) {
-                l18 = l63 - l69;
-                unstructured {
-                    goto 'label_387;
-                }
+            l18 = if (l63 > l69) {
+                l63 - l69
             } else {
-                l18 = l69 - l63;
-                unstructured {
-                    goto 'label_387;
-                }
+                l69 - l63
             };
             /* block 387 */;
             if (l18 < l42 / 2u128) {
-                unstructured {
-                    goto 'label_440;
-                }
+                
             } else {
-                a2ec4300f6df080d1::a6dc79187e3841ff0(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l26, l23, l42, l33, l34);
-                unstructured {
-                    goto 'label_440;
-                }
+                a2ec4300f6df080d1::a6dc79187e3841ff0(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l26, l23, l42, l13, l14)
             }
-        };
-        /* block 440 */
+        }
     }
 }
 
 public(friend) fun a94cdf867cab7cc5c(l0: &A0ea878587b719a64, l1: &mut BalanceManager, l2: &mut Ad1f26f3c041612f2, l3: &mut x7_Pool<SUI, USDC>, l4: &Version, l5: &mut Pool<USDC, SUI>, l6: &GlobalConfig, l7: &mut RewarderGlobalVault, l8: &mut x9_Pool<SUI, USDC, FEE500BPS>, l9: &Versioned, l10: &mut x3_Pool<SUI, USDC>, l11: &x3_GlobalConfig, l12: u64, l13: u64, l14: &Clock, l15: &mut TxContext) {
-    let l16;
     let l18 = a10868438248226c1::a9d9f98ebd95b9dad(l0, freeze(l1));
     let l17 = a10868438248226c1::ab78d0325509532d4(l0, freeze(l1));
-    if (l12 <= l18) {
-        l16 = l13 <= l17;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l16 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    if (l16) {
+    if (l12 <= l18 && l13 <= l17) {
         
     } else {
         a2ec4300f6df080d1::a5eefc623c389ac57(&a2ec4300f6df080d1::a099d08408fdb4a75(), l1, l2, l3, l4, l5, l6, l7, l8, l9, l10, l11, l14, l15)

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/almm_bin_tree.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/almm_bin_tree.mv.snap
@@ -32,18 +32,11 @@ const C4: u64 = 3u64;
 
 public fun add(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l5 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l5)) {
-        l2 = *(vec_map::get(&l0.level2, &l5));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l5)) {
+        *(vec_map::get(&l0.level2, &l5))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l6 = l2;
@@ -51,49 +44,24 @@ public fun add(l0: &mut BinTree, l1: u32): bool {
     if (l6 != l8) {
         if (vec_map::contains(&l0.level2, &l5)) {
             (reg_41, reg_42) = vec_map::remove(&mut l0.level2, &l5);
-            unstructured {
-                goto 'label_57;
-            }
-        } else {
-            unstructured {
-                goto 'label_57;
-            }
         };
         /* block 57 */;
         vec_map::insert(&mut l0.level2, l5, l8);
         if (l6 == 0u256) {
-            let l3;
             let l4 = l5 >> 8u8;
-            if (vec_map::contains(&l0.level1, &l4)) {
+            let l3 = if (vec_map::contains(&l0.level1, &l4)) {
                 let reg_61;
                 (reg_60, reg_61) = vec_map::remove(&mut l0.level1, &l4);
-                l3 = reg_61;
-                unstructured {
-                    goto 'label_86;
-                }
+                reg_61
             } else {
-                l3 = 0u256;
-                unstructured {
-                    goto 'label_86;
-                }
+                0u256
             };
             /* block 86 */;
             let l7 = l3;
             let l9 = l7 | 1u256 << l5 & C1as u256as u8;
             vec_map::insert(&mut l0.level1, l4, l9);
             if (l7 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8;
-                unstructured {
-                    goto 'label_126;
-                }
-            } else {
-                unstructured {
-                    goto 'label_126;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_126;
+                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8
             }
         };
         /* block 126 */;
@@ -134,13 +102,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = almm_bin_tree::closest_bit_left(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -157,13 +118,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_86, reg_87) = bit_math::least_significant_bit(*(vec_map::get(&l0.level2, &l14)));
             let l16 = reg_86;
             return (l14 << 8u8 | l16as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_127;
-        }
-    } else {
-        unstructured {
-            goto 'label_127;
         }
     };
     /* block 127 */;
@@ -182,13 +136,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_143, reg_144) = bit_math::least_significant_bit(*(vec_map::get(&l0.level2, &l15)));
             let l18 = reg_143;
             return (l15 << 8u8 | l18as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_206;
-        }
-    } else {
-        unstructured {
-            goto 'label_206;
         }
     };
     /* block 206 */;
@@ -204,13 +151,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = almm_bin_tree::closest_bit_right(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -226,13 +166,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_80, reg_81) = bit_math::most_significant_bit(*(vec_map::get(&l0.level2, &l14)));
             let l16 = reg_80;
             return (l14 << 8u8 | l16as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_117;
-        }
-    } else {
-        unstructured {
-            goto 'label_117;
         }
     };
     /* block 117 */;
@@ -251,13 +184,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_137, reg_138) = bit_math::most_significant_bit(*(vec_map::get(&l0.level2, &l15)));
             let l18 = reg_137;
             return (l15 << 8u8 | l18as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_196;
-        }
-    } else {
-        unstructured {
-            goto 'label_196;
         }
     };
     /* block 196 */;
@@ -266,18 +192,11 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
 
 public fun remove(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l4 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l4)) {
-        l2 = *(vec_map::get(&l0.level2, &l4));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l4)) {
+        *(vec_map::get(&l0.level2, &l4))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l5 = l2;
@@ -292,18 +211,7 @@ public fun remove(l0: &mut BinTree, l1: u32): bool {
             let l8 = reg_54 & C0 - 1u256 << l4 & 255u256as u8;
             vec_map::insert(&mut l0.level1, l3, l8);
             if (l8 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8;
-                unstructured {
-                    goto 'label_113;
-                }
-            } else {
-                unstructured {
-                    goto 'label_113;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_113;
+                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8
             }
         };
         /* block 113 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/bet_manager.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/bet_manager.mv.snap
@@ -143,128 +143,37 @@ public fun fill_bet_number(l0: &mut Bet, l1: u64) {
 }
 
 public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
-    let l3;
-    if (l1 == C0) {
-        l3 = true;
-        unstructured {
-            goto 'label_25;
-        }
-    } else {
-        if (l1 == C1) {
-            l3 = true;
-            unstructured {
-                goto 'label_25;
-            }
-        } else {
-            if (l1 == C9) {
-                l3 = true;
-                unstructured {
-                    goto 'label_25;
-                }
-            } else {
-                l3 = l1 == C10;
-                unstructured {
-                    goto 'label_25;
-                }
-            }
-        }
-    };
+    let l3 = l1 == C0 || l1 == C1 || l1 == C9 || l1 == C10;
     /* block 25 */;
     if (l3) {
         return bet_manager::mul(l0, 1000000000u64)
     };
-    let l12;
-    if (l1 == C14) {
-        l12 = true;
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        l12 = l1 == C16;
-        unstructured {
-            goto 'label_42;
-        }
-    };
+    let l12 = l1 == C14 || l1 == C16;
     /* block 42 */;
     if (l12) {
-        let l13;
         let l21 = *(option::borrow(&l2));
-        if (l21 == 4u64) {
-            l13 = true;
-            unstructured {
-                goto 'label_59;
-            }
-        } else {
-            l13 = l21 == 10u64;
-            unstructured {
-                goto 'label_59;
-            }
-        };
+        let l13 = l21 == 4u64 || l21 == 10u64;
         /* block 59 */;
         if (l13) {
             return bet_manager::mul(l0, 2000000000u64)
         };
-        let l14;
-        if (l21 == 5u64) {
-            l14 = true;
-            unstructured {
-                goto 'label_76;
-            }
-        } else {
-            l14 = l21 == 9u64;
-            unstructured {
-                goto 'label_76;
-            }
-        };
+        let l14 = l21 == 5u64 || l21 == 9u64;
         /* block 76 */;
         if (l14) {
             return bet_manager::mul(l0, 1500000000u64)
         };
         return bet_manager::mul(l0, 1200000000u64)
     };
-    let l15;
-    if (l1 == C15) {
-        l15 = true;
-        unstructured {
-            goto 'label_97;
-        }
-    } else {
-        l15 = l1 == C17;
-        unstructured {
-            goto 'label_97;
-        }
-    };
+    let l15 = l1 == C15 || l1 == C17;
     /* block 97 */;
     if (l15) {
-        let l16;
         let l22 = *(option::borrow(&l2));
-        if (l22 == 4u64) {
-            l16 = true;
-            unstructured {
-                goto 'label_114;
-            }
-        } else {
-            l16 = l22 == 10u64;
-            unstructured {
-                goto 'label_114;
-            }
-        };
+        let l16 = l22 == 4u64 || l22 == 10u64;
         /* block 114 */;
         if (l16) {
             return bet_manager::mul(l0, 500000000u64)
         };
-        let l17;
-        if (l22 == 5u64) {
-            l17 = true;
-            unstructured {
-                goto 'label_131;
-            }
-        } else {
-            l17 = l22 == 9u64;
-            unstructured {
-                goto 'label_131;
-            }
-        };
+        let l17 = l22 == 5u64 || l22 == 9u64;
         /* block 131 */;
         if (l17) {
             return bet_manager::mul(l0, 666666666u64)
@@ -272,35 +181,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 833333333u64)
     };
     if (l1 == C3) {
-        let l18;
         let l23 = *(option::borrow(&l2));
-        if (l23 == 4u64) {
-            l18 = true;
-            unstructured {
-                goto 'label_160;
-            }
-        } else {
-            l18 = l23 == 10u64;
-            unstructured {
-                goto 'label_160;
-            }
-        };
+        let l18 = l23 == 4u64 || l23 == 10u64;
         /* block 160 */;
         if (l18) {
             return bet_manager::mul(l0, 1800000000u64)
         };
-        let l19;
-        if (l23 == 5u64) {
-            l19 = true;
-            unstructured {
-                goto 'label_177;
-            }
-        } else {
-            l19 = l23 == 9u64;
-            unstructured {
-                goto 'label_177;
-            }
-        };
+        let l19 = l23 == 5u64 || l23 == 9u64;
         /* block 177 */;
         if (l19) {
             return bet_manager::mul(l0, 1400000000u64)
@@ -308,35 +195,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 1166666666u64)
     };
     if (l1 == C4) {
-        let l4;
         let l24 = *(option::borrow(&l2));
-        if (l24 == 4u64) {
-            l4 = true;
-            unstructured {
-                goto 'label_206;
-            }
-        } else {
-            l4 = l24 == 10u64;
-            unstructured {
-                goto 'label_206;
-            }
-        };
+        let l4 = l24 == 4u64 || l24 == 10u64;
         /* block 206 */;
         if (l4) {
             return bet_manager::mul(l0, 2000000000u64)
         };
-        let l5;
-        if (l24 == 5u64) {
-            l5 = true;
-            unstructured {
-                goto 'label_223;
-            }
-        } else {
-            l5 = l24 == 9u64;
-            unstructured {
-                goto 'label_223;
-            }
-        };
+        let l5 = l24 == 5u64 || l24 == 9u64;
         /* block 223 */;
         if (l5) {
             return bet_manager::mul(l0, 1500000000u64)
@@ -344,35 +209,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 1200000000u64)
     };
     if (l1 == C5) {
-        let l6;
         let l25 = *(option::borrow(&l2));
-        if (l25 == 4u64) {
-            l6 = true;
-            unstructured {
-                goto 'label_252;
-            }
-        } else {
-            l6 = l25 == 10u64;
-            unstructured {
-                goto 'label_252;
-            }
-        };
+        let l6 = l25 == 4u64 || l25 == 10u64;
         /* block 252 */;
         if (l6) {
             return bet_manager::mul(l0, 500000000u64)
         };
-        let l7;
-        if (l25 == 5u64) {
-            l7 = true;
-            unstructured {
-                goto 'label_269;
-            }
-        } else {
-            l7 = l25 == 9u64;
-            unstructured {
-                goto 'label_269;
-            }
-        };
+        let l7 = l25 == 5u64 || l25 == 9u64;
         /* block 269 */;
         if (l7) {
             return bet_manager::mul(l0, 666666666u64)
@@ -383,35 +226,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 3000000000u64)
     };
     if (l1 == C11) {
-        let l8;
         let l26 = *(option::borrow(&l2));
-        if (l26 == 4u64) {
-            l8 = true;
-            unstructured {
-                goto 'label_306;
-            }
-        } else {
-            l8 = l26 == 10u64;
-            unstructured {
-                goto 'label_306;
-            }
-        };
+        let l8 = l26 == 4u64 || l26 == 10u64;
         /* block 306 */;
         if (l8) {
             return bet_manager::mul(l0, 7000000000u64)
         };
-        let l9;
-        if (l26 == 6u64) {
-            l9 = true;
-            unstructured {
-                goto 'label_323;
-            }
-        } else {
-            l9 = l26 == 8u64;
-            unstructured {
-                goto 'label_323;
-            }
-        };
+        let l9 = l26 == 6u64 || l26 == 8u64;
         /* block 323 */;
         assert!(l9, C0);
         return bet_manager::mul(l0, 9000000000u64)
@@ -436,18 +257,7 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
     if (l1 == C13) {
         return bet_manager::mul(l0, 4000000000u64)
     };
-    let l10;
-    if (l1 == C6) {
-        l10 = true;
-        unstructured {
-            goto 'label_408;
-        }
-    } else {
-        l10 = l1 == C7;
-        unstructured {
-            goto 'label_408;
-        }
-    };
+    let l10 = l1 == C6 || l1 == C7;
     /* block 408 */;
     if (l10) {
         return bet_manager::mul(l0, 30000000000u64)
@@ -457,36 +267,10 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
     };
     assert!(l1 == C18, C0);
     if (option::is_some(&l2)) {
-        let l11;
         let l27 = *(option::borrow(&l2));
-        if (l27 == 2u64) {
-            l11 = true;
-            unstructured {
-                goto 'label_451;
-            }
-        } else {
-            if (l27 == 3u64) {
-                l11 = true;
-                unstructured {
-                    goto 'label_451;
-                }
-            } else {
-                l11 = l27 == 12u64;
-                unstructured {
-                    goto 'label_451;
-                }
-            }
-        };
         /* block 451 */;
-        if (l11) {
+        if (l27 == 2u64 || l27 == 3u64 || l27 == 12u64) {
             return bet_manager::mul(l0, 3000000000u64)
-        };
-        unstructured {
-            goto 'label_457;
-        }
-    } else {
-        unstructured {
-            goto 'label_457;
         }
     };
     /* block 457 */;
@@ -496,67 +280,23 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
 public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &VecSet<u64>, l4: u64, l5: u64, l6: u64): ( bool, bool, u64) {
     if (l0 == C12) {
         if (option::is_some(&l1)) {
-            let l7;
             let l99 = option::borrow(&l1);
-            if (l99 == &l5) {
-                l7 = *l99 == 2u64;
-                unstructured {
-                    goto 'label_24;
-                }
-            } else {
-                l7 = false;
-                unstructured {
-                    goto 'label_24;
-                }
-            };
+            let l7 = l99 == &l5 && *l99 == 2u64;
             /* block 24 */;
             if (l7) {
                 return (true, false, bet_manager::mul(l2, 30000000000u64))
             };
-            let l18;
-            if (l99 == &l5) {
-                l18 = *l99 == 3u64;
-                unstructured {
-                    goto 'label_46;
-                }
-            } else {
-                l18 = false;
-                unstructured {
-                    goto 'label_46;
-                }
-            };
+            let l18 = l99 == &l5 && *l99 == 3u64;
             /* block 46 */;
             if (l18) {
                 return (true, false, bet_manager::mul(l2, 15000000000u64))
             };
-            let l29;
-            if (l99 == &l5) {
-                l29 = *l99 == 11u64;
-                unstructured {
-                    goto 'label_68;
-                }
-            } else {
-                l29 = false;
-                unstructured {
-                    goto 'label_68;
-                }
-            };
+            let l29 = l99 == &l5 && *l99 == 11u64;
             /* block 68 */;
             if (l29) {
                 return (true, false, bet_manager::mul(l2, 15000000000u64))
             };
-            let l40;
-            if (l99 == &l5) {
-                l40 = *l99 == 12u64;
-                unstructured {
-                    goto 'label_92;
-                }
-            } else {
-                l40 = false;
-                unstructured {
-                    goto 'label_92;
-                }
-            };
+            let l40 = l99 == &l5 && *l99 == 12u64;
             /* block 92 */;
             if (l40) {
                 return (true, false, bet_manager::mul(l2, 30000000000u64))
@@ -587,90 +327,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l84;
         let l104 = *(option::borrow(&l1));
-        if (l104 == l5) {
-            let l95;
-            if (l104 == 4u64) {
-                l95 = true;
-                unstructured {
-                    goto 'label_207;
-                }
-            } else {
-                l95 = l104 == 10u64;
-                unstructured {
-                    goto 'label_207;
-                }
-            };
-            /* block 207 */;
-            l84 = l95;
-            unstructured {
-                goto 'label_212;
-            }
-        } else {
-            l84 = false;
-            unstructured {
-                goto 'label_212;
-            }
-        };
+        let l84 = l104 == l5 && /* block 207 */ l104 == 4u64 || l104 == 10u64;
         /* block 212 */;
         if (l84) {
             return (true, false, bet_manager::mul(l2, 1800000000u64))
         };
-        let l8;
-        if (l104 == l5) {
-            let l9;
-            if (l104 == 5u64) {
-                l9 = true;
-                unstructured {
-                    goto 'label_235;
-                }
-            } else {
-                l9 = l104 == 9u64;
-                unstructured {
-                    goto 'label_235;
-                }
-            };
-            /* block 235 */;
-            l8 = l9;
-            unstructured {
-                goto 'label_240;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_240;
-            }
-        };
+        let l8 = l104 == l5 && /* block 235 */ l104 == 5u64 || l104 == 9u64;
         /* block 240 */;
         if (l8) {
             return (true, false, bet_manager::mul(l2, 1400000000u64))
         };
-        let l10;
-        if (l104 == l5) {
-            let l11;
-            if (l104 == 6u64) {
-                l11 = true;
-                unstructured {
-                    goto 'label_263;
-                }
-            } else {
-                l11 = l104 == 8u64;
-                unstructured {
-                    goto 'label_263;
-                }
-            };
-            /* block 263 */;
-            l10 = l11;
-            unstructured {
-                goto 'label_268;
-            }
-        } else {
-            l10 = false;
-            unstructured {
-                goto 'label_268;
-            }
-        };
+        let l10 = l104 == l5 && /* block 263 */ l104 == 6u64 || l104 == 8u64;
         /* block 268 */;
         if (l10) {
             return (true, false, bet_manager::mul(l2, 1166666666u64))
@@ -681,90 +349,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l12;
         let l105 = *(option::borrow(&l1));
-        if (l105 == l5) {
-            let l13;
-            if (l105 == 4u64) {
-                l13 = true;
-                unstructured {
-                    goto 'label_313;
-                }
-            } else {
-                l13 = l105 == 10u64;
-                unstructured {
-                    goto 'label_313;
-                }
-            };
-            /* block 313 */;
-            l12 = l13;
-            unstructured {
-                goto 'label_318;
-            }
-        } else {
-            l12 = false;
-            unstructured {
-                goto 'label_318;
-            }
-        };
+        let l12 = l105 == l5 && /* block 313 */ l105 == 4u64 || l105 == 10u64;
         /* block 318 */;
         if (l12) {
             return (true, false, bet_manager::mul(l2, 2000000000u64))
         };
-        let l14;
-        if (l105 == l5) {
-            let l15;
-            if (l105 == 5u64) {
-                l15 = true;
-                unstructured {
-                    goto 'label_341;
-                }
-            } else {
-                l15 = l105 == 9u64;
-                unstructured {
-                    goto 'label_341;
-                }
-            };
-            /* block 341 */;
-            l14 = l15;
-            unstructured {
-                goto 'label_346;
-            }
-        } else {
-            l14 = false;
-            unstructured {
-                goto 'label_346;
-            }
-        };
+        let l14 = l105 == l5 && /* block 341 */ l105 == 5u64 || l105 == 9u64;
         /* block 346 */;
         if (l14) {
             return (true, false, bet_manager::mul(l2, 1500000000u64))
         };
-        let l16;
-        if (l105 == l5) {
-            let l17;
-            if (l105 == 6u64) {
-                l17 = true;
-                unstructured {
-                    goto 'label_369;
-                }
-            } else {
-                l17 = l105 == 8u64;
-                unstructured {
-                    goto 'label_369;
-                }
-            };
-            /* block 369 */;
-            l16 = l17;
-            unstructured {
-                goto 'label_374;
-            }
-        } else {
-            l16 = false;
-            unstructured {
-                goto 'label_374;
-            }
-        };
+        let l16 = l105 == l5 && /* block 369 */ l105 == 6u64 || l105 == 8u64;
         /* block 374 */;
         if (l16) {
             return (true, false, bet_manager::mul(l2, 1200000000u64))
@@ -773,139 +369,34 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C5) {
         if (l5 == 7u64) {
-            let l19;
             let l106 = *(option::borrow(&l1));
-            if (l106 == 4u64) {
-                l19 = true;
-                unstructured {
-                    goto 'label_411;
-                }
-            } else {
-                l19 = l106 == 10u64;
-                unstructured {
-                    goto 'label_411;
-                }
-            };
+            let l19 = l106 == 4u64 || l106 == 10u64;
             /* block 411 */;
             if (l19) {
                 return (true, false, bet_manager::mul(l2, 500000000u64))
             };
-            let l20;
-            if (l106 == 5u64) {
-                l20 = true;
-                unstructured {
-                    goto 'label_430;
-                }
-            } else {
-                l20 = l106 == 9u64;
-                unstructured {
-                    goto 'label_430;
-                }
-            };
+            let l20 = l106 == 5u64 || l106 == 9u64;
             /* block 430 */;
             if (l20) {
                 return (true, false, bet_manager::mul(l2, 666666666u64))
             };
-            let l21;
-            if (l106 == 6u64) {
-                l21 = true;
-                unstructured {
-                    goto 'label_449;
-                }
-            } else {
-                l21 = l106 == 8u64;
-                unstructured {
-                    goto 'label_449;
-                }
-            };
+            let l21 = l106 == 6u64 || l106 == 8u64;
             /* block 449 */;
             assert!(l21, C0);
             return (true, false, bet_manager::mul(l2, 833333333u64))
         };
-        let l22;
         let l107 = *(option::borrow(&l1));
-        if (l107 == l5) {
-            let l23;
-            if (l107 == 4u64) {
-                l23 = true;
-                unstructured {
-                    goto 'label_478;
-                }
-            } else {
-                l23 = l107 == 10u64;
-                unstructured {
-                    goto 'label_478;
-                }
-            };
-            /* block 478 */;
-            l22 = l23;
-            unstructured {
-                goto 'label_483;
-            }
-        } else {
-            l22 = false;
-            unstructured {
-                goto 'label_483;
-            }
-        };
+        let l22 = l107 == l5 && /* block 478 */ l107 == 4u64 || l107 == 10u64;
         /* block 483 */;
         if (l22) {
             return (false, false, 0u64)
         };
-        let l24;
-        if (l107 == l5) {
-            let l25;
-            if (l107 == 5u64) {
-                l25 = true;
-                unstructured {
-                    goto 'label_504;
-                }
-            } else {
-                l25 = l107 == 9u64;
-                unstructured {
-                    goto 'label_504;
-                }
-            };
-            /* block 504 */;
-            l24 = l25;
-            unstructured {
-                goto 'label_509;
-            }
-        } else {
-            l24 = false;
-            unstructured {
-                goto 'label_509;
-            }
-        };
+        let l24 = l107 == l5 && /* block 504 */ l107 == 5u64 || l107 == 9u64;
         /* block 509 */;
         if (l24) {
             return (false, false, 0u64)
         };
-        let l26;
-        if (l107 == l5) {
-            let l27;
-            if (l107 == 6u64) {
-                l27 = true;
-                unstructured {
-                    goto 'label_530;
-                }
-            } else {
-                l27 = l107 == 8u64;
-                unstructured {
-                    goto 'label_530;
-                }
-            };
-            /* block 530 */;
-            l26 = l27;
-            unstructured {
-                goto 'label_535;
-            }
-        } else {
-            l26 = false;
-            unstructured {
-                goto 'label_535;
-            }
-        };
+        let l26 = l107 == l5 && /* block 530 */ l107 == 6u64 || l107 == 8u64;
         /* block 535 */;
         if (l26) {
             return (false, false, 0u64)
@@ -916,42 +407,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l28;
         let l38 = 2u64;
-        if (vec_set::contains(l3, &l38)) {
+        let l28 = vec_set::contains(l3, &l38) && {
             let l36 = 3u64;
-            if (vec_set::contains(l3, &l36)) {
+            vec_set::contains(l3, &l36) && {
                 let l34 = 4u64;
-                if (vec_set::contains(l3, &l34)) {
+                vec_set::contains(l3, &l34) && {
                     let l32 = 5u64;
-                    if (vec_set::contains(l3, &l32)) {
+                    vec_set::contains(l3, &l32) && {
                         let l30 = 6u64;
-                        l28 = vec_set::contains(l3, &l30);
-                        unstructured {
-                            goto 'label_619;
-                        }
-                    } else {
-                        l28 = false;
-                        unstructured {
-                            goto 'label_619;
-                        }
-                    }
-                } else {
-                    l28 = false;
-                    unstructured {
-                        goto 'label_619;
+                        vec_set::contains(l3, &l30)
                     }
                 }
-            } else {
-                l28 = false;
-                unstructured {
-                    goto 'label_619;
-                }
-            }
-        } else {
-            l28 = false;
-            unstructured {
-                goto 'label_619;
             }
         };
         /* block 619 */;
@@ -964,42 +431,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l41;
         let l50 = 8u64;
-        if (vec_set::contains(l3, &l50)) {
+        let l41 = vec_set::contains(l3, &l50) && {
             let l48 = 9u64;
-            if (vec_set::contains(l3, &l48)) {
+            vec_set::contains(l3, &l48) && {
                 let l46 = 10u64;
-                if (vec_set::contains(l3, &l46)) {
+                vec_set::contains(l3, &l46) && {
                     let l44 = 11u64;
-                    if (vec_set::contains(l3, &l44)) {
+                    vec_set::contains(l3, &l44) && {
                         let l42 = 12u64;
-                        l41 = vec_set::contains(l3, &l42);
-                        unstructured {
-                            goto 'label_705;
-                        }
-                    } else {
-                        l41 = false;
-                        unstructured {
-                            goto 'label_705;
-                        }
-                    }
-                } else {
-                    l41 = false;
-                    unstructured {
-                        goto 'label_705;
+                        vec_set::contains(l3, &l42)
                     }
                 }
-            } else {
-                l41 = false;
-                unstructured {
-                    goto 'label_705;
-                }
-            }
-        } else {
-            l41 = false;
-            unstructured {
-                goto 'label_705;
             }
         };
         /* block 705 */;
@@ -1012,82 +455,33 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l53;
         let l74 = 2u64;
-        if (vec_set::contains(l3, &l74)) {
+        let l53 = vec_set::contains(l3, &l74) && {
             let l71 = 3u64;
-            if (vec_set::contains(l3, &l71)) {
+            vec_set::contains(l3, &l71) && {
                 let l69 = 4u64;
-                if (vec_set::contains(l3, &l69)) {
+                vec_set::contains(l3, &l69) && {
                     let l67 = 5u64;
-                    if (vec_set::contains(l3, &l67)) {
+                    vec_set::contains(l3, &l67) && {
                         let l65 = 6u64;
-                        if (vec_set::contains(l3, &l65)) {
+                        vec_set::contains(l3, &l65) && {
                             let l63 = 8u64;
-                            if (vec_set::contains(l3, &l63)) {
+                            vec_set::contains(l3, &l63) && {
                                 let l60 = 9u64;
-                                if (vec_set::contains(l3, &l60)) {
+                                vec_set::contains(l3, &l60) && {
                                     let l58 = 10u64;
-                                    if (vec_set::contains(l3, &l58)) {
+                                    vec_set::contains(l3, &l58) && {
                                         let l56 = 11u64;
-                                        if (vec_set::contains(l3, &l56)) {
+                                        vec_set::contains(l3, &l56) && {
                                             let l54 = 12u64;
-                                            l53 = vec_set::contains(l3, &l54);
-                                            unstructured {
-                                                goto 'label_856;
-                                            }
-                                        } else {
-                                            l53 = false;
-                                            unstructured {
-                                                goto 'label_856;
-                                            }
-                                        }
-                                    } else {
-                                        l53 = false;
-                                        unstructured {
-                                            goto 'label_856;
+                                            vec_set::contains(l3, &l54)
                                         }
                                     }
-                                } else {
-                                    l53 = false;
-                                    unstructured {
-                                        goto 'label_856;
-                                    }
-                                }
-                            } else {
-                                l53 = false;
-                                unstructured {
-                                    goto 'label_856;
                                 }
                             }
-                        } else {
-                            l53 = false;
-                            unstructured {
-                                goto 'label_856;
-                            }
-                        }
-                    } else {
-                        l53 = false;
-                        unstructured {
-                            goto 'label_856;
                         }
                     }
-                } else {
-                    l53 = false;
-                    unstructured {
-                        goto 'label_856;
-                    }
                 }
-            } else {
-                l53 = false;
-                unstructured {
-                    goto 'label_856;
-                }
-            }
-        } else {
-            l53 = false;
-            unstructured {
-                goto 'label_856;
             }
         };
         /* block 856 */;
@@ -1106,44 +500,14 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
             if (reg_575 != reg_576) {
                 return (false, false, 0u64)
             };
-            let l76;
-            if (l100 == 4u64) {
-                l76 = true;
-                unstructured {
-                    goto 'label_905;
-                }
-            } else {
-                l76 = l100 == 10u64;
-                unstructured {
-                    goto 'label_905;
-                }
-            };
+            let l76 = l100 == 4u64 || l100 == 10u64;
             /* block 905 */;
             if (l76) {
                 return (true, false, bet_manager::mul(l2, 7000000000u64))
             };
-            let l77;
-            if (l100 == 6u64) {
-                l77 = true;
-                unstructured {
-                    goto 'label_924;
-                }
-            } else {
-                l77 = l100 == 8u64;
-                unstructured {
-                    goto 'label_924;
-                }
-            };
             /* block 924 */;
-            if (l77) {
+            if (l100 == 6u64 || l100 == 8u64) {
                 return (true, false, bet_manager::mul(l2, 9000000000u64))
-            };
-            unstructured {
-                goto 'label_936;
-            }
-        } else {
-            unstructured {
-                goto 'label_936;
             }
         };
         /* block 936 */;
@@ -1151,41 +515,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C9) {
         if (option::is_none(&l1)) {
-            let l78;
-            if (l5 == 7u64) {
-                l78 = true;
-                unstructured {
-                    goto 'label_958;
-                }
-            } else {
-                l78 = l5 == 11u64;
-                unstructured {
-                    goto 'label_958;
-                }
-            };
+            let l78 = l5 == 7u64 || l5 == 11u64;
             /* block 958 */;
             if (l78) {
                 return (true, false, bet_manager::mul(l2, 1000000000u64))
             };
-            let l79;
-            if (l5 == 2u64) {
-                l79 = true;
-                unstructured {
-                    goto 'label_984;
-                }
-            } else {
-                if (l5 == 3u64) {
-                    l79 = true;
-                    unstructured {
-                        goto 'label_984;
-                    }
-                } else {
-                    l79 = l5 == 12u64;
-                    unstructured {
-                        goto 'label_984;
-                    }
-                }
-            };
+            let l79 = l5 == 2u64 || l5 == 3u64 || l5 == 12u64;
             /* block 984 */;
             if (l79) {
                 return (false, false, 0u64)
@@ -1208,34 +543,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l98 != l5) {
             return (false, true, 0u64)
         };
-        let l80;
-        if (l98 == 4u64) {
-            l80 = true;
-            unstructured {
-                goto 'label_1053;
-            }
-        } else {
-            l80 = l98 == 10u64;
-            unstructured {
-                goto 'label_1053;
-            }
-        };
+        let l80 = l98 == 4u64 || l98 == 10u64;
         /* block 1053 */;
         if (l80) {
             return (true, false, bet_manager::mul(l2, 2000000000u64))
         };
-        let l81;
-        if (l98 == 5u64) {
-            l81 = true;
-            unstructured {
-                goto 'label_1072;
-            }
-        } else {
-            l81 = l98 == 9u64;
-            unstructured {
-                goto 'label_1072;
-            }
-        };
+        let l81 = l98 == 5u64 || l98 == 9u64;
         /* block 1072 */;
         if (l81) {
             return (true, false, bet_manager::mul(l2, 1500000000u64))
@@ -1244,34 +557,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C10) {
         if (option::is_none(&l1)) {
-            let l82;
-            if (l5 == 7u64) {
-                l82 = true;
-                unstructured {
-                    goto 'label_1104;
-                }
-            } else {
-                l82 = l5 == 11u64;
-                unstructured {
-                    goto 'label_1104;
-                }
-            };
+            let l82 = l5 == 7u64 || l5 == 11u64;
             /* block 1104 */;
             if (l82) {
                 return (false, false, 0u64)
             };
-            let l83;
-            if (l5 == 2u64) {
-                l83 = true;
-                unstructured {
-                    goto 'label_1121;
-                }
-            } else {
-                l83 = l5 == 3u64;
-                unstructured {
-                    goto 'label_1121;
-                }
-            };
+            let l83 = l5 == 2u64 || l5 == 3u64;
             /* block 1121 */;
             if (l83) {
                 return (true, false, bet_manager::mul(l2, 1000000000u64))
@@ -1291,35 +582,13 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C17) {
         if (l5 == 7u64) {
-            let l85;
             let l101 = *(option::borrow(&l1));
-            if (l101 == 4u64) {
-                l85 = true;
-                unstructured {
-                    goto 'label_1188;
-                }
-            } else {
-                l85 = l101 == 10u64;
-                unstructured {
-                    goto 'label_1188;
-                }
-            };
+            let l85 = l101 == 4u64 || l101 == 10u64;
             /* block 1188 */;
             if (l85) {
                 return (true, false, bet_manager::mul(l2, 500000000u64))
             };
-            let l86;
-            if (l101 == 5u64) {
-                l86 = true;
-                unstructured {
-                    goto 'label_1207;
-                }
-            } else {
-                l86 = l101 == 9u64;
-                unstructured {
-                    goto 'label_1207;
-                }
-            };
+            let l86 = l101 == 5u64 || l101 == 9u64;
             /* block 1207 */;
             if (l86) {
                 return (true, false, bet_manager::mul(l2, 666666666u64))
@@ -1335,25 +604,7 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 11u64) {
             return (true, false, bet_manager::mul(l2, 7000000000u64))
         };
-        let l87;
-        if (l5 == 2u64) {
-            l87 = true;
-            unstructured {
-                goto 'label_1267;
-            }
-        } else {
-            if (l5 == 3u64) {
-                l87 = true;
-                unstructured {
-                    goto 'label_1267;
-                }
-            } else {
-                l87 = l5 == 12u64;
-                unstructured {
-                    goto 'label_1267;
-                }
-            }
-        };
+        let l87 = l5 == 2u64 || l5 == 3u64 || l5 == 12u64;
         /* block 1267 */;
         if (l87) {
             return (true, false, bet_manager::mul(l2, 3000000000u64))
@@ -1362,41 +613,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l6 == 0u64) {
         if (l0 == C0) {
-            let l88;
-            if (l5 == 7u64) {
-                l88 = true;
-                unstructured {
-                    goto 'label_1298;
-                }
-            } else {
-                l88 = l5 == 11u64;
-                unstructured {
-                    goto 'label_1298;
-                }
-            };
+            let l88 = l5 == 7u64 || l5 == 11u64;
             /* block 1298 */;
             if (l88) {
                 return (true, false, bet_manager::mul(l2, 1000000000u64))
             };
-            let l89;
-            if (l5 == 2u64) {
-                l89 = true;
-                unstructured {
-                    goto 'label_1324;
-                }
-            } else {
-                if (l5 == 3u64) {
-                    l89 = true;
-                    unstructured {
-                        goto 'label_1324;
-                    }
-                } else {
-                    l89 = l5 == 12u64;
-                    unstructured {
-                        goto 'label_1324;
-                    }
-                }
-            };
+            let l89 = l5 == 2u64 || l5 == 3u64 || l5 == 12u64;
             /* block 1324 */;
             if (l89) {
                 return (false, false, 0u64)
@@ -1404,34 +626,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
             return (false, true, 0u64)
         };
         assert!(l0 == C1, C0);
-        let l90;
-        if (l5 == 7u64) {
-            l90 = true;
-            unstructured {
-                goto 'label_1349;
-            }
-        } else {
-            l90 = l5 == 11u64;
-            unstructured {
-                goto 'label_1349;
-            }
-        };
+        let l90 = l5 == 7u64 || l5 == 11u64;
         /* block 1349 */;
         if (l90) {
             return (false, false, 0u64)
         };
-        let l91;
-        if (l5 == 2u64) {
-            l91 = true;
-            unstructured {
-                goto 'label_1366;
-            }
-        } else {
-            l91 = l5 == 3u64;
-            unstructured {
-                goto 'label_1366;
-            }
-        };
+        let l91 = l5 == 2u64 || l5 == 3u64;
         /* block 1366 */;
         if (l91) {
             return (true, false, bet_manager::mul(l2, 1000000000u64))
@@ -1446,35 +646,13 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
             return (true, false, bet_manager::mul(l2, 1000000000u64))
         };
         if (l0 == C15) {
-            let l92;
             let l102 = *(option::borrow(&l1));
-            if (l102 == 4u64) {
-                l92 = true;
-                unstructured {
-                    goto 'label_1421;
-                }
-            } else {
-                l92 = l102 == 10u64;
-                unstructured {
-                    goto 'label_1421;
-                }
-            };
+            let l92 = l102 == 4u64 || l102 == 10u64;
             /* block 1421 */;
             if (l92) {
                 return (true, false, bet_manager::mul(l2, 500000000u64))
             };
-            let l93;
-            if (l102 == 5u64) {
-                l93 = true;
-                unstructured {
-                    goto 'label_1440;
-                }
-            } else {
-                l93 = l102 == 9u64;
-                unstructured {
-                    goto 'label_1440;
-                }
-            };
+            let l93 = l102 == 5u64 || l102 == 9u64;
             /* block 1440 */;
             if (l93) {
                 return (true, false, bet_manager::mul(l2, 666666666u64))
@@ -1483,18 +661,7 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         };
         return (false, false, 0u64)
     };
-    let l94;
-    if (l0 == C1) {
-        l94 = true;
-        unstructured {
-            goto 'label_1469;
-        }
-    } else {
-        l94 = l0 == C15;
-        unstructured {
-            goto 'label_1469;
-        }
-    };
+    let l94 = l0 == C1 || l0 == C15;
     /* block 1469 */;
     if (l94) {
         if (l5 == l6) {
@@ -1505,59 +672,23 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     if (l0 == C0) {
         if (l5 == l6) {
             return (true, false, bet_manager::mul(l2, 1000000000u64))
-        };
-        unstructured {
-            goto 'label_1497;
-        }
-    } else {
-        unstructured {
-            goto 'label_1497;
         }
     };
     /* block 1497 */;
     if (l0 == C14) {
         if (l5 == l6) {
-            let l96;
             let l103 = *(option::borrow(&l1));
-            if (l103 == 4u64) {
-                l96 = true;
-                unstructured {
-                    goto 'label_1520;
-                }
-            } else {
-                l96 = l103 == 10u64;
-                unstructured {
-                    goto 'label_1520;
-                }
-            };
+            let l96 = l103 == 4u64 || l103 == 10u64;
             /* block 1520 */;
             if (l96) {
                 return (true, false, bet_manager::mul(l2, 2000000000u64))
             };
-            let l97;
-            if (l103 == 5u64) {
-                l97 = true;
-                unstructured {
-                    goto 'label_1539;
-                }
-            } else {
-                l97 = l103 == 9u64;
-                unstructured {
-                    goto 'label_1539;
-                }
-            };
+            let l97 = l103 == 5u64 || l103 == 9u64;
             /* block 1539 */;
             if (l97) {
                 return (true, false, bet_manager::mul(l2, 1500000000u64))
             };
             return (true, false, bet_manager::mul(l2, 1200000000u64))
-        };
-        unstructured {
-            goto 'label_1553;
-        }
-    } else {
-        unstructured {
-            goto 'label_1553;
         }
     };
     /* block 1553 */;
@@ -1569,57 +700,16 @@ public fun hard_ways_bet(): u64 {
 }
 
 public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u64>, l5: &vector<Bet>) {
-    let l6;
-    if (l0 < 19u64) {
-        l6 = l0 >= 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_11;
-        }
-    };
+    let l6 = l0 < 19u64 && l0 >= 0u64;
     /* block 11 */;
     assert!(l6, C0);
-    let l10;
-    if (l0 == C0) {
-        l10 = true;
-        unstructured {
-            goto 'label_29;
-        }
-    } else {
-        l10 = l0 == C1;
-        unstructured {
-            goto 'label_29;
-        }
-    };
     /* block 29 */;
-    if (l10) {
-        assert!(l3 == 0u64, C0);
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        unstructured {
-            goto 'label_40;
-        }
+    if (l0 == C0 || l0 == C1) {
+        assert!(l3 == 0u64, C0)
     };
     /* block 40 */;
     if (l0 == C14) {
-        let l11;
-        if (l3 == *(option::borrow(&l2))) {
-            l11 = l3 != 0u64;
-            unstructured {
-                goto 'label_57;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_57;
-            }
-        };
+        let l11 = l3 == *(option::borrow(&l2)) && l3 != 0u64;
         /* block 57 */;
         assert!(l11, C0);
         let l26 = 0u64;
@@ -1632,29 +722,11 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             };
             l26 = l26 + 1u64;
         };
-        assert!(l25, C0);
-        unstructured {
-            goto 'label_113;
-        }
-    } else {
-        unstructured {
-            goto 'label_113;
-        }
+        assert!(l25, C0)
     };
     /* block 113 */;
     if (l0 == C15) {
-        let l12;
-        if (l3 == *(option::borrow(&l2))) {
-            l12 = l3 != 0u64;
-            unstructured {
-                goto 'label_130;
-            }
-        } else {
-            l12 = false;
-            unstructured {
-                goto 'label_130;
-            }
-        };
+        let l12 = l3 == *(option::borrow(&l2)) && l3 != 0u64;
         /* block 130 */;
         assert!(l12, C0);
         let l27 = 0u64;
@@ -1667,39 +739,14 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             };
             l27 = l27 + 1u64;
         };
-        assert!(l24, C0);
-        unstructured {
-            goto 'label_186;
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
-        }
+        assert!(l24, C0)
     };
-    let l13;
     /* block 186 */;
-    if (l0 == C9) {
-        l13 = true;
-        unstructured {
-            goto 'label_197;
-        }
-    } else {
-        l13 = l0 == C10;
-        unstructured {
-            goto 'label_197;
-        }
-    };
+    let l13 = l0 == C9 || l0 == C10;
     /* block 197 */;
     if (l13) {
         assert!(option::is_none(&l2), C0);
-        assert!(l3 != 0u64, C0);
-        unstructured {
-            goto 'label_216;
-        }
-    } else {
-        unstructured {
-            goto 'label_216;
-        }
+        assert!(l3 != 0u64, C0)
     };
     /* block 216 */;
     if (l0 == C16) {
@@ -1725,10 +772,6 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             break
         };
         assert!(__c282, C0)
-    } else {
-        unstructured {
-            goto 'label_289;
-        }
     };
     /* block 289 */;
     if (l0 == C17) {
@@ -1754,171 +797,54 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             break
         };
         assert!(__c357, C0)
-    } else {
-        unstructured {
-            goto 'label_364;
-        }
     };
     /* block 364 */;
     if (l0 == C3) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C19, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_384;
-        }
-    } else {
-        unstructured {
-            goto 'label_384;
-        }
+        assert!(vector::contains(&C19, option::borrow(&l2)), C1)
     };
     /* block 384 */;
     if (l0 == C5) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C19, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_404;
-        }
-    } else {
-        unstructured {
-            goto 'label_404;
-        }
+        assert!(vector::contains(&C19, option::borrow(&l2)), C1)
     };
     /* block 404 */;
     if (l0 == C4) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C19, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_424;
-        }
-    } else {
-        unstructured {
-            goto 'label_424;
-        }
+        assert!(vector::contains(&C19, option::borrow(&l2)), C1)
     };
     /* block 424 */;
     if (l0 == C11) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C20, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_444;
-        }
-    } else {
-        unstructured {
-            goto 'label_444;
-        }
+        assert!(vector::contains(&C20, option::borrow(&l2)), C1)
     };
     /* block 444 */;
     if (l0 == C12) {
         if (option::is_some(&l2)) {
-            let l7;
-            if (vector::contains(&C21, option::borrow(&l2))) {
-                l7 = true;
-                unstructured {
-                    goto 'label_467;
-                }
-            } else {
-                l7 = *(option::borrow(&l2)) == 11u64;
-                unstructured {
-                    goto 'label_467;
-                }
-            };
             /* block 467 */;
-            assert!(l7, C1);
-            unstructured {
-                goto 'label_472;
-            }
-        } else {
-            unstructured {
-                goto 'label_472;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_472;
+            assert!(vector::contains(&C21, option::borrow(&l2)) || *(option::borrow(&l2)) == 11u64, C1)
         }
     };
-    let l9;
     /* block 472 */;
-    if (l0 == C6) {
-        l9 = true;
-        unstructured {
-            goto 'label_490;
-        }
-    } else {
-        if (l0 == C7) {
-            l9 = true;
-            unstructured {
-                goto 'label_490;
-            }
-        } else {
-            l9 = l0 == C8;
-            unstructured {
-                goto 'label_490;
-            }
-        }
-    };
+    let l9 = l0 == C6 || l0 == C7 || l0 == C8;
     /* block 490 */;
     if (l9) {
-        assert!(&l4.len() == 0u64, C0);
-        unstructured {
-            goto 'label_500;
-        }
-    } else {
-        unstructured {
-            goto 'label_500;
-        }
+        assert!(&l4.len() == 0u64, C0)
     };
     /* block 500 */
 }
 
 public fun is_valid_remove(l0: u64, l1: Option<u64>, l2: u64, l3: u8, l4: vector<u64>, l5: &vector<Bet>) {
     assert!(l3 != 1u8, C2);
-    let l6;
-    if (l0 == C0) {
-        l6 = true;
-        unstructured {
-            goto 'label_18;
-        }
-    } else {
-        l6 = l0 == C1;
-        unstructured {
-            goto 'label_18;
-        }
-    };
     /* block 18 */;
-    if (l6) {
-        assert!(l2 == 0u64, C2);
-        unstructured {
-            goto 'label_27;
-        }
-    } else {
-        unstructured {
-            goto 'label_27;
-        }
+    if (l0 == C0 || l0 == C1) {
+        assert!(l2 == 0u64, C2)
     };
-    let l7;
     /* block 27 */;
-    if (l0 == C9) {
-        l7 = true;
-        unstructured {
-            goto 'label_38;
-        }
-    } else {
-        l7 = l0 == C10;
-        unstructured {
-            goto 'label_38;
-        }
-    };
+    let l7 = l0 == C9 || l0 == C10;
     /* block 38 */;
     if (l7) {
-        assert!(option::is_none(&l1), C2);
-        unstructured {
-            goto 'label_46;
-        }
-    } else {
-        unstructured {
-            goto 'label_46;
-        }
+        assert!(option::is_none(&l1), C2)
     };
     /* block 46 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/cetus_clmm_worker.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/cetus_clmm_worker.mv.snap
@@ -242,15 +242,9 @@ public entry fun add_collateral_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
     let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l53);
     let l47 = cetus_clmm_worker::work_inner(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
     if (coin::value(&l47) == 0u64) {
-        coin::destroy_zero(l47);
-        unstructured {
-            goto 'label_143;
-        }
+        coin::destroy_zero(l47)
     } else {
-        pay::keep(l47, freeze(l14));
-        unstructured {
-            goto 'label_143;
-        }
+        pay::keep(l47, freeze(l14))
     };
     /* block 143 */;
     let l50 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l1), freeze(l4), l11, l12, l13);
@@ -276,15 +270,9 @@ public entry fun add_collateral_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
     let l48 = vault::get_add_collateral_context_debt(&l44);
     let l47 = cetus_clmm_worker::work_inner_reverse(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
     if (coin::value(&l47) == 0u64) {
-        coin::destroy_zero(l47);
-        unstructured {
-            goto 'label_145;
-        }
+        coin::destroy_zero(l47)
     } else {
-        pay::keep(l47, freeze(l14));
-        unstructured {
-            goto 'label_145;
-        }
+        pay::keep(l47, freeze(l14))
     };
     /* block 145 */;
     let l50 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l1), freeze(l4), l11, l12, l13);
@@ -299,31 +287,17 @@ fun add_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64, l2: u128, l3
     if (l2 > 0u128) {
         let l9 = cetus_clmm_worker::balance_to_share_inner(freeze(l0), l2, l3);
         assert!(l9 > 0u128, C3);
-        let l7;
         let l10 = &mut l0.shares;
-        if (table::contains(freeze(l10), l1)) {
-            l7 = table::borrow_mut(l10, l1);
-            unstructured {
-                goto 'label_46;
-            }
+        let l7 = if (table::contains(freeze(l10), l1)) {
+            table::borrow_mut(l10, l1)
         } else {
             table::add(l10, l1, 0u128);
-            l7 = table::borrow_mut(l10, l1);
-            unstructured {
-                goto 'label_46;
-            }
+            table::borrow_mut(l10, l1)
         };
         /* block 46 */;
         let l8 = l7;
         *l8 = *l8 + l9;
-        *(&mut l0.total_share) = *(&l0.total_share) + l9;
-        unstructured {
-            goto 'label_65;
-        }
-    } else {
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut l0.total_share) = *(&l0.total_share) + l9
     };
     /* block 65 */
 }
@@ -355,22 +329,8 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -378,22 +338,8 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -406,32 +352,12 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -447,22 +373,8 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -470,22 +382,8 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -498,32 +396,12 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -539,22 +417,8 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -562,22 +426,8 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -591,18 +441,8 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -610,37 +450,14 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -656,22 +473,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -679,22 +482,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -708,18 +497,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -727,37 +506,14 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -771,18 +527,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact_reverse(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -790,37 +536,14 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -836,22 +559,8 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -859,22 +568,8 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -888,18 +583,8 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -907,37 +592,14 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -953,22 +615,8 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -976,22 +624,8 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -1004,32 +638,12 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1045,22 +659,8 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -1068,22 +668,8 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -1097,18 +683,8 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -1116,37 +692,14 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1162,22 +715,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -1185,22 +724,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -1214,18 +739,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -1233,37 +748,14 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -1277,18 +769,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -1296,37 +778,14 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1342,22 +801,8 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -1365,22 +810,8 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -1393,32 +824,12 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1434,22 +845,8 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -1457,22 +854,8 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -1486,18 +869,8 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -1505,37 +878,14 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1551,22 +901,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -1574,22 +910,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -1603,18 +925,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -1622,37 +934,14 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -1666,18 +955,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact_reverse(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -1685,37 +964,14 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1731,22 +987,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -1754,22 +996,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -1783,18 +1011,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -1802,37 +1020,14 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -1846,18 +1041,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -1865,37 +1050,14 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1911,22 +1073,8 @@ public fun collect_reward_without_swap<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
         let l11 = mole_math::mul_div(balance::value(&l8), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l8) >= l11) {
             let l12 = balance::split(&mut l8, l11);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l5) {
@@ -1934,22 +1082,8 @@ public fun collect_reward_without_swap<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
         let l13 = mole_math::mul_div(balance::value(&l10), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_99;
-        }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
+        /* block 85 */
     };
     /* block 99 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1965,22 +1099,8 @@ public fun collect_reward_without_swap_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
         let l11 = mole_math::mul_div(balance::value(&l8), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l8) >= l11) {
             let l12 = balance::split(&mut l8, l11);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l5) {
@@ -1988,22 +1108,8 @@ public fun collect_reward_without_swap_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
         let l13 = mole_math::mul_div(balance::value(&l10), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_99;
-        }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
+        /* block 85 */
     };
     /* block 99 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -2018,18 +1124,7 @@ fun get_mkt_sell_amount(l0: u64, l1: u64, l2: u64): u64 {
     if (l0 == 0u64) {
         return 0u64
     };
-    let l3;
-    if (l1 > 0u64) {
-        l3 = l2 > 0u64;
-        unstructured {
-            goto 'label_17;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_17;
-        }
-    };
+    let l3 = l1 > 0u64 && l2 > 0u64;
     /* block 17 */;
     assert!(l3, C5);
     let l4 = l0 * 9980u64;
@@ -2058,13 +1153,6 @@ public fun health<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T0, T1>, l2
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        unstructured {
-            goto 'label_19;
-        }
     };
     let (l11, l3, l6, l9);
     /* block 19 */;
@@ -2073,30 +1161,18 @@ public fun health<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T0, T1>, l2
     let (reg_25, reg_26) = position::tick_range(option::borrow(&l0.position_nft));
     let (reg_33, reg_34) = clmm_math::get_amount_by_liquidity(reg_25, reg_26, pool::current_tick_index(l1), pool::current_sqrt_price(l1), l9, false);
     l11 = reg_34;
-    if (l9 == 0u128) {
-        l3 = 0u64;
-        unstructured {
-            goto 'label_58;
-        }
+    l3 = if (l9 == 0u128) {
+        0u64
     } else {
-        l3 = mole_math::mul_div_u128(l6, reg_33as u128, l9)as u64;
-        unstructured {
-            goto 'label_58;
-        }
+        mole_math::mul_div_u128(l6, reg_33as u128, l9)as u64
     };
     let (l12, l4);
     /* block 58 */;
     l12 = l3;
-    if (l9 == 0u128) {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_74;
-        }
+    l4 = if (l9 == 0u128) {
+        0u64
     } else {
-        l4 = mole_math::mul_div_u128(l6, l11as u128, l9)as u64;
-        unstructured {
-            goto 'label_74;
-        }
+        mole_math::mul_div_u128(l6, l11as u128, l9)as u64
     };
     /* block 74 */;
     let l13 = l4;
@@ -2109,13 +1185,6 @@ public fun health_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T1,
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        unstructured {
-            goto 'label_19;
-        }
     };
     let (l11, l3, l6, l9);
     /* block 19 */;
@@ -2124,30 +1193,18 @@ public fun health_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T1,
     let (reg_25, reg_26) = position::tick_range(option::borrow(&l0.position_nft));
     let (reg_33, reg_34) = clmm_math::get_amount_by_liquidity(reg_25, reg_26, pool::current_tick_index(l1), pool::current_sqrt_price(l1), l9, false);
     l11 = reg_33;
-    if (l9 == 0u128) {
-        l3 = 0u64;
-        unstructured {
-            goto 'label_58;
-        }
+    l3 = if (l9 == 0u128) {
+        0u64
     } else {
-        l3 = mole_math::mul_div_u128(l6, reg_34as u128, l9)as u64;
-        unstructured {
-            goto 'label_58;
-        }
+        mole_math::mul_div_u128(l6, reg_34as u128, l9)as u64
     };
     let (l12, l4);
     /* block 58 */;
     l12 = l3;
-    if (l9 == 0u128) {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_74;
-        }
+    l4 = if (l9 == 0u128) {
+        0u64
     } else {
-        l4 = mole_math::mul_div_u128(l6, l11as u128, l9)as u64;
-        unstructured {
-            goto 'label_74;
-        }
+        mole_math::mul_div_u128(l6, l11as u128, l9)as u64
     };
     /* block 74 */;
     let l13 = l4;
@@ -2189,41 +1246,17 @@ public entry fun initialize_reverse<T0, T1, T2>(l0: &AdminCap, l1: &x5_AdminCap,
 }
 
 public fun is_rebalancer<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: address): bool {
-    let l2;
     cetus_clmm_worker::checked_package_version(l0);
     let l3 = &l0.ok_rebalancers;
-    if (table::contains(l3, l1)) {
-        l2 = *(table::borrow(l3, l1));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_19;
-        }
-    };
     /* block 19 */;
-    return l2
+    return table::contains(l3, l1) && *(table::borrow(l3, l1))
 }
 
 public fun is_reinvestor<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: address): bool {
-    let l2;
     cetus_clmm_worker::checked_package_version(l0);
     let l3 = &l0.ok_reinvestors;
-    if (table::contains(l3, l1)) {
-        l2 = *(table::borrow(l3, l1));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_19;
-        }
-    };
     /* block 19 */;
-    return l2
+    return table::contains(l3, l1) && *(table::borrow(l3, l1))
 }
 
 public fun is_reserve_consistent<T0, T1, T2>(): bool {
@@ -2241,21 +1274,10 @@ public fun is_stable<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &GlobalStorage
     if (reg_16 + 86400u64 <= l12) {
         return false
     };
-    let l6;
     let l9 = reg_6 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / reg_5 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
     let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
     let l11 = worker_config::get_max_price_diff_scale();
-    if (l9 * l11 > l14 * l10) {
-        l6 = true;
-        unstructured {
-            goto 'label_91;
-        }
-    } else {
-        l6 = l9 * l10 < l14 * l11;
-        unstructured {
-            goto 'label_91;
-        }
-    };
+    let l6 = l9 * l11 > l14 * l10 || l9 * l10 < l14 * l11;
     /* block 91 */;
     if (l6) {
         return false
@@ -2274,21 +1296,10 @@ public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Globa
     if (reg_16 + 86400u64 <= l12) {
         return false
     };
-    let l6;
     let l9 = reg_5 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / reg_6 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
     let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
     let l11 = worker_config::get_max_price_diff_scale();
-    if (l9 * l11 > l14 * l10) {
-        l6 = true;
-        unstructured {
-            goto 'label_91;
-        }
-    } else {
-        l6 = l9 * l10 < l14 * l11;
-        unstructured {
-            goto 'label_91;
-        }
-    };
+    let l6 = l9 * l11 > l14 * l10 || l9 * l10 < l14 * l11;
     /* block 91 */;
     if (l6) {
         return false
@@ -2297,22 +1308,10 @@ public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Globa
 }
 
 public fun is_strategy_ok<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u8): bool {
-    let l2;
     cetus_clmm_worker::checked_package_version(l0);
     let l3 = &l0.ok_strategies;
-    if (table::contains(l3, l1)) {
-        l2 = *(table::borrow(l3, l1));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_19;
-        }
-    };
     /* block 19 */;
-    return l2
+    return table::contains(l3, l1) && *(table::borrow(l3, l1))
 }
 
 fun join_split_keep<T0>(l0: vector<Coin<T0>>, l1: u64, l2: &mut TxContext): Coin<T0> {
@@ -2408,38 +1407,21 @@ public entry fun rebalance_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
 fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
     assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
-    let l12;
     let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-    if (i32::as_u32(reg_16) == l3) {
-        l12 = i32::as_u32(reg_17) == l4;
-        unstructured {
-            goto 'label_39;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_39;
-        }
-    };
+    let l12 = i32::as_u32(reg_16) == l3 && i32::as_u32(reg_17) == l4;
     /* block 39 */;
     assert!(!(l12), C25);
     let (l13, l14);
     let l23 = pool::open_position(l1, l2, l3, l4, l10);
     let l24 = option::extract(&mut l0.position_nft);
     let l21 = position::liquidity(&l24);
-    if (l21 > 0u128) {
+    l13 = if (l21 > 0u128) {
         let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
         l14 = reg_53;
-        l13 = reg_52;
-        unstructured {
-            goto 'label_84;
-        }
+        reg_52
     } else {
         l14 = balance::zero();
-        l13 = balance::zero();
-        unstructured {
-            goto 'label_84;
-        }
+        balance::zero()
     };
     let (l15, l17, l18);
     /* block 84 */;
@@ -2447,43 +1429,15 @@ fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConf
     l17 = l13;
     pool::close_position(l1, l2, l24);
     option::fill(&mut l0.position_nft, l23);
-    if (balance::value(&l17) > 0u64) {
-        l15 = true;
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        l15 = balance::value(&l18) > 0u64;
-        unstructured {
-            goto 'label_121;
-        }
-    };
+    l15 = balance::value(&l17) > 0u64 || balance::value(&l18) > 0u64;
     /* block 121 */;
     if (l15) {
-        let l16;
         let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-        if (coin::value(&reg_99) <= l6) {
-            l16 = coin::value(&reg_100) <= l7;
-            unstructured {
-                goto 'label_154;
-            }
-        } else {
-            l16 = false;
-            unstructured {
-                goto 'label_154;
-            }
-        };
         /* block 154 */;
-        assert!(l16, C26);
-        unstructured {
-            goto 'label_186;
-        }
+        assert!(coin::value(&reg_99) <= l6 && coin::value(&reg_100) <= l7, C26)
     } else {
         balance::destroy_zero(l17);
-        balance::destroy_zero(l18);
-        unstructured {
-            goto 'label_186;
-        }
+        balance::destroy_zero(l18)
     };
     /* block 186 */;
     let l22 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2494,38 +1448,21 @@ fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConf
 fun rebalance_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
     assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
-    let l12;
     let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-    if (i32::as_u32(reg_16) == l3) {
-        l12 = i32::as_u32(reg_17) == l4;
-        unstructured {
-            goto 'label_39;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_39;
-        }
-    };
+    let l12 = i32::as_u32(reg_16) == l3 && i32::as_u32(reg_17) == l4;
     /* block 39 */;
     assert!(!(l12), C25);
     let (l13, l14);
     let l23 = pool::open_position(l1, l2, l3, l4, l10);
     let l24 = option::extract(&mut l0.position_nft);
     let l21 = position::liquidity(&l24);
-    if (l21 > 0u128) {
+    l13 = if (l21 > 0u128) {
         let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
         l14 = reg_53;
-        l13 = reg_52;
-        unstructured {
-            goto 'label_84;
-        }
+        reg_52
     } else {
         l14 = balance::zero();
-        l13 = balance::zero();
-        unstructured {
-            goto 'label_84;
-        }
+        balance::zero()
     };
     let (l15, l17, l18);
     /* block 84 */;
@@ -2533,43 +1470,15 @@ fun rebalance_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &Gl
     l18 = l13;
     pool::close_position(l1, l2, l24);
     option::fill(&mut l0.position_nft, l23);
-    if (balance::value(&l17) > 0u64) {
-        l15 = true;
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        l15 = balance::value(&l18) > 0u64;
-        unstructured {
-            goto 'label_121;
-        }
-    };
+    l15 = balance::value(&l17) > 0u64 || balance::value(&l18) > 0u64;
     /* block 121 */;
     if (l15) {
-        let l16;
         let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-        if (coin::value(&reg_99) <= l6) {
-            l16 = coin::value(&reg_100) <= l7;
-            unstructured {
-                goto 'label_154;
-            }
-        } else {
-            l16 = false;
-            unstructured {
-                goto 'label_154;
-            }
-        };
         /* block 154 */;
-        assert!(l16, C26);
-        unstructured {
-            goto 'label_186;
-        }
+        assert!(coin::value(&reg_99) <= l6 && coin::value(&reg_100) <= l7, C26)
     } else {
         balance::destroy_zero(l17);
-        balance::destroy_zero(l18);
-        unstructured {
-            goto 'label_186;
-        }
+        balance::destroy_zero(l18)
     };
     /* block 186 */;
     let l22 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2664,36 +1573,14 @@ public entry fun reinvest_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
 fun reinvest_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
     assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
-    let l10;
     let l16 = position::liquidity(option::borrow(&l0.position_nft));
     let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
     let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-    if (balance::value(&l12) == 0u64) {
-        l10 = balance::value(&l13) == 0u64;
-        unstructured {
-            goto 'label_48;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_48;
-        }
-    };
+    let l10 = balance::value(&l12) == 0u64 && balance::value(&l13) == 0u64;
     /* block 48 */;
     assert!(!(l10), C28);
-    let l11;
     let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-    if (coin::value(&reg_54) <= l4) {
-        l11 = coin::value(&reg_55) <= l5;
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_93;
-        }
-    };
+    let l11 = coin::value(&reg_54) <= l4 && coin::value(&reg_55) <= l5;
     /* block 93 */;
     assert!(l11, C26);
     let l17 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2704,36 +1591,14 @@ fun reinvest_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfi
 fun reinvest_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
     assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
-    let l10;
     let l16 = position::liquidity(option::borrow(&l0.position_nft));
     let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
     let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-    if (balance::value(&l12) == 0u64) {
-        l10 = balance::value(&l13) == 0u64;
-        unstructured {
-            goto 'label_48;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_48;
-        }
-    };
+    let l10 = balance::value(&l12) == 0u64 && balance::value(&l13) == 0u64;
     /* block 48 */;
     assert!(!(l10), C28);
-    let l11;
     let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-    if (coin::value(&reg_54) <= l4) {
-        l11 = coin::value(&reg_55) <= l5;
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_93;
-        }
-    };
+    let l11 = coin::value(&reg_54) <= l4 && coin::value(&reg_55) <= l5;
     /* block 93 */;
     assert!(l11, C26);
     let l17 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2809,13 +1674,6 @@ fun remove_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64): u128 {
             *(&mut l0.total_share) = *(&l0.total_share) - l3;
             *(table::borrow_mut(&mut l0.shares, l1)) = 0u128;
             return l2
-        };
-        unstructured {
-            goto 'label_46;
-        }
-    } else {
-        unstructured {
-            goto 'label_46;
         }
     };
     /* block 46 */;
@@ -2859,15 +1717,9 @@ public entry fun set_reinvestor_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInf
     cetus_clmm_worker::checked_package_version(freeze(l1));
     let l5 = &mut l1.ok_reinvestors;
     if (table::contains(freeze(l5), l2)) {
-        *(table::borrow_mut(l5, l2)) = l3;
-        unstructured {
-            goto 'label_23;
-        }
+        *(table::borrow_mut(l5, l2)) = l3
     } else {
-        table::add(l5, l2, l3);
-        unstructured {
-            goto 'label_23;
-        }
+        table::add(l5, l2, l3)
     };
     /* block 23 */
 }
@@ -2908,15 +1760,9 @@ public entry fun set_strategy_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<
     cetus_clmm_worker::checked_package_version(freeze(l1));
     let l5 = &mut l1.ok_strategies;
     if (table::contains(freeze(l5), l2)) {
-        *(table::borrow_mut(l5, l2)) = l3;
-        unstructured {
-            goto 'label_23;
-        }
+        *(table::borrow_mut(l5, l2)) = l3
     } else {
-        table::add(l5, l2, l3);
-        unstructured {
-            goto 'label_23;
-        }
+        table::add(l5, l2, l3)
     };
     /* block 23 */
 }
@@ -3001,15 +1847,9 @@ public entry fun withdraw_rewards_bounty<T0, T1, T2>(l0: &AdminCap, l1: &mut Wor
     if (l2) {
         l3 = balance::value(&l1.tiny_coin_base_bounty);
         l4 = balance::value(&l1.tiny_coin_farming_bounty);
-        unstructured {
-            goto 'label_40;
-        }
     } else {
         assert!(l3 <= balance::value(&l1.tiny_coin_base_bounty), C33);
-        assert!(l4 <= balance::value(&l1.tiny_coin_farming_bounty), C34);
-        unstructured {
-            goto 'label_40;
-        }
+        assert!(l4 <= balance::value(&l1.tiny_coin_farming_bounty), C34)
     };
     /* block 40 */;
     let l6 = balance::split(&mut l1.tiny_coin_base_bounty, l3);
@@ -3026,20 +1866,9 @@ public entry fun work<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Glob
 }
 
 fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u64, l4: Coin<T0>, l5: Coin<T1>, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): Coin<T0> {
-    let l11;
     let l12 = cetus_clmm_worker::remove_share(l0, l3);
     let l17 = &l0.ok_strategies;
-    if (table::contains(l17, l7)) {
-        l11 = *(table::borrow(l17, l7));
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
+    let l11 = table::contains(l17, l7) && *(table::borrow(l17, l7));
     /* block 21 */;
     assert!(l11, C21);
     assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
@@ -3048,15 +1877,9 @@ fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l
     let l16 = reg_52;
     let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
     if (coin::value(&l16) == 0u64) {
-        coin::destroy_zero(l16);
-        unstructured {
-            goto 'label_99;
-        }
+        coin::destroy_zero(l16)
     } else {
-        pay::keep(l16, freeze(l10));
-        unstructured {
-            goto 'label_99;
-        }
+        pay::keep(l16, freeze(l10))
     };
     /* block 99 */;
     cetus_clmm_worker::add_share(l0, l3, l13, l14);
@@ -3064,20 +1887,9 @@ fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l
 }
 
 fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u64, l4: Coin<T0>, l5: Coin<T1>, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): Coin<T0> {
-    let l11;
     let l12 = cetus_clmm_worker::remove_share(l0, l3);
     let l17 = &l0.ok_strategies;
-    if (table::contains(l17, l7)) {
-        l11 = *(table::borrow(l17, l7));
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
+    let l11 = table::contains(l17, l7) && *(table::borrow(l17, l7));
     /* block 21 */;
     assert!(l11, C21);
     assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
@@ -3086,15 +1898,9 @@ fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalC
     let l16 = reg_52;
     let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
     if (coin::value(&l16) == 0u64) {
-        coin::destroy_zero(l16);
-        unstructured {
-            goto 'label_99;
-        }
+        coin::destroy_zero(l16)
     } else {
-        pay::keep(l16, freeze(l10));
-        unstructured {
-            goto 'label_99;
-        }
+        pay::keep(l16, freeze(l10))
     };
     /* block 99 */;
     cetus_clmm_worker::add_share(l0, l3, l13, l14);
@@ -3154,29 +1960,16 @@ public entry fun work_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &m
     vault::merge_work_context_coin_back(l39, l31);
     if (l34 > 0u64) {
         let l29 = l5;
-        vault::set_work_context_health(l39, cetus_clmm_worker::health(freeze(l0), freeze(l4), l29));
-        unstructured {
-            goto 'label_100;
-        }
-    } else {
-        unstructured {
-            goto 'label_100;
-        }
+        vault::set_work_context_health(l39, cetus_clmm_worker::health(freeze(l0), freeze(l4), l29))
     };
     /* block 100 */;
     let l36 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l1), freeze(l4), l12, l13, l14);
     let l33 = vault::after_work(&l0.position_operator_cap, l1, l2, &l37, l38, l9, l36, l14, l15);
     coin::join(&mut l32, l33);
     if (coin::value(&l32) == 0u64) {
-        coin::destroy_zero(l32);
-        unstructured {
-            goto 'label_150;
-        }
+        coin::destroy_zero(l32)
     } else {
-        pay::keep(l32, freeze(l15));
-        unstructured {
-            goto 'label_150;
-        }
+        pay::keep(l32, freeze(l15))
     };
     /* block 150 */
 }
@@ -3197,29 +1990,16 @@ public entry fun work_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>
     vault::merge_work_context_coin_back(l39, l31);
     if (l34 > 0u64) {
         let l29 = l5;
-        vault::set_work_context_health(l39, cetus_clmm_worker::health_reverse(freeze(l0), freeze(l4), l29));
-        unstructured {
-            goto 'label_100;
-        }
-    } else {
-        unstructured {
-            goto 'label_100;
-        }
+        vault::set_work_context_health(l39, cetus_clmm_worker::health_reverse(freeze(l0), freeze(l4), l29))
     };
     /* block 100 */;
     let l36 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l1), freeze(l4), l12, l13, l14);
     let l33 = vault::after_work(&l0.position_operator_cap, l1, l2, &l37, l38, l9, l36, l14, l15);
     coin::join(&mut l32, l33);
     if (coin::value(&l32) == 0u64) {
-        coin::destroy_zero(l32);
-        unstructured {
-            goto 'label_150;
-        }
+        coin::destroy_zero(l32)
     } else {
-        pay::keep(l32, freeze(l15));
-        unstructured {
-            goto 'label_150;
-        }
+        pay::keep(l32, freeze(l15))
     };
     /* block 150 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/crank.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/crank.mv.snap
@@ -154,42 +154,21 @@ public fun validate_heartbeat<T0>(l0: &mut CrankConfig, l1: &mut Vault<T0>, l2: 
     let l7 = string::utf8(C15);
     if (!(dynamic_field::exists_(&l0.id, l5))) {
         dynamic_field::add(&mut l0.id, l5, l10);
-        dynamic_field::add(&mut l0.id, l7, l11);
-        unstructured {
-            goto 'label_128;
-        }
+        dynamic_field::add(&mut l0.id, l7, l11)
     } else {
         let l6 = *(dynamic_field::borrow(&l0.id, l7));
         if (l11 - l6 > C13) {
             *(dynamic_field::borrow_mut(&mut l0.id, l5)) = l10;
-            *(dynamic_field::borrow_mut(&mut l0.id, l7)) = l11;
-            unstructured {
-                goto 'label_128;
-            }
+            *(dynamic_field::borrow_mut(&mut l0.id, l7)) = l11
         } else {
             let l8 = *(dynamic_field::borrow(&l0.id, l5));
             if (l8 > 0u64) {
-                let l4;
-                if (l10 > l8) {
-                    l4 = l10 - l8;
-                    unstructured {
-                        goto 'label_114;
-                    }
-                } else {
-                    l4 = l8 - l10;
-                    unstructured {
-                        goto 'label_114;
-                    }
-                };
                 /* block 114 */;
-                assert!(l4as u128 * 10000u128 / l8as u128as u64 <= C12, C10);
-                unstructured {
-                    goto 'label_128;
-                }
-            } else {
-                unstructured {
-                    goto 'label_128;
-                }
+                assert!(if (l10 > l8) {
+                    l10 - l8
+                } else {
+                    l8 - l10
+                }as u128 * 10000u128 / l8as u128as u64 <= C12, C10)
             }
         }
     };
@@ -205,17 +184,10 @@ public fun validate_reroute<T0>(l0: &mut CrankConfig, l1: &ApyRegistry, l2: &Str
     let l8 = apy::get_total_apy(l1, l4);
     let l12 = apy::get_total_apy(l1, l5);
     assert!(l12 > l8, C7);
-    let l7;
-    if (l8 == 0u64) {
-        l7 = 10000u64;
-        unstructured {
-            goto 'label_89;
-        }
+    let l7 = if (l8 == 0u64) {
+        10000u64
     } else {
-        l7 = l12 - l8 * 10000u64 / l8;
-        unstructured {
-            goto 'label_89;
-        }
+        l12 - l8 * 10000u64 / l8
     };
     /* block 89 */;
     let l11 = l7;
@@ -227,28 +199,14 @@ public fun validate_reroute<T0>(l0: &mut CrankConfig, l1: &ApyRegistry, l2: &Str
     assert!(l9 >= *(&l0.reroute_cooldown_ms), C5);
     floors::assert_cooldown(l9);
     if (l4 != 0u8) {
-        apy::assert_not_stale(l1, l4, l6);
-        unstructured {
-            goto 'label_162;
-        }
-    } else {
-        unstructured {
-            goto 'label_162;
-        }
+        apy::assert_not_stale(l1, l4, l6)
     };
     /* block 162 */;
     apy::assert_not_stale(l1, l5, l6);
     let reg_103;
     (reg_102, reg_103) = strategy::decode_strategy(l5);
     if (reg_103 == 2u8) {
-        assert!(!(vault::is_depeg_active(l3)), C11);
-        unstructured {
-            goto 'label_185;
-        }
-    } else {
-        unstructured {
-            goto 'label_185;
-        }
+        assert!(!(vault::is_depeg_active(l3)), C11)
     };
     /* block 185 */;
     *(&mut l0.last_reroute_ms) = l10;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/curved_math.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/curved_math.mv.snap
@@ -140,30 +140,16 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
         };
         l15 = l15 + 1u64;
     };
-    let l21;
-    if (*(&l1.future_A_gamma_time) > l20) {
-        l21 = curved_math::solve_D(l8, l13as u256, l10);
-        unstructured {
-            goto 'label_102;
-        }
+    let l21 = if (*(&l1.future_A_gamma_time) > l20) {
+        curved_math::solve_D(l8, l13as u256, l10)
     } else {
-        l21 = *(&l1._D);
-        unstructured {
-            goto 'label_102;
-        }
+        *(&l1._D)
     };
     let l27;
     /* block 102 */;
     l27 = curved_math::solve_D(l8, l13as u256, l31);
     if (l21 == 0u256) {
         l18 = curved_math::get_xcp(l27, *(&l1.price_scale), l19as u256);
-        unstructured {
-            goto 'label_120;
-        }
-    } else {
-        unstructured {
-            goto 'label_120;
-        }
     };
     /* block 120 */;
     if (l21 > 0u256) {
@@ -173,25 +159,13 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
             *(&mut (&mut l12)[l16]) = curved_math::calculate_fee_charged(*(&(&l10)[l16]), *(&(&l31)[l16]), l21, l27, *(&(&l1.price_scale)[l16]), l11);
             l16 = l16 + 1u64;
         };
-        let l5;
         let l29 = curved_math::xp(math::subtract_vectors_u256(l30, l12), *(&l1.price_scale));
         let l28 = curved_math::solve_D(l8, l13as u256, l29);
         l18 = math::mul_div_u256(l4, l28, l21) - l4;
         l4 = l4 + l18;
         let l6 = 0u256;
-        if (l18 > math::pow_10_u256(5u8)) {
-            l5 = l23 < l19;
-            unstructured {
-                goto 'label_217;
-            }
-        } else {
-            l5 = false;
-            unstructured {
-                goto 'label_217;
-            }
-        };
         /* block 217 */;
-        if (l5) {
+        if (l18 > math::pow_10_u256(5u8) && l23 < l19) {
             let l26 = 0u256;
             let l14 = 0u64;
             while (l14 < l19) {
@@ -205,28 +179,15 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
             let l24 = *(&(&l30)[l23]);
             let l9 = l22 - math::mul_div_u256(l18, l24, l4);
             l6 = math::mul_div_u256(l26, C0, l9);
-            unstructured {
-                goto 'label_277;
-            }
-        } else {
-            unstructured {
-                goto 'label_277;
-            }
         };
         /* block 277 */;
         let l25 = *(&l1.last_prices_timestamp);
         let l17 = *(&l1.last_prices);
-        curved_math::tweak_price(l1, l8, l13as u256, l31, l23, l6, l27, l4, l25, l20, l17);
-        unstructured {
-            goto 'label_311;
-        }
+        curved_math::tweak_price(l1, l8, l13as u256, l31, l23, l6, l27, l4, l25, l20, l17)
     } else {
         *(&mut l1._D) = l27;
         *(&mut l1.virtual_price) = C0;
-        *(&mut l1.xcp_profit) = C0;
-        unstructured {
-            goto 'label_311;
-        }
+        *(&mut l1.xcp_profit) = C0
     };
     /* block 311 */;
     assert!(l18 > 0u256, C27);
@@ -235,147 +196,33 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
 
 public fun assert_new_config_params(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64) {
     if (l0 > 0u64) {
-        let l6;
-        if (l0 >= C5) {
-            l6 = l0 <= C6;
-            unstructured {
-                goto 'label_15;
-            }
-        } else {
-            l6 = false;
-            unstructured {
-                goto 'label_15;
-            }
-        };
         /* block 15 */;
-        assert!(l6, C28);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        unstructured {
-            goto 'label_20;
-        }
+        assert!(l0 >= C5 && l0 <= C6, C28)
     };
     /* block 20 */;
     if (l1 > 0u64) {
-        let l7;
-        if (l1 >= C5) {
-            l7 = l1 <= C6;
-            unstructured {
-                goto 'label_35;
-            }
-        } else {
-            l7 = false;
-            unstructured {
-                goto 'label_35;
-            }
-        };
         /* block 35 */;
-        assert!(l7, C30);
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        unstructured {
-            goto 'label_40;
-        }
+        assert!(l1 >= C5 && l1 <= C6, C30)
     };
     /* block 40 */;
     if (l2 > 0u64) {
-        let l8;
-        if (l2 >= C11) {
-            l8 = l2 <= C12;
-            unstructured {
-                goto 'label_55;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_55;
-            }
-        };
         /* block 55 */;
-        assert!(l8, C31);
-        unstructured {
-            goto 'label_60;
-        }
-    } else {
-        unstructured {
-            goto 'label_60;
-        }
+        assert!(l2 >= C11 && l2 <= C12, C31)
     };
     /* block 60 */;
     if (l4 > 0u64) {
-        let l9;
-        if (l4as u256 >= C2) {
-            l9 = l4as u256 <= C10;
-            unstructured {
-                goto 'label_77;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_77;
-            }
-        };
         /* block 77 */;
-        assert!(l9, C32);
-        unstructured {
-            goto 'label_82;
-        }
-    } else {
-        unstructured {
-            goto 'label_82;
-        }
+        assert!(l4as u256 >= C2 && l4as u256 <= C10, C32)
     };
     /* block 82 */;
     if (l5 > 0u64) {
-        let l10;
-        if (l5as u256 >= C2) {
-            l10 = l5as u256 <= C10;
-            unstructured {
-                goto 'label_99;
-            }
-        } else {
-            l10 = false;
-            unstructured {
-                goto 'label_99;
-            }
-        };
         /* block 99 */;
-        assert!(l10, C33);
-        unstructured {
-            goto 'label_104;
-        }
-    } else {
-        unstructured {
-            goto 'label_104;
-        }
+        assert!(l5as u256 >= C2 && l5as u256 <= C10, C33)
     };
     /* block 104 */;
     if (l3 > 0u64) {
-        let l11;
-        if (l3 >= C8) {
-            l11 = l3 <= C9;
-            unstructured {
-                goto 'label_119;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_119;
-            }
-        };
         /* block 119 */;
-        assert!(l11, C29);
-        unstructured {
-            goto 'label_124;
-        }
-    } else {
-        unstructured {
-            goto 'label_124;
-        }
+        assert!(l3 >= C8 && l3 <= C9, C29)
     };
     /* block 124 */
 }
@@ -385,13 +232,6 @@ public fun calc_geometric_mean(l0: vector<u256>, l1: bool): u256 {
     let l11 = l0;
     if (l1) {
         l11 = math::sort_u256(l11);
-        unstructured {
-            goto 'label_10;
-        }
-    } else {
-        unstructured {
-            goto 'label_10;
-        }
     };
     let (l4, l7);
     /* block 10 */;
@@ -424,13 +264,6 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
     let l19 = reg_7;
     if (*(&l1.future_A_gamma_time) > l24) {
         l6 = true;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        unstructured {
-            goto 'label_20;
-        }
     };
     let (l17, l20, l27);
     /* block 20 */;
@@ -445,17 +278,10 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
         };
         l20 = l20 + 1u64;
     };
-    let l25;
-    if (l6) {
-        l25 = curved_math::solve_D(l13, l19as u256, l17);
-        unstructured {
-            goto 'label_72;
-        }
+    let l25 = if (l6) {
+        curved_math::solve_D(l13, l19as u256, l17)
     } else {
-        l25 = *(&l1._D);
-        unstructured {
-            goto 'label_72;
-        }
+        *(&l1._D)
     };
     let (l10, l12, l14, l29, l8);
     /* block 72 */;
@@ -467,30 +293,9 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
     l12 = math::mul_div_u256(*(&(&l17)[l4]) - l30, C0, l27);
     *(&mut (&mut l17)[l4]) = l30;
     l10 = 0u256;
-    if (l7) {
-        l8 = l12 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_142;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_142;
-        }
-    };
-    let l9;
+    l8 = l7 && l12 > math::pow_10_u256(5u8);
     /* block 142 */;
-    if (l8) {
-        l9 = l5 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_152;
-        }
-    } else {
-        l9 = false;
-        unstructured {
-            goto 'label_152;
-        }
-    };
+    let l9 = l8 && l5 > math::pow_10_u256(5u8);
     /* block 152 */;
     if (l9) {
         let l28 = 0u256;
@@ -504,13 +309,6 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
         l28 = math::mul_div_u256(l28, l14, l25);
         let l16 = l12 - math::mul_div_u256(l14, *(&(&l2)[l4]), l25);
         l10 = math::mul_div_u256(l28, C0, l16);
-        unstructured {
-            goto 'label_206;
-        }
-    } else {
-        unstructured {
-            goto 'label_206;
-        }
     };
     /* block 206 */;
     let l26 = *(&l1.last_prices_timestamp);
@@ -525,7 +323,6 @@ public fun calculate_fee_charged(l0: u256, l1: u256, l2: u256, l3: u256, l4: u25
 }
 
 public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3: u64, l4: u256, l5: vector<u256>, l6: u256): ( u256, u256) {
-    let l7;
     let l22 = clock::timestamp_ms(l0);
     let (reg_7, reg_8) = curved_math::get_cur_A_gamma(l0, freeze(l1));
     let l13 = reg_8;
@@ -536,32 +333,14 @@ public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3
     *(&mut (&mut l17)[l2]) = *(&(&l5)[l2]) + l4;
     l17 = curved_math::xp(l17, *(&l1.price_scale));
     let l14 = *(&(&l5)[l3]);
-    if (*(&l1.init_A_gamma_time) < l22) {
-        l7 = *(&l1.future_A_gamma_time) > l22;
-        unstructured {
-            goto 'label_57;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_57;
-        }
-    };
     /* block 57 */;
-    if (l7) {
+    if (*(&l1.init_A_gamma_time) < l22 && *(&l1.future_A_gamma_time) > l22) {
         let l12 = *(&(&l1.price_scale)[l2]);
         l15 = math::mul_div_u256(l15, l12, C0);
         let l25 = *(&(&l17)[l2]);
         *(&mut (&mut l17)[l2]) = l15;
         *(&mut l1._D) = curved_math::solve_D(l13, l19as u256, l17);
-        *(&mut (&mut l17)[l2]) = l25;
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        unstructured {
-            goto 'label_93;
-        }
+        *(&mut (&mut l17)[l2]) = l25
     };
     let (l11, l16, l18, l8);
     /* block 93 */;
@@ -572,54 +351,19 @@ public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3
     l18 = math::mul_div_u256(curved_math::fee(l17, *(&l1.mid_fee), *(&l1.out_fee), *(&l1.fee_gamma)as u256), l16, C7as u256);
     *(&mut (&mut l17)[l3]) = math::mul_div_u256(l14 - l16 - l18, *(&(&l1.price_scale)[l3]), C0);
     l11 = 0u256;
-    if (l4 > math::pow_10_u256(5u8)) {
-        l8 = l16 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_181;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_181;
-        }
-    };
+    l8 = l4 > math::pow_10_u256(5u8) && l16 > math::pow_10_u256(5u8);
     /* block 181 */;
     if (l8) {
-        let l9;
-        if (l2 != 0u64) {
-            l9 = l3 != 0u64;
-            unstructured {
-                goto 'label_194;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_194;
-            }
-        };
         /* block 194 */;
-        if (l9) {
+        if (l2 != 0u64 && l3 != 0u64) {
             l11 = math::mul_div_u256(l4, *(&(&l1.last_prices)[l2]), l16);
-            unstructured {
-                goto 'label_223;
-            }
         } else {
             if (l2 == 0u64) {
                 l11 = math::mul_div_u256(l4, C0, l16);
-                unstructured {
-                    goto 'label_223;
-                }
             } else {
                 l11 = math::mul_div_u256(l16, C0, l4);
                 l24 = l2;
-                unstructured {
-                    goto 'label_223;
-                }
             }
-        }
-    } else {
-        unstructured {
-            goto 'label_223;
         }
     };
     /* block 223 */;
@@ -631,7 +375,6 @@ public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3
 }
 
 public fun compute_offer_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3: u64, l4: u256, l5: vector<u256>, l6: u256): ( u256, u256) {
-    let l7;
     let l21 = clock::timestamp_ms(l0);
     let (reg_7, reg_8) = curved_math::get_cur_A_gamma(l0, freeze(l1));
     let l12 = reg_8;
@@ -644,32 +387,14 @@ public fun compute_offer_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, 
     *(&mut (&mut l17)[l3]) = *(&(&l5)[l3]) - l13;
     l17 = curved_math::xp(l17, *(&l1.price_scale));
     let l22 = *(&(&l5)[l2]);
-    if (*(&l1.init_A_gamma_time) < l21) {
-        l7 = *(&l1.future_A_gamma_time) > l21;
-        unstructured {
-            goto 'label_83;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_83;
-        }
-    };
     /* block 83 */;
-    if (l7) {
+    if (*(&l1.init_A_gamma_time) < l21 && *(&l1.future_A_gamma_time) > l21) {
         let l11 = *(&(&l1.price_scale)[l3]);
         l15 = math::mul_div_u256(l15, l11, C0);
         let l26 = *(&(&l17)[l3]);
         *(&mut (&mut l17)[l3]) = l15;
         *(&mut l1._D) = curved_math::solve_D(l12, l19as u256, l17);
-        *(&mut (&mut l17)[l3]) = l26;
-        unstructured {
-            goto 'label_119;
-        }
-    } else {
-        unstructured {
-            goto 'label_119;
-        }
+        *(&mut (&mut l17)[l3]) = l26
     };
     let (l14, l16, l24, l8);
     /* block 119 */;
@@ -679,54 +404,19 @@ public fun compute_offer_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, 
     *(&mut (&mut l17)[l2]) = math::mul_div_u256(l22 + l16, *(&(&l1.price_scale)[l2]), C0);
     l14 = l13 - l4;
     l24 = 0u256;
-    if (l13 > math::pow_10_u256(5u8)) {
-        l8 = l16 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_190;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_190;
-        }
-    };
+    l8 = l13 > math::pow_10_u256(5u8) && l16 > math::pow_10_u256(5u8);
     /* block 190 */;
     if (l8) {
-        let l9;
-        if (l2 != 0u64) {
-            l9 = l3 != 0u64;
-            unstructured {
-                goto 'label_203;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_203;
-            }
-        };
         /* block 203 */;
-        if (l9) {
+        if (l2 != 0u64 && l3 != 0u64) {
             l24 = math::mul_div_u256(l13, *(&(&l1.last_prices)[l3]), l16);
-            unstructured {
-                goto 'label_232;
-            }
         } else {
             if (l3 == 0u64) {
                 l24 = math::mul_div_u256(l13, C0, l16);
-                unstructured {
-                    goto 'label_232;
-                }
             } else {
                 l24 = math::mul_div_u256(l16, C0, l13);
                 l25 = l3;
-                unstructured {
-                    goto 'label_232;
-                }
             }
-        }
-    } else {
-        unstructured {
-            goto 'label_232;
         }
     };
     /* block 232 */;
@@ -750,14 +440,7 @@ fun ema_recorder(l0: &mut CurvedPoolConfig, l1: u256, l2: u256, l3: vector<u256>
             l6 = l6 + 1u64;
         };
         *(&mut l0.oracle_prices) = l8;
-        *(&mut l0.last_prices_timestamp) = l2as u64;
-        unstructured {
-            goto 'label_67;
-        }
-    } else {
-        unstructured {
-            goto 'label_67;
-        }
+        *(&mut l0.last_prices_timestamp) = l2as u64
     };
     /* block 67 */
 }
@@ -770,70 +453,40 @@ public fun fee(l0: vector<u256>, l1: u64, l2: u64, l3: u256): u256 {
 }
 
 public fun get_cur_A_gamma(l0: &Clock, l1: &CurvedPoolConfig): ( u256, u64) {
-    let l2;
     let l16 = clock::timestamp_ms(l0);
     let l18 = *(&l1.future_A_gamma_time);
     let l10 = *(&l1.next_gamma);
     let l15 = *(&l1.next_amp);
-    if (*(&l1.init_A_gamma_time) < l16) {
-        l2 = l16 < l18;
-        unstructured {
-            goto 'label_28;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_28;
-        }
-    };
+    let l2 = *(&l1.init_A_gamma_time) < l16 && l16 < l18;
     let (l5, l6);
     /* block 28 */;
-    if (l2) {
-        let l3;
+    l5 = if (l2) {
         let l17 = *(&l1.init_A_gamma_time);
         let l9 = *(&l1.init_gamma);
         let l12 = *(&l1.init_amp);
         let l8 = l16 - l17;
         let l19 = l18 - l17;
         let l11 = math::mul_div_u256(math::max_u256(l10, l9) - math::min_u256(l10, l9), l8as u256, l19as u256);
-        if (l10 > l9) {
-            l3 = l9 + l11;
-            unstructured {
-                goto 'label_76;
-            }
+        let l3 = if (l10 > l9) {
+            l9 + l11
         } else {
-            l3 = l9 - l11;
-            unstructured {
-                goto 'label_76;
-            }
+            l9 - l11
         };
         let (l14, l4);
         /* block 76 */;
         l14 = l3;
         let l7 = math::mul_div(math::max_u64(l15, l12) - math::min_u64(l15, l12), l8, l19);
-        if (l15 > l12) {
-            l4 = l12 + l7;
-            unstructured {
-                goto 'label_102;
-            }
+        l4 = if (l15 > l12) {
+            l12 + l7
         } else {
-            l4 = l12 - l7;
-            unstructured {
-                goto 'label_102;
-            }
+            l12 - l7
         };
         /* block 102 */;
         l6 = l4;
-        l5 = l14;
-        unstructured {
-            goto 'label_115;
-        }
+        l14
     } else {
         l6 = l15;
-        l5 = l10;
-        unstructured {
-            goto 'label_115;
-        }
+        l10
     };
     /* block 115 */;
     return (l5, l6)
@@ -945,7 +598,6 @@ public fun initialize_curved_config(l0: &Clock, l1: vector<u64>, l2: vector<u256
     assert!(&l1.len() == 8u64, C16);
     assert!(&l2.len() == l4as u64, C16);
     assert!(*(&(&l2)[0u64]) == C0, C24);
-    let l6;
     let l41 = clock::timestamp_ms(l0);
     let l33 = *(&(&l1)[0u64]) * C1;
     let l35 = *(&(&l1)[1u64])as u256;
@@ -957,115 +609,28 @@ public fun initialize_curved_config(l0: &Clock, l1: vector<u64>, l2: vector<u256
     let l36 = *(&(&l1)[7u64]);
     let l39 = math::pow(l4, l4)as u64 * C1 / 100u64;
     let l37 = math::pow(l4, l4)as u64 * C1 * 1000u64;
-    if (l39 <= l33) {
-        l6 = l33 <= l37;
-        unstructured {
-            goto 'label_110;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_110;
-        }
-    };
+    let l6 = l39 <= l33 && l33 <= l37;
     /* block 110 */;
     assert!(l6, C21);
-    let l17;
-    if (l35 >= C2) {
-        l17 = l35 <= C3;
-        unstructured {
-            goto 'label_126;
-        }
-    } else {
-        l17 = false;
-        unstructured {
-            goto 'label_126;
-        }
-    };
+    let l17 = l35 >= C2 && l35 <= C3;
     /* block 126 */;
     assert!(l17, C25);
-    let l24;
-    if (l36 >= C8) {
-        l24 = l36 <= C9;
-        unstructured {
-            goto 'label_142;
-        }
-    } else {
-        l24 = false;
-        unstructured {
-            goto 'label_142;
-        }
-    };
+    let l24 = l36 >= C8 && l36 <= C9;
     /* block 142 */;
     assert!(l24, C29);
-    let l25;
-    if (l38 >= C5) {
-        l25 = l38 <= C6;
-        unstructured {
-            goto 'label_158;
-        }
-    } else {
-        l25 = false;
-        unstructured {
-            goto 'label_158;
-        }
-    };
+    let l25 = l38 >= C5 && l38 <= C6;
     /* block 158 */;
     assert!(l25, C28);
-    let l26;
-    if (l40 >= C5) {
-        l26 = l40 <= C6;
-        unstructured {
-            goto 'label_174;
-        }
-    } else {
-        l26 = false;
-        unstructured {
-            goto 'label_174;
-        }
-    };
+    let l26 = l40 >= C5 && l40 <= C6;
     /* block 174 */;
     assert!(l26, C30);
-    let l27;
-    if (l34 >= C11) {
-        l27 = l34 <= C12;
-        unstructured {
-            goto 'label_190;
-        }
-    } else {
-        l27 = false;
-        unstructured {
-            goto 'label_190;
-        }
-    };
+    let l27 = l34 >= C11 && l34 <= C12;
     /* block 190 */;
     assert!(l27, C31);
-    let l28;
-    if (l32 >= C2) {
-        l28 = l32 <= C10;
-        unstructured {
-            goto 'label_206;
-        }
-    } else {
-        l28 = false;
-        unstructured {
-            goto 'label_206;
-        }
-    };
+    let l28 = l32 >= C2 && l32 <= C10;
     /* block 206 */;
     assert!(l28, C32);
-    let l29;
-    if (l31 >= C2) {
-        l29 = l31 <= C10;
-        unstructured {
-            goto 'label_222;
-        }
-    } else {
-        l29 = false;
-        unstructured {
-            goto 'label_222;
-        }
-    };
+    let l29 = l31 >= C2 && l31 <= C10;
     /* block 222 */;
     assert!(l29, C33);
     let l19 = l36as u256;
@@ -1073,33 +638,11 @@ public fun initialize_curved_config(l0: &Clock, l1: vector<u64>, l2: vector<u256
 }
 
 fun newton_D(l0: u64, l1: u256, l2: vector<u256>, l3: u256): u256 {
-    let l4;
     let l19 = &l2.len();
-    if (l0 > curved_math::get_min_amp(l19) - 1u64) {
-        l4 = l0 < curved_math::get_max_amp(l19) + 1u64;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l4 = false;
-        unstructured {
-            goto 'label_20;
-        }
-    };
+    let l4 = l0 > curved_math::get_min_amp(l19) - 1u64 && l0 < curved_math::get_max_amp(l19) + 1u64;
     /* block 20 */;
     assert!(l4, C18);
-    let l5;
-    if (l1 > C2 - 1u256) {
-        l5 = l1 < C3 + 1u256;
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_40;
-        }
-    };
+    let l5 = l1 > C2 - 1u256 && l1 < C3 + 1u256;
     /* block 40 */;
     assert!(l5, C19);
     let l21 = 0u256;
@@ -1155,47 +698,14 @@ fun newton_D(l0: u64, l1: u256, l2: vector<u256>, l3: u256): u256 {
 }
 
 public fun newton_y(l0: u256, l1: u256, l2: vector<u256>, l3: u256, l4: u64): u256 {
-    let l5;
     let l25 = &l2.len();
-    if (l0as u64 > curved_math::get_min_amp(l25) - 1u64) {
-        l5 = l0as u64 < curved_math::get_max_amp(l25) + 1u64;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_22;
-        }
-    };
+    let l5 = l0as u64 > curved_math::get_min_amp(l25) - 1u64 && l0as u64 < curved_math::get_max_amp(l25) + 1u64;
     /* block 22 */;
     assert!(l5, C18);
-    let l6;
-    if (l1 > C2 - 1u256) {
-        l6 = l1 < C3 + 1u256;
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_42;
-        }
-    };
+    let l6 = l1 > C2 - 1u256 && l1 < C3 + 1u256;
     /* block 42 */;
     assert!(l6, C19);
-    let l7;
-    if (l3 > math::pow_10_u256(17u8) - 1u256) {
-        l7 = l3 < math::pow_10_u256(15u8) * C0 + 1u256;
-        unstructured {
-            goto 'label_66;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_66;
-        }
-    };
+    let l7 = l3 > math::pow_10_u256(17u8) - 1u256 && l3 < math::pow_10_u256(15u8) * C0 + 1u256;
     /* block 66 */;
     assert!(l7, C19);
     let l21 = 0u64;
@@ -1310,34 +820,16 @@ public fun reduction_coefficient(l0: vector<u256>, l1: u256): u256 {
     };
     if (l1 > 0u256) {
         l4 = l1 * C0 / l1 + C0 - l4;
-        unstructured {
-            goto 'label_63;
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
-        }
     };
     /* block 63 */;
     return l4
 }
 
 public fun solve_D(l0: u64, l1: u256, l2: vector<u256>): u256 {
-    let l3;
     let l6 = &l2.len();
     let l7 = math::sort_u256(l2);
     let l5 = *(&(&l7)[0u64]);
-    if (l5 > math::pow_10_u256(9u8) - 1u256) {
-        l3 = l5 < math::pow_10_u256(15u8) * C0 + 1u256;
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_30;
-        }
-    };
+    let l3 = l5 > math::pow_10_u256(9u8) - 1u256 && l5 < math::pow_10_u256(15u8) * C0 + 1u256;
     /* block 30 */;
     assert!(l3, C17);
     let l4 = l6as u256 * curved_math::calc_geometric_mean(l7, false);
@@ -1350,21 +842,11 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
     let l17 = l6;
     if (l6 == 0u256) {
         l17 = curved_math::solve_D(l1, l2, l3);
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        unstructured {
-            goto 'label_23;
-        }
     };
     /* block 23 */;
     if (l5 > 0u256) {
         if (l4 > 0u64) {
-            *(&mut (&mut l0.last_prices)[l4]) = l5;
-            unstructured {
-                goto 'label_120;
-            }
+            *(&mut (&mut l0.last_prices)[l4]) = l5
         } else {
             let l19 = 1u64;
             while (l19 < l24) {
@@ -1397,57 +879,21 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
     let l40 = C0;
     let l38 = C0;
     if (l32 > 0u256) {
-        let l11;
         let l39 = curved_math::calc_geometric_mean(l42, true);
         l38 = math::mul_div_u256(C0, l39, l7);
         l40 = math::mul_div_u256(l33, l38, l32);
-        if (l38 < l32) {
-            l11 = *(&l0.future_A_gamma_time) < l9;
-            unstructured {
-                goto 'label_192;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_192;
-            }
-        };
         /* block 192 */;
-        assert!(!(l11), C34);
-        unstructured {
-            goto 'label_200;
-        }
-    } else {
-        unstructured {
-            goto 'label_200;
-        }
+        assert!(!(l38 < l32 && *(&l0.future_A_gamma_time) < l9), C34)
     };
     let (l12, l25);
     /* block 200 */;
     *(&mut l0.xcp_profit) = l40;
     l25 = *(&l0.not_adjusted);
-    if (!(l25)) {
-        l12 = l38 * 2u256 - C0 > l40 + 2u256 * *(&l0.allowed_extra_profit);
-        unstructured {
-            goto 'label_228;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_228;
-        }
-    };
+    l12 = !(l25) && l38 * 2u256 - C0 > l40 + 2u256 * *(&l0.allowed_extra_profit);
     /* block 228 */;
     if (l12) {
         l25 = true;
-        *(&mut l0.not_adjusted) = true;
-        unstructured {
-            goto 'label_236;
-        }
-    } else {
-        unstructured {
-            goto 'label_236;
-        }
+        *(&mut l0.not_adjusted) = true
     };
     /* block 236 */;
     if (l25) {
@@ -1459,20 +905,8 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
             l29 = l29 + l35 * l35;
             l22 = l22 + 1u64;
         };
-        let l13;
-        if (l29 > l15 * l15) {
-            l13 = l32 > 0u256;
-            unstructured {
-                goto 'label_289;
-            }
-        } else {
-            l13 = false;
-            unstructured {
-                goto 'label_289;
-            }
-        };
         /* block 289 */;
-        if (l13) {
+        if (l29 > l15 * l15 && l32 > 0u256) {
             let l30 = math::sqrt_int_u256(l29 / C0);
             let l27 = vector[];
             (&mut l27).push_back(C0);
@@ -1495,19 +929,8 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
                 *(&mut (&mut l36)[l23]) = math::mul_div_u256(l26, C0, l34 * l24as u256);
                 l23 = l23 + 1u64;
             };
-            let l14;
             let l28 = math::mul_div_u256(curved_math::calc_geometric_mean(l36, true), C0, l7);
-            if (l28 > C0) {
-                l14 = 2u256 * l28 - C0 > l40;
-                unstructured {
-                    goto 'label_421;
-                }
-            } else {
-                l14 = false;
-                unstructured {
-                    goto 'label_421;
-                }
-            };
+            let l14 = l28 > C0 && 2u256 * l28 - C0 > l40;
             /* block 421 */;
             if (l14) {
                 *(&mut l0.price_scale) = l27;
@@ -1515,18 +938,7 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
                 *(&mut l0.virtual_price) = l28;
                 return
             };
-            *(&mut l0.not_adjusted) = false;
-            unstructured {
-                goto 'label_441;
-            }
-        } else {
-            unstructured {
-                goto 'label_441;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_441;
+            *(&mut l0.not_adjusted) = false
         }
     };
     /* block 441 */;
@@ -1535,90 +947,21 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
 }
 
 public fun update_A_and_gamma(l0: &mut CurvedPoolConfig, l1: u64, l2: u64, l3: u256, l4: u64) {
-    let l5;
     let l13 = &l0.last_prices.len()as u128;
     let l14 = math::pow(l13, l13)as u64;
     let l12 = l14 * C1 / 100u64;
     let l11 = l14 * C1 * 1000u64;
-    if (l12 < l2) {
-        l5 = l2 < l11;
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_33;
-        }
-    };
+    let l5 = l12 < l2 && l2 < l11;
     /* block 33 */;
     assert!(l5, C21);
-    let l6;
-    if (l3 >= C2) {
-        l6 = l3 <= C3 + 1u256;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = l3 >= C2 && l3 <= C3 + 1u256;
     /* block 53 */;
     assert!(l6, C25);
-    let l8;
-    if (l2 >= *(&l0.init_amp)) {
-        l8 = l2 <= *(&l0.init_amp) * C4;
-        unstructured {
-            goto 'label_77;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_77;
-        }
-    };
-    let l9;
     /* block 77 */;
-    if (l8) {
-        l9 = true;
-        unstructured {
-            goto 'label_101;
-        }
-    } else {
-        let l7;
-        if (l2 < *(&l0.init_amp)) {
-            l7 = l2 * C4 >= *(&l0.init_amp);
-            unstructured {
-                goto 'label_99;
-            }
-        } else {
-            l7 = false;
-            unstructured {
-                goto 'label_99;
-            }
-        };
-        /* block 99 */;
-        l9 = l7;
-        unstructured {
-            goto 'label_101;
-        }
-    };
+    let l9 = l2 >= *(&l0.init_amp) && l2 <= *(&l0.init_amp) * C4 || /* block 99 */ l2 < *(&l0.init_amp) && l2 * C4 >= *(&l0.init_amp);
     /* block 101 */;
     assert!(l9, C23);
-    let l10;
-    if (l4 > l1) {
-        l10 = l4 - l1 > C13;
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_121;
-        }
-    };
+    let l10 = l4 > l1 && l4 - l1 > C13;
     /* block 121 */;
     assert!(l10, C22);
     *(&mut l0.init_A_gamma_time) = l1;
@@ -1629,184 +972,53 @@ public fun update_A_and_gamma(l0: &mut CurvedPoolConfig, l1: u64, l2: u64, l3: u
 
 public fun update_config_fee_params(l0: &mut CurvedPoolConfig, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64) {
     if (l1 > 0u64) {
-        let l7;
-        if (l1 >= C5) {
-            l7 = l1 <= C6;
-            unstructured {
-                goto 'label_15;
-            }
-        } else {
-            l7 = false;
-            unstructured {
-                goto 'label_15;
-            }
-        };
+        let l7 = l1 >= C5 && l1 <= C6;
         /* block 15 */;
         assert!(l7, C28);
-        *(&mut l0.mid_fee) = l1;
-        unstructured {
-            goto 'label_26;
-        }
-    } else {
-        unstructured {
-            goto 'label_26;
-        }
+        *(&mut l0.mid_fee) = l1
     };
     /* block 26 */;
     if (l2 > 0u64) {
-        let l8;
-        if (l2 >= C5) {
-            l8 = l2 <= C6;
-            unstructured {
-                goto 'label_41;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_41;
-            }
-        };
+        let l8 = l2 >= C5 && l2 <= C6;
         /* block 41 */;
         assert!(l8, C30);
-        *(&mut l0.out_fee) = l2;
-        unstructured {
-            goto 'label_52;
-        }
-    } else {
-        unstructured {
-            goto 'label_52;
-        }
+        *(&mut l0.out_fee) = l2
     };
     /* block 52 */;
     assert!(*(&l0.mid_fee) <= *(&l0.out_fee), C20);
     if (l3 > 0u64) {
-        let l9;
-        if (l3 >= C11) {
-            l9 = l3 <= C12;
-            unstructured {
-                goto 'label_80;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_80;
-            }
-        };
+        let l9 = l3 >= C11 && l3 <= C12;
         /* block 80 */;
         assert!(l9, C31);
-        *(&mut l0.fee_gamma) = l3;
-        unstructured {
-            goto 'label_91;
-        }
-    } else {
-        unstructured {
-            goto 'label_91;
-        }
+        *(&mut l0.fee_gamma) = l3
     };
     /* block 91 */;
     if (l5 > 0u64) {
-        let l10;
-        if (l5as u256 >= C2) {
-            l10 = l5as u256 <= C10;
-            unstructured {
-                goto 'label_108;
-            }
-        } else {
-            l10 = false;
-            unstructured {
-                goto 'label_108;
-            }
-        };
+        let l10 = l5as u256 >= C2 && l5as u256 <= C10;
         /* block 108 */;
         assert!(l10, C32);
-        *(&mut l0.allowed_extra_profit) = l5as u256;
-        unstructured {
-            goto 'label_120;
-        }
-    } else {
-        unstructured {
-            goto 'label_120;
-        }
+        *(&mut l0.allowed_extra_profit) = l5as u256
     };
     /* block 120 */;
     if (l6 > 0u64) {
-        let l11;
-        if (l6as u256 >= C2) {
-            l11 = l6as u256 <= C10;
-            unstructured {
-                goto 'label_137;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_137;
-            }
-        };
+        let l11 = l6as u256 >= C2 && l6as u256 <= C10;
         /* block 137 */;
         assert!(l11, C33);
-        *(&mut l0.adjustment_step) = l6as u256;
-        unstructured {
-            goto 'label_149;
-        }
-    } else {
-        unstructured {
-            goto 'label_149;
-        }
+        *(&mut l0.adjustment_step) = l6as u256
     };
     /* block 149 */;
     if (l4 > 0u64) {
-        let l12;
-        if (l4 >= C8) {
-            l12 = l4 <= C9;
-            unstructured {
-                goto 'label_164;
-            }
-        } else {
-            l12 = false;
-            unstructured {
-                goto 'label_164;
-            }
-        };
+        let l12 = l4 >= C8 && l4 <= C9;
         /* block 164 */;
         assert!(l12, C29);
-        *(&mut l0.ma_half_time) = l4as u256;
-        unstructured {
-            goto 'label_179;
-        }
-    } else {
-        unstructured {
-            goto 'label_179;
-        }
+        *(&mut l0.ma_half_time) = l4as u256
     };
     /* block 179 */
 }
 
 public fun update_initial_prices(l0: &mut CurvedPoolConfig, l1: vector<u256>) {
-    let l2;
-    if (*(&l0._D) == 0u256) {
-        l2 = *(&l0.virtual_price) == 0u256;
-        unstructured {
-            goto 'label_15;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_15;
-        }
-    };
-    let l3;
     /* block 15 */;
-    if (l2) {
-        l3 = *(&l0.xcp_profit) == 0u256;
-        unstructured {
-            goto 'label_26;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_26;
-        }
-    };
+    let l3 = *(&l0._D) == 0u256 && *(&l0.virtual_price) == 0u256 && *(&l0.xcp_profit) == 0u256;
     /* block 26 */;
     assert!(l3, C17);
     *(&mut l0.price_scale) = l1;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
@@ -48,64 +48,26 @@ public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &
 }
 
 fun cim(l0: u8): bool {
-    let l5;
     let l13 = &l0;
     let l6 = ct::cpsos();
-    if (l13 == &l6) {
-        l5 = true;
-        unstructured {
-            goto 'label_62;
-        }
-    } else {
-        let l4;
-        let l8 = constants::post_only();
-        if (l13 == &l8) {
-            l4 = true;
-            unstructured {
-                goto 'label_60;
-            }
-        } else {
-            let l3;
-            let l10 = constants::immediate_or_cancel();
-            if (l13 == &l10) {
-                l3 = false;
-                unstructured {
-                    goto 'label_58;
-                }
-            } else {
-                let l2;
-                let l12 = constants::fill_or_kill();
-                if (l13 == &l12) {
-                    l2 = false;
-                    unstructured {
-                        goto 'label_56;
-                    }
-                } else {
-                    l2 = false;
-                    unstructured {
-                        goto 'label_56;
-                    }
-                };
-                /* block 56 */;
-                l3 = l2;
-                unstructured {
-                    goto 'label_58;
-                }
-            };
-            /* block 58 */;
-            l4 = l3;
-            unstructured {
-                goto 'label_60;
-            }
-        };
-        /* block 60 */;
-        l5 = l4;
-        unstructured {
-            goto 'label_62;
-        }
-    };
     /* block 62 */;
-    return l5
+    return l13 == &l6 || {
+        let l8 = constants::post_only();
+        /* block 60 */;
+        l13 == &l8 || {
+            let l10 = constants::immediate_or_cancel();
+            /* block 58 */;
+            l13 != &l10 && {
+                let l12 = constants::fill_or_kill();
+                /* block 56 */;
+                if (l13 == &l12) {
+                    false
+                } else {
+                    false
+                }
+            }
+        }
+    }
 }
 
 public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut BalanceManager, l3: &Clock, l4: &mut SQR, l5: u64, l6: bool, l7: u64, l8: u64, l9: vector<u8>, l10: vector<u8>, l11: vector<u64>, l12: vector<u64>, l13: vector<bool>, l14: vector<u64>, l15: &mut TxContext) {
@@ -115,14 +77,7 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
     } else {
         let l52 = bm::gdtp(l1, l2, l15);
         if (l6) {
-            pool::cancel_all_orders(l0, l2, &l52, l3, freeze(l15));
-            unstructured {
-                goto 'label_41;
-            }
-        } else {
-            unstructured {
-                goto 'label_41;
-            }
+            pool::cancel_all_orders(l0, l2, &l52, l3, freeze(l15))
         };
         let (l16, l23, l31, l32, l43, l51);
         /* block 41 */;
@@ -133,30 +88,18 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
         let l20 = balance_manager::balance(freeze(l2));
         l43 = balance_manager::balance(freeze(l2));
         l23 = balance_manager::balance(freeze(l2));
-        if (l20 > l7) {
-            l16 = l20 - l7;
-            unstructured {
-                goto 'label_70;
-            }
+        l16 = if (l20 > l7) {
+            l20 - l7
         } else {
-            l16 = 0u64;
-            unstructured {
-                goto 'label_70;
-            }
+            0u64
         };
         let (l17, l21);
         /* block 70 */;
         l21 = l16;
-        if (l43 > l8) {
-            l17 = l43 - l8;
-            unstructured {
-                goto 'label_83;
-            }
+        l17 = if (l43 > l8) {
+            l43 - l8
         } else {
-            l17 = 0u64;
-            unstructured {
-                goto 'label_83;
-            }
+            0u64
         };
         let (l19, l22, l28, l44, l50);
         /* block 83 */;
@@ -244,8 +187,8 @@ fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
     };
-    let l5;
-    if (l4) {
+    /* block 88 */;
+    return if (l4) {
         if (l1.len() == 0u64) {
             return l3
         };
@@ -257,10 +200,7 @@ fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
         if (l9 < l2) {
             return 0u64
         };
-        l5 = l9;
-        unstructured {
-            goto 'label_88;
-        }
+        l9
     } else {
         if (l0.len() == 0u64) {
             return l3
@@ -273,13 +213,8 @@ fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
         if (l10 > constants::max_u64() - l2) {
             return 0u64
         };
-        l5 = l10;
-        unstructured {
-            goto 'label_88;
-        }
-    };
-    /* block 88 */;
-    return l5
+        l10
+    }
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
@@ -289,18 +224,7 @@ fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64,
     if (l7 % l4 != 0u64) {
         return (0u64, ct::e_invalid_price())
     };
-    let l12;
-    if (!(l9)) {
-        l12 = l1 < l6;
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_30;
-        }
-    };
+    let l12 = !(l9) && l1 < l6;
     /* block 30 */;
     if (l12) {
         return (0u64, ct::e_insufficient_base_balance())
@@ -308,8 +232,7 @@ fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64,
     if (l8 < l6) {
         return (0u64, ct::e_insufficient_quantity())
     };
-    let l15;
-    if (l9) {
+    let l15 = if (l9) {
         let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
         let l21 = l25 % l5 + l5;
         if (l25 < l21) {
@@ -320,44 +243,24 @@ fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64,
             return (0u64, ct::e_insufficient_quote_balance())
         };
         let l19 = u64::max(l6, u64::min(l8, l22as u64));
-        l15 = l19 - l19 % l5;
-        unstructured {
-            goto 'label_114;
-        }
+        l19 - l19 % l5
     } else {
         let l20 = u64::max(l6, u64::min(l8, l1));
-        l15 = l20 - l20 % l5;
-        unstructured {
-            goto 'label_114;
-        }
+        l20 - l20 % l5
     };
     let (l14, l26);
     /* block 114 */;
     l26 = l15;
-    if (l11) {
-        let l13;
+    l14 = if (l11) {
         let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-        if (l10) {
-            l13 = reg_90;
-            unstructured {
-                goto 'label_137;
-            }
-        } else {
-            l13 = reg_89;
-            unstructured {
-                goto 'label_137;
-            }
-        };
         /* block 137 */;
-        l14 = l13;
-        unstructured {
-            goto 'label_144;
+        if (l10) {
+            reg_90
+        } else {
+            reg_89
         }
     } else {
-        l14 = 0u64;
-        unstructured {
-            goto 'label_144;
-        }
+        0u64
     };
     /* block 144 */;
     if (l14 > l3) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/demo.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/demo.mv.snap
@@ -554,19 +554,8 @@ const C58: vector<u8> = vector[78u8, 111u8, 32u8, 98u8, 111u8, 110u8, 117u8, 115
 
 public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     assert!(string::length(&l2) > 0u64, C23);
@@ -644,87 +633,46 @@ fun assert_not_paused<T0>(l0: &StakingPool<T0>) {
 }
 
 fun calculate_effective_reward_rate_enhanced(l0: u64, l1: u64, l2: u64, l3: u64): u64 {
-    let l4;
     let l6 = demo::safe_mul_div_precise(demo::safe_mul_div_precise(l0, l1, 10000u64), l2, 10000u64);
-    if (l3 == 0u64) {
-        l4 = l6;
-        unstructured {
-            goto 'label_24;
-        }
+    /* block 24 */;
+    return if (l3 == 0u64) {
+        l6
     } else {
         let l5 = demo::safe_add(10000u64, l3);
-        l4 = demo::safe_mul_div_precise(l6, l5, 10000u64);
-        unstructured {
-            goto 'label_24;
-        }
-    };
-    /* block 24 */;
-    return l4
+        demo::safe_mul_div_precise(l6, l5, 10000u64)
+    }
 }
 
 fun calculate_enhanced_slot_rewards(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64): u64 {
-    let l8;
     let l15 = demo::calculate_effective_reward_rate_enhanced(l3, l4, l5, l6);
-    if (l7 > 0u64) {
-        l8 = l7 < l2;
-        unstructured {
-            goto 'label_17;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_17;
-        }
-    };
-    let l9;
     /* block 17 */;
-    if (l8) {
-        l9 = l7;
-        unstructured {
-            goto 'label_24;
-        }
+    let l9 = if (l7 > 0u64 && l7 < l2) {
+        l7
     } else {
-        l9 = l2;
-        unstructured {
-            goto 'label_24;
-        }
+        l2
     };
     let (l10, l12);
     /* block 24 */;
     l12 = l9;
-    if (l1 > l0) {
-        l10 = l1;
-        unstructured {
-            goto 'label_35;
-        }
+    l10 = if (l1 > l0) {
+        l1
     } else {
-        l10 = l0;
-        unstructured {
-            goto 'label_35;
-        }
+        l0
     };
     /* block 35 */;
     let l13 = l10;
     if (l13 >= l12) {
         return 0u64
     };
-    let l11;
     let l14 = demo::safe_sub(l12, l13);
     let l17 = l15as u128 * C47 / C46as u128;
     let l16 = l14as u128 * l17 / C47;
-    if (l16 > C48as u128) {
-        l11 = C48;
-        unstructured {
-            goto 'label_73;
-        }
-    } else {
-        l11 = l16as u64;
-        unstructured {
-            goto 'label_73;
-        }
-    };
     /* block 73 */;
-    return l11
+    return if (l16 > C48as u128) {
+        C48
+    } else {
+        l16as u64
+    }
 }
 
 fun calculate_reserve(l0: u64): u64 {
@@ -734,36 +682,24 @@ fun calculate_reserve(l0: u64): u64 {
 fun calculate_slot_params(l0: u8): ( u64, u64) {
     let (l3, l4);
     let l11 = l0as u64;
-    if (l11 <= 10u64) {
+    l3 = if (l11 <= 10u64) {
         let l5 = l11 * 10000000000u64;
         l4 = 10000u64 + l11 - 1u64 * 2000u64;
-        l3 = l5;
-        unstructured {
-            goto 'label_65;
-        }
+        l5
     } else {
         let (l1, l2);
-        if (l11 <= 50u64) {
+        l1 = if (l11 <= 50u64) {
             let l6 = l11 * 20000000000u64;
             l2 = 30000u64 + l11 - 11u64 * 1000u64;
-            l1 = l6;
-            unstructured {
-                goto 'label_61;
-            }
+            l6
         } else {
             let l7 = l11 * 50000000000u64;
             l2 = 70000u64 + l11 - 51u64 * 1000u64;
-            l1 = l7;
-            unstructured {
-                goto 'label_61;
-            }
+            l7
         };
         /* block 61 */;
         l4 = l2;
-        l3 = l1;
-        unstructured {
-            goto 'label_65;
-        }
+        l1
     };
     /* block 65 */;
     return (l3, l4)
@@ -797,31 +733,18 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     let l14 = demo::calculate_enhanced_slot_rewards(l37, l21, l20, l16, l32, l23, l39, *(&l0.end_time));
     let l38 = demo::safe_add(l26, l14);
     assert!(l38 > 0u64, C4);
-    let l4;
-    if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
-        l4 = demo::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_205;
-        }
+    let l4 = if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
+        demo::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards))
     } else {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_205;
-        }
+        0u64
     };
     let l6;
     /* block 205 */;
     let l15 = l4;
-    if (l15 >= l38) {
-        l6 = l38;
-        unstructured {
-            goto 'label_216;
-        }
+    l6 = if (l15 >= l38) {
+        l38
     } else {
-        l6 = l15;
-        unstructured {
-            goto 'label_216;
-        }
+        l15
     };
     /* block 216 */;
     let l18 = l6;
@@ -830,15 +753,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l35.last_claim_time) = l20;
     *(&mut l35.total_claimed) = demo::safe_add(*(&l35.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l35.pending_rewards) = demo::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = demo::safe_sub(l38, l18)
     } else {
-        *(&mut l35.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = 0u64
     };
     /* block 261 */;
     let l31 = SlotDataKey { owner: l25, slot_number: l33 };
@@ -846,15 +763,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l30.last_claim_time) = l20;
     *(&mut l30.total_claimed) = demo::safe_add(*(&l30.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l30.pending_rewards) = demo::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = demo::safe_sub(l38, l18)
     } else {
-        *(&mut l30.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = 0u64
     };
     let (l10, l11, l12, l13, l5, l7, l8, l9);
     /* block 297 */;
@@ -869,16 +780,10 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     l10 = l20;
     l9 = *(&l0.reward_token_type);
     l8 = l18 < l38;
-    if (l18 < l38) {
-        l7 = demo::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_348;
-        }
+    l7 = if (l18 < l38) {
+        demo::safe_sub(l38, l18)
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_348;
-        }
+        0u64
     };
     /* block 348 */;
     event::emit(RewardsClaimed { pool_id: l5, nft_id: l13, owner: l12, amount: l11, claim_time: l10, reward_token_type: l9, is_partial_claim: l8, remaining_pending: l7, slot_number: l33 })
@@ -900,24 +805,13 @@ fun create_enhanced_slot_configs(): vector<SlotConfig> {
 }
 
 public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: u64, l4: u64, l5: vector<String>, l6: address, l7: u8, l8: &Clock, l9: &mut TxContext): StakingPool<T0> {
-    let l10;
     let l11 = tx_context::sender(freeze(l9));
     let l14 = object::new(l9);
     let l15 = object::uid_to_inner(&l14);
     let l17 = coin::value(&l0);
     let l18 = type_name::get();
     let l12 = clock::timestamp_ms(l8);
-    if (l7 >= 1u8) {
-        l10 = l7 <= C52;
-        unstructured {
-            goto 'label_29;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_29;
-        }
-    };
+    let l10 = l7 >= 1u8 && l7 <= C52;
     /* block 29 */;
     assert!(l10, C40);
     let l19 = demo::create_enhanced_slot_configs();
@@ -936,16 +830,10 @@ public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: 
 fun decrease_reserved_rewards(l0: &mut u64, l1: u64) {
     let l3 = demo::calculate_reserve(l1);
     if (*l0 >= l3) {
-        *l0 = demo::safe_sub(*l0, l3);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = demo::safe_sub(*l0, l3)
     } else {
         let l2 = *l0 * l3 / demo::calculate_reserve(l1);
-        *l0 = demo::safe_sub(*l0, l2);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = demo::safe_sub(*l0, l2)
     };
     /* block 29 */
 }
@@ -955,40 +843,24 @@ public fun get_admin<T0>(l0: &StakingPool<T0>): address {
 }
 
 public fun get_available_rewards<T0>(l0: &StakingPool<T0>): u64 {
-    let l1;
     let l2 = balance::value(&l0.reward_balance);
-    if (l2 <= *(&l0.reserved_rewards)) {
-        l1 = 0u64;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l1 = demo::safe_sub(l2, *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l1
+    return if (l2 <= *(&l0.reserved_rewards)) {
+        0u64
+    } else {
+        demo::safe_sub(l2, *(&l0.reserved_rewards))
+    }
 }
 
 public fun get_collection_multiplier_info<T0>(l0: &StakingPool<T0>, l1: String): Option<CollectionMultiplierInfo> {
-    let l2;
     let l3 = CollectionMultiplierKey { collection: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) });
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_30;
-        }
-    };
     /* block 30 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_default_reward_rate<T0>(l0: &StakingPool<T0>): u64 {
@@ -1016,36 +888,21 @@ public fun get_enhanced_slot_configs<T0>(l0: &StakingPool<T0>): vector<SlotConfi
 }
 
 public fun get_nft_multiplier_info<T0>(l0: &StakingPool<T0>, l1: ID, l2: String): Option<NftMultiplierInfo> {
-    let l3;
     let l4 = NftMultiplierKey { nft_id: l1, collection: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l5 = dynamic_object_field::borrow(&l0.id, l4);
-        l3 = option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) });
-        unstructured {
-            goto 'label_34;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_34;
-        }
-    };
     /* block 34 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l5 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &mut TxContext): &mut SlotData {
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
     if (!(dynamic_object_field::exists_(&l0.id, l5))) {
         let l4 = SlotData { id: object::new(l3), owner: l1, slot_number: l2, staked_nft: option::none(), staked_collection: option::none(), stake_time: 0u64, last_claim_time: 0u64, pending_rewards: 0u64, total_claimed: 0u64, is_unlocked: false, nft_type: option::none() };
-        dynamic_object_field::add(&mut l0.id, l5, l4);
-        unstructured {
-            goto 'label_32;
-        }
-    } else {
-        unstructured {
-            goto 'label_32;
-        }
+        dynamic_object_field::add(&mut l0.id, l5, l4)
     };
     /* block 32 */;
     return dynamic_object_field::borrow_mut(&mut l0.id, l5)
@@ -1054,21 +911,15 @@ fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l
 public fun get_pool_slot_limits<T0>(l0: &StakingPool<T0>): ( u8, u8, u64) {
     let (l1, l2, l3);
     let l4 = PoolSlotLimitsKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
+    l1 = if (dynamic_object_field::exists_(&l0.id, l4)) {
         let l5 = dynamic_object_field::borrow(&l0.id, l4);
         l3 = *(&l5.total_users_with_custom_limits);
         l2 = *(&l5.absolute_max_slots);
-        l1 = *(&l5.default_max_slots_per_wallet);
-        unstructured {
-            goto 'label_34;
-        }
+        *(&l5.default_max_slots_per_wallet)
     } else {
         l3 = 0u64;
         l2 = C52;
-        l1 = C51;
-        unstructured {
-            goto 'label_34;
-        }
+        C51
     };
     /* block 34 */;
     return (l1, l2, l3)
@@ -1097,22 +948,14 @@ fun get_slot_config(l0: &vector<SlotConfig>, l1: u8): &SlotConfig {
 }
 
 public fun get_slot_data<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): Option<SlotDataInfo> {
-    let l3;
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l5)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l5);
-        l3 = option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) });
-        unstructured {
-            goto 'label_49;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_49;
-        }
-    };
     /* block 49 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l5)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l5);
+        option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_slot_effective_rate<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): u64 {
@@ -1164,48 +1007,24 @@ public fun get_slot_price<T0>(l0: &StakingPool<T0>, l1: u8): u64 {
 }
 
 public fun get_slot_token_price<T0>(l0: &StakingPool<T0>, l1: u8, l2: String): u64 {
-    let l5;
     let l7 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        let l3;
+    /* block 47 */;
+    return if (dynamic_object_field::exists_(&l0.id, l7)) {
         let l6 = dynamic_object_field::borrow(&l0.id, l7);
-        if (table::contains(&l6.token_prices, l2)) {
-            l3 = *(table::borrow(&l6.token_prices, l2));
-            unstructured {
-                goto 'label_29;
-            }
-        } else {
-            l3 = 0u64;
-            unstructured {
-                goto 'label_29;
-            }
-        };
         /* block 29 */;
-        l5 = l3;
-        unstructured {
-            goto 'label_47;
+        if (table::contains(&l6.token_prices, l2)) {
+            *(table::borrow(&l6.token_prices, l2))
+        } else {
+            0u64
         }
     } else {
-        let l4;
-        if (l2 == demo::get_token_type_string_sui()) {
-            l4 = demo::get_slot_price(l0, l1);
-            unstructured {
-                goto 'label_45;
-            }
-        } else {
-            l4 = 0u64;
-            unstructured {
-                goto 'label_45;
-            }
-        };
         /* block 45 */;
-        l5 = l4;
-        unstructured {
-            goto 'label_47;
+        if (l2 == demo::get_token_type_string_sui()) {
+            demo::get_slot_price(l0, l1)
+        } else {
+            0u64
         }
-    };
-    /* block 47 */;
-    return l5
+    }
 }
 
 public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
@@ -1213,39 +1032,23 @@ public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
 }
 
 public fun get_supported_payment_tokens<T0>(l0: &StakingPool<T0>): vector<String> {
-    let l1;
     let l2 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l2)) {
-        l1 = *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l1 = vector[];
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l1
+    return if (dynamic_object_field::exists_(&l0.id, l2)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list)
+    } else {
+        vector[]
+    }
 }
 
 public fun get_token_revenue<T0>(l0: &StakingPool<T0>, l1: String): u64 {
-    let l2;
     let l3 = TokenRevenueKey { token_type: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected)
+    } else {
+        0u64
+    }
 }
 
 fun get_token_type_string_any<T0>(): String {
@@ -1263,13 +1066,6 @@ fun get_token_type_string_any<T0>(): String {
                 l1 = l1 + 1u64;
             };
             return string::utf8(l4)
-        };
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        unstructured {
-            goto 'label_50;
         }
     };
     /* block 50 */;
@@ -1285,22 +1081,14 @@ public fun get_total_staked<T0>(l0: &StakingPool<T0>): u64 {
 }
 
 public fun get_user_slot_allocation<T0>(l0: &StakingPool<T0>, l1: address): Option<UserSlotInfo> {
-    let l2;
     let l4 = UserSlotAllocationKey { user: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l4);
-        l2 = option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l3 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_user_total_claimed_rewards<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1353,19 +1141,13 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
     let l11 = dynamic_object_field::borrow(&l0.id, l35);
     let l14 = clock::timestamp_ms(l2);
     let l38 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l38)) {
+    l3 = if (dynamic_object_field::exists_(&l0.id, l38)) {
         let l39 = dynamic_object_field::borrow(&l0.id, l38);
         l4 = *(&l39.reason);
-        l3 = *(&l39.bonus_multiplier);
-        unstructured {
-            goto 'label_61;
-        }
+        *(&l39.bonus_multiplier)
     } else {
         l4 = string::utf8(C58);
-        l3 = 0u64;
-        unstructured {
-            goto 'label_61;
-        }
+        0u64
     };
     let (l18, l20, l27, l32, l34, l36, l37, l9);
     /* block 61 */;
@@ -1422,40 +1204,24 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
 }
 
 fun get_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): u64 {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier)
+    } else {
+        0u64
+    }
 }
 
 public fun get_wallet_bonus_multiplier_info<T0>(l0: &StakingPool<T0>, l1: address): Option<WalletBonusMultiplierInfo> {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_wallet_bonus_multiplier_view<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1469,19 +1235,8 @@ public fun has_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): b
 
 public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l2 >= 1u8) {
-        l5 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= 1u8 && l2 <= C52;
     /* block 31 */;
     assert!(l5, C40);
     let l13 = UserSlotAllocationKey { user: l1 };
@@ -1494,24 +1249,14 @@ public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: addr
         *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64);
         if (l2 != l9) {
             let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l10);
-            *(&mut l12.total_users_with_custom_limits) = demo::safe_add(*(&l12.total_users_with_custom_limits), 1u64);
-            unstructured {
-                goto 'label_144;
-            }
-        } else {
-            unstructured {
-                goto 'label_144;
-            }
+            *(&mut l12.total_users_with_custom_limits) = demo::safe_add(*(&l12.total_users_with_custom_limits), 1u64)
         }
     } else {
         let l7 = dynamic_object_field::borrow_mut(&mut l0.id, l13);
         let l11 = *(&l7.max_slots_allowed);
         assert!(l2 > l11, C40);
         *(&mut l7.max_slots_allowed) = l2;
-        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 });
-        unstructured {
-            goto 'label_144;
-        }
+        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 })
     };
     /* block 144 */
 }
@@ -1532,21 +1277,9 @@ public fun is_paused<T0>(l0: &StakingPool<T0>): bool {
 }
 
 public fun is_payment_token_supported<T0>(l0: &StakingPool<T0>, l1: String): bool {
-    let l2;
     let l3 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l2
+    return dynamic_object_field::exists_(&l0.id, l3) && table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1)
 }
 
 public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
@@ -1554,39 +1287,15 @@ public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
 }
 
 fun is_slot_occupied<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft)
 }
 
 fun is_slot_unlocked<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked)
 }
 
 fun is_sui_token<T0>(): bool {
@@ -1597,19 +1306,8 @@ fun is_sui_token<T0>(): bool {
 
 public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     let l8 = clock::timestamp_ms(l3);
@@ -1648,13 +1346,7 @@ public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l
     let (reg_35, reg_36) = vector::index_of(&l5.token_list, &l6);
     let l4 = reg_36;
     if (reg_35) {
-        unstructured {
-            goto 'label_63;
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
-        }
+        
     };
     /* block 63 */;
     let l3 = clock::timestamp_ms(l1);
@@ -1670,13 +1362,7 @@ public entry fun remove_payment_token<T0>(l0: &mut StakingPool<T0>, l1: String, 
     let (reg_42, reg_43) = vector::index_of(&l6.token_list, &l1);
     let l5 = reg_43;
     if (reg_42) {
-        unstructured {
-            goto 'label_75;
-        }
-    } else {
-        unstructured {
-            goto 'label_75;
-        }
+        
     };
     /* block 75 */;
     let l4 = clock::timestamp_ms(l2);
@@ -1701,18 +1387,7 @@ fun safe_add(l0: u64, l1: u64): u64 {
 }
 
 fun safe_mul_div_precise(l0: u64, l1: u64, l2: u64): u64 {
-    let l3;
-    if (l0 == 0u64) {
-        l3 = true;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l3 = l1 == 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    };
+    let l3 = l0 == 0u64 || l1 == 0u64;
     /* block 11 */;
     if (l3) {
         return 0u64
@@ -1735,38 +1410,20 @@ fun safe_sub(l0: u64, l1: u64): u64 {
 
 public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: String, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l2 >= C50) {
-        l5 = l2 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= C50 && l2 <= C54;
     /* block 31 */;
     assert!(l5, C36);
     assert!(string::length(&l1) > 0u64, C23);
     let reg_36;
     (reg_36, reg_37) = vector::index_of(&l0.supported_collections, &l1);
     assert!(reg_36, C8);
-    let l6;
     let l7 = CollectionMultiplierKey { collection: l1 };
     let l10 = clock::timestamp_ms(l3);
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier);
-        unstructured {
-            goto 'label_92;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l7)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier)
     } else {
-        l6 = 10000u64;
-        unstructured {
-            goto 'label_92;
-        }
+        10000u64
     };
     let l11;
     /* block 92 */;
@@ -1775,16 +1432,10 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
         let l8 = dynamic_object_field::borrow_mut(&mut l0.id, l7);
         *(&mut l8.default_multiplier) = l2;
         *(&mut l8.set_by) = tx_context::sender(freeze(l4));
-        *(&mut l8.set_time) = l10;
-        unstructured {
-            goto 'label_134;
-        }
+        *(&mut l8.set_time) = l10
     } else {
         let l9 = CollectionMultiplier { id: object::new(l4), collection: l1, default_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 };
-        dynamic_object_field::add(&mut l0.id, l7, l9);
-        unstructured {
-            goto 'label_134;
-        }
+        dynamic_object_field::add(&mut l0.id, l7, l9)
     };
     /* block 134 */;
     event::emit(CollectionMultiplierSet { pool_id: object::id(freeze(l0)), collection: l1, old_multiplier: l11, new_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 })
@@ -1792,19 +1443,8 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
 
 public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: String, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     demo::assert_not_paused(freeze(l0));
-    if (l3 >= C50) {
-        l7 = l3 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l3 >= C50 && l3 <= C54;
     /* block 31 */;
     assert!(l7, C36);
     assert!(string::length(&l2) > 0u64, C23);
@@ -1812,19 +1452,12 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
     let reg_44;
     (reg_44, reg_45) = vector::index_of(&l0.supported_collections, &l2);
     assert!(reg_44, C8);
-    let l8;
     let l10 = NftMultiplierKey { nft_id: l1, collection: l2 };
     let l9 = clock::timestamp_ms(l5);
-    if (dynamic_object_field::exists_(&l0.id, l10)) {
-        l8 = *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier);
-        unstructured {
-            goto 'label_107;
-        }
+    let l8 = if (dynamic_object_field::exists_(&l0.id, l10)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier)
     } else {
-        l8 = 10000u64;
-        unstructured {
-            goto 'label_107;
-        }
+        10000u64
     };
     let l13;
     /* block 107 */;
@@ -1834,16 +1467,10 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
         *(&mut l11.multiplier) = l3;
         *(&mut l11.rarity_tier) = l4;
         *(&mut l11.set_by) = tx_context::sender(freeze(l6));
-        *(&mut l11.set_time) = l9;
-        unstructured {
-            goto 'label_155;
-        }
+        *(&mut l11.set_time) = l9
     } else {
         let l12 = NftMultiplier { id: object::new(l6), nft_id: l1, collection: l2, multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 };
-        dynamic_object_field::add(&mut l0.id, l10, l12);
-        unstructured {
-            goto 'label_155;
-        }
+        dynamic_object_field::add(&mut l0.id, l10, l12)
     };
     /* block 155 */;
     event::emit(NftMultiplierSet { pool_id: object::id(freeze(l0)), nft_id: l1, collection: l2, old_multiplier: l13, new_multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 })
@@ -1851,19 +1478,8 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
 
 public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u8, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l7 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l1 >= C53 && l2 <= C52;
     /* block 31 */;
     assert!(l7, C29);
     assert!(l1 <= l2, C20);
@@ -1876,19 +1492,8 @@ public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l
 
 public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: vector<String>, l3: bool, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l8 = clock::timestamp_ms(l4);
@@ -1920,19 +1525,12 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
     demo::assert_not_paused(freeze(l0));
     assert!(l2 <= C54, C36);
     assert!(string::length(&l3) > 0u64, C20);
-    let l6;
     let l9 = WalletBonusMultiplierKey { wallet: l1 };
     let l7 = clock::timestamp_ms(l4);
-    if (dynamic_object_field::exists_(&l0.id, l9)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l9)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier)
     } else {
-        l6 = 0u64;
-        unstructured {
-            goto 'label_68;
-        }
+        0u64
     };
     let l8;
     /* block 68 */;
@@ -1942,16 +1540,10 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
         *(&mut l10.bonus_multiplier) = l2;
         *(&mut l10.reason) = l3;
         *(&mut l10.set_by) = tx_context::sender(freeze(l5));
-        *(&mut l10.set_time) = l7;
-        unstructured {
-            goto 'label_115;
-        }
+        *(&mut l10.set_time) = l7
     } else {
         let l11 = WalletBonusMultiplier { id: object::new(l5), wallet: l1, bonus_multiplier: l2, set_by: tx_context::sender(freeze(l5)), set_time: l7, reason: l3 };
-        dynamic_object_field::add(&mut l0.id, l9, l11);
-        unstructured {
-            goto 'label_115;
-        }
+        dynamic_object_field::add(&mut l0.id, l9, l11)
     };
     /* block 115 */;
     event::emit(WalletBonusMultiplierSet { pool_id: object::id(freeze(l0)), wallet: l1, old_bonus_multiplier: l8, new_bonus_multiplier: l2, reason: l3, set_by: tx_context::sender(freeze(l5)), set_time: l7 })
@@ -1961,31 +1553,13 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
     demo::assert_not_paused(freeze(l0));
     assert!(!(*(&l0.is_locked)), C5);
     assert!(string::length(&l4) > 0u64, C23);
-    let l8;
-    if (l5 >= C53) {
-        l8 = l5 <= C52;
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_50;
-        }
-    };
+    let l8 = l5 >= C53 && l5 <= C52;
     /* block 50 */;
     assert!(l8, C29);
     let l10 = clock::timestamp_ms(l6);
     assert!(l10 >= *(&l0.start_time), C7);
     if (*(&l0.end_time) > 0u64) {
-        assert!(l10 < *(&l0.end_time), C10);
-        unstructured {
-            goto 'label_108;
-        }
-    } else {
-        unstructured {
-            goto 'label_108;
-        }
+        assert!(l10 < *(&l0.end_time), C10)
     };
     /* block 108 */;
     let l15 = tx_context::sender(freeze(l7));
@@ -2019,38 +1593,16 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
 }
 
 public entry fun toggle_pause<T0>(l0: &mut StakingPool<T0>, l1: &mut TxContext) {
-    let l2;
     let l3 = tx_context::sender(freeze(l1));
-    if (l3 == *(&l0.admin)) {
-        l2 = true;
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = l3 == *(&l0.emergency_admin);
-        unstructured {
-            goto 'label_19;
-        }
-    };
+    let l2 = l3 == *(&l0.admin) || l3 == *(&l0.emergency_admin);
     /* block 19 */;
     assert!(l2, C1);
     *(&mut l0.is_paused) = !(*(&l0.is_paused))
 }
 
 public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
@@ -2061,23 +1613,13 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     let l8 = *(&l17.allowed_collections);
     let l15 = *(&l17.unlock_cost);
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_130;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l13 >= l15, C30);
         let l14 = coin::into_balance(l2);
         if (l13 > l15) {
             let l11 = demo::safe_sub(l13, l15);
-            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22);
-            unstructured {
-                goto 'label_89;
-            }
-        } else {
-            unstructured {
-                goto 'label_89;
-            }
+            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22)
         };
         let l16;
         /* block 89 */;
@@ -2085,21 +1627,11 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
         l16 = TokenRevenueKey { token_type: l21 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l19 = TokenRevenue { id: object::new(l4), token_type: l21, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l19);
-            unstructured {
-                goto 'label_112;
-            }
-        } else {
-            unstructured {
-                goto 'label_112;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l19)
         };
         /* block 112 */;
         let l20 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l20.total_collected) = demo::safe_add(*(&l20.total_collected), l15);
-        unstructured {
-            goto 'label_130;
-        }
+        *(&mut l20.total_collected) = demo::safe_add(*(&l20.total_collected), l15)
     };
     let l23;
     /* block 130 */;
@@ -2108,14 +1640,7 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l6 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l10, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l6);
-        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_168;
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
-        }
+        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 168 */;
     assert!(!(demo::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2129,81 +1654,42 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
 }
 
 public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8, l2: Coin<T0>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
     let l12 = coin::value(&l2);
     let l20 = demo::get_token_type_string_any();
     assert!(table::contains(&(dynamic_object_field::borrow(&l0.id, PaymentTokenRegistryKey { dummy_field: false })).supported_tokens, l20), C34);
-    let l7;
     let l14 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l14)) {
-        let l6;
+    let l7 = if (dynamic_object_field::exists_(&l0.id, l14)) {
         let l13 = dynamic_object_field::borrow(&l0.id, l14);
-        if (table::contains(&l13.token_prices, l20)) {
-            l6 = *(table::borrow(&l13.token_prices, l20));
-            unstructured {
-                goto 'label_81;
-            }
-        } else {
-            l6 = 0u64;
-            unstructured {
-                goto 'label_81;
-            }
-        };
         /* block 81 */;
-        l7 = l6;
-        unstructured {
-            goto 'label_86;
+        if (table::contains(&l13.token_prices, l20)) {
+            *(table::borrow(&l13.token_prices, l20))
+        } else {
+            0u64
         }
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_86;
-        }
+        0u64
     };
     let l15;
     /* block 86 */;
     l15 = l7;
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_148;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l12 == l15, C30);
         transfer::public_transfer(l2, *(&l0.admin));
         let l16 = TokenRevenueKey { token_type: l20 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l18 = TokenRevenue { id: object::new(l4), token_type: l20, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l18);
-            unstructured {
-                goto 'label_135;
-            }
-        } else {
-            unstructured {
-                goto 'label_135;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l18)
         };
         /* block 135 */;
         let l19 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l19.total_collected) = demo::safe_add(*(&l19.total_collected), l15);
-        unstructured {
-            goto 'label_148;
-        }
+        *(&mut l19.total_collected) = demo::safe_add(*(&l19.total_collected), l15)
     };
     let l23;
     /* block 148 */;
@@ -2212,14 +1698,7 @@ public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l8 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l11, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l8);
-        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_186;
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
-        }
+        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 186 */;
     assert!(!(demo::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2284,33 +1763,11 @@ public entry fun update_multiple_slot_rewards<T0>(l0: &mut StakingPool<T0>, l1: 
 
 public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
-    let l6;
-    if (l2 >= C50) {
-        l6 = l2 <= C54;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = l2 >= C50 && l2 <= C54;
     /* block 53 */;
     assert!(l6, C36);
     let l8 = clock::timestamp_ms(l3);
@@ -2337,19 +1794,8 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l9 = clock::timestamp_ms(l4);
@@ -2366,54 +1812,31 @@ public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Str
             };
             l10 = l10 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
     };
     /* block 99 */;
     let l16 = SlotTokenPricingKey { slot_number: l1 };
     if (dynamic_object_field::exists_(&l0.id, l16)) {
-        let l7;
         let l14 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        if (table::contains(&l14.token_prices, l2)) {
-            l7 = *(table::borrow(&l14.token_prices, l2));
-            unstructured {
-                goto 'label_126;
-            }
+        let l7 = if (table::contains(&l14.token_prices, l2)) {
+            *(table::borrow(&l14.token_prices, l2))
         } else {
-            l7 = 0u64;
-            unstructured {
-                goto 'label_126;
-            }
+            0u64
         };
         let l13;
         /* block 126 */;
         l13 = l7;
         if (table::contains(&l14.token_prices, l2)) {
-            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3;
-            unstructured {
-                goto 'label_145;
-            }
+            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3
         } else {
-            table::add(&mut l14.token_prices, l2, l3);
-            unstructured {
-                goto 'label_145;
-            }
+            table::add(&mut l14.token_prices, l2, l3)
         };
         /* block 145 */;
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     } else {
         let l15 = SlotTokenPricing { id: object::new(l5), slot_number: l1, token_prices: table::new(l5) };
         table::add(&mut (&mut l15).token_prices, l2, l3);
         dynamic_object_field::add(&mut l0.id, l16, l15);
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     };
     /* block 189 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/dlmm_bin_tree.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/dlmm_bin_tree.mv.snap
@@ -32,18 +32,11 @@ const C4: u64 = 3u64;
 
 public fun add(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l5 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l5)) {
-        l2 = *(vec_map::get(&l0.level2, &l5));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l5)) {
+        *(vec_map::get(&l0.level2, &l5))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l6 = l2;
@@ -51,49 +44,24 @@ public fun add(l0: &mut BinTree, l1: u32): bool {
     if (l6 != l8) {
         if (vec_map::contains(&l0.level2, &l5)) {
             (reg_41, reg_42) = vec_map::remove(&mut l0.level2, &l5);
-            unstructured {
-                goto 'label_57;
-            }
-        } else {
-            unstructured {
-                goto 'label_57;
-            }
         };
         /* block 57 */;
         vec_map::insert(&mut l0.level2, l5, l8);
         if (l6 == 0u256) {
-            let l3;
             let l4 = l5 >> 8u8;
-            if (vec_map::contains(&l0.level1, &l4)) {
+            let l3 = if (vec_map::contains(&l0.level1, &l4)) {
                 let reg_61;
                 (reg_60, reg_61) = vec_map::remove(&mut l0.level1, &l4);
-                l3 = reg_61;
-                unstructured {
-                    goto 'label_86;
-                }
+                reg_61
             } else {
-                l3 = 0u256;
-                unstructured {
-                    goto 'label_86;
-                }
+                0u256
             };
             /* block 86 */;
             let l7 = l3;
             let l9 = l7 | 1u256 << l5 & C1as u256as u8;
             vec_map::insert(&mut l0.level1, l4, l9);
             if (l7 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8;
-                unstructured {
-                    goto 'label_126;
-                }
-            } else {
-                unstructured {
-                    goto 'label_126;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_126;
+                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8
             }
         };
         /* block 126 */;
@@ -133,13 +101,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = dlmm_bin_tree::closest_bit_left(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -154,13 +115,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l14), C4);
             let l16 = *(vec_map::get(&l0.level2, &l14));
             return (l14 << 8u8 | bit_math::least_significant_bit(l16)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_126;
-        }
-    } else {
-        unstructured {
-            goto 'label_126;
         }
     };
     /* block 126 */;
@@ -175,13 +129,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l15), C4);
             let l18 = *(vec_map::get(&l0.level2, &l15));
             return (l15 << 8u8 | bit_math::least_significant_bit(l18)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_203;
-        }
-    } else {
-        unstructured {
-            goto 'label_203;
         }
     };
     /* block 203 */;
@@ -197,13 +144,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = dlmm_bin_tree::closest_bit_right(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -217,13 +157,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l14), C4);
             let l16 = *(vec_map::get(&l0.level2, &l14));
             return (l14 << 8u8 | bit_math::most_significant_bit(l16)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_116;
-        }
-    } else {
-        unstructured {
-            goto 'label_116;
         }
     };
     /* block 116 */;
@@ -238,13 +171,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l15), C4);
             let l18 = *(vec_map::get(&l0.level2, &l15));
             return (l15 << 8u8 | bit_math::most_significant_bit(l18)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_193;
-        }
-    } else {
-        unstructured {
-            goto 'label_193;
         }
     };
     /* block 193 */;
@@ -253,18 +179,11 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
 
 public fun remove(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l4 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l4)) {
-        l2 = *(vec_map::get(&l0.level2, &l4));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l4)) {
+        *(vec_map::get(&l0.level2, &l4))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l5 = l2;
@@ -279,18 +198,7 @@ public fun remove(l0: &mut BinTree, l1: u32): bool {
             let l8 = reg_54 & C0 - 1u256 << l4 & 255u256as u8;
             vec_map::insert(&mut l0.level1, l3, l8);
             if (l8 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8;
-                unstructured {
-                    goto 'label_113;
-                }
-            } else {
-                unstructured {
-                    goto 'label_113;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_113;
+                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8
             }
         };
         /* block 113 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/format.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/format.mv.snap
@@ -83,10 +83,6 @@ fun append_format_piece(l0: &mut vector<u8>, l1: &vector<u8>, l2: u64, l3: &vect
                 };
                 l10 = l10 + 1u64;
             }
-        } else {
-            unstructured {
-                goto 'label_57;
-            }
         };
         /* block 57 */;
         if (&l12.len() > 0u64) {
@@ -97,13 +93,6 @@ fun append_format_piece(l0: &mut vector<u8>, l1: &vector<u8>, l2: u64, l3: &vect
             };
             vector::append(l0, C12);
             return false
-        };
-        unstructured {
-            goto 'label_87;
-        }
-    } else {
-        unstructured {
-            goto 'label_87;
         }
     };
     /* block 87 */;
@@ -178,33 +167,7 @@ public fun format_string(l0: &x1_String, l1: &vector<u8>): x1_String {
 }
 
 public fun is_printable_char(l0: u8): bool {
-    let l2;
-    if (l0 == 10u8) {
-        l2 = true;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        let l1;
-        if (l0 >= 32u8) {
-            l1 = l0 < 126u8;
-            unstructured {
-                goto 'label_18;
-            }
-        } else {
-            l1 = false;
-            unstructured {
-                goto 'label_18;
-            }
-        };
-        /* block 18 */;
-        l2 = l1;
-        unstructured {
-            goto 'label_20;
-        }
-    };
-    /* block 20 */;
-    return l2
+    /* block 20 */ return l0 == 10u8 || /* block 18 */ l0 >= 32u8 && l0 < 126u8
 }
 
 public fun looks_like_a_string(l0: &vector<u8>, l1: u32): bool {
@@ -232,153 +195,44 @@ public fun meta_chunk_to_string(l0: &vector<u8>, l1: u32, l2: &vector<u8>): vect
     let l20 = C0;
     let l3 = C9;
     if (l2 == &l3) {
-        if (metadata::has_chunk_of_type(l0, l1)) {
-            l20 = C4;
-            unstructured {
-                goto 'label_146;
-            }
+        l20 = if (metadata::has_chunk_of_type(l0, l1)) {
+            C4
         } else {
             if (metadata::has_chunk_of_type(l0, l1)) {
-                l20 = C2;
-                unstructured {
-                    goto 'label_146;
-                }
+                C2
             } else {
-                let l5;
-                if (metadata::has_chunk_of_type(l0, l1)) {
-                    l5 = true;
-                    unstructured {
-                        goto 'label_48;
-                    }
-                } else {
-                    l5 = metadata::has_chunk_of_type(l0, l1);
-                    unstructured {
-                        goto 'label_48;
-                    }
-                };
-                let l6;
                 /* block 48 */;
-                if (l5) {
-                    l6 = true;
-                    unstructured {
-                        goto 'label_57;
-                    }
-                } else {
-                    l6 = metadata::has_chunk_of_type(l0, l1);
-                    unstructured {
-                        goto 'label_57;
-                    }
-                };
-                let l7;
+                let l6 = metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1);
                 /* block 57 */;
-                if (l6) {
-                    l7 = true;
-                    unstructured {
-                        goto 'label_66;
-                    }
-                } else {
-                    l7 = metadata::has_chunk_of_type(l0, l1);
-                    unstructured {
-                        goto 'label_66;
-                    }
-                };
+                let l7 = l6 || metadata::has_chunk_of_type(l0, l1);
                 /* block 66 */;
                 if (l7) {
-                    l20 = C8;
-                    unstructured {
-                        goto 'label_146;
-                    }
+                    C8
                 } else {
-                    let l8;
-                    if (metadata::has_chunk_of_type(l0, l1)) {
-                        l8 = true;
-                        unstructured {
-                            goto 'label_82;
-                        }
-                    } else {
-                        l8 = metadata::has_chunk_of_type(l0, l1);
-                        unstructured {
-                            goto 'label_82;
-                        }
-                    };
-                    let l9;
                     /* block 82 */;
-                    if (l8) {
-                        l9 = true;
-                        unstructured {
-                            goto 'label_91;
-                        }
-                    } else {
-                        l9 = metadata::has_chunk_of_type(l0, l1);
-                        unstructured {
-                            goto 'label_91;
-                        }
-                    };
+                    let l9 = metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1);
                     /* block 91 */;
                     if (l9) {
-                        l20 = C6;
-                        unstructured {
-                            goto 'label_146;
-                        }
+                        C6
                     } else {
-                        let l10;
-                        if (metadata::has_chunk_of_type(l0, l1)) {
-                            l10 = x2_format::looks_like_a_string(l0, l1);
-                            unstructured {
-                                goto 'label_107;
-                            }
-                        } else {
-                            l10 = false;
-                            unstructured {
-                                goto 'label_107;
-                            }
-                        };
                         /* block 107 */;
-                        if (l10) {
-                            l20 = C5;
-                            unstructured {
-                                goto 'label_146;
-                            }
+                        if (metadata::has_chunk_of_type(l0, l1) && x2_format::looks_like_a_string(l0, l1)) {
+                            C5
                         } else {
-                            let l11;
-                            if (metadata::has_chunk_of_type(l0, l1)) {
-                                l11 = true;
-                                unstructured {
-                                    goto 'label_123;
-                                }
-                            } else {
-                                l11 = metadata::has_chunk_of_type(l0, l1);
-                                unstructured {
-                                    goto 'label_123;
-                                }
-                            };
                             /* block 123 */;
-                            if (l11) {
-                                l20 = C7;
-                                unstructured {
-                                    goto 'label_146;
-                                }
+                            if (metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1)) {
+                                C7
                             } else {
-                                l20 = C0;
-                                unstructured {
-                                    goto 'label_146;
-                                }
+                                C0
                             }
                         }
                     }
                 }
             }
-        }
+        };
     } else {
         if (*(&l2[0u64]) == 58u8) {
             l20 = *(&l2[1u64]);
-            unstructured {
-                goto 'label_146;
-            }
-        } else {
-            unstructured {
-                goto 'label_146;
-            }
         }
     };
     /* block 146 */;
@@ -487,42 +341,16 @@ public fun vu8_to_hex(l0: &vector<u8>, l1: bool, l2: bool): vector<u8> {
     let l8 = 87u8;
     if (l2) {
         l8 = 55u8;
-        unstructured {
-            goto 'label_10;
-        }
-    } else {
-        unstructured {
-            goto 'label_10;
-        }
     };
     /* block 10 */;
     let l12 = l0.len();
     if (l12 == 0u64) {
         return l11
     };
-    let l3;
     let l5 = *(&l0[0u64]);
-    if (l5 > 0u8) {
-        l3 = l5as u64 == l12 - 1u64;
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_40;
-        }
-    };
     /* block 40 */;
-    if (l3) {
+    if (l5 > 0u8 && l5as u64 == l12 - 1u64) {
         l7 = 1u64;
-        unstructured {
-            goto 'label_44;
-        }
-    } else {
-        unstructured {
-            goto 'label_44;
-        }
     };
     /* block 44 */;
     let l10 = !(l1);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/gauge.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/gauge.mv.snap
@@ -141,31 +141,8 @@ const C24: vector<u8> = vector[103u8, 97u8, 117u8, 103u8, 101u8, 32u8, 110u8, 11
 // -- functions -- 
 
 public fun check_gauger_pool<T0, T1, T2>(l0: &Gauge<T0, T1, T2>, l1: &Pool<T0, T1>): bool {
-    let l2;
-    if (*(&l0.pool_id) != object::id(l1)) {
-        l2 = true;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = pool::get_magma_distribution_gauger_id(l1) != object::id(l0);
-        unstructured {
-            goto 'label_20;
-        }
-    };
-    let l3;
     /* block 20 */;
-    if (l2) {
-        l3 = false;
-        unstructured {
-            goto 'label_27;
-        }
-    } else {
-        l3 = true;
-        unstructured {
-            goto 'label_27;
-        }
-    };
+    let l3 = !(*(&l0.pool_id) != object::id(l1) || pool::get_magma_distribution_gauger_id(l1) != object::id(l0));
     /* block 27 */;
     return l3
 }
@@ -180,51 +157,27 @@ public fun claim_fees<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &NotifyRewardC
 }
 
 fun claim_fees_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool<T0, T1>): ( Balance<T0>, Balance<T1>) {
-    let l2;
     let l11 = config::week();
     let (reg_5, reg_6) = pool::collect_magma_distribution_gauger_fees(l1, option::borrow(&l0.gauge_cap));
     let l6 = reg_6;
     let l5 = reg_5;
-    if (balance::value(&l5) > 0u64) {
-        l2 = true;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        l2 = balance::value(&l6) > 0u64;
-        unstructured {
-            goto 'label_22;
-        }
-    };
+    let l2 = balance::value(&l5) > 0u64 || balance::value(&l6) > 0u64;
     /* block 22 */;
     if (l2) {
-        let l3;
         let l7 = balance::join(&mut l0.fee_a, l5);
         let l8 = balance::join(&mut l0.fee_b, l6);
-        if (l7 > l11) {
-            l3 = balance::withdraw_all(&mut l0.fee_a);
-            unstructured {
-                goto 'label_45;
-            }
+        let l3 = if (l7 > l11) {
+            balance::withdraw_all(&mut l0.fee_a)
         } else {
-            l3 = balance::zero();
-            unstructured {
-                goto 'label_45;
-            }
+            balance::zero()
         };
         let (l4, l9);
         /* block 45 */;
         l9 = l3;
-        if (l8 > l11) {
-            l4 = balance::withdraw_all(&mut l0.fee_b);
-            unstructured {
-                goto 'label_60;
-            }
+        l4 = if (l8 > l11) {
+            balance::withdraw_all(&mut l0.fee_b)
         } else {
-            l4 = balance::zero();
-            unstructured {
-                goto 'label_60;
-            }
+            balance::zero()
         };
         /* block 60 */;
         let l10 = l4;
@@ -262,10 +215,7 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
     if (!(table::contains(&l2.stakes, l13))) {
         let l15 = vector[];
         (&mut l15).push_back(l11);
-        table::add(&mut l2.stakes, l13, l15);
-        unstructured {
-            goto 'label_192;
-        }
+        table::add(&mut l2.stakes, l13, l15)
     } else {
         let l18 = table::borrow(&l2.stakes, l13);
         let l8 = 0u64;
@@ -288,17 +238,11 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
     /* block 192 */;
     object_table::add(&mut l2.staked_positions, l11, l4);
     if (!(table::contains(&l2.rewards, l11))) {
-        table::add(&mut l2.rewards, l11, RewardProfile { growth_inside: pool::get_magma_distribution_growth_inside(freeze(l3), l16, l17, 0u128), amount: 0u64, last_update_time: clock::timestamp_ms(l5) / 1000u64 });
-        unstructured {
-            goto 'label_242;
-        }
+        table::add(&mut l2.rewards, l11, RewardProfile { growth_inside: pool::get_magma_distribution_growth_inside(freeze(l3), l16, l17, 0u128), amount: 0u64, last_update_time: clock::timestamp_ms(l5) / 1000u64 })
     } else {
         let l12 = table::borrow_mut(&mut l2.rewards, l11);
         *(&mut l12.growth_inside) = pool::get_magma_distribution_growth_inside(freeze(l3), l16, l17, 0u128);
-        *(&mut l12.last_update_time) = clock::timestamp_ms(l5) / 1000u64;
-        unstructured {
-            goto 'label_242;
-        }
+        *(&mut l12.last_update_time) = clock::timestamp_ms(l5) / 1000u64
     };
     /* block 242 */;
     pool::mark_position_staked(l3, option::borrow(&l2.gauge_cap), l11);
@@ -330,52 +274,19 @@ public fun earned_by_position<T0, T1, T2>(l0: &Gauge<T0, T1, T2>, l1: &Pool<T0, 
 }
 
 fun earned_internal<T0, T1, T2>(l0: &Gauge<T0, T1, T2>, l1: &Pool<T0, T1>, l2: ID, l3: u64): u64 {
-    let l4;
     let l7 = pool::get_magma_distribution_last_updated(l1);
     let l5 = l3 - l7;
     let l6 = pool::get_magma_distribution_growth_global(l1);
     let l10 = pool::get_magma_distribution_reserve(l1)as u128 * C0;
     let l13 = pool::get_magma_distribution_staked_liquidity(l1);
-    if (l5 >= 0u64) {
-        if (l10 > 0u128) {
-            l4 = l13 > 0u128;
-            unstructured {
-                goto 'label_37;
-            }
-        } else {
-            l4 = false;
-            unstructured {
-                goto 'label_37;
-            }
-        }
-    } else {
-        l4 = false;
-        unstructured {
-            goto 'label_37;
-        }
-    };
     /* block 37 */;
-    if (l4) {
+    if (l5 >= 0u64 && l10 > 0u128 && l13 > 0u128) {
         let l11 = *(&l0.reward_rate) * l5as u128;
         if (l11 > l10) {
             l11 = l10;
-            unstructured {
-                goto 'label_52;
-            }
-        } else {
-            unstructured {
-                goto 'label_52;
-            }
         };
         /* block 52 */;
-        l6 = l6 + math_u128::checked_div_round(l11, l13, false);
-        unstructured {
-            goto 'label_59;
-        }
-    } else {
-        unstructured {
-            goto 'label_59;
-        }
+        l6 = l6 + math_u128::checked_div_round(l11, l13, false)
     };
     /* block 59 */;
     let l9 = object_table::borrow(&l0.staked_positions, l2);
@@ -449,15 +360,9 @@ fun get_reward_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool<T0
         let l6 = balance::value(&l7);
         let l5 = *(&(table::borrow(&l0.staked_position_infos, l2)).from);
         transfer::public_transfer(coin::from_balance(l7, l4), l5);
-        event::emit(EventClaimReward { from: tx_context::sender(freeze(l4)), position_id: l2, receiver: l5, amount: l6 });
-        unstructured {
-            goto 'label_50;
-        }
+        event::emit(EventClaimReward { from: tx_context::sender(freeze(l4)), position_id: l2, receiver: l5, amount: l6 })
     } else {
-        balance::destroy_zero(l7);
-        unstructured {
-            goto 'label_50;
-        }
+        balance::destroy_zero(l7)
     };
     /* block 50 */
 }
@@ -484,27 +389,15 @@ fun notify_reward_amount_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &m
     l2 = l2 + pool::get_magma_distribution_rollover(freeze(l1));
     if (l7 >= *(&l0.period_finish)) {
         *(&mut l0.reward_rate) = full_math_u128::mul_div_floor(l2as u128, C0, l8as u128);
-        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2, l6);
-        unstructured {
-            goto 'label_84;
-        }
+        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2, l6)
     } else {
         let l5 = full_math_u128::mul_div_floor(l8as u128, *(&l0.reward_rate), C0);
         *(&mut l0.reward_rate) = full_math_u128::mul_div_floor(l2as u128 + l5, C0, l8as u128);
-        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2 + l5as u64, l6);
-        unstructured {
-            goto 'label_84;
-        }
+        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2 + l5as u64, l6)
     };
     /* block 84 */;
     if (table::contains(&l0.reward_rate_by_epoch, config::epoch_start(l7))) {
-        unstructured {
-            goto 'label_96;
-        }
-    } else {
-        unstructured {
-            goto 'label_96;
-        }
+        
     };
     /* block 96 */;
     table::add(&mut l0.reward_rate_by_epoch, config::epoch_start(l7), *(&l0.reward_rate));
@@ -584,52 +477,26 @@ fun update_reward_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool
     if (*(&l10.last_update_time) >= l9) {
         return balance::zero()
     };
-    let l6;
     pool::update_magma_distribution_growth_global(l1, option::borrow(&l0.gauge_cap), l5);
     *(&mut l10.last_update_time) = l9;
     *(&mut l10.amount) = *(&l10.amount) + l8;
     *(&mut l10.growth_inside) = pool::get_magma_distribution_growth_inside(freeze(l1), l3, l4, 0u128);
     let l7 = *(&l10.amount);
     *(&mut l10.amount) = 0u64;
-    if (l7 > 0u64) {
-        l6 = balance::split(&mut l0.reserves_balance, l7);
-        unstructured {
-            goto 'label_83;
-        }
-    } else {
-        l6 = balance::zero();
-        unstructured {
-            goto 'label_83;
-        }
-    };
     /* block 83 */;
-    return l6
+    return if (l7 > 0u64) {
+        balance::split(&mut l0.reserves_balance, l7)
+    } else {
+        balance::zero()
+    }
 }
 
 public fun withdraw_position<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool<T0, T1>, l2: ID, l3: &Clock, l4: &mut TxContext) {
-    let l5;
-    if (object_table::contains(&l0.staked_positions, l2)) {
-        l5 = table::contains(&l0.staked_position_infos, l2);
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_13;
-        }
-    };
+    let l5 = object_table::contains(&l0.staked_positions, l2) && table::contains(&l0.staked_position_infos, l2);
     /* block 13 */;
     assert!(l5, 9223373686122414084u64);
     if (gauge::earned_by_position(freeze(l0), freeze(l1), l2, l3) > 0u64) {
-        gauge::get_position_reward(l0, l1, l2, l3, l4);
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        unstructured {
-            goto 'label_42;
-        }
+        gauge::get_position_reward(l0, l1, l2, l3, l4)
     };
     /* block 42 */;
     let l8 = table::remove(&mut l0.staked_position_infos, l2);
@@ -639,14 +506,7 @@ public fun withdraw_position<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Po
     let l6 = position::liquidity(&l7);
     if (l6 > 0u128) {
         let (reg_62, reg_63) = position::tick_range(&l7);
-        pool::unstake_from_magma_distribution(l1, option::borrow(&l0.gauge_cap), l6, reg_62, reg_63, l3);
-        unstructured {
-            goto 'label_107;
-        }
-    } else {
-        unstructured {
-            goto 'label_107;
-        }
+        pool::unstake_from_magma_distribution(l1, option::borrow(&l0.gauge_cap), l6, reg_62, reg_63, l3)
     };
     /* block 107 */;
     pool::mark_position_unstaked(l1, option::borrow(&l0.gauge_cap), l2);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/interest_clamm_volatile.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/interest_clamm_volatile.mv.snap
@@ -178,66 +178,34 @@ fun add_liquidity<T0>(l0: &mut StateV1<T0>, l1: &Clock, l2: vector<CoinState>, l
         l20 = l20 + 1u64;
     };
     assert!(l22 != C5, errors::must_supply_one_coin());
-    let l7;
-    if (*(&(&l0.a_gamma).future_time) != 0u64) {
+    let l7 = if (*(&(&l0.a_gamma).future_time) != 0u64) {
         if (l38 >= *(&(&l0.a_gamma).future_time)) {
-            *(&mut (&mut l0.a_gamma).future_time) = 1u64;
-            unstructured {
-                goto 'label_183;
-            }
-        } else {
-            unstructured {
-                goto 'label_183;
-            }
+            *(&mut (&mut l0.a_gamma).future_time) = 1u64
         };
         /* block 183 */;
-        l7 = volatile_math::invariant_(l10, l17, l3);
-        unstructured {
-            goto 'label_193;
-        }
+        volatile_math::invariant_(l10, l17, l3)
     } else {
-        l7 = *(&l0.d);
-        unstructured {
-            goto 'label_193;
-        }
+        *(&l0.d)
     };
     let (l23, l29, l34, l8);
     /* block 193 */;
     l34 = l7;
     l29 = volatile_math::invariant_(l10, l17, l28);
     l23 = utils::to_u256(balance::supply_value(&l0.lp_coin_supply)) * C1;
-    if (l34 != 0u256) {
-        l8 = l23 * l29 / l34 - l23;
-        unstructured {
-            goto 'label_226;
-        }
+    l8 = if (l34 != 0u256) {
+        l23 * l29 / l34 - l23
     } else {
-        l8 = interest_clamm_volatile::xcp_impl(freeze(l0), l2, l29);
-        unstructured {
-            goto 'label_226;
-        }
+        interest_clamm_volatile::xcp_impl(freeze(l0), l2, l29)
     };
     /* block 226 */;
     let l15 = l8 / C1 * C1;
     assert!(l15 != 0u256, errors::expected_a_non_zero_value());
     if (l34 != 0u256) {
-        let l9;
         l15 = l15 - math256::mul_div_up(interest_clamm_volatile::calculate_fee(freeze(l0), l12, l28), l15, 10000000000u256);
         let l24 = l23 + l15;
         let l36 = 0u256;
-        if (l15 > 1000u256) {
-            l9 = l25 > l22;
-            unstructured {
-                goto 'label_275;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_275;
-            }
-        };
         /* block 275 */;
-        if (l9) {
+        if (l15 > 1000u256 && l25 > l22) {
             let l37 = 0u256;
             let l21 = 0u64;
             while (l25 > l21) {
@@ -252,26 +220,13 @@ fun add_liquidity<T0>(l0: &mut StateV1<T0>, l1: &Clock, l2: vector<CoinState>, l
                 l21 = l21 + 1u64;
             };
             l36 = fixed_point_wad::div_down(l37 * l15 / l24, *(&(&l11)[l22]) - l15 * *(&(&l39)[l22]) / l24);
-            unstructured {
-                goto 'label_345;
-            }
-        } else {
-            unstructured {
-                goto 'label_345;
-            }
         };
         /* block 345 */;
-        interest_clamm_volatile::tweak_price(l0, l2, l38, l10, l17, l28, l22, l36, l29, l24);
-        unstructured {
-            goto 'label_369;
-        }
+        interest_clamm_volatile::tweak_price(l0, l2, l38, l10, l17, l28, l22, l36, l29, l24)
     } else {
         *(&mut l0.d) = l29;
         *(&mut l0.virtual_price) = C6;
-        *(&mut l0.xcp_profit) = C6;
-        unstructured {
-            goto 'label_369;
-        }
+        *(&mut l0.xcp_profit) = C6
     };
     /* block 369 */;
     let l16 = utils::to_u64(l15 / C1);
@@ -286,18 +241,7 @@ public fun add_liquidity_2_pool<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1:
 }
 
 public(friend) fun add_liquidity_2_pool_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: u64, l5: &mut TxContext): Coin<T2> {
-    let l6;
-    if (coin::value(&l2) != 0u64) {
-        l6 = true;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l6 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    };
+    let l6 = coin::value(&l2) != 0u64 || coin::value(&l3) != 0u64;
     /* block 13 */;
     assert!(l6, errors::must_supply_one_coin());
     assert!(interest_pool::are_coins_ordered(freeze(l0), vector[x1_type_name::get(), x1_type_name::get()]), errors::coins_must_be_in_order());
@@ -315,31 +259,8 @@ public fun add_liquidity_3_pool<T0, T1, T2, T3>(l0: &mut InterestPool<Volatile>,
 }
 
 public(friend) fun add_liquidity_3_pool_impl<T0, T1, T2, T3>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: Coin<T2>, l5: u64, l6: &mut TxContext): Coin<T3> {
-    let l7;
-    if (coin::value(&l2) != 0u64) {
-        l7 = true;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l7 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    };
-    let l8;
     /* block 13 */;
-    if (l7) {
-        l8 = true;
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        l8 = coin::value(&l4) != 0u64;
-        unstructured {
-            goto 'label_23;
-        }
-    };
+    let l8 = coin::value(&l2) != 0u64 || coin::value(&l3) != 0u64 || coin::value(&l4) != 0u64;
     /* block 23 */;
     assert!(l8, errors::must_supply_one_coin());
     assert!(interest_pool::are_coins_ordered(freeze(l0), vector[x1_type_name::get(), x1_type_name::get(), x1_type_name::get()]), errors::coins_must_be_in_order());
@@ -422,17 +343,10 @@ fun calculate_remove_one_coin_impl<T0, T1>(l0: &StateV1<T1>, l1: u256, l2: u256,
         l19 = l19 + 1u64;
     };
     assert!(l21 != 300u64, errors::invalid_coin_type());
-    let l7;
-    if (l5) {
-        l7 = volatile_math::invariant_(l1, l2, l27);
-        unstructured {
-            goto 'label_76;
-        }
+    let l7 = if (l5) {
+        volatile_math::invariant_(l1, l2, l27)
     } else {
-        l7 = *(&l0.d);
-        unstructured {
-            goto 'label_76;
-        }
+        *(&l0.d)
     };
     let (l13, l14, l15, l16, l23, l8);
     /* block 76 */;
@@ -445,30 +359,9 @@ fun calculate_remove_one_coin_impl<T0, T1>(l0: &StateV1<T1>, l1: u256, l2: u256,
     l16 = fixed_point_wad::div_down(*(&(&l27)[l21]) - l28, l24);
     *(&mut (&mut l27)[l21]) = l28;
     l23 = 0u256;
-    if (l6) {
-        l8 = l16 > 100000u256;
-        unstructured {
-            goto 'label_138;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_138;
-        }
-    };
-    let l9;
+    l8 = l6 && l16 > 100000u256;
     /* block 138 */;
-    if (l8) {
-        l9 = l4 > 100000u256;
-        unstructured {
-            goto 'label_147;
-        }
-    } else {
-        l9 = false;
-        unstructured {
-            goto 'label_147;
-        }
-    };
+    let l9 = l8 && l4 > 100000u256;
     /* block 147 */;
     if (l9) {
         let l25 = 0u256;
@@ -484,13 +377,6 @@ fun calculate_remove_one_coin_impl<T0, T1>(l0: &StateV1<T1>, l1: u256, l2: u256,
             l20 = l20 + 1u64;
         };
         l23 = fixed_point_wad::div_down(l25 * l15 / l14, l16 - l15 * *(&(&l0.balances)[l21]) / l14);
-        unstructured {
-            goto 'label_216;
-        }
-    } else {
-        unstructured {
-            goto 'label_216;
-        }
     };
     /* block 216 */;
     return (l16, l23, l13, l27, l21)
@@ -530,32 +416,14 @@ fun claim_admin_fees_impl<T0>(l0: &mut StateV1<T0>, l1: &Clock, l2: BalancesRequ
         let l8 = l18 - l19 * *(&(&l0.fees).admin_fee) / 20000000000u256;
         if (l8 != 0u256) {
             let l9 = fixed_point_wad::mul_up(utils::to_u256(balance::supply_value(&l0.lp_coin_supply)) * C1, fixed_point_wad::div_up(l17, l17 - l8) - C6);
-            *(&mut l0.xcp_profit) = l18 - l8 * 2u256;
-            unstructured {
-                goto 'label_143;
-            }
-        } else {
-            unstructured {
-                goto 'label_143;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_143;
+            *(&mut l0.xcp_profit) = l18 - l8 * 2u256
         }
     };
     /* block 143 */;
     let l7 = volatile_math::invariant_(reg_3, reg_4, interest_clamm_volatile::balances_in_price_impl(freeze(l0), l3));
     *(&mut l0.virtual_price) = fixed_point_wad::div_down(interest_clamm_volatile::xcp_impl(freeze(l0), l3, l7), utils::to_u256(balance::supply_value(&l0.lp_coin_supply)) * C1);
     if (*(&l0.xcp_profit) > l19) {
-        *(&mut l0.xcp_profit_a) = *(&l0.xcp_profit);
-        unstructured {
-            goto 'label_181;
-        }
-    } else {
-        unstructured {
-            goto 'label_181;
-        }
+        *(&mut l0.xcp_profit_a) = *(&l0.xcp_profit)
     };
     /* block 181 */
 }
@@ -681,30 +549,16 @@ fun get_a_gamma<T0>(l0: &StateV1<T0>, l1: &Clock): ( u256, u256) {
         let l8 = l7 - l6;
         l3 = l2 * utils::to_u256(l8) + l3 * utils::to_u256(l6) / utils::to_u256(l7);
         l5 = l4 * utils::to_u256(l8) + l5 * utils::to_u256(l6) / utils::to_u256(l7);
-        unstructured {
-            goto 'label_78;
-        }
-    } else {
-        unstructured {
-            goto 'label_78;
-        }
     };
     /* block 78 */;
     return (l3, l5)
 }
 
 fun increment_version<T0>(l0: &mut StateV1<T0>) {
-    let l1;
-    if (*(&l0.version) == C12) {
-        l1 = 0u256;
-        unstructured {
-            goto 'label_15;
-        }
+    let l1 = if (*(&l0.version) == C12) {
+        0u256
     } else {
-        l1 = *(&l0.version) + 1u256;
-        unstructured {
-            goto 'label_15;
-        }
+        *(&l0.version) + 1u256
     };
     /* block 15 */;
     *(&mut l0.version) = l1
@@ -821,7 +675,6 @@ public fun out_fee<T0>(l0: &mut InterestPool<Volatile>): u256 {
 }
 
 public fun quote_add_liquidity<T0>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: vector<u64>): u64 {
-    let l3;
     let (reg_1, reg_2) = interest_clamm_volatile::state_and_coin_states(l0);
     let l15 = reg_2;
     let l26 = reg_1;
@@ -830,16 +683,10 @@ public fun quote_add_liquidity<T0>(l0: &mut InterestPool<Volatile>, l1: &Clock, 
     let (reg_14, reg_15) = interest_clamm_volatile::get_a_gamma(l26, l1);
     let l9 = utils::empty_vector(*(&l26.n_coins));
     let l22 = interest_clamm_volatile::balances_in_price_impl(l26, l15);
-    if (*(&(&l26.a_gamma).future_time) != 0u64) {
-        l3 = volatile_math::invariant_(reg_14, reg_15, l22);
-        unstructured {
-            goto 'label_46;
-        }
+    let l3 = if (*(&(&l26.a_gamma).future_time) != 0u64) {
+        volatile_math::invariant_(reg_14, reg_15, l22)
     } else {
-        l3 = *(&l26.d);
-        unstructured {
-            goto 'label_46;
-        }
+        *(&l26.d)
     };
     let (l13, l20, l21, l23);
     /* block 46 */;
@@ -865,19 +712,12 @@ public fun quote_add_liquidity<T0>(l0: &mut InterestPool<Volatile>, l1: &Clock, 
         };
         l20 = l20 + 1u64;
     };
-    let l6;
     let (reg_103, reg_104) = interest_clamm_volatile::get_a_gamma(l26, l1);
     let l16 = volatile_math::invariant_(reg_103, reg_104, l13);
-    if (l23 != 0u256) {
-        l6 = l27 * l16 / l23 - l27;
-        unstructured {
-            goto 'label_160;
-        }
+    let l6 = if (l23 != 0u256) {
+        l27 * l16 / l23 - l27
     } else {
-        l6 = interest_clamm_volatile::xcp_impl(l26, l15, l16);
-        unstructured {
-            goto 'label_160;
-        }
+        interest_clamm_volatile::xcp_impl(l26, l15, l16)
     };
     /* block 160 */;
     let l17 = l6 / C1 * C1;
@@ -947,13 +787,6 @@ public fun quote_swap<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &Clock, l
     *l18 = *l18 - l10;
     if (*(&(&l11).index) != 0u64) {
         l10 = fixed_point_wad::div_down(l10, *(&(&l11).price));
-        unstructured {
-            goto 'label_143;
-        }
-    } else {
-        unstructured {
-            goto 'label_143;
-        }
     };
     /* block 143 */;
     return utils::to_u64(fixed_point_wad::mul_down(l10 - interest_clamm_volatile::fee_impl(l19, l8) * l10 / 10000000000u256, *(&(&l11).decimals_scalar)))
@@ -999,18 +832,7 @@ public fun read_balance<T0, T1>(l0: &mut InterestPool<Volatile>, l1: &mut Balanc
 }
 
 public(friend) fun register_2_pool<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: &CoinDecimals, l5: u256, l6: &mut TxContext): Coin<T2> {
-    let l7;
-    if (coin::value(&l2) != 0u64) {
-        l7 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_13;
-        }
-    };
+    let l7 = coin::value(&l2) != 0u64 && coin::value(&l3) != 0u64;
     /* block 13 */;
     assert!(l7, errors::no_zero_liquidity_amounts());
     let l8 = interest_clamm_volatile::load_mut(interest_pool::state_mut(l0));
@@ -1020,31 +842,8 @@ public(friend) fun register_2_pool<T0, T1, T2>(l0: &mut InterestPool<Volatile>, 
 }
 
 public(friend) fun register_3_pool<T0, T1, T2, T3>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: Coin<T2>, l5: &CoinDecimals, l6: vector<u256>, l7: &mut TxContext): Coin<T3> {
-    let l8;
-    if (coin::value(&l2) != 0u64) {
-        l8 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_13;
-        }
-    };
-    let l9;
     /* block 13 */;
-    if (l8) {
-        l9 = coin::value(&l4) != 0u64;
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        l9 = false;
-        unstructured {
-            goto 'label_23;
-        }
-    };
+    let l9 = coin::value(&l2) != 0u64 && coin::value(&l3) != 0u64 && coin::value(&l4) != 0u64;
     /* block 23 */;
     assert!(l9, errors::no_zero_liquidity_amounts());
     let l10 = interest_clamm_volatile::load_mut(interest_pool::state_mut(l0));
@@ -1124,14 +923,7 @@ public(friend) fun remove_liquidity_one_coin_impl<T0, T1>(l0: &mut InterestPool<
     let l13 = reg_43;
     let l7 = reg_39;
     if (l20 >= l6) {
-        *(&mut (&mut l19.a_gamma).future_time) = 1u64;
-        unstructured {
-            goto 'label_66;
-        }
-    } else {
-        unstructured {
-            goto 'label_66;
-        }
+        *(&mut (&mut l19.a_gamma).future_time) = 1u64
     };
     /* block 66 */;
     let l10 = &mut (&mut l19.balances)[l13];
@@ -1206,13 +998,6 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
     if (l36 != 0u64) {
         if (*(&l18.index) != 0u64) {
             l26 = fixed_point_wad::mul_down(l26, *(&l18.price));
-            unstructured {
-                goto 'label_109;
-            }
-        } else {
-            unstructured {
-                goto 'label_109;
-            }
         };
         /* block 109 */;
         let l16 = &mut (&mut l13)[*(&l18.index)];
@@ -1221,18 +1006,7 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
         *(&mut l35.d) = volatile_math::invariant_(l11, l25, l13);
         *(&mut (&mut l13)[*(&l18.index)]) = l34;
         if (l37 >= l36) {
-            *(&mut (&mut l35.a_gamma).future_time) = 1u64;
-            unstructured {
-                goto 'label_146;
-            }
-        } else {
-            unstructured {
-                goto 'label_146;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_146;
+            *(&mut (&mut l35.a_gamma).future_time) = 1u64
         }
     };
     let (l20, l6);
@@ -1242,16 +1016,10 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
     l20 = l24 - math256::min(l24, l28);
     let l31 = &mut (&mut l13)[*(&(&l22).index)];
     *l31 = *l31 - l20;
-    if (*(&(&l22).index) != 0u64) {
-        l6 = fixed_point_wad::div_down(l20, *(&(&l22).price));
-        unstructured {
-            goto 'label_199;
-        }
+    l6 = if (*(&(&l22).index) != 0u64) {
+        fixed_point_wad::div_down(l20, *(&(&l22).price))
     } else {
-        l6 = l20;
-        unstructured {
-            goto 'label_199;
-        }
+        l20
     };
     /* block 199 */;
     l20 = l6;
@@ -1263,80 +1031,29 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
     l21 = l21 - l20;
     if (*(&(&l22).index) != 0u64) {
         l21 = fixed_point_wad::mul_down(l21, *(&(&l22).price));
-        unstructured {
-            goto 'label_261;
-        }
-    } else {
-        unstructured {
-            goto 'label_261;
-        }
     };
     let (l14, l29, l7);
     /* block 261 */;
     *(&mut (&mut l13)[*(&(&l22).index)]) = l21;
     l14 = fixed_point_wad::div_down(utils::to_u256(l19), *(&l18.decimals_scalar));
     l29 = 0u256;
-    if (l14 > 100000u256) {
-        l7 = l20 > 100000u256;
-        unstructured {
-            goto 'label_290;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_290;
-        }
-    };
+    l7 = l14 > 100000u256 && l20 > 100000u256;
     /* block 290 */;
     if (l7) {
-        let l8;
-        if (*(&l18.index) != 0u64) {
-            l8 = *(&(&l22).index) != 0u64;
-            unstructured {
-                goto 'label_307;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_307;
-            }
-        };
-        let l10;
         /* block 307 */;
-        if (l8) {
-            l10 = *(&l18.last_price) * l14 / l20;
-            unstructured {
-                goto 'label_341;
-            }
+        let l10 = if (*(&l18.index) != 0u64 && *(&(&l22).index) != 0u64) {
+            *(&l18.last_price) * l14 / l20
         } else {
-            let l9;
+            /* block 339 */;
             if (*(&l18.index) == 0u64) {
-                l9 = fixed_point_wad::div_down(l14, l20);
-                unstructured {
-                    goto 'label_339;
-                }
+                fixed_point_wad::div_down(l14, l20)
             } else {
                 l38 = *(&l18.index);
-                l9 = fixed_point_wad::div_down(l20, l14);
-                unstructured {
-                    goto 'label_339;
-                }
-            };
-            /* block 339 */;
-            l10 = l9;
-            unstructured {
-                goto 'label_341;
+                fixed_point_wad::div_down(l20, l14)
             }
         };
         /* block 341 */;
-        l29 = l10;
-        unstructured {
-            goto 'label_346;
-        }
-    } else {
-        unstructured {
-            goto 'label_346;
-        }
+        l29 = l10
     };
     /* block 346 */;
     let l27 = utils::to_u256(balance::supply_value(&l35.lp_coin_supply));
@@ -1356,37 +1073,20 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
             *(&mut l17.price_oracle) = *(&l17.last_price) * C6 - l16 + *(&l17.price_oracle) * l16 / C6;
             l35 = l35 + 1u64;
         };
-        *(&mut l0.last_prices_timestamp) = l2;
-        unstructured {
-            goto 'label_65;
-        }
-    } else {
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut l0.last_prices_timestamp) = l2
     };
-    let l10;
     /* block 65 */;
-    if (l8 == 0u256) {
-        l10 = volatile_math::invariant_(l3, l4, l5);
-        unstructured {
-            goto 'label_77;
-        }
+    let l10 = if (l8 == 0u256) {
+        volatile_math::invariant_(l3, l4, l5)
     } else {
-        l10 = l8;
-        unstructured {
-            goto 'label_77;
-        }
+        l8
     };
     let l26;
     /* block 77 */;
     l26 = l10;
     if (l7 != 0u256) {
         if (l6 != 0u64) {
-            *(&mut (&mut (&mut l1)[l6]).last_price) = l7;
-            unstructured {
-                goto 'label_174;
-            }
+            *(&mut (&mut (&mut l1)[l6]).last_price) = l7
         } else {
             let l28 = 1u64;
             while (*(&l0.n_coins)as u64 > l28) {
@@ -1421,63 +1121,24 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
     let l49 = C6;
     let l45 = C6;
     if (l39 != 0u256) {
-        let l11;
         l45 = fixed_point_wad::div_down(volatile_math::geometric_mean(l51, true), l9);
         l49 = l40 * l45 / l39;
-        if (l39 > l45) {
-            l11 = *(&(&l0.a_gamma).future_time) == 0u64;
-            unstructured {
-                goto 'label_250;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_250;
-            }
-        };
+        let l11 = l39 > l45 && *(&(&l0.a_gamma).future_time) == 0u64;
         /* block 250 */;
         assert!(!(l11), errors::incurred_a_loss());
         if (*(&(&l0.a_gamma).future_time) == 1u64) {
-            *(&mut (&mut l0.a_gamma).future_time) = 0u64;
-            unstructured {
-                goto 'label_268;
-            }
-        } else {
-            unstructured {
-                goto 'label_268;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_268;
+            *(&mut (&mut l0.a_gamma).future_time) = 0u64
         }
     };
     let (l12, l37);
     /* block 268 */;
     *(&mut l0.xcp_profit) = l49;
     l37 = *(&l0.not_adjusted);
-    if (!(l37)) {
-        l12 = l45 * 2u256 - C6 > l49 + 2u256 * *(&(&l0.rebalancing_params).extra_profit);
-        unstructured {
-            goto 'label_297;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_297;
-        }
-    };
+    l12 = !(l37) && l45 * 2u256 - C6 > l49 + 2u256 * *(&(&l0.rebalancing_params).extra_profit);
     /* block 297 */;
     if (l12) {
         l37 = true;
-        *(&mut l0.not_adjusted) = true;
-        unstructured {
-            goto 'label_305;
-        }
-    } else {
-        unstructured {
-            goto 'label_305;
-        }
+        *(&mut l0.not_adjusted) = true
     };
     /* block 305 */;
     if (l37) {
@@ -1490,20 +1151,8 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
             l38 = l38 + math256::pow(l42, 2u256);
             l31 = l31 + 1u64;
         };
-        let l13;
-        if (l38 > math256::pow(l15, 2u256)) {
-            l13 = l39 != 0u256;
-            unstructured {
-                goto 'label_358;
-            }
-        } else {
-            l13 = false;
-            unstructured {
-                goto 'label_358;
-            }
-        };
         /* block 358 */;
-        if (l13) {
+        if (l38 > math256::pow(l15, 2u256) && l39 != 0u256) {
             l38 = volatile_math::sqrt(l38 / C6);
             let l41 = C17;
             let l52 = l5;
@@ -1523,19 +1172,8 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
                 *(&mut (&mut l52)[l33]) = fixed_point_wad::div_down(l25, *(&l0.n_coins) * *(&(&l41)[l33]));
                 l33 = l33 + 1u64;
             };
-            let l14;
             l39 = fixed_point_wad::div_down(volatile_math::geometric_mean(l52, true), l9);
-            if (l39 > C6) {
-                l14 = 2u256 * l39 - C6 > l49;
-                unstructured {
-                    goto 'label_482;
-                }
-            } else {
-                l14 = false;
-                unstructured {
-                    goto 'label_482;
-                }
-            };
+            let l14 = l39 > C6 && 2u256 * l39 - C6 > l49;
             /* block 482 */;
             if (l14) {
                 let l34 = 1u64;
@@ -1548,18 +1186,7 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
                 *(&mut l0.virtual_price) = l39;
                 return
             };
-            *(&mut l0.not_adjusted) = false;
-            unstructured {
-                goto 'label_523;
-            }
-        } else {
-            unstructured {
-                goto 'label_523;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_523;
+            *(&mut l0.not_adjusted) = false
         }
     };
     /* block 523 */;
@@ -1582,7 +1209,6 @@ fun update_coin_state_prices<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>) {
 }
 
 public fun update_parameters<T0>(l0: &mut InterestPool<Volatile>, l1: &PoolAdmin, l2: &Clock, l3: BalancesRequest, l4: vector<Option<u256>>) {
-    let l5;
     interest_pool::assert_pool_admin(freeze(l0), l1);
     let l17 = interest_pool::addy(freeze(l0));
     let (reg_7, reg_8) = interest_clamm_volatile::state_and_coin_states_mut(l0);
@@ -1595,62 +1221,19 @@ public fun update_parameters<T0>(l0: &mut InterestPool<Volatile>, l1: &PoolAdmin
     let l11 = option::destroy_with_default(*(&(&l4)[4u64]), *(&(&l18.rebalancing_params).extra_profit));
     let l9 = option::destroy_with_default(*(&(&l4)[5u64]), *(&(&l18.rebalancing_params).adjustment_step));
     let l14 = option::destroy_with_default(*(&(&l4)[6u64]), *(&(&l18.rebalancing_params).ma_half_time));
-    if (l16 <= C3) {
-        l5 = l16 >= C2;
-        unstructured {
-            goto 'label_96;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_96;
-        }
-    };
+    let l5 = l16 <= C3 && l16 >= C2;
     /* block 96 */;
     assert!(l5, errors::out_fee_out_of_range());
-    let l6;
-    if (l15 <= C3) {
-        l6 = C2 >= C2;
-        unstructured {
-            goto 'label_114;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_114;
-        }
-    };
+    let l6 = l15 <= C3 && C2 >= C2;
     /* block 114 */;
     assert!(l6, errors::mid_fee_out_of_range());
     assert!(l10 < C3, errors::admin_fee_is_too_big());
-    let l7;
-    if (l13 != 0u256) {
-        l7 = l13 <= C6;
-        unstructured {
-            goto 'label_141;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_141;
-        }
-    };
+    let l7 = l13 != 0u256 && l13 <= C6;
     /* block 141 */;
     assert!(l7, errors::gamma_fee_out_of_range());
     assert!(l11 < C6, errors::extra_profit_is_too_big());
     assert!(l9 < C6, errors::adjustment_step_is_too_big());
-    let l8;
-    if (l14 >= 1000u256) {
-        l8 = l14 <= C4;
-        unstructured {
-            goto 'label_177;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_177;
-        }
-    };
+    let l8 = l14 >= 1000u256 && l14 <= C4;
     /* block 177 */;
     assert!(l8, errors::ma_half_time_out_of_range());
     *(&mut (&mut l18.fees).admin_fee) = l10;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house.mv.snap
@@ -222,18 +222,7 @@ public fun buy_nft_with_request<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l
         if (dynamic_object_field::exists_with_type(&l0.id, l20)) {
             let Bid { id: reg_88, bidder: reg_89, amount: reg_90, timestamp: reg_91 } = dynamic_object_field::remove(&mut l0.id, l20);
             transfer::public_transfer(coin::from_balance(reg_90 : 0x2::balance::Balance<0x2::sui::SUI>, l6), l20);
-            object::delete(reg_88 : 0x2::object::UID);
-            unstructured {
-                goto 'label_149;
-            }
-        } else {
-            unstructured {
-                goto 'label_149;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_149;
+            object::delete(reg_88 : 0x2::object::UID)
         }
     };
     /* block 149 */;
@@ -257,18 +246,7 @@ public fun cancel_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID,
         if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
             let Bid { id: reg_61, bidder: reg_62, amount: reg_63, timestamp: reg_64 } = dynamic_object_field::remove(&mut l0.id, l6);
             transfer::public_transfer(coin::from_balance(reg_63 : 0x2::balance::Balance<0x2::sui::SUI>, l3), l6);
-            object::delete(reg_61 : 0x2::object::UID);
-            unstructured {
-                goto 'label_111;
-            }
-        } else {
-            unstructured {
-                goto 'label_111;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_111;
+            object::delete(reg_61 : 0x2::object::UID)
         }
     };
     /* block 111 */;
@@ -385,14 +363,7 @@ public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bi
         let l9 = object::id(&l8);
         transfer::public_transfer(l8, l4);
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) });
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     };
     /* block 51 */
 }
@@ -413,30 +384,12 @@ public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding
             if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
                 let Bid { id: reg_59, bidder: reg_60, amount: reg_61, timestamp: reg_62 } = dynamic_object_field::remove(&mut l0.id, l6);
                 transfer::public_transfer(coin::from_balance(reg_61 : 0x2::balance::Balance<0x2::sui::SUI>, l3), l6);
-                object::delete(reg_59 : 0x2::object::UID);
-                unstructured {
-                    goto 'label_95;
-                }
-            } else {
-                unstructured {
-                    goto 'label_95;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_95;
+                object::delete(reg_59 : 0x2::object::UID)
             }
         };
         /* block 95 */;
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l11 });
-        unstructured {
-            goto 'label_107;
-        }
-    } else {
-        unstructured {
-            goto 'label_107;
-        }
+        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l11 })
     };
     /* block 107 */
 }
@@ -505,32 +458,17 @@ public fun place_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: 
     assert!(*(&l11.status) == C0, C4);
     assert!(l9 <= *(&l11.expires_at), C15);
     assert!(l7 > 0u64, C3);
-    let l4;
-    if (*(&l11.highest_bid) == 0u64) {
-        l4 = 1u64;
-        unstructured {
-            goto 'label_95;
-        }
+    let l4 = if (*(&l11.highest_bid) == 0u64) {
+        1u64
     } else {
-        l4 = *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64;
-        unstructured {
-            goto 'label_95;
-        }
+        *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64
     };
     /* block 95 */;
-    let l13 = l4;
-    assert!(l7 >= l13, C5);
+    assert!(l7 >= l4, C5);
     let l15 = option::none();
     let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
     if (option::is_some(&l12.highest_bidder)) {
         l15 = option::some(*(option::borrow(&l12.highest_bidder)));
-        unstructured {
-            goto 'label_129;
-        }
-    } else {
-        unstructured {
-            goto 'label_129;
-        }
     };
     /* block 129 */;
     *(&mut l12.highest_bid) = l7;
@@ -540,18 +478,7 @@ public fun place_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: 
         if (dynamic_object_field::exists_with_type(&l0.id, l14)) {
             let Bid { id: reg_105, bidder: reg_106, amount: reg_107, timestamp: reg_108 } = dynamic_object_field::remove(&mut l0.id, l14);
             transfer::public_transfer(coin::from_balance(reg_107 : 0x2::balance::Balance<0x2::sui::SUI>, l3), l14);
-            object::delete(reg_105 : 0x2::object::UID);
-            unstructured {
-                goto 'label_165;
-            }
-        } else {
-            unstructured {
-                goto 'label_165;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_165;
+            object::delete(reg_105 : 0x2::object::UID)
         }
     };
     /* block 165 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house_dynamic_coins.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/kiosk_bidding_house_dynamic_coins.mv.snap
@@ -223,18 +223,7 @@ public fun buy_nft_with_request<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Stor
         if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
             let Bid { id: reg_100, bidder: reg_101, amount: reg_102, timestamp: reg_103 } = dynamic_object_field::remove(&mut l0.id, l9);
             transfer::public_transfer(coin::from_balance(reg_102 : 0x2::balance::Balance<T1>, l6), l21);
-            object::delete(reg_100 : 0x2::object::UID);
-            unstructured {
-                goto 'label_168;
-            }
-        } else {
-            unstructured {
-                goto 'label_168;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
+            object::delete(reg_100 : 0x2::object::UID)
         }
     };
     /* block 168 */;
@@ -261,18 +250,7 @@ public fun cancel_listing<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1:
         if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
             let Bid { id: reg_72, bidder: reg_73, amount: reg_74, timestamp: reg_75 } = dynamic_object_field::remove(&mut l0.id, l6);
             transfer::public_transfer(coin::from_balance(reg_74 : 0x2::balance::Balance<T1>, l3), l7);
-            object::delete(reg_72 : 0x2::object::UID);
-            unstructured {
-                goto 'label_129;
-            }
-        } else {
-            unstructured {
-                goto 'label_129;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_129;
+            object::delete(reg_72 : 0x2::object::UID)
         }
     };
     /* block 129 */;
@@ -383,14 +361,7 @@ public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bi
         let l9 = object::id(&l8);
         transfer::public_transfer(l8, l4);
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) });
-        unstructured {
-            goto 'label_52;
-        }
-    } else {
-        unstructured {
-            goto 'label_52;
-        }
+        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     };
     /* block 52 */
 }
@@ -406,14 +377,7 @@ public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding
         dynamic_object_field::add(&mut l0.orphaned_caps, l8, l9);
         event::emit(PurchaseCapOrphaned { nft_id: l8, kiosk_id: l7, timestamp: tx_context::epoch(freeze(l3)) });
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l8, coin_type: reg_29 : 0x1::type_name::TypeName });
-        unstructured {
-            goto 'label_72;
-        }
-    } else {
-        unstructured {
-            goto 'label_72;
-        }
+        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l8, coin_type: reg_29 : 0x1::type_name::TypeName })
     };
     /* block 72 */
 }
@@ -487,32 +451,17 @@ public fun place_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, 
     let l11 = *(&l14.coin_type);
     assert!(l11 == type_name::get(), C22);
     assert!(l7 > 0u64, C3);
-    let l4;
-    if (*(&l14.highest_bid) == 0u64) {
-        l4 = 1u64;
-        unstructured {
-            goto 'label_112;
-        }
+    let l4 = if (*(&l14.highest_bid) == 0u64) {
+        1u64
     } else {
-        l4 = *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64;
-        unstructured {
-            goto 'label_112;
-        }
+        *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64
     };
     /* block 112 */;
-    let l16 = l4;
-    assert!(l7 >= l16, C5);
+    assert!(l7 >= l4, C5);
     let l18 = option::none();
     let l15 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
     if (option::is_some(&l15.highest_bidder)) {
         l18 = option::some(*(option::borrow(&l15.highest_bidder)));
-        unstructured {
-            goto 'label_146;
-        }
-    } else {
-        unstructured {
-            goto 'label_146;
-        }
     };
     /* block 146 */;
     *(&mut l15.highest_bid) = l7;
@@ -523,18 +472,7 @@ public fun place_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, 
         if (dynamic_object_field::exists_with_type(&l0.id, l8)) {
             let Bid { id: reg_118, bidder: reg_119, amount: reg_120, timestamp: reg_121 } = dynamic_object_field::remove(&mut l0.id, l8);
             transfer::public_transfer(coin::from_balance(reg_120 : 0x2::balance::Balance<T1>, l3), l17);
-            object::delete(reg_118 : 0x2::object::UID);
-            unstructured {
-                goto 'label_186;
-            }
-        } else {
-            unstructured {
-                goto 'label_186;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
+            object::delete(reg_118 : 0x2::object::UID)
         }
     };
     /* block 186 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/leva_deep_mm.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/leva_deep_mm.mv.snap
@@ -121,7 +121,6 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
             events::emit_log_bytes(C3);
             let l97 = config::is_dry_run(l83);
             if (config::is_arbitrage_enabled(l83)) {
-                let l19;
                 let l99 = mm_state::last_arb_timestamp(freeze(l0));
                 let l86 = pool::mid_price(freeze(l3), l7);
                 let (reg_113, reg_114, reg_115, reg_116, reg_117, reg_118) = arbitrage_router::execute_arbitrage_analysis(l112, freeze(l5), l86, config::min_arb_profit_bps(l83), l99, config::arb_cooldown_ms(l83), l7);
@@ -129,87 +128,29 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                 let l65 = reg_116;
                 let l139 = reg_114;
                 let l138 = reg_113;
-                if (config::max_arb_amount(l83) > 0u64) {
-                    l19 = config::max_arb_amount(l83);
-                    unstructured {
-                        goto 'label_175;
-                    }
+                let l19 = if (config::max_arb_amount(l83) > 0u64) {
+                    config::max_arb_amount(l83)
                 } else {
-                    l19 = 0u64;
-                    unstructured {
-                        goto 'label_175;
-                    }
+                    0u64
                 };
                 let (l41, l52);
                 /* block 175 */;
                 l52 = l19;
-                if (l138) {
-                    l41 = true;
-                    unstructured {
-                        goto 'label_184;
-                    }
-                } else {
-                    l41 = l139;
-                    unstructured {
-                        goto 'label_184;
-                    }
-                };
-                let l30;
+                l41 = l138 || l139;
                 /* block 184 */;
-                if (l41) {
-                    l30 = l52 > 0u64;
-                    unstructured {
-                        goto 'label_193;
-                    }
-                } else {
-                    l30 = false;
-                    unstructured {
-                        goto 'label_193;
-                    }
-                };
+                let l30 = l41 && l52 > 0u64;
                 /* block 193 */;
                 if (l30) {
-                    let l46;
                     events::emit_log_bytes(C4);
-                    if (l138) {
-                        if (reg_115 == arbitrage_router::pool_cetus()) {
-                            l46 = !(l97);
-                            unstructured {
-                                goto 'label_214;
-                            }
-                        } else {
-                            l46 = false;
-                            unstructured {
-                                goto 'label_214;
-                            }
-                        }
-                    } else {
-                        l46 = false;
-                        unstructured {
-                            goto 'label_214;
-                        }
-                    };
                     /* block 214 */;
-                    if (l46) {
-                        let l47;
+                    if (l138 && reg_115 == arbitrage_router::pool_cetus() && !(l97)) {
                         let (reg_159, reg_160);
                         (reg_158, reg_159, reg_160) = arbitrage_router::execute_cetus_buy(l112, l2, l5, l6, l52, l65, l86, config::arb_slippage_bps(l83), l7, l18);
                         let l81 = reg_160;
                         let l129 = reg_159;
                         events::emit_log_bytes(C5);
-                        if (l81) {
-                            l47 = l129 > 0u64;
-                            unstructured {
-                                goto 'label_242;
-                            }
-                        } else {
-                            l47 = false;
-                            unstructured {
-                                goto 'label_242;
-                            }
-                        };
                         /* block 242 */;
-                        if (l47) {
+                        if (l81 && l129 > 0u64) {
                             let reg_171;
                             (reg_170, reg_171, reg_172) = pool::pool_book_params(freeze(l3));
                             let l100 = reg_171;
@@ -218,98 +159,32 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                                 let (reg_189, reg_190) = arbitrage_router::execute_deepbook_ioc(false, l3, l2, &l136, l86, l125, l83, l7, freeze(l18));
                                 if (reg_190) {
                                     events::emit_log_bytes(C6);
-                                    events::emit_arb_ioc_executed(l112, false, l86, l125, reg_189, l65, l108);
-                                    unstructured {
-                                        goto 'label_286;
-                                    }
+                                    events::emit_arb_ioc_executed(l112, false, l86, l125, reg_189, l65, l108)
                                 } else {
-                                    events::emit_log_bytes(C7);
-                                    unstructured {
-                                        goto 'label_286;
-                                    }
+                                    events::emit_log_bytes(C7)
                                 }
-                            } else {
-                                unstructured {
-                                    goto 'label_286;
-                                }
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_286;
                             }
                         };
                         /* block 286 */;
                         mm_state::record_arb_time(l0, l108);
-                        events::emit_log_bytes(C8);
-                        unstructured {
-                            goto 'label_303;
-                        }
+                        events::emit_log_bytes(C8)
                     } else {
-                        let l48;
-                        if (l138) {
-                            l48 = l97;
-                            unstructured {
-                                goto 'label_299;
-                            }
-                        } else {
-                            l48 = false;
-                            unstructured {
-                                goto 'label_299;
-                            }
-                        };
                         /* block 299 */;
-                        if (l48) {
-                            events::emit_log_bytes(C9);
-                            unstructured {
-                                goto 'label_303;
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_303;
-                            }
+                        if (l138 && l97) {
+                            events::emit_log_bytes(C9)
                         }
                     };
-                    let l49;
                     /* block 303 */;
-                    if (l139) {
-                        if (reg_117 == arbitrage_router::pool_cetus()) {
-                            l49 = !(l97);
-                            unstructured {
-                                goto 'label_318;
-                            }
-                        } else {
-                            l49 = false;
-                            unstructured {
-                                goto 'label_318;
-                            }
-                        }
-                    } else {
-                        l49 = false;
-                        unstructured {
-                            goto 'label_318;
-                        }
-                    };
+                    let l49 = l139 && reg_117 == arbitrage_router::pool_cetus() && !(l97);
                     /* block 318 */;
                     if (l49) {
-                        let l50;
                         let (reg_229, reg_231);
                         (reg_229, reg_230, reg_231) = arbitrage_router::execute_cetus_sell(l112, l2, l5, l6, l52, l67, l86, config::arb_slippage_bps(l83), l7, l18);
                         let l82 = reg_231;
                         let l130 = reg_229;
                         events::emit_log_bytes(C10);
-                        if (l82) {
-                            l50 = l130 > 0u64;
-                            unstructured {
-                                goto 'label_346;
-                            }
-                        } else {
-                            l50 = false;
-                            unstructured {
-                                goto 'label_346;
-                            }
-                        };
                         /* block 346 */;
-                        if (l50) {
+                        if (l82 && l130 > 0u64) {
                             let reg_242;
                             (reg_241, reg_242, reg_243) = pool::pool_book_params(freeze(l3));
                             let l101 = reg_242;
@@ -318,190 +193,81 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                                 let (reg_260, reg_261) = arbitrage_router::execute_deepbook_ioc(true, l3, l2, &l136, l86, l78, l83, l7, freeze(l18));
                                 if (reg_261) {
                                     events::emit_log_bytes(C11);
-                                    events::emit_arb_ioc_executed(l112, true, l86, l78, reg_260, l67, l108);
-                                    unstructured {
-                                        goto 'label_408;
-                                    }
+                                    events::emit_arb_ioc_executed(l112, true, l86, l78, reg_260, l67, l108)
                                 } else {
-                                    events::emit_log_bytes(C12);
-                                    unstructured {
-                                        goto 'label_408;
-                                    }
+                                    events::emit_log_bytes(C12)
                                 }
-                            } else {
-                                unstructured {
-                                    goto 'label_408;
-                                }
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_408;
                             }
                         };
                         /* block 408 */;
                         mm_state::record_arb_time(l0, l108);
-                        events::emit_log_bytes(C13);
-                        unstructured {
-                            goto 'label_437;
-                        }
+                        events::emit_log_bytes(C13)
                     } else {
-                        let l51;
-                        if (l139) {
-                            l51 = l97;
-                            unstructured {
-                                goto 'label_433;
-                            }
-                        } else {
-                            l51 = false;
-                            unstructured {
-                                goto 'label_433;
-                            }
-                        };
                         /* block 433 */;
-                        if (l51) {
-                            events::emit_log_bytes(C14);
-                            unstructured {
-                                goto 'label_437;
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_437;
-                            }
+                        if (l139 && l97) {
+                            events::emit_log_bytes(C14)
                         }
                     };
                     let (l131, l21);
                     /* block 437 */;
                     l131 = config::target_base_position(l83);
-                    if (l131 > 0u64) {
-                        let l20;
-                        if (l62 >= l131) {
-                            l20 = l62 - l131 * 10000u64 / l131;
-                            unstructured {
-                                goto 'label_465;
-                            }
-                        } else {
-                            l20 = l131 - l62 * 10000u64 / l131;
-                            unstructured {
-                                goto 'label_465;
-                            }
-                        };
+                    l21 = if (l131 > 0u64) {
                         /* block 465 */;
-                        l21 = l20;
-                        unstructured {
-                            goto 'label_470;
+                        if (l62 >= l131) {
+                            l62 - l131 * 10000u64 / l131
+                        } else {
+                            l131 - l62 * 10000u64 / l131
                         }
                     } else {
-                        l21 = 0u64;
-                        unstructured {
-                            goto 'label_470;
-                        }
+                        0u64
                     };
                     /* block 470 */;
                     let l93 = l21;
                     events::emit_execution_detail(mm_state::state_id(freeze(l0)), l112, l13, mm_state::execution_count(freeze(l0)), l108, l8, l8, 0u64, 0u64, l62, l114, l131, l93, false, l9, l10, 0u64, 0u64, l80, false, 0u64, l15);
                     mm_state::record_order_time(l0, l108);
                     return
-                };
-                unstructured {
-                    goto 'label_503;
-                }
-            } else {
-                unstructured {
-                    goto 'label_503;
                 }
             };
             let l27;
             /* block 503 */;
             events::emit_log_bytes(C15);
-            if (config::is_orderbook_analysis_enabled(l83)) {
-                let l22;
+            l27 = if (config::is_orderbook_analysis_enabled(l83)) {
                 let l127 = orderbook_analyzer::analyze_orderbook(freeze(l3), freeze(l2), config::min_significant_qty(l83), config::l2_tick_count(l83), l7);
-                if (orderbook_analyzer::bid_prices(&l127).len() > 0u64) {
-                    l22 = *(&(orderbook_analyzer::bid_prices(&l127))[0u64]);
-                    unstructured {
-                        goto 'label_534;
-                    }
+                let l22 = if (orderbook_analyzer::bid_prices(&l127).len() > 0u64) {
+                    *(&(orderbook_analyzer::bid_prices(&l127))[0u64])
                 } else {
-                    l22 = 0u64;
-                    unstructured {
-                        goto 'label_534;
-                    }
+                    0u64
                 };
                 let (l118, l23);
                 /* block 534 */;
                 l118 = l22;
-                if (orderbook_analyzer::ask_prices(&l127).len() > 0u64) {
-                    l23 = *(&(orderbook_analyzer::ask_prices(&l127))[0u64]);
-                    unstructured {
-                        goto 'label_551;
-                    }
+                l23 = if (orderbook_analyzer::ask_prices(&l127).len() > 0u64) {
+                    *(&(orderbook_analyzer::ask_prices(&l127))[0u64])
                 } else {
-                    l23 = 0u64;
-                    unstructured {
-                        goto 'label_551;
-                    }
+                    0u64
                 };
                 let (l117, l24);
                 /* block 551 */;
                 l117 = l23;
-                if (l118 > 0u64) {
-                    if (l117 > 0u64) {
-                        l24 = l117 > l118;
-                        unstructured {
-                            goto 'label_571;
-                        }
-                    } else {
-                        l24 = false;
-                        unstructured {
-                            goto 'label_571;
-                        }
-                    }
-                } else {
-                    l24 = false;
-                    unstructured {
-                        goto 'label_571;
-                    }
-                };
-                let l26;
+                l24 = l118 > 0u64 && l117 > 0u64 && l117 > l118;
                 /* block 571 */;
-                if (l24) {
-                    let l25;
+                let l26 = if (l24) {
                     let l121 = l118 + l117 / 2u64;
-                    if (l121 > 0u64) {
-                        l25 = l117 - l118 * 10000u64 / l121;
-                        unstructured {
-                            goto 'label_594;
-                        }
-                    } else {
-                        l25 = 0u64;
-                        unstructured {
-                            goto 'label_594;
-                        }
-                    };
                     /* block 594 */;
-                    l26 = l25;
-                    unstructured {
-                        goto 'label_599;
+                    if (l121 > 0u64) {
+                        l117 - l118 * 10000u64 / l121
+                    } else {
+                        0u64
                     }
                 } else {
-                    l26 = 0u64;
-                    unstructured {
-                        goto 'label_599;
-                    }
+                    0u64
                 };
                 /* block 599 */;
-                let l122 = l26;
-                events::emit_orderbook_analysis(l112, l108, orderbook_analyzer::bid_prices(&l127).len(), orderbook_analyzer::ask_prices(&l127).len(), l118, l117, l122, orderbook_analyzer::own_bid_qty_filtered(&l127), orderbook_analyzer::own_ask_qty_filtered(&l127), orderbook_analyzer::own_orders_count(&l127), orderbook_analyzer::best_bid(&l127), orderbook_analyzer::best_ask(&l127), orderbook_analyzer::spread_bps(&l127), orderbook_analyzer::significant_bid(&l127), orderbook_analyzer::significant_bid_qty(&l127), orderbook_analyzer::significant_ask(&l127), orderbook_analyzer::significant_ask_qty(&l127), orderbook_analyzer::total_bid_depth(&l127), orderbook_analyzer::total_ask_depth(&l127));
+                events::emit_orderbook_analysis(l112, l108, orderbook_analyzer::bid_prices(&l127).len(), orderbook_analyzer::ask_prices(&l127).len(), l118, l117, l26, orderbook_analyzer::own_bid_qty_filtered(&l127), orderbook_analyzer::own_ask_qty_filtered(&l127), orderbook_analyzer::own_orders_count(&l127), orderbook_analyzer::best_bid(&l127), orderbook_analyzer::best_ask(&l127), orderbook_analyzer::spread_bps(&l127), orderbook_analyzer::significant_bid(&l127), orderbook_analyzer::significant_bid_qty(&l127), orderbook_analyzer::significant_ask(&l127), orderbook_analyzer::significant_ask_qty(&l127), orderbook_analyzer::total_bid_depth(&l127), orderbook_analyzer::total_ask_depth(&l127));
                 events::emit_log_bytes(C16);
-                l27 = option::some(l127);
-                unstructured {
-                    goto 'label_645;
-                }
+                option::some(l127)
             } else {
-                l27 = option::none();
-                unstructured {
-                    goto 'label_645;
-                }
+                option::none()
             };
             let (l102, l105, l110, l115, l119, l133, l28, l76);
             /* block 645 */;
@@ -516,30 +282,18 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
             (reg_478, reg_479, reg_480, reg_481) = pool::get_level2_ticks_from_mid(freeze(l3), 1u64, l7);
             l76 = reg_480;
             let l77 = reg_478;
-            if (&l77.len() > 0u64) {
-                l28 = *(&(&l77)[0u64]);
-                unstructured {
-                    goto 'label_691;
-                }
+            l28 = if (&l77.len() > 0u64) {
+                *(&(&l77)[0u64])
             } else {
-                l28 = 0u64;
-                unstructured {
-                    goto 'label_691;
-                }
+                0u64
             };
             let (l29, l64);
             /* block 691 */;
             l64 = l28;
-            if (&l76.len() > 0u64) {
-                l29 = *(&(&l76)[0u64]);
-                unstructured {
-                    goto 'label_706;
-                }
+            l29 = if (&l76.len() > 0u64) {
+                *(&(&l76)[0u64])
             } else {
-                l29 = 0u64;
-                unstructured {
-                    goto 'label_706;
-                }
+                0u64
             };
             let (l31, l53, l63, l69, l84, l85);
             /* block 706 */;
@@ -548,135 +302,62 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
             l53 = false;
             l85 = l119;
             l84 = l115;
-            if (l63 > 0u64) {
-                l31 = l119 >= l63;
-                unstructured {
-                    goto 'label_727;
-                }
-            } else {
-                l31 = false;
-                unstructured {
-                    goto 'label_727;
-                }
-            };
+            l31 = l63 > 0u64 && l119 >= l63;
             /* block 727 */;
             if (l31) {
                 l69 = true;
                 l85 = l63 * 100000u64 - l11 / 100000u64;
-                unstructured {
-                    goto 'label_739;
-                }
-            } else {
-                unstructured {
-                    goto 'label_739;
-                }
             };
-            let l32;
             /* block 739 */;
-            if (l64 > 0u64) {
-                l32 = l115 <= l64;
-                unstructured {
-                    goto 'label_750;
-                }
-            } else {
-                l32 = false;
-                unstructured {
-                    goto 'label_750;
-                }
-            };
+            let l32 = l64 > 0u64 && l115 <= l64;
             /* block 750 */;
             if (l32) {
                 l53 = true;
                 l84 = l64 * 100000u64 + l12 / 100000u64;
-                unstructured {
-                    goto 'label_762;
-                }
-            } else {
-                unstructured {
-                    goto 'label_762;
-                }
             };
-            let l33;
             /* block 762 */;
-            if (l69) {
-                l33 = true;
-                unstructured {
-                    goto 'label_769;
-                }
-            } else {
-                l33 = l53;
-                unstructured {
-                    goto 'label_769;
-                }
-            };
+            let l33 = l69 || l53;
             /* block 769 */;
             if (l33) {
-                events::emit_crossing_prevented(l112, l108, l69, l53, l119, l115, l85, l84, l64, l63, l11, l12);
-                unstructured {
-                    goto 'label_784;
-                }
-            } else {
-                unstructured {
-                    goto 'label_784;
-                }
+                events::emit_crossing_prevented(l112, l108, l69, l53, l119, l115, l85, l84, l64, l63, l11, l12)
             };
             let (l116, l120, l36, l37);
             /* block 784 */;
             l120 = l85;
             l116 = l84;
-            if (option::is_some(&l110)) {
-                let l34;
+            l36 = if (option::is_some(&l110)) {
                 let l128 = option::borrow(&l110);
                 let l113 = config::price_offset_ticks(l83) * l133;
                 let (reg_570, reg_571) = orderbook_analyzer::find_optimal_price_with_reason(l128, l120, true, l113, config::min_significant_qty(l83));
                 let l124 = orders::round_bid_price(reg_570, l133);
                 let l107 = orders::round_bid_price(l120, l133);
-                if (l124 > l107) {
-                    l34 = l124 - l107;
-                    unstructured {
-                        goto 'label_827;
-                    }
+                let l34 = if (l124 > l107) {
+                    l124 - l107
                 } else {
-                    l34 = l107 - l124;
-                    unstructured {
-                        goto 'label_827;
-                    }
+                    l107 - l124
                 };
                 let (l106, l123, l35, l59);
                 /* block 827 */;
-                let l70 = l34;
                 let l71 = l124 > l107;
-                events::emit_order_placement_decision(l112, l108, true, l8, l8, l107, orderbook_analyzer::significant_bid(l128), orderbook_analyzer::significant_bid_qty(l128), l124, l70 / l133, l71, reg_571);
+                events::emit_order_placement_decision(l112, l108, true, l8, l8, l107, orderbook_analyzer::significant_bid(l128), orderbook_analyzer::significant_bid_qty(l128), l124, l34 / l133, l71, reg_571);
                 let (reg_612, reg_613) = orderbook_analyzer::find_optimal_price_with_reason(l128, l116, false, l113, config::min_significant_qty(l83));
                 l59 = reg_613;
                 l123 = orders::round_ask_price(reg_612, l133);
                 l106 = orders::round_ask_price(l116, l133);
-                if (l123 < l106) {
-                    l35 = l106 - l123;
-                    unstructured {
-                        goto 'label_878;
-                    }
+                l35 = if (l123 < l106) {
+                    l106 - l123
                 } else {
-                    l35 = l123 - l106;
-                    unstructured {
-                        goto 'label_878;
-                    }
+                    l123 - l106
                 };
                 /* block 878 */;
                 let l54 = l35;
                 let l55 = l123 < l106;
                 events::emit_order_placement_decision(l112, l108, false, l8, l8, l106, orderbook_analyzer::significant_ask(l128), orderbook_analyzer::significant_ask_qty(l128), l123, l54 / l133, l55, l59);
                 l37 = l123;
-                l36 = l124;
-                unstructured {
-                    goto 'label_914;
-                }
+                l124
             } else {
                 l37 = orders::round_ask_price(l116, l133);
-                l36 = orders::round_bid_price(l120, l133);
-                unstructured {
-                    goto 'label_914;
-                }
+                orders::round_bid_price(l120, l133)
             };
             let (l57, l58, l73, l74);
             /* block 914 */;
@@ -692,70 +373,24 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                     let l134 = l74 + l58;
                     let l60 = l73 + l57 / 2u64;
                     (reg_697, reg_698) = deep_manager::ensure_deep_balance(freeze(l3), l4, l2, &l136, l134, l60, l83, l7, freeze(l18));
-                    events::emit_log_bytes(C17);
-                    unstructured {
-                        goto 'label_974;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_974;
-                    }
+                    events::emit_log_bytes(C17)
                 };
-                let l38;
                 /* block 974 */;
-                if (l74 >= config::min_order_size(l83)) {
-                    l38 = l73 >= config::min_price(l83);
-                    unstructured {
-                        goto 'label_987;
-                    }
-                } else {
-                    l38 = false;
-                    unstructured {
-                        goto 'label_987;
-                    }
-                };
+                let l38 = l74 >= config::min_order_size(l83) && l73 >= config::min_price(l83);
                 /* block 987 */;
                 if (l38) {
                     let l72 = pool::place_limit_order(l3, l2, &l136, l15, constants::post_only(), constants::cancel_taker(), l73, l74, true, l111, l109, l7, freeze(l18));
-                    events::emit_post_only_order(l112, true, l73, l74, order_info::order_id(&l72), l8, l9, l108, l15);
-                    unstructured {
-                        goto 'label_1016;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_1016;
-                    }
+                    events::emit_post_only_order(l112, true, l73, l74, order_info::order_id(&l72), l8, l9, l108, l15)
                 };
-                let l39;
                 /* block 1016 */;
-                if (l58 >= config::min_order_size(l83)) {
-                    l39 = l57 <= config::max_price(l83);
-                    unstructured {
-                        goto 'label_1029;
-                    }
-                } else {
-                    l39 = false;
-                    unstructured {
-                        goto 'label_1029;
-                    }
-                };
+                let l39 = l58 >= config::min_order_size(l83) && l57 <= config::max_price(l83);
                 /* block 1029 */;
                 if (l39) {
                     let l56 = pool::place_limit_order(l3, l2, &l136, l15, constants::post_only(), constants::cancel_taker(), l57, l58, false, l111, l109, l7, freeze(l18));
-                    events::emit_post_only_order(l112, false, l57, l58, order_info::order_id(&l56), l8, l10, l108, l15);
-                    unstructured {
-                        goto 'label_1068;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_1068;
-                    }
+                    events::emit_post_only_order(l112, false, l57, l58, order_info::order_id(&l56), l8, l10, l108, l15)
                 }
             } else {
-                events::emit_log_bytes(C18);
-                unstructured {
-                    goto 'label_1068;
-                }
+                events::emit_log_bytes(C18)
             };
             let (l132, l137, l91, l92);
             /* block 1068 */;
@@ -769,119 +404,53 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                 let l98 = reg_798;
                 let l90 = reg_797;
                 if (l90 > 0u64) {
-                    let l40;
                     let l87 = cetus_hedger::apply_cetus_fee(l80, l79, l98);
                     l137 = l87;
-                    if (l98) {
-                        l40 = cetus_hedger::should_hedge_sell(l87, l8, config::min_hedge_profit_bps(l83));
-                        unstructured {
-                            goto 'label_1125;
-                        }
+                    let l40 = if (l98) {
+                        cetus_hedger::should_hedge_sell(l87, l8, config::min_hedge_profit_bps(l83))
                     } else {
-                        l40 = cetus_hedger::should_hedge_buy(l87, l8, config::min_hedge_profit_bps(l83));
-                        unstructured {
-                            goto 'label_1125;
-                        }
+                        cetus_hedger::should_hedge_buy(l87, l8, config::min_hedge_profit_bps(l83))
                     };
                     let (l126, l42);
                     /* block 1125 */;
                     l126 = l40;
                     l92 = cetus_hedger::calculate_hedge_profit_bps(l87, l8, l98);
                     events::emit_hedge_opportunity(mm_state::state_id(freeze(l0)), l112, l8, l80, l87, l90, l98, l126, l92, l108);
-                    if (l126) {
-                        l42 = !(l97);
-                        unstructured {
-                            goto 'label_1153;
-                        }
-                    } else {
-                        l42 = false;
-                        unstructured {
-                            goto 'label_1153;
-                        }
-                    };
+                    l42 = l126 && !(l97);
                     /* block 1153 */;
                     if (l42) {
                         if (l98) {
                             let l104 = l90 * l87 / 1000000000u64 * 99u64 / 100u64;
                             (reg_857, reg_858) = cetus_hedger::flash_swap_sell_sui(l2, l5, l6, l90, l104, l7, l18);
                             l91 = true;
-                            events::emit_log_bytes(C19);
-                            unstructured {
-                                goto 'label_1254;
-                            }
+                            events::emit_log_bytes(C19)
                         } else {
                             let l103 = l90 * l87 / 1000000000u64 * 101u64 / 100u64;
                             (reg_877, reg_878) = cetus_hedger::flash_swap_buy_sui(l2, l5, l6, l90, l103, l7, l18);
                             l91 = true;
-                            events::emit_log_bytes(C20);
-                            unstructured {
-                                goto 'label_1254;
-                            }
+                            events::emit_log_bytes(C20)
                         }
                     } else {
-                        let l43;
-                        if (l126) {
-                            l43 = l97;
-                            unstructured {
-                                goto 'label_1224;
-                            }
-                        } else {
-                            l43 = false;
-                            unstructured {
-                                goto 'label_1224;
-                            }
-                        };
                         /* block 1224 */;
-                        if (l43) {
-                            events::emit_log_bytes(C21);
-                            unstructured {
-                                goto 'label_1254;
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_1254;
-                            }
+                        if (l126 && l97) {
+                            events::emit_log_bytes(C21)
                         }
                     }
-                } else {
-                    unstructured {
-                        goto 'label_1254;
-                    }
-                }
-            } else {
-                unstructured {
-                    goto 'label_1254;
                 }
             };
-            let l45;
             /* block 1254 */;
-            if (l132 > 0u64) {
-                let l44;
-                if (l62 >= l132) {
-                    l44 = l62 - l132 * 10000u64 / l132;
-                    unstructured {
-                        goto 'label_1279;
-                    }
-                } else {
-                    l44 = l132 - l62 * 10000u64 / l132;
-                    unstructured {
-                        goto 'label_1279;
-                    }
-                };
+            let l45 = if (l132 > 0u64) {
                 /* block 1279 */;
-                l45 = l44;
-                unstructured {
-                    goto 'label_1284;
+                if (l62 >= l132) {
+                    l62 - l132 * 10000u64 / l132
+                } else {
+                    l132 - l62 * 10000u64 / l132
                 }
             } else {
-                l45 = 0u64;
-                unstructured {
-                    goto 'label_1284;
-                }
+                0u64
             };
             /* block 1284 */;
-            let l94 = l45;
-            events::emit_execution_detail(mm_state::state_id(freeze(l0)), l112, l13, mm_state::execution_count(freeze(l0)), l108, l8, l8, l73, l57, l62, l114, l132, l94, l62 > l132, l9, l10, l74, l58, l137, l91, l92, l15);
+            events::emit_execution_detail(mm_state::state_id(freeze(l0)), l112, l13, mm_state::execution_count(freeze(l0)), l108, l8, l8, l73, l57, l62, l114, l132, l45, l62 > l132, l9, l10, l74, l58, l137, l91, l92, l15);
             mm_state::record_order_time(l0, l108)
         }
     }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/main_module.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/main_module.mv.snap
@@ -272,19 +272,8 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
     assert!(*(&l1.version) <= C0, C7);
     assert!(table::contains(&l0.cabinet, l45), C3);
     assert!(coin::value(freeze(l3)) >= C1 * l2, C6);
-    let l6;
     let l44 = table::borrow_mut(&mut l0.cabinet, l45);
-    if (l2 > 0u64) {
-        l6 = *(&l44.has_stake_number) + l2 <= 50u64;
-        unstructured {
-            goto 'label_101;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_101;
-        }
-    };
+    let l6 = l2 > 0u64 && *(&l44.has_stake_number) + l2 <= 50u64;
     /* block 101 */;
     assert!(l6, C5);
     *(&mut l44.has_stake_number) = *(&l44.has_stake_number) + l2;
@@ -297,15 +286,9 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
         if (*(&l1.current_row) + 1u64 > 2u64) {
             *(&mut l1.current_row) = 0u64;
             *(&mut l1.current_floor) = *(&l1.current_floor) + 1u64;
-            (&mut l1.seating).push_back(vector[]);
-            unstructured {
-                goto 'label_189;
-            }
+            (&mut l1.seating).push_back(vector[])
         } else {
-            *(&mut l1.current_row) = *(&l1.current_row) + 1u64;
-            unstructured {
-                goto 'label_189;
-            }
+            *(&mut l1.current_row) = *(&l1.current_row) + 1u64
         };
         /* block 189 */;
         let l20 = table::borrow_mut(&mut l0.cabinet, *(&l44.affCode));
@@ -313,30 +296,17 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
         (&mut l20.invite_addresses).push_back(l45);
         let l38 = *(&l20.total_effective_invite_number);
         l44 = table::borrow_mut(&mut l0.cabinet, l45);
-        *(&mut l44.position_of_aff) = l38;
-        unstructured {
-            goto 'label_221;
-        }
-    } else {
-        unstructured {
-            goto 'label_221;
-        }
+        *(&mut l44.position_of_aff) = l38
     };
     let (l12, l29);
     /* block 221 */;
     sbt::mint(l4, l45, l5);
     event::emit(Participates { from: l45, num: l2 });
     l29 = C1 * l2;
-    if (l28 == true) {
-        l12 = l29 * 3u64;
-        unstructured {
-            goto 'label_248;
-        }
+    l12 = if (l28 == true) {
+        l29 * 3u64
     } else {
-        l12 = l29 * 22u64 / 10u64;
-        unstructured {
-            goto 'label_248;
-        }
+        l29 * 22u64 / 10u64
     };
     let (l21, l39);
     /* block 248 */;
@@ -350,39 +320,18 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
     if (*(&l44.position_of_aff) % 3u64 == 0u64) {
         transfer::public_transfer(coin::split(l3, l29 * 40u64 / 100u64, l5), *(&(&l0.team_addresses)[0u64]));
         l21 = l29 * 10u64 / 100u64;
-        unstructured {
-            goto 'label_330;
-        }
-    } else {
-        unstructured {
-            goto 'label_330;
-        }
     };
     /* block 330 */;
     l44 = table::borrow_mut(&mut l0.cabinet, l39);
     if (*(&l44.could_reward) <= l21) {
         transfer::public_transfer(coin::split(l3, l21 - *(&l44.could_reward), l5), *(&(&l0.team_addresses)[0u64]));
         l21 = *(&l44.could_reward);
-        unstructured {
-            goto 'label_359;
-        }
-    } else {
-        unstructured {
-            goto 'label_359;
-        }
     };
     /* block 359 */;
     if (l21 > 0u64) {
         transfer::public_transfer(coin::split(l3, l21, l5), l39);
         *(&mut l44.could_reward) = *(&l44.could_reward) - l21;
-        *(&mut l44.has_reward) = *(&l44.has_reward) + l21;
-        unstructured {
-            goto 'label_388;
-        }
-    } else {
-        unstructured {
-            goto 'label_388;
-        }
+        *(&mut l44.has_reward) = *(&l44.has_reward) + l21
     };
     let (l22, l30);
     /* block 388 */;
@@ -648,21 +597,13 @@ public entry fun whiteList(l0: vector<address>, l1: vector<u64>, l2: &mut Coin<S
 }
 
 public entry fun withdraw(l0: &mut TheTreasury, l1: &AdminCap, l2: Option<u64>, l3: &mut TxContext) {
-    let l4;
-    if (option::is_some(&l2)) {
+    let l4 = if (option::is_some(&l2)) {
         let l6 = option::destroy_some(l2);
         assert!(l6 <= x2_balance::value(&l0.balance), C2);
-        l4 = l6;
-        unstructured {
-            goto 'label_26;
-        }
+        l6
     } else {
-        l4 = x2_balance::value(&l0.balance);
-        unstructured {
-            goto 'label_26;
-        }
+        x2_balance::value(&l0.balance)
     };
     /* block 26 */;
-    let l5 = l4;
-    transfer::public_transfer(coin::take(&mut l0.balance, l5, l3), tx_context::sender(freeze(l3)))
+    transfer::public_transfer(coin::take(&mut l0.balance, l4, l3), tx_context::sender(freeze(l3)))
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/marketplace.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/marketplace.mv.snap
@@ -461,9 +461,6 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
     } else {
         assert!(linked_table::contains(&l29.bids, l5), C17);
         l32 = *(&(&linked_table::remove(&mut l29.bids, l5)).last_points_claimed_at);
-        unstructured {
-            goto 'label_217;
-        }
     };
     /* block 217 */;
     let l36 = dynamic_object_field::borrow_mut(&mut l1.id, l45);
@@ -492,10 +489,7 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
             std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7))
         }
     } else {
-        assert!(object::uid_to_inner(&(&linked_table::remove(&mut (linked_table::borrow_mut(&mut l36.bids, l5)).bids, l7)).id) == l6, C26);
-        unstructured {
-            goto 'label_383;
-        }
+        assert!(object::uid_to_inner(&(&linked_table::remove(&mut (linked_table::borrow_mut(&mut l36.bids, l5)).bids, l7)).id) == l6, C26)
     };
     let (l38, l48);
     /* block 383 */;
@@ -513,32 +507,19 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
     kiosk::lock(l4, &l1.escrow_kiosk_cap, l9, l44);
     let l46 = PendingClaim { buyer: l7, nft_type: l45, price: l48 - l38 };
     if (linked_table::contains(&l1.pending_claims, l7)) {
-        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l7)).pending_claims, l5, l46);
-        unstructured {
-            goto 'label_485;
-        }
+        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l7)).pending_claims, l5, l46)
     } else {
         let l47 = PendingClaims { pending_claims: linked_table::new(l12) };
         linked_table::push_back(&mut (&mut l47).pending_claims, l5, l46);
-        linked_table::push_back(&mut l1.pending_claims, l7, l47);
-        unstructured {
-            goto 'label_485;
-        }
+        linked_table::push_back(&mut l1.pending_claims, l7, l47)
     };
     let (l17, l18);
     /* block 485 */;
-    if (*(&l36.ion_points_enabled)) {
-        let l16;
-        if (*(&l36.ion_collection_multiplier) == 0u64) {
-            l16 = C5;
-            unstructured {
-                goto 'label_502;
-            }
+    l17 = if (*(&l36.ion_points_enabled)) {
+        let l16 = if (*(&l36.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l16 = *(&l36.ion_collection_multiplier);
-            unstructured {
-                goto 'label_502;
-            }
+            *(&l36.ion_collection_multiplier)
         };
         /* block 502 */;
         let l37 = l16;
@@ -552,16 +533,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
         let l30 = linked_table::borrow_mut(&mut l1.user_activity, l7);
         *(&mut l30.claimable_points) = *(&l30.claimable_points) + l33;
         l18 = l54;
-        l17 = l33;
-        unstructured {
-            goto 'label_579;
-        }
+        l33
     } else {
         l18 = 0u64;
-        l17 = 0u64;
-        unstructured {
-            goto 'label_579;
-        }
+        0u64
     };
     /* block 579 */;
     let l52 = l18;
@@ -594,14 +569,7 @@ public fun accept_trait_bid<T0: key + store, T1: key + store>(l0: &mut MarketPla
         let l8 = reg_86;
         let l10 = reg_85;
         assert!(l8 == object::id(freeze(l2)), C19);
-        kiosk::return_purchase_cap(l2, l10);
-        unstructured {
-            goto 'label_153;
-        }
-    } else {
-        unstructured {
-            goto 'label_153;
-        }
+        kiosk::return_purchase_cap(l2, l10)
     };
     /* block 153 */;
     return (kiosk::take(l2, l3, l1), l13, l7)
@@ -715,9 +683,6 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
     } else {
         assert!(linked_table::contains(&l26.bids, l5), C17);
         l29 = *(&(&linked_table::remove(&mut l26.bids, l5)).last_points_claimed_at);
-        unstructured {
-            goto 'label_190;
-        }
     };
     let (l21, l33);
     /* block 190 */;
@@ -745,9 +710,6 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
         let l19 = linked_table::borrow_mut(&mut l33.bids, l5);
         assert!(linked_table::contains(&l19.bids, l6), C17);
         let l20 = linked_table::remove(&mut l19.bids, l6);
-        unstructured {
-            goto 'label_321;
-        }
     };
     let (l35, l42, l47);
     /* block 321 */;
@@ -764,32 +726,19 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
     kiosk::lock(l3, &l1.escrow_kiosk_cap, freeze(l10), reg_244);
     let l40 = PendingClaim { buyer: l6, nft_type: l39, price: l42 - l35 };
     if (linked_table::contains(&l1.pending_claims, l6)) {
-        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l6)).pending_claims, l5, l40);
-        unstructured {
-            goto 'label_430;
-        }
+        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l6)).pending_claims, l5, l40)
     } else {
         let l41 = PendingClaims { pending_claims: linked_table::new(l13) };
         linked_table::push_back(&mut (&mut l41).pending_claims, l5, l40);
-        linked_table::push_back(&mut l1.pending_claims, l6, l41);
-        unstructured {
-            goto 'label_430;
-        }
+        linked_table::push_back(&mut l1.pending_claims, l6, l41)
     };
     let (l15, l16);
     /* block 430 */;
-    if (*(&l33.ion_points_enabled)) {
-        let l14;
-        if (*(&l33.ion_collection_multiplier) == 0u64) {
-            l14 = C5;
-            unstructured {
-                goto 'label_447;
-            }
+    l15 = if (*(&l33.ion_points_enabled)) {
+        let l14 = if (*(&l33.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l14 = *(&l33.ion_collection_multiplier);
-            unstructured {
-                goto 'label_447;
-            }
+            *(&l33.ion_collection_multiplier)
         };
         /* block 447 */;
         let l34 = l14;
@@ -801,16 +750,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
         let l27 = linked_table::borrow_mut(&mut l1.user_activity, l6);
         *(&mut l27.claimable_points) = *(&l27.claimable_points) + l30;
         l16 = l45;
-        l15 = l30;
-        unstructured {
-            goto 'label_512;
-        }
+        l30
     } else {
         l16 = 0u64;
-        l15 = 0u64;
-        unstructured {
-            goto 'label_512;
-        }
+        0u64
     };
     /* block 512 */;
     let l44 = l16;
@@ -837,55 +780,29 @@ public fun award_bid_ion_points<T0: key + store>(l0: &mut MarketPlaceStore, l1: 
     assert!(linked_table::contains(&l0.user_activity, l1), C10);
     let l23 = linked_table::borrow_mut(&mut l0.user_activity, l1);
     assert!(linked_table::contains(&l23.bids, l2), C17);
-    let l6;
     let l9 = linked_table::borrow_mut(&mut l23.bids, l2);
-    if (*(&l9.last_points_claimed_at) == 0u64) {
-        l6 = *(&l9.bid_at);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (*(&l9.last_points_claimed_at) == 0u64) {
+        *(&l9.bid_at)
     } else {
-        l6 = *(&l9.last_points_claimed_at);
-        unstructured {
-            goto 'label_68;
-        }
+        *(&l9.last_points_claimed_at)
     };
     let (l10, l21, l7);
     /* block 68 */;
-    let l14 = l6;
-    l21 = l13 - l14;
+    l21 = l13 - l6;
     l10 = dynamic_object_field::borrow(&l0.id, l15);
-    if (*(&l10.ion_points_enabled)) {
-        l7 = l21 > 0u64;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_90;
-        }
-    };
+    l7 = *(&l10.ion_points_enabled) && l21 > 0u64;
     /* block 90 */;
     if (l7) {
         let l22 = helpers::calculate_time_multiplier(l21, false);
         if (l22 > 0u64) {
-            let l8;
             let l17 = helpers::calculate_bid_proximity_multiplier(*(&l9.bid_price), *(&l10.avg_sale_price));
-            if (*(&l10.ion_collection_multiplier) == 0u64) {
-                l8 = C5;
-                unstructured {
-                    goto 'label_123;
-                }
+            let l8 = if (*(&l10.ion_collection_multiplier) == 0u64) {
+                C5
             } else {
-                l8 = *(&l10.ion_collection_multiplier);
-                unstructured {
-                    goto 'label_123;
-                }
+                *(&l10.ion_collection_multiplier)
             };
             /* block 123 */;
-            let l11 = l8;
-            let l16 = helpers::calculate_ion_points(*(&l9.bid_price), l11, l17, l22);
+            let l16 = helpers::calculate_ion_points(*(&l9.bid_price), l8, l17, l22);
             *(&mut l9.last_points_claimed_at) = l13;
             marketplace::award_ion_points_with_referral(l1, l0, l3, l16, l4, l5);
             if (ions::has_referrer(freeze(l3))) {
@@ -895,34 +812,12 @@ public fun award_bid_ion_points<T0: key + store>(l0: &mut MarketPlaceStore, l1: 
                     let l18 = l16 * C6 / 100u64;
                     if (linked_table::contains(&l0.referrals, l19)) {
                         let l12 = linked_table::borrow_mut(&mut l0.referrals, l19);
-                        *l12 = *l12 + l18;
-                        unstructured {
-                            goto 'label_221;
-                        }
+                        *l12 = *l12 + l18
                     } else {
-                        linked_table::push_back(&mut l0.referrals, l19, l18);
-                        unstructured {
-                            goto 'label_221;
-                        }
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_221;
+                        linked_table::push_back(&mut l0.referrals, l19, l18)
                     }
                 }
-            } else {
-                unstructured {
-                    goto 'label_221;
-                }
             }
-        } else {
-            unstructured {
-                goto 'label_221;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_221;
         }
     };
     /* block 221 */
@@ -940,24 +835,10 @@ fun award_ion_points_with_referral(l0: address, l1: &mut MarketPlaceStore, l2: &
             l6 = math::mul_div_u128(l3as u128, C3as u128, 100u128);
             if (linked_table::contains(&l1.referrals, *(option::borrow(&l9)))) {
                 let l7 = linked_table::borrow_mut(&mut l1.referrals, *(option::borrow(&l9)));
-                *l7 = *l7 + l8;
-                unstructured {
-                    goto 'label_64;
-                }
+                *l7 = *l7 + l8
             } else {
-                linked_table::push_back(&mut l1.referrals, *(option::borrow(&l9)), l8);
-                unstructured {
-                    goto 'label_64;
-                }
+                linked_table::push_back(&mut l1.referrals, *(option::borrow(&l9)), l8)
             }
-        } else {
-            unstructured {
-                goto 'label_64;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_64;
         }
     };
     /* block 64 */;
@@ -972,67 +853,30 @@ public fun award_listing_ion_points<T0: key + store>(l0: &mut MarketPlaceStore, 
     assert!(linked_table::contains(&l0.user_activity, l1), C10);
     let l19 = linked_table::borrow_mut(&mut l0.user_activity, l1);
     assert!(linked_table::contains(&l19.listings, l2), C11);
-    let l6;
     let l13 = linked_table::borrow_mut(&mut l19.listings, l2);
-    if (*(&l13.last_points_claimed_at) == 0u64) {
-        l6 = *(&l13.listed_at);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (*(&l13.last_points_claimed_at) == 0u64) {
+        *(&l13.listed_at)
     } else {
-        l6 = *(&l13.last_points_claimed_at);
-        unstructured {
-            goto 'label_68;
-        }
+        *(&l13.last_points_claimed_at)
     };
     let (l17, l7, l9);
     /* block 68 */;
-    let l12 = l6;
-    l17 = l11 - l12;
+    l17 = l11 - l6;
     l9 = dynamic_object_field::borrow(&l0.id, l14);
-    if (*(&l9.ion_points_enabled)) {
-        l7 = l17 > 0u64;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_90;
-        }
-    };
+    l7 = *(&l9.ion_points_enabled) && l17 > 0u64;
     /* block 90 */;
     if (l7) {
         let l18 = helpers::calculate_time_multiplier(l17, false);
         if (l18 > 0u64) {
-            let l8;
             let l16 = helpers::calculate_listing_proximity_multiplier(*(&l13.price), *(&l9.avg_sale_price));
-            if (*(&l9.ion_collection_multiplier) == 0u64) {
-                l8 = C5;
-                unstructured {
-                    goto 'label_123;
-                }
+            let l8 = if (*(&l9.ion_collection_multiplier) == 0u64) {
+                C5
             } else {
-                l8 = *(&l9.ion_collection_multiplier);
-                unstructured {
-                    goto 'label_123;
-                }
+                *(&l9.ion_collection_multiplier)
             };
             /* block 123 */;
-            let l10 = l8;
-            let l15 = helpers::calculate_ion_points(*(&l13.price), l10, l16, l18);
-            marketplace::award_ion_points_with_referral(l1, l0, l3, l15, l4, l5);
-            unstructured {
-                goto 'label_168;
-            }
-        } else {
-            unstructured {
-                goto 'label_168;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
+            let l15 = helpers::calculate_ion_points(*(&l13.price), l8, l16, l18);
+            marketplace::award_ion_points_with_referral(l1, l0, l3, l15, l4, l5)
         }
     };
     /* block 168 */
@@ -1071,18 +915,11 @@ public fun buy<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2: &mut 
     let l44 = x2_balance::split(&mut l43, l38);
     let (reg_145, reg_146) = kiosk::purchase_with_cap(l2, reg_116, coin::from_balance(l44, l7));
     let l32 = reg_145;
-    if (*(&l25.ion_points_enabled)) {
-        let l16;
-        if (*(&l25.ion_collection_multiplier) == 0u64) {
-            l16 = C5;
-            unstructured {
-                goto 'label_244;
-            }
+    l9 = if (*(&l25.ion_points_enabled)) {
+        let l16 = if (*(&l25.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l16 = *(&l25.ion_collection_multiplier);
-            unstructured {
-                goto 'label_244;
-            }
+            *(&l25.ion_collection_multiplier)
         };
         /* block 244 */;
         let l26 = l16;
@@ -1103,16 +940,10 @@ public fun buy<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2: &mut 
         let l24 = helpers::calculate_ion_points(l42, l26, l35, C5);
         marketplace::award_ion_points_with_referral(l22, l1, l5, l24, l0, l6);
         l10 = l41;
-        l9 = l24;
-        unstructured {
-            goto 'label_342;
-        }
+        l24
     } else {
         l10 = 0u64;
-        l9 = 0u64;
-        unstructured {
-            goto 'label_342;
-        }
+        0u64
     };
     /* block 342 */;
     let l40 = l10;
@@ -1146,9 +977,6 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
         let l35 = *(option::borrow(&l1));
         assert!(linked_table::contains(&l28.bids, l35), C17);
         let l21 = linked_table::remove(&mut (linked_table::borrow_mut(&mut l28.bids, l35)).bids, l27);
-        unstructured {
-            goto 'label_166;
-        }
     } else {
         assert!(linked_table::contains(&l28.collection_bids, l27), C17);
         let l20 = linked_table::borrow_mut(&mut l28.collection_bids, l27);
@@ -1202,27 +1030,17 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
         let l24 = linked_table::remove(&mut l44.bids, l36);
         l26 = *(&(&l24).bid_price);
         l34 = *(&(&l24).last_points_claimed_at);
-        unstructured {
-            goto 'label_321;
-        }
     };
     let l9;
     /* block 321 */;
     let l41 = l43 - l34;
-    if (*(&l28.ion_points_enabled)) {
-        let l14;
+    l9 = if (*(&l28.ion_points_enabled)) {
         let l42 = helpers::calculate_time_multiplier(l41, false);
         let l39 = helpers::calculate_bid_proximity_multiplier(l26, *(&l28.avg_sale_price));
-        if (*(&l28.ion_collection_multiplier) == 0u64) {
-            l14 = C5;
-            unstructured {
-                goto 'label_354;
-            }
+        let l14 = if (*(&l28.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l14 = *(&l28.ion_collection_multiplier);
-            unstructured {
-                goto 'label_354;
-            }
+            *(&l28.ion_collection_multiplier)
         };
         /* block 354 */;
         let l29 = l14;
@@ -1239,15 +1057,9 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
         debug::print(&string::utf8(C39));
         debug::print(&l38);
         marketplace::award_ion_points_with_referral(l27, l0, l3, l38, l4, l5);
-        l9 = l38;
-        unstructured {
-            goto 'label_424;
-        }
+        l38
     } else {
-        l9 = 0u64;
-        unstructured {
-            goto 'label_424;
-        }
+        0u64
     };
     /* block 424 */;
     let l32 = l9;
@@ -1290,10 +1102,6 @@ public fun cancel_trait_bid_settle<T0: key + store, T1: key + store>(l0: &Clock,
             };
             l20 = l20 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_109;
-        }
     };
     let (l12, l25);
     /* block 109 */;
@@ -1302,71 +1110,37 @@ public fun cancel_trait_bid_settle<T0: key + store, T1: key + store>(l0: &Clock,
     l25 = marketplace::destroy_active_trait_bid(l2);
     helpers::destroy_or_transfer_balance(x2_balance::split(&mut l16.sui_trait_bids_pool, l25), l15, l7);
     let l17 = dynamic_object_field::borrow(&l1.id, l23);
-    if (*(&l17.ion_points_enabled)) {
-        let l8;
-        if (l22 == 0u64) {
-            l8 = l13;
-            unstructured {
-                goto 'label_149;
-            }
+    l12 = if (*(&l17.ion_points_enabled)) {
+        let l8 = if (l22 == 0u64) {
+            l13
         } else {
-            l8 = l22;
-            unstructured {
-                goto 'label_149;
-            }
+            l22
         };
         let l11;
         /* block 149 */;
         let l26 = helpers::calculate_time_multiplier(l27 - l8, false);
-        if (l26 > 0u64) {
-            let l10;
+        l11 = if (l26 > 0u64) {
             let l24 = helpers::calculate_bid_proximity_multiplier(l25, *(&l17.avg_sale_price));
-            if (*(&l17.ion_collection_multiplier) == 0u64) {
-                l10 = C5;
-                unstructured {
-                    goto 'label_180;
-                }
+            let l10 = if (*(&l17.ion_collection_multiplier) == 0u64) {
+                C5
             } else {
-                l10 = *(&l17.ion_collection_multiplier);
-                unstructured {
-                    goto 'label_180;
-                }
+                *(&l17.ion_collection_multiplier)
             };
             /* block 180 */;
-            let l18 = l10;
-            l11 = helpers::calculate_ion_points(l25, l18, l24, l26);
-            unstructured {
-                goto 'label_193;
-            }
+            helpers::calculate_ion_points(l25, l10, l24, l26)
         } else {
-            l11 = 0u64;
-            unstructured {
-                goto 'label_193;
-            }
+            0u64
         };
         /* block 193 */;
-        l12 = l11;
-        unstructured {
-            goto 'label_200;
-        }
+        l11
     } else {
-        l12 = 0u64;
-        unstructured {
-            goto 'label_200;
-        }
+        0u64
     };
     let l21;
     /* block 200 */;
     l21 = l12;
     if (l21 > 0u64) {
-        marketplace::award_ion_points_with_referral(l15, l1, l5, l21, l0, l6);
-        unstructured {
-            goto 'label_222;
-        }
-    } else {
-        unstructured {
-            goto 'label_222;
-        }
+        marketplace::award_ion_points_with_referral(l15, l1, l5, l21, l0, l6)
     };
     /* block 222 */;
     event::emit(TraitBidCancelledEvent { nft_type: l23, bidder: l15, bid_id: l14, refund_amount: l25, ion_points_awarded: l21, cancelled_at: l27 })
@@ -1389,24 +1163,10 @@ public fun claim_referral_points(l0: &Clock, l1: &mut AnimaChef, l2: &mut Market
             l5 = math::mul_div_u128(l6as u128, C3as u128, 100u128);
             if (linked_table::contains(&l2.referrals, *(option::borrow(&l10)))) {
                 let l8 = linked_table::borrow_mut(&mut l2.referrals, *(option::borrow(&l10)));
-                *l8 = *l8 + l9;
-                unstructured {
-                    goto 'label_99;
-                }
+                *l8 = *l8 + l9
             } else {
-                linked_table::push_back(&mut l2.referrals, *(option::borrow(&l10)), l9);
-                unstructured {
-                    goto 'label_99;
-                }
+                linked_table::push_back(&mut l2.referrals, *(option::borrow(&l10)), l9)
             }
-        } else {
-            unstructured {
-                goto 'label_99;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_99;
         }
     };
     /* block 99 */;
@@ -1434,70 +1194,28 @@ fun create_trait_summary(l0: Option<String>, l1: Option<String>, l2: Option<Stri
     let l3 = true;
     if (option::is_some(&l0)) {
         if (!(l3)) {
-            ascii::append(&mut l4, ascii::string(C63));
-            unstructured {
-                goto 'label_15;
-            }
-        } else {
-            unstructured {
-                goto 'label_15;
-            }
+            ascii::append(&mut l4, ascii::string(C63))
         };
         /* block 15 */;
         ascii::append(&mut l4, *(option::borrow(&l0)));
-        l3 = false;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        unstructured {
-            goto 'label_22;
-        }
+        l3 = false
     };
     /* block 22 */;
     if (option::is_some(&l1)) {
         if (!(l3)) {
-            ascii::append(&mut l4, ascii::string(C63));
-            unstructured {
-                goto 'label_32;
-            }
-        } else {
-            unstructured {
-                goto 'label_32;
-            }
+            ascii::append(&mut l4, ascii::string(C63))
         };
         /* block 32 */;
         ascii::append(&mut l4, *(option::borrow(&l1)));
-        l3 = false;
-        unstructured {
-            goto 'label_39;
-        }
-    } else {
-        unstructured {
-            goto 'label_39;
-        }
+        l3 = false
     };
     /* block 39 */;
     if (option::is_some(&l2)) {
         if (!(l3)) {
-            ascii::append(&mut l4, ascii::string(C63));
-            unstructured {
-                goto 'label_49;
-            }
-        } else {
-            unstructured {
-                goto 'label_49;
-            }
+            ascii::append(&mut l4, ascii::string(C63))
         };
         /* block 49 */;
-        ascii::append(&mut l4, *(option::borrow(&l2)));
-        unstructured {
-            goto 'label_54;
-        }
-    } else {
-        unstructured {
-            goto 'label_54;
-        }
+        ascii::append(&mut l4, *(option::borrow(&l2)))
     };
     /* block 54 */;
     return l4
@@ -1523,14 +1241,7 @@ fun destroy_listing<T0: key + store>(l0: Listing<T0>): ( PurchaseCap<T0>, ID, u6
 fun ensure_user_activity_exists(l0: &mut LinkedTable<address, UserInfo>, l1: address, l2: &mut TxContext) {
     if (!(linked_table::contains(freeze(l0), l1))) {
         let l3 = UserInfo { id: object::new(l2), listings: linked_table::new(l2), bids: linked_table::new(l2), collection_bids: linked_table::new(l2), trait_bids: linked_table::new(l2), claimable_points: 0u64 };
-        linked_table::push_back(l0, l1, l3);
-        unstructured {
-            goto 'label_28;
-        }
-    } else {
-        unstructured {
-            goto 'label_28;
-        }
+        linked_table::push_back(l0, l1, l3)
     };
     /* block 28 */
 }
@@ -1562,18 +1273,11 @@ public fun get_bids_for_any_nft<T0: key + store>(l0: &MarketPlaceStore, l1: ID, 
     if (!(linked_table::contains(&l12.bids, l1))) {
         return (l11, l9, l10, l7, 0u64, l15)
     };
-    let l4;
     let l6 = linked_table::borrow(&l12.bids, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_67;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l6.bids));
-        unstructured {
-            goto 'label_67;
-        }
+        *(linked_table::front(&l6.bids))
     };
     let (l13, l14);
     /* block 67 */;
@@ -1605,18 +1309,11 @@ public fun get_bids_for_listing<T0: key + store>(l0: &MarketPlaceStore, l1: ID, 
     if (!(linked_table::contains(&l12.bids, l1))) {
         return (l11, l9, l10, l7, 0u64)
     };
-    let l4;
     let l6 = linked_table::borrow(&l12.bids, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_60;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l6.bids));
-        unstructured {
-            goto 'label_60;
-        }
+        *(linked_table::front(&l6.bids))
     };
     let (l13, l14);
     /* block 60 */;
@@ -1642,18 +1339,11 @@ public fun get_collection_bidders_for_collection<T0: key + store>(l0: &MarketPla
     if (!(dynamic_object_field::exists_(&l0.id, l11))) {
         return (l5, l6, 0u64)
     };
-    let l3;
     let l8 = dynamic_object_field::borrow(&l0.id, l11);
-    if (option::is_some(&l1)) {
-        l3 = l1;
-        unstructured {
-            goto 'label_35;
-        }
+    let l3 = if (option::is_some(&l1)) {
+        l1
     } else {
-        l3 = *(linked_table::front(&l8.collection_bids));
-        unstructured {
-            goto 'label_35;
-        }
+        *(linked_table::front(&l8.collection_bids))
     };
     let (l10, l9);
     /* block 35 */;
@@ -1719,18 +1409,11 @@ public fun get_listings_for_marketplace<T0: key + store>(l0: &MarketPlaceStore, 
     if (!(dynamic_object_field::exists_(&l0.id, l13))) {
         return (l15, l9, l12, l14, l6, 0u64)
     };
-    let l3;
     let l5 = dynamic_object_field::borrow(&l0.id, l13);
-    if (option::is_some(&l1)) {
-        l3 = l1;
-        unstructured {
-            goto 'label_44;
-        }
+    let l3 = if (option::is_some(&l1)) {
+        l1
     } else {
-        l3 = *(linked_table::front(&l5.listings));
-        unstructured {
-            goto 'label_44;
-        }
+        *(linked_table::front(&l5.listings))
     };
     let (l7, l8);
     /* block 44 */;
@@ -1755,20 +1438,11 @@ public fun get_marketplace_info(l0: &MarketPlaceStore): ( address, bool, u64, u6
 }
 
 public fun get_referral_points_balance(l0: &MarketPlaceStore, l1: address): u64 {
-    let l2;
-    if (linked_table::contains(&l0.referrals, l1)) {
-        l2 = *(linked_table::borrow(&l0.referrals, l1));
-        unstructured {
-            goto 'label_16;
-        }
+    /* block 16 */ return if (linked_table::contains(&l0.referrals, l1)) {
+        *(linked_table::borrow(&l0.referrals, l1))
     } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_16;
-        }
-    };
-    /* block 16 */;
-    return l2
+        0u64
+    }
 }
 
 public fun get_trait_bid_details(l0: &MarketPlaceStore, l1: address, l2: ID): (
@@ -1807,43 +1481,30 @@ public fun get_trait_bid_details(l0: &MarketPlaceStore, l1: address, l2: ID): (
 
 public fun get_user_activity_overview(l0: &MarketPlaceStore, l1: address): ( u64, u64, u64, u64, u64) {
     let (l2, l3, l4, l5, l6);
-    if (!(linked_table::contains(&l0.user_activity, l1))) {
+    l2 = if (!(linked_table::contains(&l0.user_activity, l1))) {
         l6 = 0u64;
         l5 = 0u64;
         l4 = 0u64;
         l3 = 0u64;
-        l2 = 0u64;
-        unstructured {
-            goto 'label_44;
-        }
+        0u64
     } else {
         let l7 = linked_table::borrow(&l0.user_activity, l1);
         l6 = *(&l7.claimable_points);
         l5 = linked_table::length(&l7.trait_bids);
         l4 = linked_table::length(&l7.collection_bids);
         l3 = linked_table::length(&l7.bids);
-        l2 = linked_table::length(&l7.listings);
-        unstructured {
-            goto 'label_44;
-        }
+        linked_table::length(&l7.listings)
     };
     /* block 44 */;
     return (l2, l3, l4, l5, l6)
 }
 
 public fun get_user_addresses_list(l0: &MarketPlaceStore, l1: Option<address>, l2: u64): ( vector<address>, u64) {
-    let l3;
     let l8 = vector[];
-    if (option::is_some(&l1)) {
-        l3 = l1;
-        unstructured {
-            goto 'label_13;
-        }
+    let l3 = if (option::is_some(&l1)) {
+        l1
     } else {
-        l3 = *(linked_table::front(&l0.user_activity));
-        unstructured {
-            goto 'label_13;
-        }
+        *(linked_table::front(&l0.user_activity))
     };
     let (l5, l6);
     /* block 13 */;
@@ -1868,18 +1529,11 @@ public fun get_user_bids_info(l0: &MarketPlaceStore, l1: address, l2: Option<ID>
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l14, l15, l7, l9, l6, l12, 0u64)
     };
-    let l4;
     let l16 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_44;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l16.bids));
-        unstructured {
-            goto 'label_44;
-        }
+        *(linked_table::front(&l16.bids))
     };
     let (l10, l11);
     /* block 44 */;
@@ -1932,18 +1586,11 @@ public fun get_user_collection_bids_info(l0: &MarketPlaceStore, l1: address, l2:
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l11, l6, 0u64)
     };
-    let l4;
     let l12 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_32;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l12.collection_bids));
-        unstructured {
-            goto 'label_32;
-        }
+        *(linked_table::front(&l12.collection_bids))
     };
     let (l8, l9);
     /* block 32 */;
@@ -1968,18 +1615,11 @@ public fun get_user_listings_info(l0: &MarketPlaceStore, l1: address, l2: Option
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l11, l13, l12, l8, 0u64)
     };
-    let l4;
     let l14 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_38;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l14.listings));
-        unstructured {
-            goto 'label_38;
-        }
+        *(linked_table::front(&l14.listings))
     };
     let (l6, l7);
     /* block 38 */;
@@ -2005,18 +1645,11 @@ public fun get_user_pending_claims(l0: &MarketPlaceStore, l1: address, l2: Optio
     if (!(linked_table::contains(&l0.pending_claims, l1))) {
         return (vector[], vector[], 0u64)
     };
-    let l4;
     let l10 = linked_table::borrow(&l0.pending_claims, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_34;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l10.pending_claims));
-        unstructured {
-            goto 'label_34;
-        }
+        *(linked_table::front(&l10.pending_claims))
     };
     let (l6, l8);
     /* block 34 */;
@@ -2043,18 +1676,11 @@ public fun get_user_trait_bids_info(l0: &MarketPlaceStore, l1: address, l2: Opti
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l7, l15, l8, l22, 0u64)
     };
-    let l4;
     let l24 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_40;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l24.trait_bids));
-        unstructured {
-            goto 'label_40;
-        }
+        *(linked_table::front(&l24.trait_bids))
     };
     let (l11, l9);
     /* block 40 */;
@@ -2167,31 +1793,19 @@ public entry fun make_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option
         if (linked_table::contains(&l17.bids, l19)) {
             let l10 = linked_table::borrow_mut(&mut l17.bids, l19);
             assert!(!(linked_table::contains(&l10.bids, l16)), C16);
-            linked_table::push_back(&mut l10.bids, l16, l9);
-            unstructured {
-                goto 'label_140;
-            }
+            linked_table::push_back(&mut l10.bids, l16, l9)
         } else {
             let l11 = ActiveBids { id: object::new(l5), bids: linked_table::new(l5) };
             linked_table::push_back(&mut (&mut l11).bids, l16, l9);
-            linked_table::push_back(&mut l17.bids, l19, l11);
-            unstructured {
-                goto 'label_140;
-            }
+            linked_table::push_back(&mut l17.bids, l19, l11)
         }
     } else {
         if (linked_table::contains(&l17.collection_bids, l16)) {
-            (linked_table::borrow_mut(&mut l17.collection_bids, l16)).push_back(l9);
-            unstructured {
-                goto 'label_140;
-            }
+            (linked_table::borrow_mut(&mut l17.collection_bids, l16)).push_back(l9)
         } else {
             let l12 = vector[];
             (&mut l12).push_back(l9);
-            linked_table::push_back(&mut l17.collection_bids, l16, l12);
-            unstructured {
-                goto 'label_140;
-            }
+            linked_table::push_back(&mut l17.collection_bids, l16, l12)
         }
     };
     /* block 140 */;
@@ -2200,25 +1814,16 @@ public entry fun make_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option
     let l24 = linked_table::borrow_mut(&mut l0.user_activity, l16);
     if (l18) {
         if (linked_table::contains(&l24.collection_bids, l21)) {
-            (linked_table::borrow_mut(&mut l24.collection_bids, l21)).push_back(l15);
-            unstructured {
-                goto 'label_205;
-            }
+            (linked_table::borrow_mut(&mut l24.collection_bids, l21)).push_back(l15)
         } else {
             let l13 = vector[];
             (&mut l13).push_back(l15);
-            linked_table::push_back(&mut l24.collection_bids, l21, l13);
-            unstructured {
-                goto 'label_205;
-            }
+            linked_table::push_back(&mut l24.collection_bids, l21, l13)
         }
     } else {
         let l20 = *(option::borrow(&l1));
         assert!(!(linked_table::contains(&l24.bids, l20)), C16);
-        linked_table::push_back(&mut l24.bids, l20, l15);
-        unstructured {
-            goto 'label_205;
-        }
+        linked_table::push_back(&mut l24.bids, l20, l15)
     };
     /* block 205 */;
     debug::print(&string::utf8(C44));
@@ -2243,17 +1848,11 @@ public fun make_trait_bid<T0: key + store, T1: key + store>(l0: &Clock, l1: &mut
     let l22 = linked_table::borrow_mut(&mut l1.user_activity, l14);
     let l19 = TraitBidInfo { bid_id: l13, nft_type: l17, bid_price: l11, trait_key1: l3, trait_value1: l4, trait_key2: l5, trait_value2: l6, trait_key3: l7, trait_value3: l8, bid_at: l18, last_points_claimed_at: l18 };
     if (linked_table::contains(&l22.trait_bids, l17)) {
-        (linked_table::borrow_mut(&mut l22.trait_bids, l17)).push_back(l19);
-        unstructured {
-            goto 'label_122;
-        }
+        (linked_table::borrow_mut(&mut l22.trait_bids, l17)).push_back(l19)
     } else {
         let l20 = vector[];
         (&mut l20).push_back(l19);
-        linked_table::push_back(&mut l22.trait_bids, l17, l20);
-        unstructured {
-            goto 'label_122;
-        }
+        linked_table::push_back(&mut l22.trait_bids, l17, l20)
     };
     /* block 122 */;
     let l21 = dynamic_object_field::remove(&mut l15.id, C1);
@@ -2335,25 +1934,17 @@ public fun unlist<T0: key + store>(l0: &mut MarketPlaceStore, l1: &mut Kiosk, l2
     let l23 = linked_table::remove(&mut l21.listings, l2);
     let l18 = dynamic_object_field::borrow_mut(&mut l0.id, l24);
     assert!(linked_table::contains(&l18.listings, l2), C11);
-    let l17;
     let l22 = linked_table::remove(&mut l18.listings, l2);
     let l29 = l31 - *(&(&l23).last_points_claimed_at);
     debug::print(&string::utf8(C34));
     debug::print(&l29);
-    if (*(&l18.ion_points_enabled)) {
-        let l11;
+    let l17 = if (*(&l18.ion_points_enabled)) {
         let l30 = helpers::calculate_time_multiplier(l29, false);
         let l26 = helpers::calculate_listing_proximity_multiplier(*(&(&l22).price), *(&l18.avg_sale_price));
-        if (*(&l18.ion_collection_multiplier) == 0u64) {
-            l11 = C5;
-            unstructured {
-                goto 'label_140;
-            }
+        let l11 = if (*(&l18.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l11 = *(&l18.ion_collection_multiplier);
-            unstructured {
-                goto 'label_140;
-            }
+            *(&l18.ion_collection_multiplier)
         };
         /* block 140 */;
         let l19 = l11;
@@ -2368,15 +1959,9 @@ public fun unlist<T0: key + store>(l0: &mut MarketPlaceStore, l1: &mut Kiosk, l2
         debug::print(&string::utf8(C39));
         debug::print(&l25);
         marketplace::award_ion_points_with_referral(l28, l0, l3, l25, l4, l5);
-        l17 = l25;
-        unstructured {
-            goto 'label_205;
-        }
+        l25
     } else {
-        l17 = 0u64;
-        unstructured {
-            goto 'label_205;
-        }
+        0u64
     };
     /* block 205 */;
     let l20 = l17;
@@ -2393,33 +1978,17 @@ public fun update_active_collections<T0: key + store>(l0: &mut MarketPlaceStore,
     let l7 = type_name::into_string(type_name::get());
     if (l2) {
         if (!(linked_table::contains(&l0.active_collections, l7))) {
-            linked_table::push_back(&mut l0.active_collections, l7, true);
-            unstructured {
-                goto 'label_28;
-            }
+            linked_table::push_back(&mut l0.active_collections, l7, true)
         } else {
-            *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = true;
-            unstructured {
-                goto 'label_28;
-            }
+            *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = true
         };
         /* block 28 */;
         if (!(dynamic_object_field::exists_(&l0.id, l7))) {
             let l6 = CollectionMarketPlace { id: object::new(l3), listings: linked_table::new(l3), bids: linked_table::new(l3), collection_bids: linked_table::new(l3), sui_trait_bids_pool: x2_balance::zero(), are_trait_bids_enabled: false, lifetime_volume: 0u128, ion_points_enabled: false, ion_collection_multiplier: 0u64, avg_sale_price: 0u64, recent_sale_prices: vector[] };
-            dynamic_object_field::add(&mut l0.id, l7, l6);
-            unstructured {
-                goto 'label_72;
-            }
-        } else {
-            unstructured {
-                goto 'label_72;
-            }
+            dynamic_object_field::add(&mut l0.id, l7, l6)
         }
     } else {
-        *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = false;
-        unstructured {
-            goto 'label_72;
-        }
+        *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = false
     };
     /* block 72 */;
     event::emit(UpdateActiveCollectionsEvent { nft_type: l7, boolean: l2 })
@@ -2427,13 +1996,7 @@ public fun update_active_collections<T0: key + store>(l0: &mut MarketPlaceStore,
 
 fun update_collection_avg_price<T0: key + store>(l0: &mut CollectionMarketPlace<T0>, l1: u64) {
     if (&l0.recent_sale_prices.len() >= C3) {
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        unstructured {
-            goto 'label_11;
-        }
+        
     };
     let (l2, l3);
     /* block 11 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/metadata.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/metadata.mv.snap
@@ -73,21 +73,10 @@ public fun clamp(l0: &mut vector<u8>, l1: u64, l2: u64) {
 }
 
 public fun get(l0: &vector<u8>, l1: u32): Option<vector<u8>> {
-    let l2;
     let l6 = metadata::get_chunk_offset(l0, l1);
     let l5 = metadata::get_chunk_length_at_offset(l0, l6);
     let l4 = l0.len();
-    if (l5 == 0u32) {
-        l2 = true;
-        unstructured {
-            goto 'label_25;
-        }
-    } else {
-        l2 = l4 < l6 + l5as u64;
-        unstructured {
-            goto 'label_25;
-        }
-    };
+    let l2 = l5 == 0u32 || l4 < l6 + l5as u64;
     /* block 25 */;
     if (l2) {
         return option::none()
@@ -193,22 +182,11 @@ public fun get_option_any_vec_u256(l0: &vector<u8>, l1: u32): Option<vector<u256
     if (option::is_none(&l8)) {
         return option::none()
     };
-    let l2;
     let l3 = bcs::new(option::destroy_some(l8));
     let l12 = bcs::peel_vec_length(&mut l3);
     let l9 = bcs::into_remainder_bytes(l3);
     let l4 = &l9.len();
-    if (l12 == 0u64) {
-        l2 = true;
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = l4 == 0u64;
-        unstructured {
-            goto 'label_33;
-        }
-    };
+    let l2 = l12 == 0u64 || l4 == 0u64;
     /* block 33 */;
     if (l2) {
         return option::some(vector[])
@@ -369,21 +347,10 @@ public fun get_vec_vec_u8(l0: &vector<u8>, l1: u32): vector<vector<u8>> {
 }
 
 public fun has_chunk(l0: &vector<u8>, l1: u32): bool {
-    let l2;
     let l5 = metadata::get_chunk_offset(l0, l1);
     let l4 = metadata::get_chunk_length_at_offset(l0, l5);
     let l3 = l0.len();
-    if (l4 == 0u32) {
-        l2 = true;
-        unstructured {
-            goto 'label_25;
-        }
-    } else {
-        l2 = l3 < l5 + l4as u64;
-        unstructured {
-            goto 'label_25;
-        }
-    };
+    let l2 = l4 == 0u32 || l3 < l5 + l4as u64;
     /* block 25 */;
     if (l2) {
         return false
@@ -406,133 +373,48 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                 return false
             };
             return true
-        };
-        unstructured {
-            goto 'label_383;
         }
     } else {
         let l24 = C3;
         if (l36 == &l24) {
             if (l38 == 1u32) {
                 return true
-            };
-            unstructured {
-                goto 'label_383;
             }
         } else {
             let l31 = C4;
             if (l36 == &l31) {
                 if (l38 == 8u32) {
                     return true
-                };
-                unstructured {
-                    goto 'label_383;
                 }
             } else {
                 let l33 = C5;
                 if (l36 == &l33) {
                     if (l38 == 16u32) {
                         return true
-                    };
-                    unstructured {
-                        goto 'label_383;
                     }
                 } else {
                     let l35 = C6;
                     if (l36 == &l35) {
                         if (l38 == 32u32) {
                             return true
-                        };
-                        unstructured {
-                            goto 'label_383;
                         }
                     } else {
                         let l4 = C7;
                         if (l36 == &l4) {
                             if (l38 == address::length()as u32) {
                                 return true
-                            };
-                            unstructured {
-                                goto 'label_383;
                             }
                         } else {
-                            let l6;
-                            if (l36.len() > 6u64) {
-                                l6 = *(&l36[0u64]) == 118u8;
-                                unstructured {
-                                    goto 'label_160;
-                                }
-                            } else {
-                                l6 = false;
-                                unstructured {
-                                    goto 'label_160;
-                                }
-                            };
-                            let l7;
                             /* block 160 */;
-                            if (l6) {
-                                l7 = *(&l36[1u64]) == 101u8;
-                                unstructured {
-                                    goto 'label_172;
-                                }
-                            } else {
-                                l7 = false;
-                                unstructured {
-                                    goto 'label_172;
-                                }
-                            };
-                            let l8;
+                            let l7 = l36.len() > 6u64 && *(&l36[0u64]) == 118u8 && *(&l36[1u64]) == 101u8;
                             /* block 172 */;
-                            if (l7) {
-                                l8 = *(&l36[2u64]) == 99u8;
-                                unstructured {
-                                    goto 'label_184;
-                                }
-                            } else {
-                                l8 = false;
-                                unstructured {
-                                    goto 'label_184;
-                                }
-                            };
-                            let l9;
+                            let l8 = l7 && *(&l36[2u64]) == 99u8;
                             /* block 184 */;
-                            if (l8) {
-                                l9 = *(&l36[3u64]) == 116u8;
-                                unstructured {
-                                    goto 'label_196;
-                                }
-                            } else {
-                                l9 = false;
-                                unstructured {
-                                    goto 'label_196;
-                                }
-                            };
-                            let l10;
+                            let l9 = l8 && *(&l36[3u64]) == 116u8;
                             /* block 196 */;
-                            if (l9) {
-                                l10 = *(&l36[4u64]) == 111u8;
-                                unstructured {
-                                    goto 'label_208;
-                                }
-                            } else {
-                                l10 = false;
-                                unstructured {
-                                    goto 'label_208;
-                                }
-                            };
-                            let l11;
+                            let l10 = l9 && *(&l36[4u64]) == 111u8;
                             /* block 208 */;
-                            if (l10) {
-                                l11 = *(&l36[5u64]) == 114u8;
-                                unstructured {
-                                    goto 'label_220;
-                                }
-                            } else {
-                                l11 = false;
-                                unstructured {
-                                    goto 'label_220;
-                                }
-                            };
+                            let l11 = l10 && *(&l36[5u64]) == 114u8;
                             /* block 220 */;
                             if (l11) {
                                 let l43 = 1u64;
@@ -541,48 +423,26 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                                     let l12 = C8;
                                     if (l36 == &l12) {
                                         l43 = 1u64;
-                                        unstructured {
-                                            goto 'label_334;
-                                        }
                                     } else {
                                         let l15 = C9;
                                         if (l36 == &l15) {
                                             l43 = 8u64;
-                                            unstructured {
-                                                goto 'label_334;
-                                            }
                                         } else {
                                             let l17 = C10;
                                             if (l36 == &l17) {
                                                 l43 = 4u64;
-                                                unstructured {
-                                                    goto 'label_334;
-                                                }
                                             } else {
                                                 let l19 = C11;
                                                 if (l36 == &l19) {
                                                     l43 = 32u64;
-                                                    unstructured {
-                                                        goto 'label_334;
-                                                    }
                                                 } else {
                                                     let l21 = C12;
                                                     if (l36 == &l21) {
                                                         l43 = 2u64;
-                                                        unstructured {
-                                                            goto 'label_334;
-                                                        }
                                                     } else {
                                                         let l23 = C13;
                                                         if (l36 == &l23) {
                                                             l43 = 16u64;
-                                                            unstructured {
-                                                                goto 'label_334;
-                                                            }
-                                                        } else {
-                                                            unstructured {
-                                                                goto 'label_334;
-                                                            }
                                                         }
                                                     }
                                                 }
@@ -593,21 +453,11 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                                     let l26 = C14;
                                     if (l36 == &l26) {
                                         l43 = 32u64;
-                                        unstructured {
-                                            goto 'label_334;
-                                        }
                                     } else {
                                         let l28 = C15;
                                         if (l36 == &l28) {
                                             l43 = 1u64;
                                             l37 = true;
-                                            unstructured {
-                                                goto 'label_334;
-                                            }
-                                        } else {
-                                            unstructured {
-                                                goto 'label_334;
-                                            }
                                         }
                                     }
                                 };
@@ -628,16 +478,9 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                                         };
                                         return false
                                     }
-                                } else {
-                                    unstructured {
-                                        goto 'label_377;
-                                    }
                                 };
                                 /* block 377 */;
                                 return true
-                            };
-                            unstructured {
-                                goto 'label_383;
                             }
                         }
                     }
@@ -681,25 +524,11 @@ public fun set<T0>(l0: &mut vector<u8>, l1: u32, l2: &T0): bool {
             std::vector::destroy_empty(l3);
             return true
         };
-        metadata::clamp(l0, l10, l9as u64);
-        unstructured {
-            goto 'label_72;
-        }
-    } else {
-        unstructured {
-            goto 'label_72;
-        }
+        metadata::clamp(l0, l10, l9as u64)
     };
     /* block 72 */;
     if (freeze(l0).len() == 0u64) {
-        l0.push_back(0u8);
-        unstructured {
-            goto 'label_81;
-        }
-    } else {
-        unstructured {
-            goto 'label_81;
-        }
+        l0.push_back(0u8)
     };
     /* block 81 */;
     let l6 = bcs::to_bytes(&l1);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/orlim.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/orlim.mv.snap
@@ -160,40 +160,20 @@ public fun cancel_limit_order(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &m
     if (option::is_some(&l16)) {
         let l15 = *(option::borrow(&l16));
         if (table::contains(&l0.oco_groups, l15)) {
-            let l4;
             let l14 = table::remove(&mut l0.oco_groups, l15);
-            if (*(&(&l14).order1_id) == l1) {
-                l4 = *(&(&l14).order2_id);
-                unstructured {
-                    goto 'label_105;
-                }
+            let l4 = if (*(&(&l14).order1_id) == l1) {
+                *(&(&l14).order2_id)
             } else {
-                l4 = *(&(&l14).order1_id);
-                unstructured {
-                    goto 'label_105;
-                }
+                *(&(&l14).order1_id)
             };
             /* block 105 */;
-            let l11 = l4;
             *(&mut (&mut l14).is_active) = false;
             table::add(&mut l0.oco_groups, l15, l14);
-            let l12 = l11;
+            let l12 = l4;
             if (table::contains(&l0.receipts, l12)) {
-                let l5;
                 let l13 = table::remove(&mut l0.receipts, l12);
-                if (*(&(&l13).is_active)) {
-                    l5 = vector::contains(&l0.active_orders, &l12);
-                    unstructured {
-                        goto 'label_140;
-                    }
-                } else {
-                    l5 = false;
-                    unstructured {
-                        goto 'label_140;
-                    }
-                };
                 /* block 140 */;
-                if (l5) {
+                if (*(&(&l13).is_active) && vector::contains(&l0.active_orders, &l12)) {
                     *(&mut (&mut l13).is_active) = false;
                     *(&mut (&mut l13).cancelled_at) = option::some(l6);
                     let l7 = 0u64;
@@ -210,29 +190,10 @@ public fun cancel_limit_order(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &m
                         event::emit(OCOOrderCancelledEvent { oco_group_id: l15, cancelled_order_id: l12, user: *(&l0.owner), cancelled_at: l6 });
                         break
                     }
-                } else {
-                    unstructured {
-                        goto 'label_188;
-                    }
                 };
                 /* block 188 */;
-                table::add(&mut l0.receipts, l12, l13);
-                unstructured {
-                    goto 'label_194;
-                }
-            } else {
-                unstructured {
-                    goto 'label_194;
-                }
+                table::add(&mut l0.receipts, l12, l13)
             }
-        } else {
-            unstructured {
-                goto 'label_194;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_194;
         }
     };
     let (l10, l8);
@@ -372,27 +333,15 @@ public entry fun cancel_order_by_object_entry(l0: &mut OrderManager, l1: OrderRe
     let l5 = reg_5;
     let l4 = reg_4;
     if (coin::value(&l4) > 0u64) {
-        transfer::public_transfer(l4, tx_context::sender(freeze(l3)));
-        unstructured {
-            goto 'label_20;
-        }
+        transfer::public_transfer(l4, tx_context::sender(freeze(l3)))
     } else {
-        coin::destroy_zero(l4);
-        unstructured {
-            goto 'label_20;
-        }
+        coin::destroy_zero(l4)
     };
     /* block 20 */;
     if (coin::value(&l5) > 0u64) {
-        transfer::public_transfer(l5, tx_context::sender(freeze(l3)));
-        unstructured {
-            goto 'label_35;
-        }
+        transfer::public_transfer(l5, tx_context::sender(freeze(l3)))
     } else {
-        coin::destroy_zero(l5);
-        unstructured {
-            goto 'label_35;
-        }
+        coin::destroy_zero(l5)
     };
     /* block 35 */
 }
@@ -440,25 +389,17 @@ public fun handle_oco_fill(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &mut 
     if (option::is_some(&l6.oco_group_id)) {
         let l16 = *(option::borrow(&l6.oco_group_id));
         assert!(table::contains(&l0.oco_groups, l16), C7);
-        let l4;
         let l15 = table::remove(&mut l0.oco_groups, l16);
-        if (*(&(&l15).order1_id) == l1) {
-            l4 = *(&(&l15).order2_id);
-            unstructured {
-                goto 'label_86;
-            }
+        let l4 = if (*(&(&l15).order1_id) == l1) {
+            *(&(&l15).order2_id)
         } else {
-            l4 = *(&(&l15).order1_id);
-            unstructured {
-                goto 'label_86;
-            }
+            *(&(&l15).order1_id)
         };
         let (l13, l5);
         /* block 86 */;
-        let l12 = l4;
         *(&mut (&mut l15).is_active) = false;
         table::add(&mut l0.oco_groups, l16, l15);
-        l13 = l12;
+        l13 = l4;
         l5 = clock::timestamp_ms(l2);
         if (table::contains(&l0.receipts, l13)) {
             let l14 = table::remove(&mut l0.receipts, l13);
@@ -473,20 +414,9 @@ public fun handle_oco_fill(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &mut 
                     };
                     l8 = l8 + 1u64;
                 }
-            } else {
-                unstructured {
-                    goto 'label_156;
-                }
             };
             /* block 156 */;
-            table::add(&mut l0.receipts, l13, l14);
-            unstructured {
-                goto 'label_162;
-            }
-        } else {
-            unstructured {
-                goto 'label_162;
-            }
+            table::add(&mut l0.receipts, l13, l14)
         };
         let (l11, l9);
         /* block 162 */;
@@ -507,10 +437,6 @@ public fun handle_oco_fill(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &mut 
             };
             event::emit(OCOOrderFilledEvent { oco_group_id: l16, filled_order_id: l1, cancelled_order_id: l13, user: *(&l0.owner), filled_at: l5 });
             break
-        }
-    } else {
-        unstructured {
-            goto 'label_225;
         }
     };
     /* block 225 */
@@ -551,27 +477,13 @@ public fun modify_order(l0: &mut OrderManager, l1: u64, l2: Option<u64>, l3: Opt
     if (option::is_some(&l2)) {
         let l11 = option::destroy_some(l2);
         assert!(l11 > 0u64, C1);
-        *(&mut l13.price) = l11;
-        unstructured {
-            goto 'label_96;
-        }
-    } else {
-        unstructured {
-            goto 'label_96;
-        }
+        *(&mut l13.price) = l11
     };
     /* block 96 */;
     if (option::is_some(&l3)) {
         let l12 = option::destroy_some(l3);
         assert!(l12 > 0u64, C2);
-        *(&mut l13.quantity) = l12;
-        unstructured {
-            goto 'label_115;
-        }
-    } else {
-        unstructured {
-            goto 'label_115;
-        }
+        *(&mut l13.quantity) = l12
     };
     /* block 115 */;
     let l6 = *(&l13.price);
@@ -606,32 +518,10 @@ public entry fun place_limit_order_entry(l0: &mut OrderManager, l1: vector<u8>, 
 public fun place_limit_order_oco(l0: &mut OrderManager, l1: vector<u8>, l2: u64, l3: u64, l4: bool, l5: u64, l6: u64, l7: bool, l8: &Clock, l9: &mut TxContext): ( u64, u64) {
     assert!(tx_context::sender(freeze(l9)) == *(&l0.owner), C3);
     assert!(!(*(&l0.is_paused)), C4);
-    let l10;
-    if (l2 > 0u64) {
-        l10 = l5 > 0u64;
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_42;
-        }
-    };
+    let l10 = l2 > 0u64 && l5 > 0u64;
     /* block 42 */;
     assert!(l10, C1);
-    let l11;
-    if (l3 > 0u64) {
-        l11 = l6 > 0u64;
-        unstructured {
-            goto 'label_64;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_64;
-        }
-    };
+    let l11 = l3 > 0u64 && l6 > 0u64;
     /* block 64 */;
     assert!(l11, C2);
     let l12 = clock::timestamp_ms(l8);
@@ -663,18 +553,7 @@ public fun place_limit_order_tif(l0: &mut OrderManager, l1: vector<u8>, l2: u64,
     assert!(!(*(&l0.is_paused)), C4);
     assert!(l2 > 0u64, C1);
     assert!(l3 > 0u64, C2);
-    let l10;
-    if (l5 == C13) {
-        l10 = true;
-        unstructured {
-            goto 'label_68;
-        }
-    } else {
-        l10 = l5 == C14;
-        unstructured {
-            goto 'label_68;
-        }
-    };
+    let l10 = l5 == C13 || l5 == C14;
     /* block 68 */;
     assert!(l10, C9);
     let l28 = clock::timestamp_ms(l8);
@@ -693,39 +572,19 @@ public fun place_limit_order_tif(l0: &mut OrderManager, l1: vector<u8>, l2: u64,
             let l25 = coin::split(&mut l6, l37as u64, l9);
             let l34 = coin::zero(l9);
             if (option::is_some(&l38)) {
-                coin::destroy_zero(option::extract(&mut l38));
-                unstructured {
-                    goto 'label_150;
-                }
-            } else {
-                unstructured {
-                    goto 'label_150;
-                }
+                coin::destroy_zero(option::extract(&mut l38))
             };
             /* block 150 */;
             if (option::is_some(&l39)) {
-                coin::destroy_zero(option::extract(&mut l39));
-                unstructured {
-                    goto 'label_156;
-                }
-            } else {
-                unstructured {
-                    goto 'label_156;
-                }
+                coin::destroy_zero(option::extract(&mut l39))
             };
             /* block 156 */;
             option::fill(&mut l38, l25);
             option::fill(&mut l39, l34);
-            event::emit(OrderPartialFilledEvent { order_id: l33, filled_quantity: l30, remaining_quantity: l40, user: *(&l0.owner), filled_at: l28 });
-            unstructured {
-                goto 'label_259;
-            }
+            event::emit(OrderPartialFilledEvent { order_id: l33, filled_quantity: l30, remaining_quantity: l40, user: *(&l0.owner), filled_at: l28 })
         } else {
             l32 = true;
             l31 = false;
-            unstructured {
-                goto 'label_259;
-            }
         }
     } else {
         if (l5 == C14) {
@@ -734,148 +593,65 @@ public fun place_limit_order_tif(l0: &mut OrderManager, l1: vector<u8>, l2: u64,
                 let l26 = coin::split(&mut l6, l27, l9);
                 let l35 = coin::zero(l9);
                 if (option::is_some(&l38)) {
-                    coin::destroy_zero(option::extract(&mut l38));
-                    unstructured {
-                        goto 'label_204;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_204;
-                    }
+                    coin::destroy_zero(option::extract(&mut l38))
                 };
                 /* block 204 */;
                 if (option::is_some(&l39)) {
-                    coin::destroy_zero(option::extract(&mut l39));
-                    unstructured {
-                        goto 'label_210;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_210;
-                    }
+                    coin::destroy_zero(option::extract(&mut l39))
                 };
                 /* block 210 */;
                 option::fill(&mut l38, l26);
                 option::fill(&mut l39, l35);
                 event::emit(OrderExpiredEvent { order_id: l33, user: *(&l0.owner), expired_at: l28 });
                 if (coin::value(&l6) > 0u64) {
-                    transfer::public_transfer(l6, tx_context::sender(freeze(l9)));
-                    unstructured {
-                        goto 'label_236;
-                    }
+                    transfer::public_transfer(l6, tx_context::sender(freeze(l9)))
                 } else {
-                    coin::destroy_zero(l6);
-                    unstructured {
-                        goto 'label_236;
-                    }
+                    coin::destroy_zero(l6)
                 };
                 /* block 236 */;
                 if (coin::value(&l7) > 0u64) {
-                    transfer::public_transfer(l7, tx_context::sender(freeze(l9)));
-                    unstructured {
-                        goto 'label_251;
-                    }
+                    transfer::public_transfer(l7, tx_context::sender(freeze(l9)))
                 } else {
-                    coin::destroy_zero(l7);
-                    unstructured {
-                        goto 'label_251;
-                    }
+                    coin::destroy_zero(l7)
                 };
                 /* block 251 */;
                 return (l33, l38, l39)
             };
             l32 = true;
             l31 = false;
-            unstructured {
-                goto 'label_259;
-            }
-        } else {
-            unstructured {
-                goto 'label_259;
-            }
         }
     };
-    let l18;
     /* block 259 */;
-    if (l31) {
-        l18 = true;
-        unstructured {
-            goto 'label_277;
-        }
-    } else {
-        let l19;
-        if (l5 == C13) {
-            l19 = l30 > 0u64;
-            unstructured {
-                goto 'label_275;
-            }
-        } else {
-            l19 = false;
-            unstructured {
-                goto 'label_275;
-            }
-        };
-        /* block 275 */;
-        l18 = l19;
-        unstructured {
-            goto 'label_277;
-        }
-    };
+    let l18 = l31 || /* block 275 */ l5 == C13 && l30 > 0u64;
     /* block 277 */;
     if (l18) {
-        let l20;
         (&mut l0.active_orders).push_back(l33);
         *(&mut l0.total_orders_created) = *(&l0.total_orders_created) + 1u64;
         let l24 = TimeInForce { value: l5 };
         let l22 = l31;
         let l21 = l32;
-        if (l31) {
-            l20 = option::none();
-            unstructured {
-                goto 'label_322;
-            }
+        let l20 = if (l31) {
+            option::none()
         } else {
-            l20 = option::some(l28);
-            unstructured {
-                goto 'label_322;
-            }
+            option::some(l28)
         };
         /* block 322 */;
         let l36 = OrderReceiptData { order_id: l33, deepbook_order_id: l33, pool_id: l1, price: l2, quantity: l40, original_quantity: l3, is_bid: l4, order_type: OrderType { value: C14 }, time_in_force: l24, created_at: l28, is_active: l22, is_fully_filled: l21, cancelled_at: l20, oco_group_id: option::none(), expires_at: option::none() };
         table::add(&mut l0.receipts, l33, l36);
         event::emit(TIFOrderPlacedEvent { order_id: l33, tif_type: l5, user: *(&l0.owner), created_at: l28 });
-        event::emit(OrderPlacedEvent { order_id: l33, pool_id: l1, user: *(&l0.owner), price: l2, quantity: l3, is_bid: l4, created_at: l28 });
-        unstructured {
-            goto 'label_367;
-        }
-    } else {
-        unstructured {
-            goto 'label_367;
-        }
+        event::emit(OrderPlacedEvent { order_id: l33, pool_id: l1, user: *(&l0.owner), price: l2, quantity: l3, is_bid: l4, created_at: l28 })
     };
     /* block 367 */;
     if (coin::value(&l6) > 0u64) {
-        transfer::public_transfer(l6, tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_380;
-        }
+        transfer::public_transfer(l6, tx_context::sender(freeze(l9)))
     } else {
-        coin::destroy_zero(l6);
-        unstructured {
-            goto 'label_380;
-        }
+        coin::destroy_zero(l6)
     };
     /* block 380 */;
     if (coin::value(&l7) > 0u64) {
-        transfer::public_transfer(l7, tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_395;
-        }
+        transfer::public_transfer(l7, tx_context::sender(freeze(l9)))
     } else {
-        coin::destroy_zero(l7);
-        unstructured {
-            goto 'label_395;
-        }
+        coin::destroy_zero(l7)
     };
     /* block 395 */;
     return (l33, l38, l39)
@@ -887,25 +663,11 @@ public entry fun place_limit_order_tif_entry(l0: &mut OrderManager, l1: vector<u
     let l11 = reg_12;
     let l10 = reg_11;
     if (option::is_some(&l10)) {
-        transfer::public_transfer(option::extract(&mut l10), tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        unstructured {
-            goto 'label_23;
-        }
+        transfer::public_transfer(option::extract(&mut l10), tx_context::sender(freeze(l9)))
     };
     /* block 23 */;
     if (option::is_some(&l11)) {
-        transfer::public_transfer(option::extract(&mut l11), tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_35;
-        }
-    } else {
-        unstructured {
-            goto 'label_35;
-        }
+        transfer::public_transfer(option::extract(&mut l11), tx_context::sender(freeze(l9)))
     };
     /* block 35 */;
     option::destroy_none(l10);
@@ -939,22 +701,10 @@ public entry fun transfer_order_ownership_entry(l0: OrderReceipt, l1: address, l
 
 public fun update_order_status(l0: &mut OrderManager, l1: u64, l2: bool) {
     if (table::contains(&l0.receipts, l1)) {
-        let l3;
         let l6 = table::borrow_mut(&mut l0.receipts, l1);
         *(&mut l6.is_active) = l2;
-        if (!(l2)) {
-            l3 = *(&l6.is_active);
-            unstructured {
-                goto 'label_26;
-            }
-        } else {
-            l3 = false;
-            unstructured {
-                goto 'label_26;
-            }
-        };
         /* block 26 */;
-        if (l3) {
+        if (!(l2) && *(&l6.is_active)) {
             let l4 = 0u64;
             let l5 = &l0.active_orders.len();
             while (l4 < l5) {
@@ -963,14 +713,6 @@ public fun update_order_status(l0: &mut OrderManager, l1: u64, l2: bool) {
                 };
                 l4 = l4 + 1u64;
             }
-        } else {
-            unstructured {
-                goto 'label_63;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
         }
     };
     /* block 63 */

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/format.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/format.move
@@ -80,10 +80,6 @@ fun append_format_piece(l0: &mut vector<u8>, l1: &vector<u8>, l2: u64, l3: &vect
                 };
                 l10 = l10 + 1u64;
             }
-        } else {
-            unstructured {
-                goto 'label_57;
-            }
         };
         /* block 57 */;
         if (&l12.len() > 0u64) {
@@ -94,13 +90,6 @@ fun append_format_piece(l0: &mut vector<u8>, l1: &vector<u8>, l2: u64, l3: &vect
             };
             vector::append(l0, C12);
             return false
-        };
-        unstructured {
-            goto 'label_87;
-        }
-    } else {
-        unstructured {
-            goto 'label_87;
         }
     };
     /* block 87 */;
@@ -175,33 +164,7 @@ public fun format_string(l0: &x1_String, l1: &vector<u8>): x1_String {
 }
 
 public fun is_printable_char(l0: u8): bool {
-    let l2;
-    if (l0 == 10u8) {
-        l2 = true;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        let l1;
-        if (l0 >= 32u8) {
-            l1 = l0 < 126u8;
-            unstructured {
-                goto 'label_18;
-            }
-        } else {
-            l1 = false;
-            unstructured {
-                goto 'label_18;
-            }
-        };
-        /* block 18 */;
-        l2 = l1;
-        unstructured {
-            goto 'label_20;
-        }
-    };
-    /* block 20 */;
-    return l2
+    /* block 20 */ return l0 == 10u8 || /* block 18 */ l0 >= 32u8 && l0 < 126u8
 }
 
 public fun looks_like_a_string(l0: &vector<u8>, l1: u32): bool {
@@ -229,153 +192,44 @@ public fun meta_chunk_to_string(l0: &vector<u8>, l1: u32, l2: &vector<u8>): vect
     let l20 = C0;
     let l3 = C9;
     if (l2 == &l3) {
-        if (metadata::has_chunk_of_type(l0, l1)) {
-            l20 = C4;
-            unstructured {
-                goto 'label_146;
-            }
+        l20 = if (metadata::has_chunk_of_type(l0, l1)) {
+            C4
         } else {
             if (metadata::has_chunk_of_type(l0, l1)) {
-                l20 = C2;
-                unstructured {
-                    goto 'label_146;
-                }
+                C2
             } else {
-                let l5;
-                if (metadata::has_chunk_of_type(l0, l1)) {
-                    l5 = true;
-                    unstructured {
-                        goto 'label_48;
-                    }
-                } else {
-                    l5 = metadata::has_chunk_of_type(l0, l1);
-                    unstructured {
-                        goto 'label_48;
-                    }
-                };
-                let l6;
                 /* block 48 */;
-                if (l5) {
-                    l6 = true;
-                    unstructured {
-                        goto 'label_57;
-                    }
-                } else {
-                    l6 = metadata::has_chunk_of_type(l0, l1);
-                    unstructured {
-                        goto 'label_57;
-                    }
-                };
-                let l7;
+                let l6 = metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1);
                 /* block 57 */;
-                if (l6) {
-                    l7 = true;
-                    unstructured {
-                        goto 'label_66;
-                    }
-                } else {
-                    l7 = metadata::has_chunk_of_type(l0, l1);
-                    unstructured {
-                        goto 'label_66;
-                    }
-                };
+                let l7 = l6 || metadata::has_chunk_of_type(l0, l1);
                 /* block 66 */;
                 if (l7) {
-                    l20 = C8;
-                    unstructured {
-                        goto 'label_146;
-                    }
+                    C8
                 } else {
-                    let l8;
-                    if (metadata::has_chunk_of_type(l0, l1)) {
-                        l8 = true;
-                        unstructured {
-                            goto 'label_82;
-                        }
-                    } else {
-                        l8 = metadata::has_chunk_of_type(l0, l1);
-                        unstructured {
-                            goto 'label_82;
-                        }
-                    };
-                    let l9;
                     /* block 82 */;
-                    if (l8) {
-                        l9 = true;
-                        unstructured {
-                            goto 'label_91;
-                        }
-                    } else {
-                        l9 = metadata::has_chunk_of_type(l0, l1);
-                        unstructured {
-                            goto 'label_91;
-                        }
-                    };
+                    let l9 = metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1);
                     /* block 91 */;
                     if (l9) {
-                        l20 = C6;
-                        unstructured {
-                            goto 'label_146;
-                        }
+                        C6
                     } else {
-                        let l10;
-                        if (metadata::has_chunk_of_type(l0, l1)) {
-                            l10 = x2_format::looks_like_a_string(l0, l1);
-                            unstructured {
-                                goto 'label_107;
-                            }
-                        } else {
-                            l10 = false;
-                            unstructured {
-                                goto 'label_107;
-                            }
-                        };
                         /* block 107 */;
-                        if (l10) {
-                            l20 = C5;
-                            unstructured {
-                                goto 'label_146;
-                            }
+                        if (metadata::has_chunk_of_type(l0, l1) && x2_format::looks_like_a_string(l0, l1)) {
+                            C5
                         } else {
-                            let l11;
-                            if (metadata::has_chunk_of_type(l0, l1)) {
-                                l11 = true;
-                                unstructured {
-                                    goto 'label_123;
-                                }
-                            } else {
-                                l11 = metadata::has_chunk_of_type(l0, l1);
-                                unstructured {
-                                    goto 'label_123;
-                                }
-                            };
                             /* block 123 */;
-                            if (l11) {
-                                l20 = C7;
-                                unstructured {
-                                    goto 'label_146;
-                                }
+                            if (metadata::has_chunk_of_type(l0, l1) || metadata::has_chunk_of_type(l0, l1)) {
+                                C7
                             } else {
-                                l20 = C0;
-                                unstructured {
-                                    goto 'label_146;
-                                }
+                                C0
                             }
                         }
                     }
                 }
             }
-        }
+        };
     } else {
         if (*(&l2[0u64]) == 58u8) {
             l20 = *(&l2[1u64]);
-            unstructured {
-                goto 'label_146;
-            }
-        } else {
-            unstructured {
-                goto 'label_146;
-            }
         }
     };
     /* block 146 */;
@@ -484,42 +338,16 @@ public fun vu8_to_hex(l0: &vector<u8>, l1: bool, l2: bool): vector<u8> {
     let l8 = 87u8;
     if (l2) {
         l8 = 55u8;
-        unstructured {
-            goto 'label_10;
-        }
-    } else {
-        unstructured {
-            goto 'label_10;
-        }
     };
     /* block 10 */;
     let l12 = l0.len();
     if (l12 == 0u64) {
         return l11
     };
-    let l3;
     let l5 = *(&l0[0u64]);
-    if (l5 > 0u8) {
-        l3 = l5as u64 == l12 - 1u64;
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_40;
-        }
-    };
     /* block 40 */;
-    if (l3) {
+    if (l5 > 0u8 && l5as u64 == l12 - 1u64) {
         l7 = 1u64;
-        unstructured {
-            goto 'label_44;
-        }
-    } else {
-        unstructured {
-            goto 'label_44;
-        }
     };
     /* block 44 */;
     let l10 = !(l1);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/metadata.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x020abcd433df2c68f62b794d0751d3a839945dcb6776ecf9fac76d3f0324a274/metadata.move
@@ -70,21 +70,10 @@ public fun clamp(l0: &mut vector<u8>, l1: u64, l2: u64) {
 }
 
 public fun get(l0: &vector<u8>, l1: u32): Option<vector<u8>> {
-    let l2;
     let l6 = metadata::get_chunk_offset(l0, l1);
     let l5 = metadata::get_chunk_length_at_offset(l0, l6);
     let l4 = l0.len();
-    if (l5 == 0u32) {
-        l2 = true;
-        unstructured {
-            goto 'label_25;
-        }
-    } else {
-        l2 = l4 < l6 + l5as u64;
-        unstructured {
-            goto 'label_25;
-        }
-    };
+    let l2 = l5 == 0u32 || l4 < l6 + l5as u64;
     /* block 25 */;
     if (l2) {
         return option::none()
@@ -190,22 +179,11 @@ public fun get_option_any_vec_u256(l0: &vector<u8>, l1: u32): Option<vector<u256
     if (option::is_none(&l8)) {
         return option::none()
     };
-    let l2;
     let l3 = bcs::new(option::destroy_some(l8));
     let l12 = bcs::peel_vec_length(&mut l3);
     let l9 = bcs::into_remainder_bytes(l3);
     let l4 = &l9.len();
-    if (l12 == 0u64) {
-        l2 = true;
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = l4 == 0u64;
-        unstructured {
-            goto 'label_33;
-        }
-    };
+    let l2 = l12 == 0u64 || l4 == 0u64;
     /* block 33 */;
     if (l2) {
         return option::some(vector[])
@@ -366,21 +344,10 @@ public fun get_vec_vec_u8(l0: &vector<u8>, l1: u32): vector<vector<u8>> {
 }
 
 public fun has_chunk(l0: &vector<u8>, l1: u32): bool {
-    let l2;
     let l5 = metadata::get_chunk_offset(l0, l1);
     let l4 = metadata::get_chunk_length_at_offset(l0, l5);
     let l3 = l0.len();
-    if (l4 == 0u32) {
-        l2 = true;
-        unstructured {
-            goto 'label_25;
-        }
-    } else {
-        l2 = l3 < l5 + l4as u64;
-        unstructured {
-            goto 'label_25;
-        }
-    };
+    let l2 = l4 == 0u32 || l3 < l5 + l4as u64;
     /* block 25 */;
     if (l2) {
         return false
@@ -403,133 +370,48 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                 return false
             };
             return true
-        };
-        unstructured {
-            goto 'label_383;
         }
     } else {
         let l24 = C3;
         if (l36 == &l24) {
             if (l38 == 1u32) {
                 return true
-            };
-            unstructured {
-                goto 'label_383;
             }
         } else {
             let l31 = C4;
             if (l36 == &l31) {
                 if (l38 == 8u32) {
                     return true
-                };
-                unstructured {
-                    goto 'label_383;
                 }
             } else {
                 let l33 = C5;
                 if (l36 == &l33) {
                     if (l38 == 16u32) {
                         return true
-                    };
-                    unstructured {
-                        goto 'label_383;
                     }
                 } else {
                     let l35 = C6;
                     if (l36 == &l35) {
                         if (l38 == 32u32) {
                             return true
-                        };
-                        unstructured {
-                            goto 'label_383;
                         }
                     } else {
                         let l4 = C7;
                         if (l36 == &l4) {
                             if (l38 == address::length()as u32) {
                                 return true
-                            };
-                            unstructured {
-                                goto 'label_383;
                             }
                         } else {
-                            let l6;
-                            if (l36.len() > 6u64) {
-                                l6 = *(&l36[0u64]) == 118u8;
-                                unstructured {
-                                    goto 'label_160;
-                                }
-                            } else {
-                                l6 = false;
-                                unstructured {
-                                    goto 'label_160;
-                                }
-                            };
-                            let l7;
                             /* block 160 */;
-                            if (l6) {
-                                l7 = *(&l36[1u64]) == 101u8;
-                                unstructured {
-                                    goto 'label_172;
-                                }
-                            } else {
-                                l7 = false;
-                                unstructured {
-                                    goto 'label_172;
-                                }
-                            };
-                            let l8;
+                            let l7 = l36.len() > 6u64 && *(&l36[0u64]) == 118u8 && *(&l36[1u64]) == 101u8;
                             /* block 172 */;
-                            if (l7) {
-                                l8 = *(&l36[2u64]) == 99u8;
-                                unstructured {
-                                    goto 'label_184;
-                                }
-                            } else {
-                                l8 = false;
-                                unstructured {
-                                    goto 'label_184;
-                                }
-                            };
-                            let l9;
+                            let l8 = l7 && *(&l36[2u64]) == 99u8;
                             /* block 184 */;
-                            if (l8) {
-                                l9 = *(&l36[3u64]) == 116u8;
-                                unstructured {
-                                    goto 'label_196;
-                                }
-                            } else {
-                                l9 = false;
-                                unstructured {
-                                    goto 'label_196;
-                                }
-                            };
-                            let l10;
+                            let l9 = l8 && *(&l36[3u64]) == 116u8;
                             /* block 196 */;
-                            if (l9) {
-                                l10 = *(&l36[4u64]) == 111u8;
-                                unstructured {
-                                    goto 'label_208;
-                                }
-                            } else {
-                                l10 = false;
-                                unstructured {
-                                    goto 'label_208;
-                                }
-                            };
-                            let l11;
+                            let l10 = l9 && *(&l36[4u64]) == 111u8;
                             /* block 208 */;
-                            if (l10) {
-                                l11 = *(&l36[5u64]) == 114u8;
-                                unstructured {
-                                    goto 'label_220;
-                                }
-                            } else {
-                                l11 = false;
-                                unstructured {
-                                    goto 'label_220;
-                                }
-                            };
+                            let l11 = l10 && *(&l36[5u64]) == 114u8;
                             /* block 220 */;
                             if (l11) {
                                 let l43 = 1u64;
@@ -538,48 +420,26 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                                     let l12 = C8;
                                     if (l36 == &l12) {
                                         l43 = 1u64;
-                                        unstructured {
-                                            goto 'label_334;
-                                        }
                                     } else {
                                         let l15 = C9;
                                         if (l36 == &l15) {
                                             l43 = 8u64;
-                                            unstructured {
-                                                goto 'label_334;
-                                            }
                                         } else {
                                             let l17 = C10;
                                             if (l36 == &l17) {
                                                 l43 = 4u64;
-                                                unstructured {
-                                                    goto 'label_334;
-                                                }
                                             } else {
                                                 let l19 = C11;
                                                 if (l36 == &l19) {
                                                     l43 = 32u64;
-                                                    unstructured {
-                                                        goto 'label_334;
-                                                    }
                                                 } else {
                                                     let l21 = C12;
                                                     if (l36 == &l21) {
                                                         l43 = 2u64;
-                                                        unstructured {
-                                                            goto 'label_334;
-                                                        }
                                                     } else {
                                                         let l23 = C13;
                                                         if (l36 == &l23) {
                                                             l43 = 16u64;
-                                                            unstructured {
-                                                                goto 'label_334;
-                                                            }
-                                                        } else {
-                                                            unstructured {
-                                                                goto 'label_334;
-                                                            }
                                                         }
                                                     }
                                                 }
@@ -590,21 +450,11 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                                     let l26 = C14;
                                     if (l36 == &l26) {
                                         l43 = 32u64;
-                                        unstructured {
-                                            goto 'label_334;
-                                        }
                                     } else {
                                         let l28 = C15;
                                         if (l36 == &l28) {
                                             l43 = 1u64;
                                             l37 = true;
-                                            unstructured {
-                                                goto 'label_334;
-                                            }
-                                        } else {
-                                            unstructured {
-                                                goto 'label_334;
-                                            }
                                         }
                                     }
                                 };
@@ -625,16 +475,9 @@ public fun has_chunk_of_type<T0>(l0: &vector<u8>, l1: u32): bool {
                                         };
                                         return false
                                     }
-                                } else {
-                                    unstructured {
-                                        goto 'label_377;
-                                    }
                                 };
                                 /* block 377 */;
                                 return true
-                            };
-                            unstructured {
-                                goto 'label_383;
                             }
                         }
                     }
@@ -678,25 +521,11 @@ public fun set<T0>(l0: &mut vector<u8>, l1: u32, l2: &T0): bool {
             std::vector::destroy_empty(l3);
             return true
         };
-        metadata::clamp(l0, l10, l9as u64);
-        unstructured {
-            goto 'label_72;
-        }
-    } else {
-        unstructured {
-            goto 'label_72;
-        }
+        metadata::clamp(l0, l10, l9as u64)
     };
     /* block 72 */;
     if (freeze(l0).len() == 0u64) {
-        l0.push_back(0u8);
-        unstructured {
-            goto 'label_81;
-        }
-    } else {
-        unstructured {
-            goto 'label_81;
-        }
+        l0.push_back(0u8)
     };
     /* block 81 */;
     let l6 = bcs::to_bytes(&l1);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x043c56e72265ab93219e928b742bc6465a83c70481e2846964d8e6bc3459cd06/verse.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x043c56e72265ab93219e928b742bc6465a83c70481e2846964d8e6bc3459cd06/verse.move
@@ -551,19 +551,8 @@ const C58: vector<u8> = vector[78u8, 111u8, 32u8, 98u8, 111u8, 110u8, 117u8, 115
 
 public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     assert!(string::length(&l2) > 0u64, C23);
@@ -641,87 +630,46 @@ fun assert_not_paused<T0>(l0: &StakingPool<T0>) {
 }
 
 fun calculate_effective_reward_rate_enhanced(l0: u64, l1: u64, l2: u64, l3: u64): u64 {
-    let l4;
     let l6 = verse::safe_mul_div_precise(verse::safe_mul_div_precise(l0, l1, 10000u64), l2, 10000u64);
-    if (l3 == 0u64) {
-        l4 = l6;
-        unstructured {
-            goto 'label_24;
-        }
+    /* block 24 */;
+    return if (l3 == 0u64) {
+        l6
     } else {
         let l5 = verse::safe_add(10000u64, l3);
-        l4 = verse::safe_mul_div_precise(l6, l5, 10000u64);
-        unstructured {
-            goto 'label_24;
-        }
-    };
-    /* block 24 */;
-    return l4
+        verse::safe_mul_div_precise(l6, l5, 10000u64)
+    }
 }
 
 fun calculate_enhanced_slot_rewards(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64): u64 {
-    let l8;
     let l15 = verse::calculate_effective_reward_rate_enhanced(l3, l4, l5, l6);
-    if (l7 > 0u64) {
-        l8 = l7 < l2;
-        unstructured {
-            goto 'label_17;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_17;
-        }
-    };
-    let l9;
     /* block 17 */;
-    if (l8) {
-        l9 = l7;
-        unstructured {
-            goto 'label_24;
-        }
+    let l9 = if (l7 > 0u64 && l7 < l2) {
+        l7
     } else {
-        l9 = l2;
-        unstructured {
-            goto 'label_24;
-        }
+        l2
     };
     let (l10, l12);
     /* block 24 */;
     l12 = l9;
-    if (l1 > l0) {
-        l10 = l1;
-        unstructured {
-            goto 'label_35;
-        }
+    l10 = if (l1 > l0) {
+        l1
     } else {
-        l10 = l0;
-        unstructured {
-            goto 'label_35;
-        }
+        l0
     };
     /* block 35 */;
     let l13 = l10;
     if (l13 >= l12) {
         return 0u64
     };
-    let l11;
     let l14 = verse::safe_sub(l12, l13);
     let l17 = l15as u128 * C47 / C46as u128;
     let l16 = l14as u128 * l17 / C47;
-    if (l16 > C48as u128) {
-        l11 = C48;
-        unstructured {
-            goto 'label_73;
-        }
-    } else {
-        l11 = l16as u64;
-        unstructured {
-            goto 'label_73;
-        }
-    };
     /* block 73 */;
-    return l11
+    return if (l16 > C48as u128) {
+        C48
+    } else {
+        l16as u64
+    }
 }
 
 fun calculate_reserve(l0: u64): u64 {
@@ -731,36 +679,24 @@ fun calculate_reserve(l0: u64): u64 {
 fun calculate_slot_params(l0: u8): ( u64, u64) {
     let (l3, l4);
     let l11 = l0as u64;
-    if (l11 <= 10u64) {
+    l3 = if (l11 <= 10u64) {
         let l5 = l11 * 10000000000u64;
         l4 = 10000u64 + l11 - 1u64 * 2000u64;
-        l3 = l5;
-        unstructured {
-            goto 'label_65;
-        }
+        l5
     } else {
         let (l1, l2);
-        if (l11 <= 50u64) {
+        l1 = if (l11 <= 50u64) {
             let l6 = l11 * 20000000000u64;
             l2 = 30000u64 + l11 - 11u64 * 1000u64;
-            l1 = l6;
-            unstructured {
-                goto 'label_61;
-            }
+            l6
         } else {
             let l7 = l11 * 50000000000u64;
             l2 = 70000u64 + l11 - 51u64 * 1000u64;
-            l1 = l7;
-            unstructured {
-                goto 'label_61;
-            }
+            l7
         };
         /* block 61 */;
         l4 = l2;
-        l3 = l1;
-        unstructured {
-            goto 'label_65;
-        }
+        l1
     };
     /* block 65 */;
     return (l3, l4)
@@ -794,31 +730,18 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     let l14 = verse::calculate_enhanced_slot_rewards(l37, l21, l20, l16, l32, l23, l39, *(&l0.end_time));
     let l38 = verse::safe_add(l26, l14);
     assert!(l38 > 0u64, C4);
-    let l4;
-    if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
-        l4 = verse::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_205;
-        }
+    let l4 = if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
+        verse::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards))
     } else {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_205;
-        }
+        0u64
     };
     let l6;
     /* block 205 */;
     let l15 = l4;
-    if (l15 >= l38) {
-        l6 = l38;
-        unstructured {
-            goto 'label_216;
-        }
+    l6 = if (l15 >= l38) {
+        l38
     } else {
-        l6 = l15;
-        unstructured {
-            goto 'label_216;
-        }
+        l15
     };
     /* block 216 */;
     let l18 = l6;
@@ -827,15 +750,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l35.last_claim_time) = l20;
     *(&mut l35.total_claimed) = verse::safe_add(*(&l35.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l35.pending_rewards) = verse::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = verse::safe_sub(l38, l18)
     } else {
-        *(&mut l35.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = 0u64
     };
     /* block 261 */;
     let l31 = SlotDataKey { owner: l25, slot_number: l33 };
@@ -843,15 +760,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l30.last_claim_time) = l20;
     *(&mut l30.total_claimed) = verse::safe_add(*(&l30.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l30.pending_rewards) = verse::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = verse::safe_sub(l38, l18)
     } else {
-        *(&mut l30.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = 0u64
     };
     let (l10, l11, l12, l13, l5, l7, l8, l9);
     /* block 297 */;
@@ -866,16 +777,10 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     l10 = l20;
     l9 = *(&l0.reward_token_type);
     l8 = l18 < l38;
-    if (l18 < l38) {
-        l7 = verse::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_348;
-        }
+    l7 = if (l18 < l38) {
+        verse::safe_sub(l38, l18)
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_348;
-        }
+        0u64
     };
     /* block 348 */;
     event::emit(RewardsClaimed { pool_id: l5, nft_id: l13, owner: l12, amount: l11, claim_time: l10, reward_token_type: l9, is_partial_claim: l8, remaining_pending: l7, slot_number: l33 })
@@ -897,24 +802,13 @@ fun create_enhanced_slot_configs(): vector<SlotConfig> {
 }
 
 public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: u64, l4: u64, l5: vector<String>, l6: address, l7: u8, l8: &Clock, l9: &mut TxContext): StakingPool<T0> {
-    let l10;
     let l11 = tx_context::sender(freeze(l9));
     let l14 = object::new(l9);
     let l15 = object::uid_to_inner(&l14);
     let l17 = coin::value(&l0);
     let l18 = type_name::get();
     let l12 = clock::timestamp_ms(l8);
-    if (l7 >= 1u8) {
-        l10 = l7 <= C52;
-        unstructured {
-            goto 'label_29;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_29;
-        }
-    };
+    let l10 = l7 >= 1u8 && l7 <= C52;
     /* block 29 */;
     assert!(l10, C40);
     let l19 = verse::create_enhanced_slot_configs();
@@ -933,16 +827,10 @@ public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: 
 fun decrease_reserved_rewards(l0: &mut u64, l1: u64) {
     let l3 = verse::calculate_reserve(l1);
     if (*l0 >= l3) {
-        *l0 = verse::safe_sub(*l0, l3);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = verse::safe_sub(*l0, l3)
     } else {
         let l2 = *l0 * l3 / verse::calculate_reserve(l1);
-        *l0 = verse::safe_sub(*l0, l2);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = verse::safe_sub(*l0, l2)
     };
     /* block 29 */
 }
@@ -952,40 +840,24 @@ public fun get_admin<T0>(l0: &StakingPool<T0>): address {
 }
 
 public fun get_available_rewards<T0>(l0: &StakingPool<T0>): u64 {
-    let l1;
     let l2 = balance::value(&l0.reward_balance);
-    if (l2 <= *(&l0.reserved_rewards)) {
-        l1 = 0u64;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l1 = verse::safe_sub(l2, *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l1
+    return if (l2 <= *(&l0.reserved_rewards)) {
+        0u64
+    } else {
+        verse::safe_sub(l2, *(&l0.reserved_rewards))
+    }
 }
 
 public fun get_collection_multiplier_info<T0>(l0: &StakingPool<T0>, l1: String): Option<CollectionMultiplierInfo> {
-    let l2;
     let l3 = CollectionMultiplierKey { collection: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) });
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_30;
-        }
-    };
     /* block 30 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_default_reward_rate<T0>(l0: &StakingPool<T0>): u64 {
@@ -1013,36 +885,21 @@ public fun get_enhanced_slot_configs<T0>(l0: &StakingPool<T0>): vector<SlotConfi
 }
 
 public fun get_nft_multiplier_info<T0>(l0: &StakingPool<T0>, l1: ID, l2: String): Option<NftMultiplierInfo> {
-    let l3;
     let l4 = NftMultiplierKey { nft_id: l1, collection: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l5 = dynamic_object_field::borrow(&l0.id, l4);
-        l3 = option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) });
-        unstructured {
-            goto 'label_34;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_34;
-        }
-    };
     /* block 34 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l5 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &mut TxContext): &mut SlotData {
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
     if (!(dynamic_object_field::exists_(&l0.id, l5))) {
         let l4 = SlotData { id: object::new(l3), owner: l1, slot_number: l2, staked_nft: option::none(), staked_collection: option::none(), stake_time: 0u64, last_claim_time: 0u64, pending_rewards: 0u64, total_claimed: 0u64, is_unlocked: false, nft_type: option::none() };
-        dynamic_object_field::add(&mut l0.id, l5, l4);
-        unstructured {
-            goto 'label_32;
-        }
-    } else {
-        unstructured {
-            goto 'label_32;
-        }
+        dynamic_object_field::add(&mut l0.id, l5, l4)
     };
     /* block 32 */;
     return dynamic_object_field::borrow_mut(&mut l0.id, l5)
@@ -1051,21 +908,15 @@ fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l
 public fun get_pool_slot_limits<T0>(l0: &StakingPool<T0>): ( u8, u8, u64) {
     let (l1, l2, l3);
     let l4 = PoolSlotLimitsKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
+    l1 = if (dynamic_object_field::exists_(&l0.id, l4)) {
         let l5 = dynamic_object_field::borrow(&l0.id, l4);
         l3 = *(&l5.total_users_with_custom_limits);
         l2 = *(&l5.absolute_max_slots);
-        l1 = *(&l5.default_max_slots_per_wallet);
-        unstructured {
-            goto 'label_34;
-        }
+        *(&l5.default_max_slots_per_wallet)
     } else {
         l3 = 0u64;
         l2 = C52;
-        l1 = C51;
-        unstructured {
-            goto 'label_34;
-        }
+        C51
     };
     /* block 34 */;
     return (l1, l2, l3)
@@ -1094,22 +945,14 @@ fun get_slot_config(l0: &vector<SlotConfig>, l1: u8): &SlotConfig {
 }
 
 public fun get_slot_data<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): Option<SlotDataInfo> {
-    let l3;
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l5)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l5);
-        l3 = option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) });
-        unstructured {
-            goto 'label_49;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_49;
-        }
-    };
     /* block 49 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l5)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l5);
+        option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_slot_effective_rate<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): u64 {
@@ -1161,48 +1004,24 @@ public fun get_slot_price<T0>(l0: &StakingPool<T0>, l1: u8): u64 {
 }
 
 public fun get_slot_token_price<T0>(l0: &StakingPool<T0>, l1: u8, l2: String): u64 {
-    let l5;
     let l7 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        let l3;
+    /* block 47 */;
+    return if (dynamic_object_field::exists_(&l0.id, l7)) {
         let l6 = dynamic_object_field::borrow(&l0.id, l7);
-        if (table::contains(&l6.token_prices, l2)) {
-            l3 = *(table::borrow(&l6.token_prices, l2));
-            unstructured {
-                goto 'label_29;
-            }
-        } else {
-            l3 = 0u64;
-            unstructured {
-                goto 'label_29;
-            }
-        };
         /* block 29 */;
-        l5 = l3;
-        unstructured {
-            goto 'label_47;
+        if (table::contains(&l6.token_prices, l2)) {
+            *(table::borrow(&l6.token_prices, l2))
+        } else {
+            0u64
         }
     } else {
-        let l4;
-        if (l2 == verse::get_token_type_string_sui()) {
-            l4 = verse::get_slot_price(l0, l1);
-            unstructured {
-                goto 'label_45;
-            }
-        } else {
-            l4 = 0u64;
-            unstructured {
-                goto 'label_45;
-            }
-        };
         /* block 45 */;
-        l5 = l4;
-        unstructured {
-            goto 'label_47;
+        if (l2 == verse::get_token_type_string_sui()) {
+            verse::get_slot_price(l0, l1)
+        } else {
+            0u64
         }
-    };
-    /* block 47 */;
-    return l5
+    }
 }
 
 public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
@@ -1210,39 +1029,23 @@ public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
 }
 
 public fun get_supported_payment_tokens<T0>(l0: &StakingPool<T0>): vector<String> {
-    let l1;
     let l2 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l2)) {
-        l1 = *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l1 = vector[];
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l1
+    return if (dynamic_object_field::exists_(&l0.id, l2)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list)
+    } else {
+        vector[]
+    }
 }
 
 public fun get_token_revenue<T0>(l0: &StakingPool<T0>, l1: String): u64 {
-    let l2;
     let l3 = TokenRevenueKey { token_type: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected)
+    } else {
+        0u64
+    }
 }
 
 fun get_token_type_string_any<T0>(): String {
@@ -1260,13 +1063,6 @@ fun get_token_type_string_any<T0>(): String {
                 l1 = l1 + 1u64;
             };
             return string::utf8(l4)
-        };
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        unstructured {
-            goto 'label_50;
         }
     };
     /* block 50 */;
@@ -1282,22 +1078,14 @@ public fun get_total_staked<T0>(l0: &StakingPool<T0>): u64 {
 }
 
 public fun get_user_slot_allocation<T0>(l0: &StakingPool<T0>, l1: address): Option<UserSlotInfo> {
-    let l2;
     let l4 = UserSlotAllocationKey { user: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l4);
-        l2 = option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l3 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_user_total_claimed_rewards<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1350,19 +1138,13 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
     let l11 = dynamic_object_field::borrow(&l0.id, l35);
     let l14 = clock::timestamp_ms(l2);
     let l38 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l38)) {
+    l3 = if (dynamic_object_field::exists_(&l0.id, l38)) {
         let l39 = dynamic_object_field::borrow(&l0.id, l38);
         l4 = *(&l39.reason);
-        l3 = *(&l39.bonus_multiplier);
-        unstructured {
-            goto 'label_61;
-        }
+        *(&l39.bonus_multiplier)
     } else {
         l4 = string::utf8(C58);
-        l3 = 0u64;
-        unstructured {
-            goto 'label_61;
-        }
+        0u64
     };
     let (l18, l20, l27, l32, l34, l36, l37, l9);
     /* block 61 */;
@@ -1419,40 +1201,24 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
 }
 
 fun get_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): u64 {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier)
+    } else {
+        0u64
+    }
 }
 
 public fun get_wallet_bonus_multiplier_info<T0>(l0: &StakingPool<T0>, l1: address): Option<WalletBonusMultiplierInfo> {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_wallet_bonus_multiplier_view<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1466,19 +1232,8 @@ public fun has_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): b
 
 public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l2 >= 1u8) {
-        l5 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= 1u8 && l2 <= C52;
     /* block 31 */;
     assert!(l5, C40);
     let l13 = UserSlotAllocationKey { user: l1 };
@@ -1491,24 +1246,14 @@ public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: addr
         *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64);
         if (l2 != l9) {
             let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l10);
-            *(&mut l12.total_users_with_custom_limits) = verse::safe_add(*(&l12.total_users_with_custom_limits), 1u64);
-            unstructured {
-                goto 'label_144;
-            }
-        } else {
-            unstructured {
-                goto 'label_144;
-            }
+            *(&mut l12.total_users_with_custom_limits) = verse::safe_add(*(&l12.total_users_with_custom_limits), 1u64)
         }
     } else {
         let l7 = dynamic_object_field::borrow_mut(&mut l0.id, l13);
         let l11 = *(&l7.max_slots_allowed);
         assert!(l2 > l11, C40);
         *(&mut l7.max_slots_allowed) = l2;
-        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 });
-        unstructured {
-            goto 'label_144;
-        }
+        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 })
     };
     /* block 144 */
 }
@@ -1529,21 +1274,9 @@ public fun is_paused<T0>(l0: &StakingPool<T0>): bool {
 }
 
 public fun is_payment_token_supported<T0>(l0: &StakingPool<T0>, l1: String): bool {
-    let l2;
     let l3 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l2
+    return dynamic_object_field::exists_(&l0.id, l3) && table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1)
 }
 
 public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
@@ -1551,39 +1284,15 @@ public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
 }
 
 fun is_slot_occupied<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft)
 }
 
 fun is_slot_unlocked<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked)
 }
 
 fun is_sui_token<T0>(): bool {
@@ -1594,19 +1303,8 @@ fun is_sui_token<T0>(): bool {
 
 public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     let l8 = clock::timestamp_ms(l3);
@@ -1645,13 +1343,7 @@ public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l
     let (reg_35, reg_36) = vector::index_of(&l5.token_list, &l6);
     let l4 = reg_36;
     if (reg_35) {
-        unstructured {
-            goto 'label_63;
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
-        }
+        
     };
     /* block 63 */;
     let l3 = clock::timestamp_ms(l1);
@@ -1667,13 +1359,7 @@ public entry fun remove_payment_token<T0>(l0: &mut StakingPool<T0>, l1: String, 
     let (reg_42, reg_43) = vector::index_of(&l6.token_list, &l1);
     let l5 = reg_43;
     if (reg_42) {
-        unstructured {
-            goto 'label_75;
-        }
-    } else {
-        unstructured {
-            goto 'label_75;
-        }
+        
     };
     /* block 75 */;
     let l4 = clock::timestamp_ms(l2);
@@ -1698,18 +1384,7 @@ fun safe_add(l0: u64, l1: u64): u64 {
 }
 
 fun safe_mul_div_precise(l0: u64, l1: u64, l2: u64): u64 {
-    let l3;
-    if (l0 == 0u64) {
-        l3 = true;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l3 = l1 == 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    };
+    let l3 = l0 == 0u64 || l1 == 0u64;
     /* block 11 */;
     if (l3) {
         return 0u64
@@ -1732,38 +1407,20 @@ fun safe_sub(l0: u64, l1: u64): u64 {
 
 public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: String, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l2 >= C50) {
-        l5 = l2 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= C50 && l2 <= C54;
     /* block 31 */;
     assert!(l5, C36);
     assert!(string::length(&l1) > 0u64, C23);
     let reg_36;
     (reg_36, reg_37) = vector::index_of(&l0.supported_collections, &l1);
     assert!(reg_36, C8);
-    let l6;
     let l7 = CollectionMultiplierKey { collection: l1 };
     let l10 = clock::timestamp_ms(l3);
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier);
-        unstructured {
-            goto 'label_92;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l7)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier)
     } else {
-        l6 = 10000u64;
-        unstructured {
-            goto 'label_92;
-        }
+        10000u64
     };
     let l11;
     /* block 92 */;
@@ -1772,16 +1429,10 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
         let l8 = dynamic_object_field::borrow_mut(&mut l0.id, l7);
         *(&mut l8.default_multiplier) = l2;
         *(&mut l8.set_by) = tx_context::sender(freeze(l4));
-        *(&mut l8.set_time) = l10;
-        unstructured {
-            goto 'label_134;
-        }
+        *(&mut l8.set_time) = l10
     } else {
         let l9 = CollectionMultiplier { id: object::new(l4), collection: l1, default_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 };
-        dynamic_object_field::add(&mut l0.id, l7, l9);
-        unstructured {
-            goto 'label_134;
-        }
+        dynamic_object_field::add(&mut l0.id, l7, l9)
     };
     /* block 134 */;
     event::emit(CollectionMultiplierSet { pool_id: object::id(freeze(l0)), collection: l1, old_multiplier: l11, new_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 })
@@ -1789,19 +1440,8 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
 
 public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: String, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     verse::assert_not_paused(freeze(l0));
-    if (l3 >= C50) {
-        l7 = l3 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l3 >= C50 && l3 <= C54;
     /* block 31 */;
     assert!(l7, C36);
     assert!(string::length(&l2) > 0u64, C23);
@@ -1809,19 +1449,12 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
     let reg_44;
     (reg_44, reg_45) = vector::index_of(&l0.supported_collections, &l2);
     assert!(reg_44, C8);
-    let l8;
     let l10 = NftMultiplierKey { nft_id: l1, collection: l2 };
     let l9 = clock::timestamp_ms(l5);
-    if (dynamic_object_field::exists_(&l0.id, l10)) {
-        l8 = *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier);
-        unstructured {
-            goto 'label_107;
-        }
+    let l8 = if (dynamic_object_field::exists_(&l0.id, l10)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier)
     } else {
-        l8 = 10000u64;
-        unstructured {
-            goto 'label_107;
-        }
+        10000u64
     };
     let l13;
     /* block 107 */;
@@ -1831,16 +1464,10 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
         *(&mut l11.multiplier) = l3;
         *(&mut l11.rarity_tier) = l4;
         *(&mut l11.set_by) = tx_context::sender(freeze(l6));
-        *(&mut l11.set_time) = l9;
-        unstructured {
-            goto 'label_155;
-        }
+        *(&mut l11.set_time) = l9
     } else {
         let l12 = NftMultiplier { id: object::new(l6), nft_id: l1, collection: l2, multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 };
-        dynamic_object_field::add(&mut l0.id, l10, l12);
-        unstructured {
-            goto 'label_155;
-        }
+        dynamic_object_field::add(&mut l0.id, l10, l12)
     };
     /* block 155 */;
     event::emit(NftMultiplierSet { pool_id: object::id(freeze(l0)), nft_id: l1, collection: l2, old_multiplier: l13, new_multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 })
@@ -1848,19 +1475,8 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
 
 public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u8, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l7 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l1 >= C53 && l2 <= C52;
     /* block 31 */;
     assert!(l7, C29);
     assert!(l1 <= l2, C20);
@@ -1873,19 +1489,8 @@ public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l
 
 public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: vector<String>, l3: bool, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l8 = clock::timestamp_ms(l4);
@@ -1917,19 +1522,12 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
     verse::assert_not_paused(freeze(l0));
     assert!(l2 <= C54, C36);
     assert!(string::length(&l3) > 0u64, C20);
-    let l6;
     let l9 = WalletBonusMultiplierKey { wallet: l1 };
     let l7 = clock::timestamp_ms(l4);
-    if (dynamic_object_field::exists_(&l0.id, l9)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l9)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier)
     } else {
-        l6 = 0u64;
-        unstructured {
-            goto 'label_68;
-        }
+        0u64
     };
     let l8;
     /* block 68 */;
@@ -1939,16 +1537,10 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
         *(&mut l10.bonus_multiplier) = l2;
         *(&mut l10.reason) = l3;
         *(&mut l10.set_by) = tx_context::sender(freeze(l5));
-        *(&mut l10.set_time) = l7;
-        unstructured {
-            goto 'label_115;
-        }
+        *(&mut l10.set_time) = l7
     } else {
         let l11 = WalletBonusMultiplier { id: object::new(l5), wallet: l1, bonus_multiplier: l2, set_by: tx_context::sender(freeze(l5)), set_time: l7, reason: l3 };
-        dynamic_object_field::add(&mut l0.id, l9, l11);
-        unstructured {
-            goto 'label_115;
-        }
+        dynamic_object_field::add(&mut l0.id, l9, l11)
     };
     /* block 115 */;
     event::emit(WalletBonusMultiplierSet { pool_id: object::id(freeze(l0)), wallet: l1, old_bonus_multiplier: l8, new_bonus_multiplier: l2, reason: l3, set_by: tx_context::sender(freeze(l5)), set_time: l7 })
@@ -1958,31 +1550,13 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
     verse::assert_not_paused(freeze(l0));
     assert!(!(*(&l0.is_locked)), C5);
     assert!(string::length(&l4) > 0u64, C23);
-    let l8;
-    if (l5 >= C53) {
-        l8 = l5 <= C52;
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_50;
-        }
-    };
+    let l8 = l5 >= C53 && l5 <= C52;
     /* block 50 */;
     assert!(l8, C29);
     let l10 = clock::timestamp_ms(l6);
     assert!(l10 >= *(&l0.start_time), C7);
     if (*(&l0.end_time) > 0u64) {
-        assert!(l10 < *(&l0.end_time), C10);
-        unstructured {
-            goto 'label_108;
-        }
-    } else {
-        unstructured {
-            goto 'label_108;
-        }
+        assert!(l10 < *(&l0.end_time), C10)
     };
     /* block 108 */;
     let l15 = tx_context::sender(freeze(l7));
@@ -2016,38 +1590,16 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
 }
 
 public entry fun toggle_pause<T0>(l0: &mut StakingPool<T0>, l1: &mut TxContext) {
-    let l2;
     let l3 = tx_context::sender(freeze(l1));
-    if (l3 == *(&l0.admin)) {
-        l2 = true;
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = l3 == *(&l0.emergency_admin);
-        unstructured {
-            goto 'label_19;
-        }
-    };
+    let l2 = l3 == *(&l0.admin) || l3 == *(&l0.emergency_admin);
     /* block 19 */;
     assert!(l2, C1);
     *(&mut l0.is_paused) = !(*(&l0.is_paused))
 }
 
 public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
@@ -2058,23 +1610,13 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     let l8 = *(&l17.allowed_collections);
     let l15 = *(&l17.unlock_cost);
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_130;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l13 >= l15, C30);
         let l14 = coin::into_balance(l2);
         if (l13 > l15) {
             let l11 = verse::safe_sub(l13, l15);
-            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22);
-            unstructured {
-                goto 'label_89;
-            }
-        } else {
-            unstructured {
-                goto 'label_89;
-            }
+            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22)
         };
         let l16;
         /* block 89 */;
@@ -2082,21 +1624,11 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
         l16 = TokenRevenueKey { token_type: l21 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l19 = TokenRevenue { id: object::new(l4), token_type: l21, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l19);
-            unstructured {
-                goto 'label_112;
-            }
-        } else {
-            unstructured {
-                goto 'label_112;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l19)
         };
         /* block 112 */;
         let l20 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l20.total_collected) = verse::safe_add(*(&l20.total_collected), l15);
-        unstructured {
-            goto 'label_130;
-        }
+        *(&mut l20.total_collected) = verse::safe_add(*(&l20.total_collected), l15)
     };
     let l23;
     /* block 130 */;
@@ -2105,14 +1637,7 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l6 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l10, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l6);
-        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_168;
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
-        }
+        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 168 */;
     assert!(!(verse::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2126,81 +1651,42 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
 }
 
 public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8, l2: Coin<T0>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
     let l12 = coin::value(&l2);
     let l20 = verse::get_token_type_string_any();
     assert!(table::contains(&(dynamic_object_field::borrow(&l0.id, PaymentTokenRegistryKey { dummy_field: false })).supported_tokens, l20), C34);
-    let l7;
     let l14 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l14)) {
-        let l6;
+    let l7 = if (dynamic_object_field::exists_(&l0.id, l14)) {
         let l13 = dynamic_object_field::borrow(&l0.id, l14);
-        if (table::contains(&l13.token_prices, l20)) {
-            l6 = *(table::borrow(&l13.token_prices, l20));
-            unstructured {
-                goto 'label_81;
-            }
-        } else {
-            l6 = 0u64;
-            unstructured {
-                goto 'label_81;
-            }
-        };
         /* block 81 */;
-        l7 = l6;
-        unstructured {
-            goto 'label_86;
+        if (table::contains(&l13.token_prices, l20)) {
+            *(table::borrow(&l13.token_prices, l20))
+        } else {
+            0u64
         }
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_86;
-        }
+        0u64
     };
     let l15;
     /* block 86 */;
     l15 = l7;
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_148;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l12 == l15, C30);
         transfer::public_transfer(l2, *(&l0.admin));
         let l16 = TokenRevenueKey { token_type: l20 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l18 = TokenRevenue { id: object::new(l4), token_type: l20, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l18);
-            unstructured {
-                goto 'label_135;
-            }
-        } else {
-            unstructured {
-                goto 'label_135;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l18)
         };
         /* block 135 */;
         let l19 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l19.total_collected) = verse::safe_add(*(&l19.total_collected), l15);
-        unstructured {
-            goto 'label_148;
-        }
+        *(&mut l19.total_collected) = verse::safe_add(*(&l19.total_collected), l15)
     };
     let l23;
     /* block 148 */;
@@ -2209,14 +1695,7 @@ public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l8 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l11, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l8);
-        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_186;
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
-        }
+        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 186 */;
     assert!(!(verse::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2281,33 +1760,11 @@ public entry fun update_multiple_slot_rewards<T0>(l0: &mut StakingPool<T0>, l1: 
 
 public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
-    let l6;
-    if (l2 >= C50) {
-        l6 = l2 <= C54;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = l2 >= C50 && l2 <= C54;
     /* block 53 */;
     assert!(l6, C36);
     let l8 = clock::timestamp_ms(l3);
@@ -2334,19 +1791,8 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l9 = clock::timestamp_ms(l4);
@@ -2363,54 +1809,31 @@ public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Str
             };
             l10 = l10 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
     };
     /* block 99 */;
     let l16 = SlotTokenPricingKey { slot_number: l1 };
     if (dynamic_object_field::exists_(&l0.id, l16)) {
-        let l7;
         let l14 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        if (table::contains(&l14.token_prices, l2)) {
-            l7 = *(table::borrow(&l14.token_prices, l2));
-            unstructured {
-                goto 'label_126;
-            }
+        let l7 = if (table::contains(&l14.token_prices, l2)) {
+            *(table::borrow(&l14.token_prices, l2))
         } else {
-            l7 = 0u64;
-            unstructured {
-                goto 'label_126;
-            }
+            0u64
         };
         let l13;
         /* block 126 */;
         l13 = l7;
         if (table::contains(&l14.token_prices, l2)) {
-            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3;
-            unstructured {
-                goto 'label_145;
-            }
+            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3
         } else {
-            table::add(&mut l14.token_prices, l2, l3);
-            unstructured {
-                goto 'label_145;
-            }
+            table::add(&mut l14.token_prices, l2, l3)
         };
         /* block 145 */;
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     } else {
         let l15 = SlotTokenPricing { id: object::new(l5), slot_number: l1, token_prices: table::new(l5) };
         table::add(&mut (&mut l15).token_prices, l2, l3);
         dynamic_object_field::add(&mut l0.id, l16, l15);
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     };
     /* block 189 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x2c6b186d1bb437e09132af796714340d431c7dfaa83cddfd4b9bd785204be743/bet_manager.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x2c6b186d1bb437e09132af796714340d431c7dfaa83cddfd4b9bd785204be743/bet_manager.move
@@ -140,128 +140,37 @@ public fun fill_bet_number(l0: &mut Bet, l1: u64) {
 }
 
 public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
-    let l3;
-    if (l1 == C0) {
-        l3 = true;
-        unstructured {
-            goto 'label_25;
-        }
-    } else {
-        if (l1 == C1) {
-            l3 = true;
-            unstructured {
-                goto 'label_25;
-            }
-        } else {
-            if (l1 == C9) {
-                l3 = true;
-                unstructured {
-                    goto 'label_25;
-                }
-            } else {
-                l3 = l1 == C10;
-                unstructured {
-                    goto 'label_25;
-                }
-            }
-        }
-    };
+    let l3 = l1 == C0 || l1 == C1 || l1 == C9 || l1 == C10;
     /* block 25 */;
     if (l3) {
         return bet_manager::mul(l0, 1000000000u64)
     };
-    let l12;
-    if (l1 == C14) {
-        l12 = true;
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        l12 = l1 == C16;
-        unstructured {
-            goto 'label_42;
-        }
-    };
+    let l12 = l1 == C14 || l1 == C16;
     /* block 42 */;
     if (l12) {
-        let l13;
         let l21 = *(option::borrow(&l2));
-        if (l21 == 4u64) {
-            l13 = true;
-            unstructured {
-                goto 'label_59;
-            }
-        } else {
-            l13 = l21 == 10u64;
-            unstructured {
-                goto 'label_59;
-            }
-        };
+        let l13 = l21 == 4u64 || l21 == 10u64;
         /* block 59 */;
         if (l13) {
             return bet_manager::mul(l0, 2000000000u64)
         };
-        let l14;
-        if (l21 == 5u64) {
-            l14 = true;
-            unstructured {
-                goto 'label_76;
-            }
-        } else {
-            l14 = l21 == 9u64;
-            unstructured {
-                goto 'label_76;
-            }
-        };
+        let l14 = l21 == 5u64 || l21 == 9u64;
         /* block 76 */;
         if (l14) {
             return bet_manager::mul(l0, 1500000000u64)
         };
         return bet_manager::mul(l0, 1200000000u64)
     };
-    let l15;
-    if (l1 == C15) {
-        l15 = true;
-        unstructured {
-            goto 'label_97;
-        }
-    } else {
-        l15 = l1 == C17;
-        unstructured {
-            goto 'label_97;
-        }
-    };
+    let l15 = l1 == C15 || l1 == C17;
     /* block 97 */;
     if (l15) {
-        let l16;
         let l22 = *(option::borrow(&l2));
-        if (l22 == 4u64) {
-            l16 = true;
-            unstructured {
-                goto 'label_114;
-            }
-        } else {
-            l16 = l22 == 10u64;
-            unstructured {
-                goto 'label_114;
-            }
-        };
+        let l16 = l22 == 4u64 || l22 == 10u64;
         /* block 114 */;
         if (l16) {
             return bet_manager::mul(l0, 500000000u64)
         };
-        let l17;
-        if (l22 == 5u64) {
-            l17 = true;
-            unstructured {
-                goto 'label_131;
-            }
-        } else {
-            l17 = l22 == 9u64;
-            unstructured {
-                goto 'label_131;
-            }
-        };
+        let l17 = l22 == 5u64 || l22 == 9u64;
         /* block 131 */;
         if (l17) {
             return bet_manager::mul(l0, 666666666u64)
@@ -269,35 +178,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 833333333u64)
     };
     if (l1 == C3) {
-        let l18;
         let l23 = *(option::borrow(&l2));
-        if (l23 == 4u64) {
-            l18 = true;
-            unstructured {
-                goto 'label_160;
-            }
-        } else {
-            l18 = l23 == 10u64;
-            unstructured {
-                goto 'label_160;
-            }
-        };
+        let l18 = l23 == 4u64 || l23 == 10u64;
         /* block 160 */;
         if (l18) {
             return bet_manager::mul(l0, 1800000000u64)
         };
-        let l19;
-        if (l23 == 5u64) {
-            l19 = true;
-            unstructured {
-                goto 'label_177;
-            }
-        } else {
-            l19 = l23 == 9u64;
-            unstructured {
-                goto 'label_177;
-            }
-        };
+        let l19 = l23 == 5u64 || l23 == 9u64;
         /* block 177 */;
         if (l19) {
             return bet_manager::mul(l0, 1400000000u64)
@@ -305,35 +192,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 1166666666u64)
     };
     if (l1 == C4) {
-        let l4;
         let l24 = *(option::borrow(&l2));
-        if (l24 == 4u64) {
-            l4 = true;
-            unstructured {
-                goto 'label_206;
-            }
-        } else {
-            l4 = l24 == 10u64;
-            unstructured {
-                goto 'label_206;
-            }
-        };
+        let l4 = l24 == 4u64 || l24 == 10u64;
         /* block 206 */;
         if (l4) {
             return bet_manager::mul(l0, 2000000000u64)
         };
-        let l5;
-        if (l24 == 5u64) {
-            l5 = true;
-            unstructured {
-                goto 'label_223;
-            }
-        } else {
-            l5 = l24 == 9u64;
-            unstructured {
-                goto 'label_223;
-            }
-        };
+        let l5 = l24 == 5u64 || l24 == 9u64;
         /* block 223 */;
         if (l5) {
             return bet_manager::mul(l0, 1500000000u64)
@@ -341,35 +206,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 1200000000u64)
     };
     if (l1 == C5) {
-        let l6;
         let l25 = *(option::borrow(&l2));
-        if (l25 == 4u64) {
-            l6 = true;
-            unstructured {
-                goto 'label_252;
-            }
-        } else {
-            l6 = l25 == 10u64;
-            unstructured {
-                goto 'label_252;
-            }
-        };
+        let l6 = l25 == 4u64 || l25 == 10u64;
         /* block 252 */;
         if (l6) {
             return bet_manager::mul(l0, 500000000u64)
         };
-        let l7;
-        if (l25 == 5u64) {
-            l7 = true;
-            unstructured {
-                goto 'label_269;
-            }
-        } else {
-            l7 = l25 == 9u64;
-            unstructured {
-                goto 'label_269;
-            }
-        };
+        let l7 = l25 == 5u64 || l25 == 9u64;
         /* block 269 */;
         if (l7) {
             return bet_manager::mul(l0, 666666666u64)
@@ -380,35 +223,13 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
         return bet_manager::mul(l0, 3000000000u64)
     };
     if (l1 == C11) {
-        let l8;
         let l26 = *(option::borrow(&l2));
-        if (l26 == 4u64) {
-            l8 = true;
-            unstructured {
-                goto 'label_306;
-            }
-        } else {
-            l8 = l26 == 10u64;
-            unstructured {
-                goto 'label_306;
-            }
-        };
+        let l8 = l26 == 4u64 || l26 == 10u64;
         /* block 306 */;
         if (l8) {
             return bet_manager::mul(l0, 7000000000u64)
         };
-        let l9;
-        if (l26 == 6u64) {
-            l9 = true;
-            unstructured {
-                goto 'label_323;
-            }
-        } else {
-            l9 = l26 == 8u64;
-            unstructured {
-                goto 'label_323;
-            }
-        };
+        let l9 = l26 == 6u64 || l26 == 8u64;
         /* block 323 */;
         assert!(l9, C0);
         return bet_manager::mul(l0, 9000000000u64)
@@ -433,18 +254,7 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
     if (l1 == C13) {
         return bet_manager::mul(l0, 4000000000u64)
     };
-    let l10;
-    if (l1 == C6) {
-        l10 = true;
-        unstructured {
-            goto 'label_408;
-        }
-    } else {
-        l10 = l1 == C7;
-        unstructured {
-            goto 'label_408;
-        }
-    };
+    let l10 = l1 == C6 || l1 == C7;
     /* block 408 */;
     if (l10) {
         return bet_manager::mul(l0, 30000000000u64)
@@ -454,36 +264,10 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
     };
     assert!(l1 == C18, C0);
     if (option::is_some(&l2)) {
-        let l11;
         let l27 = *(option::borrow(&l2));
-        if (l27 == 2u64) {
-            l11 = true;
-            unstructured {
-                goto 'label_451;
-            }
-        } else {
-            if (l27 == 3u64) {
-                l11 = true;
-                unstructured {
-                    goto 'label_451;
-                }
-            } else {
-                l11 = l27 == 12u64;
-                unstructured {
-                    goto 'label_451;
-                }
-            }
-        };
         /* block 451 */;
-        if (l11) {
+        if (l27 == 2u64 || l27 == 3u64 || l27 == 12u64) {
             return bet_manager::mul(l0, 3000000000u64)
-        };
-        unstructured {
-            goto 'label_457;
-        }
-    } else {
-        unstructured {
-            goto 'label_457;
         }
     };
     /* block 457 */;
@@ -493,67 +277,23 @@ public fun get_bet_max_payout(l0: u64, l1: u64, l2: Option<u64>): u64 {
 public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &VecSet<u64>, l4: u64, l5: u64, l6: u64): ( bool, bool, u64) {
     if (l0 == C12) {
         if (option::is_some(&l1)) {
-            let l7;
             let l99 = option::borrow(&l1);
-            if (l99 == &l5) {
-                l7 = *l99 == 2u64;
-                unstructured {
-                    goto 'label_24;
-                }
-            } else {
-                l7 = false;
-                unstructured {
-                    goto 'label_24;
-                }
-            };
+            let l7 = l99 == &l5 && *l99 == 2u64;
             /* block 24 */;
             if (l7) {
                 return (true, false, bet_manager::mul(l2, 30000000000u64))
             };
-            let l18;
-            if (l99 == &l5) {
-                l18 = *l99 == 3u64;
-                unstructured {
-                    goto 'label_46;
-                }
-            } else {
-                l18 = false;
-                unstructured {
-                    goto 'label_46;
-                }
-            };
+            let l18 = l99 == &l5 && *l99 == 3u64;
             /* block 46 */;
             if (l18) {
                 return (true, false, bet_manager::mul(l2, 15000000000u64))
             };
-            let l29;
-            if (l99 == &l5) {
-                l29 = *l99 == 11u64;
-                unstructured {
-                    goto 'label_68;
-                }
-            } else {
-                l29 = false;
-                unstructured {
-                    goto 'label_68;
-                }
-            };
+            let l29 = l99 == &l5 && *l99 == 11u64;
             /* block 68 */;
             if (l29) {
                 return (true, false, bet_manager::mul(l2, 15000000000u64))
             };
-            let l40;
-            if (l99 == &l5) {
-                l40 = *l99 == 12u64;
-                unstructured {
-                    goto 'label_92;
-                }
-            } else {
-                l40 = false;
-                unstructured {
-                    goto 'label_92;
-                }
-            };
+            let l40 = l99 == &l5 && *l99 == 12u64;
             /* block 92 */;
             if (l40) {
                 return (true, false, bet_manager::mul(l2, 30000000000u64))
@@ -584,90 +324,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l84;
         let l104 = *(option::borrow(&l1));
-        if (l104 == l5) {
-            let l95;
-            if (l104 == 4u64) {
-                l95 = true;
-                unstructured {
-                    goto 'label_207;
-                }
-            } else {
-                l95 = l104 == 10u64;
-                unstructured {
-                    goto 'label_207;
-                }
-            };
-            /* block 207 */;
-            l84 = l95;
-            unstructured {
-                goto 'label_212;
-            }
-        } else {
-            l84 = false;
-            unstructured {
-                goto 'label_212;
-            }
-        };
+        let l84 = l104 == l5 && /* block 207 */ l104 == 4u64 || l104 == 10u64;
         /* block 212 */;
         if (l84) {
             return (true, false, bet_manager::mul(l2, 1800000000u64))
         };
-        let l8;
-        if (l104 == l5) {
-            let l9;
-            if (l104 == 5u64) {
-                l9 = true;
-                unstructured {
-                    goto 'label_235;
-                }
-            } else {
-                l9 = l104 == 9u64;
-                unstructured {
-                    goto 'label_235;
-                }
-            };
-            /* block 235 */;
-            l8 = l9;
-            unstructured {
-                goto 'label_240;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_240;
-            }
-        };
+        let l8 = l104 == l5 && /* block 235 */ l104 == 5u64 || l104 == 9u64;
         /* block 240 */;
         if (l8) {
             return (true, false, bet_manager::mul(l2, 1400000000u64))
         };
-        let l10;
-        if (l104 == l5) {
-            let l11;
-            if (l104 == 6u64) {
-                l11 = true;
-                unstructured {
-                    goto 'label_263;
-                }
-            } else {
-                l11 = l104 == 8u64;
-                unstructured {
-                    goto 'label_263;
-                }
-            };
-            /* block 263 */;
-            l10 = l11;
-            unstructured {
-                goto 'label_268;
-            }
-        } else {
-            l10 = false;
-            unstructured {
-                goto 'label_268;
-            }
-        };
+        let l10 = l104 == l5 && /* block 263 */ l104 == 6u64 || l104 == 8u64;
         /* block 268 */;
         if (l10) {
             return (true, false, bet_manager::mul(l2, 1166666666u64))
@@ -678,90 +346,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l12;
         let l105 = *(option::borrow(&l1));
-        if (l105 == l5) {
-            let l13;
-            if (l105 == 4u64) {
-                l13 = true;
-                unstructured {
-                    goto 'label_313;
-                }
-            } else {
-                l13 = l105 == 10u64;
-                unstructured {
-                    goto 'label_313;
-                }
-            };
-            /* block 313 */;
-            l12 = l13;
-            unstructured {
-                goto 'label_318;
-            }
-        } else {
-            l12 = false;
-            unstructured {
-                goto 'label_318;
-            }
-        };
+        let l12 = l105 == l5 && /* block 313 */ l105 == 4u64 || l105 == 10u64;
         /* block 318 */;
         if (l12) {
             return (true, false, bet_manager::mul(l2, 2000000000u64))
         };
-        let l14;
-        if (l105 == l5) {
-            let l15;
-            if (l105 == 5u64) {
-                l15 = true;
-                unstructured {
-                    goto 'label_341;
-                }
-            } else {
-                l15 = l105 == 9u64;
-                unstructured {
-                    goto 'label_341;
-                }
-            };
-            /* block 341 */;
-            l14 = l15;
-            unstructured {
-                goto 'label_346;
-            }
-        } else {
-            l14 = false;
-            unstructured {
-                goto 'label_346;
-            }
-        };
+        let l14 = l105 == l5 && /* block 341 */ l105 == 5u64 || l105 == 9u64;
         /* block 346 */;
         if (l14) {
             return (true, false, bet_manager::mul(l2, 1500000000u64))
         };
-        let l16;
-        if (l105 == l5) {
-            let l17;
-            if (l105 == 6u64) {
-                l17 = true;
-                unstructured {
-                    goto 'label_369;
-                }
-            } else {
-                l17 = l105 == 8u64;
-                unstructured {
-                    goto 'label_369;
-                }
-            };
-            /* block 369 */;
-            l16 = l17;
-            unstructured {
-                goto 'label_374;
-            }
-        } else {
-            l16 = false;
-            unstructured {
-                goto 'label_374;
-            }
-        };
+        let l16 = l105 == l5 && /* block 369 */ l105 == 6u64 || l105 == 8u64;
         /* block 374 */;
         if (l16) {
             return (true, false, bet_manager::mul(l2, 1200000000u64))
@@ -770,139 +366,34 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C5) {
         if (l5 == 7u64) {
-            let l19;
             let l106 = *(option::borrow(&l1));
-            if (l106 == 4u64) {
-                l19 = true;
-                unstructured {
-                    goto 'label_411;
-                }
-            } else {
-                l19 = l106 == 10u64;
-                unstructured {
-                    goto 'label_411;
-                }
-            };
+            let l19 = l106 == 4u64 || l106 == 10u64;
             /* block 411 */;
             if (l19) {
                 return (true, false, bet_manager::mul(l2, 500000000u64))
             };
-            let l20;
-            if (l106 == 5u64) {
-                l20 = true;
-                unstructured {
-                    goto 'label_430;
-                }
-            } else {
-                l20 = l106 == 9u64;
-                unstructured {
-                    goto 'label_430;
-                }
-            };
+            let l20 = l106 == 5u64 || l106 == 9u64;
             /* block 430 */;
             if (l20) {
                 return (true, false, bet_manager::mul(l2, 666666666u64))
             };
-            let l21;
-            if (l106 == 6u64) {
-                l21 = true;
-                unstructured {
-                    goto 'label_449;
-                }
-            } else {
-                l21 = l106 == 8u64;
-                unstructured {
-                    goto 'label_449;
-                }
-            };
+            let l21 = l106 == 6u64 || l106 == 8u64;
             /* block 449 */;
             assert!(l21, C0);
             return (true, false, bet_manager::mul(l2, 833333333u64))
         };
-        let l22;
         let l107 = *(option::borrow(&l1));
-        if (l107 == l5) {
-            let l23;
-            if (l107 == 4u64) {
-                l23 = true;
-                unstructured {
-                    goto 'label_478;
-                }
-            } else {
-                l23 = l107 == 10u64;
-                unstructured {
-                    goto 'label_478;
-                }
-            };
-            /* block 478 */;
-            l22 = l23;
-            unstructured {
-                goto 'label_483;
-            }
-        } else {
-            l22 = false;
-            unstructured {
-                goto 'label_483;
-            }
-        };
+        let l22 = l107 == l5 && /* block 478 */ l107 == 4u64 || l107 == 10u64;
         /* block 483 */;
         if (l22) {
             return (false, false, 0u64)
         };
-        let l24;
-        if (l107 == l5) {
-            let l25;
-            if (l107 == 5u64) {
-                l25 = true;
-                unstructured {
-                    goto 'label_504;
-                }
-            } else {
-                l25 = l107 == 9u64;
-                unstructured {
-                    goto 'label_504;
-                }
-            };
-            /* block 504 */;
-            l24 = l25;
-            unstructured {
-                goto 'label_509;
-            }
-        } else {
-            l24 = false;
-            unstructured {
-                goto 'label_509;
-            }
-        };
+        let l24 = l107 == l5 && /* block 504 */ l107 == 5u64 || l107 == 9u64;
         /* block 509 */;
         if (l24) {
             return (false, false, 0u64)
         };
-        let l26;
-        if (l107 == l5) {
-            let l27;
-            if (l107 == 6u64) {
-                l27 = true;
-                unstructured {
-                    goto 'label_530;
-                }
-            } else {
-                l27 = l107 == 8u64;
-                unstructured {
-                    goto 'label_530;
-                }
-            };
-            /* block 530 */;
-            l26 = l27;
-            unstructured {
-                goto 'label_535;
-            }
-        } else {
-            l26 = false;
-            unstructured {
-                goto 'label_535;
-            }
-        };
+        let l26 = l107 == l5 && /* block 530 */ l107 == 6u64 || l107 == 8u64;
         /* block 535 */;
         if (l26) {
             return (false, false, 0u64)
@@ -913,42 +404,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l28;
         let l38 = 2u64;
-        if (vec_set::contains(l3, &l38)) {
+        let l28 = vec_set::contains(l3, &l38) && {
             let l36 = 3u64;
-            if (vec_set::contains(l3, &l36)) {
+            vec_set::contains(l3, &l36) && {
                 let l34 = 4u64;
-                if (vec_set::contains(l3, &l34)) {
+                vec_set::contains(l3, &l34) && {
                     let l32 = 5u64;
-                    if (vec_set::contains(l3, &l32)) {
+                    vec_set::contains(l3, &l32) && {
                         let l30 = 6u64;
-                        l28 = vec_set::contains(l3, &l30);
-                        unstructured {
-                            goto 'label_619;
-                        }
-                    } else {
-                        l28 = false;
-                        unstructured {
-                            goto 'label_619;
-                        }
-                    }
-                } else {
-                    l28 = false;
-                    unstructured {
-                        goto 'label_619;
+                        vec_set::contains(l3, &l30)
                     }
                 }
-            } else {
-                l28 = false;
-                unstructured {
-                    goto 'label_619;
-                }
-            }
-        } else {
-            l28 = false;
-            unstructured {
-                goto 'label_619;
             }
         };
         /* block 619 */;
@@ -961,42 +428,18 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l41;
         let l50 = 8u64;
-        if (vec_set::contains(l3, &l50)) {
+        let l41 = vec_set::contains(l3, &l50) && {
             let l48 = 9u64;
-            if (vec_set::contains(l3, &l48)) {
+            vec_set::contains(l3, &l48) && {
                 let l46 = 10u64;
-                if (vec_set::contains(l3, &l46)) {
+                vec_set::contains(l3, &l46) && {
                     let l44 = 11u64;
-                    if (vec_set::contains(l3, &l44)) {
+                    vec_set::contains(l3, &l44) && {
                         let l42 = 12u64;
-                        l41 = vec_set::contains(l3, &l42);
-                        unstructured {
-                            goto 'label_705;
-                        }
-                    } else {
-                        l41 = false;
-                        unstructured {
-                            goto 'label_705;
-                        }
-                    }
-                } else {
-                    l41 = false;
-                    unstructured {
-                        goto 'label_705;
+                        vec_set::contains(l3, &l42)
                     }
                 }
-            } else {
-                l41 = false;
-                unstructured {
-                    goto 'label_705;
-                }
-            }
-        } else {
-            l41 = false;
-            unstructured {
-                goto 'label_705;
             }
         };
         /* block 705 */;
@@ -1009,82 +452,33 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 7u64) {
             return (false, false, 0u64)
         };
-        let l53;
         let l74 = 2u64;
-        if (vec_set::contains(l3, &l74)) {
+        let l53 = vec_set::contains(l3, &l74) && {
             let l71 = 3u64;
-            if (vec_set::contains(l3, &l71)) {
+            vec_set::contains(l3, &l71) && {
                 let l69 = 4u64;
-                if (vec_set::contains(l3, &l69)) {
+                vec_set::contains(l3, &l69) && {
                     let l67 = 5u64;
-                    if (vec_set::contains(l3, &l67)) {
+                    vec_set::contains(l3, &l67) && {
                         let l65 = 6u64;
-                        if (vec_set::contains(l3, &l65)) {
+                        vec_set::contains(l3, &l65) && {
                             let l63 = 8u64;
-                            if (vec_set::contains(l3, &l63)) {
+                            vec_set::contains(l3, &l63) && {
                                 let l60 = 9u64;
-                                if (vec_set::contains(l3, &l60)) {
+                                vec_set::contains(l3, &l60) && {
                                     let l58 = 10u64;
-                                    if (vec_set::contains(l3, &l58)) {
+                                    vec_set::contains(l3, &l58) && {
                                         let l56 = 11u64;
-                                        if (vec_set::contains(l3, &l56)) {
+                                        vec_set::contains(l3, &l56) && {
                                             let l54 = 12u64;
-                                            l53 = vec_set::contains(l3, &l54);
-                                            unstructured {
-                                                goto 'label_856;
-                                            }
-                                        } else {
-                                            l53 = false;
-                                            unstructured {
-                                                goto 'label_856;
-                                            }
-                                        }
-                                    } else {
-                                        l53 = false;
-                                        unstructured {
-                                            goto 'label_856;
+                                            vec_set::contains(l3, &l54)
                                         }
                                     }
-                                } else {
-                                    l53 = false;
-                                    unstructured {
-                                        goto 'label_856;
-                                    }
-                                }
-                            } else {
-                                l53 = false;
-                                unstructured {
-                                    goto 'label_856;
                                 }
                             }
-                        } else {
-                            l53 = false;
-                            unstructured {
-                                goto 'label_856;
-                            }
-                        }
-                    } else {
-                        l53 = false;
-                        unstructured {
-                            goto 'label_856;
                         }
                     }
-                } else {
-                    l53 = false;
-                    unstructured {
-                        goto 'label_856;
-                    }
                 }
-            } else {
-                l53 = false;
-                unstructured {
-                    goto 'label_856;
-                }
-            }
-        } else {
-            l53 = false;
-            unstructured {
-                goto 'label_856;
             }
         };
         /* block 856 */;
@@ -1103,44 +497,14 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
             if (reg_575 != reg_576) {
                 return (false, false, 0u64)
             };
-            let l76;
-            if (l100 == 4u64) {
-                l76 = true;
-                unstructured {
-                    goto 'label_905;
-                }
-            } else {
-                l76 = l100 == 10u64;
-                unstructured {
-                    goto 'label_905;
-                }
-            };
+            let l76 = l100 == 4u64 || l100 == 10u64;
             /* block 905 */;
             if (l76) {
                 return (true, false, bet_manager::mul(l2, 7000000000u64))
             };
-            let l77;
-            if (l100 == 6u64) {
-                l77 = true;
-                unstructured {
-                    goto 'label_924;
-                }
-            } else {
-                l77 = l100 == 8u64;
-                unstructured {
-                    goto 'label_924;
-                }
-            };
             /* block 924 */;
-            if (l77) {
+            if (l100 == 6u64 || l100 == 8u64) {
                 return (true, false, bet_manager::mul(l2, 9000000000u64))
-            };
-            unstructured {
-                goto 'label_936;
-            }
-        } else {
-            unstructured {
-                goto 'label_936;
             }
         };
         /* block 936 */;
@@ -1148,41 +512,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C9) {
         if (option::is_none(&l1)) {
-            let l78;
-            if (l5 == 7u64) {
-                l78 = true;
-                unstructured {
-                    goto 'label_958;
-                }
-            } else {
-                l78 = l5 == 11u64;
-                unstructured {
-                    goto 'label_958;
-                }
-            };
+            let l78 = l5 == 7u64 || l5 == 11u64;
             /* block 958 */;
             if (l78) {
                 return (true, false, bet_manager::mul(l2, 1000000000u64))
             };
-            let l79;
-            if (l5 == 2u64) {
-                l79 = true;
-                unstructured {
-                    goto 'label_984;
-                }
-            } else {
-                if (l5 == 3u64) {
-                    l79 = true;
-                    unstructured {
-                        goto 'label_984;
-                    }
-                } else {
-                    l79 = l5 == 12u64;
-                    unstructured {
-                        goto 'label_984;
-                    }
-                }
-            };
+            let l79 = l5 == 2u64 || l5 == 3u64 || l5 == 12u64;
             /* block 984 */;
             if (l79) {
                 return (false, false, 0u64)
@@ -1205,34 +540,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l98 != l5) {
             return (false, true, 0u64)
         };
-        let l80;
-        if (l98 == 4u64) {
-            l80 = true;
-            unstructured {
-                goto 'label_1053;
-            }
-        } else {
-            l80 = l98 == 10u64;
-            unstructured {
-                goto 'label_1053;
-            }
-        };
+        let l80 = l98 == 4u64 || l98 == 10u64;
         /* block 1053 */;
         if (l80) {
             return (true, false, bet_manager::mul(l2, 2000000000u64))
         };
-        let l81;
-        if (l98 == 5u64) {
-            l81 = true;
-            unstructured {
-                goto 'label_1072;
-            }
-        } else {
-            l81 = l98 == 9u64;
-            unstructured {
-                goto 'label_1072;
-            }
-        };
+        let l81 = l98 == 5u64 || l98 == 9u64;
         /* block 1072 */;
         if (l81) {
             return (true, false, bet_manager::mul(l2, 1500000000u64))
@@ -1241,34 +554,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C10) {
         if (option::is_none(&l1)) {
-            let l82;
-            if (l5 == 7u64) {
-                l82 = true;
-                unstructured {
-                    goto 'label_1104;
-                }
-            } else {
-                l82 = l5 == 11u64;
-                unstructured {
-                    goto 'label_1104;
-                }
-            };
+            let l82 = l5 == 7u64 || l5 == 11u64;
             /* block 1104 */;
             if (l82) {
                 return (false, false, 0u64)
             };
-            let l83;
-            if (l5 == 2u64) {
-                l83 = true;
-                unstructured {
-                    goto 'label_1121;
-                }
-            } else {
-                l83 = l5 == 3u64;
-                unstructured {
-                    goto 'label_1121;
-                }
-            };
+            let l83 = l5 == 2u64 || l5 == 3u64;
             /* block 1121 */;
             if (l83) {
                 return (true, false, bet_manager::mul(l2, 1000000000u64))
@@ -1288,35 +579,13 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l0 == C17) {
         if (l5 == 7u64) {
-            let l85;
             let l101 = *(option::borrow(&l1));
-            if (l101 == 4u64) {
-                l85 = true;
-                unstructured {
-                    goto 'label_1188;
-                }
-            } else {
-                l85 = l101 == 10u64;
-                unstructured {
-                    goto 'label_1188;
-                }
-            };
+            let l85 = l101 == 4u64 || l101 == 10u64;
             /* block 1188 */;
             if (l85) {
                 return (true, false, bet_manager::mul(l2, 500000000u64))
             };
-            let l86;
-            if (l101 == 5u64) {
-                l86 = true;
-                unstructured {
-                    goto 'label_1207;
-                }
-            } else {
-                l86 = l101 == 9u64;
-                unstructured {
-                    goto 'label_1207;
-                }
-            };
+            let l86 = l101 == 5u64 || l101 == 9u64;
             /* block 1207 */;
             if (l86) {
                 return (true, false, bet_manager::mul(l2, 666666666u64))
@@ -1332,25 +601,7 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         if (l5 == 11u64) {
             return (true, false, bet_manager::mul(l2, 7000000000u64))
         };
-        let l87;
-        if (l5 == 2u64) {
-            l87 = true;
-            unstructured {
-                goto 'label_1267;
-            }
-        } else {
-            if (l5 == 3u64) {
-                l87 = true;
-                unstructured {
-                    goto 'label_1267;
-                }
-            } else {
-                l87 = l5 == 12u64;
-                unstructured {
-                    goto 'label_1267;
-                }
-            }
-        };
+        let l87 = l5 == 2u64 || l5 == 3u64 || l5 == 12u64;
         /* block 1267 */;
         if (l87) {
             return (true, false, bet_manager::mul(l2, 3000000000u64))
@@ -1359,41 +610,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     };
     if (l6 == 0u64) {
         if (l0 == C0) {
-            let l88;
-            if (l5 == 7u64) {
-                l88 = true;
-                unstructured {
-                    goto 'label_1298;
-                }
-            } else {
-                l88 = l5 == 11u64;
-                unstructured {
-                    goto 'label_1298;
-                }
-            };
+            let l88 = l5 == 7u64 || l5 == 11u64;
             /* block 1298 */;
             if (l88) {
                 return (true, false, bet_manager::mul(l2, 1000000000u64))
             };
-            let l89;
-            if (l5 == 2u64) {
-                l89 = true;
-                unstructured {
-                    goto 'label_1324;
-                }
-            } else {
-                if (l5 == 3u64) {
-                    l89 = true;
-                    unstructured {
-                        goto 'label_1324;
-                    }
-                } else {
-                    l89 = l5 == 12u64;
-                    unstructured {
-                        goto 'label_1324;
-                    }
-                }
-            };
+            let l89 = l5 == 2u64 || l5 == 3u64 || l5 == 12u64;
             /* block 1324 */;
             if (l89) {
                 return (false, false, 0u64)
@@ -1401,34 +623,12 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
             return (false, true, 0u64)
         };
         assert!(l0 == C1, C0);
-        let l90;
-        if (l5 == 7u64) {
-            l90 = true;
-            unstructured {
-                goto 'label_1349;
-            }
-        } else {
-            l90 = l5 == 11u64;
-            unstructured {
-                goto 'label_1349;
-            }
-        };
+        let l90 = l5 == 7u64 || l5 == 11u64;
         /* block 1349 */;
         if (l90) {
             return (false, false, 0u64)
         };
-        let l91;
-        if (l5 == 2u64) {
-            l91 = true;
-            unstructured {
-                goto 'label_1366;
-            }
-        } else {
-            l91 = l5 == 3u64;
-            unstructured {
-                goto 'label_1366;
-            }
-        };
+        let l91 = l5 == 2u64 || l5 == 3u64;
         /* block 1366 */;
         if (l91) {
             return (true, false, bet_manager::mul(l2, 1000000000u64))
@@ -1443,35 +643,13 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
             return (true, false, bet_manager::mul(l2, 1000000000u64))
         };
         if (l0 == C15) {
-            let l92;
             let l102 = *(option::borrow(&l1));
-            if (l102 == 4u64) {
-                l92 = true;
-                unstructured {
-                    goto 'label_1421;
-                }
-            } else {
-                l92 = l102 == 10u64;
-                unstructured {
-                    goto 'label_1421;
-                }
-            };
+            let l92 = l102 == 4u64 || l102 == 10u64;
             /* block 1421 */;
             if (l92) {
                 return (true, false, bet_manager::mul(l2, 500000000u64))
             };
-            let l93;
-            if (l102 == 5u64) {
-                l93 = true;
-                unstructured {
-                    goto 'label_1440;
-                }
-            } else {
-                l93 = l102 == 9u64;
-                unstructured {
-                    goto 'label_1440;
-                }
-            };
+            let l93 = l102 == 5u64 || l102 == 9u64;
             /* block 1440 */;
             if (l93) {
                 return (true, false, bet_manager::mul(l2, 666666666u64))
@@ -1480,18 +658,7 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
         };
         return (false, false, 0u64)
     };
-    let l94;
-    if (l0 == C1) {
-        l94 = true;
-        unstructured {
-            goto 'label_1469;
-        }
-    } else {
-        l94 = l0 == C15;
-        unstructured {
-            goto 'label_1469;
-        }
-    };
+    let l94 = l0 == C1 || l0 == C15;
     /* block 1469 */;
     if (l94) {
         if (l5 == l6) {
@@ -1502,59 +669,23 @@ public fun get_bet_result_and_payout(l0: u64, l1: Option<u64>, l2: u64, l3: &Vec
     if (l0 == C0) {
         if (l5 == l6) {
             return (true, false, bet_manager::mul(l2, 1000000000u64))
-        };
-        unstructured {
-            goto 'label_1497;
-        }
-    } else {
-        unstructured {
-            goto 'label_1497;
         }
     };
     /* block 1497 */;
     if (l0 == C14) {
         if (l5 == l6) {
-            let l96;
             let l103 = *(option::borrow(&l1));
-            if (l103 == 4u64) {
-                l96 = true;
-                unstructured {
-                    goto 'label_1520;
-                }
-            } else {
-                l96 = l103 == 10u64;
-                unstructured {
-                    goto 'label_1520;
-                }
-            };
+            let l96 = l103 == 4u64 || l103 == 10u64;
             /* block 1520 */;
             if (l96) {
                 return (true, false, bet_manager::mul(l2, 2000000000u64))
             };
-            let l97;
-            if (l103 == 5u64) {
-                l97 = true;
-                unstructured {
-                    goto 'label_1539;
-                }
-            } else {
-                l97 = l103 == 9u64;
-                unstructured {
-                    goto 'label_1539;
-                }
-            };
+            let l97 = l103 == 5u64 || l103 == 9u64;
             /* block 1539 */;
             if (l97) {
                 return (true, false, bet_manager::mul(l2, 1500000000u64))
             };
             return (true, false, bet_manager::mul(l2, 1200000000u64))
-        };
-        unstructured {
-            goto 'label_1553;
-        }
-    } else {
-        unstructured {
-            goto 'label_1553;
         }
     };
     /* block 1553 */;
@@ -1566,57 +697,16 @@ public fun hard_ways_bet(): u64 {
 }
 
 public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u64>, l5: &vector<Bet>) {
-    let l6;
-    if (l0 < 19u64) {
-        l6 = l0 >= 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_11;
-        }
-    };
+    let l6 = l0 < 19u64 && l0 >= 0u64;
     /* block 11 */;
     assert!(l6, C0);
-    let l10;
-    if (l0 == C0) {
-        l10 = true;
-        unstructured {
-            goto 'label_29;
-        }
-    } else {
-        l10 = l0 == C1;
-        unstructured {
-            goto 'label_29;
-        }
-    };
     /* block 29 */;
-    if (l10) {
-        assert!(l3 == 0u64, C0);
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        unstructured {
-            goto 'label_40;
-        }
+    if (l0 == C0 || l0 == C1) {
+        assert!(l3 == 0u64, C0)
     };
     /* block 40 */;
     if (l0 == C14) {
-        let l11;
-        if (l3 == *(option::borrow(&l2))) {
-            l11 = l3 != 0u64;
-            unstructured {
-                goto 'label_57;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_57;
-            }
-        };
+        let l11 = l3 == *(option::borrow(&l2)) && l3 != 0u64;
         /* block 57 */;
         assert!(l11, C0);
         let l26 = 0u64;
@@ -1629,29 +719,11 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             };
             l26 = l26 + 1u64;
         };
-        assert!(l25, C0);
-        unstructured {
-            goto 'label_113;
-        }
-    } else {
-        unstructured {
-            goto 'label_113;
-        }
+        assert!(l25, C0)
     };
     /* block 113 */;
     if (l0 == C15) {
-        let l12;
-        if (l3 == *(option::borrow(&l2))) {
-            l12 = l3 != 0u64;
-            unstructured {
-                goto 'label_130;
-            }
-        } else {
-            l12 = false;
-            unstructured {
-                goto 'label_130;
-            }
-        };
+        let l12 = l3 == *(option::borrow(&l2)) && l3 != 0u64;
         /* block 130 */;
         assert!(l12, C0);
         let l27 = 0u64;
@@ -1664,39 +736,14 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             };
             l27 = l27 + 1u64;
         };
-        assert!(l24, C0);
-        unstructured {
-            goto 'label_186;
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
-        }
+        assert!(l24, C0)
     };
-    let l13;
     /* block 186 */;
-    if (l0 == C9) {
-        l13 = true;
-        unstructured {
-            goto 'label_197;
-        }
-    } else {
-        l13 = l0 == C10;
-        unstructured {
-            goto 'label_197;
-        }
-    };
+    let l13 = l0 == C9 || l0 == C10;
     /* block 197 */;
     if (l13) {
         assert!(option::is_none(&l2), C0);
-        assert!(l3 != 0u64, C0);
-        unstructured {
-            goto 'label_216;
-        }
-    } else {
-        unstructured {
-            goto 'label_216;
-        }
+        assert!(l3 != 0u64, C0)
     };
     /* block 216 */;
     if (l0 == C16) {
@@ -1722,10 +769,6 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             break
         };
         assert!(__c282, C0)
-    } else {
-        unstructured {
-            goto 'label_289;
-        }
     };
     /* block 289 */;
     if (l0 == C17) {
@@ -1751,171 +794,54 @@ public fun is_valid_bet(l0: u64, l1: u64, l2: Option<u64>, l3: u64, l4: vector<u
             break
         };
         assert!(__c357, C0)
-    } else {
-        unstructured {
-            goto 'label_364;
-        }
     };
     /* block 364 */;
     if (l0 == C3) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C19, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_384;
-        }
-    } else {
-        unstructured {
-            goto 'label_384;
-        }
+        assert!(vector::contains(&C19, option::borrow(&l2)), C1)
     };
     /* block 384 */;
     if (l0 == C5) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C19, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_404;
-        }
-    } else {
-        unstructured {
-            goto 'label_404;
-        }
+        assert!(vector::contains(&C19, option::borrow(&l2)), C1)
     };
     /* block 404 */;
     if (l0 == C4) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C19, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_424;
-        }
-    } else {
-        unstructured {
-            goto 'label_424;
-        }
+        assert!(vector::contains(&C19, option::borrow(&l2)), C1)
     };
     /* block 424 */;
     if (l0 == C11) {
         assert!(option::is_some(&l2), C1);
-        assert!(vector::contains(&C20, option::borrow(&l2)), C1);
-        unstructured {
-            goto 'label_444;
-        }
-    } else {
-        unstructured {
-            goto 'label_444;
-        }
+        assert!(vector::contains(&C20, option::borrow(&l2)), C1)
     };
     /* block 444 */;
     if (l0 == C12) {
         if (option::is_some(&l2)) {
-            let l7;
-            if (vector::contains(&C21, option::borrow(&l2))) {
-                l7 = true;
-                unstructured {
-                    goto 'label_467;
-                }
-            } else {
-                l7 = *(option::borrow(&l2)) == 11u64;
-                unstructured {
-                    goto 'label_467;
-                }
-            };
             /* block 467 */;
-            assert!(l7, C1);
-            unstructured {
-                goto 'label_472;
-            }
-        } else {
-            unstructured {
-                goto 'label_472;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_472;
+            assert!(vector::contains(&C21, option::borrow(&l2)) || *(option::borrow(&l2)) == 11u64, C1)
         }
     };
-    let l9;
     /* block 472 */;
-    if (l0 == C6) {
-        l9 = true;
-        unstructured {
-            goto 'label_490;
-        }
-    } else {
-        if (l0 == C7) {
-            l9 = true;
-            unstructured {
-                goto 'label_490;
-            }
-        } else {
-            l9 = l0 == C8;
-            unstructured {
-                goto 'label_490;
-            }
-        }
-    };
+    let l9 = l0 == C6 || l0 == C7 || l0 == C8;
     /* block 490 */;
     if (l9) {
-        assert!(&l4.len() == 0u64, C0);
-        unstructured {
-            goto 'label_500;
-        }
-    } else {
-        unstructured {
-            goto 'label_500;
-        }
+        assert!(&l4.len() == 0u64, C0)
     };
     /* block 500 */
 }
 
 public fun is_valid_remove(l0: u64, l1: Option<u64>, l2: u64, l3: u8, l4: vector<u64>, l5: &vector<Bet>) {
     assert!(l3 != 1u8, C2);
-    let l6;
-    if (l0 == C0) {
-        l6 = true;
-        unstructured {
-            goto 'label_18;
-        }
-    } else {
-        l6 = l0 == C1;
-        unstructured {
-            goto 'label_18;
-        }
-    };
     /* block 18 */;
-    if (l6) {
-        assert!(l2 == 0u64, C2);
-        unstructured {
-            goto 'label_27;
-        }
-    } else {
-        unstructured {
-            goto 'label_27;
-        }
+    if (l0 == C0 || l0 == C1) {
+        assert!(l2 == 0u64, C2)
     };
-    let l7;
     /* block 27 */;
-    if (l0 == C9) {
-        l7 = true;
-        unstructured {
-            goto 'label_38;
-        }
-    } else {
-        l7 = l0 == C10;
-        unstructured {
-            goto 'label_38;
-        }
-    };
+    let l7 = l0 == C9 || l0 == C10;
     /* block 38 */;
     if (l7) {
-        assert!(option::is_none(&l1), C2);
-        unstructured {
-            goto 'label_46;
-        }
-    } else {
-        unstructured {
-            goto 'label_46;
-        }
+        assert!(option::is_none(&l1), C2)
     };
     /* block 46 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x3001c0d95f0498b8e92fe95878b25e1c2e85ff213f3ff5b1ef088390ed185fc1/cetus_clmm_worker.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x3001c0d95f0498b8e92fe95878b25e1c2e85ff213f3ff5b1ef088390ed185fc1/cetus_clmm_worker.move
@@ -239,15 +239,9 @@ public entry fun add_collateral_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
     let l45 = cetus_clmm_worker::share_to_balance(freeze(l0), l53);
     let l47 = cetus_clmm_worker::work_inner(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
     if (coin::value(&l47) == 0u64) {
-        coin::destroy_zero(l47);
-        unstructured {
-            goto 'label_143;
-        }
+        coin::destroy_zero(l47)
     } else {
-        pay::keep(l47, freeze(l14));
-        unstructured {
-            goto 'label_143;
-        }
+        pay::keep(l47, freeze(l14))
     };
     /* block 143 */;
     let l50 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l1), freeze(l4), l11, l12, l13);
@@ -273,15 +267,9 @@ public entry fun add_collateral_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
     let l48 = vault::get_add_collateral_context_debt(&l44);
     let l47 = cetus_clmm_worker::work_inner_reverse(l0, l3, l4, l5, l46, l7, l48, l9, l10, l13, l14);
     if (coin::value(&l47) == 0u64) {
-        coin::destroy_zero(l47);
-        unstructured {
-            goto 'label_145;
-        }
+        coin::destroy_zero(l47)
     } else {
-        pay::keep(l47, freeze(l14));
-        unstructured {
-            goto 'label_145;
-        }
+        pay::keep(l47, freeze(l14))
     };
     /* block 145 */;
     let l50 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l1), freeze(l4), l11, l12, l13);
@@ -296,31 +284,17 @@ fun add_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64, l2: u128, l3
     if (l2 > 0u128) {
         let l9 = cetus_clmm_worker::balance_to_share_inner(freeze(l0), l2, l3);
         assert!(l9 > 0u128, C3);
-        let l7;
         let l10 = &mut l0.shares;
-        if (table::contains(freeze(l10), l1)) {
-            l7 = table::borrow_mut(l10, l1);
-            unstructured {
-                goto 'label_46;
-            }
+        let l7 = if (table::contains(freeze(l10), l1)) {
+            table::borrow_mut(l10, l1)
         } else {
             table::add(l10, l1, 0u128);
-            l7 = table::borrow_mut(l10, l1);
-            unstructured {
-                goto 'label_46;
-            }
+            table::borrow_mut(l10, l1)
         };
         /* block 46 */;
         let l8 = l7;
         *l8 = *l8 + l9;
-        *(&mut l0.total_share) = *(&l0.total_share) + l9;
-        unstructured {
-            goto 'label_65;
-        }
-    } else {
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut l0.total_share) = *(&l0.total_share) + l9
     };
     /* block 65 */
 }
@@ -352,22 +326,8 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -375,22 +335,8 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -403,32 +349,12 @@ public fun collect_reward<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -444,22 +370,8 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -467,22 +379,8 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -495,32 +393,12 @@ public fun collect_reward_all_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -536,22 +414,8 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -559,22 +423,8 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -588,18 +438,8 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -607,37 +447,14 @@ public fun collect_reward_all_reverse_one_other<T0, T1, T2, T3>(l0: &mut WorkerI
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -653,22 +470,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -676,22 +479,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -705,18 +494,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -724,37 +503,14 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -768,18 +524,8 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact_reverse(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -787,37 +533,14 @@ public fun collect_reward_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -833,22 +556,8 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -856,22 +565,8 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -885,18 +580,8 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -904,37 +589,14 @@ public fun collect_reward_one_other<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T1, 
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -950,22 +612,8 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -973,22 +621,8 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -1001,32 +635,12 @@ public fun collect_reward_pool_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1042,22 +656,8 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -1065,22 +665,8 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -1094,18 +680,8 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -1113,37 +689,14 @@ public fun collect_reward_pool_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1159,22 +712,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -1182,22 +721,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -1211,18 +736,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -1230,37 +745,14 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -1274,18 +766,8 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -1293,37 +775,14 @@ public fun collect_reward_pool_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1339,22 +798,8 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l19 = mole_math::mul_div(balance::value(&l12), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l12) >= l19) {
             let l21 = balance::split(&mut l12, l19);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l6) {
@@ -1362,22 +807,8 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
         let l23 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l15) >= l23) {
             let l24 = balance::split(&mut l15, l23);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l7) {
@@ -1390,32 +821,12 @@ public fun collect_reward_swap_reverse<T0, T1, T2, T3>(l0: &mut WorkerInfo<T0, T
             let l20 = mole_math::mul_div(balance::value(&l13), *(&l0.reinvest_bounty_bps), C43);
             if (balance::value(&l13) >= l20) {
                 let l22 = balance::split(&mut l13, l20);
-                unstructured {
-                    goto 'label_151;
-                }
-            } else {
-                unstructured {
-                    goto 'label_151;
-                }
             };
-            /* block 151 */;
-            unstructured {
-                goto 'label_167;
-            }
+            /* block 151 */
         } else {
-            coin::destroy_zero(coin::from_balance(l16, l9));
-            unstructured {
-                goto 'label_167;
-            }
+            coin::destroy_zero(coin::from_balance(l16, l9))
         };
-        /* block 167 */;
-        unstructured {
-            goto 'label_180;
-        }
-    } else {
-        unstructured {
-            goto 'label_180;
-        }
+        /* block 167 */
     };
     /* block 180 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1431,22 +842,8 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l24 = mole_math::mul_div(balance::value(&l14), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l14) >= l24) {
             let l26 = balance::split(&mut l14, l24);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l7) {
@@ -1454,22 +851,8 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
         let l28 = mole_math::mul_div(balance::value(&l17), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l17) >= l28) {
             let l30 = balance::split(&mut l17, l28);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l8) {
@@ -1483,18 +866,8 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l25 = mole_math::mul_div(balance::value(&l15), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l15) >= l25) {
                     let l27 = balance::split(&mut l15, l25);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l11), coin::from_balance(l19, l11), false, true, l12, l10, l11);
                 coin::destroy_zero(reg_144);
@@ -1502,37 +875,14 @@ public fun collect_reward_swap_reverse_one_other<T0, T1, T2, T3>(l0: &mut Worker
                 let l29 = mole_math::mul_div(balance::value(&l18), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l18) >= l29) {
                     let l31 = balance::split(&mut l18, l29);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_223;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l19, l11));
-            unstructured {
-                goto 'label_223;
-            }
+            coin::destroy_zero(coin::from_balance(l19, l11))
         };
-        /* block 223 */;
-        unstructured {
-            goto 'label_238;
-        }
-    } else {
-        unstructured {
-            goto 'label_238;
-        }
+        /* block 223 */
     };
     /* block 238 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1548,22 +898,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -1571,22 +907,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -1600,18 +922,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact_reverse(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -1619,37 +931,14 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -1663,18 +952,8 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact_reverse(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -1682,37 +961,14 @@ public fun collect_reward_swap_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1728,22 +984,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         let l36 = mole_math::mul_div(balance::value(&l19), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l19) >= l36) {
             let l39 = balance::split(&mut l19, l36);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l9) {
@@ -1751,22 +993,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
         let l42 = mole_math::mul_div(balance::value(&l23), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l23) >= l42) {
             let l45 = balance::split(&mut l23, l42);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        unstructured {
-            goto 'label_90;
-        }
+        /* block 85 */
     };
     /* block 90 */;
     if (l10) {
@@ -1780,18 +1008,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l37 = mole_math::mul_div(balance::value(&l20), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l20) >= l37) {
                     let l40 = balance::split(&mut l20, l37);
-                    unstructured {
-                        goto 'label_155;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_155;
-                    }
                 };
-                /* block 155 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 155 */
             } else {
                 let (reg_143, reg_144) = cetus_clmm_utils::swap_exact(l1, l5, coin::zero(l15), coin::from_balance(l26, l15), false, true, l16, l14, l15);
                 coin::destroy_zero(reg_144);
@@ -1799,37 +1017,14 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l43 = mole_math::mul_div(balance::value(&l24), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l24) >= l43) {
                     let l46 = balance::split(&mut l24, l43);
-                    unstructured {
-                        goto 'label_205;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_205;
-                    }
                 };
-                /* block 205 */;
-                unstructured {
-                    goto 'label_210;
-                }
+                /* block 205 */
             };
-            /* block 210 */;
-            unstructured {
-                goto 'label_219;
-            }
+            /* block 210 */
         } else {
-            coin::destroy_zero(coin::from_balance(l26, l15));
-            unstructured {
-                goto 'label_219;
-            }
+            coin::destroy_zero(coin::from_balance(l26, l15))
         };
-        /* block 219 */;
-        unstructured {
-            goto 'label_224;
-        }
-    } else {
-        unstructured {
-            goto 'label_224;
-        }
+        /* block 219 */
     };
     /* block 224 */;
     if (l11) {
@@ -1843,18 +1038,8 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l38 = mole_math::mul_div(balance::value(&l21), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l21) >= l38) {
                     let l41 = balance::split(&mut l21, l38);
-                    unstructured {
-                        goto 'label_289;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_289;
-                    }
                 };
-                /* block 289 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 289 */
             } else {
                 let (reg_246, reg_247) = cetus_clmm_utils::swap_exact(l1, l7, coin::zero(l15), coin::from_balance(l27, l15), false, true, l17, l14, l15);
                 coin::destroy_zero(reg_247);
@@ -1862,37 +1047,14 @@ public fun collect_reward_two_others<T0, T1, T2, T3, T4>(l0: &mut WorkerInfo<T0,
                 let l44 = mole_math::mul_div(balance::value(&l25), *(&l0.reinvest_bounty_bps), C43);
                 if (balance::value(&l25) >= l44) {
                     let l47 = balance::split(&mut l25, l44);
-                    unstructured {
-                        goto 'label_339;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_339;
-                    }
                 };
-                /* block 339 */;
-                unstructured {
-                    goto 'label_344;
-                }
+                /* block 339 */
             };
-            /* block 344 */;
-            unstructured {
-                goto 'label_357;
-            }
+            /* block 344 */
         } else {
-            coin::destroy_zero(coin::from_balance(l27, l15));
-            unstructured {
-                goto 'label_357;
-            }
+            coin::destroy_zero(coin::from_balance(l27, l15))
         };
-        /* block 357 */;
-        unstructured {
-            goto 'label_372;
-        }
-    } else {
-        unstructured {
-            goto 'label_372;
-        }
+        /* block 357 */
     };
     /* block 372 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1908,22 +1070,8 @@ public fun collect_reward_without_swap<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
         let l11 = mole_math::mul_div(balance::value(&l8), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l8) >= l11) {
             let l12 = balance::split(&mut l8, l11);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l5) {
@@ -1931,22 +1079,8 @@ public fun collect_reward_without_swap<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T
         let l13 = mole_math::mul_div(balance::value(&l10), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_99;
-        }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
+        /* block 85 */
     };
     /* block 99 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -1962,22 +1096,8 @@ public fun collect_reward_without_swap_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
         let l11 = mole_math::mul_div(balance::value(&l8), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l8) >= l11) {
             let l12 = balance::split(&mut l8, l11);
-            unstructured {
-                goto 'label_46;
-            }
-        } else {
-            unstructured {
-                goto 'label_46;
-            }
         };
-        /* block 46 */;
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        /* block 46 */
     };
     /* block 51 */;
     if (l5) {
@@ -1985,22 +1105,8 @@ public fun collect_reward_without_swap_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T
         let l13 = mole_math::mul_div(balance::value(&l10), *(&l0.reinvest_bounty_bps), C43);
         if (balance::value(&l10) >= l13) {
             let l14 = balance::split(&mut l10, l13);
-            unstructured {
-                goto 'label_85;
-            }
-        } else {
-            unstructured {
-                goto 'label_85;
-            }
         };
-        /* block 85 */;
-        unstructured {
-            goto 'label_99;
-        }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
+        /* block 85 */
     };
     /* block 99 */;
     return (balance::value(&l0.tiny_coin_base), balance::value(&l0.tiny_coin_farming))
@@ -2015,18 +1121,7 @@ fun get_mkt_sell_amount(l0: u64, l1: u64, l2: u64): u64 {
     if (l0 == 0u64) {
         return 0u64
     };
-    let l3;
-    if (l1 > 0u64) {
-        l3 = l2 > 0u64;
-        unstructured {
-            goto 'label_17;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_17;
-        }
-    };
+    let l3 = l1 > 0u64 && l2 > 0u64;
     /* block 17 */;
     assert!(l3, C5);
     let l4 = l0 * 9980u64;
@@ -2055,13 +1150,6 @@ public fun health<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T0, T1>, l2
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        unstructured {
-            goto 'label_19;
-        }
     };
     let (l11, l3, l6, l9);
     /* block 19 */;
@@ -2070,30 +1158,18 @@ public fun health<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T0, T1>, l2
     let (reg_25, reg_26) = position::tick_range(option::borrow(&l0.position_nft));
     let (reg_33, reg_34) = clmm_math::get_amount_by_liquidity(reg_25, reg_26, pool::current_tick_index(l1), pool::current_sqrt_price(l1), l9, false);
     l11 = reg_34;
-    if (l9 == 0u128) {
-        l3 = 0u64;
-        unstructured {
-            goto 'label_58;
-        }
+    l3 = if (l9 == 0u128) {
+        0u64
     } else {
-        l3 = mole_math::mul_div_u128(l6, reg_33as u128, l9)as u64;
-        unstructured {
-            goto 'label_58;
-        }
+        mole_math::mul_div_u128(l6, reg_33as u128, l9)as u64
     };
     let (l12, l4);
     /* block 58 */;
     l12 = l3;
-    if (l9 == 0u128) {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_74;
-        }
+    l4 = if (l9 == 0u128) {
+        0u64
     } else {
-        l4 = mole_math::mul_div_u128(l6, l11as u128, l9)as u64;
-        unstructured {
-            goto 'label_74;
-        }
+        mole_math::mul_div_u128(l6, l11as u128, l9)as u64
     };
     /* block 74 */;
     let l13 = l4;
@@ -2106,13 +1182,6 @@ public fun health_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T1,
     let l7 = 0u128;
     if (table::contains(l8, l2)) {
         l7 = *(table::borrow(l8, l2));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        unstructured {
-            goto 'label_19;
-        }
     };
     let (l11, l3, l6, l9);
     /* block 19 */;
@@ -2121,30 +1190,18 @@ public fun health_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Pool<T1,
     let (reg_25, reg_26) = position::tick_range(option::borrow(&l0.position_nft));
     let (reg_33, reg_34) = clmm_math::get_amount_by_liquidity(reg_25, reg_26, pool::current_tick_index(l1), pool::current_sqrt_price(l1), l9, false);
     l11 = reg_33;
-    if (l9 == 0u128) {
-        l3 = 0u64;
-        unstructured {
-            goto 'label_58;
-        }
+    l3 = if (l9 == 0u128) {
+        0u64
     } else {
-        l3 = mole_math::mul_div_u128(l6, reg_34as u128, l9)as u64;
-        unstructured {
-            goto 'label_58;
-        }
+        mole_math::mul_div_u128(l6, reg_34as u128, l9)as u64
     };
     let (l12, l4);
     /* block 58 */;
     l12 = l3;
-    if (l9 == 0u128) {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_74;
-        }
+    l4 = if (l9 == 0u128) {
+        0u64
     } else {
-        l4 = mole_math::mul_div_u128(l6, l11as u128, l9)as u64;
-        unstructured {
-            goto 'label_74;
-        }
+        mole_math::mul_div_u128(l6, l11as u128, l9)as u64
     };
     /* block 74 */;
     let l13 = l4;
@@ -2186,41 +1243,17 @@ public entry fun initialize_reverse<T0, T1, T2>(l0: &AdminCap, l1: &x5_AdminCap,
 }
 
 public fun is_rebalancer<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: address): bool {
-    let l2;
     cetus_clmm_worker::checked_package_version(l0);
     let l3 = &l0.ok_rebalancers;
-    if (table::contains(l3, l1)) {
-        l2 = *(table::borrow(l3, l1));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_19;
-        }
-    };
     /* block 19 */;
-    return l2
+    return table::contains(l3, l1) && *(table::borrow(l3, l1))
 }
 
 public fun is_reinvestor<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: address): bool {
-    let l2;
     cetus_clmm_worker::checked_package_version(l0);
     let l3 = &l0.ok_reinvestors;
-    if (table::contains(l3, l1)) {
-        l2 = *(table::borrow(l3, l1));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_19;
-        }
-    };
     /* block 19 */;
-    return l2
+    return table::contains(l3, l1) && *(table::borrow(l3, l1))
 }
 
 public fun is_reserve_consistent<T0, T1, T2>(): bool {
@@ -2238,21 +1271,10 @@ public fun is_stable<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &GlobalStorage
     if (reg_16 + 86400u64 <= l12) {
         return false
     };
-    let l6;
     let l9 = reg_6 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / reg_5 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
     let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
     let l11 = worker_config::get_max_price_diff_scale();
-    if (l9 * l11 > l14 * l10) {
-        l6 = true;
-        unstructured {
-            goto 'label_91;
-        }
-    } else {
-        l6 = l9 * l10 < l14 * l11;
-        unstructured {
-            goto 'label_91;
-        }
-    };
+    let l6 = l9 * l11 > l14 * l10 || l9 * l10 < l14 * l11;
     /* block 91 */;
     if (l6) {
         return false
@@ -2271,21 +1293,10 @@ public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Globa
     if (reg_16 + 86400u64 <= l12) {
         return false
     };
-    let l6;
     let l9 = reg_5 * math::pow(10u64, 8u8)as u128 * math::pow(10u64, 9u8 - *(&l0.coin_farming_decimals))as u128 / reg_6 / math::pow(10u64, 9u8 - *(&l0.coin_base_decimals))as u128as u64;
     let l10 = worker_config::get_max_price_diff(l1, l7, cetus_clmm_worker::get_mole_cetus_worker_addr());
     let l11 = worker_config::get_max_price_diff_scale();
-    if (l9 * l11 > l14 * l10) {
-        l6 = true;
-        unstructured {
-            goto 'label_91;
-        }
-    } else {
-        l6 = l9 * l10 < l14 * l11;
-        unstructured {
-            goto 'label_91;
-        }
-    };
+    let l6 = l9 * l11 > l14 * l10 || l9 * l10 < l14 * l11;
     /* block 91 */;
     if (l6) {
         return false
@@ -2294,22 +1305,10 @@ public fun is_stable_reverse<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: &Globa
 }
 
 public fun is_strategy_ok<T0, T1, T2>(l0: &WorkerInfo<T0, T1, T2>, l1: u8): bool {
-    let l2;
     cetus_clmm_worker::checked_package_version(l0);
     let l3 = &l0.ok_strategies;
-    if (table::contains(l3, l1)) {
-        l2 = *(table::borrow(l3, l1));
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_19;
-        }
-    };
     /* block 19 */;
-    return l2
+    return table::contains(l3, l1) && *(table::borrow(l3, l1))
 }
 
 fun join_split_keep<T0>(l0: vector<Coin<T0>>, l1: u64, l2: &mut TxContext): Coin<T0> {
@@ -2405,38 +1404,21 @@ public entry fun rebalance_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut W
 fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
     assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
-    let l12;
     let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-    if (i32::as_u32(reg_16) == l3) {
-        l12 = i32::as_u32(reg_17) == l4;
-        unstructured {
-            goto 'label_39;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_39;
-        }
-    };
+    let l12 = i32::as_u32(reg_16) == l3 && i32::as_u32(reg_17) == l4;
     /* block 39 */;
     assert!(!(l12), C25);
     let (l13, l14);
     let l23 = pool::open_position(l1, l2, l3, l4, l10);
     let l24 = option::extract(&mut l0.position_nft);
     let l21 = position::liquidity(&l24);
-    if (l21 > 0u128) {
+    l13 = if (l21 > 0u128) {
         let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
         l14 = reg_53;
-        l13 = reg_52;
-        unstructured {
-            goto 'label_84;
-        }
+        reg_52
     } else {
         l14 = balance::zero();
-        l13 = balance::zero();
-        unstructured {
-            goto 'label_84;
-        }
+        balance::zero()
     };
     let (l15, l17, l18);
     /* block 84 */;
@@ -2444,43 +1426,15 @@ fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConf
     l17 = l13;
     pool::close_position(l1, l2, l24);
     option::fill(&mut l0.position_nft, l23);
-    if (balance::value(&l17) > 0u64) {
-        l15 = true;
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        l15 = balance::value(&l18) > 0u64;
-        unstructured {
-            goto 'label_121;
-        }
-    };
+    l15 = balance::value(&l17) > 0u64 || balance::value(&l18) > 0u64;
     /* block 121 */;
     if (l15) {
-        let l16;
         let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-        if (coin::value(&reg_99) <= l6) {
-            l16 = coin::value(&reg_100) <= l7;
-            unstructured {
-                goto 'label_154;
-            }
-        } else {
-            l16 = false;
-            unstructured {
-                goto 'label_154;
-            }
-        };
         /* block 154 */;
-        assert!(l16, C26);
-        unstructured {
-            goto 'label_186;
-        }
+        assert!(coin::value(&reg_99) <= l6 && coin::value(&reg_100) <= l7, C26)
     } else {
         balance::destroy_zero(l17);
-        balance::destroy_zero(l18);
-        unstructured {
-            goto 'label_186;
-        }
+        balance::destroy_zero(l18)
     };
     /* block 186 */;
     let l22 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2491,38 +1445,21 @@ fun rebalance_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConf
 fun rebalance_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u32, l4: u32, l5: u128, l6: u64, l7: u64, l8: vector<u8>, l9: &Clock, l10: &mut TxContext) {
     let l11 = tx_context::sender(freeze(l10));
     assert!(cetus_clmm_worker::is_rebalancer(freeze(l0), l11), C31);
-    let l12;
     let (reg_16, reg_17) = position::tick_range(option::borrow(&l0.position_nft));
-    if (i32::as_u32(reg_16) == l3) {
-        l12 = i32::as_u32(reg_17) == l4;
-        unstructured {
-            goto 'label_39;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_39;
-        }
-    };
+    let l12 = i32::as_u32(reg_16) == l3 && i32::as_u32(reg_17) == l4;
     /* block 39 */;
     assert!(!(l12), C25);
     let (l13, l14);
     let l23 = pool::open_position(l1, l2, l3, l4, l10);
     let l24 = option::extract(&mut l0.position_nft);
     let l21 = position::liquidity(&l24);
-    if (l21 > 0u128) {
+    l13 = if (l21 > 0u128) {
         let (reg_52, reg_53) = pool::remove_liquidity(l1, l2, &mut l24, l21, l9);
         l14 = reg_53;
-        l13 = reg_52;
-        unstructured {
-            goto 'label_84;
-        }
+        reg_52
     } else {
         l14 = balance::zero();
-        l13 = balance::zero();
-        unstructured {
-            goto 'label_84;
-        }
+        balance::zero()
     };
     let (l15, l17, l18);
     /* block 84 */;
@@ -2530,43 +1467,15 @@ fun rebalance_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &Gl
     l18 = l13;
     pool::close_position(l1, l2, l24);
     option::fill(&mut l0.position_nft, l23);
-    if (balance::value(&l17) > 0u64) {
-        l15 = true;
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        l15 = balance::value(&l18) > 0u64;
-        unstructured {
-            goto 'label_121;
-        }
-    };
+    l15 = balance::value(&l17) > 0u64 || balance::value(&l18) > 0u64;
     /* block 121 */;
     if (l15) {
-        let l16;
         let (reg_99, reg_100) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l17, l10), coin::from_balance(l18, l10), 0u128, 0u64, C38, l8, l9, l10);
-        if (coin::value(&reg_99) <= l6) {
-            l16 = coin::value(&reg_100) <= l7;
-            unstructured {
-                goto 'label_154;
-            }
-        } else {
-            l16 = false;
-            unstructured {
-                goto 'label_154;
-            }
-        };
         /* block 154 */;
-        assert!(l16, C26);
-        unstructured {
-            goto 'label_186;
-        }
+        assert!(coin::value(&reg_99) <= l6 && coin::value(&reg_100) <= l7, C26)
     } else {
         balance::destroy_zero(l17);
-        balance::destroy_zero(l18);
-        unstructured {
-            goto 'label_186;
-        }
+        balance::destroy_zero(l18)
     };
     /* block 186 */;
     let l22 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2661,36 +1570,14 @@ public entry fun reinvest_all_reverse_two_others<T0, T1, T2, T3, T4>(l0: &mut Wo
 fun reinvest_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
     assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
-    let l10;
     let l16 = position::liquidity(option::borrow(&l0.position_nft));
     let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
     let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-    if (balance::value(&l12) == 0u64) {
-        l10 = balance::value(&l13) == 0u64;
-        unstructured {
-            goto 'label_48;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_48;
-        }
-    };
+    let l10 = balance::value(&l12) == 0u64 && balance::value(&l13) == 0u64;
     /* block 48 */;
     assert!(!(l10), C28);
-    let l11;
     let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-    if (coin::value(&reg_54) <= l4) {
-        l11 = coin::value(&reg_55) <= l5;
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_93;
-        }
-    };
+    let l11 = coin::value(&reg_54) <= l4 && coin::value(&reg_55) <= l5;
     /* block 93 */;
     assert!(l11, C26);
     let l17 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2701,36 +1588,14 @@ fun reinvest_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfi
 fun reinvest_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u128, l4: u64, l5: u64, l6: vector<u8>, l7: &Clock, l8: &mut TxContext) {
     let l9 = tx_context::sender(freeze(l8));
     assert!(cetus_clmm_worker::is_reinvestor(freeze(l0), l9), C19);
-    let l10;
     let l16 = position::liquidity(option::borrow(&l0.position_nft));
     let l12 = balance::withdraw_all(&mut l0.tiny_coin_base);
     let l13 = balance::withdraw_all(&mut l0.tiny_coin_farming);
-    if (balance::value(&l12) == 0u64) {
-        l10 = balance::value(&l13) == 0u64;
-        unstructured {
-            goto 'label_48;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_48;
-        }
-    };
+    let l10 = balance::value(&l12) == 0u64 && balance::value(&l13) == 0u64;
     /* block 48 */;
     assert!(!(l10), C28);
-    let l11;
     let (reg_54, reg_55) = cetus_clmm_worker::strategy_execute_reverse(l0, l1, l2, coin::from_balance(l12, l8), coin::from_balance(l13, l8), 0u128, 0u64, C38, l6, l7, l8);
-    if (coin::value(&reg_54) <= l4) {
-        l11 = coin::value(&reg_55) <= l5;
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_93;
-        }
-    };
+    let l11 = coin::value(&reg_54) <= l4 && coin::value(&reg_55) <= l5;
     /* block 93 */;
     assert!(l11, C26);
     let l17 = position::liquidity(option::borrow(&l0.position_nft));
@@ -2806,13 +1671,6 @@ fun remove_share<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: u64): u128 {
             *(&mut l0.total_share) = *(&l0.total_share) - l3;
             *(table::borrow_mut(&mut l0.shares, l1)) = 0u128;
             return l2
-        };
-        unstructured {
-            goto 'label_46;
-        }
-    } else {
-        unstructured {
-            goto 'label_46;
         }
     };
     /* block 46 */;
@@ -2856,15 +1714,9 @@ public entry fun set_reinvestor_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInf
     cetus_clmm_worker::checked_package_version(freeze(l1));
     let l5 = &mut l1.ok_reinvestors;
     if (table::contains(freeze(l5), l2)) {
-        *(table::borrow_mut(l5, l2)) = l3;
-        unstructured {
-            goto 'label_23;
-        }
+        *(table::borrow_mut(l5, l2)) = l3
     } else {
-        table::add(l5, l2, l3);
-        unstructured {
-            goto 'label_23;
-        }
+        table::add(l5, l2, l3)
     };
     /* block 23 */
 }
@@ -2905,15 +1757,9 @@ public entry fun set_strategy_ok<T0, T1, T2>(l0: &AdminCap, l1: &mut WorkerInfo<
     cetus_clmm_worker::checked_package_version(freeze(l1));
     let l5 = &mut l1.ok_strategies;
     if (table::contains(freeze(l5), l2)) {
-        *(table::borrow_mut(l5, l2)) = l3;
-        unstructured {
-            goto 'label_23;
-        }
+        *(table::borrow_mut(l5, l2)) = l3
     } else {
-        table::add(l5, l2, l3);
-        unstructured {
-            goto 'label_23;
-        }
+        table::add(l5, l2, l3)
     };
     /* block 23 */
 }
@@ -2998,15 +1844,9 @@ public entry fun withdraw_rewards_bounty<T0, T1, T2>(l0: &AdminCap, l1: &mut Wor
     if (l2) {
         l3 = balance::value(&l1.tiny_coin_base_bounty);
         l4 = balance::value(&l1.tiny_coin_farming_bounty);
-        unstructured {
-            goto 'label_40;
-        }
     } else {
         assert!(l3 <= balance::value(&l1.tiny_coin_base_bounty), C33);
-        assert!(l4 <= balance::value(&l1.tiny_coin_farming_bounty), C34);
-        unstructured {
-            goto 'label_40;
-        }
+        assert!(l4 <= balance::value(&l1.tiny_coin_farming_bounty), C34)
     };
     /* block 40 */;
     let l6 = balance::split(&mut l1.tiny_coin_base_bounty, l3);
@@ -3023,20 +1863,9 @@ public entry fun work<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &mut Glob
 }
 
 fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T0, T1>, l3: u64, l4: Coin<T0>, l5: Coin<T1>, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): Coin<T0> {
-    let l11;
     let l12 = cetus_clmm_worker::remove_share(l0, l3);
     let l17 = &l0.ok_strategies;
-    if (table::contains(l17, l7)) {
-        l11 = *(table::borrow(l17, l7));
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
+    let l11 = table::contains(l17, l7) && *(table::borrow(l17, l7));
     /* block 21 */;
     assert!(l11, C21);
     assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
@@ -3045,15 +1874,9 @@ fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l
     let l16 = reg_52;
     let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
     if (coin::value(&l16) == 0u64) {
-        coin::destroy_zero(l16);
-        unstructured {
-            goto 'label_99;
-        }
+        coin::destroy_zero(l16)
     } else {
-        pay::keep(l16, freeze(l10));
-        unstructured {
-            goto 'label_99;
-        }
+        pay::keep(l16, freeze(l10))
     };
     /* block 99 */;
     cetus_clmm_worker::add_share(l0, l3, l13, l14);
@@ -3061,20 +1884,9 @@ fun work_inner<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l
 }
 
 fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalConfig, l2: &mut Pool<T1, T0>, l3: u64, l4: Coin<T0>, l5: Coin<T1>, l6: u64, l7: u8, l8: vector<u8>, l9: &Clock, l10: &mut TxContext): Coin<T0> {
-    let l11;
     let l12 = cetus_clmm_worker::remove_share(l0, l3);
     let l17 = &l0.ok_strategies;
-    if (table::contains(l17, l7)) {
-        l11 = *(table::borrow(l17, l7));
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
+    let l11 = table::contains(l17, l7) && *(table::borrow(l17, l7));
     /* block 21 */;
     assert!(l11, C21);
     assert!(object::id(freeze(l2)) == *(&l0.pool_id), C24);
@@ -3083,15 +1895,9 @@ fun work_inner_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &GlobalC
     let l16 = reg_52;
     let l13 = position::liquidity(option::borrow(&l0.position_nft)) - l14;
     if (coin::value(&l16) == 0u64) {
-        coin::destroy_zero(l16);
-        unstructured {
-            goto 'label_99;
-        }
+        coin::destroy_zero(l16)
     } else {
-        pay::keep(l16, freeze(l10));
-        unstructured {
-            goto 'label_99;
-        }
+        pay::keep(l16, freeze(l10))
     };
     /* block 99 */;
     cetus_clmm_worker::add_share(l0, l3, l13, l14);
@@ -3151,29 +1957,16 @@ public entry fun work_single<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>, l1: &m
     vault::merge_work_context_coin_back(l39, l31);
     if (l34 > 0u64) {
         let l29 = l5;
-        vault::set_work_context_health(l39, cetus_clmm_worker::health(freeze(l0), freeze(l4), l29));
-        unstructured {
-            goto 'label_100;
-        }
-    } else {
-        unstructured {
-            goto 'label_100;
-        }
+        vault::set_work_context_health(l39, cetus_clmm_worker::health(freeze(l0), freeze(l4), l29))
     };
     /* block 100 */;
     let l36 = cetus_clmm_worker::is_stable(freeze(l0), freeze(l1), freeze(l4), l12, l13, l14);
     let l33 = vault::after_work(&l0.position_operator_cap, l1, l2, &l37, l38, l9, l36, l14, l15);
     coin::join(&mut l32, l33);
     if (coin::value(&l32) == 0u64) {
-        coin::destroy_zero(l32);
-        unstructured {
-            goto 'label_150;
-        }
+        coin::destroy_zero(l32)
     } else {
-        pay::keep(l32, freeze(l15));
-        unstructured {
-            goto 'label_150;
-        }
+        pay::keep(l32, freeze(l15))
     };
     /* block 150 */
 }
@@ -3194,29 +1987,16 @@ public entry fun work_single_reverse<T0, T1, T2>(l0: &mut WorkerInfo<T0, T1, T2>
     vault::merge_work_context_coin_back(l39, l31);
     if (l34 > 0u64) {
         let l29 = l5;
-        vault::set_work_context_health(l39, cetus_clmm_worker::health_reverse(freeze(l0), freeze(l4), l29));
-        unstructured {
-            goto 'label_100;
-        }
-    } else {
-        unstructured {
-            goto 'label_100;
-        }
+        vault::set_work_context_health(l39, cetus_clmm_worker::health_reverse(freeze(l0), freeze(l4), l29))
     };
     /* block 100 */;
     let l36 = cetus_clmm_worker::is_stable_reverse(freeze(l0), freeze(l1), freeze(l4), l12, l13, l14);
     let l33 = vault::after_work(&l0.position_operator_cap, l1, l2, &l37, l38, l9, l36, l14, l15);
     coin::join(&mut l32, l33);
     if (coin::value(&l32) == 0u64) {
-        coin::destroy_zero(l32);
-        unstructured {
-            goto 'label_150;
-        }
+        coin::destroy_zero(l32)
     } else {
-        pay::keep(l32, freeze(l15));
-        unstructured {
-            goto 'label_150;
-        }
+        pay::keep(l32, freeze(l15))
     };
     /* block 150 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4a68c41bfa2b908ce449e411d0e16718839a62780df0fee568bc027ee2d14ebb/safu.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4a68c41bfa2b908ce449e411d0e16718839a62780df0fee568bc027ee2d14ebb/safu.move
@@ -238,17 +238,10 @@ public fun deposit_scallop_spool<T0>(l0: &Version, l1: &mut Registry, l2: u64, l
     if (l10 == 0u64) {
         balance::destroy_zero(l9)
     } else {
-        let l8;
-        if (dynamic_object_field::exists_(&l14.id, ascii::string(C3))) {
-            l8 = dynamic_object_field::remove(&mut l14.id, ascii::string(C3));
-            unstructured {
-                goto 'label_143;
-            }
+        let l8 = if (dynamic_object_field::exists_(&l14.id, ascii::string(C3))) {
+            dynamic_object_field::remove(&mut l14.id, ascii::string(C3))
         } else {
-            l8 = xe_user::new_spool_account(l5, l6, l7);
-            unstructured {
-                goto 'label_143;
-            }
+            xe_user::new_spool_account(l5, l6, l7)
         };
         /* block 143 */;
         let l13 = l8;
@@ -272,17 +265,10 @@ public fun deposit_suilend<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: &mu
     if (l9 == 0u64) {
         balance::destroy_zero(l8)
     } else {
-        let l7;
-        if (dynamic_object_field::exists_(&l13.id, ascii::string(C5))) {
-            l7 = dynamic_object_field::remove(&mut l13.id, ascii::string(C5));
-            unstructured {
-                goto 'label_126;
-            }
+        let l7 = if (dynamic_object_field::exists_(&l13.id, ascii::string(C5))) {
+            dynamic_object_field::remove(&mut l13.id, ascii::string(C5))
         } else {
-            l7 = lending_market::create_obligation(l3, l6);
-            unstructured {
-                goto 'label_126;
-            }
+            lending_market::create_obligation(l3, l6)
         };
         /* block 126 */;
         let l12 = l7;
@@ -318,10 +304,6 @@ public(friend) fun get_user_share(l0: &Registry, l1: u64, l2: address): Option<S
             };
             l4 = l4 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
     };
     /* block 99 */;
     return option::none()
@@ -337,31 +319,19 @@ public fun incentivise<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: Balance
     assert!(reg_12, C13);
     if (l4) {
         assert!(*(&(&l22.info)[C15]) == 0u64, C17);
-        *(&mut (&mut l22.info)[C15]) = 1u64;
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut (&mut l22.info)[C15]) = 1u64
     } else {
         assert!(*(&(&l22.info)[C14]) == 0u64, C17);
-        *(&mut (&mut l22.info)[C14]) = 1u64;
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut (&mut l22.info)[C14]) = 1u64
     };
     let (l11, l8, l9);
     /* block 65 */;
     l11 = ascii::string(C34);
     l9 = &mut l11;
-    if (l4) {
-        l8 = ascii::string(C35);
-        unstructured {
-            goto 'label_79;
-        }
+    l8 = if (l4) {
+        ascii::string(C35)
     } else {
-        l8 = ascii::string(C36);
-        unstructured {
-            goto 'label_79;
-        }
+        ascii::string(C36)
     };
     let (l12, l13, l14, l18, l19, l20, l21);
     /* block 79 */;
@@ -398,7 +368,6 @@ entry fun issue_typus_manager_cap(l0: &x4b_Version, l1: &mut Registry, l2: &TxCo
 }
 
 entry fun new_vault<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: u64, l11: &mut TxContext) {
-    let l12;
     version::verify(l0, freeze(l11));
     let l17 = object::new(l11);
     dynamic_field::add(&mut l17, ascii::string(C1), balance::zero());
@@ -408,16 +377,10 @@ entry fun new_vault<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: u64, l4: u
     *(&mut (&mut l18)[C9]) = l2;
     *(&mut (&mut l18)[C10]) = l3;
     *(&mut (&mut l18)[C11]) = 0u64;
-    if (l9) {
-        l12 = 1u64;
-        unstructured {
-            goto 'label_48;
-        }
+    let l12 = if (l9) {
+        1u64
     } else {
-        l12 = 0u64;
-        unstructured {
-            goto 'label_48;
-        }
+        0u64
     };
     /* block 48 */;
     *(&mut (&mut l18)[C12]) = l12;
@@ -566,23 +529,17 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
         };
         big_vector::push_back(&mut l36.share, Share { user: l35, share: l29, u64_padding: vector[0u64, l20], bcs_padding: C37 })
     };
-    let (__c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l13, l14, l15, l16, l17, l18, l21, l23, l27, l28, reg_309, reg_310);
+    let (__c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l14, l15, l16, l17, l18, l21, l23, l27, l28, reg_309, reg_310);
     let l30 = big_vector::borrow_mut(&mut l36.share, l22);
     let l26 = *(&(&l30.u64_padding)[C7])as u256 * l20 - *(&(&l30.u64_padding)[C8])as u256 * *(&(&l36.config)[C12])as u256 / 3600000u256 / 10000u256as u64;
     *(&mut (&mut l30.u64_padding)[C8]) = l20;
     let l19 = balance::value(&l6);
     *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
     *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-    if (*(&(&l30.share)[C8]) < l7) {
-        l13 = *(&(&l30.share)[C8]);
-        unstructured {
-            goto 'label_252;
-        }
+    let l13 = if (*(&(&l30.share)[C8]) < l7) {
+        *(&(&l30.share)[C8])
     } else {
-        l13 = l7;
-        unstructured {
-            goto 'label_252;
-        }
+        l7
     };
     /* block 252 */;
     l21 = l13;
@@ -591,16 +548,10 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
     *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
     *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
     __c252 = *(&(&l30.share)[C9]) < l8;
-    if (__c252) {
-        l14 = *(&(&l30.share)[C9]);
-        unstructured {
-            goto 'label_319;
-        }
+    l14 = if (__c252) {
+        *(&(&l30.share)[C9])
     } else {
-        l14 = l8;
-        unstructured {
-            goto 'label_319;
-        }
+        l8
     };
     /* block 319 */;
     l23 = l14;
@@ -618,34 +569,17 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
         __c375 = reg_309;
         if (__c375) {
             __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
-            if (__c385) {
-                l17 = *(&(&l30.share)[l27 + 5u64]);
-                unstructured {
-                    goto 'label_406;
-                }
+            l17 = if (__c385) {
+                *(&(&l30.share)[l27 + 5u64])
             } else {
-                l17 = l9;
-                unstructured {
-                    goto 'label_406;
-                }
+                l9
             };
             /* block 406 */;
             l28 = l17;
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l28;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l28;
             *(&mut (&mut l30.share)[l27 + 5u64]) = *(&(&l30.share)[l27 + 5u64]) - l28;
-            *(&mut (&mut l36.share_supply)[l27 + 5u64]) = *(&(&l36.share_supply)[l27 + 5u64]) - l28;
-            unstructured {
-                goto 'label_464;
-            }
-        } else {
-            unstructured {
-                goto 'label_464;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_464;
+            *(&mut (&mut l36.share_supply)[l27 + 5u64]) = *(&(&l36.share_supply)[l27 + 5u64]) - l28
         }
     };
     /* block 464 */;
@@ -653,17 +587,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
     __c464 = l19 + l21 + l23 + l28 > 0u64;
     assert!(__c464, C8);
     __c508 = l19 >= *(&(&l36.config)[C8]);
-    if (__c508) {
-        l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
-        unstructured {
-            goto 'label_529;
-        }
-    } else {
-        l18 = false;
-        unstructured {
-            goto 'label_529;
-        }
-    };
+    l18 = __c508 && l19 % *(&(&l36.config)[C8]) == 0u64;
     /* block 529 */;
     __c529 = l18;
     assert!(__c529, C10);
@@ -744,34 +668,21 @@ public fun refresh(l0: &Version, l1: &mut Registry, l2: u64, l3: u64, l4: u64, l
     assert!(*(&(&l16.info)[C11]) == 0u64, C14);
     assert!(*(&(&l16.info)[C14]) == 1u64, C18);
     assert!(*(&(&l16.info)[C15]) == 1u64, C18);
-    let l7;
     *(&mut (&mut l16.info)[C10]) = l3;
     *(&mut (&mut l16.info)[C8]) = *(&(&l16.info)[C8]) + 1u64;
     *(&mut (&mut l16.info)[C13]) = l4;
-    if (*(&(&l16.config)[C13]) > 0u64) {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_99;
-        }
+    let l7 = if (*(&(&l16.config)[C13]) > 0u64) {
+        0u64
     } else {
-        l7 = 1u64;
-        unstructured {
-            goto 'label_99;
-        }
+        1u64
     };
     let l8;
     /* block 99 */;
     *(&mut (&mut l16.info)[C14]) = l7;
-    if (*(&(&l16.config)[C14]) > 0u64) {
-        l8 = 0u64;
-        unstructured {
-            goto 'label_118;
-        }
+    l8 = if (*(&(&l16.config)[C14]) > 0u64) {
+        0u64
     } else {
-        l8 = 1u64;
-        unstructured {
-            goto 'label_118;
-        }
+        1u64
     };
     let (l10, l11, l13, l14, l15);
     /* block 118 */;
@@ -945,18 +856,11 @@ public fun withdraw_suilend<T0>(l0: &mut Version, l1: &mut Registry, l2: u64, l3
     assert!(*(&(&l14.info)[C12]) == 1u64, C16);
     assert!(clock::timestamp_ms(l5) < *(&(&l14.info)[C10]), C15);
     assert!(*(&(&l14.info)[C11]) == 0u64, C14);
-    let l7;
     *(&mut (&mut l14.info)[C11]) = 3u64;
-    if (dynamic_object_field::exists_(&l14.id, ascii::string(C5))) {
-        l7 = dynamic_object_field::remove(&mut l14.id, ascii::string(C5));
-        unstructured {
-            goto 'label_97;
-        }
+    let l7 = if (dynamic_object_field::exists_(&l14.id, ascii::string(C5))) {
+        dynamic_object_field::remove(&mut l14.id, ascii::string(C5))
     } else {
-        l7 = lending_market::create_obligation(l3, l6);
-        unstructured {
-            goto 'label_97;
-        }
+        lending_market::create_obligation(l3, l6)
     };
     /* block 97 */;
     let l13 = l7;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4b0f4ee1a40ce37ec81c987cc4e76a665419e74b863319492fc7d26f708b835a/tails_staking.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4b0f4ee1a40ce37ec81c987cc4e76a665419e74b863319492fc7d26f708b835a/tails_staking.move
@@ -244,14 +244,7 @@ public fun exp_down_with_fee(l0: &mut Version, l1: &mut TailsStakingRegistry, l2
     let l11 = typus_nft::tails_level(freeze(l8));
     if (option::is_some(&l7)) {
         let l10 = bag::borrow(&l1.tails_metadata, C9);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l13 - 1u64)));
-        unstructured {
-            goto 'label_109;
-        }
-    } else {
-        unstructured {
-            goto 'label_109;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l13 - 1u64)))
     };
     /* block 109 */;
     *(&mut (bag::borrow_mut(&mut l1.tails_metadata, C8))[l13 - 1u64]) = l11;
@@ -274,14 +267,7 @@ public fun exp_down_without_staking_with_fee(l0: &mut Version, l1: &TailsStaking
     let l13 = typus_nft::tails_level(freeze(l10));
     if (option::is_some(&l9)) {
         let l12 = bag::borrow(&l1.tails_metadata, C9);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l10, *(big_vector::borrow(table::borrow(l12, l13), l14 - 1u64)));
-        unstructured {
-            goto 'label_92;
-        }
-    } else {
-        unstructured {
-            goto 'label_92;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l10, *(big_vector::borrow(table::borrow(l12, l13), l14 - 1u64)))
     };
     /* block 92 */;
     event::emit(ExpDownEvent { tails: l11, log: vector[l14, l6], bcs_padding: C17 })
@@ -341,6 +327,7 @@ public fun get_max_staking_level(l0: &Version, l1: &TailsStakingRegistry, l2: ad
     let l8 = 0u64;
     let l14 = bag::borrow(&l1.tails_metadata, C8);
     let l6 = big_vector::length(&l1.staking_infos);
+    /* block 143 */;
     if (l6 > 0u64) {
         let l12 = big_vector::slice_size(&l1.staking_infos)as u64;
         let l10 = 0u64;
@@ -349,24 +336,21 @@ public fun get_max_staking_level(l0: &Version, l1: &TailsStakingRegistry, l2: ad
         let l4 = 0u64;
         let (l13, l5, l7);
         loop {
-            if (l4 < l6) {
-                l13 = big_vector::borrow_from_slice(l9, l4 % l12);
-                if (*(&l13.user) == l2) {
-                    l5 = 0u64;
-                    l7 = &l13.tails.len();
-                    break
-                };
-                if (l4 + 1u64 < l6 && l4 + 1u64 == l10 * l12 + l11) {
-                    l10 = big_vector::get_slice_idx(l9) + 1u64;
-                    l9 = big_vector::borrow_slice(&l1.staking_infos, l10);
-                    l11 = big_vector::get_slice_length(l9);
-                };
-                l4 = l4 + 1u64;
-            } else {
-                unstructured {
-                    goto 'label_143;
-                }
-            }
+            if (l4 >= l6) {
+                break 'loop_143
+            };
+            l13 = big_vector::borrow_from_slice(l9, l4 % l12);
+            if (*(&l13.user) == l2) {
+                l5 = 0u64;
+                l7 = &l13.tails.len();
+                break
+            };
+            if (l4 + 1u64 < l6 && l4 + 1u64 == l10 * l12 + l11) {
+                l10 = big_vector::get_slice_idx(l9) + 1u64;
+                l9 = big_vector::borrow_slice(&l1.staking_infos, l10);
+                l11 = big_vector::get_slice_length(l9);
+            };
+            l4 = l4 + 1u64;
         };
         while (l5 < l7) {
             let l15 = *(&(&l13.tails)[l5]);
@@ -374,16 +358,8 @@ public fun get_max_staking_level(l0: &Version, l1: &TailsStakingRegistry, l2: ad
                 l8 = *(&l14[l15 - 1u64]);
             };
             l5 = l5 + 1u64;
-        };
-        unstructured {
-            goto 'label_143;
-        }
-    } else {
-        unstructured {
-            goto 'label_143;
         }
     };
-    /* block 143 */;
     return l8
 }
 
@@ -492,16 +468,10 @@ entry fun level_up(l0: &Version, l1: &mut TailsStakingRegistry, l2: address, l3:
     let l8 = typus_nft::tails_level(freeze(l5));
     if (l3) {
         let l11 = bag::borrow(&l1.tails_metadata, C10);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(table::borrow(l11, l8 * 10000u64 + l10)));
-        unstructured {
-            goto 'label_80;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(table::borrow(l11, l8 * 10000u64 + l10)))
     } else {
         let l7 = bag::borrow(&l1.tails_metadata, C9);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(big_vector::borrow(table::borrow(l7, l8), l10 - 1u64)));
-        unstructured {
-            goto 'label_80;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(big_vector::borrow(table::borrow(l7, l8), l10 - 1u64)))
     };
     /* block 80 */;
     *(&mut (bag::borrow_mut(&mut l1.tails_metadata, C8))[l10 - 1u64]) = l8;
@@ -518,14 +488,7 @@ public fun public_exp_down(l0: &ManagerCap, l1: &Version, l2: &mut TailsStakingR
     let l9 = typus_nft::tails_level(freeze(l6));
     if (option::is_some(&typus_nft::level_up(&l2.tails_manager_cap, l6))) {
         let l8 = bag::borrow(&l2.tails_metadata, C9);
-        typus_nft::update_image_url(&l2.tails_manager_cap, l6, *(big_vector::borrow(table::borrow(l8, l9), l11 - 1u64)));
-        unstructured {
-            goto 'label_62;
-        }
-    } else {
-        unstructured {
-            goto 'label_62;
-        }
+        typus_nft::update_image_url(&l2.tails_manager_cap, l6, *(big_vector::borrow(table::borrow(l8, l9), l11 - 1u64)))
     };
     /* block 62 */;
     *(&mut (bag::borrow_mut(&mut l2.tails_metadata, C8))[l11 - 1u64]) = l9;
@@ -541,14 +504,7 @@ public fun public_exp_down_without_staking(l0: &ManagerCap, l1: &Version, l2: &T
     let l11 = typus_nft::tails_level(freeze(l8));
     if (option::is_some(&typus_nft::level_up(&l2.tails_manager_cap, l8))) {
         let l10 = bag::borrow(&l2.tails_metadata, C9);
-        typus_nft::update_image_url(&l2.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l12 - 1u64)));
-        unstructured {
-            goto 'label_55;
-        }
-    } else {
-        unstructured {
-            goto 'label_55;
-        }
+        typus_nft::update_image_url(&l2.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l12 - 1u64)))
     };
     /* block 55 */;
     event::emit(ExpDownEvent { tails: l9, log: vector[l12, l6], bcs_padding: C17 })
@@ -652,18 +608,7 @@ entry fun set_profit_sharing<T0, T1>(l0: &Version, l1: &mut TailsStakingRegistry
     if (!(l20)) {
         (&mut l1.profit_assets).push_back(l19);
         if (!(dynamic_field::exists_(&l1.id, l19))) {
-            dynamic_field::add(&mut l1.id, l19, balance::zero());
-            unstructured {
-                goto 'label_188;
-            }
-        } else {
-            unstructured {
-                goto 'label_188;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_188;
+            dynamic_field::add(&mut l1.id, l19, balance::zero())
         }
     };
     /* block 188 */;
@@ -854,17 +799,11 @@ entry fun upload_webp_bytes(l0: &Version, l1: &mut TailsStakingRegistry, l2: u64
     ecosystem::verify(l0, l5);
     let l6 = bag::borrow_mut(&mut l1.tails_metadata, C10);
     if (!(table::contains(freeze(l6), l3 * 10000u64 + l2))) {
-        table::add(l6, l3 * 10000u64 + l2, l4);
-        unstructured {
-            goto 'label_47;
-        }
+        table::add(l6, l3 * 10000u64 + l2, l4)
     } else {
         let l7 = table::borrow_mut(l6, l3 * 10000u64 + l2);
         while (!(vector::is_empty(&l4))) {
             l7.push_back((&mut l4).pop_back())
-        };
-        unstructured {
-            goto 'label_47;
         }
     };
     /* block 47 */

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
@@ -48,10 +48,16 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
+    let __c0 = l16 > l13;
+    let __c25 = l16 - l13 >= l18;
+    let __c35 = l13 - l16 >= l18;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
+        let __c44 = l16 > l13;
+        let __c59 = l16 - l13 >= l18;
+        let __c68 = l13 - l16 >= l18;
+        __c44 && __c59 || __c68 && !(__c44)
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -65,14 +71,22 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
+    let __c0 = l19 > l16;
+    let __c25 = l19 - l16 >= l21;
+    let __c35 = l16 - l19 >= l21;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c44 = l19 > l16;
+        let __c59 = l19 - l16 >= l21;
+        let __c68 = l16 - l19 >= l21;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c77 = l19 > l16;
+        let __c92 = l19 - l16 >= l21;
+        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -87,18 +101,29 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
+    let __c0 = l22 > l19;
+    let __c25 = l22 - l19 >= l24;
+    let __c35 = l19 - l22 >= l24;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c44 = l22 > l19;
+        let __c59 = l22 - l19 >= l24;
+        let __c68 = l19 - l22 >= l24;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c77 = l22 > l19;
+        let __c92 = l22 - l19 >= l24;
+        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c110 = l22 > l19;
+        let __c125 = l22 - l19 >= l24;
+        let __c134 = l19 - l22 >= l24;
+        __c110 && __c125 || __c134 && !(__c110)
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -114,22 +139,36 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
+    let __c0 = l25 > l22;
+    let __c25 = l25 - l22 >= l27;
+    let __c35 = l22 - l25 >= l27;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c44 = l25 > l22;
+        let __c59 = l25 - l22 >= l27;
+        let __c68 = l22 - l25 >= l27;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c77 = l25 > l22;
+        let __c92 = l25 - l22 >= l27;
+        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c110 = l25 > l22;
+        let __c125 = l25 - l22 >= l27;
+        let __c134 = l22 - l25 >= l27;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c143 = l25 > l22;
+        let __c158 = l25 - l22 >= l27;
+        let __c167 = l22 - l25 >= l27;
+        __c143 && __c158 || __c167 && !(__c143)
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -146,26 +185,43 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
+    let __c0 = l28 > l25;
+    let __c25 = l28 - l25 >= l30;
+    let __c35 = l25 - l28 >= l30;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c44 = l28 > l25;
+        let __c59 = l28 - l25 >= l30;
+        let __c68 = l25 - l28 >= l30;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c77 = l28 > l25;
+        let __c92 = l28 - l25 >= l30;
+        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c110 = l28 > l25;
+        let __c125 = l28 - l25 >= l30;
+        let __c134 = l25 - l28 >= l30;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c143 = l28 > l25;
+        let __c158 = l28 - l25 >= l30;
+        let __c167 = l25 - l28 >= l30;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c176 = l28 > l25;
+        let __c191 = l28 - l25 >= l30;
+        let __c200 = l25 - l28 >= l30;
+        __c176 && __c191 || __c200 && !(__c176)
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -183,30 +239,50 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
+    let __c0 = l31 > l28;
+    let __c25 = l31 - l28 >= l33;
+    let __c35 = l28 - l31 >= l33;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c44 = l31 > l28;
+        let __c59 = l31 - l28 >= l33;
+        let __c68 = l28 - l31 >= l33;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c77 = l31 > l28;
+        let __c92 = l31 - l28 >= l33;
+        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c110 = l31 > l28;
+        let __c125 = l31 - l28 >= l33;
+        let __c134 = l28 - l31 >= l33;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c143 = l31 > l28;
+        let __c158 = l31 - l28 >= l33;
+        let __c167 = l28 - l31 >= l33;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c176 = l31 > l28;
+        let __c191 = l31 - l28 >= l33;
+        let __c200 = l28 - l31 >= l33;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c209 = l31 > l28;
+        let __c224 = l31 - l28 >= l33;
+        let __c233 = l28 - l31 >= l33;
+        __c209 && __c224 || __c233 && !(__c209)
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -225,34 +301,57 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
+    let __c0 = l34 > l31;
+    let __c25 = l34 - l31 >= l36;
+    let __c35 = l31 - l34 >= l36;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c44 = l34 > l31;
+        let __c59 = l34 - l31 >= l36;
+        let __c68 = l31 - l34 >= l36;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c77 = l34 > l31;
+        let __c92 = l34 - l31 >= l36;
+        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c110 = l34 > l31;
+        let __c125 = l34 - l31 >= l36;
+        let __c134 = l31 - l34 >= l36;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c143 = l34 > l31;
+        let __c158 = l34 - l31 >= l36;
+        let __c167 = l31 - l34 >= l36;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c176 = l34 > l31;
+        let __c191 = l34 - l31 >= l36;
+        let __c200 = l31 - l34 >= l36;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c209 = l34 > l31;
+        let __c224 = l34 - l31 >= l36;
+        let __c233 = l31 - l34 >= l36;
+        __c209 && __c224 || __c233 && !(__c209)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c242 = l34 > l31;
+        let __c257 = l34 - l31 >= l36;
+        let __c266 = l31 - l34 >= l36;
+        __c242 && __c257 || __c266 && !(__c242)
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -273,19 +372,10 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l10 = clock::timestamp_ms(l7) / 1000u64;
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
-    let __dispatch_15;
     let l16;
     loop {
         if (l12 >= l14) {
-            if (l13) {
-                l12 = 0u64;
-                __dispatch_15 = 0u32;
-                break
-            };
-            let l18 = vaa::parse_and_verify(l4, l5, l7);
-            l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
-            l12 = 0u64;
-            __dispatch_15 = 1u32;
+            let __c61 = l13;
             break
         };
         let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
@@ -301,7 +391,15 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
         };
         l12 = l12 + 1u64;
     };
-    match (__dispatch_15) {
+    match (if (__c61) {
+        l12 = 0u64;
+        0u32
+    } else {
+        let l18 = vaa::parse_and_verify(l4, l5, l7);
+        l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
+        l12 = 0u64;
+        1u32
+    }) {
         0 => {
             while (l12 < l14) {
                 transfer::public_share_object((&mut l2).pop_back());

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
@@ -54,16 +54,10 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    let __c0 = l16 > l13;
-    let __c25 = l16 - l13 >= l18;
-    let __c35 = l13 - l16 >= l18;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        let __c44 = l16 > l13;
-        let __c59 = l16 - l13 >= l18;
-        let __c68 = l13 - l16 >= l18;
-        __c44 && __c59 || __c68 && !(__c44)
+        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -77,22 +71,14 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    let __c0 = l19 > l16;
-    let __c25 = l19 - l16 >= l21;
-    let __c35 = l16 - l19 >= l21;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        let __c44 = l19 > l16;
-        let __c59 = l19 - l16 >= l21;
-        let __c68 = l16 - l19 >= l21;
-        __c44 && __c59 || __c68 && !(__c44)
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        let __c77 = l19 > l16;
-        let __c92 = l19 - l16 >= l21;
-        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -107,29 +93,18 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    let __c0 = l22 > l19;
-    let __c25 = l22 - l19 >= l24;
-    let __c35 = l19 - l22 >= l24;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        let __c44 = l22 > l19;
-        let __c59 = l22 - l19 >= l24;
-        let __c68 = l19 - l22 >= l24;
-        __c44 && __c59 || __c68 && !(__c44)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        let __c77 = l22 > l19;
-        let __c92 = l22 - l19 >= l24;
-        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        let __c110 = l22 > l19;
-        let __c125 = l22 - l19 >= l24;
-        let __c134 = l19 - l22 >= l24;
-        __c110 && __c125 || __c134 && !(__c110)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -145,36 +120,22 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    let __c0 = l25 > l22;
-    let __c25 = l25 - l22 >= l27;
-    let __c35 = l22 - l25 >= l27;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        let __c44 = l25 > l22;
-        let __c59 = l25 - l22 >= l27;
-        let __c68 = l22 - l25 >= l27;
-        __c44 && __c59 || __c68 && !(__c44)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        let __c77 = l25 > l22;
-        let __c92 = l25 - l22 >= l27;
-        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        let __c110 = l25 > l22;
-        let __c125 = l25 - l22 >= l27;
-        let __c134 = l22 - l25 >= l27;
-        __c110 && __c125 || __c134 && !(__c110)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        let __c143 = l25 > l22;
-        let __c158 = l25 - l22 >= l27;
-        let __c167 = l22 - l25 >= l27;
-        __c143 && __c158 || __c167 && !(__c143)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -191,43 +152,26 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    let __c0 = l28 > l25;
-    let __c25 = l28 - l25 >= l30;
-    let __c35 = l25 - l28 >= l30;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        let __c44 = l28 > l25;
-        let __c59 = l28 - l25 >= l30;
-        let __c68 = l25 - l28 >= l30;
-        __c44 && __c59 || __c68 && !(__c44)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        let __c77 = l28 > l25;
-        let __c92 = l28 - l25 >= l30;
-        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        let __c110 = l28 > l25;
-        let __c125 = l28 - l25 >= l30;
-        let __c134 = l25 - l28 >= l30;
-        __c110 && __c125 || __c134 && !(__c110)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        let __c143 = l28 > l25;
-        let __c158 = l28 - l25 >= l30;
-        let __c167 = l25 - l28 >= l30;
-        __c143 && __c158 || __c167 && !(__c143)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        let __c176 = l28 > l25;
-        let __c191 = l28 - l25 >= l30;
-        let __c200 = l25 - l28 >= l30;
-        __c176 && __c191 || __c200 && !(__c176)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -245,50 +189,30 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    let __c0 = l31 > l28;
-    let __c25 = l31 - l28 >= l33;
-    let __c35 = l28 - l31 >= l33;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        let __c44 = l31 > l28;
-        let __c59 = l31 - l28 >= l33;
-        let __c68 = l28 - l31 >= l33;
-        __c44 && __c59 || __c68 && !(__c44)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        let __c77 = l31 > l28;
-        let __c92 = l31 - l28 >= l33;
-        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        let __c110 = l31 > l28;
-        let __c125 = l31 - l28 >= l33;
-        let __c134 = l28 - l31 >= l33;
-        __c110 && __c125 || __c134 && !(__c110)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        let __c143 = l31 > l28;
-        let __c158 = l31 - l28 >= l33;
-        let __c167 = l28 - l31 >= l33;
-        __c143 && __c158 || __c167 && !(__c143)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        let __c176 = l31 > l28;
-        let __c191 = l31 - l28 >= l33;
-        let __c200 = l28 - l31 >= l33;
-        __c176 && __c191 || __c200 && !(__c176)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        let __c209 = l31 > l28;
-        let __c224 = l31 - l28 >= l33;
-        let __c233 = l28 - l31 >= l33;
-        __c209 && __c224 || __c233 && !(__c209)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -307,57 +231,34 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    let __c0 = l34 > l31;
-    let __c25 = l34 - l31 >= l36;
-    let __c35 = l31 - l34 >= l36;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        let __c44 = l34 > l31;
-        let __c59 = l34 - l31 >= l36;
-        let __c68 = l31 - l34 >= l36;
-        __c44 && __c59 || __c68 && !(__c44)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        let __c77 = l34 > l31;
-        let __c92 = l34 - l31 >= l36;
-        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        let __c110 = l34 > l31;
-        let __c125 = l34 - l31 >= l36;
-        let __c134 = l31 - l34 >= l36;
-        __c110 && __c125 || __c134 && !(__c110)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        let __c143 = l34 > l31;
-        let __c158 = l34 - l31 >= l36;
-        let __c167 = l31 - l34 >= l36;
-        __c143 && __c158 || __c167 && !(__c143)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        let __c176 = l34 > l31;
-        let __c191 = l34 - l31 >= l36;
-        let __c200 = l31 - l34 >= l36;
-        __c176 && __c191 || __c200 && !(__c176)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        let __c209 = l34 > l31;
-        let __c224 = l34 - l31 >= l36;
-        let __c233 = l31 - l34 >= l36;
-        __c209 && __c224 || __c233 && !(__c209)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        let __c242 = l34 > l31;
-        let __c257 = l34 - l31 >= l36;
-        let __c266 = l31 - l34 >= l36;
-        __c242 && __c257 || __c266 && !(__c242)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -378,10 +279,19 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l10 = clock::timestamp_ms(l7) / 1000u64;
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
+    let __dispatch_15;
     let l16;
     loop {
         if (l12 >= l14) {
-            let __c61 = l13;
+            if (l13) {
+                l12 = 0u64;
+                __dispatch_15 = 0u32;
+                break
+            };
+            let l18 = vaa::parse_and_verify(l4, l5, l7);
+            l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
+            l12 = 0u64;
+            __dispatch_15 = 1u32;
             break
         };
         let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
@@ -397,15 +307,7 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
         };
         l12 = l12 + 1u64;
     };
-    match (if (__c61) {
-        l12 = 0u64;
-        0u32
-    } else {
-        let l18 = vaa::parse_and_verify(l4, l5, l7);
-        l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
-        l12 = 0u64;
-        1u32
-    }) {
+    match (__dispatch_15) {
         0 => {
             while (l12 < l14) {
                 transfer::public_share_object((&mut l2).pop_back());

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x4dc31d7ddf7451c801896737aae11906e12d542de3d85c7e5c71272ea6fdf1b6/pyth.move
@@ -31,16 +31,10 @@ public fun update_1(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     if (l11 > l10) {
         if (l11 - l10 < l13) {
             return
-        };
-        unstructured {
-            goto 'label_59;
         }
     } else {
         if (l10 - l11 < l13) {
             return
-        };
-        unstructured {
-            goto 'label_59;
         }
     };
     /* block 59 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5059e676e3cd64696547e0617a0a7e9dbfe2e7090d4ec3c2c396650d21960045/orlim.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5059e676e3cd64696547e0617a0a7e9dbfe2e7090d4ec3c2c396650d21960045/orlim.move
@@ -157,40 +157,20 @@ public fun cancel_limit_order(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &m
     if (option::is_some(&l16)) {
         let l15 = *(option::borrow(&l16));
         if (table::contains(&l0.oco_groups, l15)) {
-            let l4;
             let l14 = table::remove(&mut l0.oco_groups, l15);
-            if (*(&(&l14).order1_id) == l1) {
-                l4 = *(&(&l14).order2_id);
-                unstructured {
-                    goto 'label_105;
-                }
+            let l4 = if (*(&(&l14).order1_id) == l1) {
+                *(&(&l14).order2_id)
             } else {
-                l4 = *(&(&l14).order1_id);
-                unstructured {
-                    goto 'label_105;
-                }
+                *(&(&l14).order1_id)
             };
             /* block 105 */;
-            let l11 = l4;
             *(&mut (&mut l14).is_active) = false;
             table::add(&mut l0.oco_groups, l15, l14);
-            let l12 = l11;
+            let l12 = l4;
             if (table::contains(&l0.receipts, l12)) {
-                let l5;
                 let l13 = table::remove(&mut l0.receipts, l12);
-                if (*(&(&l13).is_active)) {
-                    l5 = vector::contains(&l0.active_orders, &l12);
-                    unstructured {
-                        goto 'label_140;
-                    }
-                } else {
-                    l5 = false;
-                    unstructured {
-                        goto 'label_140;
-                    }
-                };
                 /* block 140 */;
-                if (l5) {
+                if (*(&(&l13).is_active) && vector::contains(&l0.active_orders, &l12)) {
                     *(&mut (&mut l13).is_active) = false;
                     *(&mut (&mut l13).cancelled_at) = option::some(l6);
                     let l7 = 0u64;
@@ -207,29 +187,10 @@ public fun cancel_limit_order(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &m
                         event::emit(OCOOrderCancelledEvent { oco_group_id: l15, cancelled_order_id: l12, user: *(&l0.owner), cancelled_at: l6 });
                         break
                     }
-                } else {
-                    unstructured {
-                        goto 'label_188;
-                    }
                 };
                 /* block 188 */;
-                table::add(&mut l0.receipts, l12, l13);
-                unstructured {
-                    goto 'label_194;
-                }
-            } else {
-                unstructured {
-                    goto 'label_194;
-                }
+                table::add(&mut l0.receipts, l12, l13)
             }
-        } else {
-            unstructured {
-                goto 'label_194;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_194;
         }
     };
     let (l10, l8);
@@ -369,27 +330,15 @@ public entry fun cancel_order_by_object_entry(l0: &mut OrderManager, l1: OrderRe
     let l5 = reg_5;
     let l4 = reg_4;
     if (coin::value(&l4) > 0u64) {
-        transfer::public_transfer(l4, tx_context::sender(freeze(l3)));
-        unstructured {
-            goto 'label_20;
-        }
+        transfer::public_transfer(l4, tx_context::sender(freeze(l3)))
     } else {
-        coin::destroy_zero(l4);
-        unstructured {
-            goto 'label_20;
-        }
+        coin::destroy_zero(l4)
     };
     /* block 20 */;
     if (coin::value(&l5) > 0u64) {
-        transfer::public_transfer(l5, tx_context::sender(freeze(l3)));
-        unstructured {
-            goto 'label_35;
-        }
+        transfer::public_transfer(l5, tx_context::sender(freeze(l3)))
     } else {
-        coin::destroy_zero(l5);
-        unstructured {
-            goto 'label_35;
-        }
+        coin::destroy_zero(l5)
     };
     /* block 35 */
 }
@@ -437,25 +386,17 @@ public fun handle_oco_fill(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &mut 
     if (option::is_some(&l6.oco_group_id)) {
         let l16 = *(option::borrow(&l6.oco_group_id));
         assert!(table::contains(&l0.oco_groups, l16), C7);
-        let l4;
         let l15 = table::remove(&mut l0.oco_groups, l16);
-        if (*(&(&l15).order1_id) == l1) {
-            l4 = *(&(&l15).order2_id);
-            unstructured {
-                goto 'label_86;
-            }
+        let l4 = if (*(&(&l15).order1_id) == l1) {
+            *(&(&l15).order2_id)
         } else {
-            l4 = *(&(&l15).order1_id);
-            unstructured {
-                goto 'label_86;
-            }
+            *(&(&l15).order1_id)
         };
         let (l13, l5);
         /* block 86 */;
-        let l12 = l4;
         *(&mut (&mut l15).is_active) = false;
         table::add(&mut l0.oco_groups, l16, l15);
-        l13 = l12;
+        l13 = l4;
         l5 = clock::timestamp_ms(l2);
         if (table::contains(&l0.receipts, l13)) {
             let l14 = table::remove(&mut l0.receipts, l13);
@@ -470,20 +411,9 @@ public fun handle_oco_fill(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &mut 
                     };
                     l8 = l8 + 1u64;
                 }
-            } else {
-                unstructured {
-                    goto 'label_156;
-                }
             };
             /* block 156 */;
-            table::add(&mut l0.receipts, l13, l14);
-            unstructured {
-                goto 'label_162;
-            }
-        } else {
-            unstructured {
-                goto 'label_162;
-            }
+            table::add(&mut l0.receipts, l13, l14)
         };
         let (l11, l9);
         /* block 162 */;
@@ -504,10 +434,6 @@ public fun handle_oco_fill(l0: &mut OrderManager, l1: u64, l2: &Clock, l3: &mut 
             };
             event::emit(OCOOrderFilledEvent { oco_group_id: l16, filled_order_id: l1, cancelled_order_id: l13, user: *(&l0.owner), filled_at: l5 });
             break
-        }
-    } else {
-        unstructured {
-            goto 'label_225;
         }
     };
     /* block 225 */
@@ -548,27 +474,13 @@ public fun modify_order(l0: &mut OrderManager, l1: u64, l2: Option<u64>, l3: Opt
     if (option::is_some(&l2)) {
         let l11 = option::destroy_some(l2);
         assert!(l11 > 0u64, C1);
-        *(&mut l13.price) = l11;
-        unstructured {
-            goto 'label_96;
-        }
-    } else {
-        unstructured {
-            goto 'label_96;
-        }
+        *(&mut l13.price) = l11
     };
     /* block 96 */;
     if (option::is_some(&l3)) {
         let l12 = option::destroy_some(l3);
         assert!(l12 > 0u64, C2);
-        *(&mut l13.quantity) = l12;
-        unstructured {
-            goto 'label_115;
-        }
-    } else {
-        unstructured {
-            goto 'label_115;
-        }
+        *(&mut l13.quantity) = l12
     };
     /* block 115 */;
     let l6 = *(&l13.price);
@@ -603,32 +515,10 @@ public entry fun place_limit_order_entry(l0: &mut OrderManager, l1: vector<u8>, 
 public fun place_limit_order_oco(l0: &mut OrderManager, l1: vector<u8>, l2: u64, l3: u64, l4: bool, l5: u64, l6: u64, l7: bool, l8: &Clock, l9: &mut TxContext): ( u64, u64) {
     assert!(tx_context::sender(freeze(l9)) == *(&l0.owner), C3);
     assert!(!(*(&l0.is_paused)), C4);
-    let l10;
-    if (l2 > 0u64) {
-        l10 = l5 > 0u64;
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_42;
-        }
-    };
+    let l10 = l2 > 0u64 && l5 > 0u64;
     /* block 42 */;
     assert!(l10, C1);
-    let l11;
-    if (l3 > 0u64) {
-        l11 = l6 > 0u64;
-        unstructured {
-            goto 'label_64;
-        }
-    } else {
-        l11 = false;
-        unstructured {
-            goto 'label_64;
-        }
-    };
+    let l11 = l3 > 0u64 && l6 > 0u64;
     /* block 64 */;
     assert!(l11, C2);
     let l12 = clock::timestamp_ms(l8);
@@ -660,18 +550,7 @@ public fun place_limit_order_tif(l0: &mut OrderManager, l1: vector<u8>, l2: u64,
     assert!(!(*(&l0.is_paused)), C4);
     assert!(l2 > 0u64, C1);
     assert!(l3 > 0u64, C2);
-    let l10;
-    if (l5 == C13) {
-        l10 = true;
-        unstructured {
-            goto 'label_68;
-        }
-    } else {
-        l10 = l5 == C14;
-        unstructured {
-            goto 'label_68;
-        }
-    };
+    let l10 = l5 == C13 || l5 == C14;
     /* block 68 */;
     assert!(l10, C9);
     let l28 = clock::timestamp_ms(l8);
@@ -690,39 +569,19 @@ public fun place_limit_order_tif(l0: &mut OrderManager, l1: vector<u8>, l2: u64,
             let l25 = coin::split(&mut l6, l37as u64, l9);
             let l34 = coin::zero(l9);
             if (option::is_some(&l38)) {
-                coin::destroy_zero(option::extract(&mut l38));
-                unstructured {
-                    goto 'label_150;
-                }
-            } else {
-                unstructured {
-                    goto 'label_150;
-                }
+                coin::destroy_zero(option::extract(&mut l38))
             };
             /* block 150 */;
             if (option::is_some(&l39)) {
-                coin::destroy_zero(option::extract(&mut l39));
-                unstructured {
-                    goto 'label_156;
-                }
-            } else {
-                unstructured {
-                    goto 'label_156;
-                }
+                coin::destroy_zero(option::extract(&mut l39))
             };
             /* block 156 */;
             option::fill(&mut l38, l25);
             option::fill(&mut l39, l34);
-            event::emit(OrderPartialFilledEvent { order_id: l33, filled_quantity: l30, remaining_quantity: l40, user: *(&l0.owner), filled_at: l28 });
-            unstructured {
-                goto 'label_259;
-            }
+            event::emit(OrderPartialFilledEvent { order_id: l33, filled_quantity: l30, remaining_quantity: l40, user: *(&l0.owner), filled_at: l28 })
         } else {
             l32 = true;
             l31 = false;
-            unstructured {
-                goto 'label_259;
-            }
         }
     } else {
         if (l5 == C14) {
@@ -731,148 +590,65 @@ public fun place_limit_order_tif(l0: &mut OrderManager, l1: vector<u8>, l2: u64,
                 let l26 = coin::split(&mut l6, l27, l9);
                 let l35 = coin::zero(l9);
                 if (option::is_some(&l38)) {
-                    coin::destroy_zero(option::extract(&mut l38));
-                    unstructured {
-                        goto 'label_204;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_204;
-                    }
+                    coin::destroy_zero(option::extract(&mut l38))
                 };
                 /* block 204 */;
                 if (option::is_some(&l39)) {
-                    coin::destroy_zero(option::extract(&mut l39));
-                    unstructured {
-                        goto 'label_210;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_210;
-                    }
+                    coin::destroy_zero(option::extract(&mut l39))
                 };
                 /* block 210 */;
                 option::fill(&mut l38, l26);
                 option::fill(&mut l39, l35);
                 event::emit(OrderExpiredEvent { order_id: l33, user: *(&l0.owner), expired_at: l28 });
                 if (coin::value(&l6) > 0u64) {
-                    transfer::public_transfer(l6, tx_context::sender(freeze(l9)));
-                    unstructured {
-                        goto 'label_236;
-                    }
+                    transfer::public_transfer(l6, tx_context::sender(freeze(l9)))
                 } else {
-                    coin::destroy_zero(l6);
-                    unstructured {
-                        goto 'label_236;
-                    }
+                    coin::destroy_zero(l6)
                 };
                 /* block 236 */;
                 if (coin::value(&l7) > 0u64) {
-                    transfer::public_transfer(l7, tx_context::sender(freeze(l9)));
-                    unstructured {
-                        goto 'label_251;
-                    }
+                    transfer::public_transfer(l7, tx_context::sender(freeze(l9)))
                 } else {
-                    coin::destroy_zero(l7);
-                    unstructured {
-                        goto 'label_251;
-                    }
+                    coin::destroy_zero(l7)
                 };
                 /* block 251 */;
                 return (l33, l38, l39)
             };
             l32 = true;
             l31 = false;
-            unstructured {
-                goto 'label_259;
-            }
-        } else {
-            unstructured {
-                goto 'label_259;
-            }
         }
     };
-    let l18;
     /* block 259 */;
-    if (l31) {
-        l18 = true;
-        unstructured {
-            goto 'label_277;
-        }
-    } else {
-        let l19;
-        if (l5 == C13) {
-            l19 = l30 > 0u64;
-            unstructured {
-                goto 'label_275;
-            }
-        } else {
-            l19 = false;
-            unstructured {
-                goto 'label_275;
-            }
-        };
-        /* block 275 */;
-        l18 = l19;
-        unstructured {
-            goto 'label_277;
-        }
-    };
+    let l18 = l31 || /* block 275 */ l5 == C13 && l30 > 0u64;
     /* block 277 */;
     if (l18) {
-        let l20;
         (&mut l0.active_orders).push_back(l33);
         *(&mut l0.total_orders_created) = *(&l0.total_orders_created) + 1u64;
         let l24 = TimeInForce { value: l5 };
         let l22 = l31;
         let l21 = l32;
-        if (l31) {
-            l20 = option::none();
-            unstructured {
-                goto 'label_322;
-            }
+        let l20 = if (l31) {
+            option::none()
         } else {
-            l20 = option::some(l28);
-            unstructured {
-                goto 'label_322;
-            }
+            option::some(l28)
         };
         /* block 322 */;
         let l36 = OrderReceiptData { order_id: l33, deepbook_order_id: l33, pool_id: l1, price: l2, quantity: l40, original_quantity: l3, is_bid: l4, order_type: OrderType { value: C14 }, time_in_force: l24, created_at: l28, is_active: l22, is_fully_filled: l21, cancelled_at: l20, oco_group_id: option::none(), expires_at: option::none() };
         table::add(&mut l0.receipts, l33, l36);
         event::emit(TIFOrderPlacedEvent { order_id: l33, tif_type: l5, user: *(&l0.owner), created_at: l28 });
-        event::emit(OrderPlacedEvent { order_id: l33, pool_id: l1, user: *(&l0.owner), price: l2, quantity: l3, is_bid: l4, created_at: l28 });
-        unstructured {
-            goto 'label_367;
-        }
-    } else {
-        unstructured {
-            goto 'label_367;
-        }
+        event::emit(OrderPlacedEvent { order_id: l33, pool_id: l1, user: *(&l0.owner), price: l2, quantity: l3, is_bid: l4, created_at: l28 })
     };
     /* block 367 */;
     if (coin::value(&l6) > 0u64) {
-        transfer::public_transfer(l6, tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_380;
-        }
+        transfer::public_transfer(l6, tx_context::sender(freeze(l9)))
     } else {
-        coin::destroy_zero(l6);
-        unstructured {
-            goto 'label_380;
-        }
+        coin::destroy_zero(l6)
     };
     /* block 380 */;
     if (coin::value(&l7) > 0u64) {
-        transfer::public_transfer(l7, tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_395;
-        }
+        transfer::public_transfer(l7, tx_context::sender(freeze(l9)))
     } else {
-        coin::destroy_zero(l7);
-        unstructured {
-            goto 'label_395;
-        }
+        coin::destroy_zero(l7)
     };
     /* block 395 */;
     return (l33, l38, l39)
@@ -884,25 +660,11 @@ public entry fun place_limit_order_tif_entry(l0: &mut OrderManager, l1: vector<u
     let l11 = reg_12;
     let l10 = reg_11;
     if (option::is_some(&l10)) {
-        transfer::public_transfer(option::extract(&mut l10), tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        unstructured {
-            goto 'label_23;
-        }
+        transfer::public_transfer(option::extract(&mut l10), tx_context::sender(freeze(l9)))
     };
     /* block 23 */;
     if (option::is_some(&l11)) {
-        transfer::public_transfer(option::extract(&mut l11), tx_context::sender(freeze(l9)));
-        unstructured {
-            goto 'label_35;
-        }
-    } else {
-        unstructured {
-            goto 'label_35;
-        }
+        transfer::public_transfer(option::extract(&mut l11), tx_context::sender(freeze(l9)))
     };
     /* block 35 */;
     option::destroy_none(l10);
@@ -936,22 +698,10 @@ public entry fun transfer_order_ownership_entry(l0: OrderReceipt, l1: address, l
 
 public fun update_order_status(l0: &mut OrderManager, l1: u64, l2: bool) {
     if (table::contains(&l0.receipts, l1)) {
-        let l3;
         let l6 = table::borrow_mut(&mut l0.receipts, l1);
         *(&mut l6.is_active) = l2;
-        if (!(l2)) {
-            l3 = *(&l6.is_active);
-            unstructured {
-                goto 'label_26;
-            }
-        } else {
-            l3 = false;
-            unstructured {
-                goto 'label_26;
-            }
-        };
         /* block 26 */;
-        if (l3) {
+        if (!(l2) && *(&l6.is_active)) {
             let l4 = 0u64;
             let l5 = &l0.active_orders.len();
             while (l4 < l5) {
@@ -960,14 +710,6 @@ public fun update_order_status(l0: &mut OrderManager, l1: u64, l2: bool) {
                 };
                 l4 = l4 + 1u64;
             }
-        } else {
-            unstructured {
-                goto 'label_63;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
         }
     };
     /* block 63 */

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5ee0b2b5f427cb68cd3d4443a509694602f63b8f1039eb886c0353b539b2ecfd/curved_math.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5ee0b2b5f427cb68cd3d4443a509694602f63b8f1039eb886c0353b539b2ecfd/curved_math.move
@@ -137,30 +137,16 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
         };
         l15 = l15 + 1u64;
     };
-    let l21;
-    if (*(&l1.future_A_gamma_time) > l20) {
-        l21 = curved_math::solve_D(l8, l13as u256, l10);
-        unstructured {
-            goto 'label_102;
-        }
+    let l21 = if (*(&l1.future_A_gamma_time) > l20) {
+        curved_math::solve_D(l8, l13as u256, l10)
     } else {
-        l21 = *(&l1._D);
-        unstructured {
-            goto 'label_102;
-        }
+        *(&l1._D)
     };
     let l27;
     /* block 102 */;
     l27 = curved_math::solve_D(l8, l13as u256, l31);
     if (l21 == 0u256) {
         l18 = curved_math::get_xcp(l27, *(&l1.price_scale), l19as u256);
-        unstructured {
-            goto 'label_120;
-        }
-    } else {
-        unstructured {
-            goto 'label_120;
-        }
     };
     /* block 120 */;
     if (l21 > 0u256) {
@@ -170,25 +156,13 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
             *(&mut (&mut l12)[l16]) = curved_math::calculate_fee_charged(*(&(&l10)[l16]), *(&(&l31)[l16]), l21, l27, *(&(&l1.price_scale)[l16]), l11);
             l16 = l16 + 1u64;
         };
-        let l5;
         let l29 = curved_math::xp(math::subtract_vectors_u256(l30, l12), *(&l1.price_scale));
         let l28 = curved_math::solve_D(l8, l13as u256, l29);
         l18 = math::mul_div_u256(l4, l28, l21) - l4;
         l4 = l4 + l18;
         let l6 = 0u256;
-        if (l18 > math::pow_10_u256(5u8)) {
-            l5 = l23 < l19;
-            unstructured {
-                goto 'label_217;
-            }
-        } else {
-            l5 = false;
-            unstructured {
-                goto 'label_217;
-            }
-        };
         /* block 217 */;
-        if (l5) {
+        if (l18 > math::pow_10_u256(5u8) && l23 < l19) {
             let l26 = 0u256;
             let l14 = 0u64;
             while (l14 < l19) {
@@ -202,28 +176,15 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
             let l24 = *(&(&l30)[l23]);
             let l9 = l22 - math::mul_div_u256(l18, l24, l4);
             l6 = math::mul_div_u256(l26, C0, l9);
-            unstructured {
-                goto 'label_277;
-            }
-        } else {
-            unstructured {
-                goto 'label_277;
-            }
         };
         /* block 277 */;
         let l25 = *(&l1.last_prices_timestamp);
         let l17 = *(&l1.last_prices);
-        curved_math::tweak_price(l1, l8, l13as u256, l31, l23, l6, l27, l4, l25, l20, l17);
-        unstructured {
-            goto 'label_311;
-        }
+        curved_math::tweak_price(l1, l8, l13as u256, l31, l23, l6, l27, l4, l25, l20, l17)
     } else {
         *(&mut l1._D) = l27;
         *(&mut l1.virtual_price) = C0;
-        *(&mut l1.xcp_profit) = C0;
-        unstructured {
-            goto 'label_311;
-        }
+        *(&mut l1.xcp_profit) = C0
     };
     /* block 311 */;
     assert!(l18 > 0u256, C27);
@@ -232,147 +193,33 @@ public fun add_liquidity_computation(l0: &Clock, l1: &mut CurvedPoolConfig, l2: 
 
 public fun assert_new_config_params(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64) {
     if (l0 > 0u64) {
-        let l6;
-        if (l0 >= C5) {
-            l6 = l0 <= C6;
-            unstructured {
-                goto 'label_15;
-            }
-        } else {
-            l6 = false;
-            unstructured {
-                goto 'label_15;
-            }
-        };
         /* block 15 */;
-        assert!(l6, C28);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        unstructured {
-            goto 'label_20;
-        }
+        assert!(l0 >= C5 && l0 <= C6, C28)
     };
     /* block 20 */;
     if (l1 > 0u64) {
-        let l7;
-        if (l1 >= C5) {
-            l7 = l1 <= C6;
-            unstructured {
-                goto 'label_35;
-            }
-        } else {
-            l7 = false;
-            unstructured {
-                goto 'label_35;
-            }
-        };
         /* block 35 */;
-        assert!(l7, C30);
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        unstructured {
-            goto 'label_40;
-        }
+        assert!(l1 >= C5 && l1 <= C6, C30)
     };
     /* block 40 */;
     if (l2 > 0u64) {
-        let l8;
-        if (l2 >= C11) {
-            l8 = l2 <= C12;
-            unstructured {
-                goto 'label_55;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_55;
-            }
-        };
         /* block 55 */;
-        assert!(l8, C31);
-        unstructured {
-            goto 'label_60;
-        }
-    } else {
-        unstructured {
-            goto 'label_60;
-        }
+        assert!(l2 >= C11 && l2 <= C12, C31)
     };
     /* block 60 */;
     if (l4 > 0u64) {
-        let l9;
-        if (l4as u256 >= C2) {
-            l9 = l4as u256 <= C10;
-            unstructured {
-                goto 'label_77;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_77;
-            }
-        };
         /* block 77 */;
-        assert!(l9, C32);
-        unstructured {
-            goto 'label_82;
-        }
-    } else {
-        unstructured {
-            goto 'label_82;
-        }
+        assert!(l4as u256 >= C2 && l4as u256 <= C10, C32)
     };
     /* block 82 */;
     if (l5 > 0u64) {
-        let l10;
-        if (l5as u256 >= C2) {
-            l10 = l5as u256 <= C10;
-            unstructured {
-                goto 'label_99;
-            }
-        } else {
-            l10 = false;
-            unstructured {
-                goto 'label_99;
-            }
-        };
         /* block 99 */;
-        assert!(l10, C33);
-        unstructured {
-            goto 'label_104;
-        }
-    } else {
-        unstructured {
-            goto 'label_104;
-        }
+        assert!(l5as u256 >= C2 && l5as u256 <= C10, C33)
     };
     /* block 104 */;
     if (l3 > 0u64) {
-        let l11;
-        if (l3 >= C8) {
-            l11 = l3 <= C9;
-            unstructured {
-                goto 'label_119;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_119;
-            }
-        };
         /* block 119 */;
-        assert!(l11, C29);
-        unstructured {
-            goto 'label_124;
-        }
-    } else {
-        unstructured {
-            goto 'label_124;
-        }
+        assert!(l3 >= C8 && l3 <= C9, C29)
     };
     /* block 124 */
 }
@@ -382,13 +229,6 @@ public fun calc_geometric_mean(l0: vector<u256>, l1: bool): u256 {
     let l11 = l0;
     if (l1) {
         l11 = math::sort_u256(l11);
-        unstructured {
-            goto 'label_10;
-        }
-    } else {
-        unstructured {
-            goto 'label_10;
-        }
     };
     let (l4, l7);
     /* block 10 */;
@@ -421,13 +261,6 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
     let l19 = reg_7;
     if (*(&l1.future_A_gamma_time) > l24) {
         l6 = true;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        unstructured {
-            goto 'label_20;
-        }
     };
     let (l17, l20, l27);
     /* block 20 */;
@@ -442,17 +275,10 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
         };
         l20 = l20 + 1u64;
     };
-    let l25;
-    if (l6) {
-        l25 = curved_math::solve_D(l13, l19as u256, l17);
-        unstructured {
-            goto 'label_72;
-        }
+    let l25 = if (l6) {
+        curved_math::solve_D(l13, l19as u256, l17)
     } else {
-        l25 = *(&l1._D);
-        unstructured {
-            goto 'label_72;
-        }
+        *(&l1._D)
     };
     let (l10, l12, l14, l29, l8);
     /* block 72 */;
@@ -464,30 +290,9 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
     l12 = math::mul_div_u256(*(&(&l17)[l4]) - l30, C0, l27);
     *(&mut (&mut l17)[l4]) = l30;
     l10 = 0u256;
-    if (l7) {
-        l8 = l12 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_142;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_142;
-        }
-    };
-    let l9;
+    l8 = l7 && l12 > math::pow_10_u256(5u8);
     /* block 142 */;
-    if (l8) {
-        l9 = l5 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_152;
-        }
-    } else {
-        l9 = false;
-        unstructured {
-            goto 'label_152;
-        }
-    };
+    let l9 = l8 && l5 > math::pow_10_u256(5u8);
     /* block 152 */;
     if (l9) {
         let l28 = 0u256;
@@ -501,13 +306,6 @@ public fun calc_withdraw_one_coin(l0: &Clock, l1: &mut CurvedPoolConfig, l2: vec
         l28 = math::mul_div_u256(l28, l14, l25);
         let l16 = l12 - math::mul_div_u256(l14, *(&(&l2)[l4]), l25);
         l10 = math::mul_div_u256(l28, C0, l16);
-        unstructured {
-            goto 'label_206;
-        }
-    } else {
-        unstructured {
-            goto 'label_206;
-        }
     };
     /* block 206 */;
     let l26 = *(&l1.last_prices_timestamp);
@@ -522,7 +320,6 @@ public fun calculate_fee_charged(l0: u256, l1: u256, l2: u256, l3: u256, l4: u25
 }
 
 public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3: u64, l4: u256, l5: vector<u256>, l6: u256): ( u256, u256) {
-    let l7;
     let l22 = clock::timestamp_ms(l0);
     let (reg_7, reg_8) = curved_math::get_cur_A_gamma(l0, freeze(l1));
     let l13 = reg_8;
@@ -533,32 +330,14 @@ public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3
     *(&mut (&mut l17)[l2]) = *(&(&l5)[l2]) + l4;
     l17 = curved_math::xp(l17, *(&l1.price_scale));
     let l14 = *(&(&l5)[l3]);
-    if (*(&l1.init_A_gamma_time) < l22) {
-        l7 = *(&l1.future_A_gamma_time) > l22;
-        unstructured {
-            goto 'label_57;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_57;
-        }
-    };
     /* block 57 */;
-    if (l7) {
+    if (*(&l1.init_A_gamma_time) < l22 && *(&l1.future_A_gamma_time) > l22) {
         let l12 = *(&(&l1.price_scale)[l2]);
         l15 = math::mul_div_u256(l15, l12, C0);
         let l25 = *(&(&l17)[l2]);
         *(&mut (&mut l17)[l2]) = l15;
         *(&mut l1._D) = curved_math::solve_D(l13, l19as u256, l17);
-        *(&mut (&mut l17)[l2]) = l25;
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        unstructured {
-            goto 'label_93;
-        }
+        *(&mut (&mut l17)[l2]) = l25
     };
     let (l11, l16, l18, l8);
     /* block 93 */;
@@ -569,54 +348,19 @@ public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3
     l18 = math::mul_div_u256(curved_math::fee(l17, *(&l1.mid_fee), *(&l1.out_fee), *(&l1.fee_gamma)as u256), l16, C7as u256);
     *(&mut (&mut l17)[l3]) = math::mul_div_u256(l14 - l16 - l18, *(&(&l1.price_scale)[l3]), C0);
     l11 = 0u256;
-    if (l4 > math::pow_10_u256(5u8)) {
-        l8 = l16 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_181;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_181;
-        }
-    };
+    l8 = l4 > math::pow_10_u256(5u8) && l16 > math::pow_10_u256(5u8);
     /* block 181 */;
     if (l8) {
-        let l9;
-        if (l2 != 0u64) {
-            l9 = l3 != 0u64;
-            unstructured {
-                goto 'label_194;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_194;
-            }
-        };
         /* block 194 */;
-        if (l9) {
+        if (l2 != 0u64 && l3 != 0u64) {
             l11 = math::mul_div_u256(l4, *(&(&l1.last_prices)[l2]), l16);
-            unstructured {
-                goto 'label_223;
-            }
         } else {
             if (l2 == 0u64) {
                 l11 = math::mul_div_u256(l4, C0, l16);
-                unstructured {
-                    goto 'label_223;
-                }
             } else {
                 l11 = math::mul_div_u256(l16, C0, l4);
                 l24 = l2;
-                unstructured {
-                    goto 'label_223;
-                }
             }
-        }
-    } else {
-        unstructured {
-            goto 'label_223;
         }
     };
     /* block 223 */;
@@ -628,7 +372,6 @@ public fun compute_ask_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3
 }
 
 public fun compute_offer_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, l3: u64, l4: u256, l5: vector<u256>, l6: u256): ( u256, u256) {
-    let l7;
     let l21 = clock::timestamp_ms(l0);
     let (reg_7, reg_8) = curved_math::get_cur_A_gamma(l0, freeze(l1));
     let l12 = reg_8;
@@ -641,32 +384,14 @@ public fun compute_offer_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, 
     *(&mut (&mut l17)[l3]) = *(&(&l5)[l3]) - l13;
     l17 = curved_math::xp(l17, *(&l1.price_scale));
     let l22 = *(&(&l5)[l2]);
-    if (*(&l1.init_A_gamma_time) < l21) {
-        l7 = *(&l1.future_A_gamma_time) > l21;
-        unstructured {
-            goto 'label_83;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_83;
-        }
-    };
     /* block 83 */;
-    if (l7) {
+    if (*(&l1.init_A_gamma_time) < l21 && *(&l1.future_A_gamma_time) > l21) {
         let l11 = *(&(&l1.price_scale)[l3]);
         l15 = math::mul_div_u256(l15, l11, C0);
         let l26 = *(&(&l17)[l3]);
         *(&mut (&mut l17)[l3]) = l15;
         *(&mut l1._D) = curved_math::solve_D(l12, l19as u256, l17);
-        *(&mut (&mut l17)[l3]) = l26;
-        unstructured {
-            goto 'label_119;
-        }
-    } else {
-        unstructured {
-            goto 'label_119;
-        }
+        *(&mut (&mut l17)[l3]) = l26
     };
     let (l14, l16, l24, l8);
     /* block 119 */;
@@ -676,54 +401,19 @@ public fun compute_offer_amount(l0: &Clock, l1: &mut CurvedPoolConfig, l2: u64, 
     *(&mut (&mut l17)[l2]) = math::mul_div_u256(l22 + l16, *(&(&l1.price_scale)[l2]), C0);
     l14 = l13 - l4;
     l24 = 0u256;
-    if (l13 > math::pow_10_u256(5u8)) {
-        l8 = l16 > math::pow_10_u256(5u8);
-        unstructured {
-            goto 'label_190;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_190;
-        }
-    };
+    l8 = l13 > math::pow_10_u256(5u8) && l16 > math::pow_10_u256(5u8);
     /* block 190 */;
     if (l8) {
-        let l9;
-        if (l2 != 0u64) {
-            l9 = l3 != 0u64;
-            unstructured {
-                goto 'label_203;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_203;
-            }
-        };
         /* block 203 */;
-        if (l9) {
+        if (l2 != 0u64 && l3 != 0u64) {
             l24 = math::mul_div_u256(l13, *(&(&l1.last_prices)[l3]), l16);
-            unstructured {
-                goto 'label_232;
-            }
         } else {
             if (l3 == 0u64) {
                 l24 = math::mul_div_u256(l13, C0, l16);
-                unstructured {
-                    goto 'label_232;
-                }
             } else {
                 l24 = math::mul_div_u256(l16, C0, l13);
                 l25 = l3;
-                unstructured {
-                    goto 'label_232;
-                }
             }
-        }
-    } else {
-        unstructured {
-            goto 'label_232;
         }
     };
     /* block 232 */;
@@ -747,14 +437,7 @@ fun ema_recorder(l0: &mut CurvedPoolConfig, l1: u256, l2: u256, l3: vector<u256>
             l6 = l6 + 1u64;
         };
         *(&mut l0.oracle_prices) = l8;
-        *(&mut l0.last_prices_timestamp) = l2as u64;
-        unstructured {
-            goto 'label_67;
-        }
-    } else {
-        unstructured {
-            goto 'label_67;
-        }
+        *(&mut l0.last_prices_timestamp) = l2as u64
     };
     /* block 67 */
 }
@@ -767,70 +450,40 @@ public fun fee(l0: vector<u256>, l1: u64, l2: u64, l3: u256): u256 {
 }
 
 public fun get_cur_A_gamma(l0: &Clock, l1: &CurvedPoolConfig): ( u256, u64) {
-    let l2;
     let l16 = clock::timestamp_ms(l0);
     let l18 = *(&l1.future_A_gamma_time);
     let l10 = *(&l1.next_gamma);
     let l15 = *(&l1.next_amp);
-    if (*(&l1.init_A_gamma_time) < l16) {
-        l2 = l16 < l18;
-        unstructured {
-            goto 'label_28;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_28;
-        }
-    };
+    let l2 = *(&l1.init_A_gamma_time) < l16 && l16 < l18;
     let (l5, l6);
     /* block 28 */;
-    if (l2) {
-        let l3;
+    l5 = if (l2) {
         let l17 = *(&l1.init_A_gamma_time);
         let l9 = *(&l1.init_gamma);
         let l12 = *(&l1.init_amp);
         let l8 = l16 - l17;
         let l19 = l18 - l17;
         let l11 = math::mul_div_u256(math::max_u256(l10, l9) - math::min_u256(l10, l9), l8as u256, l19as u256);
-        if (l10 > l9) {
-            l3 = l9 + l11;
-            unstructured {
-                goto 'label_76;
-            }
+        let l3 = if (l10 > l9) {
+            l9 + l11
         } else {
-            l3 = l9 - l11;
-            unstructured {
-                goto 'label_76;
-            }
+            l9 - l11
         };
         let (l14, l4);
         /* block 76 */;
         l14 = l3;
         let l7 = math::mul_div(math::max_u64(l15, l12) - math::min_u64(l15, l12), l8, l19);
-        if (l15 > l12) {
-            l4 = l12 + l7;
-            unstructured {
-                goto 'label_102;
-            }
+        l4 = if (l15 > l12) {
+            l12 + l7
         } else {
-            l4 = l12 - l7;
-            unstructured {
-                goto 'label_102;
-            }
+            l12 - l7
         };
         /* block 102 */;
         l6 = l4;
-        l5 = l14;
-        unstructured {
-            goto 'label_115;
-        }
+        l14
     } else {
         l6 = l15;
-        l5 = l10;
-        unstructured {
-            goto 'label_115;
-        }
+        l10
     };
     /* block 115 */;
     return (l5, l6)
@@ -942,7 +595,6 @@ public fun initialize_curved_config(l0: &Clock, l1: vector<u64>, l2: vector<u256
     assert!(&l1.len() == 8u64, C16);
     assert!(&l2.len() == l4as u64, C16);
     assert!(*(&(&l2)[0u64]) == C0, C24);
-    let l6;
     let l41 = clock::timestamp_ms(l0);
     let l33 = *(&(&l1)[0u64]) * C1;
     let l35 = *(&(&l1)[1u64])as u256;
@@ -954,115 +606,28 @@ public fun initialize_curved_config(l0: &Clock, l1: vector<u64>, l2: vector<u256
     let l36 = *(&(&l1)[7u64]);
     let l39 = math::pow(l4, l4)as u64 * C1 / 100u64;
     let l37 = math::pow(l4, l4)as u64 * C1 * 1000u64;
-    if (l39 <= l33) {
-        l6 = l33 <= l37;
-        unstructured {
-            goto 'label_110;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_110;
-        }
-    };
+    let l6 = l39 <= l33 && l33 <= l37;
     /* block 110 */;
     assert!(l6, C21);
-    let l17;
-    if (l35 >= C2) {
-        l17 = l35 <= C3;
-        unstructured {
-            goto 'label_126;
-        }
-    } else {
-        l17 = false;
-        unstructured {
-            goto 'label_126;
-        }
-    };
+    let l17 = l35 >= C2 && l35 <= C3;
     /* block 126 */;
     assert!(l17, C25);
-    let l24;
-    if (l36 >= C8) {
-        l24 = l36 <= C9;
-        unstructured {
-            goto 'label_142;
-        }
-    } else {
-        l24 = false;
-        unstructured {
-            goto 'label_142;
-        }
-    };
+    let l24 = l36 >= C8 && l36 <= C9;
     /* block 142 */;
     assert!(l24, C29);
-    let l25;
-    if (l38 >= C5) {
-        l25 = l38 <= C6;
-        unstructured {
-            goto 'label_158;
-        }
-    } else {
-        l25 = false;
-        unstructured {
-            goto 'label_158;
-        }
-    };
+    let l25 = l38 >= C5 && l38 <= C6;
     /* block 158 */;
     assert!(l25, C28);
-    let l26;
-    if (l40 >= C5) {
-        l26 = l40 <= C6;
-        unstructured {
-            goto 'label_174;
-        }
-    } else {
-        l26 = false;
-        unstructured {
-            goto 'label_174;
-        }
-    };
+    let l26 = l40 >= C5 && l40 <= C6;
     /* block 174 */;
     assert!(l26, C30);
-    let l27;
-    if (l34 >= C11) {
-        l27 = l34 <= C12;
-        unstructured {
-            goto 'label_190;
-        }
-    } else {
-        l27 = false;
-        unstructured {
-            goto 'label_190;
-        }
-    };
+    let l27 = l34 >= C11 && l34 <= C12;
     /* block 190 */;
     assert!(l27, C31);
-    let l28;
-    if (l32 >= C2) {
-        l28 = l32 <= C10;
-        unstructured {
-            goto 'label_206;
-        }
-    } else {
-        l28 = false;
-        unstructured {
-            goto 'label_206;
-        }
-    };
+    let l28 = l32 >= C2 && l32 <= C10;
     /* block 206 */;
     assert!(l28, C32);
-    let l29;
-    if (l31 >= C2) {
-        l29 = l31 <= C10;
-        unstructured {
-            goto 'label_222;
-        }
-    } else {
-        l29 = false;
-        unstructured {
-            goto 'label_222;
-        }
-    };
+    let l29 = l31 >= C2 && l31 <= C10;
     /* block 222 */;
     assert!(l29, C33);
     let l19 = l36as u256;
@@ -1070,33 +635,11 @@ public fun initialize_curved_config(l0: &Clock, l1: vector<u64>, l2: vector<u256
 }
 
 fun newton_D(l0: u64, l1: u256, l2: vector<u256>, l3: u256): u256 {
-    let l4;
     let l19 = &l2.len();
-    if (l0 > curved_math::get_min_amp(l19) - 1u64) {
-        l4 = l0 < curved_math::get_max_amp(l19) + 1u64;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l4 = false;
-        unstructured {
-            goto 'label_20;
-        }
-    };
+    let l4 = l0 > curved_math::get_min_amp(l19) - 1u64 && l0 < curved_math::get_max_amp(l19) + 1u64;
     /* block 20 */;
     assert!(l4, C18);
-    let l5;
-    if (l1 > C2 - 1u256) {
-        l5 = l1 < C3 + 1u256;
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_40;
-        }
-    };
+    let l5 = l1 > C2 - 1u256 && l1 < C3 + 1u256;
     /* block 40 */;
     assert!(l5, C19);
     let l21 = 0u256;
@@ -1152,47 +695,14 @@ fun newton_D(l0: u64, l1: u256, l2: vector<u256>, l3: u256): u256 {
 }
 
 public fun newton_y(l0: u256, l1: u256, l2: vector<u256>, l3: u256, l4: u64): u256 {
-    let l5;
     let l25 = &l2.len();
-    if (l0as u64 > curved_math::get_min_amp(l25) - 1u64) {
-        l5 = l0as u64 < curved_math::get_max_amp(l25) + 1u64;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_22;
-        }
-    };
+    let l5 = l0as u64 > curved_math::get_min_amp(l25) - 1u64 && l0as u64 < curved_math::get_max_amp(l25) + 1u64;
     /* block 22 */;
     assert!(l5, C18);
-    let l6;
-    if (l1 > C2 - 1u256) {
-        l6 = l1 < C3 + 1u256;
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_42;
-        }
-    };
+    let l6 = l1 > C2 - 1u256 && l1 < C3 + 1u256;
     /* block 42 */;
     assert!(l6, C19);
-    let l7;
-    if (l3 > math::pow_10_u256(17u8) - 1u256) {
-        l7 = l3 < math::pow_10_u256(15u8) * C0 + 1u256;
-        unstructured {
-            goto 'label_66;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_66;
-        }
-    };
+    let l7 = l3 > math::pow_10_u256(17u8) - 1u256 && l3 < math::pow_10_u256(15u8) * C0 + 1u256;
     /* block 66 */;
     assert!(l7, C19);
     let l21 = 0u64;
@@ -1307,34 +817,16 @@ public fun reduction_coefficient(l0: vector<u256>, l1: u256): u256 {
     };
     if (l1 > 0u256) {
         l4 = l1 * C0 / l1 + C0 - l4;
-        unstructured {
-            goto 'label_63;
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
-        }
     };
     /* block 63 */;
     return l4
 }
 
 public fun solve_D(l0: u64, l1: u256, l2: vector<u256>): u256 {
-    let l3;
     let l6 = &l2.len();
     let l7 = math::sort_u256(l2);
     let l5 = *(&(&l7)[0u64]);
-    if (l5 > math::pow_10_u256(9u8) - 1u256) {
-        l3 = l5 < math::pow_10_u256(15u8) * C0 + 1u256;
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_30;
-        }
-    };
+    let l3 = l5 > math::pow_10_u256(9u8) - 1u256 && l5 < math::pow_10_u256(15u8) * C0 + 1u256;
     /* block 30 */;
     assert!(l3, C17);
     let l4 = l6as u256 * curved_math::calc_geometric_mean(l7, false);
@@ -1347,21 +839,11 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
     let l17 = l6;
     if (l6 == 0u256) {
         l17 = curved_math::solve_D(l1, l2, l3);
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        unstructured {
-            goto 'label_23;
-        }
     };
     /* block 23 */;
     if (l5 > 0u256) {
         if (l4 > 0u64) {
-            *(&mut (&mut l0.last_prices)[l4]) = l5;
-            unstructured {
-                goto 'label_120;
-            }
+            *(&mut (&mut l0.last_prices)[l4]) = l5
         } else {
             let l19 = 1u64;
             while (l19 < l24) {
@@ -1394,57 +876,21 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
     let l40 = C0;
     let l38 = C0;
     if (l32 > 0u256) {
-        let l11;
         let l39 = curved_math::calc_geometric_mean(l42, true);
         l38 = math::mul_div_u256(C0, l39, l7);
         l40 = math::mul_div_u256(l33, l38, l32);
-        if (l38 < l32) {
-            l11 = *(&l0.future_A_gamma_time) < l9;
-            unstructured {
-                goto 'label_192;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_192;
-            }
-        };
         /* block 192 */;
-        assert!(!(l11), C34);
-        unstructured {
-            goto 'label_200;
-        }
-    } else {
-        unstructured {
-            goto 'label_200;
-        }
+        assert!(!(l38 < l32 && *(&l0.future_A_gamma_time) < l9), C34)
     };
     let (l12, l25);
     /* block 200 */;
     *(&mut l0.xcp_profit) = l40;
     l25 = *(&l0.not_adjusted);
-    if (!(l25)) {
-        l12 = l38 * 2u256 - C0 > l40 + 2u256 * *(&l0.allowed_extra_profit);
-        unstructured {
-            goto 'label_228;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_228;
-        }
-    };
+    l12 = !(l25) && l38 * 2u256 - C0 > l40 + 2u256 * *(&l0.allowed_extra_profit);
     /* block 228 */;
     if (l12) {
         l25 = true;
-        *(&mut l0.not_adjusted) = true;
-        unstructured {
-            goto 'label_236;
-        }
-    } else {
-        unstructured {
-            goto 'label_236;
-        }
+        *(&mut l0.not_adjusted) = true
     };
     /* block 236 */;
     if (l25) {
@@ -1456,20 +902,8 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
             l29 = l29 + l35 * l35;
             l22 = l22 + 1u64;
         };
-        let l13;
-        if (l29 > l15 * l15) {
-            l13 = l32 > 0u256;
-            unstructured {
-                goto 'label_289;
-            }
-        } else {
-            l13 = false;
-            unstructured {
-                goto 'label_289;
-            }
-        };
         /* block 289 */;
-        if (l13) {
+        if (l29 > l15 * l15 && l32 > 0u256) {
             let l30 = math::sqrt_int_u256(l29 / C0);
             let l27 = vector[];
             (&mut l27).push_back(C0);
@@ -1492,19 +926,8 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
                 *(&mut (&mut l36)[l23]) = math::mul_div_u256(l26, C0, l34 * l24as u256);
                 l23 = l23 + 1u64;
             };
-            let l14;
             let l28 = math::mul_div_u256(curved_math::calc_geometric_mean(l36, true), C0, l7);
-            if (l28 > C0) {
-                l14 = 2u256 * l28 - C0 > l40;
-                unstructured {
-                    goto 'label_421;
-                }
-            } else {
-                l14 = false;
-                unstructured {
-                    goto 'label_421;
-                }
-            };
+            let l14 = l28 > C0 && 2u256 * l28 - C0 > l40;
             /* block 421 */;
             if (l14) {
                 *(&mut l0.price_scale) = l27;
@@ -1512,18 +935,7 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
                 *(&mut l0.virtual_price) = l28;
                 return
             };
-            *(&mut l0.not_adjusted) = false;
-            unstructured {
-                goto 'label_441;
-            }
-        } else {
-            unstructured {
-                goto 'label_441;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_441;
+            *(&mut l0.not_adjusted) = false
         }
     };
     /* block 441 */;
@@ -1532,90 +944,21 @@ fun tweak_price(l0: &mut CurvedPoolConfig, l1: u64, l2: u256, l3: vector<u256>, 
 }
 
 public fun update_A_and_gamma(l0: &mut CurvedPoolConfig, l1: u64, l2: u64, l3: u256, l4: u64) {
-    let l5;
     let l13 = &l0.last_prices.len()as u128;
     let l14 = math::pow(l13, l13)as u64;
     let l12 = l14 * C1 / 100u64;
     let l11 = l14 * C1 * 1000u64;
-    if (l12 < l2) {
-        l5 = l2 < l11;
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_33;
-        }
-    };
+    let l5 = l12 < l2 && l2 < l11;
     /* block 33 */;
     assert!(l5, C21);
-    let l6;
-    if (l3 >= C2) {
-        l6 = l3 <= C3 + 1u256;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = l3 >= C2 && l3 <= C3 + 1u256;
     /* block 53 */;
     assert!(l6, C25);
-    let l8;
-    if (l2 >= *(&l0.init_amp)) {
-        l8 = l2 <= *(&l0.init_amp) * C4;
-        unstructured {
-            goto 'label_77;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_77;
-        }
-    };
-    let l9;
     /* block 77 */;
-    if (l8) {
-        l9 = true;
-        unstructured {
-            goto 'label_101;
-        }
-    } else {
-        let l7;
-        if (l2 < *(&l0.init_amp)) {
-            l7 = l2 * C4 >= *(&l0.init_amp);
-            unstructured {
-                goto 'label_99;
-            }
-        } else {
-            l7 = false;
-            unstructured {
-                goto 'label_99;
-            }
-        };
-        /* block 99 */;
-        l9 = l7;
-        unstructured {
-            goto 'label_101;
-        }
-    };
+    let l9 = l2 >= *(&l0.init_amp) && l2 <= *(&l0.init_amp) * C4 || /* block 99 */ l2 < *(&l0.init_amp) && l2 * C4 >= *(&l0.init_amp);
     /* block 101 */;
     assert!(l9, C23);
-    let l10;
-    if (l4 > l1) {
-        l10 = l4 - l1 > C13;
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_121;
-        }
-    };
+    let l10 = l4 > l1 && l4 - l1 > C13;
     /* block 121 */;
     assert!(l10, C22);
     *(&mut l0.init_A_gamma_time) = l1;
@@ -1626,184 +969,53 @@ public fun update_A_and_gamma(l0: &mut CurvedPoolConfig, l1: u64, l2: u64, l3: u
 
 public fun update_config_fee_params(l0: &mut CurvedPoolConfig, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64) {
     if (l1 > 0u64) {
-        let l7;
-        if (l1 >= C5) {
-            l7 = l1 <= C6;
-            unstructured {
-                goto 'label_15;
-            }
-        } else {
-            l7 = false;
-            unstructured {
-                goto 'label_15;
-            }
-        };
+        let l7 = l1 >= C5 && l1 <= C6;
         /* block 15 */;
         assert!(l7, C28);
-        *(&mut l0.mid_fee) = l1;
-        unstructured {
-            goto 'label_26;
-        }
-    } else {
-        unstructured {
-            goto 'label_26;
-        }
+        *(&mut l0.mid_fee) = l1
     };
     /* block 26 */;
     if (l2 > 0u64) {
-        let l8;
-        if (l2 >= C5) {
-            l8 = l2 <= C6;
-            unstructured {
-                goto 'label_41;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_41;
-            }
-        };
+        let l8 = l2 >= C5 && l2 <= C6;
         /* block 41 */;
         assert!(l8, C30);
-        *(&mut l0.out_fee) = l2;
-        unstructured {
-            goto 'label_52;
-        }
-    } else {
-        unstructured {
-            goto 'label_52;
-        }
+        *(&mut l0.out_fee) = l2
     };
     /* block 52 */;
     assert!(*(&l0.mid_fee) <= *(&l0.out_fee), C20);
     if (l3 > 0u64) {
-        let l9;
-        if (l3 >= C11) {
-            l9 = l3 <= C12;
-            unstructured {
-                goto 'label_80;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_80;
-            }
-        };
+        let l9 = l3 >= C11 && l3 <= C12;
         /* block 80 */;
         assert!(l9, C31);
-        *(&mut l0.fee_gamma) = l3;
-        unstructured {
-            goto 'label_91;
-        }
-    } else {
-        unstructured {
-            goto 'label_91;
-        }
+        *(&mut l0.fee_gamma) = l3
     };
     /* block 91 */;
     if (l5 > 0u64) {
-        let l10;
-        if (l5as u256 >= C2) {
-            l10 = l5as u256 <= C10;
-            unstructured {
-                goto 'label_108;
-            }
-        } else {
-            l10 = false;
-            unstructured {
-                goto 'label_108;
-            }
-        };
+        let l10 = l5as u256 >= C2 && l5as u256 <= C10;
         /* block 108 */;
         assert!(l10, C32);
-        *(&mut l0.allowed_extra_profit) = l5as u256;
-        unstructured {
-            goto 'label_120;
-        }
-    } else {
-        unstructured {
-            goto 'label_120;
-        }
+        *(&mut l0.allowed_extra_profit) = l5as u256
     };
     /* block 120 */;
     if (l6 > 0u64) {
-        let l11;
-        if (l6as u256 >= C2) {
-            l11 = l6as u256 <= C10;
-            unstructured {
-                goto 'label_137;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_137;
-            }
-        };
+        let l11 = l6as u256 >= C2 && l6as u256 <= C10;
         /* block 137 */;
         assert!(l11, C33);
-        *(&mut l0.adjustment_step) = l6as u256;
-        unstructured {
-            goto 'label_149;
-        }
-    } else {
-        unstructured {
-            goto 'label_149;
-        }
+        *(&mut l0.adjustment_step) = l6as u256
     };
     /* block 149 */;
     if (l4 > 0u64) {
-        let l12;
-        if (l4 >= C8) {
-            l12 = l4 <= C9;
-            unstructured {
-                goto 'label_164;
-            }
-        } else {
-            l12 = false;
-            unstructured {
-                goto 'label_164;
-            }
-        };
+        let l12 = l4 >= C8 && l4 <= C9;
         /* block 164 */;
         assert!(l12, C29);
-        *(&mut l0.ma_half_time) = l4as u256;
-        unstructured {
-            goto 'label_179;
-        }
-    } else {
-        unstructured {
-            goto 'label_179;
-        }
+        *(&mut l0.ma_half_time) = l4as u256
     };
     /* block 179 */
 }
 
 public fun update_initial_prices(l0: &mut CurvedPoolConfig, l1: vector<u256>) {
-    let l2;
-    if (*(&l0._D) == 0u256) {
-        l2 = *(&l0.virtual_price) == 0u256;
-        unstructured {
-            goto 'label_15;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_15;
-        }
-    };
-    let l3;
     /* block 15 */;
-    if (l2) {
-        l3 = *(&l0.xcp_profit) == 0u256;
-        unstructured {
-            goto 'label_26;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_26;
-        }
-    };
+    let l3 = *(&l0._D) == 0u256 && *(&l0.virtual_price) == 0u256 && *(&l0.xcp_profit) == 0u256;
     /* block 26 */;
     assert!(l3, C17);
     *(&mut l0.price_scale) = l1;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x74c15e5ee047a5a841228aa0f49f33c7d7752891d653fc3692646f8ed6cbe987/main_module.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x74c15e5ee047a5a841228aa0f49f33c7d7752891d653fc3692646f8ed6cbe987/main_module.move
@@ -269,19 +269,8 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
     assert!(*(&l1.version) <= C0, C7);
     assert!(table::contains(&l0.cabinet, l45), C3);
     assert!(coin::value(freeze(l3)) >= C1 * l2, C6);
-    let l6;
     let l44 = table::borrow_mut(&mut l0.cabinet, l45);
-    if (l2 > 0u64) {
-        l6 = *(&l44.has_stake_number) + l2 <= 50u64;
-        unstructured {
-            goto 'label_101;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_101;
-        }
-    };
+    let l6 = l2 > 0u64 && *(&l44.has_stake_number) + l2 <= 50u64;
     /* block 101 */;
     assert!(l6, C5);
     *(&mut l44.has_stake_number) = *(&l44.has_stake_number) + l2;
@@ -294,15 +283,9 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
         if (*(&l1.current_row) + 1u64 > 2u64) {
             *(&mut l1.current_row) = 0u64;
             *(&mut l1.current_floor) = *(&l1.current_floor) + 1u64;
-            (&mut l1.seating).push_back(vector[]);
-            unstructured {
-                goto 'label_189;
-            }
+            (&mut l1.seating).push_back(vector[])
         } else {
-            *(&mut l1.current_row) = *(&l1.current_row) + 1u64;
-            unstructured {
-                goto 'label_189;
-            }
+            *(&mut l1.current_row) = *(&l1.current_row) + 1u64
         };
         /* block 189 */;
         let l20 = table::borrow_mut(&mut l0.cabinet, *(&l44.affCode));
@@ -310,30 +293,17 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
         (&mut l20.invite_addresses).push_back(l45);
         let l38 = *(&l20.total_effective_invite_number);
         l44 = table::borrow_mut(&mut l0.cabinet, l45);
-        *(&mut l44.position_of_aff) = l38;
-        unstructured {
-            goto 'label_221;
-        }
-    } else {
-        unstructured {
-            goto 'label_221;
-        }
+        *(&mut l44.position_of_aff) = l38
     };
     let (l12, l29);
     /* block 221 */;
     sbt::mint(l4, l45, l5);
     event::emit(Participates { from: l45, num: l2 });
     l29 = C1 * l2;
-    if (l28 == true) {
-        l12 = l29 * 3u64;
-        unstructured {
-            goto 'label_248;
-        }
+    l12 = if (l28 == true) {
+        l29 * 3u64
     } else {
-        l12 = l29 * 22u64 / 10u64;
-        unstructured {
-            goto 'label_248;
-        }
+        l29 * 22u64 / 10u64
     };
     let (l21, l39);
     /* block 248 */;
@@ -347,39 +317,18 @@ public entry fun participate(l0: &mut InviteArchieves, l1: &mut SeatingChart, l2
     if (*(&l44.position_of_aff) % 3u64 == 0u64) {
         transfer::public_transfer(coin::split(l3, l29 * 40u64 / 100u64, l5), *(&(&l0.team_addresses)[0u64]));
         l21 = l29 * 10u64 / 100u64;
-        unstructured {
-            goto 'label_330;
-        }
-    } else {
-        unstructured {
-            goto 'label_330;
-        }
     };
     /* block 330 */;
     l44 = table::borrow_mut(&mut l0.cabinet, l39);
     if (*(&l44.could_reward) <= l21) {
         transfer::public_transfer(coin::split(l3, l21 - *(&l44.could_reward), l5), *(&(&l0.team_addresses)[0u64]));
         l21 = *(&l44.could_reward);
-        unstructured {
-            goto 'label_359;
-        }
-    } else {
-        unstructured {
-            goto 'label_359;
-        }
     };
     /* block 359 */;
     if (l21 > 0u64) {
         transfer::public_transfer(coin::split(l3, l21, l5), l39);
         *(&mut l44.could_reward) = *(&l44.could_reward) - l21;
-        *(&mut l44.has_reward) = *(&l44.has_reward) + l21;
-        unstructured {
-            goto 'label_388;
-        }
-    } else {
-        unstructured {
-            goto 'label_388;
-        }
+        *(&mut l44.has_reward) = *(&l44.has_reward) + l21
     };
     let (l22, l30);
     /* block 388 */;
@@ -645,22 +594,14 @@ public entry fun whiteList(l0: vector<address>, l1: vector<u64>, l2: &mut Coin<S
 }
 
 public entry fun withdraw(l0: &mut TheTreasury, l1: &AdminCap, l2: Option<u64>, l3: &mut TxContext) {
-    let l4;
-    if (option::is_some(&l2)) {
+    let l4 = if (option::is_some(&l2)) {
         let l6 = option::destroy_some(l2);
         assert!(l6 <= x2_balance::value(&l0.balance), C2);
-        l4 = l6;
-        unstructured {
-            goto 'label_26;
-        }
+        l6
     } else {
-        l4 = x2_balance::value(&l0.balance);
-        unstructured {
-            goto 'label_26;
-        }
+        x2_balance::value(&l0.balance)
     };
     /* block 26 */;
-    let l5 = l4;
-    transfer::public_transfer(coin::take(&mut l0.balance, l5, l3), tx_context::sender(freeze(l3)))
+    transfer::public_transfer(coin::take(&mut l0.balance, l4, l3), tx_context::sender(freeze(l3)))
 }
 

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x97e21376b9fe82f849b32ae42fd7499f89c947ca922dd19e3ee2350dd9cfe726/gauge.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x97e21376b9fe82f849b32ae42fd7499f89c947ca922dd19e3ee2350dd9cfe726/gauge.move
@@ -138,31 +138,8 @@ const C24: vector<u8> = vector[103u8, 97u8, 117u8, 103u8, 101u8, 32u8, 110u8, 11
 // -- functions -- 
 
 public fun check_gauger_pool<T0, T1, T2>(l0: &Gauge<T0, T1, T2>, l1: &Pool<T0, T1>): bool {
-    let l2;
-    if (*(&l0.pool_id) != object::id(l1)) {
-        l2 = true;
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = pool::get_magma_distribution_gauger_id(l1) != object::id(l0);
-        unstructured {
-            goto 'label_20;
-        }
-    };
-    let l3;
     /* block 20 */;
-    if (l2) {
-        l3 = false;
-        unstructured {
-            goto 'label_27;
-        }
-    } else {
-        l3 = true;
-        unstructured {
-            goto 'label_27;
-        }
-    };
+    let l3 = !(*(&l0.pool_id) != object::id(l1) || pool::get_magma_distribution_gauger_id(l1) != object::id(l0));
     /* block 27 */;
     return l3
 }
@@ -177,51 +154,27 @@ public fun claim_fees<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &NotifyRewardC
 }
 
 fun claim_fees_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool<T0, T1>): ( Balance<T0>, Balance<T1>) {
-    let l2;
     let l11 = config::week();
     let (reg_5, reg_6) = pool::collect_magma_distribution_gauger_fees(l1, option::borrow(&l0.gauge_cap));
     let l6 = reg_6;
     let l5 = reg_5;
-    if (balance::value(&l5) > 0u64) {
-        l2 = true;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        l2 = balance::value(&l6) > 0u64;
-        unstructured {
-            goto 'label_22;
-        }
-    };
+    let l2 = balance::value(&l5) > 0u64 || balance::value(&l6) > 0u64;
     /* block 22 */;
     if (l2) {
-        let l3;
         let l7 = balance::join(&mut l0.fee_a, l5);
         let l8 = balance::join(&mut l0.fee_b, l6);
-        if (l7 > l11) {
-            l3 = balance::withdraw_all(&mut l0.fee_a);
-            unstructured {
-                goto 'label_45;
-            }
+        let l3 = if (l7 > l11) {
+            balance::withdraw_all(&mut l0.fee_a)
         } else {
-            l3 = balance::zero();
-            unstructured {
-                goto 'label_45;
-            }
+            balance::zero()
         };
         let (l4, l9);
         /* block 45 */;
         l9 = l3;
-        if (l8 > l11) {
-            l4 = balance::withdraw_all(&mut l0.fee_b);
-            unstructured {
-                goto 'label_60;
-            }
+        l4 = if (l8 > l11) {
+            balance::withdraw_all(&mut l0.fee_b)
         } else {
-            l4 = balance::zero();
-            unstructured {
-                goto 'label_60;
-            }
+            balance::zero()
         };
         /* block 60 */;
         let l10 = l4;
@@ -259,10 +212,7 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
     if (!(table::contains(&l2.stakes, l13))) {
         let l15 = vector[];
         (&mut l15).push_back(l11);
-        table::add(&mut l2.stakes, l13, l15);
-        unstructured {
-            goto 'label_192;
-        }
+        table::add(&mut l2.stakes, l13, l15)
     } else {
         let l18 = table::borrow(&l2.stakes, l13);
         let l8 = 0u64;
@@ -285,17 +235,11 @@ public fun deposit_position<T0, T1, T2>(l0: &GlobalConfig, l1: &DistributionConf
     /* block 192 */;
     object_table::add(&mut l2.staked_positions, l11, l4);
     if (!(table::contains(&l2.rewards, l11))) {
-        table::add(&mut l2.rewards, l11, RewardProfile { growth_inside: pool::get_magma_distribution_growth_inside(freeze(l3), l16, l17, 0u128), amount: 0u64, last_update_time: clock::timestamp_ms(l5) / 1000u64 });
-        unstructured {
-            goto 'label_242;
-        }
+        table::add(&mut l2.rewards, l11, RewardProfile { growth_inside: pool::get_magma_distribution_growth_inside(freeze(l3), l16, l17, 0u128), amount: 0u64, last_update_time: clock::timestamp_ms(l5) / 1000u64 })
     } else {
         let l12 = table::borrow_mut(&mut l2.rewards, l11);
         *(&mut l12.growth_inside) = pool::get_magma_distribution_growth_inside(freeze(l3), l16, l17, 0u128);
-        *(&mut l12.last_update_time) = clock::timestamp_ms(l5) / 1000u64;
-        unstructured {
-            goto 'label_242;
-        }
+        *(&mut l12.last_update_time) = clock::timestamp_ms(l5) / 1000u64
     };
     /* block 242 */;
     pool::mark_position_staked(l3, option::borrow(&l2.gauge_cap), l11);
@@ -327,52 +271,19 @@ public fun earned_by_position<T0, T1, T2>(l0: &Gauge<T0, T1, T2>, l1: &Pool<T0, 
 }
 
 fun earned_internal<T0, T1, T2>(l0: &Gauge<T0, T1, T2>, l1: &Pool<T0, T1>, l2: ID, l3: u64): u64 {
-    let l4;
     let l7 = pool::get_magma_distribution_last_updated(l1);
     let l5 = l3 - l7;
     let l6 = pool::get_magma_distribution_growth_global(l1);
     let l10 = pool::get_magma_distribution_reserve(l1)as u128 * C0;
     let l13 = pool::get_magma_distribution_staked_liquidity(l1);
-    if (l5 >= 0u64) {
-        if (l10 > 0u128) {
-            l4 = l13 > 0u128;
-            unstructured {
-                goto 'label_37;
-            }
-        } else {
-            l4 = false;
-            unstructured {
-                goto 'label_37;
-            }
-        }
-    } else {
-        l4 = false;
-        unstructured {
-            goto 'label_37;
-        }
-    };
     /* block 37 */;
-    if (l4) {
+    if (l5 >= 0u64 && l10 > 0u128 && l13 > 0u128) {
         let l11 = *(&l0.reward_rate) * l5as u128;
         if (l11 > l10) {
             l11 = l10;
-            unstructured {
-                goto 'label_52;
-            }
-        } else {
-            unstructured {
-                goto 'label_52;
-            }
         };
         /* block 52 */;
-        l6 = l6 + math_u128::checked_div_round(l11, l13, false);
-        unstructured {
-            goto 'label_59;
-        }
-    } else {
-        unstructured {
-            goto 'label_59;
-        }
+        l6 = l6 + math_u128::checked_div_round(l11, l13, false)
     };
     /* block 59 */;
     let l9 = object_table::borrow(&l0.staked_positions, l2);
@@ -446,15 +357,9 @@ fun get_reward_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool<T0
         let l6 = balance::value(&l7);
         let l5 = *(&(table::borrow(&l0.staked_position_infos, l2)).from);
         transfer::public_transfer(coin::from_balance(l7, l4), l5);
-        event::emit(EventClaimReward { from: tx_context::sender(freeze(l4)), position_id: l2, receiver: l5, amount: l6 });
-        unstructured {
-            goto 'label_50;
-        }
+        event::emit(EventClaimReward { from: tx_context::sender(freeze(l4)), position_id: l2, receiver: l5, amount: l6 })
     } else {
-        balance::destroy_zero(l7);
-        unstructured {
-            goto 'label_50;
-        }
+        balance::destroy_zero(l7)
     };
     /* block 50 */
 }
@@ -481,27 +386,15 @@ fun notify_reward_amount_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &m
     l2 = l2 + pool::get_magma_distribution_rollover(freeze(l1));
     if (l7 >= *(&l0.period_finish)) {
         *(&mut l0.reward_rate) = full_math_u128::mul_div_floor(l2as u128, C0, l8as u128);
-        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2, l6);
-        unstructured {
-            goto 'label_84;
-        }
+        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2, l6)
     } else {
         let l5 = full_math_u128::mul_div_floor(l8as u128, *(&l0.reward_rate), C0);
         *(&mut l0.reward_rate) = full_math_u128::mul_div_floor(l2as u128 + l5, C0, l8as u128);
-        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2 + l5as u64, l6);
-        unstructured {
-            goto 'label_84;
-        }
+        pool::sync_magma_distribution_reward(l1, option::borrow(&l0.gauge_cap), *(&l0.reward_rate), l2 + l5as u64, l6)
     };
     /* block 84 */;
     if (table::contains(&l0.reward_rate_by_epoch, config::epoch_start(l7))) {
-        unstructured {
-            goto 'label_96;
-        }
-    } else {
-        unstructured {
-            goto 'label_96;
-        }
+        
     };
     /* block 96 */;
     table::add(&mut l0.reward_rate_by_epoch, config::epoch_start(l7), *(&l0.reward_rate));
@@ -581,52 +474,26 @@ fun update_reward_internal<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool
     if (*(&l10.last_update_time) >= l9) {
         return balance::zero()
     };
-    let l6;
     pool::update_magma_distribution_growth_global(l1, option::borrow(&l0.gauge_cap), l5);
     *(&mut l10.last_update_time) = l9;
     *(&mut l10.amount) = *(&l10.amount) + l8;
     *(&mut l10.growth_inside) = pool::get_magma_distribution_growth_inside(freeze(l1), l3, l4, 0u128);
     let l7 = *(&l10.amount);
     *(&mut l10.amount) = 0u64;
-    if (l7 > 0u64) {
-        l6 = balance::split(&mut l0.reserves_balance, l7);
-        unstructured {
-            goto 'label_83;
-        }
-    } else {
-        l6 = balance::zero();
-        unstructured {
-            goto 'label_83;
-        }
-    };
     /* block 83 */;
-    return l6
+    return if (l7 > 0u64) {
+        balance::split(&mut l0.reserves_balance, l7)
+    } else {
+        balance::zero()
+    }
 }
 
 public fun withdraw_position<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Pool<T0, T1>, l2: ID, l3: &Clock, l4: &mut TxContext) {
-    let l5;
-    if (object_table::contains(&l0.staked_positions, l2)) {
-        l5 = table::contains(&l0.staked_position_infos, l2);
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_13;
-        }
-    };
+    let l5 = object_table::contains(&l0.staked_positions, l2) && table::contains(&l0.staked_position_infos, l2);
     /* block 13 */;
     assert!(l5, 9223373686122414084u64);
     if (gauge::earned_by_position(freeze(l0), freeze(l1), l2, l3) > 0u64) {
-        gauge::get_position_reward(l0, l1, l2, l3, l4);
-        unstructured {
-            goto 'label_42;
-        }
-    } else {
-        unstructured {
-            goto 'label_42;
-        }
+        gauge::get_position_reward(l0, l1, l2, l3, l4)
     };
     /* block 42 */;
     let l8 = table::remove(&mut l0.staked_position_infos, l2);
@@ -636,14 +503,7 @@ public fun withdraw_position<T0, T1, T2>(l0: &mut Gauge<T0, T1, T2>, l1: &mut Po
     let l6 = position::liquidity(&l7);
     if (l6 > 0u128) {
         let (reg_62, reg_63) = position::tick_range(&l7);
-        pool::unstake_from_magma_distribution(l1, option::borrow(&l0.gauge_cap), l6, reg_62, reg_63, l3);
-        unstructured {
-            goto 'label_107;
-        }
-    } else {
-        unstructured {
-            goto 'label_107;
-        }
+        pool::unstake_from_magma_distribution(l1, option::borrow(&l0.gauge_cap), l6, reg_62, reg_63, l3)
     };
     /* block 107 */;
     pool::mark_position_unstaked(l1, option::borrow(&l0.gauge_cap), l2);

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xa32574713e612fa6d9eb439723cb7d69f06ae55117d8c9a028330cea98c5f391/marketplace.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xa32574713e612fa6d9eb439723cb7d69f06ae55117d8c9a028330cea98c5f391/marketplace.move
@@ -458,9 +458,6 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
     } else {
         assert!(linked_table::contains(&l29.bids, l5), C17);
         l32 = *(&(&linked_table::remove(&mut l29.bids, l5)).last_points_claimed_at);
-        unstructured {
-            goto 'label_217;
-        }
     };
     /* block 217 */;
     let l36 = dynamic_object_field::borrow_mut(&mut l1.id, l45);
@@ -489,10 +486,7 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
             std::vector::destroy_empty(linked_table::remove(&mut l36.collection_bids, l7))
         }
     } else {
-        assert!(object::uid_to_inner(&(&linked_table::remove(&mut (linked_table::borrow_mut(&mut l36.bids, l5)).bids, l7)).id) == l6, C26);
-        unstructured {
-            goto 'label_383;
-        }
+        assert!(object::uid_to_inner(&(&linked_table::remove(&mut (linked_table::borrow_mut(&mut l36.bids, l5)).bids, l7)).id) == l6, C26)
     };
     let (l38, l48);
     /* block 383 */;
@@ -510,32 +504,19 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
     kiosk::lock(l4, &l1.escrow_kiosk_cap, l9, l44);
     let l46 = PendingClaim { buyer: l7, nft_type: l45, price: l48 - l38 };
     if (linked_table::contains(&l1.pending_claims, l7)) {
-        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l7)).pending_claims, l5, l46);
-        unstructured {
-            goto 'label_485;
-        }
+        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l7)).pending_claims, l5, l46)
     } else {
         let l47 = PendingClaims { pending_claims: linked_table::new(l12) };
         linked_table::push_back(&mut (&mut l47).pending_claims, l5, l46);
-        linked_table::push_back(&mut l1.pending_claims, l7, l47);
-        unstructured {
-            goto 'label_485;
-        }
+        linked_table::push_back(&mut l1.pending_claims, l7, l47)
     };
     let (l17, l18);
     /* block 485 */;
-    if (*(&l36.ion_points_enabled)) {
-        let l16;
-        if (*(&l36.ion_collection_multiplier) == 0u64) {
-            l16 = C5;
-            unstructured {
-                goto 'label_502;
-            }
+    l17 = if (*(&l36.ion_points_enabled)) {
+        let l16 = if (*(&l36.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l16 = *(&l36.ion_collection_multiplier);
-            unstructured {
-                goto 'label_502;
-            }
+            *(&l36.ion_collection_multiplier)
         };
         /* block 502 */;
         let l37 = l16;
@@ -549,16 +530,10 @@ public fun accept_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2
         let l30 = linked_table::borrow_mut(&mut l1.user_activity, l7);
         *(&mut l30.claimable_points) = *(&l30.claimable_points) + l33;
         l18 = l54;
-        l17 = l33;
-        unstructured {
-            goto 'label_579;
-        }
+        l33
     } else {
         l18 = 0u64;
-        l17 = 0u64;
-        unstructured {
-            goto 'label_579;
-        }
+        0u64
     };
     /* block 579 */;
     let l52 = l18;
@@ -591,14 +566,7 @@ public fun accept_trait_bid<T0: key + store, T1: key + store>(l0: &mut MarketPla
         let l8 = reg_86;
         let l10 = reg_85;
         assert!(l8 == object::id(freeze(l2)), C19);
-        kiosk::return_purchase_cap(l2, l10);
-        unstructured {
-            goto 'label_153;
-        }
-    } else {
-        unstructured {
-            goto 'label_153;
-        }
+        kiosk::return_purchase_cap(l2, l10)
     };
     /* block 153 */;
     return (kiosk::take(l2, l3, l1), l13, l7)
@@ -712,9 +680,6 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
     } else {
         assert!(linked_table::contains(&l26.bids, l5), C17);
         l29 = *(&(&linked_table::remove(&mut l26.bids, l5)).last_points_claimed_at);
-        unstructured {
-            goto 'label_190;
-        }
     };
     let (l21, l33);
     /* block 190 */;
@@ -742,9 +707,6 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
         let l19 = linked_table::borrow_mut(&mut l33.bids, l5);
         assert!(linked_table::contains(&l19.bids, l6), C17);
         let l20 = linked_table::remove(&mut l19.bids, l6);
-        unstructured {
-            goto 'label_321;
-        }
     };
     let (l35, l42, l47);
     /* block 321 */;
@@ -761,32 +723,19 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
     kiosk::lock(l3, &l1.escrow_kiosk_cap, freeze(l10), reg_244);
     let l40 = PendingClaim { buyer: l6, nft_type: l39, price: l42 - l35 };
     if (linked_table::contains(&l1.pending_claims, l6)) {
-        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l6)).pending_claims, l5, l40);
-        unstructured {
-            goto 'label_430;
-        }
+        linked_table::push_back(&mut (linked_table::borrow_mut(&mut l1.pending_claims, l6)).pending_claims, l5, l40)
     } else {
         let l41 = PendingClaims { pending_claims: linked_table::new(l13) };
         linked_table::push_back(&mut (&mut l41).pending_claims, l5, l40);
-        linked_table::push_back(&mut l1.pending_claims, l6, l41);
-        unstructured {
-            goto 'label_430;
-        }
+        linked_table::push_back(&mut l1.pending_claims, l6, l41)
     };
     let (l15, l16);
     /* block 430 */;
-    if (*(&l33.ion_points_enabled)) {
-        let l14;
-        if (*(&l33.ion_collection_multiplier) == 0u64) {
-            l14 = C5;
-            unstructured {
-                goto 'label_447;
-            }
+    l15 = if (*(&l33.ion_points_enabled)) {
+        let l14 = if (*(&l33.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l14 = *(&l33.ion_collection_multiplier);
-            unstructured {
-                goto 'label_447;
-            }
+            *(&l33.ion_collection_multiplier)
         };
         /* block 447 */;
         let l34 = l14;
@@ -798,16 +747,10 @@ public fun accept_unlisted_bid<T0: key + store>(l0: &Clock, l1: &mut MarketPlace
         let l27 = linked_table::borrow_mut(&mut l1.user_activity, l6);
         *(&mut l27.claimable_points) = *(&l27.claimable_points) + l30;
         l16 = l45;
-        l15 = l30;
-        unstructured {
-            goto 'label_512;
-        }
+        l30
     } else {
         l16 = 0u64;
-        l15 = 0u64;
-        unstructured {
-            goto 'label_512;
-        }
+        0u64
     };
     /* block 512 */;
     let l44 = l16;
@@ -834,55 +777,29 @@ public fun award_bid_ion_points<T0: key + store>(l0: &mut MarketPlaceStore, l1: 
     assert!(linked_table::contains(&l0.user_activity, l1), C10);
     let l23 = linked_table::borrow_mut(&mut l0.user_activity, l1);
     assert!(linked_table::contains(&l23.bids, l2), C17);
-    let l6;
     let l9 = linked_table::borrow_mut(&mut l23.bids, l2);
-    if (*(&l9.last_points_claimed_at) == 0u64) {
-        l6 = *(&l9.bid_at);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (*(&l9.last_points_claimed_at) == 0u64) {
+        *(&l9.bid_at)
     } else {
-        l6 = *(&l9.last_points_claimed_at);
-        unstructured {
-            goto 'label_68;
-        }
+        *(&l9.last_points_claimed_at)
     };
     let (l10, l21, l7);
     /* block 68 */;
-    let l14 = l6;
-    l21 = l13 - l14;
+    l21 = l13 - l6;
     l10 = dynamic_object_field::borrow(&l0.id, l15);
-    if (*(&l10.ion_points_enabled)) {
-        l7 = l21 > 0u64;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_90;
-        }
-    };
+    l7 = *(&l10.ion_points_enabled) && l21 > 0u64;
     /* block 90 */;
     if (l7) {
         let l22 = helpers::calculate_time_multiplier(l21, false);
         if (l22 > 0u64) {
-            let l8;
             let l17 = helpers::calculate_bid_proximity_multiplier(*(&l9.bid_price), *(&l10.avg_sale_price));
-            if (*(&l10.ion_collection_multiplier) == 0u64) {
-                l8 = C5;
-                unstructured {
-                    goto 'label_123;
-                }
+            let l8 = if (*(&l10.ion_collection_multiplier) == 0u64) {
+                C5
             } else {
-                l8 = *(&l10.ion_collection_multiplier);
-                unstructured {
-                    goto 'label_123;
-                }
+                *(&l10.ion_collection_multiplier)
             };
             /* block 123 */;
-            let l11 = l8;
-            let l16 = helpers::calculate_ion_points(*(&l9.bid_price), l11, l17, l22);
+            let l16 = helpers::calculate_ion_points(*(&l9.bid_price), l8, l17, l22);
             *(&mut l9.last_points_claimed_at) = l13;
             marketplace::award_ion_points_with_referral(l1, l0, l3, l16, l4, l5);
             if (ions::has_referrer(freeze(l3))) {
@@ -892,34 +809,12 @@ public fun award_bid_ion_points<T0: key + store>(l0: &mut MarketPlaceStore, l1: 
                     let l18 = l16 * C6 / 100u64;
                     if (linked_table::contains(&l0.referrals, l19)) {
                         let l12 = linked_table::borrow_mut(&mut l0.referrals, l19);
-                        *l12 = *l12 + l18;
-                        unstructured {
-                            goto 'label_221;
-                        }
+                        *l12 = *l12 + l18
                     } else {
-                        linked_table::push_back(&mut l0.referrals, l19, l18);
-                        unstructured {
-                            goto 'label_221;
-                        }
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_221;
+                        linked_table::push_back(&mut l0.referrals, l19, l18)
                     }
                 }
-            } else {
-                unstructured {
-                    goto 'label_221;
-                }
             }
-        } else {
-            unstructured {
-                goto 'label_221;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_221;
         }
     };
     /* block 221 */
@@ -937,24 +832,10 @@ fun award_ion_points_with_referral(l0: address, l1: &mut MarketPlaceStore, l2: &
             l6 = math::mul_div_u128(l3as u128, C3as u128, 100u128);
             if (linked_table::contains(&l1.referrals, *(option::borrow(&l9)))) {
                 let l7 = linked_table::borrow_mut(&mut l1.referrals, *(option::borrow(&l9)));
-                *l7 = *l7 + l8;
-                unstructured {
-                    goto 'label_64;
-                }
+                *l7 = *l7 + l8
             } else {
-                linked_table::push_back(&mut l1.referrals, *(option::borrow(&l9)), l8);
-                unstructured {
-                    goto 'label_64;
-                }
+                linked_table::push_back(&mut l1.referrals, *(option::borrow(&l9)), l8)
             }
-        } else {
-            unstructured {
-                goto 'label_64;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_64;
         }
     };
     /* block 64 */;
@@ -969,67 +850,30 @@ public fun award_listing_ion_points<T0: key + store>(l0: &mut MarketPlaceStore, 
     assert!(linked_table::contains(&l0.user_activity, l1), C10);
     let l19 = linked_table::borrow_mut(&mut l0.user_activity, l1);
     assert!(linked_table::contains(&l19.listings, l2), C11);
-    let l6;
     let l13 = linked_table::borrow_mut(&mut l19.listings, l2);
-    if (*(&l13.last_points_claimed_at) == 0u64) {
-        l6 = *(&l13.listed_at);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (*(&l13.last_points_claimed_at) == 0u64) {
+        *(&l13.listed_at)
     } else {
-        l6 = *(&l13.last_points_claimed_at);
-        unstructured {
-            goto 'label_68;
-        }
+        *(&l13.last_points_claimed_at)
     };
     let (l17, l7, l9);
     /* block 68 */;
-    let l12 = l6;
-    l17 = l11 - l12;
+    l17 = l11 - l6;
     l9 = dynamic_object_field::borrow(&l0.id, l14);
-    if (*(&l9.ion_points_enabled)) {
-        l7 = l17 > 0u64;
-        unstructured {
-            goto 'label_90;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_90;
-        }
-    };
+    l7 = *(&l9.ion_points_enabled) && l17 > 0u64;
     /* block 90 */;
     if (l7) {
         let l18 = helpers::calculate_time_multiplier(l17, false);
         if (l18 > 0u64) {
-            let l8;
             let l16 = helpers::calculate_listing_proximity_multiplier(*(&l13.price), *(&l9.avg_sale_price));
-            if (*(&l9.ion_collection_multiplier) == 0u64) {
-                l8 = C5;
-                unstructured {
-                    goto 'label_123;
-                }
+            let l8 = if (*(&l9.ion_collection_multiplier) == 0u64) {
+                C5
             } else {
-                l8 = *(&l9.ion_collection_multiplier);
-                unstructured {
-                    goto 'label_123;
-                }
+                *(&l9.ion_collection_multiplier)
             };
             /* block 123 */;
-            let l10 = l8;
-            let l15 = helpers::calculate_ion_points(*(&l13.price), l10, l16, l18);
-            marketplace::award_ion_points_with_referral(l1, l0, l3, l15, l4, l5);
-            unstructured {
-                goto 'label_168;
-            }
-        } else {
-            unstructured {
-                goto 'label_168;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
+            let l15 = helpers::calculate_ion_points(*(&l13.price), l8, l16, l18);
+            marketplace::award_ion_points_with_referral(l1, l0, l3, l15, l4, l5)
         }
     };
     /* block 168 */
@@ -1068,18 +912,11 @@ public fun buy<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2: &mut 
     let l44 = x2_balance::split(&mut l43, l38);
     let (reg_145, reg_146) = kiosk::purchase_with_cap(l2, reg_116, coin::from_balance(l44, l7));
     let l32 = reg_145;
-    if (*(&l25.ion_points_enabled)) {
-        let l16;
-        if (*(&l25.ion_collection_multiplier) == 0u64) {
-            l16 = C5;
-            unstructured {
-                goto 'label_244;
-            }
+    l9 = if (*(&l25.ion_points_enabled)) {
+        let l16 = if (*(&l25.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l16 = *(&l25.ion_collection_multiplier);
-            unstructured {
-                goto 'label_244;
-            }
+            *(&l25.ion_collection_multiplier)
         };
         /* block 244 */;
         let l26 = l16;
@@ -1100,16 +937,10 @@ public fun buy<T0: key + store>(l0: &Clock, l1: &mut MarketPlaceStore, l2: &mut 
         let l24 = helpers::calculate_ion_points(l42, l26, l35, C5);
         marketplace::award_ion_points_with_referral(l22, l1, l5, l24, l0, l6);
         l10 = l41;
-        l9 = l24;
-        unstructured {
-            goto 'label_342;
-        }
+        l24
     } else {
         l10 = 0u64;
-        l9 = 0u64;
-        unstructured {
-            goto 'label_342;
-        }
+        0u64
     };
     /* block 342 */;
     let l40 = l10;
@@ -1143,9 +974,6 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
         let l35 = *(option::borrow(&l1));
         assert!(linked_table::contains(&l28.bids, l35), C17);
         let l21 = linked_table::remove(&mut (linked_table::borrow_mut(&mut l28.bids, l35)).bids, l27);
-        unstructured {
-            goto 'label_166;
-        }
     } else {
         assert!(linked_table::contains(&l28.collection_bids, l27), C17);
         let l20 = linked_table::borrow_mut(&mut l28.collection_bids, l27);
@@ -1199,27 +1027,17 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
         let l24 = linked_table::remove(&mut l44.bids, l36);
         l26 = *(&(&l24).bid_price);
         l34 = *(&(&l24).last_points_claimed_at);
-        unstructured {
-            goto 'label_321;
-        }
     };
     let l9;
     /* block 321 */;
     let l41 = l43 - l34;
-    if (*(&l28.ion_points_enabled)) {
-        let l14;
+    l9 = if (*(&l28.ion_points_enabled)) {
         let l42 = helpers::calculate_time_multiplier(l41, false);
         let l39 = helpers::calculate_bid_proximity_multiplier(l26, *(&l28.avg_sale_price));
-        if (*(&l28.ion_collection_multiplier) == 0u64) {
-            l14 = C5;
-            unstructured {
-                goto 'label_354;
-            }
+        let l14 = if (*(&l28.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l14 = *(&l28.ion_collection_multiplier);
-            unstructured {
-                goto 'label_354;
-            }
+            *(&l28.ion_collection_multiplier)
         };
         /* block 354 */;
         let l29 = l14;
@@ -1236,15 +1054,9 @@ public fun cancel_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option<ID>
         debug::print(&string::utf8(C39));
         debug::print(&l38);
         marketplace::award_ion_points_with_referral(l27, l0, l3, l38, l4, l5);
-        l9 = l38;
-        unstructured {
-            goto 'label_424;
-        }
+        l38
     } else {
-        l9 = 0u64;
-        unstructured {
-            goto 'label_424;
-        }
+        0u64
     };
     /* block 424 */;
     let l32 = l9;
@@ -1287,10 +1099,6 @@ public fun cancel_trait_bid_settle<T0: key + store, T1: key + store>(l0: &Clock,
             };
             l20 = l20 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_109;
-        }
     };
     let (l12, l25);
     /* block 109 */;
@@ -1299,71 +1107,37 @@ public fun cancel_trait_bid_settle<T0: key + store, T1: key + store>(l0: &Clock,
     l25 = marketplace::destroy_active_trait_bid(l2);
     helpers::destroy_or_transfer_balance(x2_balance::split(&mut l16.sui_trait_bids_pool, l25), l15, l7);
     let l17 = dynamic_object_field::borrow(&l1.id, l23);
-    if (*(&l17.ion_points_enabled)) {
-        let l8;
-        if (l22 == 0u64) {
-            l8 = l13;
-            unstructured {
-                goto 'label_149;
-            }
+    l12 = if (*(&l17.ion_points_enabled)) {
+        let l8 = if (l22 == 0u64) {
+            l13
         } else {
-            l8 = l22;
-            unstructured {
-                goto 'label_149;
-            }
+            l22
         };
         let l11;
         /* block 149 */;
         let l26 = helpers::calculate_time_multiplier(l27 - l8, false);
-        if (l26 > 0u64) {
-            let l10;
+        l11 = if (l26 > 0u64) {
             let l24 = helpers::calculate_bid_proximity_multiplier(l25, *(&l17.avg_sale_price));
-            if (*(&l17.ion_collection_multiplier) == 0u64) {
-                l10 = C5;
-                unstructured {
-                    goto 'label_180;
-                }
+            let l10 = if (*(&l17.ion_collection_multiplier) == 0u64) {
+                C5
             } else {
-                l10 = *(&l17.ion_collection_multiplier);
-                unstructured {
-                    goto 'label_180;
-                }
+                *(&l17.ion_collection_multiplier)
             };
             /* block 180 */;
-            let l18 = l10;
-            l11 = helpers::calculate_ion_points(l25, l18, l24, l26);
-            unstructured {
-                goto 'label_193;
-            }
+            helpers::calculate_ion_points(l25, l10, l24, l26)
         } else {
-            l11 = 0u64;
-            unstructured {
-                goto 'label_193;
-            }
+            0u64
         };
         /* block 193 */;
-        l12 = l11;
-        unstructured {
-            goto 'label_200;
-        }
+        l11
     } else {
-        l12 = 0u64;
-        unstructured {
-            goto 'label_200;
-        }
+        0u64
     };
     let l21;
     /* block 200 */;
     l21 = l12;
     if (l21 > 0u64) {
-        marketplace::award_ion_points_with_referral(l15, l1, l5, l21, l0, l6);
-        unstructured {
-            goto 'label_222;
-        }
-    } else {
-        unstructured {
-            goto 'label_222;
-        }
+        marketplace::award_ion_points_with_referral(l15, l1, l5, l21, l0, l6)
     };
     /* block 222 */;
     event::emit(TraitBidCancelledEvent { nft_type: l23, bidder: l15, bid_id: l14, refund_amount: l25, ion_points_awarded: l21, cancelled_at: l27 })
@@ -1386,24 +1160,10 @@ public fun claim_referral_points(l0: &Clock, l1: &mut AnimaChef, l2: &mut Market
             l5 = math::mul_div_u128(l6as u128, C3as u128, 100u128);
             if (linked_table::contains(&l2.referrals, *(option::borrow(&l10)))) {
                 let l8 = linked_table::borrow_mut(&mut l2.referrals, *(option::borrow(&l10)));
-                *l8 = *l8 + l9;
-                unstructured {
-                    goto 'label_99;
-                }
+                *l8 = *l8 + l9
             } else {
-                linked_table::push_back(&mut l2.referrals, *(option::borrow(&l10)), l9);
-                unstructured {
-                    goto 'label_99;
-                }
+                linked_table::push_back(&mut l2.referrals, *(option::borrow(&l10)), l9)
             }
-        } else {
-            unstructured {
-                goto 'label_99;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_99;
         }
     };
     /* block 99 */;
@@ -1431,70 +1191,28 @@ fun create_trait_summary(l0: Option<String>, l1: Option<String>, l2: Option<Stri
     let l3 = true;
     if (option::is_some(&l0)) {
         if (!(l3)) {
-            ascii::append(&mut l4, ascii::string(C63));
-            unstructured {
-                goto 'label_15;
-            }
-        } else {
-            unstructured {
-                goto 'label_15;
-            }
+            ascii::append(&mut l4, ascii::string(C63))
         };
         /* block 15 */;
         ascii::append(&mut l4, *(option::borrow(&l0)));
-        l3 = false;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        unstructured {
-            goto 'label_22;
-        }
+        l3 = false
     };
     /* block 22 */;
     if (option::is_some(&l1)) {
         if (!(l3)) {
-            ascii::append(&mut l4, ascii::string(C63));
-            unstructured {
-                goto 'label_32;
-            }
-        } else {
-            unstructured {
-                goto 'label_32;
-            }
+            ascii::append(&mut l4, ascii::string(C63))
         };
         /* block 32 */;
         ascii::append(&mut l4, *(option::borrow(&l1)));
-        l3 = false;
-        unstructured {
-            goto 'label_39;
-        }
-    } else {
-        unstructured {
-            goto 'label_39;
-        }
+        l3 = false
     };
     /* block 39 */;
     if (option::is_some(&l2)) {
         if (!(l3)) {
-            ascii::append(&mut l4, ascii::string(C63));
-            unstructured {
-                goto 'label_49;
-            }
-        } else {
-            unstructured {
-                goto 'label_49;
-            }
+            ascii::append(&mut l4, ascii::string(C63))
         };
         /* block 49 */;
-        ascii::append(&mut l4, *(option::borrow(&l2)));
-        unstructured {
-            goto 'label_54;
-        }
-    } else {
-        unstructured {
-            goto 'label_54;
-        }
+        ascii::append(&mut l4, *(option::borrow(&l2)))
     };
     /* block 54 */;
     return l4
@@ -1520,14 +1238,7 @@ fun destroy_listing<T0: key + store>(l0: Listing<T0>): ( PurchaseCap<T0>, ID, u6
 fun ensure_user_activity_exists(l0: &mut LinkedTable<address, UserInfo>, l1: address, l2: &mut TxContext) {
     if (!(linked_table::contains(freeze(l0), l1))) {
         let l3 = UserInfo { id: object::new(l2), listings: linked_table::new(l2), bids: linked_table::new(l2), collection_bids: linked_table::new(l2), trait_bids: linked_table::new(l2), claimable_points: 0u64 };
-        linked_table::push_back(l0, l1, l3);
-        unstructured {
-            goto 'label_28;
-        }
-    } else {
-        unstructured {
-            goto 'label_28;
-        }
+        linked_table::push_back(l0, l1, l3)
     };
     /* block 28 */
 }
@@ -1559,18 +1270,11 @@ public fun get_bids_for_any_nft<T0: key + store>(l0: &MarketPlaceStore, l1: ID, 
     if (!(linked_table::contains(&l12.bids, l1))) {
         return (l11, l9, l10, l7, 0u64, l15)
     };
-    let l4;
     let l6 = linked_table::borrow(&l12.bids, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_67;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l6.bids));
-        unstructured {
-            goto 'label_67;
-        }
+        *(linked_table::front(&l6.bids))
     };
     let (l13, l14);
     /* block 67 */;
@@ -1602,18 +1306,11 @@ public fun get_bids_for_listing<T0: key + store>(l0: &MarketPlaceStore, l1: ID, 
     if (!(linked_table::contains(&l12.bids, l1))) {
         return (l11, l9, l10, l7, 0u64)
     };
-    let l4;
     let l6 = linked_table::borrow(&l12.bids, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_60;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l6.bids));
-        unstructured {
-            goto 'label_60;
-        }
+        *(linked_table::front(&l6.bids))
     };
     let (l13, l14);
     /* block 60 */;
@@ -1639,18 +1336,11 @@ public fun get_collection_bidders_for_collection<T0: key + store>(l0: &MarketPla
     if (!(dynamic_object_field::exists_(&l0.id, l11))) {
         return (l5, l6, 0u64)
     };
-    let l3;
     let l8 = dynamic_object_field::borrow(&l0.id, l11);
-    if (option::is_some(&l1)) {
-        l3 = l1;
-        unstructured {
-            goto 'label_35;
-        }
+    let l3 = if (option::is_some(&l1)) {
+        l1
     } else {
-        l3 = *(linked_table::front(&l8.collection_bids));
-        unstructured {
-            goto 'label_35;
-        }
+        *(linked_table::front(&l8.collection_bids))
     };
     let (l10, l9);
     /* block 35 */;
@@ -1716,18 +1406,11 @@ public fun get_listings_for_marketplace<T0: key + store>(l0: &MarketPlaceStore, 
     if (!(dynamic_object_field::exists_(&l0.id, l13))) {
         return (l15, l9, l12, l14, l6, 0u64)
     };
-    let l3;
     let l5 = dynamic_object_field::borrow(&l0.id, l13);
-    if (option::is_some(&l1)) {
-        l3 = l1;
-        unstructured {
-            goto 'label_44;
-        }
+    let l3 = if (option::is_some(&l1)) {
+        l1
     } else {
-        l3 = *(linked_table::front(&l5.listings));
-        unstructured {
-            goto 'label_44;
-        }
+        *(linked_table::front(&l5.listings))
     };
     let (l7, l8);
     /* block 44 */;
@@ -1752,20 +1435,11 @@ public fun get_marketplace_info(l0: &MarketPlaceStore): ( address, bool, u64, u6
 }
 
 public fun get_referral_points_balance(l0: &MarketPlaceStore, l1: address): u64 {
-    let l2;
-    if (linked_table::contains(&l0.referrals, l1)) {
-        l2 = *(linked_table::borrow(&l0.referrals, l1));
-        unstructured {
-            goto 'label_16;
-        }
+    /* block 16 */ return if (linked_table::contains(&l0.referrals, l1)) {
+        *(linked_table::borrow(&l0.referrals, l1))
     } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_16;
-        }
-    };
-    /* block 16 */;
-    return l2
+        0u64
+    }
 }
 
 public fun get_trait_bid_details(l0: &MarketPlaceStore, l1: address, l2: ID): (
@@ -1804,43 +1478,30 @@ public fun get_trait_bid_details(l0: &MarketPlaceStore, l1: address, l2: ID): (
 
 public fun get_user_activity_overview(l0: &MarketPlaceStore, l1: address): ( u64, u64, u64, u64, u64) {
     let (l2, l3, l4, l5, l6);
-    if (!(linked_table::contains(&l0.user_activity, l1))) {
+    l2 = if (!(linked_table::contains(&l0.user_activity, l1))) {
         l6 = 0u64;
         l5 = 0u64;
         l4 = 0u64;
         l3 = 0u64;
-        l2 = 0u64;
-        unstructured {
-            goto 'label_44;
-        }
+        0u64
     } else {
         let l7 = linked_table::borrow(&l0.user_activity, l1);
         l6 = *(&l7.claimable_points);
         l5 = linked_table::length(&l7.trait_bids);
         l4 = linked_table::length(&l7.collection_bids);
         l3 = linked_table::length(&l7.bids);
-        l2 = linked_table::length(&l7.listings);
-        unstructured {
-            goto 'label_44;
-        }
+        linked_table::length(&l7.listings)
     };
     /* block 44 */;
     return (l2, l3, l4, l5, l6)
 }
 
 public fun get_user_addresses_list(l0: &MarketPlaceStore, l1: Option<address>, l2: u64): ( vector<address>, u64) {
-    let l3;
     let l8 = vector[];
-    if (option::is_some(&l1)) {
-        l3 = l1;
-        unstructured {
-            goto 'label_13;
-        }
+    let l3 = if (option::is_some(&l1)) {
+        l1
     } else {
-        l3 = *(linked_table::front(&l0.user_activity));
-        unstructured {
-            goto 'label_13;
-        }
+        *(linked_table::front(&l0.user_activity))
     };
     let (l5, l6);
     /* block 13 */;
@@ -1865,18 +1526,11 @@ public fun get_user_bids_info(l0: &MarketPlaceStore, l1: address, l2: Option<ID>
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l14, l15, l7, l9, l6, l12, 0u64)
     };
-    let l4;
     let l16 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_44;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l16.bids));
-        unstructured {
-            goto 'label_44;
-        }
+        *(linked_table::front(&l16.bids))
     };
     let (l10, l11);
     /* block 44 */;
@@ -1929,18 +1583,11 @@ public fun get_user_collection_bids_info(l0: &MarketPlaceStore, l1: address, l2:
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l11, l6, 0u64)
     };
-    let l4;
     let l12 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_32;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l12.collection_bids));
-        unstructured {
-            goto 'label_32;
-        }
+        *(linked_table::front(&l12.collection_bids))
     };
     let (l8, l9);
     /* block 32 */;
@@ -1965,18 +1612,11 @@ public fun get_user_listings_info(l0: &MarketPlaceStore, l1: address, l2: Option
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l11, l13, l12, l8, 0u64)
     };
-    let l4;
     let l14 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_38;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l14.listings));
-        unstructured {
-            goto 'label_38;
-        }
+        *(linked_table::front(&l14.listings))
     };
     let (l6, l7);
     /* block 38 */;
@@ -2002,18 +1642,11 @@ public fun get_user_pending_claims(l0: &MarketPlaceStore, l1: address, l2: Optio
     if (!(linked_table::contains(&l0.pending_claims, l1))) {
         return (vector[], vector[], 0u64)
     };
-    let l4;
     let l10 = linked_table::borrow(&l0.pending_claims, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_34;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l10.pending_claims));
-        unstructured {
-            goto 'label_34;
-        }
+        *(linked_table::front(&l10.pending_claims))
     };
     let (l6, l8);
     /* block 34 */;
@@ -2040,18 +1673,11 @@ public fun get_user_trait_bids_info(l0: &MarketPlaceStore, l1: address, l2: Opti
     if (!(linked_table::contains(&l0.user_activity, l1))) {
         return (l7, l15, l8, l22, 0u64)
     };
-    let l4;
     let l24 = linked_table::borrow(&l0.user_activity, l1);
-    if (option::is_some(&l2)) {
-        l4 = l2;
-        unstructured {
-            goto 'label_40;
-        }
+    let l4 = if (option::is_some(&l2)) {
+        l2
     } else {
-        l4 = *(linked_table::front(&l24.trait_bids));
-        unstructured {
-            goto 'label_40;
-        }
+        *(linked_table::front(&l24.trait_bids))
     };
     let (l11, l9);
     /* block 40 */;
@@ -2164,31 +1790,19 @@ public entry fun make_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option
         if (linked_table::contains(&l17.bids, l19)) {
             let l10 = linked_table::borrow_mut(&mut l17.bids, l19);
             assert!(!(linked_table::contains(&l10.bids, l16)), C16);
-            linked_table::push_back(&mut l10.bids, l16, l9);
-            unstructured {
-                goto 'label_140;
-            }
+            linked_table::push_back(&mut l10.bids, l16, l9)
         } else {
             let l11 = ActiveBids { id: object::new(l5), bids: linked_table::new(l5) };
             linked_table::push_back(&mut (&mut l11).bids, l16, l9);
-            linked_table::push_back(&mut l17.bids, l19, l11);
-            unstructured {
-                goto 'label_140;
-            }
+            linked_table::push_back(&mut l17.bids, l19, l11)
         }
     } else {
         if (linked_table::contains(&l17.collection_bids, l16)) {
-            (linked_table::borrow_mut(&mut l17.collection_bids, l16)).push_back(l9);
-            unstructured {
-                goto 'label_140;
-            }
+            (linked_table::borrow_mut(&mut l17.collection_bids, l16)).push_back(l9)
         } else {
             let l12 = vector[];
             (&mut l12).push_back(l9);
-            linked_table::push_back(&mut l17.collection_bids, l16, l12);
-            unstructured {
-                goto 'label_140;
-            }
+            linked_table::push_back(&mut l17.collection_bids, l16, l12)
         }
     };
     /* block 140 */;
@@ -2197,25 +1811,16 @@ public entry fun make_bid<T0: key + store>(l0: &mut MarketPlaceStore, l1: Option
     let l24 = linked_table::borrow_mut(&mut l0.user_activity, l16);
     if (l18) {
         if (linked_table::contains(&l24.collection_bids, l21)) {
-            (linked_table::borrow_mut(&mut l24.collection_bids, l21)).push_back(l15);
-            unstructured {
-                goto 'label_205;
-            }
+            (linked_table::borrow_mut(&mut l24.collection_bids, l21)).push_back(l15)
         } else {
             let l13 = vector[];
             (&mut l13).push_back(l15);
-            linked_table::push_back(&mut l24.collection_bids, l21, l13);
-            unstructured {
-                goto 'label_205;
-            }
+            linked_table::push_back(&mut l24.collection_bids, l21, l13)
         }
     } else {
         let l20 = *(option::borrow(&l1));
         assert!(!(linked_table::contains(&l24.bids, l20)), C16);
-        linked_table::push_back(&mut l24.bids, l20, l15);
-        unstructured {
-            goto 'label_205;
-        }
+        linked_table::push_back(&mut l24.bids, l20, l15)
     };
     /* block 205 */;
     debug::print(&string::utf8(C44));
@@ -2240,17 +1845,11 @@ public fun make_trait_bid<T0: key + store, T1: key + store>(l0: &Clock, l1: &mut
     let l22 = linked_table::borrow_mut(&mut l1.user_activity, l14);
     let l19 = TraitBidInfo { bid_id: l13, nft_type: l17, bid_price: l11, trait_key1: l3, trait_value1: l4, trait_key2: l5, trait_value2: l6, trait_key3: l7, trait_value3: l8, bid_at: l18, last_points_claimed_at: l18 };
     if (linked_table::contains(&l22.trait_bids, l17)) {
-        (linked_table::borrow_mut(&mut l22.trait_bids, l17)).push_back(l19);
-        unstructured {
-            goto 'label_122;
-        }
+        (linked_table::borrow_mut(&mut l22.trait_bids, l17)).push_back(l19)
     } else {
         let l20 = vector[];
         (&mut l20).push_back(l19);
-        linked_table::push_back(&mut l22.trait_bids, l17, l20);
-        unstructured {
-            goto 'label_122;
-        }
+        linked_table::push_back(&mut l22.trait_bids, l17, l20)
     };
     /* block 122 */;
     let l21 = dynamic_object_field::remove(&mut l15.id, C1);
@@ -2332,25 +1931,17 @@ public fun unlist<T0: key + store>(l0: &mut MarketPlaceStore, l1: &mut Kiosk, l2
     let l23 = linked_table::remove(&mut l21.listings, l2);
     let l18 = dynamic_object_field::borrow_mut(&mut l0.id, l24);
     assert!(linked_table::contains(&l18.listings, l2), C11);
-    let l17;
     let l22 = linked_table::remove(&mut l18.listings, l2);
     let l29 = l31 - *(&(&l23).last_points_claimed_at);
     debug::print(&string::utf8(C34));
     debug::print(&l29);
-    if (*(&l18.ion_points_enabled)) {
-        let l11;
+    let l17 = if (*(&l18.ion_points_enabled)) {
         let l30 = helpers::calculate_time_multiplier(l29, false);
         let l26 = helpers::calculate_listing_proximity_multiplier(*(&(&l22).price), *(&l18.avg_sale_price));
-        if (*(&l18.ion_collection_multiplier) == 0u64) {
-            l11 = C5;
-            unstructured {
-                goto 'label_140;
-            }
+        let l11 = if (*(&l18.ion_collection_multiplier) == 0u64) {
+            C5
         } else {
-            l11 = *(&l18.ion_collection_multiplier);
-            unstructured {
-                goto 'label_140;
-            }
+            *(&l18.ion_collection_multiplier)
         };
         /* block 140 */;
         let l19 = l11;
@@ -2365,15 +1956,9 @@ public fun unlist<T0: key + store>(l0: &mut MarketPlaceStore, l1: &mut Kiosk, l2
         debug::print(&string::utf8(C39));
         debug::print(&l25);
         marketplace::award_ion_points_with_referral(l28, l0, l3, l25, l4, l5);
-        l17 = l25;
-        unstructured {
-            goto 'label_205;
-        }
+        l25
     } else {
-        l17 = 0u64;
-        unstructured {
-            goto 'label_205;
-        }
+        0u64
     };
     /* block 205 */;
     let l20 = l17;
@@ -2390,33 +1975,17 @@ public fun update_active_collections<T0: key + store>(l0: &mut MarketPlaceStore,
     let l7 = type_name::into_string(type_name::get());
     if (l2) {
         if (!(linked_table::contains(&l0.active_collections, l7))) {
-            linked_table::push_back(&mut l0.active_collections, l7, true);
-            unstructured {
-                goto 'label_28;
-            }
+            linked_table::push_back(&mut l0.active_collections, l7, true)
         } else {
-            *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = true;
-            unstructured {
-                goto 'label_28;
-            }
+            *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = true
         };
         /* block 28 */;
         if (!(dynamic_object_field::exists_(&l0.id, l7))) {
             let l6 = CollectionMarketPlace { id: object::new(l3), listings: linked_table::new(l3), bids: linked_table::new(l3), collection_bids: linked_table::new(l3), sui_trait_bids_pool: x2_balance::zero(), are_trait_bids_enabled: false, lifetime_volume: 0u128, ion_points_enabled: false, ion_collection_multiplier: 0u64, avg_sale_price: 0u64, recent_sale_prices: vector[] };
-            dynamic_object_field::add(&mut l0.id, l7, l6);
-            unstructured {
-                goto 'label_72;
-            }
-        } else {
-            unstructured {
-                goto 'label_72;
-            }
+            dynamic_object_field::add(&mut l0.id, l7, l6)
         }
     } else {
-        *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = false;
-        unstructured {
-            goto 'label_72;
-        }
+        *(linked_table::borrow_mut(&mut l0.active_collections, l7)) = false
     };
     /* block 72 */;
     event::emit(UpdateActiveCollectionsEvent { nft_type: l7, boolean: l2 })
@@ -2424,13 +1993,7 @@ public fun update_active_collections<T0: key + store>(l0: &mut MarketPlaceStore,
 
 fun update_collection_avg_price<T0: key + store>(l0: &mut CollectionMarketPlace<T0>, l1: u64) {
     if (&l0.recent_sale_prices.len() >= C3) {
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        unstructured {
-            goto 'label_11;
-        }
+        
     };
     let (l2, l3);
     /* block 11 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xaeb83a6f7faeb742ecd0b72fce593a9364b962c56f1a419a3d6296355720a9a1/sui20.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xaeb83a6f7faeb742ecd0b72fce593a9364b962c56f1a419a3d6296355720a9a1/sui20.move
@@ -141,13 +141,6 @@ public fun deploy(l0: &mut Global, l1: &Clock, l2: vector<u8>, l3: u64, l4: u64,
     let l9 = l10;
     if (l7 > l10) {
         l9 = l7;
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        unstructured {
-            goto 'label_30;
-        }
     };
     /* block 30 */;
     let l11 = Sui20Data { meta: Sui20Meta { tick: l12, max: l3, limit: l4, decimals: l5, fee: l6, start_at: l9 }, enable_to_coin: false, total_minted: 0u64, txs: 0u64, user_infos: table::new(l8), users: vector[], upgrade_bag: bag::new(l8) };
@@ -166,13 +159,6 @@ public fun get_mint_data(l0: &mut Global, l1: String, l2: &mut TxContext) {
         l8 = *(&l4.minted_amount);
         l6 = *(&l4.hold_amount);
         l7 = *(&l4.last_mint_at);
-        unstructured {
-            goto 'label_47;
-        }
-    } else {
-        unstructured {
-            goto 'label_47;
-        }
     };
     /* block 47 */;
     event::emit(QueryDataEvent { tick: *(&(&l3.meta).tick), start_at: *(&(&l3.meta).start_at), total_cap: *(&(&l3.meta).max), limit_per_mint: *(&(&l3.meta).limit), decimals: *(&(&l3.meta).decimals), mint_fee: *(&(&l3.meta).fee), total_minted: *(&l3.total_minted), remain_supply: *(&(&l3.meta).max) - *(&l3.total_minted), txs: *(&l3.txs), user_minted_amount: l8, user_hold_amount: l6, user_last_mint_at: l7 })
@@ -221,14 +207,7 @@ public fun mint(l0: &mut Global, l1: &Clock, l2: String, l3: u64, l4: Coin<SUI>,
     *(&mut l7.total_minted) = *(&l7.total_minted) + l3;
     *(&mut l7.txs) = *(&l7.txs) + 1u64;
     if (!(table::contains(&l7.user_infos, l15))) {
-        table::add(&mut l7.user_infos, l15, UserInfo { minted_amount: 0u64, last_mint_at: 0u64, hold_amount: 0u64 });
-        unstructured {
-            goto 'label_137;
-        }
-    } else {
-        unstructured {
-            goto 'label_137;
-        }
+        table::add(&mut l7.user_infos, l15, UserInfo { minted_amount: 0u64, last_mint_at: 0u64, hold_amount: 0u64 })
     };
     /* block 137 */;
     let l9 = table::borrow_mut(&mut l7.user_infos, l15);
@@ -260,10 +239,6 @@ public fun mint(l0: &mut Global, l1: &Clock, l2: String, l3: u64, l4: Coin<SUI>,
                 
             }
         }
-    } else {
-        unstructured {
-            goto 'label_241;
-        }
     };
     /* block 241 */;
     x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l7.meta).tick), amount: l3 }, l15);
@@ -290,14 +265,7 @@ public fun transfer(l0: &mut Global, l1: String, l2: vector<Sui20>, l3: address,
     x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l8.meta).tick), amount: l4 }, l3);
     let l10 = l11 - l4;
     if (l10 > 0u64) {
-        x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l8.meta).tick), amount: l10 }, l12);
-        unstructured {
-            goto 'label_109;
-        }
-    } else {
-        unstructured {
-            goto 'label_109;
-        }
+        x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l8.meta).tick), amount: l10 }, l12)
     };
     /* block 109 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xaec7902b4b095e4c1c4ce27e3e26229e6a1d9f9bceb5561e649061d45407c656/interest_clamm_volatile.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xaec7902b4b095e4c1c4ce27e3e26229e6a1d9f9bceb5561e649061d45407c656/interest_clamm_volatile.move
@@ -175,66 +175,34 @@ fun add_liquidity<T0>(l0: &mut StateV1<T0>, l1: &Clock, l2: vector<CoinState>, l
         l20 = l20 + 1u64;
     };
     assert!(l22 != C5, errors::must_supply_one_coin());
-    let l7;
-    if (*(&(&l0.a_gamma).future_time) != 0u64) {
+    let l7 = if (*(&(&l0.a_gamma).future_time) != 0u64) {
         if (l38 >= *(&(&l0.a_gamma).future_time)) {
-            *(&mut (&mut l0.a_gamma).future_time) = 1u64;
-            unstructured {
-                goto 'label_183;
-            }
-        } else {
-            unstructured {
-                goto 'label_183;
-            }
+            *(&mut (&mut l0.a_gamma).future_time) = 1u64
         };
         /* block 183 */;
-        l7 = volatile_math::invariant_(l10, l17, l3);
-        unstructured {
-            goto 'label_193;
-        }
+        volatile_math::invariant_(l10, l17, l3)
     } else {
-        l7 = *(&l0.d);
-        unstructured {
-            goto 'label_193;
-        }
+        *(&l0.d)
     };
     let (l23, l29, l34, l8);
     /* block 193 */;
     l34 = l7;
     l29 = volatile_math::invariant_(l10, l17, l28);
     l23 = utils::to_u256(balance::supply_value(&l0.lp_coin_supply)) * C1;
-    if (l34 != 0u256) {
-        l8 = l23 * l29 / l34 - l23;
-        unstructured {
-            goto 'label_226;
-        }
+    l8 = if (l34 != 0u256) {
+        l23 * l29 / l34 - l23
     } else {
-        l8 = interest_clamm_volatile::xcp_impl(freeze(l0), l2, l29);
-        unstructured {
-            goto 'label_226;
-        }
+        interest_clamm_volatile::xcp_impl(freeze(l0), l2, l29)
     };
     /* block 226 */;
     let l15 = l8 / C1 * C1;
     assert!(l15 != 0u256, errors::expected_a_non_zero_value());
     if (l34 != 0u256) {
-        let l9;
         l15 = l15 - math256::mul_div_up(interest_clamm_volatile::calculate_fee(freeze(l0), l12, l28), l15, 10000000000u256);
         let l24 = l23 + l15;
         let l36 = 0u256;
-        if (l15 > 1000u256) {
-            l9 = l25 > l22;
-            unstructured {
-                goto 'label_275;
-            }
-        } else {
-            l9 = false;
-            unstructured {
-                goto 'label_275;
-            }
-        };
         /* block 275 */;
-        if (l9) {
+        if (l15 > 1000u256 && l25 > l22) {
             let l37 = 0u256;
             let l21 = 0u64;
             while (l25 > l21) {
@@ -249,26 +217,13 @@ fun add_liquidity<T0>(l0: &mut StateV1<T0>, l1: &Clock, l2: vector<CoinState>, l
                 l21 = l21 + 1u64;
             };
             l36 = fixed_point_wad::div_down(l37 * l15 / l24, *(&(&l11)[l22]) - l15 * *(&(&l39)[l22]) / l24);
-            unstructured {
-                goto 'label_345;
-            }
-        } else {
-            unstructured {
-                goto 'label_345;
-            }
         };
         /* block 345 */;
-        interest_clamm_volatile::tweak_price(l0, l2, l38, l10, l17, l28, l22, l36, l29, l24);
-        unstructured {
-            goto 'label_369;
-        }
+        interest_clamm_volatile::tweak_price(l0, l2, l38, l10, l17, l28, l22, l36, l29, l24)
     } else {
         *(&mut l0.d) = l29;
         *(&mut l0.virtual_price) = C6;
-        *(&mut l0.xcp_profit) = C6;
-        unstructured {
-            goto 'label_369;
-        }
+        *(&mut l0.xcp_profit) = C6
     };
     /* block 369 */;
     let l16 = utils::to_u64(l15 / C1);
@@ -283,18 +238,7 @@ public fun add_liquidity_2_pool<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1:
 }
 
 public(friend) fun add_liquidity_2_pool_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: u64, l5: &mut TxContext): Coin<T2> {
-    let l6;
-    if (coin::value(&l2) != 0u64) {
-        l6 = true;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l6 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    };
+    let l6 = coin::value(&l2) != 0u64 || coin::value(&l3) != 0u64;
     /* block 13 */;
     assert!(l6, errors::must_supply_one_coin());
     assert!(interest_pool::are_coins_ordered(freeze(l0), vector[x1_type_name::get(), x1_type_name::get()]), errors::coins_must_be_in_order());
@@ -312,31 +256,8 @@ public fun add_liquidity_3_pool<T0, T1, T2, T3>(l0: &mut InterestPool<Volatile>,
 }
 
 public(friend) fun add_liquidity_3_pool_impl<T0, T1, T2, T3>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: Coin<T2>, l5: u64, l6: &mut TxContext): Coin<T3> {
-    let l7;
-    if (coin::value(&l2) != 0u64) {
-        l7 = true;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l7 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    };
-    let l8;
     /* block 13 */;
-    if (l7) {
-        l8 = true;
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        l8 = coin::value(&l4) != 0u64;
-        unstructured {
-            goto 'label_23;
-        }
-    };
+    let l8 = coin::value(&l2) != 0u64 || coin::value(&l3) != 0u64 || coin::value(&l4) != 0u64;
     /* block 23 */;
     assert!(l8, errors::must_supply_one_coin());
     assert!(interest_pool::are_coins_ordered(freeze(l0), vector[x1_type_name::get(), x1_type_name::get(), x1_type_name::get()]), errors::coins_must_be_in_order());
@@ -419,17 +340,10 @@ fun calculate_remove_one_coin_impl<T0, T1>(l0: &StateV1<T1>, l1: u256, l2: u256,
         l19 = l19 + 1u64;
     };
     assert!(l21 != 300u64, errors::invalid_coin_type());
-    let l7;
-    if (l5) {
-        l7 = volatile_math::invariant_(l1, l2, l27);
-        unstructured {
-            goto 'label_76;
-        }
+    let l7 = if (l5) {
+        volatile_math::invariant_(l1, l2, l27)
     } else {
-        l7 = *(&l0.d);
-        unstructured {
-            goto 'label_76;
-        }
+        *(&l0.d)
     };
     let (l13, l14, l15, l16, l23, l8);
     /* block 76 */;
@@ -442,30 +356,9 @@ fun calculate_remove_one_coin_impl<T0, T1>(l0: &StateV1<T1>, l1: u256, l2: u256,
     l16 = fixed_point_wad::div_down(*(&(&l27)[l21]) - l28, l24);
     *(&mut (&mut l27)[l21]) = l28;
     l23 = 0u256;
-    if (l6) {
-        l8 = l16 > 100000u256;
-        unstructured {
-            goto 'label_138;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_138;
-        }
-    };
-    let l9;
+    l8 = l6 && l16 > 100000u256;
     /* block 138 */;
-    if (l8) {
-        l9 = l4 > 100000u256;
-        unstructured {
-            goto 'label_147;
-        }
-    } else {
-        l9 = false;
-        unstructured {
-            goto 'label_147;
-        }
-    };
+    let l9 = l8 && l4 > 100000u256;
     /* block 147 */;
     if (l9) {
         let l25 = 0u256;
@@ -481,13 +374,6 @@ fun calculate_remove_one_coin_impl<T0, T1>(l0: &StateV1<T1>, l1: u256, l2: u256,
             l20 = l20 + 1u64;
         };
         l23 = fixed_point_wad::div_down(l25 * l15 / l14, l16 - l15 * *(&(&l0.balances)[l21]) / l14);
-        unstructured {
-            goto 'label_216;
-        }
-    } else {
-        unstructured {
-            goto 'label_216;
-        }
     };
     /* block 216 */;
     return (l16, l23, l13, l27, l21)
@@ -527,32 +413,14 @@ fun claim_admin_fees_impl<T0>(l0: &mut StateV1<T0>, l1: &Clock, l2: BalancesRequ
         let l8 = l18 - l19 * *(&(&l0.fees).admin_fee) / 20000000000u256;
         if (l8 != 0u256) {
             let l9 = fixed_point_wad::mul_up(utils::to_u256(balance::supply_value(&l0.lp_coin_supply)) * C1, fixed_point_wad::div_up(l17, l17 - l8) - C6);
-            *(&mut l0.xcp_profit) = l18 - l8 * 2u256;
-            unstructured {
-                goto 'label_143;
-            }
-        } else {
-            unstructured {
-                goto 'label_143;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_143;
+            *(&mut l0.xcp_profit) = l18 - l8 * 2u256
         }
     };
     /* block 143 */;
     let l7 = volatile_math::invariant_(reg_3, reg_4, interest_clamm_volatile::balances_in_price_impl(freeze(l0), l3));
     *(&mut l0.virtual_price) = fixed_point_wad::div_down(interest_clamm_volatile::xcp_impl(freeze(l0), l3, l7), utils::to_u256(balance::supply_value(&l0.lp_coin_supply)) * C1);
     if (*(&l0.xcp_profit) > l19) {
-        *(&mut l0.xcp_profit_a) = *(&l0.xcp_profit);
-        unstructured {
-            goto 'label_181;
-        }
-    } else {
-        unstructured {
-            goto 'label_181;
-        }
+        *(&mut l0.xcp_profit_a) = *(&l0.xcp_profit)
     };
     /* block 181 */
 }
@@ -678,30 +546,16 @@ fun get_a_gamma<T0>(l0: &StateV1<T0>, l1: &Clock): ( u256, u256) {
         let l8 = l7 - l6;
         l3 = l2 * utils::to_u256(l8) + l3 * utils::to_u256(l6) / utils::to_u256(l7);
         l5 = l4 * utils::to_u256(l8) + l5 * utils::to_u256(l6) / utils::to_u256(l7);
-        unstructured {
-            goto 'label_78;
-        }
-    } else {
-        unstructured {
-            goto 'label_78;
-        }
     };
     /* block 78 */;
     return (l3, l5)
 }
 
 fun increment_version<T0>(l0: &mut StateV1<T0>) {
-    let l1;
-    if (*(&l0.version) == C12) {
-        l1 = 0u256;
-        unstructured {
-            goto 'label_15;
-        }
+    let l1 = if (*(&l0.version) == C12) {
+        0u256
     } else {
-        l1 = *(&l0.version) + 1u256;
-        unstructured {
-            goto 'label_15;
-        }
+        *(&l0.version) + 1u256
     };
     /* block 15 */;
     *(&mut l0.version) = l1
@@ -818,7 +672,6 @@ public fun out_fee<T0>(l0: &mut InterestPool<Volatile>): u256 {
 }
 
 public fun quote_add_liquidity<T0>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: vector<u64>): u64 {
-    let l3;
     let (reg_1, reg_2) = interest_clamm_volatile::state_and_coin_states(l0);
     let l15 = reg_2;
     let l26 = reg_1;
@@ -827,16 +680,10 @@ public fun quote_add_liquidity<T0>(l0: &mut InterestPool<Volatile>, l1: &Clock, 
     let (reg_14, reg_15) = interest_clamm_volatile::get_a_gamma(l26, l1);
     let l9 = utils::empty_vector(*(&l26.n_coins));
     let l22 = interest_clamm_volatile::balances_in_price_impl(l26, l15);
-    if (*(&(&l26.a_gamma).future_time) != 0u64) {
-        l3 = volatile_math::invariant_(reg_14, reg_15, l22);
-        unstructured {
-            goto 'label_46;
-        }
+    let l3 = if (*(&(&l26.a_gamma).future_time) != 0u64) {
+        volatile_math::invariant_(reg_14, reg_15, l22)
     } else {
-        l3 = *(&l26.d);
-        unstructured {
-            goto 'label_46;
-        }
+        *(&l26.d)
     };
     let (l13, l20, l21, l23);
     /* block 46 */;
@@ -862,19 +709,12 @@ public fun quote_add_liquidity<T0>(l0: &mut InterestPool<Volatile>, l1: &Clock, 
         };
         l20 = l20 + 1u64;
     };
-    let l6;
     let (reg_103, reg_104) = interest_clamm_volatile::get_a_gamma(l26, l1);
     let l16 = volatile_math::invariant_(reg_103, reg_104, l13);
-    if (l23 != 0u256) {
-        l6 = l27 * l16 / l23 - l27;
-        unstructured {
-            goto 'label_160;
-        }
+    let l6 = if (l23 != 0u256) {
+        l27 * l16 / l23 - l27
     } else {
-        l6 = interest_clamm_volatile::xcp_impl(l26, l15, l16);
-        unstructured {
-            goto 'label_160;
-        }
+        interest_clamm_volatile::xcp_impl(l26, l15, l16)
     };
     /* block 160 */;
     let l17 = l6 / C1 * C1;
@@ -944,13 +784,6 @@ public fun quote_swap<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &Clock, l
     *l18 = *l18 - l10;
     if (*(&(&l11).index) != 0u64) {
         l10 = fixed_point_wad::div_down(l10, *(&(&l11).price));
-        unstructured {
-            goto 'label_143;
-        }
-    } else {
-        unstructured {
-            goto 'label_143;
-        }
     };
     /* block 143 */;
     return utils::to_u64(fixed_point_wad::mul_down(l10 - interest_clamm_volatile::fee_impl(l19, l8) * l10 / 10000000000u256, *(&(&l11).decimals_scalar)))
@@ -996,18 +829,7 @@ public fun read_balance<T0, T1>(l0: &mut InterestPool<Volatile>, l1: &mut Balanc
 }
 
 public(friend) fun register_2_pool<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: &CoinDecimals, l5: u256, l6: &mut TxContext): Coin<T2> {
-    let l7;
-    if (coin::value(&l2) != 0u64) {
-        l7 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_13;
-        }
-    };
+    let l7 = coin::value(&l2) != 0u64 && coin::value(&l3) != 0u64;
     /* block 13 */;
     assert!(l7, errors::no_zero_liquidity_amounts());
     let l8 = interest_clamm_volatile::load_mut(interest_pool::state_mut(l0));
@@ -1017,31 +839,8 @@ public(friend) fun register_2_pool<T0, T1, T2>(l0: &mut InterestPool<Volatile>, 
 }
 
 public(friend) fun register_3_pool<T0, T1, T2, T3>(l0: &mut InterestPool<Volatile>, l1: &Clock, l2: Coin<T0>, l3: Coin<T1>, l4: Coin<T2>, l5: &CoinDecimals, l6: vector<u256>, l7: &mut TxContext): Coin<T3> {
-    let l8;
-    if (coin::value(&l2) != 0u64) {
-        l8 = coin::value(&l3) != 0u64;
-        unstructured {
-            goto 'label_13;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_13;
-        }
-    };
-    let l9;
     /* block 13 */;
-    if (l8) {
-        l9 = coin::value(&l4) != 0u64;
-        unstructured {
-            goto 'label_23;
-        }
-    } else {
-        l9 = false;
-        unstructured {
-            goto 'label_23;
-        }
-    };
+    let l9 = coin::value(&l2) != 0u64 && coin::value(&l3) != 0u64 && coin::value(&l4) != 0u64;
     /* block 23 */;
     assert!(l9, errors::no_zero_liquidity_amounts());
     let l10 = interest_clamm_volatile::load_mut(interest_pool::state_mut(l0));
@@ -1121,14 +920,7 @@ public(friend) fun remove_liquidity_one_coin_impl<T0, T1>(l0: &mut InterestPool<
     let l13 = reg_43;
     let l7 = reg_39;
     if (l20 >= l6) {
-        *(&mut (&mut l19.a_gamma).future_time) = 1u64;
-        unstructured {
-            goto 'label_66;
-        }
-    } else {
-        unstructured {
-            goto 'label_66;
-        }
+        *(&mut (&mut l19.a_gamma).future_time) = 1u64
     };
     /* block 66 */;
     let l10 = &mut (&mut l19.balances)[l13];
@@ -1203,13 +995,6 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
     if (l36 != 0u64) {
         if (*(&l18.index) != 0u64) {
             l26 = fixed_point_wad::mul_down(l26, *(&l18.price));
-            unstructured {
-                goto 'label_109;
-            }
-        } else {
-            unstructured {
-                goto 'label_109;
-            }
         };
         /* block 109 */;
         let l16 = &mut (&mut l13)[*(&l18.index)];
@@ -1218,18 +1003,7 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
         *(&mut l35.d) = volatile_math::invariant_(l11, l25, l13);
         *(&mut (&mut l13)[*(&l18.index)]) = l34;
         if (l37 >= l36) {
-            *(&mut (&mut l35.a_gamma).future_time) = 1u64;
-            unstructured {
-                goto 'label_146;
-            }
-        } else {
-            unstructured {
-                goto 'label_146;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_146;
+            *(&mut (&mut l35.a_gamma).future_time) = 1u64
         }
     };
     let (l20, l6);
@@ -1239,16 +1013,10 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
     l20 = l24 - math256::min(l24, l28);
     let l31 = &mut (&mut l13)[*(&(&l22).index)];
     *l31 = *l31 - l20;
-    if (*(&(&l22).index) != 0u64) {
-        l6 = fixed_point_wad::div_down(l20, *(&(&l22).price));
-        unstructured {
-            goto 'label_199;
-        }
+    l6 = if (*(&(&l22).index) != 0u64) {
+        fixed_point_wad::div_down(l20, *(&(&l22).price))
     } else {
-        l6 = l20;
-        unstructured {
-            goto 'label_199;
-        }
+        l20
     };
     /* block 199 */;
     l20 = l6;
@@ -1260,80 +1028,29 @@ public(friend) fun swap_impl<T0, T1, T2>(l0: &mut InterestPool<Volatile>, l1: &C
     l21 = l21 - l20;
     if (*(&(&l22).index) != 0u64) {
         l21 = fixed_point_wad::mul_down(l21, *(&(&l22).price));
-        unstructured {
-            goto 'label_261;
-        }
-    } else {
-        unstructured {
-            goto 'label_261;
-        }
     };
     let (l14, l29, l7);
     /* block 261 */;
     *(&mut (&mut l13)[*(&(&l22).index)]) = l21;
     l14 = fixed_point_wad::div_down(utils::to_u256(l19), *(&l18.decimals_scalar));
     l29 = 0u256;
-    if (l14 > 100000u256) {
-        l7 = l20 > 100000u256;
-        unstructured {
-            goto 'label_290;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_290;
-        }
-    };
+    l7 = l14 > 100000u256 && l20 > 100000u256;
     /* block 290 */;
     if (l7) {
-        let l8;
-        if (*(&l18.index) != 0u64) {
-            l8 = *(&(&l22).index) != 0u64;
-            unstructured {
-                goto 'label_307;
-            }
-        } else {
-            l8 = false;
-            unstructured {
-                goto 'label_307;
-            }
-        };
-        let l10;
         /* block 307 */;
-        if (l8) {
-            l10 = *(&l18.last_price) * l14 / l20;
-            unstructured {
-                goto 'label_341;
-            }
+        let l10 = if (*(&l18.index) != 0u64 && *(&(&l22).index) != 0u64) {
+            *(&l18.last_price) * l14 / l20
         } else {
-            let l9;
+            /* block 339 */;
             if (*(&l18.index) == 0u64) {
-                l9 = fixed_point_wad::div_down(l14, l20);
-                unstructured {
-                    goto 'label_339;
-                }
+                fixed_point_wad::div_down(l14, l20)
             } else {
                 l38 = *(&l18.index);
-                l9 = fixed_point_wad::div_down(l20, l14);
-                unstructured {
-                    goto 'label_339;
-                }
-            };
-            /* block 339 */;
-            l10 = l9;
-            unstructured {
-                goto 'label_341;
+                fixed_point_wad::div_down(l20, l14)
             }
         };
         /* block 341 */;
-        l29 = l10;
-        unstructured {
-            goto 'label_346;
-        }
-    } else {
-        unstructured {
-            goto 'label_346;
-        }
+        l29 = l10
     };
     /* block 346 */;
     let l27 = utils::to_u256(balance::supply_value(&l35.lp_coin_supply));
@@ -1353,37 +1070,20 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
             *(&mut l17.price_oracle) = *(&l17.last_price) * C6 - l16 + *(&l17.price_oracle) * l16 / C6;
             l35 = l35 + 1u64;
         };
-        *(&mut l0.last_prices_timestamp) = l2;
-        unstructured {
-            goto 'label_65;
-        }
-    } else {
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut l0.last_prices_timestamp) = l2
     };
-    let l10;
     /* block 65 */;
-    if (l8 == 0u256) {
-        l10 = volatile_math::invariant_(l3, l4, l5);
-        unstructured {
-            goto 'label_77;
-        }
+    let l10 = if (l8 == 0u256) {
+        volatile_math::invariant_(l3, l4, l5)
     } else {
-        l10 = l8;
-        unstructured {
-            goto 'label_77;
-        }
+        l8
     };
     let l26;
     /* block 77 */;
     l26 = l10;
     if (l7 != 0u256) {
         if (l6 != 0u64) {
-            *(&mut (&mut (&mut l1)[l6]).last_price) = l7;
-            unstructured {
-                goto 'label_174;
-            }
+            *(&mut (&mut (&mut l1)[l6]).last_price) = l7
         } else {
             let l28 = 1u64;
             while (*(&l0.n_coins)as u64 > l28) {
@@ -1418,63 +1118,24 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
     let l49 = C6;
     let l45 = C6;
     if (l39 != 0u256) {
-        let l11;
         l45 = fixed_point_wad::div_down(volatile_math::geometric_mean(l51, true), l9);
         l49 = l40 * l45 / l39;
-        if (l39 > l45) {
-            l11 = *(&(&l0.a_gamma).future_time) == 0u64;
-            unstructured {
-                goto 'label_250;
-            }
-        } else {
-            l11 = false;
-            unstructured {
-                goto 'label_250;
-            }
-        };
+        let l11 = l39 > l45 && *(&(&l0.a_gamma).future_time) == 0u64;
         /* block 250 */;
         assert!(!(l11), errors::incurred_a_loss());
         if (*(&(&l0.a_gamma).future_time) == 1u64) {
-            *(&mut (&mut l0.a_gamma).future_time) = 0u64;
-            unstructured {
-                goto 'label_268;
-            }
-        } else {
-            unstructured {
-                goto 'label_268;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_268;
+            *(&mut (&mut l0.a_gamma).future_time) = 0u64
         }
     };
     let (l12, l37);
     /* block 268 */;
     *(&mut l0.xcp_profit) = l49;
     l37 = *(&l0.not_adjusted);
-    if (!(l37)) {
-        l12 = l45 * 2u256 - C6 > l49 + 2u256 * *(&(&l0.rebalancing_params).extra_profit);
-        unstructured {
-            goto 'label_297;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_297;
-        }
-    };
+    l12 = !(l37) && l45 * 2u256 - C6 > l49 + 2u256 * *(&(&l0.rebalancing_params).extra_profit);
     /* block 297 */;
     if (l12) {
         l37 = true;
-        *(&mut l0.not_adjusted) = true;
-        unstructured {
-            goto 'label_305;
-        }
-    } else {
-        unstructured {
-            goto 'label_305;
-        }
+        *(&mut l0.not_adjusted) = true
     };
     /* block 305 */;
     if (l37) {
@@ -1487,20 +1148,8 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
             l38 = l38 + math256::pow(l42, 2u256);
             l31 = l31 + 1u64;
         };
-        let l13;
-        if (l38 > math256::pow(l15, 2u256)) {
-            l13 = l39 != 0u256;
-            unstructured {
-                goto 'label_358;
-            }
-        } else {
-            l13 = false;
-            unstructured {
-                goto 'label_358;
-            }
-        };
         /* block 358 */;
-        if (l13) {
+        if (l38 > math256::pow(l15, 2u256) && l39 != 0u256) {
             l38 = volatile_math::sqrt(l38 / C6);
             let l41 = C17;
             let l52 = l5;
@@ -1520,19 +1169,8 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
                 *(&mut (&mut l52)[l33]) = fixed_point_wad::div_down(l25, *(&l0.n_coins) * *(&(&l41)[l33]));
                 l33 = l33 + 1u64;
             };
-            let l14;
             l39 = fixed_point_wad::div_down(volatile_math::geometric_mean(l52, true), l9);
-            if (l39 > C6) {
-                l14 = 2u256 * l39 - C6 > l49;
-                unstructured {
-                    goto 'label_482;
-                }
-            } else {
-                l14 = false;
-                unstructured {
-                    goto 'label_482;
-                }
-            };
+            let l14 = l39 > C6 && 2u256 * l39 - C6 > l49;
             /* block 482 */;
             if (l14) {
                 let l34 = 1u64;
@@ -1545,18 +1183,7 @@ fun tweak_price<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>, l2: u64, l3: u2
                 *(&mut l0.virtual_price) = l39;
                 return
             };
-            *(&mut l0.not_adjusted) = false;
-            unstructured {
-                goto 'label_523;
-            }
-        } else {
-            unstructured {
-                goto 'label_523;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_523;
+            *(&mut l0.not_adjusted) = false
         }
     };
     /* block 523 */;
@@ -1579,7 +1206,6 @@ fun update_coin_state_prices<T0>(l0: &mut StateV1<T0>, l1: vector<CoinState>) {
 }
 
 public fun update_parameters<T0>(l0: &mut InterestPool<Volatile>, l1: &PoolAdmin, l2: &Clock, l3: BalancesRequest, l4: vector<Option<u256>>) {
-    let l5;
     interest_pool::assert_pool_admin(freeze(l0), l1);
     let l17 = interest_pool::addy(freeze(l0));
     let (reg_7, reg_8) = interest_clamm_volatile::state_and_coin_states_mut(l0);
@@ -1592,62 +1218,19 @@ public fun update_parameters<T0>(l0: &mut InterestPool<Volatile>, l1: &PoolAdmin
     let l11 = option::destroy_with_default(*(&(&l4)[4u64]), *(&(&l18.rebalancing_params).extra_profit));
     let l9 = option::destroy_with_default(*(&(&l4)[5u64]), *(&(&l18.rebalancing_params).adjustment_step));
     let l14 = option::destroy_with_default(*(&(&l4)[6u64]), *(&(&l18.rebalancing_params).ma_half_time));
-    if (l16 <= C3) {
-        l5 = l16 >= C2;
-        unstructured {
-            goto 'label_96;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_96;
-        }
-    };
+    let l5 = l16 <= C3 && l16 >= C2;
     /* block 96 */;
     assert!(l5, errors::out_fee_out_of_range());
-    let l6;
-    if (l15 <= C3) {
-        l6 = C2 >= C2;
-        unstructured {
-            goto 'label_114;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_114;
-        }
-    };
+    let l6 = l15 <= C3 && C2 >= C2;
     /* block 114 */;
     assert!(l6, errors::mid_fee_out_of_range());
     assert!(l10 < C3, errors::admin_fee_is_too_big());
-    let l7;
-    if (l13 != 0u256) {
-        l7 = l13 <= C6;
-        unstructured {
-            goto 'label_141;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_141;
-        }
-    };
+    let l7 = l13 != 0u256 && l13 <= C6;
     /* block 141 */;
     assert!(l7, errors::gamma_fee_out_of_range());
     assert!(l11 < C6, errors::extra_profit_is_too_big());
     assert!(l9 < C6, errors::adjustment_step_is_too_big());
-    let l8;
-    if (l14 >= 1000u256) {
-        l8 = l14 <= C4;
-        unstructured {
-            goto 'label_177;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_177;
-        }
-    };
+    let l8 = l14 >= 1000u256 && l14 <= C4;
     /* block 177 */;
     assert!(l8, errors::ma_half_time_out_of_range());
     *(&mut (&mut l18.fees).admin_fee) = l10;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb247a3071c9a70a0ecc96c1841acf389147609e007f343f7ddf00acab769752c/demo.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb247a3071c9a70a0ecc96c1841acf389147609e007f343f7ddf00acab769752c/demo.move
@@ -551,19 +551,8 @@ const C58: vector<u8> = vector[78u8, 111u8, 32u8, 98u8, 111u8, 110u8, 117u8, 115
 
 public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     assert!(string::length(&l2) > 0u64, C23);
@@ -641,87 +630,46 @@ fun assert_not_paused<T0>(l0: &StakingPool<T0>) {
 }
 
 fun calculate_effective_reward_rate_enhanced(l0: u64, l1: u64, l2: u64, l3: u64): u64 {
-    let l4;
     let l6 = demo::safe_mul_div_precise(demo::safe_mul_div_precise(l0, l1, 10000u64), l2, 10000u64);
-    if (l3 == 0u64) {
-        l4 = l6;
-        unstructured {
-            goto 'label_24;
-        }
+    /* block 24 */;
+    return if (l3 == 0u64) {
+        l6
     } else {
         let l5 = demo::safe_add(10000u64, l3);
-        l4 = demo::safe_mul_div_precise(l6, l5, 10000u64);
-        unstructured {
-            goto 'label_24;
-        }
-    };
-    /* block 24 */;
-    return l4
+        demo::safe_mul_div_precise(l6, l5, 10000u64)
+    }
 }
 
 fun calculate_enhanced_slot_rewards(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64): u64 {
-    let l8;
     let l15 = demo::calculate_effective_reward_rate_enhanced(l3, l4, l5, l6);
-    if (l7 > 0u64) {
-        l8 = l7 < l2;
-        unstructured {
-            goto 'label_17;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_17;
-        }
-    };
-    let l9;
     /* block 17 */;
-    if (l8) {
-        l9 = l7;
-        unstructured {
-            goto 'label_24;
-        }
+    let l9 = if (l7 > 0u64 && l7 < l2) {
+        l7
     } else {
-        l9 = l2;
-        unstructured {
-            goto 'label_24;
-        }
+        l2
     };
     let (l10, l12);
     /* block 24 */;
     l12 = l9;
-    if (l1 > l0) {
-        l10 = l1;
-        unstructured {
-            goto 'label_35;
-        }
+    l10 = if (l1 > l0) {
+        l1
     } else {
-        l10 = l0;
-        unstructured {
-            goto 'label_35;
-        }
+        l0
     };
     /* block 35 */;
     let l13 = l10;
     if (l13 >= l12) {
         return 0u64
     };
-    let l11;
     let l14 = demo::safe_sub(l12, l13);
     let l17 = l15as u128 * C47 / C46as u128;
     let l16 = l14as u128 * l17 / C47;
-    if (l16 > C48as u128) {
-        l11 = C48;
-        unstructured {
-            goto 'label_73;
-        }
-    } else {
-        l11 = l16as u64;
-        unstructured {
-            goto 'label_73;
-        }
-    };
     /* block 73 */;
-    return l11
+    return if (l16 > C48as u128) {
+        C48
+    } else {
+        l16as u64
+    }
 }
 
 fun calculate_reserve(l0: u64): u64 {
@@ -731,36 +679,24 @@ fun calculate_reserve(l0: u64): u64 {
 fun calculate_slot_params(l0: u8): ( u64, u64) {
     let (l3, l4);
     let l11 = l0as u64;
-    if (l11 <= 10u64) {
+    l3 = if (l11 <= 10u64) {
         let l5 = l11 * 10000000000u64;
         l4 = 10000u64 + l11 - 1u64 * 2000u64;
-        l3 = l5;
-        unstructured {
-            goto 'label_65;
-        }
+        l5
     } else {
         let (l1, l2);
-        if (l11 <= 50u64) {
+        l1 = if (l11 <= 50u64) {
             let l6 = l11 * 20000000000u64;
             l2 = 30000u64 + l11 - 11u64 * 1000u64;
-            l1 = l6;
-            unstructured {
-                goto 'label_61;
-            }
+            l6
         } else {
             let l7 = l11 * 50000000000u64;
             l2 = 70000u64 + l11 - 51u64 * 1000u64;
-            l1 = l7;
-            unstructured {
-                goto 'label_61;
-            }
+            l7
         };
         /* block 61 */;
         l4 = l2;
-        l3 = l1;
-        unstructured {
-            goto 'label_65;
-        }
+        l1
     };
     /* block 65 */;
     return (l3, l4)
@@ -794,31 +730,18 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     let l14 = demo::calculate_enhanced_slot_rewards(l37, l21, l20, l16, l32, l23, l39, *(&l0.end_time));
     let l38 = demo::safe_add(l26, l14);
     assert!(l38 > 0u64, C4);
-    let l4;
-    if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
-        l4 = demo::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_205;
-        }
+    let l4 = if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
+        demo::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards))
     } else {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_205;
-        }
+        0u64
     };
     let l6;
     /* block 205 */;
     let l15 = l4;
-    if (l15 >= l38) {
-        l6 = l38;
-        unstructured {
-            goto 'label_216;
-        }
+    l6 = if (l15 >= l38) {
+        l38
     } else {
-        l6 = l15;
-        unstructured {
-            goto 'label_216;
-        }
+        l15
     };
     /* block 216 */;
     let l18 = l6;
@@ -827,15 +750,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l35.last_claim_time) = l20;
     *(&mut l35.total_claimed) = demo::safe_add(*(&l35.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l35.pending_rewards) = demo::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = demo::safe_sub(l38, l18)
     } else {
-        *(&mut l35.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = 0u64
     };
     /* block 261 */;
     let l31 = SlotDataKey { owner: l25, slot_number: l33 };
@@ -843,15 +760,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l30.last_claim_time) = l20;
     *(&mut l30.total_claimed) = demo::safe_add(*(&l30.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l30.pending_rewards) = demo::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = demo::safe_sub(l38, l18)
     } else {
-        *(&mut l30.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = 0u64
     };
     let (l10, l11, l12, l13, l5, l7, l8, l9);
     /* block 297 */;
@@ -866,16 +777,10 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     l10 = l20;
     l9 = *(&l0.reward_token_type);
     l8 = l18 < l38;
-    if (l18 < l38) {
-        l7 = demo::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_348;
-        }
+    l7 = if (l18 < l38) {
+        demo::safe_sub(l38, l18)
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_348;
-        }
+        0u64
     };
     /* block 348 */;
     event::emit(RewardsClaimed { pool_id: l5, nft_id: l13, owner: l12, amount: l11, claim_time: l10, reward_token_type: l9, is_partial_claim: l8, remaining_pending: l7, slot_number: l33 })
@@ -897,24 +802,13 @@ fun create_enhanced_slot_configs(): vector<SlotConfig> {
 }
 
 public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: u64, l4: u64, l5: vector<String>, l6: address, l7: u8, l8: &Clock, l9: &mut TxContext): StakingPool<T0> {
-    let l10;
     let l11 = tx_context::sender(freeze(l9));
     let l14 = object::new(l9);
     let l15 = object::uid_to_inner(&l14);
     let l17 = coin::value(&l0);
     let l18 = type_name::get();
     let l12 = clock::timestamp_ms(l8);
-    if (l7 >= 1u8) {
-        l10 = l7 <= C52;
-        unstructured {
-            goto 'label_29;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_29;
-        }
-    };
+    let l10 = l7 >= 1u8 && l7 <= C52;
     /* block 29 */;
     assert!(l10, C40);
     let l19 = demo::create_enhanced_slot_configs();
@@ -933,16 +827,10 @@ public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: 
 fun decrease_reserved_rewards(l0: &mut u64, l1: u64) {
     let l3 = demo::calculate_reserve(l1);
     if (*l0 >= l3) {
-        *l0 = demo::safe_sub(*l0, l3);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = demo::safe_sub(*l0, l3)
     } else {
         let l2 = *l0 * l3 / demo::calculate_reserve(l1);
-        *l0 = demo::safe_sub(*l0, l2);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = demo::safe_sub(*l0, l2)
     };
     /* block 29 */
 }
@@ -952,40 +840,24 @@ public fun get_admin<T0>(l0: &StakingPool<T0>): address {
 }
 
 public fun get_available_rewards<T0>(l0: &StakingPool<T0>): u64 {
-    let l1;
     let l2 = balance::value(&l0.reward_balance);
-    if (l2 <= *(&l0.reserved_rewards)) {
-        l1 = 0u64;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l1 = demo::safe_sub(l2, *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l1
+    return if (l2 <= *(&l0.reserved_rewards)) {
+        0u64
+    } else {
+        demo::safe_sub(l2, *(&l0.reserved_rewards))
+    }
 }
 
 public fun get_collection_multiplier_info<T0>(l0: &StakingPool<T0>, l1: String): Option<CollectionMultiplierInfo> {
-    let l2;
     let l3 = CollectionMultiplierKey { collection: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) });
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_30;
-        }
-    };
     /* block 30 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_default_reward_rate<T0>(l0: &StakingPool<T0>): u64 {
@@ -1013,36 +885,21 @@ public fun get_enhanced_slot_configs<T0>(l0: &StakingPool<T0>): vector<SlotConfi
 }
 
 public fun get_nft_multiplier_info<T0>(l0: &StakingPool<T0>, l1: ID, l2: String): Option<NftMultiplierInfo> {
-    let l3;
     let l4 = NftMultiplierKey { nft_id: l1, collection: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l5 = dynamic_object_field::borrow(&l0.id, l4);
-        l3 = option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) });
-        unstructured {
-            goto 'label_34;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_34;
-        }
-    };
     /* block 34 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l5 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &mut TxContext): &mut SlotData {
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
     if (!(dynamic_object_field::exists_(&l0.id, l5))) {
         let l4 = SlotData { id: object::new(l3), owner: l1, slot_number: l2, staked_nft: option::none(), staked_collection: option::none(), stake_time: 0u64, last_claim_time: 0u64, pending_rewards: 0u64, total_claimed: 0u64, is_unlocked: false, nft_type: option::none() };
-        dynamic_object_field::add(&mut l0.id, l5, l4);
-        unstructured {
-            goto 'label_32;
-        }
-    } else {
-        unstructured {
-            goto 'label_32;
-        }
+        dynamic_object_field::add(&mut l0.id, l5, l4)
     };
     /* block 32 */;
     return dynamic_object_field::borrow_mut(&mut l0.id, l5)
@@ -1051,21 +908,15 @@ fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l
 public fun get_pool_slot_limits<T0>(l0: &StakingPool<T0>): ( u8, u8, u64) {
     let (l1, l2, l3);
     let l4 = PoolSlotLimitsKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
+    l1 = if (dynamic_object_field::exists_(&l0.id, l4)) {
         let l5 = dynamic_object_field::borrow(&l0.id, l4);
         l3 = *(&l5.total_users_with_custom_limits);
         l2 = *(&l5.absolute_max_slots);
-        l1 = *(&l5.default_max_slots_per_wallet);
-        unstructured {
-            goto 'label_34;
-        }
+        *(&l5.default_max_slots_per_wallet)
     } else {
         l3 = 0u64;
         l2 = C52;
-        l1 = C51;
-        unstructured {
-            goto 'label_34;
-        }
+        C51
     };
     /* block 34 */;
     return (l1, l2, l3)
@@ -1094,22 +945,14 @@ fun get_slot_config(l0: &vector<SlotConfig>, l1: u8): &SlotConfig {
 }
 
 public fun get_slot_data<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): Option<SlotDataInfo> {
-    let l3;
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l5)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l5);
-        l3 = option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) });
-        unstructured {
-            goto 'label_49;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_49;
-        }
-    };
     /* block 49 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l5)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l5);
+        option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_slot_effective_rate<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): u64 {
@@ -1161,48 +1004,24 @@ public fun get_slot_price<T0>(l0: &StakingPool<T0>, l1: u8): u64 {
 }
 
 public fun get_slot_token_price<T0>(l0: &StakingPool<T0>, l1: u8, l2: String): u64 {
-    let l5;
     let l7 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        let l3;
+    /* block 47 */;
+    return if (dynamic_object_field::exists_(&l0.id, l7)) {
         let l6 = dynamic_object_field::borrow(&l0.id, l7);
-        if (table::contains(&l6.token_prices, l2)) {
-            l3 = *(table::borrow(&l6.token_prices, l2));
-            unstructured {
-                goto 'label_29;
-            }
-        } else {
-            l3 = 0u64;
-            unstructured {
-                goto 'label_29;
-            }
-        };
         /* block 29 */;
-        l5 = l3;
-        unstructured {
-            goto 'label_47;
+        if (table::contains(&l6.token_prices, l2)) {
+            *(table::borrow(&l6.token_prices, l2))
+        } else {
+            0u64
         }
     } else {
-        let l4;
-        if (l2 == demo::get_token_type_string_sui()) {
-            l4 = demo::get_slot_price(l0, l1);
-            unstructured {
-                goto 'label_45;
-            }
-        } else {
-            l4 = 0u64;
-            unstructured {
-                goto 'label_45;
-            }
-        };
         /* block 45 */;
-        l5 = l4;
-        unstructured {
-            goto 'label_47;
+        if (l2 == demo::get_token_type_string_sui()) {
+            demo::get_slot_price(l0, l1)
+        } else {
+            0u64
         }
-    };
-    /* block 47 */;
-    return l5
+    }
 }
 
 public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
@@ -1210,39 +1029,23 @@ public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
 }
 
 public fun get_supported_payment_tokens<T0>(l0: &StakingPool<T0>): vector<String> {
-    let l1;
     let l2 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l2)) {
-        l1 = *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l1 = vector[];
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l1
+    return if (dynamic_object_field::exists_(&l0.id, l2)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list)
+    } else {
+        vector[]
+    }
 }
 
 public fun get_token_revenue<T0>(l0: &StakingPool<T0>, l1: String): u64 {
-    let l2;
     let l3 = TokenRevenueKey { token_type: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected)
+    } else {
+        0u64
+    }
 }
 
 fun get_token_type_string_any<T0>(): String {
@@ -1260,13 +1063,6 @@ fun get_token_type_string_any<T0>(): String {
                 l1 = l1 + 1u64;
             };
             return string::utf8(l4)
-        };
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        unstructured {
-            goto 'label_50;
         }
     };
     /* block 50 */;
@@ -1282,22 +1078,14 @@ public fun get_total_staked<T0>(l0: &StakingPool<T0>): u64 {
 }
 
 public fun get_user_slot_allocation<T0>(l0: &StakingPool<T0>, l1: address): Option<UserSlotInfo> {
-    let l2;
     let l4 = UserSlotAllocationKey { user: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l4);
-        l2 = option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l3 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_user_total_claimed_rewards<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1350,19 +1138,13 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
     let l11 = dynamic_object_field::borrow(&l0.id, l35);
     let l14 = clock::timestamp_ms(l2);
     let l38 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l38)) {
+    l3 = if (dynamic_object_field::exists_(&l0.id, l38)) {
         let l39 = dynamic_object_field::borrow(&l0.id, l38);
         l4 = *(&l39.reason);
-        l3 = *(&l39.bonus_multiplier);
-        unstructured {
-            goto 'label_61;
-        }
+        *(&l39.bonus_multiplier)
     } else {
         l4 = string::utf8(C58);
-        l3 = 0u64;
-        unstructured {
-            goto 'label_61;
-        }
+        0u64
     };
     let (l18, l20, l27, l32, l34, l36, l37, l9);
     /* block 61 */;
@@ -1419,40 +1201,24 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
 }
 
 fun get_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): u64 {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier)
+    } else {
+        0u64
+    }
 }
 
 public fun get_wallet_bonus_multiplier_info<T0>(l0: &StakingPool<T0>, l1: address): Option<WalletBonusMultiplierInfo> {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_wallet_bonus_multiplier_view<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1466,19 +1232,8 @@ public fun has_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): b
 
 public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l2 >= 1u8) {
-        l5 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= 1u8 && l2 <= C52;
     /* block 31 */;
     assert!(l5, C40);
     let l13 = UserSlotAllocationKey { user: l1 };
@@ -1491,24 +1246,14 @@ public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: addr
         *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64);
         if (l2 != l9) {
             let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l10);
-            *(&mut l12.total_users_with_custom_limits) = demo::safe_add(*(&l12.total_users_with_custom_limits), 1u64);
-            unstructured {
-                goto 'label_144;
-            }
-        } else {
-            unstructured {
-                goto 'label_144;
-            }
+            *(&mut l12.total_users_with_custom_limits) = demo::safe_add(*(&l12.total_users_with_custom_limits), 1u64)
         }
     } else {
         let l7 = dynamic_object_field::borrow_mut(&mut l0.id, l13);
         let l11 = *(&l7.max_slots_allowed);
         assert!(l2 > l11, C40);
         *(&mut l7.max_slots_allowed) = l2;
-        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 });
-        unstructured {
-            goto 'label_144;
-        }
+        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 })
     };
     /* block 144 */
 }
@@ -1529,21 +1274,9 @@ public fun is_paused<T0>(l0: &StakingPool<T0>): bool {
 }
 
 public fun is_payment_token_supported<T0>(l0: &StakingPool<T0>, l1: String): bool {
-    let l2;
     let l3 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l2
+    return dynamic_object_field::exists_(&l0.id, l3) && table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1)
 }
 
 public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
@@ -1551,39 +1284,15 @@ public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
 }
 
 fun is_slot_occupied<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft)
 }
 
 fun is_slot_unlocked<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked)
 }
 
 fun is_sui_token<T0>(): bool {
@@ -1594,19 +1303,8 @@ fun is_sui_token<T0>(): bool {
 
 public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     let l8 = clock::timestamp_ms(l3);
@@ -1645,13 +1343,7 @@ public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l
     let (reg_35, reg_36) = vector::index_of(&l5.token_list, &l6);
     let l4 = reg_36;
     if (reg_35) {
-        unstructured {
-            goto 'label_63;
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
-        }
+        
     };
     /* block 63 */;
     let l3 = clock::timestamp_ms(l1);
@@ -1667,13 +1359,7 @@ public entry fun remove_payment_token<T0>(l0: &mut StakingPool<T0>, l1: String, 
     let (reg_42, reg_43) = vector::index_of(&l6.token_list, &l1);
     let l5 = reg_43;
     if (reg_42) {
-        unstructured {
-            goto 'label_75;
-        }
-    } else {
-        unstructured {
-            goto 'label_75;
-        }
+        
     };
     /* block 75 */;
     let l4 = clock::timestamp_ms(l2);
@@ -1698,18 +1384,7 @@ fun safe_add(l0: u64, l1: u64): u64 {
 }
 
 fun safe_mul_div_precise(l0: u64, l1: u64, l2: u64): u64 {
-    let l3;
-    if (l0 == 0u64) {
-        l3 = true;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l3 = l1 == 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    };
+    let l3 = l0 == 0u64 || l1 == 0u64;
     /* block 11 */;
     if (l3) {
         return 0u64
@@ -1732,38 +1407,20 @@ fun safe_sub(l0: u64, l1: u64): u64 {
 
 public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: String, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l2 >= C50) {
-        l5 = l2 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= C50 && l2 <= C54;
     /* block 31 */;
     assert!(l5, C36);
     assert!(string::length(&l1) > 0u64, C23);
     let reg_36;
     (reg_36, reg_37) = vector::index_of(&l0.supported_collections, &l1);
     assert!(reg_36, C8);
-    let l6;
     let l7 = CollectionMultiplierKey { collection: l1 };
     let l10 = clock::timestamp_ms(l3);
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier);
-        unstructured {
-            goto 'label_92;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l7)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier)
     } else {
-        l6 = 10000u64;
-        unstructured {
-            goto 'label_92;
-        }
+        10000u64
     };
     let l11;
     /* block 92 */;
@@ -1772,16 +1429,10 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
         let l8 = dynamic_object_field::borrow_mut(&mut l0.id, l7);
         *(&mut l8.default_multiplier) = l2;
         *(&mut l8.set_by) = tx_context::sender(freeze(l4));
-        *(&mut l8.set_time) = l10;
-        unstructured {
-            goto 'label_134;
-        }
+        *(&mut l8.set_time) = l10
     } else {
         let l9 = CollectionMultiplier { id: object::new(l4), collection: l1, default_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 };
-        dynamic_object_field::add(&mut l0.id, l7, l9);
-        unstructured {
-            goto 'label_134;
-        }
+        dynamic_object_field::add(&mut l0.id, l7, l9)
     };
     /* block 134 */;
     event::emit(CollectionMultiplierSet { pool_id: object::id(freeze(l0)), collection: l1, old_multiplier: l11, new_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 })
@@ -1789,19 +1440,8 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
 
 public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: String, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     demo::assert_not_paused(freeze(l0));
-    if (l3 >= C50) {
-        l7 = l3 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l3 >= C50 && l3 <= C54;
     /* block 31 */;
     assert!(l7, C36);
     assert!(string::length(&l2) > 0u64, C23);
@@ -1809,19 +1449,12 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
     let reg_44;
     (reg_44, reg_45) = vector::index_of(&l0.supported_collections, &l2);
     assert!(reg_44, C8);
-    let l8;
     let l10 = NftMultiplierKey { nft_id: l1, collection: l2 };
     let l9 = clock::timestamp_ms(l5);
-    if (dynamic_object_field::exists_(&l0.id, l10)) {
-        l8 = *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier);
-        unstructured {
-            goto 'label_107;
-        }
+    let l8 = if (dynamic_object_field::exists_(&l0.id, l10)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier)
     } else {
-        l8 = 10000u64;
-        unstructured {
-            goto 'label_107;
-        }
+        10000u64
     };
     let l13;
     /* block 107 */;
@@ -1831,16 +1464,10 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
         *(&mut l11.multiplier) = l3;
         *(&mut l11.rarity_tier) = l4;
         *(&mut l11.set_by) = tx_context::sender(freeze(l6));
-        *(&mut l11.set_time) = l9;
-        unstructured {
-            goto 'label_155;
-        }
+        *(&mut l11.set_time) = l9
     } else {
         let l12 = NftMultiplier { id: object::new(l6), nft_id: l1, collection: l2, multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 };
-        dynamic_object_field::add(&mut l0.id, l10, l12);
-        unstructured {
-            goto 'label_155;
-        }
+        dynamic_object_field::add(&mut l0.id, l10, l12)
     };
     /* block 155 */;
     event::emit(NftMultiplierSet { pool_id: object::id(freeze(l0)), nft_id: l1, collection: l2, old_multiplier: l13, new_multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 })
@@ -1848,19 +1475,8 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
 
 public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u8, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l7 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l1 >= C53 && l2 <= C52;
     /* block 31 */;
     assert!(l7, C29);
     assert!(l1 <= l2, C20);
@@ -1873,19 +1489,8 @@ public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l
 
 public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: vector<String>, l3: bool, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l8 = clock::timestamp_ms(l4);
@@ -1917,19 +1522,12 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
     demo::assert_not_paused(freeze(l0));
     assert!(l2 <= C54, C36);
     assert!(string::length(&l3) > 0u64, C20);
-    let l6;
     let l9 = WalletBonusMultiplierKey { wallet: l1 };
     let l7 = clock::timestamp_ms(l4);
-    if (dynamic_object_field::exists_(&l0.id, l9)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l9)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier)
     } else {
-        l6 = 0u64;
-        unstructured {
-            goto 'label_68;
-        }
+        0u64
     };
     let l8;
     /* block 68 */;
@@ -1939,16 +1537,10 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
         *(&mut l10.bonus_multiplier) = l2;
         *(&mut l10.reason) = l3;
         *(&mut l10.set_by) = tx_context::sender(freeze(l5));
-        *(&mut l10.set_time) = l7;
-        unstructured {
-            goto 'label_115;
-        }
+        *(&mut l10.set_time) = l7
     } else {
         let l11 = WalletBonusMultiplier { id: object::new(l5), wallet: l1, bonus_multiplier: l2, set_by: tx_context::sender(freeze(l5)), set_time: l7, reason: l3 };
-        dynamic_object_field::add(&mut l0.id, l9, l11);
-        unstructured {
-            goto 'label_115;
-        }
+        dynamic_object_field::add(&mut l0.id, l9, l11)
     };
     /* block 115 */;
     event::emit(WalletBonusMultiplierSet { pool_id: object::id(freeze(l0)), wallet: l1, old_bonus_multiplier: l8, new_bonus_multiplier: l2, reason: l3, set_by: tx_context::sender(freeze(l5)), set_time: l7 })
@@ -1958,31 +1550,13 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
     demo::assert_not_paused(freeze(l0));
     assert!(!(*(&l0.is_locked)), C5);
     assert!(string::length(&l4) > 0u64, C23);
-    let l8;
-    if (l5 >= C53) {
-        l8 = l5 <= C52;
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_50;
-        }
-    };
+    let l8 = l5 >= C53 && l5 <= C52;
     /* block 50 */;
     assert!(l8, C29);
     let l10 = clock::timestamp_ms(l6);
     assert!(l10 >= *(&l0.start_time), C7);
     if (*(&l0.end_time) > 0u64) {
-        assert!(l10 < *(&l0.end_time), C10);
-        unstructured {
-            goto 'label_108;
-        }
-    } else {
-        unstructured {
-            goto 'label_108;
-        }
+        assert!(l10 < *(&l0.end_time), C10)
     };
     /* block 108 */;
     let l15 = tx_context::sender(freeze(l7));
@@ -2016,38 +1590,16 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
 }
 
 public entry fun toggle_pause<T0>(l0: &mut StakingPool<T0>, l1: &mut TxContext) {
-    let l2;
     let l3 = tx_context::sender(freeze(l1));
-    if (l3 == *(&l0.admin)) {
-        l2 = true;
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = l3 == *(&l0.emergency_admin);
-        unstructured {
-            goto 'label_19;
-        }
-    };
+    let l2 = l3 == *(&l0.admin) || l3 == *(&l0.emergency_admin);
     /* block 19 */;
     assert!(l2, C1);
     *(&mut l0.is_paused) = !(*(&l0.is_paused))
 }
 
 public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
@@ -2058,23 +1610,13 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     let l8 = *(&l17.allowed_collections);
     let l15 = *(&l17.unlock_cost);
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_130;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l13 >= l15, C30);
         let l14 = coin::into_balance(l2);
         if (l13 > l15) {
             let l11 = demo::safe_sub(l13, l15);
-            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22);
-            unstructured {
-                goto 'label_89;
-            }
-        } else {
-            unstructured {
-                goto 'label_89;
-            }
+            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22)
         };
         let l16;
         /* block 89 */;
@@ -2082,21 +1624,11 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
         l16 = TokenRevenueKey { token_type: l21 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l19 = TokenRevenue { id: object::new(l4), token_type: l21, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l19);
-            unstructured {
-                goto 'label_112;
-            }
-        } else {
-            unstructured {
-                goto 'label_112;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l19)
         };
         /* block 112 */;
         let l20 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l20.total_collected) = demo::safe_add(*(&l20.total_collected), l15);
-        unstructured {
-            goto 'label_130;
-        }
+        *(&mut l20.total_collected) = demo::safe_add(*(&l20.total_collected), l15)
     };
     let l23;
     /* block 130 */;
@@ -2105,14 +1637,7 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l6 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l10, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l6);
-        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_168;
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
-        }
+        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 168 */;
     assert!(!(demo::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2126,81 +1651,42 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
 }
 
 public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8, l2: Coin<T0>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
     let l12 = coin::value(&l2);
     let l20 = demo::get_token_type_string_any();
     assert!(table::contains(&(dynamic_object_field::borrow(&l0.id, PaymentTokenRegistryKey { dummy_field: false })).supported_tokens, l20), C34);
-    let l7;
     let l14 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l14)) {
-        let l6;
+    let l7 = if (dynamic_object_field::exists_(&l0.id, l14)) {
         let l13 = dynamic_object_field::borrow(&l0.id, l14);
-        if (table::contains(&l13.token_prices, l20)) {
-            l6 = *(table::borrow(&l13.token_prices, l20));
-            unstructured {
-                goto 'label_81;
-            }
-        } else {
-            l6 = 0u64;
-            unstructured {
-                goto 'label_81;
-            }
-        };
         /* block 81 */;
-        l7 = l6;
-        unstructured {
-            goto 'label_86;
+        if (table::contains(&l13.token_prices, l20)) {
+            *(table::borrow(&l13.token_prices, l20))
+        } else {
+            0u64
         }
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_86;
-        }
+        0u64
     };
     let l15;
     /* block 86 */;
     l15 = l7;
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_148;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l12 == l15, C30);
         transfer::public_transfer(l2, *(&l0.admin));
         let l16 = TokenRevenueKey { token_type: l20 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l18 = TokenRevenue { id: object::new(l4), token_type: l20, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l18);
-            unstructured {
-                goto 'label_135;
-            }
-        } else {
-            unstructured {
-                goto 'label_135;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l18)
         };
         /* block 135 */;
         let l19 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l19.total_collected) = demo::safe_add(*(&l19.total_collected), l15);
-        unstructured {
-            goto 'label_148;
-        }
+        *(&mut l19.total_collected) = demo::safe_add(*(&l19.total_collected), l15)
     };
     let l23;
     /* block 148 */;
@@ -2209,14 +1695,7 @@ public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l8 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l11, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l8);
-        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_186;
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
-        }
+        *(&mut l0.total_users_with_slots) = demo::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 186 */;
     assert!(!(demo::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2281,33 +1760,11 @@ public entry fun update_multiple_slot_rewards<T0>(l0: &mut StakingPool<T0>, l1: 
 
 public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
-    let l6;
-    if (l2 >= C50) {
-        l6 = l2 <= C54;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = l2 >= C50 && l2 <= C54;
     /* block 53 */;
     assert!(l6, C36);
     let l8 = clock::timestamp_ms(l3);
@@ -2334,19 +1791,8 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     demo::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l9 = clock::timestamp_ms(l4);
@@ -2363,54 +1809,31 @@ public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Str
             };
             l10 = l10 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
     };
     /* block 99 */;
     let l16 = SlotTokenPricingKey { slot_number: l1 };
     if (dynamic_object_field::exists_(&l0.id, l16)) {
-        let l7;
         let l14 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        if (table::contains(&l14.token_prices, l2)) {
-            l7 = *(table::borrow(&l14.token_prices, l2));
-            unstructured {
-                goto 'label_126;
-            }
+        let l7 = if (table::contains(&l14.token_prices, l2)) {
+            *(table::borrow(&l14.token_prices, l2))
         } else {
-            l7 = 0u64;
-            unstructured {
-                goto 'label_126;
-            }
+            0u64
         };
         let l13;
         /* block 126 */;
         l13 = l7;
         if (table::contains(&l14.token_prices, l2)) {
-            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3;
-            unstructured {
-                goto 'label_145;
-            }
+            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3
         } else {
-            table::add(&mut l14.token_prices, l2, l3);
-            unstructured {
-                goto 'label_145;
-            }
+            table::add(&mut l14.token_prices, l2, l3)
         };
         /* block 145 */;
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     } else {
         let l15 = SlotTokenPricing { id: object::new(l5), slot_number: l1, token_prices: table::new(l5) };
         table::add(&mut (&mut l15).token_prices, l2, l3);
         dynamic_object_field::add(&mut l0.id, l16, l15);
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     };
     /* block 189 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
@@ -45,64 +45,26 @@ public fun caw<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut BalanceManager, l2: &
 }
 
 fun cim(l0: u8): bool {
-    let l5;
     let l13 = &l0;
     let l6 = ct::cpsos();
-    if (l13 == &l6) {
-        l5 = true;
-        unstructured {
-            goto 'label_62;
-        }
-    } else {
-        let l4;
-        let l8 = constants::post_only();
-        if (l13 == &l8) {
-            l4 = true;
-            unstructured {
-                goto 'label_60;
-            }
-        } else {
-            let l3;
-            let l10 = constants::immediate_or_cancel();
-            if (l13 == &l10) {
-                l3 = false;
-                unstructured {
-                    goto 'label_58;
-                }
-            } else {
-                let l2;
-                let l12 = constants::fill_or_kill();
-                if (l13 == &l12) {
-                    l2 = false;
-                    unstructured {
-                        goto 'label_56;
-                    }
-                } else {
-                    l2 = false;
-                    unstructured {
-                        goto 'label_56;
-                    }
-                };
-                /* block 56 */;
-                l3 = l2;
-                unstructured {
-                    goto 'label_58;
-                }
-            };
-            /* block 58 */;
-            l4 = l3;
-            unstructured {
-                goto 'label_60;
-            }
-        };
-        /* block 60 */;
-        l5 = l4;
-        unstructured {
-            goto 'label_62;
-        }
-    };
     /* block 62 */;
-    return l5
+    return l13 == &l6 || {
+        let l8 = constants::post_only();
+        /* block 60 */;
+        l13 == &l8 || {
+            let l10 = constants::immediate_or_cancel();
+            /* block 58 */;
+            l13 != &l10 && {
+                let l12 = constants::fill_or_kill();
+                /* block 56 */;
+                if (l13 == &l12) {
+                    false
+                } else {
+                    false
+                }
+            }
+        }
+    }
 }
 
 public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut BalanceManager, l3: &Clock, l4: &mut SQR, l5: u64, l6: bool, l7: u64, l8: u64, l9: vector<u8>, l10: vector<u8>, l11: vector<u64>, l12: vector<u64>, l13: vector<bool>, l14: vector<u64>, l15: &mut TxContext) {
@@ -112,14 +74,7 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
     } else {
         let l52 = bm::gdtp(l1, l2, l15);
         if (l6) {
-            pool::cancel_all_orders(l0, l2, &l52, l3, freeze(l15));
-            unstructured {
-                goto 'label_41;
-            }
-        } else {
-            unstructured {
-                goto 'label_41;
-            }
+            pool::cancel_all_orders(l0, l2, &l52, l3, freeze(l15))
         };
         let (l16, l23, l31, l32, l43, l51);
         /* block 41 */;
@@ -130,30 +85,18 @@ public fun elf<T0, T1, T2>(l0: &mut Pool<T0, T1>, l1: &mut CBM, l2: &mut Balance
         let l20 = balance_manager::balance(freeze(l2));
         l43 = balance_manager::balance(freeze(l2));
         l23 = balance_manager::balance(freeze(l2));
-        if (l20 > l7) {
-            l16 = l20 - l7;
-            unstructured {
-                goto 'label_70;
-            }
+        l16 = if (l20 > l7) {
+            l20 - l7
         } else {
-            l16 = 0u64;
-            unstructured {
-                goto 'label_70;
-            }
+            0u64
         };
         let (l17, l21);
         /* block 70 */;
         l21 = l16;
-        if (l43 > l8) {
-            l17 = l43 - l8;
-            unstructured {
-                goto 'label_83;
-            }
+        l17 = if (l43 > l8) {
+            l43 - l8
         } else {
-            l17 = 0u64;
-            unstructured {
-                goto 'label_83;
-            }
+            0u64
         };
         let (l19, l22, l28, l44, l50);
         /* block 83 */;
@@ -241,8 +184,8 @@ fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
     if (l3 % l2 != 0u64) {
         return 0u64
     };
-    let l5;
-    if (l4) {
+    /* block 88 */;
+    return if (l4) {
         if (l1.len() == 0u64) {
             return l3
         };
@@ -254,10 +197,7 @@ fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
         if (l9 < l2) {
             return 0u64
         };
-        l5 = l9;
-        unstructured {
-            goto 'label_88;
-        }
+        l9
     } else {
         if (l0.len() == 0u64) {
             return l3
@@ -270,13 +210,8 @@ fun sp(l0: &vector<u64>, l1: &vector<u64>, l2: u64, l3: u64, l4: bool): u64 {
         if (l10 > constants::max_u64() - l2) {
             return 0u64
         };
-        l5 = l10;
-        unstructured {
-            goto 'label_88;
-        }
-    };
-    /* block 88 */;
-    return l5
+        l10
+    }
 }
 
 fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: bool, l11: bool): ( u64, u64) {
@@ -286,18 +221,7 @@ fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64,
     if (l7 % l4 != 0u64) {
         return (0u64, ct::e_invalid_price())
     };
-    let l12;
-    if (!(l9)) {
-        l12 = l1 < l6;
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l12 = false;
-        unstructured {
-            goto 'label_30;
-        }
-    };
+    let l12 = !(l9) && l1 < l6;
     /* block 30 */;
     if (l12) {
         return (0u64, ct::e_insufficient_base_balance())
@@ -305,8 +229,7 @@ fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64,
     if (l8 < l6) {
         return (0u64, ct::e_insufficient_quantity())
     };
-    let l15;
-    if (l9) {
+    let l15 = if (l9) {
         let l25 = l2as u128 * constants::float_scaling_u128() / l7as u128as u64;
         let l21 = l25 % l5 + l5;
         if (l25 < l21) {
@@ -317,44 +240,24 @@ fun vbac<T0, T1>(l0: &Pool<T0, T1>, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64,
             return (0u64, ct::e_insufficient_quote_balance())
         };
         let l19 = u64::max(l6, u64::min(l8, l22as u64));
-        l15 = l19 - l19 % l5;
-        unstructured {
-            goto 'label_114;
-        }
+        l19 - l19 % l5
     } else {
         let l20 = u64::max(l6, u64::min(l8, l1));
-        l15 = l20 - l20 % l5;
-        unstructured {
-            goto 'label_114;
-        }
+        l20 - l20 % l5
     };
     let (l14, l26);
     /* block 114 */;
     l26 = l15;
-    if (l11) {
-        let l13;
+    l14 = if (l11) {
         let (reg_89, reg_90) = pool::get_order_deep_required(l0, l26, l7);
-        if (l10) {
-            l13 = reg_90;
-            unstructured {
-                goto 'label_137;
-            }
-        } else {
-            l13 = reg_89;
-            unstructured {
-                goto 'label_137;
-            }
-        };
         /* block 137 */;
-        l14 = l13;
-        unstructured {
-            goto 'label_144;
+        if (l10) {
+            reg_90
+        } else {
+            reg_89
         }
     } else {
-        l14 = 0u64;
-        unstructured {
-            goto 'label_144;
-        }
+        0u64
     };
     /* block 144 */;
     if (l14 > l3) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb3a44310c59536782d1b5c29d01a066798750ff0c15242a7f3eb7e55d188cfc3/dlmm_bin_tree.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb3a44310c59536782d1b5c29d01a066798750ff0c15242a7f3eb7e55d188cfc3/dlmm_bin_tree.move
@@ -29,18 +29,11 @@ const C4: u64 = 3u64;
 
 public fun add(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l5 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l5)) {
-        l2 = *(vec_map::get(&l0.level2, &l5));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l5)) {
+        *(vec_map::get(&l0.level2, &l5))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l6 = l2;
@@ -48,49 +41,24 @@ public fun add(l0: &mut BinTree, l1: u32): bool {
     if (l6 != l8) {
         if (vec_map::contains(&l0.level2, &l5)) {
             (reg_41, reg_42) = vec_map::remove(&mut l0.level2, &l5);
-            unstructured {
-                goto 'label_57;
-            }
-        } else {
-            unstructured {
-                goto 'label_57;
-            }
         };
         /* block 57 */;
         vec_map::insert(&mut l0.level2, l5, l8);
         if (l6 == 0u256) {
-            let l3;
             let l4 = l5 >> 8u8;
-            if (vec_map::contains(&l0.level1, &l4)) {
+            let l3 = if (vec_map::contains(&l0.level1, &l4)) {
                 let reg_61;
                 (reg_60, reg_61) = vec_map::remove(&mut l0.level1, &l4);
-                l3 = reg_61;
-                unstructured {
-                    goto 'label_86;
-                }
+                reg_61
             } else {
-                l3 = 0u256;
-                unstructured {
-                    goto 'label_86;
-                }
+                0u256
             };
             /* block 86 */;
             let l7 = l3;
             let l9 = l7 | 1u256 << l5 & C1as u256as u8;
             vec_map::insert(&mut l0.level1, l4, l9);
             if (l7 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8;
-                unstructured {
-                    goto 'label_126;
-                }
-            } else {
-                unstructured {
-                    goto 'label_126;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_126;
+                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8
             }
         };
         /* block 126 */;
@@ -130,13 +98,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = dlmm_bin_tree::closest_bit_left(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -151,13 +112,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l14), C4);
             let l16 = *(vec_map::get(&l0.level2, &l14));
             return (l14 << 8u8 | bit_math::least_significant_bit(l16)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_126;
-        }
-    } else {
-        unstructured {
-            goto 'label_126;
         }
     };
     /* block 126 */;
@@ -172,13 +126,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l15), C4);
             let l18 = *(vec_map::get(&l0.level2, &l15));
             return (l15 << 8u8 | bit_math::least_significant_bit(l18)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_203;
-        }
-    } else {
-        unstructured {
-            goto 'label_203;
         }
     };
     /* block 203 */;
@@ -194,13 +141,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = dlmm_bin_tree::closest_bit_right(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -214,13 +154,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l14), C4);
             let l16 = *(vec_map::get(&l0.level2, &l14));
             return (l14 << 8u8 | bit_math::most_significant_bit(l16)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_116;
-        }
-    } else {
-        unstructured {
-            goto 'label_116;
         }
     };
     /* block 116 */;
@@ -235,13 +168,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             assert!(vec_map::contains(&l0.level2, &l15), C4);
             let l18 = *(vec_map::get(&l0.level2, &l15));
             return (l15 << 8u8 | bit_math::most_significant_bit(l18)as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_193;
-        }
-    } else {
-        unstructured {
-            goto 'label_193;
         }
     };
     /* block 193 */;
@@ -250,18 +176,11 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
 
 public fun remove(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l4 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l4)) {
-        l2 = *(vec_map::get(&l0.level2, &l4));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l4)) {
+        *(vec_map::get(&l0.level2, &l4))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l5 = l2;
@@ -276,18 +195,7 @@ public fun remove(l0: &mut BinTree, l1: u32): bool {
             let l8 = reg_54 & C0 - 1u256 << l4 & 255u256as u8;
             vec_map::insert(&mut l0.level1, l3, l8);
             if (l8 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8;
-                unstructured {
-                    goto 'label_113;
-                }
-            } else {
-                unstructured {
-                    goto 'label_113;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_113;
+                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8
             }
         };
         /* block 113 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xbdd9e0fa962f8c16f14560ebf595853edd4d22214560f9d34eb26b06a234b6b0/acbdd009a143591b1.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xbdd9e0fa962f8c16f14560ebf595853edd4d22214560f9d34eb26b06a234b6b0/acbdd009a143591b1.move
@@ -55,17 +55,12 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
         let l29 = l10;
         let l28 = l11;
         let l39 = l12;
-        let l33 = l13;
-        let l34 = l14;
         let l51 = a2ec4300f6df080d1::a558d3d4811fa675d(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28);
         let l52 = a2ec4300f6df080d1::ac4104d3c58483259(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28, l51);
+        /* block 440 */;
         if (a10868438248226c1::ad3e462cd25333e7f(l51, l39) > l52) {
-            a2ec4300f6df080d1::a5eefc623c389ac57(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l33, l34);
-            unstructured {
-                goto 'label_440;
-            }
+            a2ec4300f6df080d1::a5eefc623c389ac57(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l13, l14)
         } else {
-            let l19;
             let l38 = a2ec4300f6df080d1::a99ab6d0cf8644a81(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28);
             let l54 = a2ec4300f6df080d1::aa8fecb213cfb45e1(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28);
             let l37 = i32::div(l38, l54);
@@ -77,79 +72,39 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
             let l46 = a10868438248226c1::ab78d0325509532d4(l25, freeze(l27));
             let l58 = l47;
             let l64 = a783956f993d811bc::ae2894da560e9dfaf(l25);
-            if (l58 < l64) {
-                l19 = l58;
-                unstructured {
-                    goto 'label_187;
-                }
+            let l19 = if (l58 < l64) {
+                l58
             } else {
-                l19 = l64;
-                unstructured {
-                    goto 'label_187;
-                }
+                l64
             };
             let l20;
             /* block 187 */;
             l47 = l19;
             let l59 = l46;
             let l65 = a783956f993d811bc::a8f57f404176c397b(l25);
-            if (l59 < l65) {
-                l20 = l59;
-                unstructured {
-                    goto 'label_203;
-                }
+            l20 = if (l59 < l65) {
+                l59
             } else {
-                l20 = l65;
-                unstructured {
-                    goto 'label_203;
-                }
+                l65
             };
             let (l21, l36);
             /* block 203 */;
             l46 = l20;
             l36 = a2ec4300f6df080d1::a1d4c92881210dfd5(l40, l24);
-            if (ad9e4d11aecc532fa::a86e56d31feeb19a6(&l36) == l26) {
-                l21 = ad9e4d11aecc532fa::a21b8c64204576499(&l36) == l23;
-                unstructured {
-                    goto 'label_222;
-                }
-            } else {
-                l21 = false;
-                unstructured {
-                    goto 'label_222;
-                }
-            };
+            l21 = ad9e4d11aecc532fa::a86e56d31feeb19a6(&l36) == l26 && ad9e4d11aecc532fa::a21b8c64204576499(&l36) == l23;
             /* block 222 */;
             if (l21) {
-                let l22;
                 let l53 = a10868438248226c1::aa2c4ceebf26949f7(l25, l46, l47, l39);
                 let l35 = a10868438248226c1::aa2c4ceebf26949f7(l25, ad9e4d11aecc532fa::ae18556b7140949ca(&l36), ad9e4d11aecc532fa::a888b107d980228f4(&l36), l39);
                 let l60 = l53;
                 let l66 = l35;
-                if (l60 > l66) {
-                    l22 = l60 - l66;
-                    unstructured {
-                        goto 'label_255;
-                    }
-                } else {
-                    l22 = l66 - l60;
-                    unstructured {
-                        goto 'label_255;
-                    }
-                };
                 /* block 255 */;
-                if (l22 < l53 / 2u64) {
-                    unstructured {
-                        goto 'label_440;
-                    }
+                if (if (l60 > l66) {
+                    l60 - l66
                 } else {
-                    unstructured {
-                        goto 'label_292;
-                    }
-                }
-            } else {
-                unstructured {
-                    goto 'label_292;
+                    l66 - l60
+                } < l53 / 2u64) {
+                    break 'loop_440
                 }
             };
             let l16;
@@ -158,16 +113,10 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
             let l43 = a2ec4300f6df080d1::a7235c62aa5b27437(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28, l26, l23, l46, true);
             let l61 = l44;
             let l67 = l43;
-            if (l61 < l67) {
-                l16 = l61;
-                unstructured {
-                    goto 'label_337;
-                }
+            l16 = if (l61 < l67) {
+                l61
             } else {
-                l16 = l67;
-                unstructured {
-                    goto 'label_337;
-                }
+                l67
             };
             let l17;
             /* block 337 */;
@@ -175,66 +124,36 @@ public(friend) fun a40f8bc58a06c8b33(l0: &A0ea878587b719a64, l1: &mut Ad1f26f3c0
             let l48 = a2ec4300f6df080d1::a8fa7d5a111cd2750(l40, l49, l50, l31, l30, l32, l55, l56, l29, l28) * a783956f993d811bc::afa416ea5d7b9d0f7(l25);
             let l62 = l41;
             let l68 = l48;
-            if (l62 < l68) {
-                l17 = l62;
-                unstructured {
-                    goto 'label_367;
-                }
+            l17 = if (l62 < l68) {
+                l62
             } else {
-                l17 = l68;
-                unstructured {
-                    goto 'label_367;
-                }
+                l68
             };
             let (l18, l42);
             /* block 367 */;
             l42 = l17;
             let l63 = l42;
             let l69 = ad9e4d11aecc532fa::afb1904d62fe08653(&l36);
-            if (l63 > l69) {
-                l18 = l63 - l69;
-                unstructured {
-                    goto 'label_387;
-                }
+            l18 = if (l63 > l69) {
+                l63 - l69
             } else {
-                l18 = l69 - l63;
-                unstructured {
-                    goto 'label_387;
-                }
+                l69 - l63
             };
             /* block 387 */;
             if (l18 < l42 / 2u128) {
-                unstructured {
-                    goto 'label_440;
-                }
+                
             } else {
-                a2ec4300f6df080d1::a6dc79187e3841ff0(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l26, l23, l42, l33, l34);
-                unstructured {
-                    goto 'label_440;
-                }
+                a2ec4300f6df080d1::a6dc79187e3841ff0(l40, l27, l24, l49, l50, l31, l30, l32, l55, l56, l29, l28, l26, l23, l42, l13, l14)
             }
-        };
-        /* block 440 */
+        }
     }
 }
 
 public(friend) fun a94cdf867cab7cc5c(l0: &A0ea878587b719a64, l1: &mut BalanceManager, l2: &mut Ad1f26f3c041612f2, l3: &mut x7_Pool<SUI, USDC>, l4: &Version, l5: &mut Pool<USDC, SUI>, l6: &GlobalConfig, l7: &mut RewarderGlobalVault, l8: &mut x9_Pool<SUI, USDC, FEE500BPS>, l9: &Versioned, l10: &mut x3_Pool<SUI, USDC>, l11: &x3_GlobalConfig, l12: u64, l13: u64, l14: &Clock, l15: &mut TxContext) {
-    let l16;
     let l18 = a10868438248226c1::a9d9f98ebd95b9dad(l0, freeze(l1));
     let l17 = a10868438248226c1::ab78d0325509532d4(l0, freeze(l1));
-    if (l12 <= l18) {
-        l16 = l13 <= l17;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l16 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    if (l16) {
+    if (l12 <= l18 && l13 <= l17) {
         
     } else {
         a2ec4300f6df080d1::a5eefc623c389ac57(&a2ec4300f6df080d1::a099d08408fdb4a75(), l1, l2, l3, l4, l5, l6, l7, l8, l9, l10, l11, l14, l15)

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xc7f4524aad685d7a334b559aea1a1464287a2a62d571243be1877ef53e2a916b/almm_bin_tree.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xc7f4524aad685d7a334b559aea1a1464287a2a62d571243be1877ef53e2a916b/almm_bin_tree.move
@@ -29,18 +29,11 @@ const C4: u64 = 3u64;
 
 public fun add(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l5 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l5)) {
-        l2 = *(vec_map::get(&l0.level2, &l5));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l5)) {
+        *(vec_map::get(&l0.level2, &l5))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l6 = l2;
@@ -48,49 +41,24 @@ public fun add(l0: &mut BinTree, l1: u32): bool {
     if (l6 != l8) {
         if (vec_map::contains(&l0.level2, &l5)) {
             (reg_41, reg_42) = vec_map::remove(&mut l0.level2, &l5);
-            unstructured {
-                goto 'label_57;
-            }
-        } else {
-            unstructured {
-                goto 'label_57;
-            }
         };
         /* block 57 */;
         vec_map::insert(&mut l0.level2, l5, l8);
         if (l6 == 0u256) {
-            let l3;
             let l4 = l5 >> 8u8;
-            if (vec_map::contains(&l0.level1, &l4)) {
+            let l3 = if (vec_map::contains(&l0.level1, &l4)) {
                 let reg_61;
                 (reg_60, reg_61) = vec_map::remove(&mut l0.level1, &l4);
-                l3 = reg_61;
-                unstructured {
-                    goto 'label_86;
-                }
+                reg_61
             } else {
-                l3 = 0u256;
-                unstructured {
-                    goto 'label_86;
-                }
+                0u256
             };
             /* block 86 */;
             let l7 = l3;
             let l9 = l7 | 1u256 << l5 & C1as u256as u8;
             vec_map::insert(&mut l0.level1, l4, l9);
             if (l7 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8;
-                unstructured {
-                    goto 'label_126;
-                }
-            } else {
-                unstructured {
-                    goto 'label_126;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_126;
+                *(&mut l0.level0) = *(&l0.level0) | 1u256 << l4 & 255u256as u8
             }
         };
         /* block 126 */;
@@ -131,13 +99,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = almm_bin_tree::closest_bit_left(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -154,13 +115,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_86, reg_87) = bit_math::least_significant_bit(*(vec_map::get(&l0.level2, &l14)));
             let l16 = reg_86;
             return (l14 << 8u8 | l16as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_127;
-        }
-    } else {
-        unstructured {
-            goto 'label_127;
         }
     };
     /* block 127 */;
@@ -179,13 +133,6 @@ public fun find_first_left(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_143, reg_144) = bit_math::least_significant_bit(*(vec_map::get(&l0.level2, &l15)));
             let l18 = reg_143;
             return (l15 << 8u8 | l18as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_206;
-        }
-    } else {
-        unstructured {
-            goto 'label_206;
         }
     };
     /* block 206 */;
@@ -201,13 +148,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
         let (reg_31, reg_32) = almm_bin_tree::closest_bit_right(*(vec_map::get(&l0.level2, &l13)), l2);
         if (reg_32) {
             return (l13 << 8u8 | reg_31as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_58;
-        }
-    } else {
-        unstructured {
-            goto 'label_58;
         }
     };
     let l11;
@@ -223,13 +163,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_80, reg_81) = bit_math::most_significant_bit(*(vec_map::get(&l0.level2, &l14)));
             let l16 = reg_80;
             return (l14 << 8u8 | l16as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_117;
-        }
-    } else {
-        unstructured {
-            goto 'label_117;
         }
     };
     /* block 117 */;
@@ -248,13 +181,6 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
             (reg_137, reg_138) = bit_math::most_significant_bit(*(vec_map::get(&l0.level2, &l15)));
             let l18 = reg_137;
             return (l15 << 8u8 | l18as u256as u32, true)
-        };
-        unstructured {
-            goto 'label_196;
-        }
-    } else {
-        unstructured {
-            goto 'label_196;
         }
     };
     /* block 196 */;
@@ -263,18 +189,11 @@ public fun find_first_right(l0: &BinTree, l1: u32): ( u32, bool) {
 
 public fun remove(l0: &mut BinTree, l1: u32): bool {
     assert!(l1 >> 24u8 == 0u32, C2);
-    let l2;
     let l4 = l1 >> 8u8as u256;
-    if (vec_map::contains(&l0.level2, &l4)) {
-        l2 = *(vec_map::get(&l0.level2, &l4));
-        unstructured {
-            goto 'label_30;
-        }
+    let l2 = if (vec_map::contains(&l0.level2, &l4)) {
+        *(vec_map::get(&l0.level2, &l4))
     } else {
-        l2 = 0u256;
-        unstructured {
-            goto 'label_30;
-        }
+        0u256
     };
     /* block 30 */;
     let l5 = l2;
@@ -289,18 +208,7 @@ public fun remove(l0: &mut BinTree, l1: u32): bool {
             let l8 = reg_54 & C0 - 1u256 << l4 & 255u256as u8;
             vec_map::insert(&mut l0.level1, l3, l8);
             if (l8 == 0u256) {
-                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8;
-                unstructured {
-                    goto 'label_113;
-                }
-            } else {
-                unstructured {
-                    goto 'label_113;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_113;
+                *(&mut l0.level0) = *(&l0.level0) & C0 - 1u256 << l3 & 255u256as u8
             }
         };
         /* block 113 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xdf19017658b71f03834211e033b013470e20695d18084b82c4e495c8f7ed8bb6/leva_deep_mm.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xdf19017658b71f03834211e033b013470e20695d18084b82c4e495c8f7ed8bb6/leva_deep_mm.move
@@ -118,7 +118,6 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
             events::emit_log_bytes(C3);
             let l97 = config::is_dry_run(l83);
             if (config::is_arbitrage_enabled(l83)) {
-                let l19;
                 let l99 = mm_state::last_arb_timestamp(freeze(l0));
                 let l86 = pool::mid_price(freeze(l3), l7);
                 let (reg_113, reg_114, reg_115, reg_116, reg_117, reg_118) = arbitrage_router::execute_arbitrage_analysis(l112, freeze(l5), l86, config::min_arb_profit_bps(l83), l99, config::arb_cooldown_ms(l83), l7);
@@ -126,87 +125,29 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                 let l65 = reg_116;
                 let l139 = reg_114;
                 let l138 = reg_113;
-                if (config::max_arb_amount(l83) > 0u64) {
-                    l19 = config::max_arb_amount(l83);
-                    unstructured {
-                        goto 'label_175;
-                    }
+                let l19 = if (config::max_arb_amount(l83) > 0u64) {
+                    config::max_arb_amount(l83)
                 } else {
-                    l19 = 0u64;
-                    unstructured {
-                        goto 'label_175;
-                    }
+                    0u64
                 };
                 let (l41, l52);
                 /* block 175 */;
                 l52 = l19;
-                if (l138) {
-                    l41 = true;
-                    unstructured {
-                        goto 'label_184;
-                    }
-                } else {
-                    l41 = l139;
-                    unstructured {
-                        goto 'label_184;
-                    }
-                };
-                let l30;
+                l41 = l138 || l139;
                 /* block 184 */;
-                if (l41) {
-                    l30 = l52 > 0u64;
-                    unstructured {
-                        goto 'label_193;
-                    }
-                } else {
-                    l30 = false;
-                    unstructured {
-                        goto 'label_193;
-                    }
-                };
+                let l30 = l41 && l52 > 0u64;
                 /* block 193 */;
                 if (l30) {
-                    let l46;
                     events::emit_log_bytes(C4);
-                    if (l138) {
-                        if (reg_115 == arbitrage_router::pool_cetus()) {
-                            l46 = !(l97);
-                            unstructured {
-                                goto 'label_214;
-                            }
-                        } else {
-                            l46 = false;
-                            unstructured {
-                                goto 'label_214;
-                            }
-                        }
-                    } else {
-                        l46 = false;
-                        unstructured {
-                            goto 'label_214;
-                        }
-                    };
                     /* block 214 */;
-                    if (l46) {
-                        let l47;
+                    if (l138 && reg_115 == arbitrage_router::pool_cetus() && !(l97)) {
                         let (reg_159, reg_160);
                         (reg_158, reg_159, reg_160) = arbitrage_router::execute_cetus_buy(l112, l2, l5, l6, l52, l65, l86, config::arb_slippage_bps(l83), l7, l18);
                         let l81 = reg_160;
                         let l129 = reg_159;
                         events::emit_log_bytes(C5);
-                        if (l81) {
-                            l47 = l129 > 0u64;
-                            unstructured {
-                                goto 'label_242;
-                            }
-                        } else {
-                            l47 = false;
-                            unstructured {
-                                goto 'label_242;
-                            }
-                        };
                         /* block 242 */;
-                        if (l47) {
+                        if (l81 && l129 > 0u64) {
                             let reg_171;
                             (reg_170, reg_171, reg_172) = pool::pool_book_params(freeze(l3));
                             let l100 = reg_171;
@@ -215,98 +156,32 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                                 let (reg_189, reg_190) = arbitrage_router::execute_deepbook_ioc(false, l3, l2, &l136, l86, l125, l83, l7, freeze(l18));
                                 if (reg_190) {
                                     events::emit_log_bytes(C6);
-                                    events::emit_arb_ioc_executed(l112, false, l86, l125, reg_189, l65, l108);
-                                    unstructured {
-                                        goto 'label_286;
-                                    }
+                                    events::emit_arb_ioc_executed(l112, false, l86, l125, reg_189, l65, l108)
                                 } else {
-                                    events::emit_log_bytes(C7);
-                                    unstructured {
-                                        goto 'label_286;
-                                    }
+                                    events::emit_log_bytes(C7)
                                 }
-                            } else {
-                                unstructured {
-                                    goto 'label_286;
-                                }
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_286;
                             }
                         };
                         /* block 286 */;
                         mm_state::record_arb_time(l0, l108);
-                        events::emit_log_bytes(C8);
-                        unstructured {
-                            goto 'label_303;
-                        }
+                        events::emit_log_bytes(C8)
                     } else {
-                        let l48;
-                        if (l138) {
-                            l48 = l97;
-                            unstructured {
-                                goto 'label_299;
-                            }
-                        } else {
-                            l48 = false;
-                            unstructured {
-                                goto 'label_299;
-                            }
-                        };
                         /* block 299 */;
-                        if (l48) {
-                            events::emit_log_bytes(C9);
-                            unstructured {
-                                goto 'label_303;
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_303;
-                            }
+                        if (l138 && l97) {
+                            events::emit_log_bytes(C9)
                         }
                     };
-                    let l49;
                     /* block 303 */;
-                    if (l139) {
-                        if (reg_117 == arbitrage_router::pool_cetus()) {
-                            l49 = !(l97);
-                            unstructured {
-                                goto 'label_318;
-                            }
-                        } else {
-                            l49 = false;
-                            unstructured {
-                                goto 'label_318;
-                            }
-                        }
-                    } else {
-                        l49 = false;
-                        unstructured {
-                            goto 'label_318;
-                        }
-                    };
+                    let l49 = l139 && reg_117 == arbitrage_router::pool_cetus() && !(l97);
                     /* block 318 */;
                     if (l49) {
-                        let l50;
                         let (reg_229, reg_231);
                         (reg_229, reg_230, reg_231) = arbitrage_router::execute_cetus_sell(l112, l2, l5, l6, l52, l67, l86, config::arb_slippage_bps(l83), l7, l18);
                         let l82 = reg_231;
                         let l130 = reg_229;
                         events::emit_log_bytes(C10);
-                        if (l82) {
-                            l50 = l130 > 0u64;
-                            unstructured {
-                                goto 'label_346;
-                            }
-                        } else {
-                            l50 = false;
-                            unstructured {
-                                goto 'label_346;
-                            }
-                        };
                         /* block 346 */;
-                        if (l50) {
+                        if (l82 && l130 > 0u64) {
                             let reg_242;
                             (reg_241, reg_242, reg_243) = pool::pool_book_params(freeze(l3));
                             let l101 = reg_242;
@@ -315,190 +190,81 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                                 let (reg_260, reg_261) = arbitrage_router::execute_deepbook_ioc(true, l3, l2, &l136, l86, l78, l83, l7, freeze(l18));
                                 if (reg_261) {
                                     events::emit_log_bytes(C11);
-                                    events::emit_arb_ioc_executed(l112, true, l86, l78, reg_260, l67, l108);
-                                    unstructured {
-                                        goto 'label_408;
-                                    }
+                                    events::emit_arb_ioc_executed(l112, true, l86, l78, reg_260, l67, l108)
                                 } else {
-                                    events::emit_log_bytes(C12);
-                                    unstructured {
-                                        goto 'label_408;
-                                    }
+                                    events::emit_log_bytes(C12)
                                 }
-                            } else {
-                                unstructured {
-                                    goto 'label_408;
-                                }
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_408;
                             }
                         };
                         /* block 408 */;
                         mm_state::record_arb_time(l0, l108);
-                        events::emit_log_bytes(C13);
-                        unstructured {
-                            goto 'label_437;
-                        }
+                        events::emit_log_bytes(C13)
                     } else {
-                        let l51;
-                        if (l139) {
-                            l51 = l97;
-                            unstructured {
-                                goto 'label_433;
-                            }
-                        } else {
-                            l51 = false;
-                            unstructured {
-                                goto 'label_433;
-                            }
-                        };
                         /* block 433 */;
-                        if (l51) {
-                            events::emit_log_bytes(C14);
-                            unstructured {
-                                goto 'label_437;
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_437;
-                            }
+                        if (l139 && l97) {
+                            events::emit_log_bytes(C14)
                         }
                     };
                     let (l131, l21);
                     /* block 437 */;
                     l131 = config::target_base_position(l83);
-                    if (l131 > 0u64) {
-                        let l20;
-                        if (l62 >= l131) {
-                            l20 = l62 - l131 * 10000u64 / l131;
-                            unstructured {
-                                goto 'label_465;
-                            }
-                        } else {
-                            l20 = l131 - l62 * 10000u64 / l131;
-                            unstructured {
-                                goto 'label_465;
-                            }
-                        };
+                    l21 = if (l131 > 0u64) {
                         /* block 465 */;
-                        l21 = l20;
-                        unstructured {
-                            goto 'label_470;
+                        if (l62 >= l131) {
+                            l62 - l131 * 10000u64 / l131
+                        } else {
+                            l131 - l62 * 10000u64 / l131
                         }
                     } else {
-                        l21 = 0u64;
-                        unstructured {
-                            goto 'label_470;
-                        }
+                        0u64
                     };
                     /* block 470 */;
                     let l93 = l21;
                     events::emit_execution_detail(mm_state::state_id(freeze(l0)), l112, l13, mm_state::execution_count(freeze(l0)), l108, l8, l8, 0u64, 0u64, l62, l114, l131, l93, false, l9, l10, 0u64, 0u64, l80, false, 0u64, l15);
                     mm_state::record_order_time(l0, l108);
                     return
-                };
-                unstructured {
-                    goto 'label_503;
-                }
-            } else {
-                unstructured {
-                    goto 'label_503;
                 }
             };
             let l27;
             /* block 503 */;
             events::emit_log_bytes(C15);
-            if (config::is_orderbook_analysis_enabled(l83)) {
-                let l22;
+            l27 = if (config::is_orderbook_analysis_enabled(l83)) {
                 let l127 = orderbook_analyzer::analyze_orderbook(freeze(l3), freeze(l2), config::min_significant_qty(l83), config::l2_tick_count(l83), l7);
-                if (orderbook_analyzer::bid_prices(&l127).len() > 0u64) {
-                    l22 = *(&(orderbook_analyzer::bid_prices(&l127))[0u64]);
-                    unstructured {
-                        goto 'label_534;
-                    }
+                let l22 = if (orderbook_analyzer::bid_prices(&l127).len() > 0u64) {
+                    *(&(orderbook_analyzer::bid_prices(&l127))[0u64])
                 } else {
-                    l22 = 0u64;
-                    unstructured {
-                        goto 'label_534;
-                    }
+                    0u64
                 };
                 let (l118, l23);
                 /* block 534 */;
                 l118 = l22;
-                if (orderbook_analyzer::ask_prices(&l127).len() > 0u64) {
-                    l23 = *(&(orderbook_analyzer::ask_prices(&l127))[0u64]);
-                    unstructured {
-                        goto 'label_551;
-                    }
+                l23 = if (orderbook_analyzer::ask_prices(&l127).len() > 0u64) {
+                    *(&(orderbook_analyzer::ask_prices(&l127))[0u64])
                 } else {
-                    l23 = 0u64;
-                    unstructured {
-                        goto 'label_551;
-                    }
+                    0u64
                 };
                 let (l117, l24);
                 /* block 551 */;
                 l117 = l23;
-                if (l118 > 0u64) {
-                    if (l117 > 0u64) {
-                        l24 = l117 > l118;
-                        unstructured {
-                            goto 'label_571;
-                        }
-                    } else {
-                        l24 = false;
-                        unstructured {
-                            goto 'label_571;
-                        }
-                    }
-                } else {
-                    l24 = false;
-                    unstructured {
-                        goto 'label_571;
-                    }
-                };
-                let l26;
+                l24 = l118 > 0u64 && l117 > 0u64 && l117 > l118;
                 /* block 571 */;
-                if (l24) {
-                    let l25;
+                let l26 = if (l24) {
                     let l121 = l118 + l117 / 2u64;
-                    if (l121 > 0u64) {
-                        l25 = l117 - l118 * 10000u64 / l121;
-                        unstructured {
-                            goto 'label_594;
-                        }
-                    } else {
-                        l25 = 0u64;
-                        unstructured {
-                            goto 'label_594;
-                        }
-                    };
                     /* block 594 */;
-                    l26 = l25;
-                    unstructured {
-                        goto 'label_599;
+                    if (l121 > 0u64) {
+                        l117 - l118 * 10000u64 / l121
+                    } else {
+                        0u64
                     }
                 } else {
-                    l26 = 0u64;
-                    unstructured {
-                        goto 'label_599;
-                    }
+                    0u64
                 };
                 /* block 599 */;
-                let l122 = l26;
-                events::emit_orderbook_analysis(l112, l108, orderbook_analyzer::bid_prices(&l127).len(), orderbook_analyzer::ask_prices(&l127).len(), l118, l117, l122, orderbook_analyzer::own_bid_qty_filtered(&l127), orderbook_analyzer::own_ask_qty_filtered(&l127), orderbook_analyzer::own_orders_count(&l127), orderbook_analyzer::best_bid(&l127), orderbook_analyzer::best_ask(&l127), orderbook_analyzer::spread_bps(&l127), orderbook_analyzer::significant_bid(&l127), orderbook_analyzer::significant_bid_qty(&l127), orderbook_analyzer::significant_ask(&l127), orderbook_analyzer::significant_ask_qty(&l127), orderbook_analyzer::total_bid_depth(&l127), orderbook_analyzer::total_ask_depth(&l127));
+                events::emit_orderbook_analysis(l112, l108, orderbook_analyzer::bid_prices(&l127).len(), orderbook_analyzer::ask_prices(&l127).len(), l118, l117, l26, orderbook_analyzer::own_bid_qty_filtered(&l127), orderbook_analyzer::own_ask_qty_filtered(&l127), orderbook_analyzer::own_orders_count(&l127), orderbook_analyzer::best_bid(&l127), orderbook_analyzer::best_ask(&l127), orderbook_analyzer::spread_bps(&l127), orderbook_analyzer::significant_bid(&l127), orderbook_analyzer::significant_bid_qty(&l127), orderbook_analyzer::significant_ask(&l127), orderbook_analyzer::significant_ask_qty(&l127), orderbook_analyzer::total_bid_depth(&l127), orderbook_analyzer::total_ask_depth(&l127));
                 events::emit_log_bytes(C16);
-                l27 = option::some(l127);
-                unstructured {
-                    goto 'label_645;
-                }
+                option::some(l127)
             } else {
-                l27 = option::none();
-                unstructured {
-                    goto 'label_645;
-                }
+                option::none()
             };
             let (l102, l105, l110, l115, l119, l133, l28, l76);
             /* block 645 */;
@@ -513,30 +279,18 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
             (reg_478, reg_479, reg_480, reg_481) = pool::get_level2_ticks_from_mid(freeze(l3), 1u64, l7);
             l76 = reg_480;
             let l77 = reg_478;
-            if (&l77.len() > 0u64) {
-                l28 = *(&(&l77)[0u64]);
-                unstructured {
-                    goto 'label_691;
-                }
+            l28 = if (&l77.len() > 0u64) {
+                *(&(&l77)[0u64])
             } else {
-                l28 = 0u64;
-                unstructured {
-                    goto 'label_691;
-                }
+                0u64
             };
             let (l29, l64);
             /* block 691 */;
             l64 = l28;
-            if (&l76.len() > 0u64) {
-                l29 = *(&(&l76)[0u64]);
-                unstructured {
-                    goto 'label_706;
-                }
+            l29 = if (&l76.len() > 0u64) {
+                *(&(&l76)[0u64])
             } else {
-                l29 = 0u64;
-                unstructured {
-                    goto 'label_706;
-                }
+                0u64
             };
             let (l31, l53, l63, l69, l84, l85);
             /* block 706 */;
@@ -545,135 +299,62 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
             l53 = false;
             l85 = l119;
             l84 = l115;
-            if (l63 > 0u64) {
-                l31 = l119 >= l63;
-                unstructured {
-                    goto 'label_727;
-                }
-            } else {
-                l31 = false;
-                unstructured {
-                    goto 'label_727;
-                }
-            };
+            l31 = l63 > 0u64 && l119 >= l63;
             /* block 727 */;
             if (l31) {
                 l69 = true;
                 l85 = l63 * 100000u64 - l11 / 100000u64;
-                unstructured {
-                    goto 'label_739;
-                }
-            } else {
-                unstructured {
-                    goto 'label_739;
-                }
             };
-            let l32;
             /* block 739 */;
-            if (l64 > 0u64) {
-                l32 = l115 <= l64;
-                unstructured {
-                    goto 'label_750;
-                }
-            } else {
-                l32 = false;
-                unstructured {
-                    goto 'label_750;
-                }
-            };
+            let l32 = l64 > 0u64 && l115 <= l64;
             /* block 750 */;
             if (l32) {
                 l53 = true;
                 l84 = l64 * 100000u64 + l12 / 100000u64;
-                unstructured {
-                    goto 'label_762;
-                }
-            } else {
-                unstructured {
-                    goto 'label_762;
-                }
             };
-            let l33;
             /* block 762 */;
-            if (l69) {
-                l33 = true;
-                unstructured {
-                    goto 'label_769;
-                }
-            } else {
-                l33 = l53;
-                unstructured {
-                    goto 'label_769;
-                }
-            };
+            let l33 = l69 || l53;
             /* block 769 */;
             if (l33) {
-                events::emit_crossing_prevented(l112, l108, l69, l53, l119, l115, l85, l84, l64, l63, l11, l12);
-                unstructured {
-                    goto 'label_784;
-                }
-            } else {
-                unstructured {
-                    goto 'label_784;
-                }
+                events::emit_crossing_prevented(l112, l108, l69, l53, l119, l115, l85, l84, l64, l63, l11, l12)
             };
             let (l116, l120, l36, l37);
             /* block 784 */;
             l120 = l85;
             l116 = l84;
-            if (option::is_some(&l110)) {
-                let l34;
+            l36 = if (option::is_some(&l110)) {
                 let l128 = option::borrow(&l110);
                 let l113 = config::price_offset_ticks(l83) * l133;
                 let (reg_570, reg_571) = orderbook_analyzer::find_optimal_price_with_reason(l128, l120, true, l113, config::min_significant_qty(l83));
                 let l124 = orders::round_bid_price(reg_570, l133);
                 let l107 = orders::round_bid_price(l120, l133);
-                if (l124 > l107) {
-                    l34 = l124 - l107;
-                    unstructured {
-                        goto 'label_827;
-                    }
+                let l34 = if (l124 > l107) {
+                    l124 - l107
                 } else {
-                    l34 = l107 - l124;
-                    unstructured {
-                        goto 'label_827;
-                    }
+                    l107 - l124
                 };
                 let (l106, l123, l35, l59);
                 /* block 827 */;
-                let l70 = l34;
                 let l71 = l124 > l107;
-                events::emit_order_placement_decision(l112, l108, true, l8, l8, l107, orderbook_analyzer::significant_bid(l128), orderbook_analyzer::significant_bid_qty(l128), l124, l70 / l133, l71, reg_571);
+                events::emit_order_placement_decision(l112, l108, true, l8, l8, l107, orderbook_analyzer::significant_bid(l128), orderbook_analyzer::significant_bid_qty(l128), l124, l34 / l133, l71, reg_571);
                 let (reg_612, reg_613) = orderbook_analyzer::find_optimal_price_with_reason(l128, l116, false, l113, config::min_significant_qty(l83));
                 l59 = reg_613;
                 l123 = orders::round_ask_price(reg_612, l133);
                 l106 = orders::round_ask_price(l116, l133);
-                if (l123 < l106) {
-                    l35 = l106 - l123;
-                    unstructured {
-                        goto 'label_878;
-                    }
+                l35 = if (l123 < l106) {
+                    l106 - l123
                 } else {
-                    l35 = l123 - l106;
-                    unstructured {
-                        goto 'label_878;
-                    }
+                    l123 - l106
                 };
                 /* block 878 */;
                 let l54 = l35;
                 let l55 = l123 < l106;
                 events::emit_order_placement_decision(l112, l108, false, l8, l8, l106, orderbook_analyzer::significant_ask(l128), orderbook_analyzer::significant_ask_qty(l128), l123, l54 / l133, l55, l59);
                 l37 = l123;
-                l36 = l124;
-                unstructured {
-                    goto 'label_914;
-                }
+                l124
             } else {
                 l37 = orders::round_ask_price(l116, l133);
-                l36 = orders::round_bid_price(l120, l133);
-                unstructured {
-                    goto 'label_914;
-                }
+                orders::round_bid_price(l120, l133)
             };
             let (l57, l58, l73, l74);
             /* block 914 */;
@@ -689,70 +370,24 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                     let l134 = l74 + l58;
                     let l60 = l73 + l57 / 2u64;
                     (reg_697, reg_698) = deep_manager::ensure_deep_balance(freeze(l3), l4, l2, &l136, l134, l60, l83, l7, freeze(l18));
-                    events::emit_log_bytes(C17);
-                    unstructured {
-                        goto 'label_974;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_974;
-                    }
+                    events::emit_log_bytes(C17)
                 };
-                let l38;
                 /* block 974 */;
-                if (l74 >= config::min_order_size(l83)) {
-                    l38 = l73 >= config::min_price(l83);
-                    unstructured {
-                        goto 'label_987;
-                    }
-                } else {
-                    l38 = false;
-                    unstructured {
-                        goto 'label_987;
-                    }
-                };
+                let l38 = l74 >= config::min_order_size(l83) && l73 >= config::min_price(l83);
                 /* block 987 */;
                 if (l38) {
                     let l72 = pool::place_limit_order(l3, l2, &l136, l15, constants::post_only(), constants::cancel_taker(), l73, l74, true, l111, l109, l7, freeze(l18));
-                    events::emit_post_only_order(l112, true, l73, l74, order_info::order_id(&l72), l8, l9, l108, l15);
-                    unstructured {
-                        goto 'label_1016;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_1016;
-                    }
+                    events::emit_post_only_order(l112, true, l73, l74, order_info::order_id(&l72), l8, l9, l108, l15)
                 };
-                let l39;
                 /* block 1016 */;
-                if (l58 >= config::min_order_size(l83)) {
-                    l39 = l57 <= config::max_price(l83);
-                    unstructured {
-                        goto 'label_1029;
-                    }
-                } else {
-                    l39 = false;
-                    unstructured {
-                        goto 'label_1029;
-                    }
-                };
+                let l39 = l58 >= config::min_order_size(l83) && l57 <= config::max_price(l83);
                 /* block 1029 */;
                 if (l39) {
                     let l56 = pool::place_limit_order(l3, l2, &l136, l15, constants::post_only(), constants::cancel_taker(), l57, l58, false, l111, l109, l7, freeze(l18));
-                    events::emit_post_only_order(l112, false, l57, l58, order_info::order_id(&l56), l8, l10, l108, l15);
-                    unstructured {
-                        goto 'label_1068;
-                    }
-                } else {
-                    unstructured {
-                        goto 'label_1068;
-                    }
+                    events::emit_post_only_order(l112, false, l57, l58, order_info::order_id(&l56), l8, l10, l108, l15)
                 }
             } else {
-                events::emit_log_bytes(C18);
-                unstructured {
-                    goto 'label_1068;
-                }
+                events::emit_log_bytes(C18)
             };
             let (l132, l137, l91, l92);
             /* block 1068 */;
@@ -766,119 +401,53 @@ public fun execute<T0, T1, T2, T3, T4>(l0: &mut MMState, l1: &MMRegistry, l2: &m
                 let l98 = reg_798;
                 let l90 = reg_797;
                 if (l90 > 0u64) {
-                    let l40;
                     let l87 = cetus_hedger::apply_cetus_fee(l80, l79, l98);
                     l137 = l87;
-                    if (l98) {
-                        l40 = cetus_hedger::should_hedge_sell(l87, l8, config::min_hedge_profit_bps(l83));
-                        unstructured {
-                            goto 'label_1125;
-                        }
+                    let l40 = if (l98) {
+                        cetus_hedger::should_hedge_sell(l87, l8, config::min_hedge_profit_bps(l83))
                     } else {
-                        l40 = cetus_hedger::should_hedge_buy(l87, l8, config::min_hedge_profit_bps(l83));
-                        unstructured {
-                            goto 'label_1125;
-                        }
+                        cetus_hedger::should_hedge_buy(l87, l8, config::min_hedge_profit_bps(l83))
                     };
                     let (l126, l42);
                     /* block 1125 */;
                     l126 = l40;
                     l92 = cetus_hedger::calculate_hedge_profit_bps(l87, l8, l98);
                     events::emit_hedge_opportunity(mm_state::state_id(freeze(l0)), l112, l8, l80, l87, l90, l98, l126, l92, l108);
-                    if (l126) {
-                        l42 = !(l97);
-                        unstructured {
-                            goto 'label_1153;
-                        }
-                    } else {
-                        l42 = false;
-                        unstructured {
-                            goto 'label_1153;
-                        }
-                    };
+                    l42 = l126 && !(l97);
                     /* block 1153 */;
                     if (l42) {
                         if (l98) {
                             let l104 = l90 * l87 / 1000000000u64 * 99u64 / 100u64;
                             (reg_857, reg_858) = cetus_hedger::flash_swap_sell_sui(l2, l5, l6, l90, l104, l7, l18);
                             l91 = true;
-                            events::emit_log_bytes(C19);
-                            unstructured {
-                                goto 'label_1254;
-                            }
+                            events::emit_log_bytes(C19)
                         } else {
                             let l103 = l90 * l87 / 1000000000u64 * 101u64 / 100u64;
                             (reg_877, reg_878) = cetus_hedger::flash_swap_buy_sui(l2, l5, l6, l90, l103, l7, l18);
                             l91 = true;
-                            events::emit_log_bytes(C20);
-                            unstructured {
-                                goto 'label_1254;
-                            }
+                            events::emit_log_bytes(C20)
                         }
                     } else {
-                        let l43;
-                        if (l126) {
-                            l43 = l97;
-                            unstructured {
-                                goto 'label_1224;
-                            }
-                        } else {
-                            l43 = false;
-                            unstructured {
-                                goto 'label_1224;
-                            }
-                        };
                         /* block 1224 */;
-                        if (l43) {
-                            events::emit_log_bytes(C21);
-                            unstructured {
-                                goto 'label_1254;
-                            }
-                        } else {
-                            unstructured {
-                                goto 'label_1254;
-                            }
+                        if (l126 && l97) {
+                            events::emit_log_bytes(C21)
                         }
                     }
-                } else {
-                    unstructured {
-                        goto 'label_1254;
-                    }
-                }
-            } else {
-                unstructured {
-                    goto 'label_1254;
                 }
             };
-            let l45;
             /* block 1254 */;
-            if (l132 > 0u64) {
-                let l44;
-                if (l62 >= l132) {
-                    l44 = l62 - l132 * 10000u64 / l132;
-                    unstructured {
-                        goto 'label_1279;
-                    }
-                } else {
-                    l44 = l132 - l62 * 10000u64 / l132;
-                    unstructured {
-                        goto 'label_1279;
-                    }
-                };
+            let l45 = if (l132 > 0u64) {
                 /* block 1279 */;
-                l45 = l44;
-                unstructured {
-                    goto 'label_1284;
+                if (l62 >= l132) {
+                    l62 - l132 * 10000u64 / l132
+                } else {
+                    l132 - l62 * 10000u64 / l132
                 }
             } else {
-                l45 = 0u64;
-                unstructured {
-                    goto 'label_1284;
-                }
+                0u64
             };
             /* block 1284 */;
-            let l94 = l45;
-            events::emit_execution_detail(mm_state::state_id(freeze(l0)), l112, l13, mm_state::execution_count(freeze(l0)), l108, l8, l8, l73, l57, l62, l114, l132, l94, l62 > l132, l9, l10, l74, l58, l137, l91, l92, l15);
+            events::emit_execution_detail(mm_state::state_id(freeze(l0)), l112, l13, mm_state::execution_count(freeze(l0)), l108, l8, l8, l73, l57, l62, l114, l132, l45, l62 > l132, l9, l10, l74, l58, l137, l91, l92, l15);
             mm_state::record_order_time(l0, l108)
         }
     }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1672e093ccbb2f477e460361040e1c7dd62e4b23615caafe05b7b3cf5ce7e25/crank.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1672e093ccbb2f477e460361040e1c7dd62e4b23615caafe05b7b3cf5ce7e25/crank.move
@@ -151,42 +151,21 @@ public fun validate_heartbeat<T0>(l0: &mut CrankConfig, l1: &mut Vault<T0>, l2: 
     let l7 = string::utf8(C15);
     if (!(dynamic_field::exists_(&l0.id, l5))) {
         dynamic_field::add(&mut l0.id, l5, l10);
-        dynamic_field::add(&mut l0.id, l7, l11);
-        unstructured {
-            goto 'label_128;
-        }
+        dynamic_field::add(&mut l0.id, l7, l11)
     } else {
         let l6 = *(dynamic_field::borrow(&l0.id, l7));
         if (l11 - l6 > C13) {
             *(dynamic_field::borrow_mut(&mut l0.id, l5)) = l10;
-            *(dynamic_field::borrow_mut(&mut l0.id, l7)) = l11;
-            unstructured {
-                goto 'label_128;
-            }
+            *(dynamic_field::borrow_mut(&mut l0.id, l7)) = l11
         } else {
             let l8 = *(dynamic_field::borrow(&l0.id, l5));
             if (l8 > 0u64) {
-                let l4;
-                if (l10 > l8) {
-                    l4 = l10 - l8;
-                    unstructured {
-                        goto 'label_114;
-                    }
-                } else {
-                    l4 = l8 - l10;
-                    unstructured {
-                        goto 'label_114;
-                    }
-                };
                 /* block 114 */;
-                assert!(l4as u128 * 10000u128 / l8as u128as u64 <= C12, C10);
-                unstructured {
-                    goto 'label_128;
-                }
-            } else {
-                unstructured {
-                    goto 'label_128;
-                }
+                assert!(if (l10 > l8) {
+                    l10 - l8
+                } else {
+                    l8 - l10
+                }as u128 * 10000u128 / l8as u128as u64 <= C12, C10)
             }
         }
     };
@@ -202,17 +181,10 @@ public fun validate_reroute<T0>(l0: &mut CrankConfig, l1: &ApyRegistry, l2: &Str
     let l8 = apy::get_total_apy(l1, l4);
     let l12 = apy::get_total_apy(l1, l5);
     assert!(l12 > l8, C7);
-    let l7;
-    if (l8 == 0u64) {
-        l7 = 10000u64;
-        unstructured {
-            goto 'label_89;
-        }
+    let l7 = if (l8 == 0u64) {
+        10000u64
     } else {
-        l7 = l12 - l8 * 10000u64 / l8;
-        unstructured {
-            goto 'label_89;
-        }
+        l12 - l8 * 10000u64 / l8
     };
     /* block 89 */;
     let l11 = l7;
@@ -224,28 +196,14 @@ public fun validate_reroute<T0>(l0: &mut CrankConfig, l1: &ApyRegistry, l2: &Str
     assert!(l9 >= *(&l0.reroute_cooldown_ms), C5);
     floors::assert_cooldown(l9);
     if (l4 != 0u8) {
-        apy::assert_not_stale(l1, l4, l6);
-        unstructured {
-            goto 'label_162;
-        }
-    } else {
-        unstructured {
-            goto 'label_162;
-        }
+        apy::assert_not_stale(l1, l4, l6)
     };
     /* block 162 */;
     apy::assert_not_stale(l1, l5, l6);
     let reg_103;
     (reg_102, reg_103) = strategy::decode_strategy(l5);
     if (reg_103 == 2u8) {
-        assert!(!(vault::is_depeg_active(l3)), C11);
-        unstructured {
-            goto 'label_185;
-        }
-    } else {
-        unstructured {
-            goto 'label_185;
-        }
+        assert!(!(vault::is_depeg_active(l3)), C11)
     };
     /* block 185 */;
     *(&mut l0.last_reroute_ms) = l10;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house.move
@@ -219,18 +219,7 @@ public fun buy_nft_with_request<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l
         if (dynamic_object_field::exists_with_type(&l0.id, l20)) {
             let Bid { id: reg_88, bidder: reg_89, amount: reg_90, timestamp: reg_91 } = dynamic_object_field::remove(&mut l0.id, l20);
             transfer::public_transfer(coin::from_balance(reg_90 : 0x2::balance::Balance<0x2::sui::SUI>, l6), l20);
-            object::delete(reg_88 : 0x2::object::UID);
-            unstructured {
-                goto 'label_149;
-            }
-        } else {
-            unstructured {
-                goto 'label_149;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_149;
+            object::delete(reg_88 : 0x2::object::UID)
         }
     };
     /* block 149 */;
@@ -254,18 +243,7 @@ public fun cancel_listing<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID,
         if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
             let Bid { id: reg_61, bidder: reg_62, amount: reg_63, timestamp: reg_64 } = dynamic_object_field::remove(&mut l0.id, l6);
             transfer::public_transfer(coin::from_balance(reg_63 : 0x2::balance::Balance<0x2::sui::SUI>, l3), l6);
-            object::delete(reg_61 : 0x2::object::UID);
-            unstructured {
-                goto 'label_111;
-            }
-        } else {
-            unstructured {
-                goto 'label_111;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_111;
+            object::delete(reg_61 : 0x2::object::UID)
         }
     };
     /* block 111 */;
@@ -382,14 +360,7 @@ public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bi
         let l9 = object::id(&l8);
         transfer::public_transfer(l8, l4);
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) });
-        unstructured {
-            goto 'label_51;
-        }
-    } else {
-        unstructured {
-            goto 'label_51;
-        }
+        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     };
     /* block 51 */
 }
@@ -410,30 +381,12 @@ public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding
             if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
                 let Bid { id: reg_59, bidder: reg_60, amount: reg_61, timestamp: reg_62 } = dynamic_object_field::remove(&mut l0.id, l6);
                 transfer::public_transfer(coin::from_balance(reg_61 : 0x2::balance::Balance<0x2::sui::SUI>, l3), l6);
-                object::delete(reg_59 : 0x2::object::UID);
-                unstructured {
-                    goto 'label_95;
-                }
-            } else {
-                unstructured {
-                    goto 'label_95;
-                }
-            }
-        } else {
-            unstructured {
-                goto 'label_95;
+                object::delete(reg_59 : 0x2::object::UID)
             }
         };
         /* block 95 */;
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l11 });
-        unstructured {
-            goto 'label_107;
-        }
-    } else {
-        unstructured {
-            goto 'label_107;
-        }
+        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l11 })
     };
     /* block 107 */
 }
@@ -502,32 +455,17 @@ public fun place_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: 
     assert!(*(&l11.status) == C0, C4);
     assert!(l9 <= *(&l11.expires_at), C15);
     assert!(l7 > 0u64, C3);
-    let l4;
-    if (*(&l11.highest_bid) == 0u64) {
-        l4 = 1u64;
-        unstructured {
-            goto 'label_95;
-        }
+    let l4 = if (*(&l11.highest_bid) == 0u64) {
+        1u64
     } else {
-        l4 = *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64;
-        unstructured {
-            goto 'label_95;
-        }
+        *(&l11.highest_bid) + *(&l11.highest_bid) * C2as u64 / 10000u64
     };
     /* block 95 */;
-    let l13 = l4;
-    assert!(l7 >= l13, C5);
+    assert!(l7 >= l4, C5);
     let l15 = option::none();
     let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
     if (option::is_some(&l12.highest_bidder)) {
         l15 = option::some(*(option::borrow(&l12.highest_bidder)));
-        unstructured {
-            goto 'label_129;
-        }
-    } else {
-        unstructured {
-            goto 'label_129;
-        }
     };
     /* block 129 */;
     *(&mut l12.highest_bid) = l7;
@@ -537,18 +475,7 @@ public fun place_bid<T0: key + store>(l0: &mut Kiosk_Bidding_Store, l1: ID, l2: 
         if (dynamic_object_field::exists_with_type(&l0.id, l14)) {
             let Bid { id: reg_105, bidder: reg_106, amount: reg_107, timestamp: reg_108 } = dynamic_object_field::remove(&mut l0.id, l14);
             transfer::public_transfer(coin::from_balance(reg_107 : 0x2::balance::Balance<0x2::sui::SUI>, l3), l14);
-            object::delete(reg_105 : 0x2::object::UID);
-            unstructured {
-                goto 'label_165;
-            }
-        } else {
-            unstructured {
-                goto 'label_165;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_165;
+            object::delete(reg_105 : 0x2::object::UID)
         }
     };
     /* block 165 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house_dynamic_coins.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xe1a12941831f00ec5e8b5669cb3e1acf0a62f5e0ced63aebab310b192c25a498/kiosk_bidding_house_dynamic_coins.move
@@ -220,18 +220,7 @@ public fun buy_nft_with_request<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Stor
         if (dynamic_object_field::exists_with_type(&l0.id, l9)) {
             let Bid { id: reg_100, bidder: reg_101, amount: reg_102, timestamp: reg_103 } = dynamic_object_field::remove(&mut l0.id, l9);
             transfer::public_transfer(coin::from_balance(reg_102 : 0x2::balance::Balance<T1>, l6), l21);
-            object::delete(reg_100 : 0x2::object::UID);
-            unstructured {
-                goto 'label_168;
-            }
-        } else {
-            unstructured {
-                goto 'label_168;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
+            object::delete(reg_100 : 0x2::object::UID)
         }
     };
     /* block 168 */;
@@ -258,18 +247,7 @@ public fun cancel_listing<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1:
         if (dynamic_object_field::exists_with_type(&l0.id, l6)) {
             let Bid { id: reg_72, bidder: reg_73, amount: reg_74, timestamp: reg_75 } = dynamic_object_field::remove(&mut l0.id, l6);
             transfer::public_transfer(coin::from_balance(reg_74 : 0x2::balance::Balance<T1>, l3), l7);
-            object::delete(reg_72 : 0x2::object::UID);
-            unstructured {
-                goto 'label_129;
-            }
-        } else {
-            unstructured {
-                goto 'label_129;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_129;
+            object::delete(reg_72 : 0x2::object::UID)
         }
     };
     /* block 129 */;
@@ -380,14 +358,7 @@ public entry fun emergency_reset_accepted_bid<T0: key + store>(l0: &mut Kiosk_Bi
         let l9 = object::id(&l8);
         transfer::public_transfer(l8, l4);
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) });
-        unstructured {
-            goto 'label_52;
-        }
-    } else {
-        unstructured {
-            goto 'label_52;
-        }
+        event::emit(BidClaimed { listing_id: reg_18 : 0x2::object::ID, bidder: l4, nft_id: l9, timestamp: tx_context::epoch(freeze(l3)) })
     };
     /* block 52 */
 }
@@ -403,14 +374,7 @@ public entry fun emergency_reset_listing<T0: key + store>(l0: &mut Kiosk_Bidding
         dynamic_object_field::add(&mut l0.orphaned_caps, l8, l9);
         event::emit(PurchaseCapOrphaned { nft_id: l8, kiosk_id: l7, timestamp: tx_context::epoch(freeze(l3)) });
         object::delete(reg_17 : 0x2::object::UID);
-        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l8, coin_type: reg_29 : 0x1::type_name::TypeName });
-        unstructured {
-            goto 'label_72;
-        }
-    } else {
-        unstructured {
-            goto 'label_72;
-        }
+        event::emit(ListingCancelled { listing_id: l2, seller: reg_18 : address, nft_id: l8, coin_type: reg_29 : 0x1::type_name::TypeName })
     };
     /* block 72 */
 }
@@ -484,32 +448,17 @@ public fun place_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, 
     let l11 = *(&l14.coin_type);
     assert!(l11 == type_name::get(), C22);
     assert!(l7 > 0u64, C3);
-    let l4;
-    if (*(&l14.highest_bid) == 0u64) {
-        l4 = 1u64;
-        unstructured {
-            goto 'label_112;
-        }
+    let l4 = if (*(&l14.highest_bid) == 0u64) {
+        1u64
     } else {
-        l4 = *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64;
-        unstructured {
-            goto 'label_112;
-        }
+        *(&l14.highest_bid) + *(&l14.highest_bid) * C2as u64 / 10000u64
     };
     /* block 112 */;
-    let l16 = l4;
-    assert!(l7 >= l16, C5);
+    assert!(l7 >= l4, C5);
     let l18 = option::none();
     let l15 = dynamic_object_field::borrow_mut(&mut l0.id, l1);
     if (option::is_some(&l15.highest_bidder)) {
         l18 = option::some(*(option::borrow(&l15.highest_bidder)));
-        unstructured {
-            goto 'label_146;
-        }
-    } else {
-        unstructured {
-            goto 'label_146;
-        }
     };
     /* block 146 */;
     *(&mut l15.highest_bid) = l7;
@@ -520,18 +469,7 @@ public fun place_bid<T0: key + store, T1>(l0: &mut Kiosk_Bidding_Store, l1: ID, 
         if (dynamic_object_field::exists_with_type(&l0.id, l8)) {
             let Bid { id: reg_118, bidder: reg_119, amount: reg_120, timestamp: reg_121 } = dynamic_object_field::remove(&mut l0.id, l8);
             transfer::public_transfer(coin::from_balance(reg_120 : 0x2::balance::Balance<T1>, l3), l17);
-            object::delete(reg_118 : 0x2::object::UID);
-            unstructured {
-                goto 'label_186;
-            }
-        } else {
-            unstructured {
-                goto 'label_186;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
+            object::delete(reg_118 : 0x2::object::UID)
         }
     };
     /* block 186 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xffec77bdbb001fb7d9770bfdee1d3d1e5f48598d77c6ba793d8452e166ccb0d4/ART20.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xffec77bdbb001fb7d9770bfdee1d3d1e5f48598d77c6ba793d8452e166ccb0d4/ART20.move
@@ -238,20 +238,9 @@ const C42: vector<u8> = vector[104u8, 116u8, 116u8, 112u8, 115u8, 58u8, 47u8, 47
 // -- functions -- 
 
 public entry fun add_to_deny_list(l0: &mut CollectionCap, l1: vector<address>, l2: &mut TxContext) {
-    let l3;
     let l9 = tx_context::sender(freeze(l2));
     let l5 = &l1.len();
-    if (l5 > 0u64) {
-        l3 = l5 <= C29;
-        unstructured {
-            goto 'label_18;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_18;
-        }
-    };
+    let l3 = l5 > 0u64 && l5 <= C29;
     /* block 18 */;
     assert!(l3, C11);
     assert!(l9 == *(&l0.creator), C1);
@@ -320,21 +309,10 @@ public entry fun batch_burn_art20(l0: vector<NFT>, l1: &mut CollectionCap, l2: v
 }
 
 public entry fun batch_burn_art20_by_asset_ids(l0: &mut CollectionCap, l1: vector<NFT>, l2: vector<UserBalance>, l3: vector<u64>, l4: &mut TxContext) {
-    let l5;
     let l22 = tx_context::sender(freeze(l4));
     let l13 = xf_ART20::get_collection_cap_id(freeze(l0));
     let l8 = &l3.len();
-    if (l8 > 0u64) {
-        l5 = l8 <= C29;
-        unstructured {
-            goto 'label_22;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_22;
-        }
-    };
+    let l5 = l8 > 0u64 && l8 <= C29;
     /* block 22 */;
     assert!(l5, C11);
     assert!(*(&l0.current_supply) >= l8, C4);
@@ -421,18 +399,7 @@ public entry fun batch_update_art20_image_uri_by_asset_ids(l0: &CollectionCap, l
     xf_ART20::check_deny_list_restrictions(l0, l17);
     let l7 = &l2.len();
     assert!(l7 == &l3.len(), C0);
-    let l5;
-    if (l7 > 0u64) {
-        l5 = l7 <= C29;
-        unstructured {
-            goto 'label_45;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_45;
-        }
-    };
+    let l5 = l7 > 0u64 && l7 <= C29;
     /* block 45 */;
     assert!(l5, C11);
     let l11 = 0u64;
@@ -487,47 +454,19 @@ public entry fun batch_update_metadata(l0: &CollectionCap, l1: vector<NFT>, l2: 
     let l10 = tx_context::sender(freeze(l6));
     let l8 = xf_ART20::get_collection_cap_id(l0);
     if (option::is_some(&l2)) {
-        assert!(string::length(option::borrow(&l2)) <= 128u64, C10);
-        unstructured {
-            goto 'label_24;
-        }
-    } else {
-        unstructured {
-            goto 'label_24;
-        }
+        assert!(string::length(option::borrow(&l2)) <= 128u64, C10)
     };
     /* block 24 */;
     if (option::is_some(&l3)) {
-        assert!(string::length(option::borrow(&l3)) <= 1000u64, C10);
-        unstructured {
-            goto 'label_38;
-        }
-    } else {
-        unstructured {
-            goto 'label_38;
-        }
+        assert!(string::length(option::borrow(&l3)) <= 1000u64, C10)
     };
     /* block 38 */;
     if (option::is_some(&l4)) {
-        assert!(option::borrow(&l4).len() <= 256u64, C10);
-        unstructured {
-            goto 'label_52;
-        }
-    } else {
-        unstructured {
-            goto 'label_52;
-        }
+        assert!(option::borrow(&l4).len() <= 256u64, C10)
     };
     /* block 52 */;
     if (option::is_some(&l5)) {
-        assert!(option::borrow(&l5).len() <= 256u64, C10);
-        unstructured {
-            goto 'label_66;
-        }
-    } else {
-        unstructured {
-            goto 'label_66;
-        }
+        assert!(option::borrow(&l5).len() <= 256u64, C10)
     };
     /* block 66 */;
     let l9 = 0u64;
@@ -558,21 +497,10 @@ public entry fun batch_update_metadata(l0: &CollectionCap, l1: vector<NFT>, l2: 
 }
 
 public entry fun batch_update_metadata_by_asset_ids(l0: &CollectionCap, l1: vector<NFT>, l2: vector<u64>, l3: Option<String>, l4: Option<String>, l5: Option<vector<u8>>, l6: Option<vector<u8>>, l7: &mut TxContext) {
-    let l8;
     let l22 = tx_context::sender(freeze(l7));
     let l14 = xf_ART20::get_collection_cap_id(l0);
     let l10 = &l2.len();
-    if (l10 > 0u64) {
-        l8 = l10 <= C29;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
+    let l8 = l10 > 0u64 && l10 <= C29;
     /* block 21 */;
     assert!(l8, C11);
     if (option::is_some(&l3)) {
@@ -580,14 +508,7 @@ public entry fun batch_update_metadata_by_asset_ids(l0: &CollectionCap, l1: vect
         assert!(string::length(l19) <= 128u64, C10);
         let l12 = string::as_bytes(l19);
         assert!(l12.len() <= 512u64, C10);
-        assert!(l12.len() > 0u64, C10);
-        unstructured {
-            goto 'label_79;
-        }
-    } else {
-        unstructured {
-            goto 'label_79;
-        }
+        assert!(l12.len() > 0u64, C10)
     };
     /* block 79 */;
     if (option::is_some(&l4)) {
@@ -595,40 +516,19 @@ public entry fun batch_update_metadata_by_asset_ids(l0: &CollectionCap, l1: vect
         assert!(string::length(l15) <= 1000u64, C10);
         let l13 = string::as_bytes(l15);
         assert!(l13.len() <= 4000u64, C10);
-        assert!(l13.len() > 0u64, C10);
-        unstructured {
-            goto 'label_128;
-        }
-    } else {
-        unstructured {
-            goto 'label_128;
-        }
+        assert!(l13.len() > 0u64, C10)
     };
     /* block 128 */;
     if (option::is_some(&l5)) {
         let l24 = option::borrow(&l5);
         assert!(l24.len() <= 256u64, C10);
-        assert!(l24.len() > 0u64, C10);
-        unstructured {
-            goto 'label_160;
-        }
-    } else {
-        unstructured {
-            goto 'label_160;
-        }
+        assert!(l24.len() > 0u64, C10)
     };
     /* block 160 */;
     if (option::is_some(&l6)) {
         let l18 = option::borrow(&l6);
         assert!(l18.len() <= 256u64, C10);
-        assert!(l18.len() > 0u64, C10);
-        unstructured {
-            goto 'label_192;
-        }
-    } else {
-        unstructured {
-            goto 'label_192;
-        }
+        assert!(l18.len() > 0u64, C10)
     };
     let (l17, l21);
     /* block 192 */;
@@ -685,18 +585,7 @@ public entry fun batch_update_token_logo_uri(l0: vector<NFT>, l1: vector<vector<
     let l9 = &l0.len();
     assert!(*(&l2.is_mutable), C2);
     assert!(l9 == &l1.len(), C0);
-    let l4;
-    if (l9 > 0u64) {
-        l4 = l9 <= C29;
-        unstructured {
-            goto 'label_40;
-        }
-    } else {
-        l4 = false;
-        unstructured {
-            goto 'label_40;
-        }
-    };
+    let l4 = l9 > 0u64 && l9 <= C29;
     /* block 40 */;
     assert!(l4, C11);
     xf_ART20::check_deny_list_restrictions(l2, l10);
@@ -839,14 +728,7 @@ public fun drop_collection_cap(l0: CollectionCap, l1: &mut TxContext) {
     let CollectionCap { id: reg_15, max_supply: reg_16, current_supply: reg_17, creator: reg_18, name: reg_19, description: reg_20, uri: reg_21, logo_uri: reg_22, is_mutable: reg_23, is_mintable: reg_24, has_deny_list_authority: reg_25, value_source: reg_26, is_api_source: reg_27 } = l0;
     let l2 = reg_15 : 0x2::object::UID;
     if (dynamic_field::exists_(&l2, DenyListKey { dummy_field: false })) {
-        table::drop(dynamic_field::remove(&mut l2, DenyListKey { dummy_field: false }));
-        unstructured {
-            goto 'label_45;
-        }
-    } else {
-        unstructured {
-            goto 'label_45;
-        }
+        table::drop(dynamic_field::remove(&mut l2, DenyListKey { dummy_field: false }))
     };
     /* block 45 */;
     object::delete(l2)
@@ -901,7 +783,6 @@ public fun get_collection_current_supply(l0: &CollectionCap): u64 {
 }
 
 public fun get_collection_details(l0: &CollectionCap): ( ID, address, String, String, Url, Url, u64, u64, bool, bool, u64) {
-    let l1;
     let l3 = xf_ART20::get_collection_cap_id(l0);
     let l2 = *(&l0.creator);
     let l11 = *(&l0.name);
@@ -912,16 +793,10 @@ public fun get_collection_details(l0: &CollectionCap): ( ID, address, String, St
     let l6 = *(&l0.max_supply);
     let l5 = *(&l0.is_mutable);
     let l4 = *(&l0.has_deny_list_authority);
-    if (xf_ART20::has_deny_list(l0)) {
-        l1 = xf_ART20::deny_list_size(l0);
-        unstructured {
-            goto 'label_50;
-        }
+    let l1 = if (xf_ART20::has_deny_list(l0)) {
+        xf_ART20::deny_list_size(l0)
     } else {
-        l1 = 0u64;
-        unstructured {
-            goto 'label_50;
-        }
+        0u64
     };
     /* block 50 */;
     return (l3, l2, l11, l10, l9, l8, l7, l6, l5, l4, l1)
@@ -1024,20 +899,13 @@ public fun get_holder_info(l0: &vector<NFT>, l1: &CollectionCap, l2: &vector<Use
         };
         l11 = l11 + 1u64;
     };
-    let l4;
     let l10 = xf_ART20::has_deny_list(l1);
     let l8 = xf_ART20::has_deny_list_authority(l1);
     let l12 = xf_ART20::is_denied(l1, l3);
-    if (l10) {
-        l4 = xf_ART20::deny_list_size(l1);
-        unstructured {
-            goto 'label_57;
-        }
+    let l4 = if (l10) {
+        xf_ART20::deny_list_size(l1)
     } else {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_57;
-        }
+        0u64
     };
     let (l13, l16, l17, l18, l19, l20, l21, l5, l9);
     /* block 57 */;
@@ -1191,27 +1059,13 @@ public fun is_denied(l0: &CollectionCap, l1: address): bool {
 public entry fun mint_additional_art20(l0: &mut CollectionCap, l1: u64, l2: &mut TokenIdCounter, l3: vector<UserBalance>, l4: &Clock, l5: &mut TxContext) {
     assert!(*(&l0.is_mutable), C21);
     assert!(tx_context::sender(freeze(l5)) == *(&l0.creator), C1);
-    let l6;
-    if (*(&l0.max_supply) == 0u64) {
-        l6 = true;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = *(&l0.current_supply) + l1 <= *(&l0.max_supply);
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = *(&l0.max_supply) == 0u64 || *(&l0.current_supply) + l1 <= *(&l0.max_supply);
     /* block 53 */;
     assert!(l6, C13);
     let l11 = object::uid_to_inner(&l0.id);
     let l14 = tx_context::sender(freeze(l5));
     if (vector::is_empty(&l3)) {
-        transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14);
-        unstructured {
-            goto 'label_132;
-        }
+        transfer::transfer(UserBalance { id: object::new(l5), collection_id: l11, balance: l1 }, l14)
     } else {
         let l10 = false;
         let l12 = 0u64;
@@ -1267,41 +1121,17 @@ public entry fun mint_art20<T0>(l0: vector<u8>, l1: vector<u8>, l2: u64, l3: u64
         assert!(type_name::get() == *(&l11.fee_coin_type), C20);
         if (l20 > *(&l11.fee_amount)) {
             let l21 = l20 - *(&l11.fee_amount);
-            transfer::public_transfer(coin::split(&mut l12, l21, l14), tx_context::sender(freeze(l14)));
-            unstructured {
-                goto 'label_129;
-            }
-        } else {
-            unstructured {
-                goto 'label_129;
-            }
+            transfer::public_transfer(coin::split(&mut l12, l21, l14), tx_context::sender(freeze(l14)))
         };
         /* block 129 */;
-        transfer::public_transfer(l12, *(&l11.fee_collector));
-        unstructured {
-            goto 'label_142;
-        }
+        transfer::public_transfer(l12, *(&l11.fee_collector))
     } else {
-        transfer::public_transfer(l12, tx_context::sender(freeze(l14)));
-        unstructured {
-            goto 'label_142;
-        }
+        transfer::public_transfer(l12, tx_context::sender(freeze(l14)))
     };
     /* block 142 */;
     assert!(l3 <= C28, C13);
     assert!(l2 <= C28, C13);
-    let l15;
-    if (l3 == 0u64) {
-        l15 = true;
-        unstructured {
-            goto 'label_179;
-        }
-    } else {
-        l15 = l2 <= l3;
-        unstructured {
-            goto 'label_179;
-        }
-    };
+    let l15 = l3 == 0u64 || l2 <= l3;
     /* block 179 */;
     assert!(l15, C19);
     assert!(*(&l10.last_id) <= C27 - l2, C12);
@@ -1331,20 +1161,9 @@ public entry fun mint_art20<T0>(l0: vector<u8>, l1: vector<u8>, l2: u64, l3: u64
 }
 
 public entry fun remove_from_deny_list(l0: &mut CollectionCap, l1: vector<address>, l2: &mut TxContext) {
-    let l3;
     let l9 = tx_context::sender(freeze(l2));
     let l5 = &l1.len();
-    if (l5 > 0u64) {
-        l3 = l5 <= C29;
-        unstructured {
-            goto 'label_18;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_18;
-        }
-    };
+    let l3 = l5 > 0u64 && l5 <= C29;
     /* block 18 */;
     assert!(l3, C11);
     assert!(l9 == *(&l0.creator), C1);
@@ -1401,22 +1220,13 @@ public entry fun set_collection_value_source(l0: &mut CollectionCap, l1: vector<
         };
         assert!(__c84, C16)
     } else {
-        assert!(string::length(&l9) == 64u64, C17);
-        unstructured {
-            goto 'label_105;
-        }
+        assert!(string::length(&l9) == 64u64, C17)
     };
     /* block 105 */;
     if (option::is_none(&l0.value_source)) {
-        *(&mut l0.value_source) = option::some(l9);
-        unstructured {
-            goto 'label_120;
-        }
+        *(&mut l0.value_source) = option::some(l9)
     } else {
-        *(option::borrow_mut(&mut l0.value_source)) = l9;
-        unstructured {
-            goto 'label_120;
-        }
+        *(option::borrow_mut(&mut l0.value_source)) = l9
     };
     /* block 120 */;
     *(&mut l0.is_api_source) = l2;
@@ -1706,14 +1516,7 @@ public entry fun update_metadata_by_asset_id(l0: &CollectionCap, l1: vector<NFT>
         assert!(string::length(l15) <= 128u64, C10);
         let l16 = string::as_bytes(l15);
         assert!(l16.len() <= 512u64, C10);
-        assert!(l16.len() > 0u64, C10);
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        unstructured {
-            goto 'label_50;
-        }
+        assert!(l16.len() > 0u64, C10)
     };
     /* block 50 */;
     if (option::is_some(&l4)) {
@@ -1721,40 +1524,19 @@ public entry fun update_metadata_by_asset_id(l0: &CollectionCap, l1: vector<NFT>
         assert!(string::length(l12) <= 1000u64, C10);
         let l11 = string::as_bytes(l12);
         assert!(l11.len() <= 4000u64, C10);
-        assert!(l11.len() > 0u64, C10);
-        unstructured {
-            goto 'label_93;
-        }
-    } else {
-        unstructured {
-            goto 'label_93;
-        }
+        assert!(l11.len() > 0u64, C10)
     };
     /* block 93 */;
     if (option::is_some(&l5)) {
         let l20 = option::borrow(&l5);
         assert!(l20.len() <= 256u64, C10);
-        assert!(l20.len() > 0u64, C10);
-        unstructured {
-            goto 'label_121;
-        }
-    } else {
-        unstructured {
-            goto 'label_121;
-        }
+        assert!(l20.len() > 0u64, C10)
     };
     /* block 121 */;
     if (option::is_some(&l6)) {
         let l14 = option::borrow(&l6);
         assert!(l14.len() <= 256u64, C10);
-        assert!(l14.len() > 0u64, C10);
-        unstructured {
-            goto 'label_149;
-        }
-    } else {
-        unstructured {
-            goto 'label_149;
-        }
+        assert!(l14.len() > 0u64, C10)
     };
     let (l13, l19);
     /* block 149 */;
@@ -1800,53 +1582,25 @@ public entry fun update_metadata_by_object(l0: &mut NFT, l1: &CollectionCap, l2:
     if (option::is_some(&l2)) {
         let l9 = option::extract(&mut l2);
         assert!(string::length(&l9) <= 128u64, C10);
-        *(&mut l0.name) = l9;
-        unstructured {
-            goto 'label_60;
-        }
-    } else {
-        unstructured {
-            goto 'label_60;
-        }
+        *(&mut l0.name) = l9
     };
     /* block 60 */;
     if (option::is_some(&l3)) {
         let l7 = option::extract(&mut l3);
         assert!(string::length(&l7) <= 1000u64, C10);
-        *(&mut l0.description) = l7;
-        unstructured {
-            goto 'label_80;
-        }
-    } else {
-        unstructured {
-            goto 'label_80;
-        }
+        *(&mut l0.description) = l7
     };
     /* block 80 */;
     if (option::is_some(&l4)) {
         let l10 = option::extract(&mut l4);
         assert!(&l10.len() <= 256u64, C10);
-        *(&mut l0.uri) = url::new_unsafe_from_bytes(l10);
-        unstructured {
-            goto 'label_101;
-        }
-    } else {
-        unstructured {
-            goto 'label_101;
-        }
+        *(&mut l0.uri) = url::new_unsafe_from_bytes(l10)
     };
     /* block 101 */;
     if (option::is_some(&l5)) {
         let l8 = option::extract(&mut l5);
         assert!(&l8.len() <= 256u64, C10);
-        *(&mut l0.logo_uri) = url::new_unsafe_from_bytes(l8);
-        unstructured {
-            goto 'label_122;
-        }
-    } else {
-        unstructured {
-            goto 'label_122;
-        }
+        *(&mut l0.logo_uri) = url::new_unsafe_from_bytes(l8)
     };
     /* block 122 */;
     event::emit(MetadataUpdateEvent { id: object::uid_to_inner(&l0.id), new_name: *(&l0.name), new_description: *(&l0.description) })

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
@@ -51,10 +51,16 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
+    let __c0 = l16 > l13;
+    let __c25 = l16 - l13 >= l18;
+    let __c35 = l13 - l16 >= l18;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
+        let __c44 = l16 > l13;
+        let __c59 = l16 - l13 >= l18;
+        let __c68 = l13 - l16 >= l18;
+        __c44 && __c59 || __c68 && !(__c44)
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -68,14 +74,22 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
+    let __c0 = l19 > l16;
+    let __c25 = l19 - l16 >= l21;
+    let __c35 = l16 - l19 >= l21;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c44 = l19 > l16;
+        let __c59 = l19 - l16 >= l21;
+        let __c68 = l16 - l19 >= l21;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
+        let __c77 = l19 > l16;
+        let __c92 = l19 - l16 >= l21;
+        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -90,18 +104,29 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
+    let __c0 = l22 > l19;
+    let __c25 = l22 - l19 >= l24;
+    let __c35 = l19 - l22 >= l24;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c44 = l22 > l19;
+        let __c59 = l22 - l19 >= l24;
+        let __c68 = l19 - l22 >= l24;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c77 = l22 > l19;
+        let __c92 = l22 - l19 >= l24;
+        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
+        let __c110 = l22 > l19;
+        let __c125 = l22 - l19 >= l24;
+        let __c134 = l19 - l22 >= l24;
+        __c110 && __c125 || __c134 && !(__c110)
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -117,22 +142,36 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
+    let __c0 = l25 > l22;
+    let __c25 = l25 - l22 >= l27;
+    let __c35 = l22 - l25 >= l27;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c44 = l25 > l22;
+        let __c59 = l25 - l22 >= l27;
+        let __c68 = l22 - l25 >= l27;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c77 = l25 > l22;
+        let __c92 = l25 - l22 >= l27;
+        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c110 = l25 > l22;
+        let __c125 = l25 - l22 >= l27;
+        let __c134 = l22 - l25 >= l27;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
+        let __c143 = l25 > l22;
+        let __c158 = l25 - l22 >= l27;
+        let __c167 = l22 - l25 >= l27;
+        __c143 && __c158 || __c167 && !(__c143)
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -149,26 +188,43 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
+    let __c0 = l28 > l25;
+    let __c25 = l28 - l25 >= l30;
+    let __c35 = l25 - l28 >= l30;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c44 = l28 > l25;
+        let __c59 = l28 - l25 >= l30;
+        let __c68 = l25 - l28 >= l30;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c77 = l28 > l25;
+        let __c92 = l28 - l25 >= l30;
+        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c110 = l28 > l25;
+        let __c125 = l28 - l25 >= l30;
+        let __c134 = l25 - l28 >= l30;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c143 = l28 > l25;
+        let __c158 = l28 - l25 >= l30;
+        let __c167 = l25 - l28 >= l30;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
+        let __c176 = l28 > l25;
+        let __c191 = l28 - l25 >= l30;
+        let __c200 = l25 - l28 >= l30;
+        __c176 && __c191 || __c200 && !(__c176)
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -186,30 +242,50 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
+    let __c0 = l31 > l28;
+    let __c25 = l31 - l28 >= l33;
+    let __c35 = l28 - l31 >= l33;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c44 = l31 > l28;
+        let __c59 = l31 - l28 >= l33;
+        let __c68 = l28 - l31 >= l33;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c77 = l31 > l28;
+        let __c92 = l31 - l28 >= l33;
+        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c110 = l31 > l28;
+        let __c125 = l31 - l28 >= l33;
+        let __c134 = l28 - l31 >= l33;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c143 = l31 > l28;
+        let __c158 = l31 - l28 >= l33;
+        let __c167 = l28 - l31 >= l33;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c176 = l31 > l28;
+        let __c191 = l31 - l28 >= l33;
+        let __c200 = l28 - l31 >= l33;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
+        let __c209 = l31 > l28;
+        let __c224 = l31 - l28 >= l33;
+        let __c233 = l28 - l31 >= l33;
+        __c209 && __c224 || __c233 && !(__c209)
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -228,34 +304,57 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
+    let __c0 = l34 > l31;
+    let __c25 = l34 - l31 >= l36;
+    let __c35 = l31 - l34 >= l36;
+    if (__c0 && __c25 || __c35 && !(__c0) || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c44 = l34 > l31;
+        let __c59 = l34 - l31 >= l36;
+        let __c68 = l31 - l34 >= l36;
+        __c44 && __c59 || __c68 && !(__c44)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c77 = l34 > l31;
+        let __c92 = l34 - l31 >= l36;
+        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c110 = l34 > l31;
+        let __c125 = l34 - l31 >= l36;
+        let __c134 = l31 - l34 >= l36;
+        __c110 && __c125 || __c134 && !(__c110)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c143 = l34 > l31;
+        let __c158 = l34 - l31 >= l36;
+        let __c167 = l31 - l34 >= l36;
+        __c143 && __c158 || __c167 && !(__c143)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c176 = l34 > l31;
+        let __c191 = l34 - l31 >= l36;
+        let __c200 = l31 - l34 >= l36;
+        __c176 && __c191 || __c200 && !(__c176)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c209 = l34 > l31;
+        let __c224 = l34 - l31 >= l36;
+        let __c233 = l31 - l34 >= l36;
+        __c209 && __c224 || __c233 && !(__c209)
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
+        let __c242 = l34 > l31;
+        let __c257 = l34 - l31 >= l36;
+        let __c266 = l31 - l34 >= l36;
+        __c242 && __c257 || __c266 && !(__c242)
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -276,19 +375,10 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l10 = clock::timestamp_ms(l7) / 1000u64;
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
-    let __dispatch_15;
     let l16;
     loop {
         if (l12 >= l14) {
-            if (l13) {
-                l12 = 0u64;
-                __dispatch_15 = 0u32;
-                break
-            };
-            let l18 = vaa::parse_and_verify(l4, l5, l7);
-            l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
-            l12 = 0u64;
-            __dispatch_15 = 1u32;
+            let __c61 = l13;
             break
         };
         let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
@@ -304,7 +394,15 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
         };
         l12 = l12 + 1u64;
     };
-    match (__dispatch_15) {
+    match (if (__c61) {
+        l12 = 0u64;
+        0u32
+    } else {
+        let l18 = vaa::parse_and_verify(l4, l5, l7);
+        l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
+        l12 = 0u64;
+        1u32
+    }) {
         0 => {
             while (l12 < l14) {
                 transfer::public_share_object((&mut l2).pop_back());

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
@@ -57,16 +57,10 @@ public fun update_2(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l13 = clock::timestamp_ms(l9) / 1000u64;
     let l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
     let l18 = option::get_with_default(&l5, l14);
-    let __c0 = l16 > l13;
-    let __c25 = l16 - l13 >= l18;
-    let __c35 = l13 - l16 >= l18;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18 || {
         l16 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l18 = option::get_with_default(&l3, l14);
-        let __c44 = l16 > l13;
-        let __c59 = l16 - l13 >= l18;
-        let __c68 = l13 - l16 >= l18;
-        __c44 && __c59 || __c68 && !(__c44)
+        l16 > l13 && l16 - l13 >= l18 || l16 <= l13 && l13 - l16 >= l18
     }) {
         let l19 = vaa::parse_and_verify(l6, l7, l9);
         let l17 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l19, l9);
@@ -80,22 +74,14 @@ public fun update_3(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l16 = clock::timestamp_ms(l11) / 1000u64;
     let l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
     let l21 = option::get_with_default(&l7, l17);
-    let __c0 = l19 > l16;
-    let __c25 = l19 - l16 >= l21;
-    let __c35 = l16 - l19 >= l21;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21 || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l21 = option::get_with_default(&l5, l17);
-        let __c44 = l19 > l16;
-        let __c59 = l19 - l16 >= l21;
-        let __c68 = l16 - l19 >= l21;
-        __c44 && __c59 || __c68 && !(__c44)
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     } || {
         l19 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l21 = option::get_with_default(&l3, l17);
-        let __c77 = l19 > l16;
-        let __c92 = l19 - l16 >= l21;
-        l16 - l19 >= l21 && !(__c77) || __c77 && __c92
+        l19 > l16 && l19 - l16 >= l21 || l19 <= l16 && l16 - l19 >= l21
     }) {
         let l22 = vaa::parse_and_verify(l8, l9, l11);
         let l20 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l22, l11);
@@ -110,29 +96,18 @@ public fun update_4(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l19 = clock::timestamp_ms(l13) / 1000u64;
     let l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
     let l24 = option::get_with_default(&l9, l20);
-    let __c0 = l22 > l19;
-    let __c25 = l22 - l19 >= l24;
-    let __c35 = l19 - l22 >= l24;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24 || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l24 = option::get_with_default(&l7, l20);
-        let __c44 = l22 > l19;
-        let __c59 = l22 - l19 >= l24;
-        let __c68 = l19 - l22 >= l24;
-        __c44 && __c59 || __c68 && !(__c44)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l24 = option::get_with_default(&l5, l20);
-        let __c77 = l22 > l19;
-        let __c92 = l22 - l19 >= l24;
-        l19 - l22 >= l24 && !(__c77) || __c77 && __c92
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     } || {
         l22 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l24 = option::get_with_default(&l3, l20);
-        let __c110 = l22 > l19;
-        let __c125 = l22 - l19 >= l24;
-        let __c134 = l19 - l22 >= l24;
-        __c110 && __c125 || __c134 && !(__c110)
+        l22 > l19 && l22 - l19 >= l24 || l22 <= l19 && l19 - l22 >= l24
     }) {
         let l25 = vaa::parse_and_verify(l10, l11, l13);
         let l23 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l25, l13);
@@ -148,36 +123,22 @@ public fun update_5(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l22 = clock::timestamp_ms(l15) / 1000u64;
     let l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
     let l27 = option::get_with_default(&l11, l23);
-    let __c0 = l25 > l22;
-    let __c25 = l25 - l22 >= l27;
-    let __c35 = l22 - l25 >= l27;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27 || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l27 = option::get_with_default(&l9, l23);
-        let __c44 = l25 > l22;
-        let __c59 = l25 - l22 >= l27;
-        let __c68 = l22 - l25 >= l27;
-        __c44 && __c59 || __c68 && !(__c44)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l27 = option::get_with_default(&l7, l23);
-        let __c77 = l25 > l22;
-        let __c92 = l25 - l22 >= l27;
-        l22 - l25 >= l27 && !(__c77) || __c77 && __c92
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l27 = option::get_with_default(&l5, l23);
-        let __c110 = l25 > l22;
-        let __c125 = l25 - l22 >= l27;
-        let __c134 = l22 - l25 >= l27;
-        __c110 && __c125 || __c134 && !(__c110)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     } || {
         l25 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l27 = option::get_with_default(&l3, l23);
-        let __c143 = l25 > l22;
-        let __c158 = l25 - l22 >= l27;
-        let __c167 = l22 - l25 >= l27;
-        __c143 && __c158 || __c167 && !(__c143)
+        l25 > l22 && l25 - l22 >= l27 || l25 <= l22 && l22 - l25 >= l27
     }) {
         let l28 = vaa::parse_and_verify(l12, l13, l15);
         let l26 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l28, l15);
@@ -194,43 +155,26 @@ public fun update_6(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l25 = clock::timestamp_ms(l17) / 1000u64;
     let l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
     let l30 = option::get_with_default(&l13, l26);
-    let __c0 = l28 > l25;
-    let __c25 = l28 - l25 >= l30;
-    let __c35 = l25 - l28 >= l30;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30 || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l30 = option::get_with_default(&l11, l26);
-        let __c44 = l28 > l25;
-        let __c59 = l28 - l25 >= l30;
-        let __c68 = l25 - l28 >= l30;
-        __c44 && __c59 || __c68 && !(__c44)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l30 = option::get_with_default(&l9, l26);
-        let __c77 = l28 > l25;
-        let __c92 = l28 - l25 >= l30;
-        l25 - l28 >= l30 && !(__c77) || __c77 && __c92
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l30 = option::get_with_default(&l7, l26);
-        let __c110 = l28 > l25;
-        let __c125 = l28 - l25 >= l30;
-        let __c134 = l25 - l28 >= l30;
-        __c110 && __c125 || __c134 && !(__c110)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l30 = option::get_with_default(&l5, l26);
-        let __c143 = l28 > l25;
-        let __c158 = l28 - l25 >= l30;
-        let __c167 = l25 - l28 >= l30;
-        __c143 && __c158 || __c167 && !(__c143)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     } || {
         l28 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l30 = option::get_with_default(&l3, l26);
-        let __c176 = l28 > l25;
-        let __c191 = l28 - l25 >= l30;
-        let __c200 = l25 - l28 >= l30;
-        __c176 && __c191 || __c200 && !(__c176)
+        l28 > l25 && l28 - l25 >= l30 || l28 <= l25 && l25 - l28 >= l30
     }) {
         let l31 = vaa::parse_and_verify(l14, l15, l17);
         let l29 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l31, l17);
@@ -248,50 +192,30 @@ public fun update_7(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l28 = clock::timestamp_ms(l19) / 1000u64;
     let l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
     let l33 = option::get_with_default(&l15, l29);
-    let __c0 = l31 > l28;
-    let __c25 = l31 - l28 >= l33;
-    let __c35 = l28 - l31 >= l33;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33 || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l33 = option::get_with_default(&l13, l29);
-        let __c44 = l31 > l28;
-        let __c59 = l31 - l28 >= l33;
-        let __c68 = l28 - l31 >= l33;
-        __c44 && __c59 || __c68 && !(__c44)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l33 = option::get_with_default(&l11, l29);
-        let __c77 = l31 > l28;
-        let __c92 = l31 - l28 >= l33;
-        l28 - l31 >= l33 && !(__c77) || __c77 && __c92
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l33 = option::get_with_default(&l9, l29);
-        let __c110 = l31 > l28;
-        let __c125 = l31 - l28 >= l33;
-        let __c134 = l28 - l31 >= l33;
-        __c110 && __c125 || __c134 && !(__c110)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l33 = option::get_with_default(&l7, l29);
-        let __c143 = l31 > l28;
-        let __c158 = l31 - l28 >= l33;
-        let __c167 = l28 - l31 >= l33;
-        __c143 && __c158 || __c167 && !(__c143)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l33 = option::get_with_default(&l5, l29);
-        let __c176 = l31 > l28;
-        let __c191 = l31 - l28 >= l33;
-        let __c200 = l28 - l31 >= l33;
-        __c176 && __c191 || __c200 && !(__c176)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     } || {
         l31 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l33 = option::get_with_default(&l3, l29);
-        let __c209 = l31 > l28;
-        let __c224 = l31 - l28 >= l33;
-        let __c233 = l28 - l31 >= l33;
-        __c209 && __c224 || __c233 && !(__c209)
+        l31 > l28 && l31 - l28 >= l33 || l31 <= l28 && l28 - l31 >= l33
     }) {
         let l34 = vaa::parse_and_verify(l16, l17, l19);
         let l32 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l34, l19);
@@ -310,57 +234,34 @@ public fun update_8(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     let l31 = clock::timestamp_ms(l21) / 1000u64;
     let l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l16)));
     let l36 = option::get_with_default(&l17, l32);
-    let __c0 = l34 > l31;
-    let __c25 = l34 - l31 >= l36;
-    let __c35 = l31 - l34 >= l36;
-    if (__c0 && __c25 || __c35 && !(__c0) || {
+    if (l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36 || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l14)));
         l36 = option::get_with_default(&l15, l32);
-        let __c44 = l34 > l31;
-        let __c59 = l34 - l31 >= l36;
-        let __c68 = l31 - l34 >= l36;
-        __c44 && __c59 || __c68 && !(__c44)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l12)));
         l36 = option::get_with_default(&l13, l32);
-        let __c77 = l34 > l31;
-        let __c92 = l34 - l31 >= l36;
-        l31 - l34 >= l36 && !(__c77) || __c77 && __c92
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l10)));
         l36 = option::get_with_default(&l11, l32);
-        let __c110 = l34 > l31;
-        let __c125 = l34 - l31 >= l36;
-        let __c134 = l31 - l34 >= l36;
-        __c110 && __c125 || __c134 && !(__c110)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l8)));
         l36 = option::get_with_default(&l9, l32);
-        let __c143 = l34 > l31;
-        let __c158 = l34 - l31 >= l36;
-        let __c167 = l31 - l34 >= l36;
-        __c143 && __c158 || __c167 && !(__c143)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l6)));
         l36 = option::get_with_default(&l7, l32);
-        let __c176 = l34 > l31;
-        let __c191 = l34 - l31 >= l36;
-        let __c200 = l31 - l34 >= l36;
-        __c176 && __c191 || __c200 && !(__c176)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l4)));
         l36 = option::get_with_default(&l5, l32);
-        let __c209 = l34 > l31;
-        let __c224 = l34 - l31 >= l36;
-        let __c233 = l31 - l34 >= l36;
-        __c209 && __c224 || __c233 && !(__c209)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     } || {
         l34 = price::get_timestamp(&pyth::get_price_unsafe(freeze(l2)));
         l36 = option::get_with_default(&l3, l32);
-        let __c242 = l34 > l31;
-        let __c257 = l34 - l31 >= l36;
-        let __c266 = l31 - l34 >= l36;
-        __c242 && __c257 || __c266 && !(__c242)
+        l34 > l31 && l34 - l31 >= l36 || l34 <= l31 && l31 - l34 >= l36
     }) {
         let l37 = vaa::parse_and_verify(l18, l19, l21);
         let l35 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l37, l21);
@@ -381,10 +282,19 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
     let l10 = clock::timestamp_ms(l7) / 1000u64;
     let l11 = state::get_stale_price_threshold_secs(l0);
     let l13 = true;
+    let __dispatch_15;
     let l16;
     loop {
         if (l12 >= l14) {
-            let __c61 = l13;
+            if (l13) {
+                l12 = 0u64;
+                __dispatch_15 = 0u32;
+                break
+            };
+            let l18 = vaa::parse_and_verify(l4, l5, l7);
+            l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
+            l12 = 0u64;
+            __dispatch_15 = 1u32;
             break
         };
         let l15 = price::get_timestamp(&pyth::get_price_unsafe(&(&l2)[l12]));
@@ -400,15 +310,7 @@ public fun update_all(l0: &x8_State, l1: vector<u8>, l2: vector<PriceInfoObject>
         };
         l12 = l12 + 1u64;
     };
-    match (if (__c61) {
-        l12 = 0u64;
-        0u32
-    } else {
-        let l18 = vaa::parse_and_verify(l4, l5, l7);
-        l16 = pyth::create_authenticated_price_infos_using_accumulator(l0, l1, l18, l7);
-        l12 = 0u64;
-        1u32
-    }) {
+    match (__dispatch_15) {
         0 => {
             while (l12 < l14) {
                 transfer::public_share_object((&mut l2).pop_back());

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/pyth.mv.snap
@@ -34,16 +34,10 @@ public fun update_1(l0: &x8_State, l1: vector<u8>, l2: &mut PriceInfoObject, l3:
     if (l11 > l10) {
         if (l11 - l10 < l13) {
             return
-        };
-        unstructured {
-            goto 'label_59;
         }
     } else {
         if (l10 - l11 < l13) {
             return
-        };
-        unstructured {
-            goto 'label_59;
         }
     };
     /* block 59 */;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/safu.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/safu.mv.snap
@@ -241,17 +241,10 @@ public fun deposit_scallop_spool<T0>(l0: &Version, l1: &mut Registry, l2: u64, l
     if (l10 == 0u64) {
         balance::destroy_zero(l9)
     } else {
-        let l8;
-        if (dynamic_object_field::exists_(&l14.id, ascii::string(C3))) {
-            l8 = dynamic_object_field::remove(&mut l14.id, ascii::string(C3));
-            unstructured {
-                goto 'label_143;
-            }
+        let l8 = if (dynamic_object_field::exists_(&l14.id, ascii::string(C3))) {
+            dynamic_object_field::remove(&mut l14.id, ascii::string(C3))
         } else {
-            l8 = xe_user::new_spool_account(l5, l6, l7);
-            unstructured {
-                goto 'label_143;
-            }
+            xe_user::new_spool_account(l5, l6, l7)
         };
         /* block 143 */;
         let l13 = l8;
@@ -275,17 +268,10 @@ public fun deposit_suilend<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: &mu
     if (l9 == 0u64) {
         balance::destroy_zero(l8)
     } else {
-        let l7;
-        if (dynamic_object_field::exists_(&l13.id, ascii::string(C5))) {
-            l7 = dynamic_object_field::remove(&mut l13.id, ascii::string(C5));
-            unstructured {
-                goto 'label_126;
-            }
+        let l7 = if (dynamic_object_field::exists_(&l13.id, ascii::string(C5))) {
+            dynamic_object_field::remove(&mut l13.id, ascii::string(C5))
         } else {
-            l7 = lending_market::create_obligation(l3, l6);
-            unstructured {
-                goto 'label_126;
-            }
+            lending_market::create_obligation(l3, l6)
         };
         /* block 126 */;
         let l12 = l7;
@@ -321,10 +307,6 @@ public(friend) fun get_user_share(l0: &Registry, l1: u64, l2: address): Option<S
             };
             l4 = l4 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
     };
     /* block 99 */;
     return option::none()
@@ -340,31 +322,19 @@ public fun incentivise<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: Balance
     assert!(reg_12, C13);
     if (l4) {
         assert!(*(&(&l22.info)[C15]) == 0u64, C17);
-        *(&mut (&mut l22.info)[C15]) = 1u64;
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut (&mut l22.info)[C15]) = 1u64
     } else {
         assert!(*(&(&l22.info)[C14]) == 0u64, C17);
-        *(&mut (&mut l22.info)[C14]) = 1u64;
-        unstructured {
-            goto 'label_65;
-        }
+        *(&mut (&mut l22.info)[C14]) = 1u64
     };
     let (l11, l8, l9);
     /* block 65 */;
     l11 = ascii::string(C34);
     l9 = &mut l11;
-    if (l4) {
-        l8 = ascii::string(C35);
-        unstructured {
-            goto 'label_79;
-        }
+    l8 = if (l4) {
+        ascii::string(C35)
     } else {
-        l8 = ascii::string(C36);
-        unstructured {
-            goto 'label_79;
-        }
+        ascii::string(C36)
     };
     let (l12, l13, l14, l18, l19, l20, l21);
     /* block 79 */;
@@ -401,7 +371,6 @@ entry fun issue_typus_manager_cap(l0: &x4b_Version, l1: &mut Registry, l2: &TxCo
 }
 
 entry fun new_vault<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64, l8: u64, l9: bool, l10: u64, l11: &mut TxContext) {
-    let l12;
     version::verify(l0, freeze(l11));
     let l17 = object::new(l11);
     dynamic_field::add(&mut l17, ascii::string(C1), balance::zero());
@@ -411,16 +380,10 @@ entry fun new_vault<T0>(l0: &Version, l1: &mut Registry, l2: u64, l3: u64, l4: u
     *(&mut (&mut l18)[C9]) = l2;
     *(&mut (&mut l18)[C10]) = l3;
     *(&mut (&mut l18)[C11]) = 0u64;
-    if (l9) {
-        l12 = 1u64;
-        unstructured {
-            goto 'label_48;
-        }
+    let l12 = if (l9) {
+        1u64
     } else {
-        l12 = 0u64;
-        unstructured {
-            goto 'label_48;
-        }
+        0u64
     };
     /* block 48 */;
     *(&mut (&mut l18)[C12]) = l12;
@@ -569,23 +532,17 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
         };
         big_vector::push_back(&mut l36.share, Share { user: l35, share: l29, u64_padding: vector[0u64, l20], bcs_padding: C37 })
     };
-    let (__c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l13, l14, l15, l16, l17, l18, l21, l23, l27, l28, reg_309, reg_310);
+    let (__c252, __c319, __c375, __c385, __c464, __c508, __c529, __c538, __c553, l14, l15, l16, l17, l18, l21, l23, l27, l28, reg_309, reg_310);
     let l30 = big_vector::borrow_mut(&mut l36.share, l22);
     let l26 = *(&(&l30.u64_padding)[C7])as u256 * l20 - *(&(&l30.u64_padding)[C8])as u256 * *(&(&l36.config)[C12])as u256 / 3600000u256 / 10000u256as u64;
     *(&mut (&mut l30.u64_padding)[C8]) = l20;
     let l19 = balance::value(&l6);
     *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l19;
     *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l19;
-    if (*(&(&l30.share)[C8]) < l7) {
-        l13 = *(&(&l30.share)[C8]);
-        unstructured {
-            goto 'label_252;
-        }
+    let l13 = if (*(&(&l30.share)[C8]) < l7) {
+        *(&(&l30.share)[C8])
     } else {
-        l13 = l7;
-        unstructured {
-            goto 'label_252;
-        }
+        l7
     };
     /* block 252 */;
     l21 = l13;
@@ -594,16 +551,10 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
     *(&mut (&mut l30.share)[C8]) = *(&(&l30.share)[C8]) - l21;
     *(&mut (&mut l36.share_supply)[C8]) = *(&(&l36.share_supply)[C8]) - l21;
     __c252 = *(&(&l30.share)[C9]) < l8;
-    if (__c252) {
-        l14 = *(&(&l30.share)[C9]);
-        unstructured {
-            goto 'label_319;
-        }
+    l14 = if (__c252) {
+        *(&(&l30.share)[C9])
     } else {
-        l14 = l8;
-        unstructured {
-            goto 'label_319;
-        }
+        l8
     };
     /* block 319 */;
     l23 = l14;
@@ -621,34 +572,17 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
         __c375 = reg_309;
         if (__c375) {
             __c385 = *(&(&l30.share)[l27 + 5u64]) < l9;
-            if (__c385) {
-                l17 = *(&(&l30.share)[l27 + 5u64]);
-                unstructured {
-                    goto 'label_406;
-                }
+            l17 = if (__c385) {
+                *(&(&l30.share)[l27 + 5u64])
             } else {
-                l17 = l9;
-                unstructured {
-                    goto 'label_406;
-                }
+                l9
             };
             /* block 406 */;
             l28 = l17;
             *(&mut (&mut l30.share)[C10]) = *(&(&l30.share)[C10]) + l28;
             *(&mut (&mut l36.share_supply)[C10]) = *(&(&l36.share_supply)[C10]) + l28;
             *(&mut (&mut l30.share)[l27 + 5u64]) = *(&(&l30.share)[l27 + 5u64]) - l28;
-            *(&mut (&mut l36.share_supply)[l27 + 5u64]) = *(&(&l36.share_supply)[l27 + 5u64]) - l28;
-            unstructured {
-                goto 'label_464;
-            }
-        } else {
-            unstructured {
-                goto 'label_464;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_464;
+            *(&mut (&mut l36.share_supply)[l27 + 5u64]) = *(&(&l36.share_supply)[l27 + 5u64]) - l28
         }
     };
     /* block 464 */;
@@ -656,17 +590,7 @@ public fun raise_fund<T0>(l0: &x4b_Version, l1: &mut TypusLeaderboardRegistry, l
     __c464 = l19 + l21 + l23 + l28 > 0u64;
     assert!(__c464, C8);
     __c508 = l19 >= *(&(&l36.config)[C8]);
-    if (__c508) {
-        l18 = l19 % *(&(&l36.config)[C8]) == 0u64;
-        unstructured {
-            goto 'label_529;
-        }
-    } else {
-        l18 = false;
-        unstructured {
-            goto 'label_529;
-        }
-    };
+    l18 = __c508 && l19 % *(&(&l36.config)[C8]) == 0u64;
     /* block 529 */;
     __c529 = l18;
     assert!(__c529, C10);
@@ -747,34 +671,21 @@ public fun refresh(l0: &Version, l1: &mut Registry, l2: u64, l3: u64, l4: u64, l
     assert!(*(&(&l16.info)[C11]) == 0u64, C14);
     assert!(*(&(&l16.info)[C14]) == 1u64, C18);
     assert!(*(&(&l16.info)[C15]) == 1u64, C18);
-    let l7;
     *(&mut (&mut l16.info)[C10]) = l3;
     *(&mut (&mut l16.info)[C8]) = *(&(&l16.info)[C8]) + 1u64;
     *(&mut (&mut l16.info)[C13]) = l4;
-    if (*(&(&l16.config)[C13]) > 0u64) {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_99;
-        }
+    let l7 = if (*(&(&l16.config)[C13]) > 0u64) {
+        0u64
     } else {
-        l7 = 1u64;
-        unstructured {
-            goto 'label_99;
-        }
+        1u64
     };
     let l8;
     /* block 99 */;
     *(&mut (&mut l16.info)[C14]) = l7;
-    if (*(&(&l16.config)[C14]) > 0u64) {
-        l8 = 0u64;
-        unstructured {
-            goto 'label_118;
-        }
+    l8 = if (*(&(&l16.config)[C14]) > 0u64) {
+        0u64
     } else {
-        l8 = 1u64;
-        unstructured {
-            goto 'label_118;
-        }
+        1u64
     };
     let (l10, l11, l13, l14, l15);
     /* block 118 */;
@@ -948,18 +859,11 @@ public fun withdraw_suilend<T0>(l0: &mut Version, l1: &mut Registry, l2: u64, l3
     assert!(*(&(&l14.info)[C12]) == 1u64, C16);
     assert!(clock::timestamp_ms(l5) < *(&(&l14.info)[C10]), C15);
     assert!(*(&(&l14.info)[C11]) == 0u64, C14);
-    let l7;
     *(&mut (&mut l14.info)[C11]) = 3u64;
-    if (dynamic_object_field::exists_(&l14.id, ascii::string(C5))) {
-        l7 = dynamic_object_field::remove(&mut l14.id, ascii::string(C5));
-        unstructured {
-            goto 'label_97;
-        }
+    let l7 = if (dynamic_object_field::exists_(&l14.id, ascii::string(C5))) {
+        dynamic_object_field::remove(&mut l14.id, ascii::string(C5))
     } else {
-        l7 = lending_market::create_obligation(l3, l6);
-        unstructured {
-            goto 'label_97;
-        }
+        lending_market::create_obligation(l3, l6)
     };
     /* block 97 */;
     let l13 = l7;

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/sui20.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/sui20.mv.snap
@@ -144,13 +144,6 @@ public fun deploy(l0: &mut Global, l1: &Clock, l2: vector<u8>, l3: u64, l4: u64,
     let l9 = l10;
     if (l7 > l10) {
         l9 = l7;
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        unstructured {
-            goto 'label_30;
-        }
     };
     /* block 30 */;
     let l11 = Sui20Data { meta: Sui20Meta { tick: l12, max: l3, limit: l4, decimals: l5, fee: l6, start_at: l9 }, enable_to_coin: false, total_minted: 0u64, txs: 0u64, user_infos: table::new(l8), users: vector[], upgrade_bag: bag::new(l8) };
@@ -169,13 +162,6 @@ public fun get_mint_data(l0: &mut Global, l1: String, l2: &mut TxContext) {
         l8 = *(&l4.minted_amount);
         l6 = *(&l4.hold_amount);
         l7 = *(&l4.last_mint_at);
-        unstructured {
-            goto 'label_47;
-        }
-    } else {
-        unstructured {
-            goto 'label_47;
-        }
     };
     /* block 47 */;
     event::emit(QueryDataEvent { tick: *(&(&l3.meta).tick), start_at: *(&(&l3.meta).start_at), total_cap: *(&(&l3.meta).max), limit_per_mint: *(&(&l3.meta).limit), decimals: *(&(&l3.meta).decimals), mint_fee: *(&(&l3.meta).fee), total_minted: *(&l3.total_minted), remain_supply: *(&(&l3.meta).max) - *(&l3.total_minted), txs: *(&l3.txs), user_minted_amount: l8, user_hold_amount: l6, user_last_mint_at: l7 })
@@ -224,14 +210,7 @@ public fun mint(l0: &mut Global, l1: &Clock, l2: String, l3: u64, l4: Coin<SUI>,
     *(&mut l7.total_minted) = *(&l7.total_minted) + l3;
     *(&mut l7.txs) = *(&l7.txs) + 1u64;
     if (!(table::contains(&l7.user_infos, l15))) {
-        table::add(&mut l7.user_infos, l15, UserInfo { minted_amount: 0u64, last_mint_at: 0u64, hold_amount: 0u64 });
-        unstructured {
-            goto 'label_137;
-        }
-    } else {
-        unstructured {
-            goto 'label_137;
-        }
+        table::add(&mut l7.user_infos, l15, UserInfo { minted_amount: 0u64, last_mint_at: 0u64, hold_amount: 0u64 })
     };
     /* block 137 */;
     let l9 = table::borrow_mut(&mut l7.user_infos, l15);
@@ -263,10 +242,6 @@ public fun mint(l0: &mut Global, l1: &Clock, l2: String, l3: u64, l4: Coin<SUI>,
                 
             }
         }
-    } else {
-        unstructured {
-            goto 'label_241;
-        }
     };
     /* block 241 */;
     x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l7.meta).tick), amount: l3 }, l15);
@@ -293,14 +268,7 @@ public fun transfer(l0: &mut Global, l1: String, l2: vector<Sui20>, l3: address,
     x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l8.meta).tick), amount: l4 }, l3);
     let l10 = l11 - l4;
     if (l10 > 0u64) {
-        x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l8.meta).tick), amount: l10 }, l12);
-        unstructured {
-            goto 'label_109;
-        }
-    } else {
-        unstructured {
-            goto 'label_109;
-        }
+        x2_transfer::public_transfer(Sui20 { id: object::new(l5), tick: *(&(&l8.meta).tick), amount: l10 }, l12)
     };
     /* block 109 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/tails_staking.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/tails_staking.mv.snap
@@ -247,14 +247,7 @@ public fun exp_down_with_fee(l0: &mut Version, l1: &mut TailsStakingRegistry, l2
     let l11 = typus_nft::tails_level(freeze(l8));
     if (option::is_some(&l7)) {
         let l10 = bag::borrow(&l1.tails_metadata, C9);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l13 - 1u64)));
-        unstructured {
-            goto 'label_109;
-        }
-    } else {
-        unstructured {
-            goto 'label_109;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l13 - 1u64)))
     };
     /* block 109 */;
     *(&mut (bag::borrow_mut(&mut l1.tails_metadata, C8))[l13 - 1u64]) = l11;
@@ -277,14 +270,7 @@ public fun exp_down_without_staking_with_fee(l0: &mut Version, l1: &TailsStaking
     let l13 = typus_nft::tails_level(freeze(l10));
     if (option::is_some(&l9)) {
         let l12 = bag::borrow(&l1.tails_metadata, C9);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l10, *(big_vector::borrow(table::borrow(l12, l13), l14 - 1u64)));
-        unstructured {
-            goto 'label_92;
-        }
-    } else {
-        unstructured {
-            goto 'label_92;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l10, *(big_vector::borrow(table::borrow(l12, l13), l14 - 1u64)))
     };
     /* block 92 */;
     event::emit(ExpDownEvent { tails: l11, log: vector[l14, l6], bcs_padding: C17 })
@@ -344,6 +330,7 @@ public fun get_max_staking_level(l0: &Version, l1: &TailsStakingRegistry, l2: ad
     let l8 = 0u64;
     let l14 = bag::borrow(&l1.tails_metadata, C8);
     let l6 = big_vector::length(&l1.staking_infos);
+    /* block 143 */;
     if (l6 > 0u64) {
         let l12 = big_vector::slice_size(&l1.staking_infos)as u64;
         let l10 = 0u64;
@@ -352,24 +339,21 @@ public fun get_max_staking_level(l0: &Version, l1: &TailsStakingRegistry, l2: ad
         let l4 = 0u64;
         let (l13, l5, l7);
         loop {
-            if (l4 < l6) {
-                l13 = big_vector::borrow_from_slice(l9, l4 % l12);
-                if (*(&l13.user) == l2) {
-                    l5 = 0u64;
-                    l7 = &l13.tails.len();
-                    break
-                };
-                if (l4 + 1u64 < l6 && l4 + 1u64 == l10 * l12 + l11) {
-                    l10 = big_vector::get_slice_idx(l9) + 1u64;
-                    l9 = big_vector::borrow_slice(&l1.staking_infos, l10);
-                    l11 = big_vector::get_slice_length(l9);
-                };
-                l4 = l4 + 1u64;
-            } else {
-                unstructured {
-                    goto 'label_143;
-                }
-            }
+            if (l4 >= l6) {
+                break 'loop_143
+            };
+            l13 = big_vector::borrow_from_slice(l9, l4 % l12);
+            if (*(&l13.user) == l2) {
+                l5 = 0u64;
+                l7 = &l13.tails.len();
+                break
+            };
+            if (l4 + 1u64 < l6 && l4 + 1u64 == l10 * l12 + l11) {
+                l10 = big_vector::get_slice_idx(l9) + 1u64;
+                l9 = big_vector::borrow_slice(&l1.staking_infos, l10);
+                l11 = big_vector::get_slice_length(l9);
+            };
+            l4 = l4 + 1u64;
         };
         while (l5 < l7) {
             let l15 = *(&(&l13.tails)[l5]);
@@ -377,16 +361,8 @@ public fun get_max_staking_level(l0: &Version, l1: &TailsStakingRegistry, l2: ad
                 l8 = *(&l14[l15 - 1u64]);
             };
             l5 = l5 + 1u64;
-        };
-        unstructured {
-            goto 'label_143;
-        }
-    } else {
-        unstructured {
-            goto 'label_143;
         }
     };
-    /* block 143 */;
     return l8
 }
 
@@ -495,16 +471,10 @@ entry fun level_up(l0: &Version, l1: &mut TailsStakingRegistry, l2: address, l3:
     let l8 = typus_nft::tails_level(freeze(l5));
     if (l3) {
         let l11 = bag::borrow(&l1.tails_metadata, C10);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(table::borrow(l11, l8 * 10000u64 + l10)));
-        unstructured {
-            goto 'label_80;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(table::borrow(l11, l8 * 10000u64 + l10)))
     } else {
         let l7 = bag::borrow(&l1.tails_metadata, C9);
-        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(big_vector::borrow(table::borrow(l7, l8), l10 - 1u64)));
-        unstructured {
-            goto 'label_80;
-        }
+        typus_nft::update_image_url(&l1.tails_manager_cap, l5, *(big_vector::borrow(table::borrow(l7, l8), l10 - 1u64)))
     };
     /* block 80 */;
     *(&mut (bag::borrow_mut(&mut l1.tails_metadata, C8))[l10 - 1u64]) = l8;
@@ -521,14 +491,7 @@ public fun public_exp_down(l0: &ManagerCap, l1: &Version, l2: &mut TailsStakingR
     let l9 = typus_nft::tails_level(freeze(l6));
     if (option::is_some(&typus_nft::level_up(&l2.tails_manager_cap, l6))) {
         let l8 = bag::borrow(&l2.tails_metadata, C9);
-        typus_nft::update_image_url(&l2.tails_manager_cap, l6, *(big_vector::borrow(table::borrow(l8, l9), l11 - 1u64)));
-        unstructured {
-            goto 'label_62;
-        }
-    } else {
-        unstructured {
-            goto 'label_62;
-        }
+        typus_nft::update_image_url(&l2.tails_manager_cap, l6, *(big_vector::borrow(table::borrow(l8, l9), l11 - 1u64)))
     };
     /* block 62 */;
     *(&mut (bag::borrow_mut(&mut l2.tails_metadata, C8))[l11 - 1u64]) = l9;
@@ -544,14 +507,7 @@ public fun public_exp_down_without_staking(l0: &ManagerCap, l1: &Version, l2: &T
     let l11 = typus_nft::tails_level(freeze(l8));
     if (option::is_some(&typus_nft::level_up(&l2.tails_manager_cap, l8))) {
         let l10 = bag::borrow(&l2.tails_metadata, C9);
-        typus_nft::update_image_url(&l2.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l12 - 1u64)));
-        unstructured {
-            goto 'label_55;
-        }
-    } else {
-        unstructured {
-            goto 'label_55;
-        }
+        typus_nft::update_image_url(&l2.tails_manager_cap, l8, *(big_vector::borrow(table::borrow(l10, l11), l12 - 1u64)))
     };
     /* block 55 */;
     event::emit(ExpDownEvent { tails: l9, log: vector[l12, l6], bcs_padding: C17 })
@@ -655,18 +611,7 @@ entry fun set_profit_sharing<T0, T1>(l0: &Version, l1: &mut TailsStakingRegistry
     if (!(l20)) {
         (&mut l1.profit_assets).push_back(l19);
         if (!(dynamic_field::exists_(&l1.id, l19))) {
-            dynamic_field::add(&mut l1.id, l19, balance::zero());
-            unstructured {
-                goto 'label_188;
-            }
-        } else {
-            unstructured {
-                goto 'label_188;
-            }
-        }
-    } else {
-        unstructured {
-            goto 'label_188;
+            dynamic_field::add(&mut l1.id, l19, balance::zero())
         }
     };
     /* block 188 */;
@@ -857,17 +802,11 @@ entry fun upload_webp_bytes(l0: &Version, l1: &mut TailsStakingRegistry, l2: u64
     ecosystem::verify(l0, l5);
     let l6 = bag::borrow_mut(&mut l1.tails_metadata, C10);
     if (!(table::contains(freeze(l6), l3 * 10000u64 + l2))) {
-        table::add(l6, l3 * 10000u64 + l2, l4);
-        unstructured {
-            goto 'label_47;
-        }
+        table::add(l6, l3 * 10000u64 + l2, l4)
     } else {
         let l7 = table::borrow_mut(l6, l3 * 10000u64 + l2);
         while (!(vector::is_empty(&l4))) {
             l7.push_back((&mut l4).pop_back())
-        };
-        unstructured {
-            goto 'label_47;
         }
     };
     /* block 47 */

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/verse.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/verse.mv.snap
@@ -554,19 +554,8 @@ const C58: vector<u8> = vector[78u8, 111u8, 32u8, 98u8, 111u8, 110u8, 117u8, 115
 
 public entry fun add_collection_to_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     assert!(string::length(&l2) > 0u64, C23);
@@ -644,87 +633,46 @@ fun assert_not_paused<T0>(l0: &StakingPool<T0>) {
 }
 
 fun calculate_effective_reward_rate_enhanced(l0: u64, l1: u64, l2: u64, l3: u64): u64 {
-    let l4;
     let l6 = verse::safe_mul_div_precise(verse::safe_mul_div_precise(l0, l1, 10000u64), l2, 10000u64);
-    if (l3 == 0u64) {
-        l4 = l6;
-        unstructured {
-            goto 'label_24;
-        }
+    /* block 24 */;
+    return if (l3 == 0u64) {
+        l6
     } else {
         let l5 = verse::safe_add(10000u64, l3);
-        l4 = verse::safe_mul_div_precise(l6, l5, 10000u64);
-        unstructured {
-            goto 'label_24;
-        }
-    };
-    /* block 24 */;
-    return l4
+        verse::safe_mul_div_precise(l6, l5, 10000u64)
+    }
 }
 
 fun calculate_enhanced_slot_rewards(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64): u64 {
-    let l8;
     let l15 = verse::calculate_effective_reward_rate_enhanced(l3, l4, l5, l6);
-    if (l7 > 0u64) {
-        l8 = l7 < l2;
-        unstructured {
-            goto 'label_17;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_17;
-        }
-    };
-    let l9;
     /* block 17 */;
-    if (l8) {
-        l9 = l7;
-        unstructured {
-            goto 'label_24;
-        }
+    let l9 = if (l7 > 0u64 && l7 < l2) {
+        l7
     } else {
-        l9 = l2;
-        unstructured {
-            goto 'label_24;
-        }
+        l2
     };
     let (l10, l12);
     /* block 24 */;
     l12 = l9;
-    if (l1 > l0) {
-        l10 = l1;
-        unstructured {
-            goto 'label_35;
-        }
+    l10 = if (l1 > l0) {
+        l1
     } else {
-        l10 = l0;
-        unstructured {
-            goto 'label_35;
-        }
+        l0
     };
     /* block 35 */;
     let l13 = l10;
     if (l13 >= l12) {
         return 0u64
     };
-    let l11;
     let l14 = verse::safe_sub(l12, l13);
     let l17 = l15as u128 * C47 / C46as u128;
     let l16 = l14as u128 * l17 / C47;
-    if (l16 > C48as u128) {
-        l11 = C48;
-        unstructured {
-            goto 'label_73;
-        }
-    } else {
-        l11 = l16as u64;
-        unstructured {
-            goto 'label_73;
-        }
-    };
     /* block 73 */;
-    return l11
+    return if (l16 > C48as u128) {
+        C48
+    } else {
+        l16as u64
+    }
 }
 
 fun calculate_reserve(l0: u64): u64 {
@@ -734,36 +682,24 @@ fun calculate_reserve(l0: u64): u64 {
 fun calculate_slot_params(l0: u8): ( u64, u64) {
     let (l3, l4);
     let l11 = l0as u64;
-    if (l11 <= 10u64) {
+    l3 = if (l11 <= 10u64) {
         let l5 = l11 * 10000000000u64;
         l4 = 10000u64 + l11 - 1u64 * 2000u64;
-        l3 = l5;
-        unstructured {
-            goto 'label_65;
-        }
+        l5
     } else {
         let (l1, l2);
-        if (l11 <= 50u64) {
+        l1 = if (l11 <= 50u64) {
             let l6 = l11 * 20000000000u64;
             l2 = 30000u64 + l11 - 11u64 * 1000u64;
-            l1 = l6;
-            unstructured {
-                goto 'label_61;
-            }
+            l6
         } else {
             let l7 = l11 * 50000000000u64;
             l2 = 70000u64 + l11 - 51u64 * 1000u64;
-            l1 = l7;
-            unstructured {
-                goto 'label_61;
-            }
+            l7
         };
         /* block 61 */;
         l4 = l2;
-        l3 = l1;
-        unstructured {
-            goto 'label_65;
-        }
+        l1
     };
     /* block 65 */;
     return (l3, l4)
@@ -797,31 +733,18 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     let l14 = verse::calculate_enhanced_slot_rewards(l37, l21, l20, l16, l32, l23, l39, *(&l0.end_time));
     let l38 = verse::safe_add(l26, l14);
     assert!(l38 > 0u64, C4);
-    let l4;
-    if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
-        l4 = verse::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_205;
-        }
+    let l4 = if (balance::value(&l0.reward_balance) > *(&l0.reserved_rewards)) {
+        verse::safe_sub(balance::value(&l0.reward_balance), *(&l0.reserved_rewards))
     } else {
-        l4 = 0u64;
-        unstructured {
-            goto 'label_205;
-        }
+        0u64
     };
     let l6;
     /* block 205 */;
     let l15 = l4;
-    if (l15 >= l38) {
-        l6 = l38;
-        unstructured {
-            goto 'label_216;
-        }
+    l6 = if (l15 >= l38) {
+        l38
     } else {
-        l6 = l15;
-        unstructured {
-            goto 'label_216;
-        }
+        l15
     };
     /* block 216 */;
     let l18 = l6;
@@ -830,15 +753,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l35.last_claim_time) = l20;
     *(&mut l35.total_claimed) = verse::safe_add(*(&l35.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l35.pending_rewards) = verse::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = verse::safe_sub(l38, l18)
     } else {
-        *(&mut l35.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_261;
-        }
+        *(&mut l35.pending_rewards) = 0u64
     };
     /* block 261 */;
     let l31 = SlotDataKey { owner: l25, slot_number: l33 };
@@ -846,15 +763,9 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     *(&mut l30.last_claim_time) = l20;
     *(&mut l30.total_claimed) = verse::safe_add(*(&l30.total_claimed), l18);
     if (l18 < l38) {
-        *(&mut l30.pending_rewards) = verse::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = verse::safe_sub(l38, l18)
     } else {
-        *(&mut l30.pending_rewards) = 0u64;
-        unstructured {
-            goto 'label_297;
-        }
+        *(&mut l30.pending_rewards) = 0u64
     };
     let (l10, l11, l12, l13, l5, l7, l8, l9);
     /* block 297 */;
@@ -869,16 +780,10 @@ public entry fun claim_slot_rewards<T0: key + store, T1>(l0: &mut StakingPool<T1
     l10 = l20;
     l9 = *(&l0.reward_token_type);
     l8 = l18 < l38;
-    if (l18 < l38) {
-        l7 = verse::safe_sub(l38, l18);
-        unstructured {
-            goto 'label_348;
-        }
+    l7 = if (l18 < l38) {
+        verse::safe_sub(l38, l18)
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_348;
-        }
+        0u64
     };
     /* block 348 */;
     event::emit(RewardsClaimed { pool_id: l5, nft_id: l13, owner: l12, amount: l11, claim_time: l10, reward_token_type: l9, is_partial_claim: l8, remaining_pending: l7, slot_number: l33 })
@@ -900,24 +805,13 @@ fun create_enhanced_slot_configs(): vector<SlotConfig> {
 }
 
 public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: u64, l4: u64, l5: vector<String>, l6: address, l7: u8, l8: &Clock, l9: &mut TxContext): StakingPool<T0> {
-    let l10;
     let l11 = tx_context::sender(freeze(l9));
     let l14 = object::new(l9);
     let l15 = object::uid_to_inner(&l14);
     let l17 = coin::value(&l0);
     let l18 = type_name::get();
     let l12 = clock::timestamp_ms(l8);
-    if (l7 >= 1u8) {
-        l10 = l7 <= C52;
-        unstructured {
-            goto 'label_29;
-        }
-    } else {
-        l10 = false;
-        unstructured {
-            goto 'label_29;
-        }
-    };
+    let l10 = l7 >= 1u8 && l7 <= C52;
     /* block 29 */;
     assert!(l10, C40);
     let l19 = verse::create_enhanced_slot_configs();
@@ -936,16 +830,10 @@ public fun create_enhanced_staking_pool<T0>(l0: Coin<T0>, l1: u64, l2: u64, l3: 
 fun decrease_reserved_rewards(l0: &mut u64, l1: u64) {
     let l3 = verse::calculate_reserve(l1);
     if (*l0 >= l3) {
-        *l0 = verse::safe_sub(*l0, l3);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = verse::safe_sub(*l0, l3)
     } else {
         let l2 = *l0 * l3 / verse::calculate_reserve(l1);
-        *l0 = verse::safe_sub(*l0, l2);
-        unstructured {
-            goto 'label_29;
-        }
+        *l0 = verse::safe_sub(*l0, l2)
     };
     /* block 29 */
 }
@@ -955,40 +843,24 @@ public fun get_admin<T0>(l0: &StakingPool<T0>): address {
 }
 
 public fun get_available_rewards<T0>(l0: &StakingPool<T0>): u64 {
-    let l1;
     let l2 = balance::value(&l0.reward_balance);
-    if (l2 <= *(&l0.reserved_rewards)) {
-        l1 = 0u64;
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l1 = verse::safe_sub(l2, *(&l0.reserved_rewards));
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l1
+    return if (l2 <= *(&l0.reserved_rewards)) {
+        0u64
+    } else {
+        verse::safe_sub(l2, *(&l0.reserved_rewards))
+    }
 }
 
 public fun get_collection_multiplier_info<T0>(l0: &StakingPool<T0>, l1: String): Option<CollectionMultiplierInfo> {
-    let l2;
     let l3 = CollectionMultiplierKey { collection: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) });
-        unstructured {
-            goto 'label_30;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_30;
-        }
-    };
     /* block 30 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(CollectionMultiplierInfo { default_multiplier: *(&l4.default_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_default_reward_rate<T0>(l0: &StakingPool<T0>): u64 {
@@ -1016,36 +888,21 @@ public fun get_enhanced_slot_configs<T0>(l0: &StakingPool<T0>): vector<SlotConfi
 }
 
 public fun get_nft_multiplier_info<T0>(l0: &StakingPool<T0>, l1: ID, l2: String): Option<NftMultiplierInfo> {
-    let l3;
     let l4 = NftMultiplierKey { nft_id: l1, collection: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l5 = dynamic_object_field::borrow(&l0.id, l4);
-        l3 = option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) });
-        unstructured {
-            goto 'label_34;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_34;
-        }
-    };
     /* block 34 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l5 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(NftMultiplierInfo { multiplier: *(&l5.multiplier), rarity_tier: *(&l5.rarity_tier), set_by: *(&l5.set_by), set_time: *(&l5.set_time) })
+    } else {
+        option::none()
+    }
 }
 
 fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &mut TxContext): &mut SlotData {
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
     if (!(dynamic_object_field::exists_(&l0.id, l5))) {
         let l4 = SlotData { id: object::new(l3), owner: l1, slot_number: l2, staked_nft: option::none(), staked_collection: option::none(), stake_time: 0u64, last_claim_time: 0u64, pending_rewards: 0u64, total_claimed: 0u64, is_unlocked: false, nft_type: option::none() };
-        dynamic_object_field::add(&mut l0.id, l5, l4);
-        unstructured {
-            goto 'label_32;
-        }
-    } else {
-        unstructured {
-            goto 'label_32;
-        }
+        dynamic_object_field::add(&mut l0.id, l5, l4)
     };
     /* block 32 */;
     return dynamic_object_field::borrow_mut(&mut l0.id, l5)
@@ -1054,21 +911,15 @@ fun get_or_create_slot_data<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l
 public fun get_pool_slot_limits<T0>(l0: &StakingPool<T0>): ( u8, u8, u64) {
     let (l1, l2, l3);
     let l4 = PoolSlotLimitsKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
+    l1 = if (dynamic_object_field::exists_(&l0.id, l4)) {
         let l5 = dynamic_object_field::borrow(&l0.id, l4);
         l3 = *(&l5.total_users_with_custom_limits);
         l2 = *(&l5.absolute_max_slots);
-        l1 = *(&l5.default_max_slots_per_wallet);
-        unstructured {
-            goto 'label_34;
-        }
+        *(&l5.default_max_slots_per_wallet)
     } else {
         l3 = 0u64;
         l2 = C52;
-        l1 = C51;
-        unstructured {
-            goto 'label_34;
-        }
+        C51
     };
     /* block 34 */;
     return (l1, l2, l3)
@@ -1097,22 +948,14 @@ fun get_slot_config(l0: &vector<SlotConfig>, l1: u8): &SlotConfig {
 }
 
 public fun get_slot_data<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): Option<SlotDataInfo> {
-    let l3;
     let l5 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l5)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l5);
-        l3 = option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) });
-        unstructured {
-            goto 'label_49;
-        }
-    } else {
-        l3 = option::none();
-        unstructured {
-            goto 'label_49;
-        }
-    };
     /* block 49 */;
-    return l3
+    return if (dynamic_object_field::exists_(&l0.id, l5)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l5);
+        option::some(SlotDataInfo { owner: *(&l4.owner), slot_number: *(&l4.slot_number), staked_nft: *(&l4.staked_nft), staked_collection: *(&l4.staked_collection), stake_time: *(&l4.stake_time), last_claim_time: *(&l4.last_claim_time), pending_rewards: *(&l4.pending_rewards), total_claimed: *(&l4.total_claimed), is_unlocked: *(&l4.is_unlocked) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_slot_effective_rate<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): u64 {
@@ -1164,48 +1007,24 @@ public fun get_slot_price<T0>(l0: &StakingPool<T0>, l1: u8): u64 {
 }
 
 public fun get_slot_token_price<T0>(l0: &StakingPool<T0>, l1: u8, l2: String): u64 {
-    let l5;
     let l7 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        let l3;
+    /* block 47 */;
+    return if (dynamic_object_field::exists_(&l0.id, l7)) {
         let l6 = dynamic_object_field::borrow(&l0.id, l7);
-        if (table::contains(&l6.token_prices, l2)) {
-            l3 = *(table::borrow(&l6.token_prices, l2));
-            unstructured {
-                goto 'label_29;
-            }
-        } else {
-            l3 = 0u64;
-            unstructured {
-                goto 'label_29;
-            }
-        };
         /* block 29 */;
-        l5 = l3;
-        unstructured {
-            goto 'label_47;
+        if (table::contains(&l6.token_prices, l2)) {
+            *(table::borrow(&l6.token_prices, l2))
+        } else {
+            0u64
         }
     } else {
-        let l4;
-        if (l2 == verse::get_token_type_string_sui()) {
-            l4 = verse::get_slot_price(l0, l1);
-            unstructured {
-                goto 'label_45;
-            }
-        } else {
-            l4 = 0u64;
-            unstructured {
-                goto 'label_45;
-            }
-        };
         /* block 45 */;
-        l5 = l4;
-        unstructured {
-            goto 'label_47;
+        if (l2 == verse::get_token_type_string_sui()) {
+            verse::get_slot_price(l0, l1)
+        } else {
+            0u64
         }
-    };
-    /* block 47 */;
-    return l5
+    }
 }
 
 public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
@@ -1213,39 +1032,23 @@ public fun get_supported_collections<T0>(l0: &StakingPool<T0>): vector<String> {
 }
 
 public fun get_supported_payment_tokens<T0>(l0: &StakingPool<T0>): vector<String> {
-    let l1;
     let l2 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l2)) {
-        l1 = *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l1 = vector[];
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l1
+    return if (dynamic_object_field::exists_(&l0.id, l2)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l2)).token_list)
+    } else {
+        vector[]
+    }
 }
 
 public fun get_token_revenue<T0>(l0: &StakingPool<T0>, l1: String): u64 {
-    let l2;
     let l3 = TokenRevenueKey { token_type: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).total_collected)
+    } else {
+        0u64
+    }
 }
 
 fun get_token_type_string_any<T0>(): String {
@@ -1263,13 +1066,6 @@ fun get_token_type_string_any<T0>(): String {
                 l1 = l1 + 1u64;
             };
             return string::utf8(l4)
-        };
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        unstructured {
-            goto 'label_50;
         }
     };
     /* block 50 */;
@@ -1285,22 +1081,14 @@ public fun get_total_staked<T0>(l0: &StakingPool<T0>): u64 {
 }
 
 public fun get_user_slot_allocation<T0>(l0: &StakingPool<T0>, l1: address): Option<UserSlotInfo> {
-    let l2;
     let l4 = UserSlotAllocationKey { user: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        let l3 = dynamic_object_field::borrow(&l0.id, l4);
-        l2 = option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l4)) {
+        let l3 = dynamic_object_field::borrow(&l0.id, l4);
+        option::some(UserSlotInfo { owner: *(&l3.owner), max_slots_allowed: *(&l3.max_slots_allowed), total_slots_unlocked: *(&l3.total_slots_unlocked), unlocked_slot_numbers: *(&l3.unlocked_slot_numbers) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_user_total_claimed_rewards<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1353,19 +1141,13 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
     let l11 = dynamic_object_field::borrow(&l0.id, l35);
     let l14 = clock::timestamp_ms(l2);
     let l38 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l38)) {
+    l3 = if (dynamic_object_field::exists_(&l0.id, l38)) {
         let l39 = dynamic_object_field::borrow(&l0.id, l38);
         l4 = *(&l39.reason);
-        l3 = *(&l39.bonus_multiplier);
-        unstructured {
-            goto 'label_61;
-        }
+        *(&l39.bonus_multiplier)
     } else {
         l4 = string::utf8(C58);
-        l3 = 0u64;
-        unstructured {
-            goto 'label_61;
-        }
+        0u64
     };
     let (l18, l20, l27, l32, l34, l36, l37, l9);
     /* block 61 */;
@@ -1422,40 +1204,24 @@ public fun get_user_wallet_details<T0>(l0: &StakingPool<T0>, l1: address, l2: &C
 }
 
 fun get_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): u64 {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier);
-        unstructured {
-            goto 'label_20;
-        }
-    } else {
-        l2 = 0u64;
-        unstructured {
-            goto 'label_20;
-        }
-    };
     /* block 20 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l3)).bonus_multiplier)
+    } else {
+        0u64
+    }
 }
 
 public fun get_wallet_bonus_multiplier_info<T0>(l0: &StakingPool<T0>, l1: address): Option<WalletBonusMultiplierInfo> {
-    let l2;
     let l3 = WalletBonusMultiplierKey { wallet: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        let l4 = dynamic_object_field::borrow(&l0.id, l3);
-        l2 = option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) });
-        unstructured {
-            goto 'label_33;
-        }
-    } else {
-        l2 = option::none();
-        unstructured {
-            goto 'label_33;
-        }
-    };
     /* block 33 */;
-    return l2
+    return if (dynamic_object_field::exists_(&l0.id, l3)) {
+        let l4 = dynamic_object_field::borrow(&l0.id, l3);
+        option::some(WalletBonusMultiplierInfo { bonus_multiplier: *(&l4.bonus_multiplier), set_by: *(&l4.set_by), set_time: *(&l4.set_time), reason: *(&l4.reason) })
+    } else {
+        option::none()
+    }
 }
 
 public fun get_wallet_bonus_multiplier_view<T0>(l0: &StakingPool<T0>, l1: address): u64 {
@@ -1469,19 +1235,8 @@ public fun has_wallet_bonus_multiplier<T0>(l0: &StakingPool<T0>, l1: address): b
 
 public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: address, l2: u8, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l2 >= 1u8) {
-        l5 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= 1u8 && l2 <= C52;
     /* block 31 */;
     assert!(l5, C40);
     let l13 = UserSlotAllocationKey { user: l1 };
@@ -1494,24 +1249,14 @@ public entry fun increase_user_slot_limit<T0>(l0: &mut StakingPool<T0>, l1: addr
         *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64);
         if (l2 != l9) {
             let l12 = dynamic_object_field::borrow_mut(&mut l0.id, l10);
-            *(&mut l12.total_users_with_custom_limits) = verse::safe_add(*(&l12.total_users_with_custom_limits), 1u64);
-            unstructured {
-                goto 'label_144;
-            }
-        } else {
-            unstructured {
-                goto 'label_144;
-            }
+            *(&mut l12.total_users_with_custom_limits) = verse::safe_add(*(&l12.total_users_with_custom_limits), 1u64)
         }
     } else {
         let l7 = dynamic_object_field::borrow_mut(&mut l0.id, l13);
         let l11 = *(&l7.max_slots_allowed);
         assert!(l2 > l11, C40);
         *(&mut l7.max_slots_allowed) = l2;
-        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 });
-        unstructured {
-            goto 'label_144;
-        }
+        event::emit(UserSlotLimitIncreased { pool_id: object::id(freeze(l0)), user: l1, old_limit: l11, new_limit: l2, increased_by: tx_context::sender(freeze(l4)), increase_time: l8 })
     };
     /* block 144 */
 }
@@ -1532,21 +1277,9 @@ public fun is_paused<T0>(l0: &StakingPool<T0>): bool {
 }
 
 public fun is_payment_token_supported<T0>(l0: &StakingPool<T0>, l1: String): bool {
-    let l2;
     let l3 = PaymentTokenRegistryKey { dummy_field: false };
-    if (dynamic_object_field::exists_(&l0.id, l3)) {
-        l2 = table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l2
+    return dynamic_object_field::exists_(&l0.id, l3) && table::contains(&(dynamic_object_field::borrow(&l0.id, l3)).supported_tokens, l1)
 }
 
 public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
@@ -1554,39 +1287,15 @@ public fun is_slot_free<T0>(l0: &StakingPool<T0>, l1: u8): bool {
 }
 
 fun is_slot_occupied<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && option::is_some(&(dynamic_object_field::borrow(&l0.id, l4)).staked_nft)
 }
 
 fun is_slot_unlocked<T0>(l0: &StakingPool<T0>, l1: address, l2: u8): bool {
-    let l3;
     let l4 = SlotDataKey { owner: l1, slot_number: l2 };
-    if (dynamic_object_field::exists_(&l0.id, l4)) {
-        l3 = *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked);
-        unstructured {
-            goto 'label_21;
-        }
-    } else {
-        l3 = false;
-        unstructured {
-            goto 'label_21;
-        }
-    };
     /* block 21 */;
-    return l3
+    return dynamic_object_field::exists_(&l0.id, l4) && *(&(dynamic_object_field::borrow(&l0.id, l4)).is_unlocked)
 }
 
 fun is_sui_token<T0>(): bool {
@@ -1597,19 +1306,8 @@ fun is_sui_token<T0>(): bool {
 
 public entry fun remove_collection_from_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
     let l8 = clock::timestamp_ms(l3);
@@ -1648,13 +1346,7 @@ public entry fun remove_payment_custom_token<T0, T1>(l0: &mut StakingPool<T1>, l
     let (reg_35, reg_36) = vector::index_of(&l5.token_list, &l6);
     let l4 = reg_36;
     if (reg_35) {
-        unstructured {
-            goto 'label_63;
-        }
-    } else {
-        unstructured {
-            goto 'label_63;
-        }
+        
     };
     /* block 63 */;
     let l3 = clock::timestamp_ms(l1);
@@ -1670,13 +1362,7 @@ public entry fun remove_payment_token<T0>(l0: &mut StakingPool<T0>, l1: String, 
     let (reg_42, reg_43) = vector::index_of(&l6.token_list, &l1);
     let l5 = reg_43;
     if (reg_42) {
-        unstructured {
-            goto 'label_75;
-        }
-    } else {
-        unstructured {
-            goto 'label_75;
-        }
+        
     };
     /* block 75 */;
     let l4 = clock::timestamp_ms(l2);
@@ -1701,18 +1387,7 @@ fun safe_add(l0: u64, l1: u64): u64 {
 }
 
 fun safe_mul_div_precise(l0: u64, l1: u64, l2: u64): u64 {
-    let l3;
-    if (l0 == 0u64) {
-        l3 = true;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l3 = l1 == 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    };
+    let l3 = l0 == 0u64 || l1 == 0u64;
     /* block 11 */;
     if (l3) {
         return 0u64
@@ -1735,38 +1410,20 @@ fun safe_sub(l0: u64, l1: u64): u64 {
 
 public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: String, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l2 >= C50) {
-        l5 = l2 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l2 >= C50 && l2 <= C54;
     /* block 31 */;
     assert!(l5, C36);
     assert!(string::length(&l1) > 0u64, C23);
     let reg_36;
     (reg_36, reg_37) = vector::index_of(&l0.supported_collections, &l1);
     assert!(reg_36, C8);
-    let l6;
     let l7 = CollectionMultiplierKey { collection: l1 };
     let l10 = clock::timestamp_ms(l3);
-    if (dynamic_object_field::exists_(&l0.id, l7)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier);
-        unstructured {
-            goto 'label_92;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l7)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l7)).default_multiplier)
     } else {
-        l6 = 10000u64;
-        unstructured {
-            goto 'label_92;
-        }
+        10000u64
     };
     let l11;
     /* block 92 */;
@@ -1775,16 +1432,10 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
         let l8 = dynamic_object_field::borrow_mut(&mut l0.id, l7);
         *(&mut l8.default_multiplier) = l2;
         *(&mut l8.set_by) = tx_context::sender(freeze(l4));
-        *(&mut l8.set_time) = l10;
-        unstructured {
-            goto 'label_134;
-        }
+        *(&mut l8.set_time) = l10
     } else {
         let l9 = CollectionMultiplier { id: object::new(l4), collection: l1, default_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 };
-        dynamic_object_field::add(&mut l0.id, l7, l9);
-        unstructured {
-            goto 'label_134;
-        }
+        dynamic_object_field::add(&mut l0.id, l7, l9)
     };
     /* block 134 */;
     event::emit(CollectionMultiplierSet { pool_id: object::id(freeze(l0)), collection: l1, old_multiplier: l11, new_multiplier: l2, set_by: tx_context::sender(freeze(l4)), set_time: l10 })
@@ -1792,19 +1443,8 @@ public entry fun set_collection_multiplier<T0>(l0: &mut StakingPool<T0>, l1: Str
 
 public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: String, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     verse::assert_not_paused(freeze(l0));
-    if (l3 >= C50) {
-        l7 = l3 <= C54;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l3 >= C50 && l3 <= C54;
     /* block 31 */;
     assert!(l7, C36);
     assert!(string::length(&l2) > 0u64, C23);
@@ -1812,19 +1452,12 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
     let reg_44;
     (reg_44, reg_45) = vector::index_of(&l0.supported_collections, &l2);
     assert!(reg_44, C8);
-    let l8;
     let l10 = NftMultiplierKey { nft_id: l1, collection: l2 };
     let l9 = clock::timestamp_ms(l5);
-    if (dynamic_object_field::exists_(&l0.id, l10)) {
-        l8 = *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier);
-        unstructured {
-            goto 'label_107;
-        }
+    let l8 = if (dynamic_object_field::exists_(&l0.id, l10)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l10)).multiplier)
     } else {
-        l8 = 10000u64;
-        unstructured {
-            goto 'label_107;
-        }
+        10000u64
     };
     let l13;
     /* block 107 */;
@@ -1834,16 +1467,10 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
         *(&mut l11.multiplier) = l3;
         *(&mut l11.rarity_tier) = l4;
         *(&mut l11.set_by) = tx_context::sender(freeze(l6));
-        *(&mut l11.set_time) = l9;
-        unstructured {
-            goto 'label_155;
-        }
+        *(&mut l11.set_time) = l9
     } else {
         let l12 = NftMultiplier { id: object::new(l6), nft_id: l1, collection: l2, multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 };
-        dynamic_object_field::add(&mut l0.id, l10, l12);
-        unstructured {
-            goto 'label_155;
-        }
+        dynamic_object_field::add(&mut l0.id, l10, l12)
     };
     /* block 155 */;
     event::emit(NftMultiplierSet { pool_id: object::id(freeze(l0)), nft_id: l1, collection: l2, old_multiplier: l13, new_multiplier: l3, rarity_tier: l4, set_by: tx_context::sender(freeze(l6)), set_time: l9 })
@@ -1851,19 +1478,8 @@ public entry fun set_nft_multiplier<T0>(l0: &mut StakingPool<T0>, l1: ID, l2: St
 
 public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u8, l3: u64, l4: String, l5: &Clock, l6: &mut TxContext) {
     assert!(tx_context::sender(freeze(l6)) == *(&l0.admin), C1);
-    let l7;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l7 = l2 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l7 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l7 = l1 >= C53 && l2 <= C52;
     /* block 31 */;
     assert!(l7, C29);
     assert!(l1 <= l2, C20);
@@ -1876,19 +1492,8 @@ public entry fun set_promotional_pricing<T0>(l0: &mut StakingPool<T0>, l1: u8, l
 
 public entry fun set_slot_allowed_collections<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: vector<String>, l3: bool, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l8 = clock::timestamp_ms(l4);
@@ -1920,19 +1525,12 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
     verse::assert_not_paused(freeze(l0));
     assert!(l2 <= C54, C36);
     assert!(string::length(&l3) > 0u64, C20);
-    let l6;
     let l9 = WalletBonusMultiplierKey { wallet: l1 };
     let l7 = clock::timestamp_ms(l4);
-    if (dynamic_object_field::exists_(&l0.id, l9)) {
-        l6 = *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier);
-        unstructured {
-            goto 'label_68;
-        }
+    let l6 = if (dynamic_object_field::exists_(&l0.id, l9)) {
+        *(&(dynamic_object_field::borrow(&l0.id, l9)).bonus_multiplier)
     } else {
-        l6 = 0u64;
-        unstructured {
-            goto 'label_68;
-        }
+        0u64
     };
     let l8;
     /* block 68 */;
@@ -1942,16 +1540,10 @@ public entry fun set_wallet_bonus_multiplier<T0>(l0: &mut StakingPool<T0>, l1: a
         *(&mut l10.bonus_multiplier) = l2;
         *(&mut l10.reason) = l3;
         *(&mut l10.set_by) = tx_context::sender(freeze(l5));
-        *(&mut l10.set_time) = l7;
-        unstructured {
-            goto 'label_115;
-        }
+        *(&mut l10.set_time) = l7
     } else {
         let l11 = WalletBonusMultiplier { id: object::new(l5), wallet: l1, bonus_multiplier: l2, set_by: tx_context::sender(freeze(l5)), set_time: l7, reason: l3 };
-        dynamic_object_field::add(&mut l0.id, l9, l11);
-        unstructured {
-            goto 'label_115;
-        }
+        dynamic_object_field::add(&mut l0.id, l9, l11)
     };
     /* block 115 */;
     event::emit(WalletBonusMultiplierSet { pool_id: object::id(freeze(l0)), wallet: l1, old_bonus_multiplier: l8, new_bonus_multiplier: l2, reason: l3, set_by: tx_context::sender(freeze(l5)), set_time: l7 })
@@ -1961,31 +1553,13 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
     verse::assert_not_paused(freeze(l0));
     assert!(!(*(&l0.is_locked)), C5);
     assert!(string::length(&l4) > 0u64, C23);
-    let l8;
-    if (l5 >= C53) {
-        l8 = l5 <= C52;
-        unstructured {
-            goto 'label_50;
-        }
-    } else {
-        l8 = false;
-        unstructured {
-            goto 'label_50;
-        }
-    };
+    let l8 = l5 >= C53 && l5 <= C52;
     /* block 50 */;
     assert!(l8, C29);
     let l10 = clock::timestamp_ms(l6);
     assert!(l10 >= *(&l0.start_time), C7);
     if (*(&l0.end_time) > 0u64) {
-        assert!(l10 < *(&l0.end_time), C10);
-        unstructured {
-            goto 'label_108;
-        }
-    } else {
-        unstructured {
-            goto 'label_108;
-        }
+        assert!(l10 < *(&l0.end_time), C10)
     };
     /* block 108 */;
     let l15 = tx_context::sender(freeze(l7));
@@ -2019,38 +1593,16 @@ public entry fun stake_nft_in_slot<T0: key + store, T1>(l0: &mut StakingPool<T1>
 }
 
 public entry fun toggle_pause<T0>(l0: &mut StakingPool<T0>, l1: &mut TxContext) {
-    let l2;
     let l3 = tx_context::sender(freeze(l1));
-    if (l3 == *(&l0.admin)) {
-        l2 = true;
-        unstructured {
-            goto 'label_19;
-        }
-    } else {
-        l2 = l3 == *(&l0.emergency_admin);
-        unstructured {
-            goto 'label_19;
-        }
-    };
+    let l2 = l3 == *(&l0.admin) || l3 == *(&l0.emergency_admin);
     /* block 19 */;
     assert!(l2, C1);
     *(&mut l0.is_paused) = !(*(&l0.is_paused))
 }
 
 public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
@@ -2061,23 +1613,13 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     let l8 = *(&l17.allowed_collections);
     let l15 = *(&l17.unlock_cost);
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_130;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l13 >= l15, C30);
         let l14 = coin::into_balance(l2);
         if (l13 > l15) {
             let l11 = verse::safe_sub(l13, l15);
-            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22);
-            unstructured {
-                goto 'label_89;
-            }
-        } else {
-            unstructured {
-                goto 'label_89;
-            }
+            transfer::public_transfer(coin::from_balance(balance::split(&mut l14, l11), l4), l22)
         };
         let l16;
         /* block 89 */;
@@ -2085,21 +1627,11 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
         l16 = TokenRevenueKey { token_type: l21 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l19 = TokenRevenue { id: object::new(l4), token_type: l21, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l19);
-            unstructured {
-                goto 'label_112;
-            }
-        } else {
-            unstructured {
-                goto 'label_112;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l19)
         };
         /* block 112 */;
         let l20 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l20.total_collected) = verse::safe_add(*(&l20.total_collected), l15);
-        unstructured {
-            goto 'label_130;
-        }
+        *(&mut l20.total_collected) = verse::safe_add(*(&l20.total_collected), l15)
     };
     let l23;
     /* block 130 */;
@@ -2108,14 +1640,7 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l6 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l10, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l6);
-        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_168;
-        }
-    } else {
-        unstructured {
-            goto 'label_168;
-        }
+        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 168 */;
     assert!(!(verse::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2129,81 +1654,42 @@ public entry fun unlock_slot<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Coin<SUI>
 }
 
 public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8, l2: Coin<T0>, l3: &Clock, l4: &mut TxContext) {
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_14;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_14;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 14 */;
     assert!(l5, C29);
     let l22 = tx_context::sender(freeze(l4));
     let l12 = coin::value(&l2);
     let l20 = verse::get_token_type_string_any();
     assert!(table::contains(&(dynamic_object_field::borrow(&l0.id, PaymentTokenRegistryKey { dummy_field: false })).supported_tokens, l20), C34);
-    let l7;
     let l14 = SlotTokenPricingKey { slot_number: l1 };
-    if (dynamic_object_field::exists_(&l0.id, l14)) {
-        let l6;
+    let l7 = if (dynamic_object_field::exists_(&l0.id, l14)) {
         let l13 = dynamic_object_field::borrow(&l0.id, l14);
-        if (table::contains(&l13.token_prices, l20)) {
-            l6 = *(table::borrow(&l13.token_prices, l20));
-            unstructured {
-                goto 'label_81;
-            }
-        } else {
-            l6 = 0u64;
-            unstructured {
-                goto 'label_81;
-            }
-        };
         /* block 81 */;
-        l7 = l6;
-        unstructured {
-            goto 'label_86;
+        if (table::contains(&l13.token_prices, l20)) {
+            *(table::borrow(&l13.token_prices, l20))
+        } else {
+            0u64
         }
     } else {
-        l7 = 0u64;
-        unstructured {
-            goto 'label_86;
-        }
+        0u64
     };
     let l15;
     /* block 86 */;
     l15 = l7;
     if (l15 == 0u64) {
-        transfer::public_transfer(l2, l22);
-        unstructured {
-            goto 'label_148;
-        }
+        transfer::public_transfer(l2, l22)
     } else {
         assert!(l12 == l15, C30);
         transfer::public_transfer(l2, *(&l0.admin));
         let l16 = TokenRevenueKey { token_type: l20 };
         if (!(dynamic_object_field::exists_(&l0.id, l16))) {
             let l18 = TokenRevenue { id: object::new(l4), token_type: l20, total_collected: 0u64, sui_balance: balance::zero() };
-            dynamic_object_field::add(&mut l0.id, l16, l18);
-            unstructured {
-                goto 'label_135;
-            }
-        } else {
-            unstructured {
-                goto 'label_135;
-            }
+            dynamic_object_field::add(&mut l0.id, l16, l18)
         };
         /* block 135 */;
         let l19 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        *(&mut l19.total_collected) = verse::safe_add(*(&l19.total_collected), l15);
-        unstructured {
-            goto 'label_148;
-        }
+        *(&mut l19.total_collected) = verse::safe_add(*(&l19.total_collected), l15)
     };
     let l23;
     /* block 148 */;
@@ -2212,14 +1698,7 @@ public entry fun unlock_slot_with_token<T0, T1>(l0: &mut StakingPool<T1>, l1: u8
     if (!(dynamic_object_field::exists_(&l0.id, l23))) {
         let l8 = UserSlotAllocation { id: object::new(l4), owner: l22, max_slots_allowed: l11, total_slots_unlocked: 0u8, unlocked_slot_numbers: vector[] };
         dynamic_object_field::add(&mut l0.id, l23, l8);
-        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64);
-        unstructured {
-            goto 'label_186;
-        }
-    } else {
-        unstructured {
-            goto 'label_186;
-        }
+        *(&mut l0.total_users_with_slots) = verse::safe_add(*(&l0.total_users_with_slots), 1u64)
     };
     /* block 186 */;
     assert!(!(verse::is_slot_unlocked(freeze(l0), l22, l1)), C32);
@@ -2284,33 +1763,11 @@ public entry fun update_multiple_slot_rewards<T0>(l0: &mut StakingPool<T0>, l1: 
 
 public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: u64, l3: &Clock, l4: &mut TxContext) {
     assert!(tx_context::sender(freeze(l4)) == *(&l0.admin), C1);
-    let l5;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l5 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l5 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l5 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l5, C29);
-    let l6;
-    if (l2 >= C50) {
-        l6 = l2 <= C54;
-        unstructured {
-            goto 'label_53;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_53;
-        }
-    };
+    let l6 = l2 >= C50 && l2 <= C54;
     /* block 53 */;
     assert!(l6, C36);
     let l8 = clock::timestamp_ms(l3);
@@ -2337,19 +1794,8 @@ public entry fun update_slot_multiplier<T0>(l0: &mut StakingPool<T0>, l1: u8, l2
 
 public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: String, l3: u64, l4: &Clock, l5: &mut TxContext) {
     assert!(tx_context::sender(freeze(l5)) == *(&l0.admin), C1);
-    let l6;
     verse::assert_not_paused(freeze(l0));
-    if (l1 >= C53) {
-        l6 = l1 <= C52;
-        unstructured {
-            goto 'label_31;
-        }
-    } else {
-        l6 = false;
-        unstructured {
-            goto 'label_31;
-        }
-    };
+    let l6 = l1 >= C53 && l1 <= C52;
     /* block 31 */;
     assert!(l6, C29);
     let l9 = clock::timestamp_ms(l4);
@@ -2366,54 +1812,31 @@ public entry fun update_slot_price<T0>(l0: &mut StakingPool<T0>, l1: u8, l2: Str
             };
             l10 = l10 + 1u64;
         }
-    } else {
-        unstructured {
-            goto 'label_99;
-        }
     };
     /* block 99 */;
     let l16 = SlotTokenPricingKey { slot_number: l1 };
     if (dynamic_object_field::exists_(&l0.id, l16)) {
-        let l7;
         let l14 = dynamic_object_field::borrow_mut(&mut l0.id, l16);
-        if (table::contains(&l14.token_prices, l2)) {
-            l7 = *(table::borrow(&l14.token_prices, l2));
-            unstructured {
-                goto 'label_126;
-            }
+        let l7 = if (table::contains(&l14.token_prices, l2)) {
+            *(table::borrow(&l14.token_prices, l2))
         } else {
-            l7 = 0u64;
-            unstructured {
-                goto 'label_126;
-            }
+            0u64
         };
         let l13;
         /* block 126 */;
         l13 = l7;
         if (table::contains(&l14.token_prices, l2)) {
-            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3;
-            unstructured {
-                goto 'label_145;
-            }
+            *(table::borrow_mut(&mut l14.token_prices, l2)) = l3
         } else {
-            table::add(&mut l14.token_prices, l2, l3);
-            unstructured {
-                goto 'label_145;
-            }
+            table::add(&mut l14.token_prices, l2, l3)
         };
         /* block 145 */;
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: l13, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     } else {
         let l15 = SlotTokenPricing { id: object::new(l5), slot_number: l1, token_prices: table::new(l5) };
         table::add(&mut (&mut l15).token_prices, l2, l3);
         dynamic_object_field::add(&mut l0.id, l16, l15);
-        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 });
-        unstructured {
-            goto 'label_189;
-        }
+        event::emit(SlotPriceUpdated { pool_id: object::id(freeze(l0)), slot_number: l1, token_type: l2, old_price: 0u64, new_price: l3, updated_by: tx_context::sender(freeze(l5)), update_time: l9 })
     };
     /* block 189 */
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/action.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/action.snap
@@ -7,21 +7,12 @@ module action {
         match(&l2: Action) {
             Action::Stop => {
                 let Action::Stop {} = l2;
-                unstructured {
-                    goto 'label_26;
-                }
             },
             Action::MoveTo { x: reg_6, y: reg_7 } => {
                 let Action::MoveTo { x: reg_9, y: reg_10 } = l2;
-                unstructured {
-                    goto 'label_26;
-                }
             },
             Action::ChangeSpeed { pos0: reg_12 } => {
                 let Action::ChangeSpeed { pos0: reg_14 } = l2;
-                unstructured {
-                    goto 'label_26;
-                }
             },
         }
     }
@@ -53,16 +44,10 @@ module action {
             Action::MoveTo { x: reg_7, y: reg_8 } => {
                 let Action::MoveTo { x: reg_10, y: reg_11 } = &l3;
                 l1 =         *reg_10 : &u64;
-                unstructured {
-                    goto 'label_29;
-                }
             },
             Action::ChangeSpeed { pos0: reg_14 } => {
                 let Action::ChangeSpeed { pos0: reg_16 } = &l3;
                 l1 =         *reg_16 : &u64;
-                unstructured {
-                    goto 'label_29;
-                }
             },
         }
         return l1

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/action@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/action@full.snap
@@ -19,22 +19,13 @@ public fun destroy_action(l0: Action) {
     let l2 = l0;
     match (&l2) {
         Stop => {
-            let Action::Stop {} = l2;
-            unstructured {
-                goto 'label_26;
-            }
+            let Action::Stop {} = l2
         },
         MoveTo { x: reg_6, y: reg_7 } => {
-            let Action::MoveTo { x: reg_9, y: reg_10 } = l2;
-            unstructured {
-                goto 'label_26;
-            }
+            let Action::MoveTo { x: reg_9, y: reg_10 } = l2
         },
         ChangeSpeed { pos0: reg_12 } => {
-            let Action::ChangeSpeed { pos0: reg_14 } = l2;
-            unstructured {
-                goto 'label_26;
-            }
+            let Action::ChangeSpeed { pos0: reg_14 } = l2
         }
     };
     /* block 26 */
@@ -67,16 +58,10 @@ public fun speed(l0: &Action): u64 {
         MoveTo { x: reg_7, y: reg_8 } => {
             let Action::MoveTo { x: reg_10, y: reg_11 } = &l3;
             l1 = *reg_10 : &u64;
-            unstructured {
-                goto 'label_29;
-            }
         },
         ChangeSpeed { pos0: reg_14 } => {
             let Action::ChangeSpeed { pos0: reg_16 } = &l3;
             l1 = *reg_16 : &u64;
-            unstructured {
-                goto 'label_29;
-            }
         }
     };
     /* block 29 */;

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/colors.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/colors.snap
@@ -8,22 +8,13 @@ module colors {
         match(&l3: Color) {
             Color::Red => {
                 l1 = false;
-                unstructured {
-                    goto 'label_22;
-                }
             },
             Color::Green => {
                 l1 = false;
-                unstructured {
-                    goto 'label_22;
-                }
             },
             Color::Blue => {
                 let Color::Blue {} = l3;
                 l1 = true;
-                unstructured {
-                    goto 'label_22;
-                }
             },
         }
         return l1
@@ -35,22 +26,13 @@ module colors {
         match(&l3: Color) {
             Color::Red => {
                 l1 = false;
-                unstructured {
-                    goto 'label_22;
-                }
             },
             Color::Green => {
                 let Color::Green {} = l3;
                 l1 = true;
-                unstructured {
-                    goto 'label_22;
-                }
             },
             Color::Blue => {
                 l1 = false;
-                unstructured {
-                    goto 'label_22;
-                }
             },
         }
         return l1
@@ -63,21 +45,12 @@ module colors {
             Color::Red => {
                 let Color::Red {} = l3;
                 l1 = true;
-                unstructured {
-                    goto 'label_22;
-                }
             },
             Color::Green => {
                 l1 = false;
-                unstructured {
-                    goto 'label_22;
-                }
             },
             Color::Blue => {
                 l1 = false;
-                unstructured {
-                    goto 'label_22;
-                }
             },
         }
         return l1

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/colors@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/colors@full.snap
@@ -21,22 +21,13 @@ public fun is_blue(l0: Color): bool {
     match (&l3) {
         Red => {
             l1 = false;
-            unstructured {
-                goto 'label_22;
-            }
         },
         Green => {
             l1 = false;
-            unstructured {
-                goto 'label_22;
-            }
         },
         Blue => {
             let Color::Blue {} = l3;
             l1 = true;
-            unstructured {
-                goto 'label_22;
-            }
         }
     };
     /* block 22 */;
@@ -49,22 +40,13 @@ public fun is_green(l0: Color): bool {
     match (&l3) {
         Red => {
             l1 = false;
-            unstructured {
-                goto 'label_22;
-            }
         },
         Green => {
             let Color::Green {} = l3;
             l1 = true;
-            unstructured {
-                goto 'label_22;
-            }
         },
         Blue => {
             l1 = false;
-            unstructured {
-                goto 'label_22;
-            }
         }
     };
     /* block 22 */;
@@ -78,21 +60,12 @@ public fun is_red(l0: Color): bool {
         Red => {
             let Color::Red {} = l3;
             l1 = true;
-            unstructured {
-                goto 'label_22;
-            }
         },
         Green => {
             l1 = false;
-            unstructured {
-                goto 'label_22;
-            }
         },
         Blue => {
             l1 = false;
-            unstructured {
-                goto 'label_22;
-            }
         }
     };
     /* block 22 */;

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/geometry.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/geometry.snap
@@ -10,16 +10,10 @@ module geometry {
                 let Shape::Square { side: reg_6 } = l4;
                 let l7 = reg_6 : u64;
                 l1 = l7 * l7;
-                unstructured {
-                    goto 'label_33;
-                }
             },
             Shape::Triangle { base: reg_11, height: reg_12 } => {
                 let Shape::Triangle { base: reg_14, height: reg_15 } = l4;
                 l1 = reg_14 : u64 * reg_15 : u64 / 2u64;
-                unstructured {
-                    goto 'label_33;
-                }
             },
         }
         return l1

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/geometry@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/geometry@full.snap
@@ -26,16 +26,10 @@ public fun get_area(l0: Shape): u64 {
             let Shape::Square { side: reg_6 } = l4;
             let l7 = reg_6 : u64;
             l1 = l7 * l7;
-            unstructured {
-                goto 'label_33;
-            }
         },
         Triangle { base: reg_11, height: reg_12 } => {
             let Shape::Triangle { base: reg_14, height: reg_15 } = l4;
             l1 = reg_14 : u64 * reg_15 : u64 / 2u64;
-            unstructured {
-                goto 'label_33;
-            }
         }
     };
     /* block 33 */;

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/temperature.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/temperature.snap
@@ -11,15 +11,9 @@ module temperature {
         match(&l2: Temperature) {
             Temperature::Fahrenheit { pos0: reg_4 } => {
                 let Temperature::Fahrenheit { pos0: reg_6 } = l2;
-                unstructured {
-                    goto 'label_19;
-                }
             },
             Temperature::Celcius { pos0: reg_8 } => {
                 let Temperature::Celcius { pos0: reg_10 } = l2;
-                unstructured {
-                    goto 'label_19;
-                }
             },
         }
     }
@@ -33,15 +27,9 @@ module temperature {
         match(l0: Temperature) {
             Temperature::Fahrenheit { pos0: reg_3 } => {
                 l1 = true;
-                unstructured {
-                    goto 'label_14;
-                }
             },
             Temperature::Celcius => {
                 l1 = false;
-                unstructured {
-                    goto 'label_14;
-                }
             },
         }
         return l1

--- a/external-crates/move/crates/move-decompiler/tests/move/enums/temperature@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/enums/temperature@full.snap
@@ -22,16 +22,10 @@ public fun dtor(l0: Temperature) {
     let l2 = l0;
     match (&l2) {
         Fahrenheit { pos0: reg_4 } => {
-            let Temperature::Fahrenheit { pos0: reg_6 } = l2;
-            unstructured {
-                goto 'label_19;
-            }
+            let Temperature::Fahrenheit { pos0: reg_6 } = l2
         },
         Celcius { pos0: reg_8 } => {
-            let Temperature::Celcius { pos0: reg_10 } = l2;
-            unstructured {
-                goto 'label_19;
-            }
+            let Temperature::Celcius { pos0: reg_10 } = l2
         }
     };
     /* block 19 */
@@ -46,15 +40,9 @@ public fun is_temperature_fahrenheit(l0: &Temperature): bool {
     match (l0) {
         Fahrenheit { pos0: reg_3 } => {
             l1 = true;
-            unstructured {
-                goto 'label_14;
-            }
         },
         Celcius => {
             l1 = false;
-            unstructured {
-                goto 'label_14;
-            }
         }
     };
     /* block 14 */;

--- a/external-crates/move/crates/move-decompiler/tests/move/refinements/bool_if_simplify.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/refinements/bool_if_simplify.snap
@@ -3,67 +3,19 @@ source: crates/move-decompiler/tests/tests.rs
 ---
 module bool_if_simplify {
     public fun and_left () {
-        let l2;
-        if (l0 == 0u64) {
-            l2 = l1 > 0u64;
-            unstructured {
-                goto 'label_11;
-            }
-        } else {
-            l2 = false;
-            unstructured {
-                goto 'label_11;
-            }
-        }
-        return l2
+        return l0 == 0u64 && l1 > 0u64
     }
 
     public fun ident () {
-        let l1;
-        if (l0 == 0u64) {
-            l1 = true;
-            unstructured {
-                goto 'label_9;
-            }
-        } else {
-            l1 = false;
-            unstructured {
-                goto 'label_9;
-            }
-        }
-        return l1
+        return l0 == 0u64
     }
 
     public fun neg () {
-        let l1;
-        if (l0 == 0u64) {
-            l1 = false;
-            unstructured {
-                goto 'label_9;
-            }
-        } else {
-            l1 = true;
-            unstructured {
-                goto 'label_9;
-            }
-        }
-        return l1
+        return l0 != 0u64
     }
 
     public fun or_right () {
-        let l2;
-        if (l0 == 0u64) {
-            l2 = true;
-            unstructured {
-                goto 'label_11;
-            }
-        } else {
-            l2 = l1 > 0u64;
-            unstructured {
-                goto 'label_11;
-            }
-        }
-        return l2
+        return l0 == 0u64 || l1 > 0u64
     }
 
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/refinements/bool_if_simplify@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/refinements/bool_if_simplify@full.snap
@@ -8,69 +8,17 @@ module refinements::bool_if_simplify;
 // -- functions -- 
 
 public fun and_left(l0: u64, l1: u64): bool {
-    let l2;
-    if (l0 == 0u64) {
-        l2 = l1 > 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l2 = false;
-        unstructured {
-            goto 'label_11;
-        }
-    };
-    /* block 11 */;
-    return l2
+    /* block 11 */ return l0 == 0u64 && l1 > 0u64
 }
 
 public fun ident(l0: u64): bool {
-    let l1;
-    if (l0 == 0u64) {
-        l1 = true;
-        unstructured {
-            goto 'label_9;
-        }
-    } else {
-        l1 = false;
-        unstructured {
-            goto 'label_9;
-        }
-    };
-    /* block 9 */;
-    return l1
+    /* block 9 */ return l0 == 0u64
 }
 
 public fun neg(l0: u64): bool {
-    let l1;
-    if (l0 == 0u64) {
-        l1 = false;
-        unstructured {
-            goto 'label_9;
-        }
-    } else {
-        l1 = true;
-        unstructured {
-            goto 'label_9;
-        }
-    };
-    /* block 9 */;
-    return l1
+    /* block 9 */ return l0 != 0u64
 }
 
 public fun or_right(l0: u64, l1: u64): bool {
-    let l2;
-    if (l0 == 0u64) {
-        l2 = true;
-        unstructured {
-            goto 'label_11;
-        }
-    } else {
-        l2 = l1 > 0u64;
-        unstructured {
-            goto 'label_11;
-        }
-    };
-    /* block 11 */;
-    return l2
+    /* block 11 */ return l0 == 0u64 || l1 > 0u64
 }

--- a/external-crates/move/crates/move-decompiler/tests/move/staleness/staleness.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/staleness/staleness.snap
@@ -48,25 +48,11 @@ module staleness {
         if (l0 > l1) {
             if (l0 - l1 >= l2) {
                 *l4 = false
-                unstructured {
-                    goto 'label_39;
-                }
-            } else {
-                unstructured {
-                    goto 'label_39;
-                }
             }
         } else {
             if (l1 - l0 >= l2) {
                 *l4 = false
                 *l3 =         *l3 + 1u64
-                unstructured {
-                    goto 'label_39;
-                }
-            } else {
-                unstructured {
-                    goto 'label_39;
-                }
             }
         }
     }

--- a/external-crates/move/crates/move-decompiler/tests/move/staleness/staleness@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/staleness/staleness@full.snap
@@ -53,26 +53,12 @@ public fun inner_loop_two_feed(l0: u64, l1: u64, l2: u64, l3: u64, l4: &mut bool
 public fun non_uniform_arms(l0: u64, l1: u64, l2: u64, l3: &mut u64, l4: &mut bool) {
     if (l0 > l1) {
         if (l0 - l1 >= l2) {
-            *l4 = false;
-            unstructured {
-                goto 'label_39;
-            }
-        } else {
-            unstructured {
-                goto 'label_39;
-            }
+            *l4 = false
         }
     } else {
         if (l1 - l0 >= l2) {
             *l4 = false;
-            *l3 = *l3 + 1u64;
-            unstructured {
-                goto 'label_39;
-            }
-        } else {
-            unstructured {
-                goto 'label_39;
-            }
+            *l3 = *l3 + 1u64
         }
     };
     /* block 39 */


### PR DESCRIPTION
## Description

Two refinements plus a pretty-printer change that take the surviving goto count from 1779 down to 1. `elide_tail_goto_to_block` handles the dominant residual pattern post-dom-tree-elision: an `IfElse` (or other tail-bearing form) whose arms end with `Unstructured(Goto(N))`, immediately followed by `Block(N, _)` in the same `Seq`. Fall-through from the if-else's natural exit already lands on the block, so the trailing goto is redundant; this strips it from every tail position. Walks past side-effect-free `Declare(_)` statements that `hoist_declarations` floated between the if-else and the labeled block. `goto_to_break` handles the remaining forward gotos: for a surviving `Goto(N)` whose `Block(N, body)` lives later in the same Seq (a forward jump), wraps `items[k..=block_index]` in `Block(N, ...)`, rewrites each `Goto(N)` in the wrapped prefix to `Break(Some(N))`, and splices the landing body's items out to follow the wrap. Strict forward-only — a goto whose target appears earlier (backward) is a structurer-missed loop and stays raw; same for a goto from inside the block body to the block itself. Consumes the shared `rewrite_gotos_as_breaks` + walker helpers from the previous PR. Pretty-printer: `Context` now carries `goto_targets: HashSet<u64>`, populated per-function from `translate::collect_goto_targets` (`pub(crate)` for this); `Block(N)` renders as `'label_N: { body }` when targeted (vs the legacy `/* block N */` inline comment), and `Break(Some(N))` / `Continue(Some(N))` render as `'label_N` for targeted block ids vs `'loop_N` for loop labels. The one residual goto is a CFG-irreducible case where the target sits inside a loop the goto sits outside.

## Test Plan

`cargo nextest run` from `external-crates/move/crates/move-decompiler` — corpus snapshots regenerate to reflect the labeled-break rendering across the bytecode corpus; 100 tests pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
