### PR TITLE
ci(release): pin checkout to the tag namespace and validate the tag prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,13 @@ jobs:
         shell: bash
         run: |
           export sui_tag=$(echo ${{ env.TAG_NAME }} | sed s/'refs\/tags\/'//)
-          [[ "${sui_tag}" == "main" ]] && echo "tag cannot be equals to 'main'" && exit 1
+          # only published release tags may be built: a workflow_dispatch runs
+          # with a trusted main OIDC sub while building this input, so an
+          # unconstrained ref here would let arbitrary code run under that sub
+          if [[ ! "${sui_tag}" =~ ^(devnet|testnet|mainnet)-v ]]; then
+            echo "sui_tag must be a release tag (devnet-v*/testnet-v*/mainnet-v*), got: ${sui_tag}"
+            exit 1
+          fi
           echo "sui_tag=${sui_tag}" >> $GITHUB_ENV
           export sui_version=$(echo ${sui_tag} | sed -e 's/mainnet-v//' -e 's/testnet-v//')
           echo "sui_version=${sui_version}" >> $GITHUB_ENV
@@ -67,7 +73,8 @@ jobs:
       - name: Check out ${{ env.sui_tag }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
-          ref: ${{ env.sui_tag }}          
+          # pin to the tag namespace so the input can never resolve to a branch
+          ref: refs/tags/${{ env.sui_tag }}          
 
       - name: Set os/arch variables (Windows)
         if: ${{ matrix.os == 'windows-ghcloud' }}


### PR DESCRIPTION
## Summary

Closes the trusted-sub / chosen-ref footgun in `release.yml`, as a standalone hardening and a hard prerequisite for flipping its sccache call site to OIDC (see `.github/AWS_OIDC_MIGRATION_INVENTORY.md` §release.yml):

A `workflow_dispatch` of this workflow runs with the OIDC sub `refs/heads/main` — a trusted subject — while checking out whatever `inputs.sui_tag` names. Before this change that input could resolve to **any ref, including a branch**, so arbitrary code could run under the trusted sub (and, once Role 1 gains tag trust, would hold the RW cache role).

Two guards, mirroring the `sui_repo_ref` guard pattern used in rust.yml/bridge.yml:

1. **Tag-prefix validation** in the existing cleanup step: anything not matching `^(devnet|testnet|mainnet)-v` is rejected before any checkout or credentialed step runs. This subsumes the old `tag != "main"` check.
2. **Checkout pinned to the tag namespace**: `ref: refs/tags/${{ env.sui_tag }}` — the input can never resolve to a branch or other ref type, even if it shares a name with one.

No behavior change for legitimate runs: `release: created` events always carry a release tag, and real dispatches always name one.

## Test plan

- [x] Validation matrix (local bash, same regex):
  - `mainnet-v1.72.5` / `testnet-v1.73.1` / `devnet-v1.74.0` → accepted
  - `refs/tags/mainnet-v1.72.5` (the `release:` event form, after the existing sed) → accepted
  - `main`, a branch name, a CI tag (`sui_v1.74.0_*_ci`), empty string → rejected with a clear error
- [x] `actionlint`: identical finding count to main (33/33 pre-existing); zero new findings

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: