### PR TITLE
Remove old checkpoint splitting path

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2321,6 +2321,13 @@ mod test {
     async fn test_simulated_load_previous_execution_version() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
 
+        // The consensus handler requires this flag; it is enabled on all chains at the
+        // latest protocol version, but not at the older version this test targets.
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_split_checkpoints_in_consensus_handler_for_testing(true);
+            config
+        });
+
         let target_version = find_previous_execution_version_protocol()
             .expect("no protocol version found with an older execution version");
         info!(

--- a/crates/sui-core/src/accumulators/mod.rs
+++ b/crates/sui-core/src/accumulators/mod.rs
@@ -310,10 +310,6 @@ impl AccumulatorSettlementTxBuilder {
         }
     }
 
-    pub fn num_updates(&self) -> usize {
-        self.updates.len()
-    }
-
     pub fn num_deposits(&self) -> u64 {
         self.num_deposits
     }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -25,9 +25,8 @@ use mysten_common::assert_reachable;
 use mysten_common::random_util::randomize_cache_capacity_in_tests;
 use mysten_common::sync::notify_once::NotifyOnce;
 use mysten_common::sync::notify_read::NotifyRead;
-use mysten_common::{debug_fatal, fatal, in_test_configuration};
+use mysten_common::{debug_fatal, in_test_configuration};
 use mysten_metrics::monitored_scope;
-use nonempty::NonEmpty;
 use parking_lot::RwLock;
 use parking_lot::{Mutex, RwLockReadGuard, RwLockWriteGuard};
 use serde::{Deserialize, Serialize};
@@ -78,7 +77,7 @@ use sui_types::transaction::{
     VerifiedSignedTransaction, VerifiedTransaction, VerifiedTransactionWithAliases, WithAliases,
 };
 use tap::TapOptional;
-use tokio::sync::{OnceCell, mpsc, oneshot};
+use tokio::sync::{OnceCell, mpsc};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
@@ -110,7 +109,7 @@ use crate::authority::shared_object_version_manager::{
     AsTx, AssignedTxAndVersions, ConsensusSharedObjVerAssignment, Schedulable, SharedObjVerManager,
 };
 use crate::checkpoints::{
-    BuilderCheckpointSummary, CheckpointHeight, EpochStats, PendingCheckpoint, PendingCheckpointV2,
+    BuilderCheckpointSummary, CheckpointHeight, EpochStats, PendingCheckpoint,
 };
 use crate::consensus_handler::{
     ConsensusCommitInfo, SequencedConsensusTransaction, SequencedConsensusTransactionKey,
@@ -465,26 +464,9 @@ pub struct AuthorityPerEpochStore {
     /// A cache which tracks recently finalized transactions.
     pub(crate) finalized_transactions_cache: MokaCache<TransactionDigest, ()>,
 
-    /// Waiters for settlement transactions. Used by execution scheduler to wait for
-    /// settlement transaction keys to resolve to transactions.
-    /// Stored in AuthorityPerEpochStore so that it is automatically cleaned up at the end of the epoch.
-    settlement_registrations: Arc<Mutex<HashMap<TransactionKey, SettlementRegistration>>>,
-
-    /// Waiters for barrier transactions. Used by execution scheduler to wait for
-    /// barrier transaction (keyed by the same AccumulatorSettlement key as settlements).
-    barrier_registrations: Arc<Mutex<HashMap<TransactionKey, BarrierRegistration>>>,
-
     /// The node's role for this epoch, derived from committee membership and
     /// the configured sync mode. Computed once at construction.
     node_role: NodeRole,
-}
-enum SettlementRegistration {
-    Ready(Vec<VerifiedExecutableTransaction>),
-    Waiting(oneshot::Sender<Vec<VerifiedExecutableTransaction>>),
-}
-enum BarrierRegistration {
-    Ready(Box<VerifiedExecutableTransaction>),
-    Waiting(oneshot::Sender<VerifiedExecutableTransaction>),
 }
 
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
@@ -1289,8 +1271,6 @@ impl AuthorityPerEpochStore {
             tx_reject_reason_cache,
             submitted_transaction_cache,
             finalized_transactions_cache,
-            settlement_registrations: Default::default(),
-            barrier_registrations: Default::default(),
             node_role: NodeRole::from_committee(&committee, &name, fullnode_sync_mode),
         });
 
@@ -1972,86 +1952,6 @@ impl AuthorityPerEpochStore {
         } else {
             Ok(tables.transaction_key_to_digest.get(key).expect("db error"))
         }
-    }
-
-    pub(crate) fn notify_settlement_transactions_ready(
-        &self,
-        tx_key: TransactionKey,
-        txns: Vec<VerifiedExecutableTransaction>,
-    ) {
-        debug_assert!(matches!(tx_key, TransactionKey::AccumulatorSettlement(..)));
-        let mut registrations = self.settlement_registrations.lock();
-        if let Some(registration) = registrations.remove(&tx_key) {
-            let SettlementRegistration::Waiting(tx) = registration else {
-                fatal!("Settlement registration should be waiting");
-            };
-            // Receiver is held in a `within_alive_epoch` task, so it may have
-            // been dropped already.
-            tx.send(txns).ok();
-        } else {
-            registrations.insert(tx_key, SettlementRegistration::Ready(txns));
-        }
-    }
-
-    pub(crate) async fn wait_for_settlement_transactions(
-        &self,
-        key: TransactionKey,
-    ) -> Vec<VerifiedExecutableTransaction> {
-        let rx = {
-            let mut registrations = self.settlement_registrations.lock();
-            if let Some(registration) = registrations.remove(&key) {
-                let SettlementRegistration::Ready(txns) = registration else {
-                    fatal!("Settlement registration should be ready");
-                };
-                return txns;
-            } else {
-                let (tx, rx) = oneshot::channel();
-                registrations.insert(key, SettlementRegistration::Waiting(tx));
-                rx
-            }
-        };
-
-        rx.await.unwrap()
-    }
-
-    pub(crate) fn notify_barrier_transaction_ready(
-        &self,
-        tx_key: TransactionKey,
-        txn: VerifiedExecutableTransaction,
-    ) {
-        debug_assert!(matches!(tx_key, TransactionKey::AccumulatorSettlement(..)));
-        let mut registrations = self.barrier_registrations.lock();
-        if let Some(registration) = registrations.remove(&tx_key) {
-            let BarrierRegistration::Waiting(tx) = registration else {
-                fatal!("Barrier registration should be waiting");
-            };
-            // Receiver may have been dropped if the scheduler cancelled its wait
-            // (e.g. checkpoint executor already executed this transaction).
-            tx.send(txn).ok();
-        } else {
-            registrations.insert(tx_key, BarrierRegistration::Ready(Box::new(txn)));
-        }
-    }
-
-    pub(crate) async fn wait_for_barrier_transaction(
-        &self,
-        key: TransactionKey,
-    ) -> VerifiedExecutableTransaction {
-        let rx = {
-            let mut registrations = self.barrier_registrations.lock();
-            if let Some(registration) = registrations.remove(&key) {
-                let BarrierRegistration::Ready(txn) = registration else {
-                    fatal!("Barrier registration should be ready");
-                };
-                return *txn;
-            } else {
-                let (tx, rx) = oneshot::channel();
-                registrations.insert(key, BarrierRegistration::Waiting(tx));
-                rx
-            }
-        };
-
-        rx.await.unwrap()
     }
 
     pub fn insert_effects_digest_and_signature(
@@ -3365,14 +3265,6 @@ impl AuthorityPerEpochStore {
             .expect("test should not be write past end of epoch")
     }
 
-    pub(crate) fn calculate_pending_checkpoint_height(&self, consensus_round: u64) -> u64 {
-        if self.randomness_state_enabled() {
-            consensus_round * 2
-        } else {
-            consensus_round
-        }
-    }
-
     // Assigns shared object versions to transactions and updates the next shared object version state.
     // Shared object versions in cancelled transactions are assigned to special versions that will
     // cause the transactions to be cancelled in execution engine.
@@ -3480,12 +3372,7 @@ impl AuthorityPerEpochStore {
         debug!(
             checkpoint_commit_height = checkpoint.height(),
             "Pending checkpoint has {} roots",
-            checkpoint.roots().len(),
-        );
-        trace!(
-            checkpoint_commit_height = checkpoint.height(),
-            "Transaction roots for pending checkpoint: {:?}",
-            checkpoint.roots()
+            checkpoint.num_roots(),
         );
 
         output.insert_pending_checkpoint(checkpoint.clone());
@@ -3510,61 +3397,21 @@ impl AuthorityPerEpochStore {
             .pending_checkpoint_exists(index))
     }
 
-    pub(crate) fn write_pending_checkpoint_v2(
-        &self,
-        output: &mut ConsensusCommitOutput,
-        checkpoint: &PendingCheckpointV2,
-    ) -> SuiResult {
-        assert!(
-            !self.pending_checkpoint_exists_v2(&checkpoint.height())?,
-            "Duplicate pending checkpoint notification at height {:?}",
-            checkpoint.height()
-        );
-
-        debug!(
-            checkpoint_commit_height = checkpoint.height(),
-            "Pending checkpoint has {} roots",
-            checkpoint.num_roots(),
-        );
-
-        output.insert_pending_checkpoint_v2(checkpoint.clone());
-
-        Ok(())
-    }
-
-    pub fn get_pending_checkpoints_v2(
-        &self,
-        last: Option<CheckpointHeight>,
-    ) -> SuiResult<Vec<(CheckpointHeight, PendingCheckpointV2)>> {
-        Ok(self
-            .consensus_quarantine
-            .read()
-            .get_pending_checkpoints_v2(last))
-    }
-
-    fn pending_checkpoint_exists_v2(&self, index: &CheckpointHeight) -> SuiResult<bool> {
-        Ok(self
-            .consensus_quarantine
-            .read()
-            .pending_checkpoint_exists_v2(index))
-    }
-
     pub fn process_constructed_checkpoint(
         &self,
         commit_height: CheckpointHeight,
-        content_info: NonEmpty<(CheckpointSummary, CheckpointContents)>,
+        content_info: (CheckpointSummary, CheckpointContents),
     ) {
         let mut consensus_quarantine = self.consensus_quarantine.write();
-        for (position_in_commit, (summary, transactions)) in content_info.into_iter().enumerate() {
-            let sequence_number = summary.sequence_number;
-            let summary = BuilderCheckpointSummary {
-                summary,
-                checkpoint_height: Some(commit_height),
-                position_in_commit,
-            };
+        let (summary, transactions) = content_info;
+        let sequence_number = summary.sequence_number;
+        let summary = BuilderCheckpointSummary {
+            summary,
+            checkpoint_height: Some(commit_height),
+            position_in_commit: 0,
+        };
 
-            consensus_quarantine.insert_builder_summary(sequence_number, summary, transactions);
-        }
+        consensus_quarantine.insert_builder_summary(sequence_number, summary, transactions);
 
         // Because builder can run behind state sync, the data may be immediately ready to be committed.
         consensus_quarantine

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -33,7 +33,7 @@ use sui_types::{
     messages_consensus::{Round, TimestampMs, VersionedDkgConfirmation},
     signature::GenericSignature,
 };
-use tracing::{debug, info};
+use tracing::debug;
 use typed_store::Map;
 use typed_store::rocks::DBBatch;
 
@@ -42,7 +42,7 @@ use crate::{
         authority_per_epoch_store::AuthorityPerEpochStore,
         shared_object_congestion_tracker::CongestionPerObjectDebt,
     },
-    checkpoints::{CheckpointHeight, PendingCheckpoint, PendingCheckpointV2},
+    checkpoints::{CheckpointHeight, PendingCheckpoint},
     consensus_handler::SequencedConsensusTransactionKey,
     epoch::{
         randomness::{VersionedProcessedMessage, VersionedUsedProcessedMessages},
@@ -70,7 +70,6 @@ pub(crate) struct ConsensusCommitOutput {
 
     // checkpoint state
     pending_checkpoints: Vec<PendingCheckpoint>,
-    pending_checkpoints_v2: Vec<PendingCheckpointV2>,
 
     // random beacon state
     next_randomness_round: Option<(RandomnessRound, TimestampMs)>,
@@ -144,25 +143,6 @@ impl ConsensusCommitOutput {
             .any(|cp| cp.height() == *index)
     }
 
-    fn get_pending_checkpoints_v2(
-        &self,
-        last: Option<CheckpointHeight>,
-    ) -> impl Iterator<Item = &PendingCheckpointV2> {
-        self.pending_checkpoints_v2.iter().filter(move |cp| {
-            if let Some(last) = last {
-                cp.height() > last
-            } else {
-                true
-            }
-        })
-    }
-
-    fn pending_checkpoint_exists_v2(&self, index: &CheckpointHeight) -> bool {
-        self.pending_checkpoints_v2
-            .iter()
-            .any(|cp| cp.height() == *index)
-    }
-
     fn get_round(&self) -> Option<u64> {
         self.consensus_commit_stats
             .as_ref()
@@ -229,10 +209,6 @@ impl ConsensusCommitOutput {
 
     pub fn insert_pending_checkpoint(&mut self, checkpoint: PendingCheckpoint) {
         self.pending_checkpoints.push(checkpoint);
-    }
-
-    pub fn insert_pending_checkpoint_v2(&mut self, checkpoint: PendingCheckpointV2) {
-        self.pending_checkpoints_v2.push(checkpoint);
     }
 
     pub fn reserve_next_randomness_round(
@@ -693,60 +669,32 @@ impl ConsensusOutputQuarantine {
             return Ok(());
         };
 
-        let split_checkpoints_in_consensus_handler = epoch_store
-            .protocol_config()
-            .split_checkpoints_in_consensus_handler();
-
-        if split_checkpoints_in_consensus_handler {
-            // V2: only commit outputs up to the last one where the checkpoint queue
-            // was fully drained (no pending roots). If the queue is empty after an
-            // output, there are no roots that could be lost on restart. Any outputs
-            // after the last drain point stay in the quarantine and get full-replayed
-            // on restart with correct root reconstruction.
-            let mut last_drain_idx = None;
-            for (i, output) in self.output_queue.iter().enumerate() {
-                let stats = output
-                    .consensus_commit_stats
-                    .as_ref()
-                    .expect("consensus_commit_stats must be set");
-                if stats.height > highest_committed_height {
-                    break;
-                }
-                if output.checkpoint_queue_drained {
-                    last_drain_idx = Some(i);
-                }
+        // Only commit outputs up to the last one where the checkpoint queue
+        // was fully drained (no pending roots). If the queue is empty after an
+        // output, there are no roots that could be lost on restart. Any outputs
+        // after the last drain point stay in the quarantine and get full-replayed
+        // on restart with correct root reconstruction.
+        let mut last_drain_idx = None;
+        for (i, output) in self.output_queue.iter().enumerate() {
+            let stats = output
+                .consensus_commit_stats
+                .as_ref()
+                .expect("consensus_commit_stats must be set");
+            if stats.height > highest_committed_height {
+                break;
             }
-            if let Some(idx) = last_drain_idx {
-                for _ in 0..=idx {
-                    let output = self.output_queue.pop_front().unwrap();
-                    self.remove_shared_object_next_versions(&output);
-                    self.remove_processed_consensus_messages(&output);
-                    self.remove_congestion_control_debts(&output);
-                    self.remove_owned_object_locks(&output);
-                    output.write_to_batch(epoch_store, batch)?;
-                }
+            if output.checkpoint_queue_drained {
+                last_drain_idx = Some(i);
             }
-        } else {
-            while !self.output_queue.is_empty() {
-                let output = self.output_queue.front().unwrap();
-                let Some(highest_in_commit) = output.get_highest_pending_checkpoint_height() else {
-                    break;
-                };
-
-                if highest_in_commit <= highest_committed_height {
-                    info!(
-                        "committing output with highest pending checkpoint height {:?}",
-                        highest_in_commit
-                    );
-                    let output = self.output_queue.pop_front().unwrap();
-                    self.remove_shared_object_next_versions(&output);
-                    self.remove_processed_consensus_messages(&output);
-                    self.remove_congestion_control_debts(&output);
-                    self.remove_owned_object_locks(&output);
-                    output.write_to_batch(epoch_store, batch)?;
-                } else {
-                    break;
-                }
+        }
+        if let Some(idx) = last_drain_idx {
+            for _ in 0..=idx {
+                let output = self.output_queue.pop_front().unwrap();
+                self.remove_shared_object_next_versions(&output);
+                self.remove_processed_consensus_messages(&output);
+                self.remove_congestion_control_debts(&output);
+                self.remove_owned_object_locks(&output);
+                output.write_to_batch(epoch_store, batch)?;
             }
         }
 
@@ -949,36 +897,6 @@ impl ConsensusOutputQuarantine {
         self.output_queue
             .iter()
             .any(|output| output.pending_checkpoint_exists(index))
-    }
-
-    pub(super) fn get_pending_checkpoints_v2(
-        &self,
-        last: Option<CheckpointHeight>,
-    ) -> Vec<(CheckpointHeight, PendingCheckpointV2)> {
-        let mut checkpoints = Vec::new();
-        for output in &self.output_queue {
-            checkpoints.extend(
-                output
-                    .get_pending_checkpoints_v2(last)
-                    .map(|cp| (cp.height(), cp.clone())),
-            );
-        }
-        if cfg!(debug_assertions) {
-            let mut prev = None;
-            for (height, _) in &checkpoints {
-                if let Some(prev) = prev {
-                    assert!(prev < *height);
-                }
-                prev = Some(*height);
-            }
-        }
-        checkpoints
-    }
-
-    pub(super) fn pending_checkpoint_exists_v2(&self, index: &CheckpointHeight) -> bool {
-        self.output_queue
-            .iter()
-            .any(|output| output.pending_checkpoint_exists_v2(index))
     }
 
     pub(super) fn get_new_jwks(
@@ -1223,13 +1141,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drain_boundary_prevents_premature_commit() {
-        let mut protocol_config =
-            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config.set_split_checkpoints_in_consensus_handler_for_testing(true);
-        let state = TestAuthorityBuilder::new()
-            .with_protocol_config(protocol_config)
-            .build()
-            .await;
+        let state = TestAuthorityBuilder::new().build().await;
         let epoch_store = state.epoch_store_for_testing();
 
         let metrics = epoch_store.metrics.clone();
@@ -1267,13 +1179,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drain_boundary_commits_at_safe_point() {
-        let mut protocol_config =
-            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config.set_split_checkpoints_in_consensus_handler_for_testing(true);
-        let state = TestAuthorityBuilder::new()
-            .with_protocol_config(protocol_config)
-            .build()
-            .await;
+        let state = TestAuthorityBuilder::new().build().await;
         let epoch_store = state.epoch_store_for_testing();
 
         let metrics = epoch_store.metrics.clone();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -19,7 +19,6 @@ pub use crate::checkpoints::metrics::CheckpointMetrics;
 use crate::consensus_manager::ReplayWaiter;
 use crate::execution_cache::TransactionCacheRead;
 
-use crate::execution_scheduler::funds_withdraw_scheduler::FundsSettlement;
 use crate::global_state_hasher::GlobalStateHasher;
 use crate::stake_aggregator::{InsertResult, MultiStakeAggregator};
 use consensus_core::CommitRef;
@@ -30,20 +29,18 @@ use mysten_common::random::get_rng;
 use mysten_common::sync::notify_read::{CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME, NotifyRead};
 use mysten_common::{assert_reachable, debug_fatal, fatal, in_antithesis};
 use mysten_metrics::{MonitoredFutureExt, monitored_scope, spawn_monitored_task};
-use nonempty::NonEmpty;
 use parking_lot::Mutex;
 use pin_project_lite::pin_project;
 use serde::{Deserialize, Serialize};
 use sui_macros::fail_point_arg;
 use sui_network::default_mysten_network_config;
+use sui_types::accumulator_metadata;
 use sui_types::base_types::{ConciseableName, SequenceNumber};
-use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution::ExecutionTimeObservationKey;
 use sui_types::messages_checkpoint::{
     CheckpointArtifacts, CheckpointCommitment, VersionedFullCheckpointContents,
 };
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
-use sui_types::{SUI_ACCUMULATOR_ROOT_OBJECT_ID, accumulator_metadata};
 use tokio::sync::{mpsc, watch};
 use typed_store::rocks::{DBOptions, ReadWriteOptions, default_db_options};
 
@@ -51,7 +48,7 @@ use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::authority_store_pruner::PrunerWatermarks;
 use crate::consensus_handler::SequencedConsensusTransactionKey;
 use rand::seq::SliceRandom;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::future::Future;
 use std::io::Write;
@@ -108,21 +105,12 @@ pub struct EpochStats {
 pub struct PendingCheckpointInfo {
     pub timestamp_ms: CheckpointTimestamp,
     pub last_of_epoch: bool,
-    // Computed in calculate_pending_checkpoint_height() from consensus round,
-    // there is no guarantee that this is increasing per checkpoint, because of checkpoint splitting.
     pub checkpoint_height: CheckpointHeight,
     // Consensus commit ref and rejected transactions digest which corresponds to this checkpoint.
     pub consensus_commit_ref: CommitRef,
     pub rejected_transactions_digest: Digest,
     // Pre-assigned checkpoint sequence number from consensus handler.
-    // Only set when split_checkpoints_in_consensus_handler is enabled.
-    pub checkpoint_seq: Option<CheckpointSequenceNumber>,
-}
-
-#[derive(Clone, Debug)]
-pub struct PendingCheckpoint {
-    pub roots: Vec<TransactionKey>,
-    pub details: PendingCheckpointInfo,
+    pub checkpoint_seq: CheckpointSequenceNumber,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -132,14 +120,10 @@ pub struct CheckpointRoots {
     pub height: CheckpointHeight,
 }
 
-/// PendingCheckpointV2 is merged and split in ConsensusHandler
-/// instead of CheckpointBuilder. It contains 1 or more
-/// CheckpointRoots which represents a group of transactions
-/// settled together.
-/// Usage of PendingCheckpointV2 is gated by split_checkpoints_in_consensus_handler
-/// We need to support dual implementations until this feature flag is removed.
+/// Consensus commits are merged and split into PendingCheckpoints in ConsensusHandler.
+/// Each CheckpointRoots represents a group of transactions settled together.
 #[derive(Clone, Debug)]
-pub struct PendingCheckpointV2 {
+pub struct PendingCheckpoint {
     pub roots: Vec<CheckpointRoots>,
     pub details: PendingCheckpointInfo,
 }
@@ -149,6 +133,8 @@ pub struct BuilderCheckpointSummary {
     pub summary: CheckpointSummary,
     // Height at which this checkpoint summary was built. None for genesis checkpoint
     pub checkpoint_height: Option<CheckpointHeight>,
+    // Always 0: each height now maps to exactly one checkpoint. Kept for DB format
+    // compatibility; old rows may contain nonzero values from builder-side splitting.
     pub position_in_commit: usize,
 }
 
@@ -1354,8 +1340,6 @@ pub struct CheckpointBuilder {
     send_to_hasher: mpsc::Sender<(CheckpointSequenceNumber, Vec<TransactionEffects>)>,
     output: Box<dyn CheckpointOutput>,
     metrics: Arc<CheckpointMetrics>,
-    max_transactions_per_checkpoint: usize,
-    max_checkpoint_size_bytes: usize,
 }
 
 pub struct CheckpointAggregator {
@@ -1396,8 +1380,6 @@ impl CheckpointBuilder {
         notify_aggregator: Arc<Notify>,
         last_built: watch::Sender<CheckpointSequenceNumber>,
         metrics: Arc<CheckpointMetrics>,
-        max_transactions_per_checkpoint: usize,
-        max_checkpoint_size_bytes: usize,
     ) -> Self {
         Self {
             state,
@@ -1411,8 +1393,6 @@ impl CheckpointBuilder {
             notify_aggregator,
             last_built,
             metrics,
-            max_transactions_per_checkpoint,
-            max_checkpoint_size_bytes,
         }
     }
 
@@ -1454,107 +1434,6 @@ impl CheckpointBuilder {
     }
 
     async fn maybe_build_checkpoints(&mut self) -> CheckpointBuilderResult {
-        if self
-            .epoch_store
-            .protocol_config()
-            .split_checkpoints_in_consensus_handler()
-        {
-            self.maybe_build_checkpoints_v2().await
-        } else {
-            self.maybe_build_checkpoints_v1().await
-        }
-    }
-
-    async fn maybe_build_checkpoints_v1(&mut self) -> CheckpointBuilderResult {
-        let _scope = monitored_scope("BuildCheckpoints");
-
-        // Collect info about the most recently built checkpoint.
-        let summary = self
-            .epoch_store
-            .last_built_checkpoint_builder_summary()
-            .expect("epoch should not have ended");
-        let mut last_height = summary.clone().and_then(|s| s.checkpoint_height);
-        let mut last_timestamp = summary.map(|s| s.summary.timestamp_ms);
-
-        let min_checkpoint_interval_ms = self
-            .epoch_store
-            .protocol_config()
-            .min_checkpoint_interval_ms_as_option()
-            .unwrap_or_default();
-        let mut grouped_pending_checkpoints = Vec::new();
-        let mut checkpoints_iter = self
-            .epoch_store
-            .get_pending_checkpoints(last_height)
-            .expect("unexpected epoch store error")
-            .into_iter()
-            .peekable();
-        while let Some((height, pending)) = checkpoints_iter.next() {
-            // Group PendingCheckpoints until:
-            // - minimum interval has elapsed ...
-            let current_timestamp = pending.details().timestamp_ms;
-            let can_build = match last_timestamp {
-                    Some(last_timestamp) => {
-                        current_timestamp >= last_timestamp + min_checkpoint_interval_ms
-                    }
-                    None => true,
-                // - or, next PendingCheckpoint is last-of-epoch (since the last-of-epoch checkpoint
-                //   should be written separately) ...
-                } || checkpoints_iter
-                    .peek()
-                    .is_some_and(|(_, next_pending)| next_pending.details().last_of_epoch)
-                // - or, we have reached end of epoch.
-                    || pending.details().last_of_epoch;
-            grouped_pending_checkpoints.push(pending);
-            if !can_build {
-                debug!(
-                    checkpoint_commit_height = height,
-                    ?last_timestamp,
-                    ?current_timestamp,
-                    "waiting for more PendingCheckpoints: minimum interval not yet elapsed"
-                );
-                continue;
-            }
-
-            // Min interval has elapsed, we can now coalesce and build a checkpoint.
-            last_height = Some(height);
-            last_timestamp = Some(current_timestamp);
-            debug!(
-                checkpoint_commit_height_from = grouped_pending_checkpoints
-                    .first()
-                    .unwrap()
-                    .details()
-                    .checkpoint_height,
-                checkpoint_commit_height_to = last_height,
-                "Making checkpoint with commit height range"
-            );
-
-            let seq = self
-                .make_checkpoint(std::mem::take(&mut grouped_pending_checkpoints))
-                .await?;
-
-            self.last_built.send_if_modified(|cur| {
-                // when rebuilding checkpoints at startup, seq can be for an old checkpoint
-                if seq > *cur {
-                    *cur = seq;
-                    true
-                } else {
-                    false
-                }
-            });
-
-            // ensure that the task can be cancelled at end of epoch, even if no other await yields
-            // execution.
-            tokio::task::yield_now().await;
-        }
-        debug!(
-            "Waiting for more checkpoints from consensus after processing {last_height:?}; {} pending checkpoints left unprocessed until next interval",
-            grouped_pending_checkpoints.len(),
-        );
-
-        Ok(())
-    }
-
-    async fn maybe_build_checkpoints_v2(&mut self) -> CheckpointBuilderResult {
         let _scope = monitored_scope("BuildCheckpoints");
 
         // Collect info about the most recently built checkpoint.
@@ -1566,12 +1445,12 @@ impl CheckpointBuilder {
 
         for (height, pending) in self
             .epoch_store
-            .get_pending_checkpoints_v2(last_height)
+            .get_pending_checkpoints(last_height)
             .expect("unexpected epoch store error")
         {
             debug!(checkpoint_commit_height = height, "Making checkpoint");
 
-            let seq = self.make_checkpoint_v2(pending).await?;
+            let seq = self.make_checkpoint(pending).await?;
 
             self.last_built.send_if_modified(|cur| {
                 // when rebuilding checkpoints at startup, seq can be for an old checkpoint
@@ -1591,70 +1470,10 @@ impl CheckpointBuilder {
         Ok(())
     }
 
-    #[instrument(level = "debug", skip_all, fields(last_height = pendings.last().unwrap().details().checkpoint_height))]
+    #[instrument(level = "debug", skip_all, fields(height = pending.details.checkpoint_height))]
     async fn make_checkpoint(
         &mut self,
-        pendings: Vec<PendingCheckpoint>,
-    ) -> CheckpointBuilderResult<CheckpointSequenceNumber> {
-        let _scope = monitored_scope("CheckpointBuilder::make_checkpoint");
-
-        let pending_ckpt_str = pendings
-            .iter()
-            .map(|p| {
-                format!(
-                    "height={}, commit={}",
-                    p.details().checkpoint_height,
-                    p.details().consensus_commit_ref
-                )
-            })
-            .join("; ");
-
-        let last_details = pendings.last().unwrap().details().clone();
-
-        // Stores the transactions that should be included in the checkpoint. Transactions will be recorded in the checkpoint
-        // in this order.
-        let highest_executed_sequence = self
-            .store
-            .get_highest_executed_checkpoint_seq_number()
-            .expect("db error")
-            .unwrap_or(0);
-
-        let (poll_count, result) = poll_count(self.resolve_checkpoint_transactions(pendings)).await;
-        let (sorted_tx_effects_included_in_checkpoint, all_roots) = result?;
-
-        let new_checkpoints = self
-            .create_checkpoints(
-                sorted_tx_effects_included_in_checkpoint,
-                &last_details,
-                &all_roots,
-            )
-            .await?;
-        let highest_sequence = *new_checkpoints.last().0.sequence_number();
-        if highest_sequence <= highest_executed_sequence && poll_count > 1 {
-            debug_fatal!(
-                "resolve_checkpoint_transactions should be instantaneous when executed checkpoint is ahead of checkpoint builder"
-            );
-        }
-
-        let new_ckpt_str = new_checkpoints
-            .iter()
-            .map(|(ckpt, _)| format!("seq={}, digest={}", ckpt.sequence_number(), ckpt.digest()))
-            .join("; ");
-
-        self.write_checkpoints(last_details.checkpoint_height, new_checkpoints)
-            .await?;
-        info!(
-            "Made new checkpoint {} from pending checkpoint {}",
-            new_ckpt_str, pending_ckpt_str
-        );
-
-        Ok(highest_sequence)
-    }
-
-    #[instrument(level = "debug", skip_all, fields(height = pending.details.checkpoint_height))]
-    async fn make_checkpoint_v2(
-        &mut self,
-        pending: PendingCheckpointV2,
+        pending: PendingCheckpoint,
     ) -> CheckpointBuilderResult<CheckpointSequenceNumber> {
         let _scope = monitored_scope("CheckpointBuilder::make_checkpoint");
 
@@ -1666,27 +1485,25 @@ impl CheckpointBuilder {
             .expect("db error")
             .unwrap_or(0);
 
-        let (poll_count, result) =
-            poll_count(self.resolve_checkpoint_transactions_v2(pending)).await;
+        let (poll_count, result) = poll_count(self.resolve_checkpoint_transactions(pending)).await;
         let (sorted_tx_effects_included_in_checkpoint, all_roots) = result?;
 
-        let new_checkpoints = self
-            .create_checkpoints(
+        let new_checkpoint = self
+            .create_checkpoint(
                 sorted_tx_effects_included_in_checkpoint,
                 &details,
                 &all_roots,
             )
             .await?;
-        assert_eq!(new_checkpoints.len(), 1, "Expected exactly one checkpoint");
-        let sequence = *new_checkpoints.first().0.sequence_number();
-        let digest = new_checkpoints.first().0.digest();
+        let sequence = *new_checkpoint.0.sequence_number();
+        let digest = new_checkpoint.0.digest();
         if sequence <= highest_executed_sequence && poll_count > 1 {
             debug_fatal!(
                 "resolve_checkpoint_transactions should be instantaneous when executed checkpoint is ahead of checkpoint builder"
             );
         }
 
-        self.write_checkpoints(details.checkpoint_height, new_checkpoints)
+        self.write_checkpoint(details.checkpoint_height, new_checkpoint)
             .await?;
         info!(
             seq = sequence,
@@ -1699,309 +1516,12 @@ impl CheckpointBuilder {
         Ok(sequence)
     }
 
-    async fn construct_and_execute_settlement_transactions(
-        &self,
-        sorted_tx_effects_included_in_checkpoint: &[TransactionEffects],
-        checkpoint_height: CheckpointHeight,
-        checkpoint_seq: CheckpointSequenceNumber,
-        tx_index_offset: u64,
-    ) -> (TransactionKey, Vec<TransactionEffects>) {
-        let _scope =
-            monitored_scope("CheckpointBuilder::construct_and_execute_settlement_transactions");
-
-        let tx_key =
-            TransactionKey::AccumulatorSettlement(self.epoch_store.epoch(), checkpoint_height);
-
-        let epoch = self.epoch_store.epoch();
-        let accumulator_root_obj_initial_shared_version = self
-            .epoch_store
-            .epoch_start_config()
-            .accumulator_root_obj_initial_shared_version()
-            .expect("accumulator root object must exist");
-
-        let builder = AccumulatorSettlementTxBuilder::new(
-            Some(self.effects_store.as_ref()),
-            sorted_tx_effects_included_in_checkpoint,
-            checkpoint_seq,
-            tx_index_offset,
-        );
-
-        let funds_changes = builder.collect_funds_changes();
-        let num_updates = builder.num_updates();
-        let settlement_txns = builder.build_tx(
-            self.epoch_store.protocol_config(),
-            epoch,
-            accumulator_root_obj_initial_shared_version,
-            checkpoint_height,
-            checkpoint_seq,
-        );
-
-        let settlement_txns: Vec<_> = settlement_txns
-            .into_iter()
-            .map(|tx| {
-                VerifiedExecutableTransaction::new_system(
-                    VerifiedTransaction::new_system_transaction(tx),
-                    self.epoch_store.epoch(),
-                )
-            })
-            .collect();
-
-        let settlement_digests: Vec<_> = settlement_txns.iter().map(|tx| *tx.digest()).collect();
-
-        debug!(
-            ?settlement_digests,
-            ?tx_key,
-            "created settlement transactions with {num_updates} updates"
-        );
-
-        self.epoch_store
-            .notify_settlement_transactions_ready(tx_key, settlement_txns);
-
-        let settlement_effects = wait_for_effects_with_retry(
-            self.effects_store.as_ref(),
-            "CheckpointBuilder::notify_read_settlement_effects",
-            &settlement_digests,
-            tx_key,
-        )
-        .await;
-        let (accounts_created, accounts_deleted) =
-            accumulators::count_accumulator_object_changes(&settlement_effects);
-        self.metrics
-            .report_accumulator_account_changes(accounts_created, accounts_deleted);
-
-        let barrier_tx = accumulators::build_accumulator_barrier_tx(
-            epoch,
-            accumulator_root_obj_initial_shared_version,
-            checkpoint_height,
-            &settlement_effects,
-        );
-
-        let barrier_tx = VerifiedExecutableTransaction::new_system(
-            VerifiedTransaction::new_system_transaction(barrier_tx),
-            self.epoch_store.epoch(),
-        );
-        let barrier_digest = *barrier_tx.digest();
-
-        self.epoch_store
-            .notify_barrier_transaction_ready(tx_key, barrier_tx);
-
-        let barrier_effects = wait_for_effects_with_retry(
-            self.effects_store.as_ref(),
-            "CheckpointBuilder::notify_read_barrier_effects",
-            &[barrier_digest],
-            tx_key,
-        )
-        .await;
-
-        let settlement_and_barrier_effects: Vec<_> = settlement_effects
-            .into_iter()
-            .chain(barrier_effects)
-            .collect();
-
-        let mut next_accumulator_version = None;
-        for fx in settlement_and_barrier_effects.iter() {
-            assert!(
-                fx.status().is_ok(),
-                "settlement transaction cannot fail (digest: {:?}) {:#?}",
-                fx.transaction_digest(),
-                fx
-            );
-            if let Some(version) = fx
-                .mutated()
-                .iter()
-                .find_map(|(oref, _)| (oref.0 == SUI_ACCUMULATOR_ROOT_OBJECT_ID).then_some(oref.1))
-            {
-                assert!(
-                    next_accumulator_version.is_none(),
-                    "Only one settlement transaction should mutate the accumulator root object"
-                );
-                next_accumulator_version = Some(version);
-            }
-        }
-        let settlements = FundsSettlement {
-            next_accumulator_version: next_accumulator_version
-                .expect("Accumulator root object should be mutated in the settlement transactions"),
-            funds_changes,
-        };
-
-        self.state
-            .execution_scheduler()
-            .settle_address_funds(settlements);
-
-        (tx_key, settlement_and_barrier_effects)
-    }
-
     // Given the root transactions of a pending checkpoint, resolve the transactions should be included in
     // the checkpoint, and return them in the order they should be included in the checkpoint.
-    // `effects_in_current_checkpoint` tracks the transactions that already exist in the current
-    // checkpoint.
     #[instrument(level = "debug", skip_all)]
     async fn resolve_checkpoint_transactions(
         &self,
-        pending_checkpoints: Vec<PendingCheckpoint>,
-    ) -> SuiResult<(Vec<TransactionEffects>, HashSet<TransactionDigest>)> {
-        let _scope = monitored_scope("CheckpointBuilder::resolve_checkpoint_transactions");
-
-        // Keeps track of the effects that are already included in the current checkpoint.
-        // This is used when there are multiple pending checkpoints to create a single checkpoint
-        // because in such scenarios, dependencies of a transaction may in earlier created checkpoints,
-        // or in earlier pending checkpoints.
-        let mut effects_in_current_checkpoint = BTreeSet::new();
-
-        let mut tx_effects = Vec::new();
-        let mut tx_roots = HashSet::new();
-
-        for pending_checkpoint in pending_checkpoints.into_iter() {
-            let mut pending = pending_checkpoint;
-            debug!(
-                checkpoint_commit_height = pending.details.checkpoint_height,
-                "Resolving checkpoint transactions for pending checkpoint.",
-            );
-
-            trace!(
-                "roots for pending checkpoint {:?}: {:?}",
-                pending.details.checkpoint_height, pending.roots,
-            );
-
-            let settlement_root = if self.epoch_store.accumulators_enabled() {
-                let Some(settlement_root @ TransactionKey::AccumulatorSettlement(..)) =
-                    pending.roots.pop()
-                else {
-                    fatal!("No settlement root found");
-                };
-                Some(settlement_root)
-            } else {
-                None
-            };
-
-            let roots = &pending.roots;
-
-            self.metrics
-                .checkpoint_roots_count
-                .inc_by(roots.len() as u64);
-
-            let root_digests = self
-                .epoch_store
-                .notify_read_tx_key_to_digest(roots)
-                .in_monitored_scope("CheckpointNotifyDigests")
-                .await?;
-            let root_effects = self
-                .effects_store
-                .notify_read_executed_effects(
-                    CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME,
-                    &root_digests,
-                )
-                .in_monitored_scope("CheckpointNotifyRead")
-                .await;
-
-            assert!(
-                self.epoch_store
-                    .protocol_config()
-                    .prepend_prologue_tx_in_consensus_commit_in_checkpoints()
-            );
-
-            // If the roots contains consensus commit prologue transaction, we want to extract it,
-            // and put it to the front of the checkpoint.
-            let consensus_commit_prologue =
-                self.extract_consensus_commit_prologue(&root_digests, &root_effects)?;
-
-            // Get the unincluded depdnencies of the consensus commit prologue. We should expect no
-            // other dependencies that haven't been included in any previous checkpoints.
-            if let Some((ccp_digest, ccp_effects)) = &consensus_commit_prologue {
-                let unsorted_ccp = self.complete_checkpoint_effects(
-                    vec![ccp_effects.clone()],
-                    &mut effects_in_current_checkpoint,
-                )?;
-
-                // No other dependencies of this consensus commit prologue that haven't been included
-                // in any previous checkpoint.
-                if unsorted_ccp.len() != 1 {
-                    fatal!(
-                        "Expected 1 consensus commit prologue, got {:?}",
-                        unsorted_ccp
-                            .iter()
-                            .map(|e| e.transaction_digest())
-                            .collect::<Vec<_>>()
-                    );
-                }
-                assert_eq!(unsorted_ccp.len(), 1);
-                assert_eq!(unsorted_ccp[0].transaction_digest(), ccp_digest);
-            }
-
-            let unsorted =
-                self.complete_checkpoint_effects(root_effects, &mut effects_in_current_checkpoint)?;
-
-            let _scope = monitored_scope("CheckpointBuilder::causal_sort");
-            let mut sorted: Vec<TransactionEffects> = Vec::with_capacity(unsorted.len() + 1);
-            if let Some((ccp_digest, ccp_effects)) = consensus_commit_prologue {
-                if cfg!(debug_assertions) {
-                    // When consensus_commit_prologue is extracted, it should not be included in the `unsorted`.
-                    for tx in unsorted.iter() {
-                        assert!(tx.transaction_digest() != &ccp_digest);
-                    }
-                }
-                sorted.push(ccp_effects);
-            }
-            sorted.extend(CausalOrder::causal_sort(unsorted));
-
-            if let Some(settlement_root) = settlement_root {
-                //TODO: this is an incorrect heuristic for checkpoint seq number
-                //      due to checkpoint splitting, to be fixed separately
-                let last_checkpoint =
-                    Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.store)?;
-                let next_checkpoint_seq = last_checkpoint
-                    .as_ref()
-                    .map(|(seq, _)| *seq)
-                    .unwrap_or_default()
-                    + 1;
-                let tx_index_offset = tx_effects.len() as u64;
-
-                let (tx_key, settlement_effects) = self
-                    .construct_and_execute_settlement_transactions(
-                        &sorted,
-                        pending.details.checkpoint_height,
-                        next_checkpoint_seq,
-                        tx_index_offset,
-                    )
-                    .await;
-                debug!(?tx_key, "executed settlement transactions");
-
-                assert_eq!(settlement_root, tx_key);
-
-                // Note: we do not need to add the settlement digests to `tx_roots` - `tx_roots`
-                // should only include the digests of transactions that were originally roots in
-                // the pending checkpoint. It is later used to identify transactions which were
-                // added as dependencies, so that those transactions can be waited on using
-                // `consensus_messages_processed_notify()`. System transactions (such as
-                // settlements) are exempt from this already.
-                //
-                // However, we DO need to add them to `effects_in_current_checkpoint` so that
-                // `complete_checkpoint_effects` won't pull them in again as dependencies when
-                // processing later pending checkpoints in the same batch.
-                effects_in_current_checkpoint
-                    .extend(settlement_effects.iter().map(|e| *e.transaction_digest()));
-                sorted.extend(settlement_effects);
-            }
-
-            #[cfg(msim)]
-            {
-                // Check consensus commit prologue invariants in sim test.
-                self.expensive_consensus_commit_prologue_invariants_check(&root_digests, &sorted);
-            }
-
-            tx_effects.extend(sorted);
-            tx_roots.extend(root_digests);
-        }
-
-        Ok((tx_effects, tx_roots))
-    }
-
-    // Given the root transactions of a pending checkpoint, resolve the transactions should be included in
-    // the checkpoint, and return them in the order they should be included in the checkpoint.
-    #[instrument(level = "debug", skip_all)]
-    async fn resolve_checkpoint_transactions_v2(
-        &self,
-        pending: PendingCheckpointV2,
+        pending: PendingCheckpoint,
     ) -> SuiResult<(Vec<TransactionEffects>, HashSet<TransactionDigest>)> {
         let _scope = monitored_scope("CheckpointBuilder::resolve_checkpoint_transactions");
 
@@ -2055,10 +1575,7 @@ impl CheckpointBuilder {
             let mut sorted = CausalOrder::causal_sort_with_ccp(root_effects, ccp_digest);
 
             if let Some(settlement_key) = &checkpoint_roots.settlement_root {
-                let checkpoint_seq = pending
-                    .details
-                    .checkpoint_seq
-                    .expect("checkpoint_seq must be set");
+                let checkpoint_seq = pending.details.checkpoint_seq;
                 let tx_index_offset = all_effects.len() as u64;
                 let effects = self
                     .resolve_settlement_effects(
@@ -2189,166 +1706,76 @@ impl CheckpointBuilder {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn write_checkpoints(
+    async fn write_checkpoint(
         &mut self,
         height: CheckpointHeight,
-        new_checkpoints: NonEmpty<(CheckpointSummary, CheckpointContents)>,
+        new_checkpoint: (CheckpointSummary, CheckpointContents),
     ) -> SuiResult {
-        let _scope = monitored_scope("CheckpointBuilder::write_checkpoints");
+        let _scope = monitored_scope("CheckpointBuilder::write_checkpoint");
         let mut batch = self.store.tables.checkpoint_content.batch();
-        let mut all_tx_digests =
-            Vec::with_capacity(new_checkpoints.iter().map(|(_, c)| c.size()).sum());
 
-        for (summary, contents) in &new_checkpoints {
-            debug!(
-                checkpoint_commit_height = height,
-                checkpoint_seq = summary.sequence_number,
-                contents_digest = ?contents.digest(),
-                "writing checkpoint",
+        let (summary, contents) = &new_checkpoint;
+        debug!(
+            checkpoint_commit_height = height,
+            checkpoint_seq = summary.sequence_number,
+            contents_digest = ?contents.digest(),
+            "writing checkpoint",
+        );
+
+        if let Some(previously_computed_summary) = self
+            .store
+            .tables
+            .locally_computed_checkpoints
+            .get(&summary.sequence_number)?
+            && previously_computed_summary.digest() != summary.digest()
+        {
+            fatal!(
+                "Checkpoint {} was previously built with a different result: previously_computed_summary {:?} vs current_summary {:?}",
+                summary.sequence_number,
+                previously_computed_summary.digest(),
+                summary.digest()
             );
-
-            if let Some(previously_computed_summary) = self
-                .store
-                .tables
-                .locally_computed_checkpoints
-                .get(&summary.sequence_number)?
-                && previously_computed_summary.digest() != summary.digest()
-            {
-                fatal!(
-                    "Checkpoint {} was previously built with a different result: previously_computed_summary {:?} vs current_summary {:?}",
-                    summary.sequence_number,
-                    previously_computed_summary.digest(),
-                    summary.digest()
-                );
-            }
-
-            all_tx_digests.extend(contents.iter().map(|digests| digests.transaction));
-
-            self.metrics
-                .transactions_included_in_checkpoint
-                .inc_by(contents.size() as u64);
-            let sequence_number = summary.sequence_number;
-            self.metrics
-                .last_constructed_checkpoint
-                .set(sequence_number as i64);
-
-            batch.insert_batch(
-                &self.store.tables.checkpoint_content,
-                [(contents.digest(), contents)],
-            )?;
-
-            batch.insert_batch(
-                &self.store.tables.locally_computed_checkpoints,
-                [(sequence_number, summary)],
-            )?;
         }
+
+        self.metrics
+            .transactions_included_in_checkpoint
+            .inc_by(contents.size() as u64);
+        let sequence_number = summary.sequence_number;
+        self.metrics
+            .last_constructed_checkpoint
+            .set(sequence_number as i64);
+
+        batch.insert_batch(
+            &self.store.tables.checkpoint_content,
+            [(contents.digest(), contents)],
+        )?;
+
+        batch.insert_batch(
+            &self.store.tables.locally_computed_checkpoints,
+            [(sequence_number, summary)],
+        )?;
 
         batch.write()?;
 
-        // Send all checkpoint sigs to consensus.
-        for (summary, contents) in &new_checkpoints {
-            self.output
-                .checkpoint_created(summary, contents, &self.epoch_store, &self.store)
-                .await?;
-        }
+        // Send checkpoint sigs to consensus.
+        self.output
+            .checkpoint_created(summary, contents, &self.epoch_store, &self.store)
+            .await?;
 
-        for (local_checkpoint, _) in &new_checkpoints {
-            if let Some(certified_checkpoint) = self
-                .store
-                .tables
-                .certified_checkpoints
-                .get(local_checkpoint.sequence_number())?
-            {
-                self.store
-                    .check_for_checkpoint_fork(local_checkpoint, &certified_checkpoint.into());
-            }
+        if let Some(certified_checkpoint) = self
+            .store
+            .tables
+            .certified_checkpoints
+            .get(summary.sequence_number())?
+        {
+            self.store
+                .check_for_checkpoint_fork(summary, &certified_checkpoint.into());
         }
 
         self.notify_aggregator.notify_one();
         self.epoch_store
-            .process_constructed_checkpoint(height, new_checkpoints);
+            .process_constructed_checkpoint(height, new_checkpoint);
         Ok(())
-    }
-
-    #[allow(clippy::type_complexity)]
-    fn split_checkpoint_chunks(
-        &self,
-        effects_and_transaction_sizes: Vec<(TransactionEffects, usize)>,
-        signatures: Vec<Vec<(GenericSignature, Option<SequenceNumber>)>>,
-    ) -> CheckpointBuilderResult<
-        Vec<
-            Vec<(
-                TransactionEffects,
-                Vec<(GenericSignature, Option<SequenceNumber>)>,
-            )>,
-        >,
-    > {
-        let _guard = monitored_scope("CheckpointBuilder::split_checkpoint_chunks");
-
-        // If splitting is done in consensus_handler, return everything as one chunk.
-        if self
-            .epoch_store
-            .protocol_config()
-            .split_checkpoints_in_consensus_handler()
-        {
-            let chunk: Vec<_> = effects_and_transaction_sizes
-                .into_iter()
-                .zip_debug_eq(signatures)
-                .map(|((effects, _size), sigs)| (effects, sigs))
-                .collect();
-            return Ok(vec![chunk]);
-        }
-        let mut chunks = Vec::new();
-        let mut chunk = Vec::new();
-        let mut chunk_size: usize = 0;
-        for ((effects, transaction_size), signatures) in effects_and_transaction_sizes
-            .into_iter()
-            .zip_debug_eq(signatures.into_iter())
-        {
-            // Roll over to a new chunk after either max count or max size is reached.
-            // The size calculation here is intended to estimate the size of the
-            // FullCheckpointContents struct. If this code is modified, that struct
-            // should also be updated accordingly.
-            let signatures_size = if self.epoch_store.protocol_config().address_aliases() {
-                bcs::serialized_size(&signatures)?
-            } else {
-                let signatures: Vec<&GenericSignature> =
-                    signatures.iter().map(|(s, _)| s).collect();
-                bcs::serialized_size(&signatures)?
-            };
-            let size = transaction_size + bcs::serialized_size(&effects)? + signatures_size;
-            if chunk.len() == self.max_transactions_per_checkpoint
-                || (chunk_size + size) > self.max_checkpoint_size_bytes
-            {
-                if chunk.is_empty() {
-                    // Always allow at least one tx in a checkpoint.
-                    warn!(
-                        "Size of single transaction ({size}) exceeds max checkpoint size ({}); allowing excessively large checkpoint to go through.",
-                        self.max_checkpoint_size_bytes
-                    );
-                } else {
-                    chunks.push(chunk);
-                    chunk = Vec::new();
-                    chunk_size = 0;
-                }
-            }
-
-            chunk.push((effects, signatures));
-            chunk_size += size;
-        }
-
-        if !chunk.is_empty() || chunks.is_empty() {
-            // We intentionally create an empty checkpoint if there is no content provided
-            // to make a 'heartbeat' checkpoint.
-            // Important: if some conditions are added here later, we need to make sure we always
-            // have at least one chunk if last_pending_of_epoch is set
-            chunks.push(chunk);
-            // Note: empty checkpoints are ok - they shouldn't happen at all on a network with even
-            // modest load. Even if they do happen, it is still useful as it allows fullnodes to
-            // distinguish between "no transactions have happened" and "i am not receiving new
-            // checkpoints".
-        }
-        Ok(chunks)
     }
 
     fn load_last_built_checkpoint_summary(
@@ -2376,23 +1803,22 @@ impl CheckpointBuilder {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn create_checkpoints(
+    async fn create_checkpoint(
         &self,
         all_effects: Vec<TransactionEffects>,
         details: &PendingCheckpointInfo,
         all_roots: &HashSet<TransactionDigest>,
-    ) -> CheckpointBuilderResult<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
-        let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
+    ) -> CheckpointBuilderResult<(CheckpointSummary, CheckpointContents)> {
+        let _scope = monitored_scope("CheckpointBuilder::create_checkpoint");
 
-        let total = all_effects.len();
-        let mut last_checkpoint =
+        let last_checkpoint =
             Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.store)?;
         let last_checkpoint_seq = last_checkpoint.as_ref().map(|(seq, _)| *seq);
         debug!(
             checkpoint_commit_height = details.checkpoint_height,
             next_checkpoint_seq = last_checkpoint_seq.unwrap_or_default() + 1,
             checkpoint_timestamp = details.timestamp_ms,
-            "Creating checkpoint(s) for {} transactions",
+            "Creating checkpoint for {} transactions",
             all_effects.len(),
         );
 
@@ -2400,11 +1826,10 @@ impl CheckpointBuilder {
             .iter()
             .map(|effect| *effect.transaction_digest())
             .collect();
-        let transactions_and_sizes = self
+        let transaction_blocks = self
             .state
             .get_transaction_cache_reader()
-            .get_transactions_and_serialized_sizes(&all_digests)?;
-        let mut all_effects_and_transaction_sizes = Vec::with_capacity(all_effects.len());
+            .multi_get_transaction_blocks(&all_digests);
         let mut transactions = Vec::with_capacity(all_effects.len());
         let mut transaction_keys = Vec::with_capacity(all_effects.len());
         let mut randomness_rounds = BTreeMap::new();
@@ -2416,11 +1841,11 @@ impl CheckpointBuilder {
                 all_effects.len()
             );
 
-            for (effects, transaction_and_size) in all_effects
-                .into_iter()
-                .zip_debug_eq(transactions_and_sizes.into_iter())
+            for (effects, transaction) in all_effects
+                .iter()
+                .zip_debug_eq(transaction_blocks.into_iter())
             {
-                let (transaction, size) = transaction_and_size
+                let transaction = transaction
                     .unwrap_or_else(|| panic!("Could not find executed transaction {:?}", effects));
                 match transaction.inner().transaction_data().kind() {
                     TransactionKind::ConsensusCommitPrologue(_)
@@ -2458,8 +1883,7 @@ impl CheckpointBuilder {
                         }
                     }
                 }
-                transactions.push(transaction);
-                all_effects_and_transaction_sizes.push((effects, size));
+                transactions.push((*transaction).clone());
             }
 
             self.epoch_store
@@ -2476,7 +1900,7 @@ impl CheckpointBuilder {
             signatures.len()
         );
 
-        let mut end_of_epoch_observation_keys: Option<Vec<_>> = if details.last_of_epoch {
+        let end_of_epoch_observation_keys: Option<Vec<_>> = if details.last_of_epoch {
             Some(
                 transactions
                     .iter()
@@ -2499,200 +1923,178 @@ impl CheckpointBuilder {
             None
         };
 
-        let chunks = self.split_checkpoint_chunks(all_effects_and_transaction_sizes, signatures)?;
-        let chunks_count = chunks.len();
-
-        let mut checkpoints = Vec::with_capacity(chunks_count);
-        debug!(
-            ?last_checkpoint_seq,
-            "Creating {} checkpoints with {} transactions", chunks_count, total,
-        );
-
         let epoch = self.epoch_store.epoch();
-        for (index, transactions) in chunks.into_iter().enumerate() {
-            let first_checkpoint_of_epoch = index == 0
-                && last_checkpoint
-                    .as_ref()
-                    .map(|(_, c)| c.epoch != epoch)
-                    .unwrap_or(true);
-            if first_checkpoint_of_epoch {
-                self.epoch_store
-                    .record_epoch_first_checkpoint_creation_time_metric();
-            }
-            let last_checkpoint_of_epoch = details.last_of_epoch && index == chunks_count - 1;
+        let first_checkpoint_of_epoch = last_checkpoint
+            .as_ref()
+            .map(|(_, c)| c.epoch != epoch)
+            .unwrap_or(true);
+        if first_checkpoint_of_epoch {
+            self.epoch_store
+                .record_epoch_first_checkpoint_creation_time_metric();
+        }
+        let last_checkpoint_of_epoch = details.last_of_epoch;
 
-            let sequence_number = if let Some(preassigned_seq) = details.checkpoint_seq {
-                preassigned_seq
-            } else {
-                last_checkpoint
-                    .as_ref()
-                    .map(|(_, c)| c.sequence_number + 1)
-                    .unwrap_or_default()
-            };
-            let mut timestamp_ms = details.timestamp_ms;
-            if let Some((_, last_checkpoint)) = &last_checkpoint
-                && last_checkpoint.timestamp_ms > timestamp_ms
-            {
-                // First consensus commit of an epoch can have zero timestamp.
-                debug!(
-                    "Decrease of checkpoint timestamp, possibly due to epoch change. Sequence: {}, previous: {}, current: {}",
-                    sequence_number, last_checkpoint.timestamp_ms, timestamp_ms,
-                );
-                if self
-                    .epoch_store
-                    .protocol_config()
-                    .enforce_checkpoint_timestamp_monotonicity()
-                {
-                    timestamp_ms = last_checkpoint.timestamp_ms;
-                }
-            }
-
-            let (mut effects, mut signatures): (Vec<_>, Vec<_>) = transactions.into_iter().unzip();
-            let epoch_rolling_gas_cost_summary =
-                self.get_epoch_total_gas_cost(last_checkpoint.as_ref().map(|(_, c)| c), &effects);
-
-            let end_of_epoch_data = if last_checkpoint_of_epoch {
-                let system_state_obj = self
-                    .augment_epoch_last_checkpoint(
-                        &epoch_rolling_gas_cost_summary,
-                        timestamp_ms,
-                        &mut effects,
-                        &mut signatures,
-                        sequence_number,
-                        std::mem::take(&mut end_of_epoch_observation_keys).expect("end_of_epoch_observation_keys must be populated for the last checkpoint"),
-                        last_checkpoint_seq.unwrap_or_default(),
-                    )
-                    .await?;
-
-                let committee = system_state_obj
-                    .get_current_epoch_committee()
-                    .committee()
-                    .clone();
-
-                // This must happen after the call to augment_epoch_last_checkpoint,
-                // otherwise we will not capture the change_epoch tx.
-                let root_state_digest = {
-                    let state_acc = self
-                        .global_state_hasher
-                        .upgrade()
-                        .expect("No checkpoints should be getting built after local configuration");
-                    let acc = state_acc.accumulate_checkpoint(
-                        &effects,
-                        sequence_number,
-                        &self.epoch_store,
-                    )?;
-
-                    state_acc
-                        .wait_for_previous_running_root(&self.epoch_store, sequence_number)
-                        .await?;
-
-                    state_acc.accumulate_running_root(
-                        &self.epoch_store,
-                        sequence_number,
-                        Some(acc),
-                    )?;
-                    state_acc
-                        .digest_epoch(self.epoch_store.clone(), sequence_number)
-                        .await?
-                };
-                self.metrics.highest_accumulated_epoch.set(epoch as i64);
-                info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
-
-                let epoch_commitments = if self
-                    .epoch_store
-                    .protocol_config()
-                    .check_commit_root_state_digest_supported()
-                {
-                    vec![root_state_digest.into()]
-                } else {
-                    vec![]
-                };
-
-                Some(EndOfEpochData {
-                    next_epoch_committee: committee.voting_rights,
-                    next_epoch_protocol_version: ProtocolVersion::new(
-                        system_state_obj.protocol_version(),
-                    ),
-                    epoch_commitments,
-                })
-            } else {
-                self.send_to_hasher
-                    .send((sequence_number, effects.clone()))
-                    .await?;
-
-                None
-            };
-            let contents = if self.epoch_store.protocol_config().address_aliases() {
-                CheckpointContents::new_v2(&effects, signatures)
-            } else {
-                CheckpointContents::new_with_digests_and_signatures(
-                    effects.iter().map(TransactionEffects::execution_digests),
-                    signatures
-                        .into_iter()
-                        .map(|sigs| sigs.into_iter().map(|(s, _)| s).collect())
-                        .collect(),
-                )
-            };
-
-            let num_txns = contents.size() as u64;
-
-            let network_total_transactions = last_checkpoint
-                .as_ref()
-                .map(|(_, c)| c.network_total_transactions + num_txns)
-                .unwrap_or(num_txns);
-
-            let previous_digest = last_checkpoint.as_ref().map(|(_, c)| c.digest());
-
-            let matching_randomness_rounds: Vec<_> = effects
-                .iter()
-                .filter_map(|e| randomness_rounds.get(e.transaction_digest()))
-                .copied()
-                .collect();
-
-            let checkpoint_commitments = if self
+        let sequence_number = details.checkpoint_seq;
+        let mut timestamp_ms = details.timestamp_ms;
+        if let Some((_, last_checkpoint)) = &last_checkpoint
+            && last_checkpoint.timestamp_ms > timestamp_ms
+        {
+            // First consensus commit of an epoch can have zero timestamp.
+            debug!(
+                "Decrease of checkpoint timestamp, possibly due to epoch change. Sequence: {}, previous: {}, current: {}",
+                sequence_number, last_checkpoint.timestamp_ms, timestamp_ms,
+            );
+            if self
                 .epoch_store
                 .protocol_config()
-                .include_checkpoint_artifacts_digest_in_summary()
+                .enforce_checkpoint_timestamp_monotonicity()
             {
-                let artifacts = CheckpointArtifacts::from(&effects[..]);
-                let artifacts_digest = artifacts.digest()?;
-                vec![artifacts_digest.into()]
-            } else {
-                Default::default()
-            };
-
-            let summary = CheckpointSummary::new(
-                self.epoch_store.protocol_config(),
-                epoch,
-                sequence_number,
-                network_total_transactions,
-                &contents,
-                previous_digest,
-                epoch_rolling_gas_cost_summary,
-                end_of_epoch_data,
-                timestamp_ms,
-                matching_randomness_rounds,
-                checkpoint_commitments,
-            );
-            summary.report_checkpoint_age(
-                &self.metrics.last_created_checkpoint_age,
-                &self.metrics.last_created_checkpoint_age_ms,
-            );
-            if last_checkpoint_of_epoch {
-                info!(
-                    checkpoint_seq = sequence_number,
-                    "creating last checkpoint of epoch {}", epoch
-                );
-                if let Some(stats) = self.store.get_epoch_stats(epoch, &summary) {
-                    self.epoch_store
-                        .report_epoch_metrics_at_last_checkpoint(stats);
-                }
+                timestamp_ms = last_checkpoint.timestamp_ms;
             }
-            last_checkpoint = Some((sequence_number, summary.clone()));
-            checkpoints.push((summary, contents));
         }
 
-        Ok(NonEmpty::from_vec(checkpoints).expect("at least one checkpoint"))
+        let mut effects = all_effects;
+        let mut signatures = signatures;
+        let epoch_rolling_gas_cost_summary =
+            self.get_epoch_total_gas_cost(last_checkpoint.as_ref().map(|(_, c)| c), &effects);
+
+        let end_of_epoch_data = if last_checkpoint_of_epoch {
+            let system_state_obj = self
+                .augment_epoch_last_checkpoint(
+                    &epoch_rolling_gas_cost_summary,
+                    timestamp_ms,
+                    &mut effects,
+                    &mut signatures,
+                    sequence_number,
+                    end_of_epoch_observation_keys.expect(
+                        "end_of_epoch_observation_keys must be populated for the last checkpoint",
+                    ),
+                    last_checkpoint_seq.unwrap_or_default(),
+                )
+                .await?;
+
+            let committee = system_state_obj
+                .get_current_epoch_committee()
+                .committee()
+                .clone();
+
+            // This must happen after the call to augment_epoch_last_checkpoint,
+            // otherwise we will not capture the change_epoch tx.
+            let root_state_digest = {
+                let state_acc = self
+                    .global_state_hasher
+                    .upgrade()
+                    .expect("No checkpoints should be getting built after local configuration");
+                let acc = state_acc.accumulate_checkpoint(
+                    &effects,
+                    sequence_number,
+                    &self.epoch_store,
+                )?;
+
+                state_acc
+                    .wait_for_previous_running_root(&self.epoch_store, sequence_number)
+                    .await?;
+
+                state_acc.accumulate_running_root(&self.epoch_store, sequence_number, Some(acc))?;
+                state_acc
+                    .digest_epoch(self.epoch_store.clone(), sequence_number)
+                    .await?
+            };
+            self.metrics.highest_accumulated_epoch.set(epoch as i64);
+            info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
+
+            let epoch_commitments = if self
+                .epoch_store
+                .protocol_config()
+                .check_commit_root_state_digest_supported()
+            {
+                vec![root_state_digest.into()]
+            } else {
+                vec![]
+            };
+
+            Some(EndOfEpochData {
+                next_epoch_committee: committee.voting_rights,
+                next_epoch_protocol_version: ProtocolVersion::new(
+                    system_state_obj.protocol_version(),
+                ),
+                epoch_commitments,
+            })
+        } else {
+            self.send_to_hasher
+                .send((sequence_number, effects.clone()))
+                .await?;
+
+            None
+        };
+        let contents = if self.epoch_store.protocol_config().address_aliases() {
+            CheckpointContents::new_v2(&effects, signatures)
+        } else {
+            CheckpointContents::new_with_digests_and_signatures(
+                effects.iter().map(TransactionEffects::execution_digests),
+                signatures
+                    .into_iter()
+                    .map(|sigs| sigs.into_iter().map(|(s, _)| s).collect())
+                    .collect(),
+            )
+        };
+
+        let num_txns = contents.size() as u64;
+
+        let network_total_transactions = last_checkpoint
+            .as_ref()
+            .map(|(_, c)| c.network_total_transactions + num_txns)
+            .unwrap_or(num_txns);
+
+        let previous_digest = last_checkpoint.as_ref().map(|(_, c)| c.digest());
+
+        let matching_randomness_rounds: Vec<_> = effects
+            .iter()
+            .filter_map(|e| randomness_rounds.get(e.transaction_digest()))
+            .copied()
+            .collect();
+
+        let checkpoint_commitments = if self
+            .epoch_store
+            .protocol_config()
+            .include_checkpoint_artifacts_digest_in_summary()
+        {
+            let artifacts = CheckpointArtifacts::from(&effects[..]);
+            let artifacts_digest = artifacts.digest()?;
+            vec![artifacts_digest.into()]
+        } else {
+            Default::default()
+        };
+
+        let summary = CheckpointSummary::new(
+            self.epoch_store.protocol_config(),
+            epoch,
+            sequence_number,
+            network_total_transactions,
+            &contents,
+            previous_digest,
+            epoch_rolling_gas_cost_summary,
+            end_of_epoch_data,
+            timestamp_ms,
+            matching_randomness_rounds,
+            checkpoint_commitments,
+        );
+        summary.report_checkpoint_age(
+            &self.metrics.last_created_checkpoint_age,
+            &self.metrics.last_created_checkpoint_age_ms,
+        );
+        if last_checkpoint_of_epoch {
+            info!(
+                checkpoint_seq = sequence_number,
+                "creating last checkpoint of epoch {}", epoch
+            );
+            if let Some(stats) = self.store.get_epoch_stats(epoch, &summary) {
+                self.epoch_store
+                    .report_epoch_metrics_at_last_checkpoint(stats);
+            }
+        }
+
+        Ok((summary, contents))
     }
 
     fn get_epoch_total_gas_cost(
@@ -2745,93 +2147,6 @@ impl CheckpointBuilder {
         checkpoint_effects.push(effects);
         signatures.push(vec![]);
         Ok(system_state)
-    }
-
-    /// For the given roots return complete list of effects to include in checkpoint
-    /// This list includes the roots and all their dependencies, which are not part of checkpoint already.
-    /// Note that this function may be called multiple times to construct the checkpoint.
-    /// `existing_tx_digests_in_checkpoint` is used to track the transactions that are already included in the checkpoint.
-    /// Txs in `roots` that need to be included in the checkpoint will be added to `existing_tx_digests_in_checkpoint`
-    /// after the call of this function.
-    #[instrument(level = "debug", skip_all)]
-    fn complete_checkpoint_effects(
-        &self,
-        mut roots: Vec<TransactionEffects>,
-        existing_tx_digests_in_checkpoint: &mut BTreeSet<TransactionDigest>,
-    ) -> SuiResult<Vec<TransactionEffects>> {
-        let _scope = monitored_scope("CheckpointBuilder::complete_checkpoint_effects");
-        let mut results = vec![];
-        let mut seen = HashSet::new();
-        loop {
-            let mut pending = HashSet::new();
-
-            let transactions_included = self
-                .epoch_store
-                .builder_included_transactions_in_checkpoint(
-                    roots.iter().map(|e| e.transaction_digest()),
-                )?;
-
-            for (effect, tx_included) in roots
-                .into_iter()
-                .zip_debug_eq(transactions_included.into_iter())
-            {
-                let digest = effect.transaction_digest();
-                // Unnecessary to read effects of a dependency if the effect is already processed.
-                seen.insert(*digest);
-
-                // Skip roots that are already included in the checkpoint.
-                if existing_tx_digests_in_checkpoint.contains(effect.transaction_digest()) {
-                    continue;
-                }
-
-                // Skip roots already included in checkpoints or roots from previous epochs
-                if tx_included || effect.executed_epoch() < self.epoch_store.epoch() {
-                    continue;
-                }
-
-                let existing_effects = self
-                    .epoch_store
-                    .transactions_executed_in_cur_epoch(effect.dependencies())?;
-
-                for (dependency, effects_signature_exists) in effect
-                    .dependencies()
-                    .iter()
-                    .zip_debug_eq(existing_effects.iter())
-                {
-                    // Skip here if dependency not executed in the current epoch.
-                    // Note that the existence of an effects signature in the
-                    // epoch store for the given digest indicates that the transaction
-                    // was locally executed in the current epoch
-                    if !effects_signature_exists {
-                        continue;
-                    }
-                    if seen.insert(*dependency) {
-                        pending.insert(*dependency);
-                    }
-                }
-                results.push(effect);
-            }
-            if pending.is_empty() {
-                break;
-            }
-            let pending = pending.into_iter().collect::<Vec<_>>();
-            let effects = self.effects_store.multi_get_executed_effects(&pending);
-            let effects = effects
-                .into_iter()
-                .zip_debug_eq(pending)
-                .map(|(opt, digest)| match opt {
-                    Some(x) => x,
-                    None => panic!(
-                        "Can not find effect for transaction {:?}, however transaction that depend on it was already executed",
-                        digest
-                    ),
-                })
-                .collect::<Vec<_>>();
-            roots = effects;
-        }
-
-        existing_tx_digests_in_checkpoint.extend(results.iter().map(|e| e.transaction_digest()));
-        Ok(results)
     }
 
     // Checks the invariants of the consensus commit prologue transactions in the checkpoint
@@ -3498,12 +2813,8 @@ impl CheckpointService {
         checkpoint_output: Box<dyn CheckpointOutput>,
         certified_checkpoint_output: Box<dyn CertifiedCheckpointOutput>,
         metrics: Arc<CheckpointMetrics>,
-        max_transactions_per_checkpoint: usize,
-        max_checkpoint_size_bytes: usize,
     ) -> Arc<Self> {
-        info!(
-            "Starting checkpoint service with {max_transactions_per_checkpoint} max_transactions_per_checkpoint and {max_checkpoint_size_bytes} max_checkpoint_size_bytes"
-        );
+        info!("Starting checkpoint service");
         Self::initialize_accumulator_account_metrics(&state, &epoch_store, &metrics);
         let notify_builder = Arc::new(Notify::new());
         let notify_aggregator = Arc::new(Notify::new());
@@ -3555,8 +2866,6 @@ impl CheckpointService {
             notify_aggregator.clone(),
             highest_currently_built_seq_tx.clone(),
             metrics.clone(),
-            max_transactions_per_checkpoint,
-            max_checkpoint_size_bytes,
         );
 
         Arc::new(Self {
@@ -3783,20 +3092,6 @@ impl PendingCheckpoint {
         self.details.checkpoint_height
     }
 
-    pub fn roots(&self) -> &Vec<TransactionKey> {
-        &self.roots
-    }
-
-    pub fn details(&self) -> &PendingCheckpointInfo {
-        &self.details
-    }
-}
-
-impl PendingCheckpointV2 {
-    pub fn height(&self) -> CheckpointHeight {
-        self.details.checkpoint_height
-    }
-
     pub(crate) fn num_roots(&self) -> usize {
         self.roots.iter().map(|r| r.tx_roots.len()).sum()
     }
@@ -3841,7 +3136,6 @@ fn poll_count<Fut>(future: Fut) -> PollCounter<Fut> {
 mod tests {
     use super::*;
     use crate::authority::test_authority_builder::TestAuthorityBuilder;
-    use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
     use futures::FutureExt as _;
     use futures::future::BoxFuture;
     use std::collections::HashMap;
@@ -3849,7 +3143,6 @@ mod tests {
     use sui_macros::sim_test;
     use sui_protocol_config::{Chain, ProtocolConfig};
     use sui_types::accumulator_event::AccumulatorEvent;
-    use sui_types::authenticator_state::ActiveJwk;
     use sui_types::base_types::{SequenceNumber, TransactionEffectsDigest};
     use sui_types::crypto::Signature;
     use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -3984,8 +3277,6 @@ mod tests {
         let mut protocol_config =
             ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
         protocol_config.disable_accumulators_for_testing();
-        protocol_config.set_split_checkpoints_in_consensus_handler_for_testing(false);
-        protocol_config.set_min_checkpoint_interval_ms_for_testing(100);
         let state = TestAuthorityBuilder::new()
             .with_protocol_config(protocol_config)
             .build()
@@ -3998,43 +3289,12 @@ mod tests {
             SequenceNumber::new(),
         );
 
-        let jwks = {
-            let mut jwks = Vec::new();
-            while bcs::to_bytes(&jwks).unwrap().len() < 40_000 {
-                jwks.push(ActiveJwk {
-                    jwk_id: JwkId::new(
-                        "https://accounts.google.com".to_string(),
-                        "1234567890".to_string(),
-                    ),
-                    jwk: JWK {
-                        kty: "RSA".to_string(),
-                        e: "AQAB".to_string(),
-                        n: "1234567890".to_string(),
-                        alg: "RS256".to_string(),
-                    },
-                    epoch: 0,
-                });
-            }
-            jwks
-        };
-
-        let dummy_tx_with_data =
-            VerifiedTransaction::new_authenticator_state_update(0, 1, jwks, SequenceNumber::new());
-
-        for i in 0..15 {
+        for i in 0..20 {
             state
                 .database_for_testing()
                 .perpetual_tables
                 .transactions
                 .insert(&d(i), dummy_tx.serializable_ref())
-                .unwrap();
-        }
-        for i in 15..20 {
-            state
-                .database_for_testing()
-                .perpetual_tables
-                .transactions
-                .insert(&d(i), dummy_tx_with_data.serializable_ref())
                 .unwrap();
         }
 
@@ -4116,8 +3376,6 @@ mod tests {
             Box::new(output),
             Box::new(certified_output),
             CheckpointMetrics::new_for_tests(),
-            3,
-            100_000,
         );
         checkpoint_service.spawn(epoch_store.clone(), None).await;
 
@@ -4153,47 +3411,40 @@ mod tests {
             GasCostSummary::new(41, 42, 41, 1)
         );
 
-        assert_eq!(c2t, vec![d(3), d(2), d(1)]);
+        // Causal order places d(3) before d(1), which depends on it.
+        assert_eq!(c2t, vec![d(3), d(1)]);
         assert_eq!(c2s.previous_digest, Some(c1s.digest()));
         assert_eq!(c2s.sequence_number, 1);
         assert_eq!(
             c2s.epoch_rolling_gas_cost_summary,
-            GasCostSummary::new(104, 108, 104, 4)
+            GasCostSummary::new(83, 86, 83, 3)
         );
 
-        // Pending at index 2 had 4 transactions, and we configured 3 transactions max.
-        // Verify that we split into 2 checkpoints.
+        // Each pending checkpoint produces exactly one checkpoint; splitting is
+        // done in the consensus handler.
         let (c3c, c3s) = result.recv().await.unwrap();
         let c3t = c3c.iter().map(|d| d.transaction).collect::<Vec<_>>();
-        let (c4c, c4s) = result.recv().await.unwrap();
-        let c4t = c4c.iter().map(|d| d.transaction).collect::<Vec<_>>();
         assert_eq!(c3s.sequence_number, 2);
         assert_eq!(c3s.previous_digest, Some(c2s.digest()));
+        assert_eq!(c3t, vec![d(10), d(11), d(12), d(13)]);
+
+        let (c4c, c4s) = result.recv().await.unwrap();
+        let c4t = c4c.iter().map(|d| d.transaction).collect::<Vec<_>>();
         assert_eq!(c4s.sequence_number, 3);
         assert_eq!(c4s.previous_digest, Some(c3s.digest()));
-        assert_eq!(c3t, vec![d(10), d(11), d(12)]);
-        assert_eq!(c4t, vec![d(13)]);
+        assert_eq!(c4t, vec![d(15), d(16), d(17)]);
 
-        // Pending at index 3 had 3 transactions of 40K size, and we configured 100K max.
-        // Verify that we split into 2 checkpoints.
         let (c5c, c5s) = result.recv().await.unwrap();
         let c5t = c5c.iter().map(|d| d.transaction).collect::<Vec<_>>();
-        let (c6c, c6s) = result.recv().await.unwrap();
-        let c6t = c6c.iter().map(|d| d.transaction).collect::<Vec<_>>();
         assert_eq!(c5s.sequence_number, 4);
         assert_eq!(c5s.previous_digest, Some(c4s.digest()));
+        assert_eq!(c5t, vec![d(5)]);
+
+        let (c6c, c6s) = result.recv().await.unwrap();
+        let c6t = c6c.iter().map(|d| d.transaction).collect::<Vec<_>>();
         assert_eq!(c6s.sequence_number, 5);
         assert_eq!(c6s.previous_digest, Some(c5s.digest()));
-        assert_eq!(c5t, vec![d(15), d(16)]);
-        assert_eq!(c6t, vec![d(17)]);
-
-        // Pending at index 4 was too soon after the prior one and should be coalesced into
-        // the next one.
-        let (c7c, c7s) = result.recv().await.unwrap();
-        let c7t = c7c.iter().map(|d| d.transaction).collect::<Vec<_>>();
-        assert_eq!(c7t, vec![d(5), d(6)]);
-        assert_eq!(c7s.previous_digest, Some(c6s.digest()));
-        assert_eq!(c7s.sequence_number, 6);
+        assert_eq!(c6t, vec![d(6)]);
 
         let c1ss = SignedCheckpointSummary::new(c1s.epoch, c1s, state.secret.deref(), state.name);
         let c2ss = SignedCheckpointSummary::new(c2s.epoch, c2s, state.secret.deref(), state.name);
@@ -4322,17 +3573,21 @@ mod tests {
 
     fn p(i: u64, t: Vec<u8>, timestamp_ms: u64) -> PendingCheckpoint {
         PendingCheckpoint {
-            roots: t
-                .into_iter()
-                .map(|t| TransactionKey::Digest(d(t)))
-                .collect(),
+            roots: vec![CheckpointRoots {
+                tx_roots: t
+                    .into_iter()
+                    .map(|t| TransactionKey::Digest(d(t)))
+                    .collect(),
+                settlement_root: None,
+                height: i,
+            }],
             details: PendingCheckpointInfo {
                 timestamp_ms,
                 last_of_epoch: false,
                 checkpoint_height: i,
                 consensus_commit_ref: CommitRef::default(),
                 rejected_transactions_digest: Digest::default(),
-                checkpoint_seq: None,
+                checkpoint_seq: i,
             },
         }
     }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -78,7 +78,7 @@ use crate::{
     },
     checkpoints::{
         CheckpointHeight, CheckpointRoots, CheckpointService, CheckpointServiceNotify,
-        PendingCheckpoint, PendingCheckpointInfo, PendingCheckpointV2,
+        PendingCheckpoint, PendingCheckpointInfo,
     },
     consensus_adapter::ConsensusAdapter,
     consensus_throughput_calculator::ConsensusThroughputCalculator,
@@ -585,9 +585,9 @@ impl From<Chunk<VerifiedExecutableTransactionWithAliases>> for Chunk {
     }
 }
 
-// Accumulates checkpoint roots from consensus and flushes them into PendingCheckpointV2s.
+// Accumulates checkpoint roots from consensus and flushes them into PendingCheckpoints.
 // Roots are buffered in `pending_roots` until a flush is triggered (by max_tx overflow or
-// time interval). A flush always drains all buffered roots into a single PendingCheckpointV2,
+// time interval). A flush always drains all buffered roots into a single PendingCheckpoint,
 // so the queue only ever holds roots for one pending checkpoint at a time.
 //
 // Owns an ExecutionSchedulerSender so push_chunk can send schedulables and settlement info
@@ -686,7 +686,7 @@ impl CheckpointQueue {
         timestamp: CheckpointTimestamp,
         consensus_commit_ref: CommitRef,
         rejected_transactions_digest: Digest,
-    ) -> Vec<PendingCheckpointV2> {
+    ) -> Vec<PendingCheckpoint> {
         let max_tx = self.max_tx;
         let user_tx_count = chunk.schedulables.len();
 
@@ -743,7 +743,7 @@ impl CheckpointQueue {
         &mut self,
         current_timestamp: CheckpointTimestamp,
         force: bool,
-    ) -> Option<PendingCheckpointV2> {
+    ) -> Option<PendingCheckpoint> {
         if !force && current_timestamp < self.last_built_timestamp + self.min_checkpoint_interval_ms
         {
             return None;
@@ -751,7 +751,7 @@ impl CheckpointQueue {
         self.flush_forced()
     }
 
-    fn flush_forced(&mut self) -> Option<PendingCheckpointV2> {
+    fn flush_forced(&mut self) -> Option<PendingCheckpoint> {
         if self.pending_roots.is_empty() {
             return None;
         }
@@ -759,7 +759,7 @@ impl CheckpointQueue {
         let to_flush: Vec<_> = self.pending_roots.drain(..).collect();
         let last_root = to_flush.last().unwrap();
 
-        let checkpoint = PendingCheckpointV2 {
+        let checkpoint = PendingCheckpoint {
             roots: to_flush.iter().map(|q| q.roots.clone()).collect(),
             details: PendingCheckpointInfo {
                 timestamp_ms: last_root.timestamp,
@@ -767,7 +767,7 @@ impl CheckpointQueue {
                 checkpoint_height: last_root.roots.height,
                 consensus_commit_ref: last_root.consensus_commit_ref,
                 rejected_transactions_digest: last_root.rejected_transactions_digest,
-                checkpoint_seq: Some(self.current_checkpoint_seq),
+                checkpoint_seq: self.current_checkpoint_seq,
             },
         };
 
@@ -803,8 +803,6 @@ pub struct ConsensusHandler<C> {
     metrics: Arc<AuthorityMetrics>,
     /// Lru cache to quickly discard transactions processed by consensus
     processed_cache: LruCache<SequencedConsensusTransactionKey, ()>,
-    /// Enqueues transactions to the execution scheduler via a separate task.
-    execution_scheduler_sender: ExecutionSchedulerSender,
     /// Consensus adapter for submitting transactions to consensus
     consensus_adapter: Arc<ConsensusAdapter>,
 
@@ -851,6 +849,13 @@ impl<C> ConsensusHandler<C> {
             "support for congestion control modes other than PerObjectCongestionControlMode::ExecutionTimeEstimate has been removed"
         );
 
+        assert!(
+            epoch_store
+                .protocol_config()
+                .split_checkpoints_in_consensus_handler(),
+            "support for splitting checkpoints outside of consensus handler has been removed"
+        );
+
         // Recover last_consensus_stats so it is consistent across validators.
         let mut last_consensus_stats = epoch_store
             .get_last_consensus_stats()
@@ -858,12 +863,7 @@ impl<C> ConsensusHandler<C> {
         // stats is empty at the beginning of epoch.
         if !last_consensus_stats.stats.is_initialized() {
             last_consensus_stats.stats = ConsensusStats::new(committee.size());
-            if epoch_store
-                .protocol_config()
-                .split_checkpoints_in_consensus_handler()
-            {
-                last_consensus_stats.checkpoint_seq = epoch_store.previous_epoch_last_checkpoint();
-            }
+            last_consensus_stats.checkpoint_seq = epoch_store.previous_epoch_last_checkpoint();
         }
         let max_tx = epoch_store
             .protocol_config()
@@ -879,14 +879,7 @@ impl<C> ConsensusHandler<C> {
             .get_consensus_commit_rate_estimation_window_size();
         let last_built_timestamp = last_consensus_stats.last_checkpoint_flush_timestamp;
         let checkpoint_height = last_consensus_stats.height;
-        let next_checkpoint_seq = if epoch_store
-            .protocol_config()
-            .split_checkpoints_in_consensus_handler()
-        {
-            last_consensus_stats.checkpoint_seq + 1
-        } else {
-            0
-        };
+        let next_checkpoint_seq = last_consensus_stats.checkpoint_seq + 1;
         Self {
             epoch_store,
             last_consensus_stats,
@@ -897,7 +890,6 @@ impl<C> ConsensusHandler<C> {
             processed_cache: LruCache::new(
                 NonZeroUsize::new(randomize_cache_capacity_in_tests(PROCESSED_CACHE_CAP)).unwrap(),
             ),
-            execution_scheduler_sender: execution_scheduler_sender.clone(),
             consensus_adapter,
             throughput_calculator,
             additional_consensus_state: AdditionalConsensusState::new(
@@ -958,7 +950,6 @@ impl<C> ConsensusHandler<C> {
             processed_cache: LruCache::new(
                 NonZeroUsize::new(randomize_cache_capacity_in_tests(PROCESSED_CACHE_CAP)).unwrap(),
             ),
-            execution_scheduler_sender: execution_scheduler_sender.clone(),
             consensus_adapter,
             throughput_calculator,
             additional_consensus_state: AdditionalConsensusState::new(
@@ -1219,136 +1210,75 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let authenticator_state_update_transaction =
             self.create_authenticator_state_update(last_committed_round, &commit_info);
 
-        let split_checkpoints = self
-            .epoch_store
-            .protocol_config()
-            .split_checkpoints_in_consensus_handler();
+        let (
+            transactions_to_schedule,
+            randomness_transactions_to_schedule,
+            cancelled_txns,
+            randomness_state_update_transaction,
+        ) = self.collect_transactions_to_schedule(
+            &mut state,
+            &mut execution_time_estimator,
+            &commit_info,
+            user_transactions,
+        );
 
-        let (lock, final_round, num_schedulables, checkpoint_height) = if !split_checkpoints {
-            let (schedulables, randomness_schedulables, assigned_versions) = self
-                .process_transactions(
-                    &mut state,
-                    &mut execution_time_estimator,
-                    &commit_info,
-                    authenticator_state_update_transaction,
-                    user_transactions,
-                );
+        let (should_accept_tx, lock, final_round) =
+            self.handle_close_epoch(&mut state, &commit_info, end_of_publish_transactions);
 
-            let (should_accept_tx, lock, final_round) =
-                self.handle_close_epoch(&mut state, &commit_info, end_of_publish_transactions);
+        let make_checkpoint = should_accept_tx || final_round;
+        if !make_checkpoint {
+            // No need for any further processing
+            return;
+        }
 
-            let make_checkpoint = should_accept_tx || final_round;
-            if !make_checkpoint {
-                // No need for any further processing
-                return;
-            }
+        // If this is the final round, record execution time observations for storage in the
+        // end-of-epoch tx.
+        if final_round {
+            self.record_end_of_epoch_execution_time_observations(&mut execution_time_estimator);
+        }
 
-            // If this is the final round, record execution time observations for storage in the
-            // end-of-epoch tx.
-            if final_round {
-                self.record_end_of_epoch_execution_time_observations(&mut execution_time_estimator);
-            }
+        let consensus_commit_prologue = (!commit_info.skip_consensus_commit_prologue_in_test)
+            .then_some(Schedulable::ConsensusCommitPrologue(
+                epoch,
+                commit_info.round,
+                commit_info.consensus_commit_ref.index,
+            ));
 
-            let checkpoint_height = self
-                .epoch_store
-                .calculate_pending_checkpoint_height(commit_info.round);
-
-            self.create_pending_checkpoints(
-                &mut state,
-                &commit_info,
-                &schedulables,
-                &randomness_schedulables,
-                final_round,
-            );
-
-            let num_schedulables = schedulables.len();
-            let mut all_schedulables = schedulables;
-            all_schedulables.extend(randomness_schedulables);
-            let assigned_versions = assigned_versions.into_map();
-            let paired: Vec<_> = all_schedulables
+        let schedulables: Vec<_> = itertools::chain!(
+            consensus_commit_prologue.into_iter(),
+            authenticator_state_update_transaction
                 .into_iter()
-                .map(|s| {
-                    let versions = assigned_versions.get(&s.key()).cloned().unwrap_or_default();
-                    (s, versions)
-                })
-                .collect();
-            self.execution_scheduler_sender.send(paired, None);
+                .map(Schedulable::Transaction),
+            transactions_to_schedule
+                .into_iter()
+                .map(Schedulable::Transaction),
+        )
+        .collect();
 
-            (lock, final_round, num_schedulables, checkpoint_height)
-        } else {
-            let (
-                transactions_to_schedule,
-                randomness_transactions_to_schedule,
-                cancelled_txns,
-                randomness_state_update_transaction,
-            ) = self.collect_transactions_to_schedule(
-                &mut state,
-                &mut execution_time_estimator,
-                &commit_info,
-                user_transactions,
-            );
-
-            let (should_accept_tx, lock, final_round) =
-                self.handle_close_epoch(&mut state, &commit_info, end_of_publish_transactions);
-
-            let make_checkpoint = should_accept_tx || final_round;
-            if !make_checkpoint {
-                // No need for any further processing
-                return;
-            }
-
-            // If this is the final round, record execution time observations for storage in the
-            // end-of-epoch tx.
-            if final_round {
-                self.record_end_of_epoch_execution_time_observations(&mut execution_time_estimator);
-            }
-
-            let epoch = self.epoch_store.epoch();
-            let consensus_commit_prologue = (!commit_info.skip_consensus_commit_prologue_in_test)
-                .then_some(Schedulable::ConsensusCommitPrologue(
-                    epoch,
-                    commit_info.round,
-                    commit_info.consensus_commit_ref.index,
-                ));
-
-            let schedulables: Vec<_> = itertools::chain!(
-                consensus_commit_prologue.into_iter(),
-                authenticator_state_update_transaction
-                    .into_iter()
-                    .map(Schedulable::Transaction),
-                transactions_to_schedule
+        let randomness_schedulables: Vec<_> = randomness_state_update_transaction
+            .into_iter()
+            .chain(
+                randomness_transactions_to_schedule
                     .into_iter()
                     .map(Schedulable::Transaction),
             )
             .collect();
 
-            let randomness_schedulables: Vec<_> = randomness_state_update_transaction
-                .into_iter()
-                .chain(
-                    randomness_transactions_to_schedule
-                        .into_iter()
-                        .map(Schedulable::Transaction),
-                )
-                .collect();
-
-            let num_schedulables = schedulables.len();
-            let checkpoint_height = self.create_pending_checkpoints_v2(
-                &mut state,
-                &commit_info,
-                schedulables,
-                randomness_schedulables,
-                &cancelled_txns,
-                final_round,
-            );
-
-            (lock, final_round, num_schedulables, checkpoint_height)
-        };
+        let num_schedulables = schedulables.len();
+        let checkpoint_height = self.create_pending_checkpoints(
+            &mut state,
+            &commit_info,
+            schedulables,
+            randomness_schedulables,
+            &cancelled_txns,
+            final_round,
+        );
 
         let notifications = state.get_notifications();
 
         let mut stats_to_record = self.last_consensus_stats.clone();
         stats_to_record.height = checkpoint_height;
-        if split_checkpoints {
+        {
             let queue = self.checkpoint_queue.lock().unwrap();
             stats_to_record.last_checkpoint_flush_timestamp = queue.last_built_timestamp();
             stats_to_record.checkpoint_seq = queue.checkpoint_seq();
@@ -1460,72 +1390,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 "Notified last checkpoint"
             );
             self.epoch_store.record_end_of_message_quorum_time_metric();
-        }
-    }
-
-    fn create_pending_checkpoints(
-        &self,
-        state: &mut CommitHandlerState,
-        commit_info: &ConsensusCommitInfo,
-        schedulables: &[Schedulable],
-        randomness_schedulables: &[Schedulable],
-        final_round: bool,
-    ) {
-        assert!(
-            !self
-                .epoch_store
-                .protocol_config()
-                .split_checkpoints_in_consensus_handler()
-        );
-
-        let checkpoint_height = self
-            .epoch_store
-            .calculate_pending_checkpoint_height(commit_info.round);
-
-        // Determine whether to write pending checkpoint for user tx with randomness.
-        // - If randomness is not generated for this commit, we will skip the
-        //   checkpoint with the associated height. Therefore checkpoint heights may
-        //   not be contiguous.
-        // - Exception: if DKG fails, we always need to write out a PendingCheckpoint
-        //   for randomness tx that are canceled.
-        let should_write_random_checkpoint = state.randomness_round.is_some()
-            || (state.dkg_failed && !randomness_schedulables.is_empty());
-
-        let pending_checkpoint = PendingCheckpoint {
-            roots: schedulables.iter().map(|s| s.key()).collect(),
-            details: PendingCheckpointInfo {
-                timestamp_ms: commit_info.timestamp,
-                last_of_epoch: final_round && !should_write_random_checkpoint,
-                checkpoint_height,
-                consensus_commit_ref: commit_info.consensus_commit_ref,
-                rejected_transactions_digest: commit_info.rejected_transactions_digest,
-                checkpoint_seq: None,
-            },
-        };
-        self.epoch_store
-            .write_pending_checkpoint(&mut state.output, &pending_checkpoint)
-            .expect("failed to write pending checkpoint");
-
-        info!(
-            "Written pending checkpoint: {:?}",
-            pending_checkpoint.details,
-        );
-
-        if should_write_random_checkpoint {
-            let pending_checkpoint = PendingCheckpoint {
-                roots: randomness_schedulables.iter().map(|s| s.key()).collect(),
-                details: PendingCheckpointInfo {
-                    timestamp_ms: commit_info.timestamp,
-                    last_of_epoch: final_round,
-                    checkpoint_height: checkpoint_height + 1,
-                    consensus_commit_ref: commit_info.consensus_commit_ref,
-                    rejected_transactions_digest: commit_info.rejected_transactions_digest,
-                    checkpoint_seq: None,
-                },
-            };
-            self.epoch_store
-                .write_pending_checkpoint(&mut state.output, &pending_checkpoint)
-                .expect("failed to write pending checkpoint");
         }
     }
 
@@ -1679,121 +1543,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         )
     }
 
-    fn process_transactions(
-        &self,
-        state: &mut CommitHandlerState,
-        execution_time_estimator: &mut ExecutionTimeEstimator,
-        commit_info: &ConsensusCommitInfo,
-        authenticator_state_update_transaction: Option<VerifiedExecutableTransactionWithAliases>,
-        user_transactions: Vec<VerifiedExecutableTransactionWithAliases>,
-    ) -> (Vec<Schedulable>, Vec<Schedulable>, AssignedTxAndVersions) {
-        let protocol_config = self.epoch_store.protocol_config();
-        assert!(!protocol_config.split_checkpoints_in_consensus_handler());
-        let epoch = self.epoch_store.epoch();
-
-        let (
-            transactions_to_schedule,
-            randomness_transactions_to_schedule,
-            cancelled_txns,
-            randomness_state_update_transaction,
-        ) = self.collect_transactions_to_schedule(
-            state,
-            execution_time_estimator,
-            commit_info,
-            user_transactions,
-        );
-
-        let mut settlement = None;
-        let mut randomness_settlement = None;
-        if self.epoch_store.accumulators_enabled() {
-            let checkpoint_height = self
-                .epoch_store
-                .calculate_pending_checkpoint_height(commit_info.round);
-
-            settlement = Some(Schedulable::AccumulatorSettlement(epoch, checkpoint_height));
-
-            if state.randomness_round.is_some() || !randomness_transactions_to_schedule.is_empty() {
-                randomness_settlement = Some(Schedulable::AccumulatorSettlement(
-                    epoch,
-                    checkpoint_height + 1,
-                ));
-            }
-        }
-
-        let consensus_commit_prologue = (!commit_info.skip_consensus_commit_prologue_in_test)
-            .then_some(Schedulable::ConsensusCommitPrologue(
-                epoch,
-                commit_info.round,
-                commit_info.consensus_commit_ref.index,
-            ));
-
-        let schedulables: Vec<_> = itertools::chain!(
-            consensus_commit_prologue.into_iter(),
-            authenticator_state_update_transaction
-                .into_iter()
-                .map(Schedulable::Transaction),
-            transactions_to_schedule
-                .into_iter()
-                .map(Schedulable::Transaction),
-            settlement,
-        )
-        .collect();
-
-        let randomness_schedulables: Vec<_> = randomness_state_update_transaction
-            .into_iter()
-            .chain(
-                randomness_transactions_to_schedule
-                    .into_iter()
-                    .map(Schedulable::Transaction),
-            )
-            .chain(randomness_settlement)
-            .collect();
-
-        let assigned_versions = self
-            .epoch_store
-            .process_consensus_transaction_shared_object_versions(
-                self.cache_reader.as_ref(),
-                schedulables.iter(),
-                randomness_schedulables.iter(),
-                &cancelled_txns,
-                &mut state.output,
-            )
-            .expect("failed to assign shared object versions");
-
-        let consensus_commit_prologue =
-            self.add_consensus_commit_prologue_transaction(state, commit_info, &assigned_versions);
-
-        let mut schedulables = schedulables;
-        let mut assigned_versions = assigned_versions;
-        if let Some(consensus_commit_prologue) = consensus_commit_prologue {
-            assert!(matches!(
-                schedulables[0],
-                Schedulable::ConsensusCommitPrologue(..)
-            ));
-            assert!(matches!(
-                assigned_versions.0[0].0,
-                TransactionKey::ConsensusCommitPrologue(..)
-            ));
-            assigned_versions.0[0].0 =
-                TransactionKey::Digest(*consensus_commit_prologue.tx().digest());
-            schedulables[0] = Schedulable::Transaction(consensus_commit_prologue);
-        }
-
-        self.epoch_store
-            .process_user_signatures(schedulables.iter().chain(randomness_schedulables.iter()));
-
-        // After this point we can throw away alias version information.
-        let schedulables: Vec<Schedulable> = schedulables.into_iter().map(|s| s.into()).collect();
-        let randomness_schedulables: Vec<Schedulable> = randomness_schedulables
-            .into_iter()
-            .map(|s| s.into())
-            .collect();
-
-        (schedulables, randomness_schedulables, assigned_versions)
-    }
-
     #[allow(clippy::type_complexity)]
-    fn create_pending_checkpoints_v2(
+    fn create_pending_checkpoints(
         &self,
         state: &mut CommitHandlerState,
         commit_info: &ConsensusCommitInfo,
@@ -1803,8 +1554,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         final_round: bool,
     ) -> CheckpointHeight {
         let protocol_config = self.epoch_store.protocol_config();
-        assert!(protocol_config.split_checkpoints_in_consensus_handler());
-
         let epoch = self.epoch_store.epoch();
         let accumulators_enabled = self.epoch_store.accumulators_enabled();
         let max_transactions_per_checkpoint =
@@ -1974,7 +1723,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 "Writing pending checkpoint",
             );
             self.epoch_store
-                .write_pending_checkpoint_v2(&mut state.output, &pending_checkpoint)
+                .write_pending_checkpoint(&mut state.output, &pending_checkpoint)
                 .expect("failed to write pending checkpoint");
         }
 
@@ -4470,7 +4219,7 @@ mod tests {
                 Digest::default(),
             );
             assert_eq!(flushed.len(), 1);
-            assert_eq!(flushed[0].details.checkpoint_seq, Some(initial_seq));
+            assert_eq!(flushed[0].details.checkpoint_seq, initial_seq);
 
             // The second settlement must have checkpoint_seq = initial_seq + 1,
             // because the flush incremented current_checkpoint_seq.
@@ -4478,13 +4227,10 @@ mod tests {
             let settlement2 = msg2.1.unwrap();
             assert_eq!(settlement2.checkpoint_seq, initial_seq + 1);
 
-            // Flush the remaining roots and verify the PendingCheckpointV2's seq
+            // Flush the remaining roots and verify the PendingCheckpoint's seq
             // matches the settlement's seq.
             let pending = queue.flush_forced().unwrap();
-            assert_eq!(
-                pending.details.checkpoint_seq,
-                Some(settlement2.checkpoint_seq)
-            );
+            assert_eq!(pending.details.checkpoint_seq, settlement2.checkpoint_seq);
         }
 
         #[test]
@@ -4502,7 +4248,7 @@ mod tests {
 
             let pending = queue.flush(1000, true).unwrap();
 
-            assert_eq!(pending.details.checkpoint_seq, Some(10));
+            assert_eq!(pending.details.checkpoint_seq, 10);
             assert_eq!(queue.current_checkpoint_seq, 11);
         }
 

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -41,7 +41,6 @@ use sui_types::{
     object::Owner,
     storage::InputKey,
 };
-use tracing::instrument;
 use typed_store::rocks::DBBatch;
 
 pub(crate) mod cache_types;
@@ -447,29 +446,6 @@ pub trait TransactionCacheRead: Send + Sync {
         self.multi_get_transaction_blocks(&[*digest])
             .pop()
             .expect("multi-get must return correct number of items")
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    fn get_transactions_and_serialized_sizes(
-        &self,
-        digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<(VerifiedTransaction, usize)>>> {
-        let txns = self.multi_get_transaction_blocks(digests);
-        txns.into_iter()
-            .map(|txn| {
-                txn.map(|txn| {
-                    // Note: if the transaction is read from the db, we are wasting some
-                    // effort relative to reading the raw bytes from the db instead of
-                    // calling serialized_size. However, transactions should usually be
-                    // fetched from cache.
-                    match txn.serialized_size() {
-                        Ok(size) => Ok(((*txn).clone(), size)),
-                        Err(e) => Err(e),
-                    }
-                })
-                .transpose()
-            })
-            .collect::<Result<Vec<_>, _>>()
     }
 
     fn multi_get_executed_effects_digests(

--- a/crates/sui-core/src/execution_scheduler/settlement_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/settlement_scheduler.rs
@@ -15,7 +15,6 @@ use crate::{
     execution_scheduler::execution_scheduler_impl::{BarrierDependencyBuilder, ExecutionScheduler},
     execution_scheduler::funds_withdraw_scheduler::FundsSettlement,
 };
-use futures::stream::{FuturesUnordered, StreamExt};
 use mysten_metrics::{monitored_mpsc, spawn_monitored_task};
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -86,22 +85,13 @@ impl SettlementScheduler {
         certs: Vec<(Schedulable, ExecutionEnv)>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
-        let mut rest = Vec::with_capacity(certs.len());
-        let mut settlement_txns = Vec::new();
-
-        for (schedulable, env) in certs {
-            match &schedulable {
-                Schedulable::AccumulatorSettlement(_, _) => {
-                    settlement_txns.push((schedulable.key(), env));
-                }
-                _ => {
-                    rest.push((schedulable, env));
-                }
-            }
-        }
-
-        self.execution_scheduler.enqueue(rest, epoch_store);
-        self.schedule_settlement_transactions(settlement_txns, epoch_store);
+        assert!(
+            certs
+                .iter()
+                .all(|(s, _)| !matches!(s, Schedulable::AccumulatorSettlement(_, _))),
+            "settlement transactions must be scheduled via enqueue_v2"
+        );
+        self.execution_scheduler.enqueue(certs, epoch_store);
     }
 
     pub(crate) fn enqueue_v2(
@@ -117,77 +107,6 @@ impl SettlementScheduler {
             env: ExecutionEnv::new().with_assigned_versions(settlement.assigned_versions.clone()),
             batch_info: settlement,
         });
-    }
-
-    fn schedule_settlement_transactions(
-        &self,
-        settlement_txns: Vec<(TransactionKey, ExecutionEnv)>,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) {
-        if settlement_txns.is_empty() {
-            return;
-        }
-
-        let execution_scheduler = self.execution_scheduler.clone();
-        let epoch_store = epoch_store.clone();
-        spawn_monitored_task!(epoch_store.clone().within_alive_epoch(async move {
-            let mut futures: FuturesUnordered<_> = settlement_txns
-                .into_iter()
-                .map(|(key, env)| {
-                    let epoch_store = epoch_store.clone();
-                    async move {
-                        let keys = [key];
-                        tokio::select! {
-                            txns = epoch_store.wait_for_settlement_transactions(key) => {
-                                (key, Some(txns), env)
-                            }
-                            result = epoch_store.notify_read_tx_key_to_digest(&keys) => {
-                                let _ = result;
-                                debug!(?key, "Settlement already executed, skipping scheduler wait");
-                                (key, None, env)
-                            }
-                        }
-                    }
-                })
-                .collect();
-
-            while let Some((settlement_key, txns, env)) = futures.next().await {
-                let Some(txns) = txns else {
-                    continue;
-                };
-
-                let mut barrier_deps = BarrierDependencyBuilder::new();
-                let txns = txns
-                    .into_iter()
-                    .map(|tx| {
-                        let deps = barrier_deps.process_tx(*tx.digest(), tx.transaction_data());
-                        let env = env.clone().with_barrier_dependencies(deps);
-                        (tx, env)
-                    })
-                    .collect::<Vec<_>>();
-
-                execution_scheduler.enqueue_transactions(txns, &epoch_store);
-
-                let execution_scheduler = execution_scheduler.clone();
-                let epoch_store = epoch_store.clone();
-                let env = env.clone();
-                spawn_monitored_task!(epoch_store.clone().within_alive_epoch(async move {
-                    let keys = [settlement_key];
-                    tokio::select! {
-                        barrier_tx = epoch_store.wait_for_barrier_transaction(settlement_key) => {
-                            let deps = barrier_deps
-                                .process_tx(*barrier_tx.digest(), barrier_tx.transaction_data());
-                            let env = env.with_barrier_dependencies(deps);
-                            execution_scheduler.enqueue_transactions(vec![(barrier_tx, env)], &epoch_store);
-                        }
-                        result = epoch_store.notify_read_tx_key_to_digest(&keys) => {
-                            let _ = result;
-                            debug!(?settlement_key, "Barrier already executed, skipping scheduler wait");
-                        }
-                    }
-                }));
-            }
-        }));
     }
 
     fn get_or_start_queue(

--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -2284,7 +2284,6 @@ mod tests {
     use move_core_types::account_address::AccountAddress;
     use prometheus::Registry;
     use std::collections::BTreeMap;
-    use std::env::temp_dir;
     use sui_types::base_types::{ObjectInfo, ObjectType, SuiAddress};
     use sui_types::digests::TransactionDigest;
     use sui_types::effects::TransactionEvents;
@@ -2301,8 +2300,13 @@ mod tests {
         // and verified from both db and cache.
         // This tests make sure we are invalidating entries in the cache and always reading latest
         // balance.
-        let index_store =
-            IndexStore::new_without_init(temp_dir(), &Registry::default(), Some(128), false);
+        let dir = tempfile::tempdir().unwrap();
+        let index_store = IndexStore::new_without_init(
+            dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+            false,
+        );
         let address: SuiAddress = AccountAddress::random().into();
         let mut written_objects = BTreeMap::new();
         let mut input_objects = BTreeMap::new();
@@ -2437,7 +2441,13 @@ mod tests {
         use sui_types::base_types::ObjectID;
         use typed_store::Map;
 
-        let index_store = IndexStore::new(temp_dir(), &Registry::default(), Some(128), false);
+        let dir = tempfile::tempdir().unwrap();
+        let index_store = IndexStore::new(
+            dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+            false,
+        );
         let db = &index_store.tables.transactions_by_move_function;
         db.insert(
             &(

--- a/crates/sui-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -62,13 +62,13 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
 /// Verifies that calling `notify_barrier_executed` with an `AccumulatorSettlement`
 /// key resolves `notify_read_tx_key_to_digest`, which is the mechanism used by the
 /// scheduler to detect that the barrier transaction has already been executed
-/// (e.g. by the checkpoint executor) and skip the settlement wait.
+/// (e.g. by the checkpoint executor).
 ///
 /// Unlike `insert_tx_key`, `notify_barrier_executed` is in-memory-only (no DB
 /// persistence), so it won't leave stale entries that survive a crash while
 /// the effects may not.
 #[tokio::test]
-async fn test_notify_barrier_executed_resolves_settlement_wait() {
+async fn test_notify_barrier_executed_resolves_tx_key_wait() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
 
@@ -77,19 +77,13 @@ async fn test_notify_barrier_executed_resolves_settlement_wait() {
     let key = TransactionKey::AccumulatorSettlement(epoch, checkpoint_height);
     let barrier_digest = TransactionDigest::random();
 
-    // Spawn a task that races wait_for_settlement_transactions against
-    // notify_read_tx_key_to_digest, simulating the scheduler's select! pattern.
     let store_clone = authority_state.epoch_store_for_testing();
     let handle = tokio::spawn(async move {
         let keys = [key];
-        tokio::select! {
-            _txns = store_clone.wait_for_settlement_transactions(key) => {
-                false // resolved via checkpoint builder notification
-            }
-            result = store_clone.notify_read_tx_key_to_digest(&keys) => {
-                result.is_ok() // resolved via barrier tx execution
-            }
-        }
+        store_clone
+            .notify_read_tx_key_to_digest(&keys)
+            .await
+            .is_ok()
     });
 
     // Give the spawned task time to register with notify_read_tx_key_to_digest.
@@ -106,6 +100,6 @@ async fn test_notify_barrier_executed_resolves_settlement_wait() {
 
     assert!(
         resolved_via_tx_key,
-        "select! should resolve on notify_read_tx_key_to_digest, not wait_for_settlement_transactions"
+        "notify_read_tx_key_to_digest should resolve after notify_barrier_executed"
     );
 }

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -43,8 +43,6 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
         Box::new(output),
         Box::new(certified_output),
         CheckpointMetrics::new_for_tests(),
-        3,
-        100_000,
     );
     checkpoint_service
         .spawn(epoch_store.clone(), None)

--- a/crates/sui-e2e-tests/tests/coin_registry_tests.rs
+++ b/crates/sui-e2e-tests/tests/coin_registry_tests.rs
@@ -22,6 +22,7 @@ async fn test_create_coin_registry_object() {
             config.set_cancel_for_failed_dkg_early_for_testing(true);
             config.set_use_mfp_txns_in_load_initial_object_debts_for_testing(true);
             config.set_authority_capabilities_v2_for_testing(true);
+            config.set_split_checkpoints_in_consensus_handler_for_testing(true);
             config
         });
 

--- a/crates/sui-e2e-tests/tests/display_registry_tests.rs
+++ b/crates/sui-e2e-tests/tests/display_registry_tests.rs
@@ -19,6 +19,7 @@ async fn test_create_display_registry_object() {
             config.set_cancel_for_failed_dkg_early_for_testing(true);
             config.set_use_mfp_txns_in_load_initial_object_debts_for_testing(true);
             config.set_authority_capabilities_v2_for_testing(true);
+            config.set_split_checkpoints_in_consensus_handler_for_testing(true);
             config
         });
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1564,9 +1564,6 @@ impl SuiNode {
         };
 
         let certified_checkpoint_output = SendCheckpointToStateSync::new(state_sync_handle);
-        let max_tx_per_checkpoint = max_tx_per_checkpoint(epoch_store.protocol_config());
-        let max_checkpoint_size_bytes =
-            epoch_store.protocol_config().max_checkpoint_size_bytes() as usize;
 
         CheckpointService::build(
             state.clone(),
@@ -1577,8 +1574,6 @@ impl SuiNode {
             checkpoint_output,
             Box::new(certified_checkpoint_output),
             checkpoint_metrics,
-            max_tx_per_checkpoint,
-            max_checkpoint_size_bytes,
         )
     }
 
@@ -2682,16 +2677,6 @@ async fn build_http_servers(
         },
         Some(subscription_service_checkpoint_sender),
     ))
-}
-
-#[cfg(not(test))]
-fn max_tx_per_checkpoint(protocol_config: &ProtocolConfig) -> usize {
-    protocol_config.max_transactions_per_checkpoint() as usize
-}
-
-#[cfg(test)]
-fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
-    2
 }
 
 #[derive(Default)]

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -891,10 +891,7 @@ impl std::ops::Index<usize> for CheckpointContentsView<'_> {
 
 /// Same as CheckpointContents, but contains full contents of all transactions, effects,
 /// and user signatures associated with the checkpoint.
-// NOTE: This data structure is used for state sync of checkpoints. Therefore we attempt
-// to estimate its size in CheckpointBuilder in order to limit the maximum serialized
-// size of a checkpoint sent over the network. If this struct is modified,
-// CheckpointBuilder::split_checkpoint_chunks should also be updated accordingly.
+// NOTE: This data structure is used for state sync of checkpoints.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VersionedFullCheckpointContents {
     V1(FullCheckpointContents),


### PR DESCRIPTION
## Description

Checkpoint splitting in the consensus handler (`split_checkpoints_in_consensus_handler`) is enabled on all networks including mainnet (since protocol v124). This removes the old, disabled code path and asserts the flag is enabled.

## Test plan

- `cargo nextest run -p sui-core`: 704/704 pass
- `cargo simtest -p sui-core` (checkpoint/quarantine/consensus filters): pass
- `cargo simtest -p sui-e2e-tests`: checkpoint (22), reconfiguration (8), protocol_version (7), coin_registry, display_registry — all pass
- `cargo check --workspace --all-targets`, `cargo xclippy -D warnings`, `cargo fmt --check`: clean
