### PR TITLE
ci(release): split sui-releases S3 ops into an OIDC environment job (Phase 5)

### DIFF
--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -73,9 +73,11 @@ Note `extensions` push is **not** trusted (branch is 404 → excluded) → local
 `release-build`, prefix `${{ matrix.os }}`. Triggers on `release: created`
 (tag) + `workflow_dispatch`.
 
-**Done — option (b), the job split.** `release-build` no longer configures AWS
-credentials at all: the existing-archive download uses the bucket's public read
-access, and all `sui-releases` writes moved to `upload-release-archives-to-s3`,
+**Done — option (b), the job split.** `release-build` no longer holds any
+`sui-releases` credentials (its only remaining AWS credentials are the static
+sccache keys passed to `setup-sccache`): the existing-archive download uses the
+bucket's public read access, and all `sui-releases` writes moved to
+`upload-release-archives-to-s3`,
 which declares `environment: release` and assumes the `release-s3` role via OIDC
 (roles doc, Role 2). The `release` GitHub Environment exists with a custom
 deployment branch policy (`main` + `devnet-v*`/`testnet-v*`/`mainnet-v*` tags).

--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -26,7 +26,7 @@ Keep any new `SCCACHE_ROLE` gate in sync with this exact set.
 | `rust.yml`           | 11         | push, pull_request, workflow_dispatch        | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
 | `external.yml`       | 2          | push, pull_request                           | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
 | `bridge.yml`         | 2          | push, pull_request, workflow_dispatch        | **dual-pass ✅** (PR #26927)                 | 3 ✅ → 4 |
-| `release.yml`        | 1          | release, workflow_dispatch                   | static keys                                  | 5        |
+| `release.yml`        | 1          | release, workflow_dispatch                   | sccache static; **S3 ops OIDC ✅** (release env) | 5 (S3 ✅) |
 
 ## How each event/ref classifies
 
@@ -68,24 +68,24 @@ Note `extensions` push is **not** trusted (branch is 404 → excluded) → local
 
 `clippy` (L85), `test` (L111). Prefix `ubuntu-ghcloud`.
 
-### `release.yml` — 1 site — **Phase 5, special**
+### `release.yml` — 1 site — **Phase 5: S3 done (job split), sccache remains**
 
-`release-build` (L155), prefix `${{ matrix.os }}`. Triggers on `release: created`
-(tag) + `workflow_dispatch`. **Two reasons it is not part of the Phase-3 batch:**
-1. It also writes to `s3://sui-releases` via the **separate** `release-s3` role in
-   the **same job**, and `configure-aws-credentials` overwrites cred env vars — the
-   job must re-assume the right role before each S3 op (see roles doc §"Credential
-   sequencing"). The `release` GitHub Environment for that role now exists.
-2. **Environment-sub subtlety (not a tag-trust gap).** Once `release-build` declares
-   `environment: release` (required for the `release-s3` role), **every** OIDC assume
-   in that job — the sccache one included — presents
-   `sub=repo:MystenLabs/sui:environment:release`, **not** a tag/branch ref. So adding
-   `*-v*` tag trust to role #1 would do **nothing** for the sccache step. To give it
-   OIDC, pick one in Phase 5:
-   - **(a)** role #1 **also** trusts `repo:MystenLabs/sui:environment:release`; or
-   - **(b)** restructure `release.yml` so the sccache **build** runs in a job
-     *without* `environment: release` (gets a branch/tag sub role #1 trusts) and only
-     the S3 upload/download runs in a job *with* `environment: release`.
+`release-build`, prefix `${{ matrix.os }}`. Triggers on `release: created`
+(tag) + `workflow_dispatch`.
+
+**Done — option (b), the job split.** `release-build` no longer configures AWS
+credentials at all: the existing-archive download uses the bucket's public read
+access, and all `sui-releases` writes moved to `upload-release-archives-to-s3`,
+which declares `environment: release` and assumes the `release-s3` role via OIDC
+(roles doc, Role 2). The `release` GitHub Environment exists with a custom
+deployment branch policy (`main` + `devnet-v*`/`testnet-v*`/`mainnet-v*` tags).
+
+**Remaining — the sccache call site.** Because of the split, `release-build`'s
+OIDC sub is now a plain tag/branch ref (no environment), so giving sccache OIDC
+needs role #1 to trust the release subs: `refs/tags/{devnet,testnet,mainnet}-v*`
+for `release:` events plus `refs/heads/main` (already trusted) for dispatch.
+Until that trust is added, sccache keeps static keys here — it must stay working
+through Phase 7 or release builds lose the S3 cache.
 
 ## Trust-policy gaps — status
 
@@ -98,10 +98,11 @@ to local cache):
 2. **`extensions` branch** — **excluded.** The branch returns 404 (not active), so
    trusting it now is unused attack surface. Add only if it is confirmed active again;
    until then `external.yml` `extensions` pushes fall back to local cache.
-3. **`release.yml` sccache** — **not a tag-trust gap.** Because `release-build` will
-   declare `environment: release`, its OIDC sub is `environment:release`, not a tag
-   ref — adding `*-v*` tag trust would not help. See the `release.yml` section above
-   for the two Phase-5 options.
+3. **`release.yml` sccache** — **now a tag-trust gap (post job-split).** With the
+   S3 ops moved to their own `environment: release` job, `release-build`'s sub is a
+   plain tag/branch ref. Giving its sccache step OIDC requires role #1 to trust
+   `refs/tags/{devnet,testnet,mainnet}-v*` (dispatch-from-main is already covered).
+   Static keys remain on this one call site until then.
 
 ## Recommended Phase-3 mechanic for mixed-trigger callers
 

--- a/.github/AWS_OIDC_ROLES.md
+++ b/.github/AWS_OIDC_ROLES.md
@@ -258,13 +258,14 @@ artifacts to `sui-releases` (Role 2). `configure-aws-credentials` (and therefore
 `setup-sccache`) **overwrites the AWS credential env vars** each time it runs —
 whichever role was configured last wins within a job.
 
-Resolved with a **two-job split**: `release-build` no longer configures AWS
-credentials at all (the existing-archive download uses the bucket's public read
-access; sccache still uses static keys pending Role 1 trust for release-event
-subs), and the `upload-release-archives-to-s3` job — `environment: release`,
-Role 2 — receives the archives as workflow artifacts and performs every
-`sui-releases` write. The two roles never coexist in one job, so there is no
-credential sequencing to manage.
+Resolved with a **two-job split**: `release-build` no longer holds any
+`sui-releases` credentials — its only remaining AWS credentials are the static
+sccache keys `setup-sccache` configures for the cache bucket (pending Role 1
+trust for release-event subs), and the existing-archive download uses the
+bucket's public read access. The `upload-release-archives-to-s3` job —
+`environment: release`, Role 2 — receives the archives as workflow artifacts
+and performs every `sui-releases` write. The two roles never coexist in one
+job, so there is no credential sequencing to manage.
 
 ---
 

--- a/.github/AWS_OIDC_ROLES.md
+++ b/.github/AWS_OIDC_ROLES.md
@@ -181,14 +181,14 @@ fork exclusion must drop that permission, not just the role input.)
 `workflow_dispatch`. Keep this **separate** from the cache role (different
 bucket, narrower trust).
 
-> **Status: PROVISIONED 2026-06-08** as
+> **Status: ACTIVE.** Provisioned 2026-06-08 as
 > **`arn:aws:iam::011083325127:role/sui-releases-rw-github`** (inline policy
 > `sui-releases-rw` = exactly the least-privilege policy below). Trust =
 > `repo:MystenLabs/sui:environment:release` (the environment variant), aud
-> pinned, no wildcard. **Not yet assumable** — Phase 5 must still (1) create the
-> `release` GitHub Environment with branch/tag protection + reviewers, and
-> (2) add `environment: release` to the release job. Until both exist, no run can
-> assume it (safe by construction).
+> pinned, no wildcard. The `release` GitHub Environment exists with a custom
+> deployment branch policy (`main` branch + `devnet-v*`/`testnet-v*`/`mainnet-v*`
+> tags), and `release.yml`'s `upload-release-archives-to-s3` job declares
+> `environment: release` and assumes this role.
 
 ### Trust policy — use a `release` environment (do NOT use tag subjects alone)
 
@@ -251,26 +251,20 @@ cover cleanup of interrupted transfers):
 > It can reuse Role 1 (it runs on `main`/scheduled), so no separate role is
 > needed there.
 
-### Credential sequencing — `release.yml` touches BOTH buckets in one job
+### Credential sequencing — `release.yml` touches BOTH buckets
 
 `release.yml` builds with sccache (`mystenlabs-sccache`, Role 1) **and** uploads
-artifacts to `sui-releases` (Role 2) in the same job. `configure-aws-credentials`
-(and therefore `setup-sccache`) **overwrites the AWS credential env vars** each
-time it runs — whichever role was configured last wins. Do **not** assume the
-build-time sccache creds are still active at the `aws s3 cp` upload step.
+artifacts to `sui-releases` (Role 2). `configure-aws-credentials` (and therefore
+`setup-sccache`) **overwrites the AWS credential env vars** each time it runs —
+whichever role was configured last wins within a job.
 
-Manage the switch deliberately. Options:
-
-- **Re-assume `release-s3` immediately before the upload/download steps** — add a
-  dedicated `configure-aws-credentials` (with `role-to-assume: <release-s3 ARN>`,
-  `allowed-account-ids: '011083325127'`) right before the `aws s3 cp` block, so
-  the release creds are the active ones at upload time. Simplest, recommended.
-- **Split into two jobs** — a build job (Role 1, sccache) and an upload job
-  (Role 2, `sui-releases`), passing artifacts between them. Cleaner credential
-  isolation; costs an artifact handoff.
-
-Whichever is chosen, the two roles stay separate (different buckets, different
-trust) — the only question is *when* each set of creds is active in the job.
+Resolved with a **two-job split**: `release-build` no longer configures AWS
+credentials at all (the existing-archive download uses the bucket's public read
+access; sccache still uses static keys pending Role 1 trust for release-event
+subs), and the `upload-release-archives-to-s3` job — `environment: release`,
+Role 2 — receives the archives as workflow artifacts and performs every
+`sui-releases` write. The two roles never coexist in one job, so there is no
+credential sequencing to manage.
 
 ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,13 +69,6 @@ jobs:
         with:
           ref: ${{ env.sui_tag }}          
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
       - name: Set os/arch variables (Windows)
         if: ${{ matrix.os == 'windows-ghcloud' }}
         shell: bash
@@ -108,7 +101,9 @@ jobs:
         shell: bash
         run: |
           mkdir -p ${{ env.TMP_BUILD_DIR }}
-          aws s3 cp s3://sui-releases/${{ env.s3_existing_archive }} ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz
+          # released archives are publicly readable (the existence check above
+          # relies on that), so no AWS credentials are needed here
+          curl -fSs -o ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz https://sui-releases.s3.us-east-1.amazonaws.com/${{ env.s3_existing_archive }}
           tar -xf ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz -C ${{ env.TMP_BUILD_DIR }}
 
       - name: Install nexttest (Windows)
@@ -197,9 +192,6 @@ jobs:
           mv ./target/debug/sui${{ env.extention }} ${{ env.TMP_BUILD_DIR }}/sui-debug${{ env.extention }}
           tar -cvzf ./tmp/sui-${{ env.sui_tag }}-${{ env.os_type }}.tgz -C ${{ env.TMP_BUILD_DIR }} .
 
-          # Upload tar balls to s3 so that we don't have to rebuild if they have already built
-          aws s3 cp ./tmp/sui-${{ env.sui_tag }}-${{ env.os_type }}.tgz s3://sui-releases/releases/sui-${{ env.sui_tag }}-${{ env.os_type }}.tgz || true
-
       - name: Publish Windows sui binary to Chocolatey
         if: ${{ matrix.os == 'windows-ghcloud' && contains(env.sui_tag, 'testnet') }}
         shell: bash
@@ -244,6 +236,44 @@ jobs:
           token: ${{ secrets.WALRUS_REPO_DISPATCH }}
           event-type: update-walrus-sui-testnet-tag
           client-payload: '{"new_tag": "${{ env.sui_tag }}"}'
+
+  # Copy built archives to s3://sui-releases so future runs skip the rebuild and
+  # node operators can pull binaries by tag. Runs in the protected `release`
+  # environment to assume the dedicated release-s3 OIDC role, credential-isolated
+  # from the build job (see .github/AWS_OIDC_ROLES.md, Role 2). `!cancelled()`
+  # preserves the old per-platform best-effort upload: archives from matrix legs
+  # that succeeded are uploaded even if another leg failed.
+  upload-release-archives-to-s3:
+    name: Upload release archives to S3
+    needs: release-build
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # OIDC token to assume the release-s3 role
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # pin@v6.0.0
+        with:
+          pattern: sui-binaries-*
+          merge-multiple: true
+          path: ./archives
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+        with:
+          role-to-assume: arn:aws:iam::011083325127:role/sui-releases-rw-github
+          allowed-account-ids: '011083325127'
+          aws-region: us-west-2
+
+      - name: Upload archives to s3://sui-releases
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for f in ./archives/*.tgz; do
+            aws s3 cp "$f" "s3://sui-releases/releases/$(basename "$f")" || true
+          done
 
   update-homebrew-formula:
     name: Bump sui formula on Homebrew/homebrew-core


### PR DESCRIPTION
## Summary

Phase 5 of the static-key → OIDC migration (see `.github/AWS_OIDC_MIGRATION_INVENTORY.md`), implementing the job-split option from `.github/AWS_OIDC_ROLES.md` §"Credential sequencing" — chosen over widening the cache role's trust to the `release` environment sub, which would have extended RW-cache trust to any job declaring that environment.

**`release-build` (matrix job) no longer holds any `sui-releases` credentials** (its only remaining AWS credentials are the static sccache keys inside `setup-sccache`):
- The standalone `configure-aws-credentials` (static keys) step is removed.
- The existing-archive download switches from `aws s3 cp` to `curl -fSs` — the bucket grants public read on `releases/` (the existence check on the line above already depends on that).
- The `aws s3 cp` upload moves out of the build job entirely.
- sccache keeps static keys here for now: post-split the job's OIDC sub is a plain tag ref, and Role 1 doesn't trust `refs/tags/*-v*` yet. That's the one remaining static call site, documented in the inventory.

**New `upload-release-archives-to-s3` job:**
- `needs: release-build`, `if: !cancelled()` — preserves the old per-platform best-effort semantics (legs that built still upload if a sibling leg failed).
- Declares `environment: release` (exists, with custom deployment policy: `main` + `devnet-v*`/`testnet-v*`/`mainnet-v*` tags — covering both the `release:` and `workflow_dispatch` trigger paths) and assumes `arn:aws:iam::011083325127:role/sui-releases-rw-github` via OIDC (`id-token: write` scoped to this job only).
- Pulls the per-OS `.tgz` archives from the workflow artifacts the build job already uploads, and copies each to `s3://sui-releases/releases/` with the old `|| true` best-effort behavior per file.

Result: the cache role (1) and release role (2) never coexist in a job, eliminating the credential-sequencing hazard the roles doc warned about. Both docs updated to reflect the implemented state.

## Security notes

- Role 2 trust is `sub=repo:MystenLabs/sui:environment:release` (aud-pinned, no wildcards); the environment's deployment policy restricts entry to `main` and release tags.
- The build job loses its job-wide ambient AWS credentials — a compromised build step can no longer write to `sui-releases` (it could before, via the job-wide static creds). The static sccache keys remain scoped to the cache bucket via `setup-sccache`.
- GH release attachment, Chocolatey publish, and the repo dispatches are unchanged.

## Test plan

- [x] `actionlint`: identical finding count to main (33/33 — all pre-existing runner-label/shellcheck items); zero new findings
- [x] Verified the `release` GitHub Environment exists with the required deployment branch/tag policies (`gh api .../environments/release`)
- [x] Verified `releases/` objects are publicly readable (the existence-check curl already returns `200 OK` unauthenticated; we have downloaded archives anonymously)
- [x] `download-artifact` pinned to the v6.0.0 commit (`018cc2c`), pairing with the build job's `upload-artifact` v6.0.0
- [ ] Post-merge validation: `workflow_dispatch` this workflow with an **already-released tag** — the build legs will fast-path via the public download, and the new job exercises the OIDC role assumption + S3 copy end-to-end with idempotent re-uploads. Confirm `AssumeRoleWithWebIdentity` for `sui-releases-rw-github` in the job log / CloudTrail.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:

