### PR TITLE
ci(sccache): dual-pass OIDC for rust.yml and external.yml (Phase 3)

### DIFF
--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -19,14 +19,14 @@ Keep any new `SCCACHE_ROLE` gate in sync with this exact set.
 
 ## Status
 
-| Workflow             | Call sites | Triggers                                     | Auth today  | Phase |
-| -------------------- | ---------- | -------------------------------------------- | ----------- | ----- |
-| `sccache-warmup.yml` | 2          | schedule, workflow_dispatch                  | **OIDC ✅** | 1 ✅  |
-| `nightly.yml`        | 1          | schedule, workflow_dispatch (disabled)       | **OIDC ✅** | 2 ✅  |
-| `rust.yml`           | 11         | push, pull_request, workflow_dispatch        | static keys | 3/4   |
-| `external.yml`       | 2          | push, pull_request                           | static keys | 3/4   |
-| `bridge.yml`         | 2          | push, pull_request, workflow_dispatch        | static keys | 3/4   |
-| `release.yml`        | 1          | release, workflow_dispatch                   | static keys | 5     |
+| Workflow             | Call sites | Triggers                                     | Auth today                                   | Phase    |
+| -------------------- | ---------- | -------------------------------------------- | -------------------------------------------- | -------- |
+| `sccache-warmup.yml` | 2          | schedule, workflow_dispatch                  | **OIDC ✅**                                  | 1 ✅     |
+| `nightly.yml`        | 1          | schedule, workflow_dispatch (disabled)       | **OIDC ✅**                                  | 2 ✅     |
+| `rust.yml`           | 11         | push, pull_request, workflow_dispatch        | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
+| `external.yml`       | 2          | push, pull_request                           | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
+| `bridge.yml`         | 2          | push, pull_request, workflow_dispatch        | **dual-pass ✅** (PR #26927)                 | 3 ✅ → 4 |
+| `release.yml`        | 1          | release, workflow_dispatch                   | static keys                                  | 5        |
 
 ## How each event/ref classifies
 

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -33,6 +33,12 @@ env:
   RUST_BACKTRACE: short
   # RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
+  # sccache RW role on trusted refs only. Empty elsewhere → setup-sccache falls
+  # back to static keys (same-repo PRs) or a local cache (forks). The extensions
+  # branch is deliberately not in the role trust (dormant; see
+  # AWS_OIDC_MIGRATION_INVENTORY.md). No workflow_dispatch here, so no
+  # override-ref clause. Keep in sync with the sui-sccache-rw-github trust policy.
+  SCCACHE_ROLE: ${{ (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
 
 jobs:
   diff:
@@ -47,6 +53,9 @@ jobs:
         id: diff
 
   external-crates-test:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
@@ -65,6 +74,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -99,6 +109,9 @@ jobs:
       - run: 'echo "No build required" '
 
   clippy:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ubuntu-ghcloud]
@@ -106,6 +119,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,13 @@ env:
   # Set log level in CI to error. If you need more information to debug a CI
   # failure, change this temporarily and rerun your tests
   RUST_LOG: error
+  # sccache RW role on trusted refs only (protected branches + release branches),
+  # AND only when not building an override ref: a workflow_dispatch with a non-empty
+  # sui_repo_ref checks out arbitrary code, so it must NOT hold the RW cache even
+  # though github.ref (and the OIDC sub) is main. Empty elsewhere → setup-sccache
+  # falls back to static keys (same-repo PRs) or a local cache (forks / overrides).
+  # Keep in sync with the sui-sccache-rw-github trust policy.
+  SCCACHE_ROLE: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.sui_repo_ref == '') && (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
 
 jobs:
   diff:
@@ -76,6 +83,9 @@ jobs:
         run: scripts/git-checks.sh
 
   test:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
@@ -96,6 +106,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -125,6 +136,9 @@ jobs:
         shell: bash
 
   test-tidehunter:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
@@ -145,6 +159,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -190,6 +205,9 @@ jobs:
       - run: 'echo "No build required" '
 
   test-extra:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
@@ -210,6 +228,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -264,6 +283,9 @@ jobs:
         shell: bash
 
   benchmark-smoke:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     name: benchmark (smoke)
     needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
@@ -275,6 +297,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -323,6 +346,9 @@ jobs:
           cargo bench --package consensus-core --bench commit_finalizer_bench -- --test
 
   windows-build:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
@@ -333,6 +359,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: windows-ghcloud
@@ -345,6 +372,9 @@ jobs:
           cargo build --all-features
 
   windows-cli-tests:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
@@ -360,6 +390,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: windows-ghcloud
@@ -373,6 +404,9 @@ jobs:
           cargo nextest run -p sui --no-fail-fast --profile ci --cargo-quiet --filter-expr "not test(shell_tests::with_network)"
 
   simtest:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
     timeout-minutes: 45
@@ -385,6 +419,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -408,6 +443,9 @@ jobs:
           scripts/simtest/stress-new-tests.sh
 
   simtest-mainnet:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
     timeout-minutes: 45
@@ -421,6 +459,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -447,6 +486,9 @@ jobs:
   # to Move code but not Rust code (If there are Rust changes, they
   # will be run as part of a larger test suite).
   move-test:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: diff
     if: needs.diff.outputs.isRust == 'false' && needs.diff.outputs.isMove == 'true'
     timeout-minutes: 10
@@ -457,6 +499,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -544,6 +587,9 @@ jobs:
       - run: 'echo "No build required" '
 
   clippy:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ ubuntu-ghcloud ]
@@ -553,6 +599,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
@@ -624,6 +671,9 @@ jobs:
       - run: cargo deny check advisories --hide-inclusion-graph
 
   sui-excution-cut:
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the sccache role on trusted refs
     name: cutting a new execution layer
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true'
@@ -634,6 +684,7 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud


### PR DESCRIPTION
## Summary

Replicates the dual-pass OIDC pattern validated in `bridge.yml` (#26927) to the two remaining mixed-trigger sccache callers, completing Phase 3 of the static-key → OIDC migration (see `.github/AWS_OIDC_MIGRATION_INVENTORY.md`):

- **`rust.yml`** — all 11 call sites: workflow-level `SCCACHE_ROLE` (identical expression to bridge.yml, including the `sui_repo_ref` override-ref guard: a `workflow_dispatch` from main building an override ref has a trusted OIDC sub but runs untrusted code, so it must not hold the RW role), `role-to-assume` on each `setup-sccache` call, and `permissions: {contents: read, id-token: write}` on each sccache job.
- **`external.yml`** — both call sites: same, minus the override-ref clause (no `workflow_dispatch` input). The dormant `extensions` branch remains outside the role trust by design.
- Inventory doc status table updated: rust/external/bridge now dual-pass, Phase 3 complete.

Behavior matrix (unchanged for PRs):

| Event/ref | Before | After |
|---|---|---|
| push to protected/release branches | static keys (RW) | **OIDC RW** |
| dispatch from main, no override ref | static keys (RW) | **OIDC RW** |
| dispatch building `sui_repo_ref` override | static keys (RW) | static keys (conservative; Phase 4 target) |
| same-repo `pull_request` | static keys (RW) | static keys — **unchanged** |
| fork `pull_request` | no secrets → local cache | local cache — **unchanged** |

Phase 4 (PR cache model A/B/C decision) and Phase 5 (`release.yml` environment-sub handling) remain, after which static keys can be removed (Phase 7).

## Test plan

- [x] `actionlint` on both workflows: zero new findings (the 11 pre-existing shellcheck/isSolidity infos are identical on `main`)
- [x] `SCCACHE_ROLE` expression is byte-identical to the bridge.yml one already validated in production (3 successful trusted-push runs since #26927 merged)
- [x] All 13 call sites confirmed: `role-to-assume` line count 11+2; `id-token: write` count 11+2
- [x] Audited every step of all 13 jobs for `GITHUB_TOKEN` write usage before adding restricted `permissions:` blocks — all are pure build/test (taiki-e / cargo-install actions only need contents read)
- [ ] Post-merge: confirm first trusted push run assumes the role (sccache step logs show OIDC) and PR runs still use static keys

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: