### PR TITLE
Fall back to newest public version in protocol compatibility check

### DIFF
--- a/scripts/compatibility/check-protocol-compatibility.sh
+++ b/scripts/compatibility/check-protocol-compatibility.sh
@@ -4,6 +4,8 @@
 
 NETWORK="$1"
 
+git fetch -q || exit 1
+
 if [ -z "$RELEASED_COMMIT" ]; then
   # check if API_USER and API_KEY env vars are set
   if [ -z "$API_USER" ] || [ -z "$API_KEY" ]; then
@@ -38,13 +40,34 @@ if [ -z "$RELEASED_COMMIT" ]; then
   echo "Found following versions on $NETWORK:"
   echo "$VERSIONS"
   echo ""
-  echo "Using most frequent version $TOP_VERSION for compatibility check"
 
-  # TOP_VERSION looks like "1.0.0-ae1212baf8", split out the commit hash
-  RELEASED_COMMIT=$(echo "$TOP_VERSION" | cut -d- -f2)
+  # Versions look like "1.0.0-ae1212baf8"; the suffix is the commit the node
+  # was built from. During a private security release the dominant suffix is a
+  # sui-private commit that does not resolve in this repo, so walk down the
+  # list (most frequent first) to the newest publicly-resolvable commit: the
+  # public base the private fix was built on, which carries the same protocol
+  # snapshots. This check gates the public source, so comparing against the
+  # public ancestor checks the same protocol surface.
+  for version in $(echo "$VERSIONS" | awk '{print $2}'); do
+    sha=$(echo "$version" | cut -d- -f2)
+    if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+      RELEASED_COMMIT="$sha"
+      if [ "$version" = "$TOP_VERSION" ]; then
+        echo "Using most frequent version $version for compatibility check"
+      else
+        echo "WARNING: most frequent version $TOP_VERSION does not resolve in this repo (private release?)"
+        echo "Falling back to most frequent publicly-resolvable version $version for compatibility check"
+      fi
+      break
+    fi
+  done
+
+  if [ -z "$RELEASED_COMMIT" ]; then
+    echo "Error: no version on $NETWORK resolves to a commit in this repo"
+    exit 1
+  fi
 fi
 
-git fetch -q || exit 1
 SOURCE_COMMIT=$(git rev-parse HEAD)
 SOURCE_BRANCH=$(git branch -a --contains "$SOURCE_COMMIT" | head -n 1 | cut -d' ' -f2-)
 

--- a/scripts/compatibility/check-protocol-compatibility.sh
+++ b/scripts/compatibility/check-protocol-compatibility.sh
@@ -42,25 +42,36 @@ if [ -z "$RELEASED_COMMIT" ]; then
   echo ""
 
   # Versions look like "1.0.0-ae1212baf8"; the suffix is the commit the node
-  # was built from. During a private security release the dominant suffix is a
-  # sui-private commit that does not resolve in this repo, so walk down the
-  # list (most frequent first) to the newest publicly-resolvable commit: the
-  # public base the private fix was built on, which carries the same protocol
-  # snapshots. This check gates the public source, so comparing against the
-  # public ancestor checks the same protocol surface.
-  for version in $(echo "$VERSIONS" | awk '{print $2}'); do
-    sha=$(echo "$version" | cut -d- -f2)
-    if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
-      RELEASED_COMMIT="$sha"
-      if [ "$version" = "$TOP_VERSION" ]; then
-        echo "Using most frequent version $version for compatibility check"
-      else
-        echo "WARNING: most frequent version $TOP_VERSION does not resolve in this repo (private release?)"
-        echo "Falling back to most frequent publicly-resolvable version $version for compatibility check"
+  # was built from. Use the most frequent version exactly when its commit
+  # resolves here. During a private security release that suffix is a
+  # sui-private commit that does not resolve in this repo: approximate its
+  # public base instead — the highest publicly-resolvable version that is not
+  # newer than the dominant one (ties broken by node count). The semver
+  # ceiling keeps a stray node on a newer public build from hijacking the
+  # baseline, and "highest" (rather than most frequent) tracks the private
+  # build's lineage even when an older public cohort has more nodes. This
+  # check gates the public source, so the public base carries the protocol
+  # snapshots being validated.
+  TOP_SHA=$(echo "$TOP_VERSION" | cut -d- -f2)
+  if git cat-file -e "${TOP_SHA}^{commit}" 2>/dev/null; then
+    RELEASED_COMMIT="$TOP_SHA"
+    echo "Using most frequent version $TOP_VERSION for compatibility check"
+  else
+    TOP_BASE=${TOP_VERSION%%-*}
+    while read -r semver sha count fullver; do
+      # skip versions newer than the dominant one
+      if [ "$semver" != "$TOP_BASE" ] && \
+         [ "$(printf '%s\n%s\n' "$semver" "$TOP_BASE" | sort -V | tail -n1)" = "$semver" ]; then
+        continue
       fi
-      break
-    fi
-  done
+      if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+        RELEASED_COMMIT="$sha"
+        echo "WARNING: most frequent version $TOP_VERSION does not resolve in this repo (private release?)"
+        echo "Falling back to highest publicly-resolvable version $fullver ($count nodes) for compatibility check"
+        break
+      fi
+    done < <(echo "$VERSIONS" | awk '{split($2, a, "-"); print a[1], a[2], $1, $2}' | sort -k1,1Vr -k3,3nr)
+  fi
 
   if [ -z "$RELEASED_COMMIT" ]; then
     echo "Error: no version on $NETWORK resolves to a commit in this repo"


### PR DESCRIPTION
## Summary

`check-protocol-compatibility.sh` resolves the fleet's most frequent version suffix to a commit in this repo. During a private security release (like the current v1.72.6 rollout) the dominant suffix is a `sui-private` commit, so the check dies with `fatal: invalid reference: a13edbc73d31` ([failed run](https://github.com/MystenLabs/sui-operations/actions/runs/27331251891/job/80843504710)) — and stays broken until a public release dominates fleet telemetry again.

Fix, in two layers:

1. **Dominant version resolves publicly** → exact existing behavior, unchanged.
2. **Dominant version is private** → fall back to the **highest publicly-resolvable version that is not newer than the dominant one** (ties broken by node count), with a loud warning. "Highest under the dominant's semver" — rather than most-frequent-public — tracks the private build's lineage even when an older public cohort has more nodes, and the semver ceiling keeps a stray node on a newer public build from hijacking the baseline. Fails closed if nothing on the network resolves.

Also moves `git fetch` ahead of version selection so resolution checks see fresh refs.

Caveat documented in the script: a hypothetical private release that *changed* protocol snapshots would be compared against its public base — acceptable, since a privately-shipped protocol change is incompatible by definition and this check gates the public source.

## Test plan

All runs in a worktree pinned to `004a12a0fe` — the exact source commit of the failed CI run — with the version list injected in place of the gateway curl. Full script runs end-to-end including `cargo test --package sui-protocol-config snapshot_tests`:

- [x] **Reproduce**: original script with live mainnet data (108×`1.72.6-a13edbc73d31` dominant, 19 versions) fails byte-for-byte like the incident (`fatal: invalid reference`, exit 1)
- [x] **Live data**: warns, falls back to `1.72.5-5445323ef25a` (34 nodes), snapshot checks + tests pass, exit 0
- [x] **Lineage over frequency** (review blind spot): private dominant + public counts skewed older (50×`1.72.2`, 5×`1.72.5`) → selects `1.72.5` (the private build's base), not the larger `1.72.2` cohort
- [x] **Semver ceiling**: a stray node on public `1.73.2` (newer than the 1.72.6 dominant) is skipped; baseline stays `1.72.5`
- [x] **Happy path**: public dominant → `Using most frequent version …`, no warning, identical flow to the old script, exit 0
- [x] **Fail-closed**: no version resolves publicly → explicit error, exit 1
- [x] `shellcheck` clean on the changed lines (two pre-existing findings untouched); truncated fleet suffixes (10-char) resolve fine

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: