### PR TITLE
[sui-adapter][easy] Skip collecting runtime telemetry for dry-run/dev-inspect

### DIFF
--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -460,62 +460,66 @@ mod checked {
             *epoch_id,
         );
 
-        metrics.vm_telemetry_metrics.try_update(|vm_metrics| {
-            let t = move_vm.get_telemetry_report();
-            vm_metrics
-                .move_vm_package_cache_count
-                .set(t.package_cache_count as i64);
-            vm_metrics
-                .move_vm_total_arena_size_bytes
-                .set(t.total_arena_size as i64);
-            vm_metrics.move_vm_module_count.set(t.module_count as i64);
-            vm_metrics
-                .move_vm_function_count
-                .set(t.function_count as i64);
-            vm_metrics.move_vm_type_count.set(t.type_count as i64);
-            vm_metrics.move_vm_interner_size.set(t.interner_size as i64);
-            vm_metrics
-                .move_vm_vtable_cache_count
-                .set(t.vtable_cache_count as i64);
-            vm_metrics
-                .move_vm_vtable_cache_hits
-                .set(t.vtable_cache_hits as i64);
-            vm_metrics
-                .move_vm_vtable_cache_misses
-                .set(t.vtable_cache_misses as i64);
-            vm_metrics
-                .move_vm_load_time_ms
-                .set(t.total_load_time as i64);
-            vm_metrics.move_vm_load_count.set(t.load_count as i64);
-            vm_metrics
-                .move_vm_validation_time_ms
-                .set(t.total_validation_time as i64);
-            vm_metrics
-                .move_vm_validation_count
-                .set(t.validation_count as i64);
-            vm_metrics.move_vm_jit_time_ms.set(t.total_jit_time as i64);
-            vm_metrics.move_vm_jit_count.set(t.jit_count as i64);
-            vm_metrics
-                .move_vm_execution_time_ms
-                .set(t.total_execution_time as i64);
-            vm_metrics
-                .move_vm_execution_count
-                .set(t.execution_count as i64);
-            vm_metrics
-                .move_vm_interpreter_time_ms
-                .set(t.total_interpreter_time as i64);
-            vm_metrics
-                .move_vm_interpreter_count
-                .set(t.interpreter_count as i64);
-            vm_metrics
-                .move_vm_max_callstack_size
-                .set(t.max_callstack_size as i64);
-            vm_metrics
-                .move_vm_max_valuestack_size
-                .set(t.max_valuestack_size as i64);
-            vm_metrics.move_vm_total_time_ms.set(t.total_time as i64);
-            vm_metrics.move_vm_total_count.set(t.total_count as i64);
-        });
+        // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
+        // spun-up each time.
+        if !Mode::TRACK_EXECUTION {
+            metrics.vm_telemetry_metrics.try_update(|vm_metrics| {
+                let t = move_vm.get_telemetry_report();
+                vm_metrics
+                    .move_vm_package_cache_count
+                    .set(t.package_cache_count as i64);
+                vm_metrics
+                    .move_vm_total_arena_size_bytes
+                    .set(t.total_arena_size as i64);
+                vm_metrics.move_vm_module_count.set(t.module_count as i64);
+                vm_metrics
+                    .move_vm_function_count
+                    .set(t.function_count as i64);
+                vm_metrics.move_vm_type_count.set(t.type_count as i64);
+                vm_metrics.move_vm_interner_size.set(t.interner_size as i64);
+                vm_metrics
+                    .move_vm_vtable_cache_count
+                    .set(t.vtable_cache_count as i64);
+                vm_metrics
+                    .move_vm_vtable_cache_hits
+                    .set(t.vtable_cache_hits as i64);
+                vm_metrics
+                    .move_vm_vtable_cache_misses
+                    .set(t.vtable_cache_misses as i64);
+                vm_metrics
+                    .move_vm_load_time_ms
+                    .set(t.total_load_time as i64);
+                vm_metrics.move_vm_load_count.set(t.load_count as i64);
+                vm_metrics
+                    .move_vm_validation_time_ms
+                    .set(t.total_validation_time as i64);
+                vm_metrics
+                    .move_vm_validation_count
+                    .set(t.validation_count as i64);
+                vm_metrics.move_vm_jit_time_ms.set(t.total_jit_time as i64);
+                vm_metrics.move_vm_jit_count.set(t.jit_count as i64);
+                vm_metrics
+                    .move_vm_execution_time_ms
+                    .set(t.total_execution_time as i64);
+                vm_metrics
+                    .move_vm_execution_count
+                    .set(t.execution_count as i64);
+                vm_metrics
+                    .move_vm_interpreter_time_ms
+                    .set(t.total_interpreter_time as i64);
+                vm_metrics
+                    .move_vm_interpreter_count
+                    .set(t.interpreter_count as i64);
+                vm_metrics
+                    .move_vm_max_callstack_size
+                    .set(t.max_callstack_size as i64);
+                vm_metrics
+                    .move_vm_max_valuestack_size
+                    .set(t.max_valuestack_size as i64);
+                vm_metrics.move_vm_total_time_ms.set(t.total_time as i64);
+                vm_metrics.move_vm_total_count.set(t.total_count as i64);
+            });
+        }
 
         (
             inner,


### PR DESCRIPTION
## Description 

A new runtime is spun up for dry-run/dev-inspect calls, so any VM telemetry from those calls shouldn't be reported as it will have pollute metrics (esp. cache metrics).

Skip reporting for these cases by wrapping it in an `if !Mode::TRACK_EXECUTION` which is set only for these two. Diff looks larger than it is because of the formatting change. 

## Test plan 

👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
