### PR TITLE
Bound accumulator amounts to representable limits before charging gas

### DIFF
--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -2157,6 +2157,445 @@ async fn test_multiple_deposits_merged_in_effects() {
     test_env.trigger_reconfiguration().await;
 }
 
+/// A single transaction produces two Merge accumulator events to the same `(sender, Balance<SUI>)`
+/// key whose amounts sum past `u64::MAX`:
+///
+///   1. A Move-native Merge of exactly `u64::MAX` (an object-sourced withdrawal redeemed and
+///      deposited back to the sender). This is accepted by the object-runtime per-key cap, which
+///      rejects only totals strictly greater than `u64::MAX`.
+///   2. An uncapped Merge of `coin.value >= 1` emitted by the gas charger during gas smashing,
+///      because the gas payment mixes an address-balance reservation (the smash target) with a gas
+///      coin, so `deposit = total_smashed - reservation = coin.value` is merged into the same key.
+///
+/// The combined gross Merge total `u64::MAX + coin.value` is not representable in `u64`. This test
+/// asserts that such a transaction is aborted as a recoverable `CoinBalanceOverflow` before gas is
+/// charged, rather than reaching the per-key merge fold in `AccumulatorWriteV1::merge` or the
+/// SUI-conservation sum.
+#[sim_test]
+async fn test_accumulator_merge_overflow_poison_pill() {
+    let mut test_env = TestEnvBuilder::new().with_num_validators(1).build().await;
+
+    // Publish the test package and fund the sender's SUI address balance so that the gas-payment
+    // reservation (the smash target) is backed at signing time.
+    let pkg = test_env.setup_test_package(move_test_code_path()).await;
+
+    let (sender, gas) = test_env.get_sender_and_gas(0);
+    let fund_tx = test_env
+        .tx_builder(sender)
+        .transfer_sui_to_address_balance(FundSource::coin(gas), vec![(100_000_000, sender)])
+        .build();
+    test_env.exec_tx_directly(fund_tx).await.unwrap();
+    test_env.verify_accumulator_exists(sender, 100_000_000);
+
+    // PTB: call the entry function that emits a Move-native Merge of u64::MAX to
+    // (sender, Balance<SUI>).
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("accumulator_overflow").unwrap(),
+        Identifier::new("merge_u64_max").unwrap(),
+        vec![],
+        vec![],
+    );
+    let pt = builder.finish();
+
+    // Refresh the sender's gas coin and build a mixed gas payment: [reservation, coin]. The
+    // reservation is listed first so it becomes the smash target (an address balance), and the
+    // gas coin's value is deposited back into that same address balance as an *uncapped* Merge.
+    let (sender, gas_coin) = test_env.get_sender_and_gas(0);
+    let reservation_ref = test_env.encode_coin_reservation(sender, 0, 1_000);
+
+    let poison_tx = TransactionData::V1(TransactionDataV1 {
+        kind: TransactionKind::ProgrammableTransaction(pt),
+        sender,
+        gas_data: GasData {
+            payment: vec![reservation_ref, gas_coin],
+            owner: sender,
+            price: test_env.rgp,
+            budget: 10_000_000,
+        },
+        expiration: TransactionExpiration::ValidDuring {
+            min_epoch: Some(0),
+            max_epoch: Some(0),
+            min_timestamp: None,
+            max_timestamp: None,
+            chain: test_env.chain_id,
+            nonce: 0,
+        },
+    });
+
+    // The transaction is aborted cleanly with CoinBalanceOverflow.
+    let (_, effects) = test_env
+        .exec_tx_directly(poison_tx)
+        .await
+        .expect("execution must not panic the node");
+
+    let status = effects.status();
+    assert!(
+        matches!(
+            status,
+            sui_types::execution_status::ExecutionStatus::Failure(failure)
+                if failure.error == sui_types::execution_status::ExecutionFailureStatus::CoinBalanceOverflow
+        ),
+        "expected CoinBalanceOverflow abort, got: {status:?}"
+    );
+
+    // The sender's balance is untouched (only gas was charged) and a subsequent reconfiguration
+    // succeeds.
+    test_env.trigger_reconfiguration().await;
+}
+
+/// Per-key overflow for a *custom* coin type.
+///
+/// Gas is always paid in SUI, so the uncapped gas-smash deposit Merge that can defeat the
+/// object-runtime cap for `Balance<SUI>` has no analogue for an arbitrary `Balance<T>`. The only
+/// way to merge to a `Balance<COIN_A>` key is a Move-native deposit, every one of which is counted
+/// by the object-runtime per-key cap. So an attempt to merge past `u64::MAX` is rejected during
+/// execution (an arithmetic error from the native) and the transaction aborts cleanly.
+/// (Conservation checking does not apply to non-SUI types.) The
+/// `check_accumulator_amounts_representable` guard is also type-agnostic, so it backstops this even
+/// if the cap were ever bypassed.
+#[sim_test]
+async fn test_accumulator_merge_overflow_custom_coin_capped() {
+    let mut test_env = TestEnvBuilder::new().with_num_validators(1).build().await;
+
+    let pkg = test_env.setup_test_package(move_test_code_path()).await;
+    let (_publisher, coin_a_type) = test_env.setup_custom_coin().await;
+
+    // Two unbacked object-sourced u64::MAX deposits of Balance<COIN_A> to the sender, in one tx.
+    let (sender, gas) = test_env.get_sender_and_gas(0);
+    // COIN_A's `init` mints a starting balance to its publisher (== sender here); capture it so we
+    // can assert the aborted tx credits nothing.
+    let balance_before = test_env.get_balance_ab(sender, coin_a_type.clone());
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("accumulator_overflow").unwrap(),
+        Identifier::new("double_merge_u64_max").unwrap(),
+        vec![coin_a_type.clone()],
+        vec![],
+    );
+    let tx = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+
+    // The second merge pushes the per-key total past u64::MAX and is rejected by the object-runtime
+    // cap; the tx aborts.
+    let (_, effects) = test_env
+        .exec_tx_directly(tx)
+        .await
+        .expect("execution must not panic the node");
+    let status = effects.status();
+    assert!(
+        matches!(
+            status,
+            sui_types::execution_status::ExecutionStatus::Failure(failure)
+                if matches!(
+                    failure.error,
+                    sui_types::execution_status::ExecutionFailureStatus::MovePrimitiveRuntimeError(_)
+                )
+        ),
+        "expected the over-cap custom-coin merge to abort with an arithmetic (merge-cap) error, \
+         got: {status:?}"
+    );
+
+    // Nothing was credited to the sender's COIN_A balance.
+    assert_eq!(
+        test_env.get_balance_ab(sender, coin_a_type),
+        balance_before,
+        "aborted tx must not change the COIN_A balance"
+    );
+    test_env.trigger_reconfiguration().await;
+}
+
+/// A single object-sourced `u64::MAX` SUI withdrawal redeemed and deposited to the sender. The
+/// per-key representability guard bounds SUI accumulator totals to the total supply, so this
+/// `u64::MAX` (both the input-side `Split` and the deposit `Merge`) exceeds the supply and is
+/// rejected as `CoinBalanceOverflow` *before* gas is charged — well before the SUI-conservation sum
+/// or the withdrawal-backing check run. (The conservation sum still accumulates in `u128` as
+/// defense-in-depth for multi-key totals that individually stay within supply but jointly exceed
+/// `u64::MAX`.)
+#[sim_test]
+async fn test_accumulator_conservation_overflow_single_withdrawal() {
+    let mut test_env = TestEnvBuilder::new().with_num_validators(1).build().await;
+
+    let pkg = test_env.setup_test_package(move_test_code_path()).await;
+
+    // A single u64::MAX SUI withdrawal deposited to the sender, paid with a normal gas coin (no
+    // address-balance reservation). u64::MAX exceeds the total SUI supply, so the per-key guard
+    // rejects it before gas charging / conservation.
+    let (sender, gas) = test_env.get_sender_and_gas(0);
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("accumulator_overflow").unwrap(),
+        Identifier::new("merge_u64_max").unwrap(),
+        vec![],
+        vec![],
+    );
+    let tx = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        builder.finish(),
+        10_000_000,
+        test_env.rgp,
+    );
+
+    // The u64::MAX deposit exceeds the total SUI supply, so the per-key representability guard
+    // aborts the transaction with CoinBalanceOverflow before gas is charged.
+    let (_, effects) = test_env
+        .exec_tx_directly(tx)
+        .await
+        .expect("execution must not panic the node");
+    let status = effects.status();
+    assert!(
+        matches!(
+            status,
+            sui_types::execution_status::ExecutionStatus::Failure(failure)
+                if failure.error
+                    == sui_types::execution_status::ExecutionFailureStatus::CoinBalanceOverflow
+        ),
+        "expected CoinBalanceOverflow, got: {status:?}"
+    );
+    test_env.trigger_reconfiguration().await;
+}
+
+/// A gas-refund Merge to a key already at `u64::MAX`. Bounding the per-key guard to `u64::MAX` alone
+/// would let a Move-native Merge of exactly `u64::MAX` to `(sender, Balance<SUI>)` pass; `charge_gas`
+/// then emits a refund Merge (`net_gas_usage() < 0`, gas paid from the sender's SUI address balance)
+/// to that same key *after* the guard, and the fold in `AccumulatorWriteV1::merge` would compute
+/// `u64::MAX + refund`, which is not representable.
+///
+/// This test sets up that shape: a single address-balance gas reservation (empty `payment` +
+/// `ValidDuring`, so no smash-time deposit Merge) plus a net refund produced by deleting a large
+/// pre-existing owned object. Because the supply bound makes the `u64::MAX` Merge exceed
+/// `TOTAL_SUPPLY_MIST`, it is rejected as `CoinBalanceOverflow` before gas is charged, so the refund
+/// is never emitted.
+#[sim_test]
+async fn test_accumulator_merge_overflow_gas_refund_poison_pill() {
+    let mut test_env = TestEnvBuilder::new().with_num_validators(1).build().await;
+
+    let pkg = test_env.setup_test_package(move_test_code_path()).await;
+
+    // Fund the sender's SUI address balance so the (empty-payment) address-balance gas reservation
+    // is backed at signing time.
+    let (sender, gas) = test_env.get_sender_and_gas(0);
+    let fund_tx = test_env
+        .tx_builder(sender)
+        .transfer_sui_to_address_balance(FundSource::coin(gas), vec![(1_000_000_000, sender)])
+        .build();
+    test_env.exec_tx_directly(fund_tx).await.unwrap();
+    test_env.verify_accumulator_exists(sender, 1_000_000_000);
+
+    // Setup: create a large owned object, paying its (large) storage cost now via a normal coin gas
+    // payment. Deleting it in the later tx then returns a storage rebate big enough to make that tx
+    // net-negative (a gas refund). 16_000 bytes stays under the 16_384-byte max pure-argument size;
+    // at obj_data_cost_refundable (100) * storage_gas_price (76) = 7600 MIST/byte that is ~120M MIST
+    // of storage cost, whose rebate dwarfs the later tx's two-call computation.
+    let (sender, gas) = test_env.get_sender_and_gas(0);
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let value = builder.pure(1u64).unwrap();
+    let data_arg = builder.pure(vec![0u8; 16_000]).unwrap();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("gas_test").unwrap(),
+        Identifier::new("create_object_with_large_storage").unwrap(),
+        vec![],
+        vec![value, data_arg],
+    );
+    let create_tx = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        builder.finish(),
+        2_000_000_000,
+        test_env.rgp,
+    );
+    let (_, create_effects) = test_env.exec_tx_directly(create_tx).await.unwrap();
+    assert!(
+        create_effects.status().is_ok(),
+        "large-object create failed: {:?}",
+        create_effects.status()
+    );
+    let large_obj = create_effects.created()[0].0;
+
+    // PTB: delete the large object (storage rebate >> computation => net refund) and emit a
+    // Move-native Merge of u64::MAX to (sender, Balance<SUI>) via the object-sourced withdrawal.
+    let (sender, _gas) = test_env.get_sender_and_gas(0);
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let obj_arg = builder.obj(ObjectArg::ImmOrOwnedObject(large_obj)).unwrap();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("gas_test").unwrap(),
+        Identifier::new("delete_object").unwrap(),
+        vec![],
+        vec![obj_arg],
+    );
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("accumulator_overflow").unwrap(),
+        Identifier::new("merge_u64_max").unwrap(),
+        vec![],
+        vec![],
+    );
+    let tx_kind = TransactionKind::ProgrammableTransaction(builder.finish());
+
+    // Empty gas payment + ValidDuring expiration => gas is paid from the sender's SUI address
+    // balance (a single reservation, the smash target). No smash-time deposit Merge is emitted, so
+    // the only over-limit event would be the final (refund) Merge emitted inside charge_gas, after
+    // the guard — which is why the guard must reject the u64::MAX deposit (above the supply) up
+    // front, before that refund is ever computed.
+    let poison_tx = create_address_balance_transaction(
+        tx_kind,
+        sender,
+        100_000_000,
+        test_env.rgp,
+        test_env.chain_id,
+    );
+
+    // The over-supply deposit is rejected as CoinBalanceOverflow before gas is charged.
+    let (_, effects) = test_env
+        .exec_tx_directly(poison_tx)
+        .await
+        .expect("execution must not panic the node");
+    let status = effects.status();
+    assert!(
+        matches!(
+            status,
+            sui_types::execution_status::ExecutionStatus::Failure(failure)
+                if failure.error
+                    == sui_types::execution_status::ExecutionFailureStatus::CoinBalanceOverflow
+        ),
+        "expected CoinBalanceOverflow, got: {status:?}"
+    );
+
+    test_env.trigger_reconfiguration().await;
+}
+
+/// Gas-coin overflow via `Argument::GasCoin`. The per-key supply guard bounds SUI *accumulator*
+/// amounts, but merging SUI into the PTB gas coin via a `MergeCoins` command is an object mutation,
+/// not an accumulator event, so it escapes that guard. `MergeCoins` only rejects sums strictly
+/// greater than `u64::MAX`, so it permits driving the gas coin's raw value up to exactly `u64::MAX`.
+/// If the transaction then nets a gas *refund* (`net_gas_usage() < 0`), `deduct_gas` would compute
+/// `u64::MAX + refund`, which is not representable.
+///
+/// The gas coin is driven to `u64::MAX` with two object-sourced SUI withdrawals — each
+/// `< TOTAL_SUPPLY_MIST`, so each passes the per-key supply guard — redeemed to `Coin<SUI>` and
+/// merged into the gas coin; the refund is produced by deleting a large pre-existing object.
+/// Reaching this requires ~`u64::MAX` MIST of SUI in one coin, more than the total supply.
+///
+/// The cross-key total-SUI-withdraw bound covers this: the two withdrawals sum to ~`u64::MAX`, which
+/// exceeds the total supply, so the transaction is rejected as `CoinBalanceOverflow` before gas is
+/// charged. (The per-key supply guard alone does not catch this — each withdrawal is under supply.)
+#[sim_test]
+async fn test_gas_coin_overflow_via_merge_into_gas_coin() {
+    let mut test_env = TestEnvBuilder::new().with_num_validators(1).build().await;
+
+    let pkg = test_env.setup_test_package(move_test_code_path()).await;
+
+    // Create a large owned object up front; deleting it in the later tx yields a storage rebate
+    // big enough to make that tx net-negative (a gas refund), which is what makes deduct_gas *add*
+    // to the (already u64::MAX) gas coin rather than subtract.
+    let (sender, gas) = test_env.get_sender_and_gas(0);
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let value = builder.pure(1u64).unwrap();
+    let data_arg = builder.pure(vec![0u8; 16_000]).unwrap();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("gas_test").unwrap(),
+        Identifier::new("create_object_with_large_storage").unwrap(),
+        vec![],
+        vec![value, data_arg],
+    );
+    let create_tx = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        builder.finish(),
+        2_000_000_000,
+        test_env.rgp,
+    );
+    let (_, create_effects) = test_env.exec_tx_directly(create_tx).await.unwrap();
+    assert!(
+        create_effects.status().is_ok(),
+        "large-object create failed: {:?}",
+        create_effects.status()
+    );
+    let large_obj = create_effects.created()[0].0;
+
+    // Drive the gas coin to exactly u64::MAX: gas_coin_value + amount1 + amount2 == u64::MAX, with
+    // each withdrawal kept under total supply so the per-key supply guard passes.
+    let (sender, gas) = test_env.get_sender_and_gas(0);
+    let gas_value = test_env.get_coin_balance(gas.0).await;
+    let needed = u64::MAX - gas_value;
+    let amount1 = needed / 2;
+    let amount2 = needed - amount1;
+    assert!(
+        amount1 < sui_types::gas_coin::TOTAL_SUPPLY_MIST
+            && amount2 < sui_types::gas_coin::TOTAL_SUPPLY_MIST,
+        "each phantom withdrawal ({amount1}, {amount2}) must stay under total supply to pass the guard"
+    );
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    // Delete the large object (storage rebate >> computation => net refund).
+    let obj_arg = builder.obj(ObjectArg::ImmOrOwnedObject(large_obj)).unwrap();
+    builder.programmable_move_call(
+        pkg,
+        Identifier::new("gas_test").unwrap(),
+        Identifier::new("delete_object").unwrap(),
+        vec![],
+        vec![obj_arg],
+    );
+    // Two SUI withdrawals returned as Coin<SUI>.
+    let a1 = builder.pure(amount1).unwrap();
+    let c1 = builder.programmable_move_call(
+        pkg,
+        Identifier::new("accumulator_overflow").unwrap(),
+        Identifier::new("withdraw_sui_as_coin").unwrap(),
+        vec![],
+        vec![a1],
+    );
+    let a2 = builder.pure(amount2).unwrap();
+    let c2 = builder.programmable_move_call(
+        pkg,
+        Identifier::new("accumulator_overflow").unwrap(),
+        Identifier::new("withdraw_sui_as_coin").unwrap(),
+        vec![],
+        vec![a2],
+    );
+    // Merge both into the gas coin: gas + amount1 + amount2 == u64::MAX, which MergeCoins permits
+    // (it rejects only sums strictly above u64::MAX).
+    builder.command(Command::MergeCoins(Argument::GasCoin, vec![c1, c2]));
+
+    let poison_tx = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        builder.finish(),
+        100_000_000,
+        test_env.rgp,
+    );
+
+    // The over-supply aggregate withdraw is rejected as CoinBalanceOverflow before gas is charged.
+    let (_, effects) = test_env
+        .exec_tx_directly(poison_tx)
+        .await
+        .expect("execution must not panic the node");
+    let status = effects.status();
+    assert!(
+        matches!(
+            status,
+            sui_types::execution_status::ExecutionStatus::Failure(failure)
+                if failure.error
+                    == sui_types::execution_status::ExecutionFailureStatus::CoinBalanceOverflow
+        ),
+        "expected CoinBalanceOverflow, got: {status:?}"
+    );
+
+    test_env.trigger_reconfiguration().await;
+}
+
 #[sim_test]
 async fn test_address_balance_gas_budget_enforcement_with_storage() {
     let mut test_env = TestEnvBuilder::new().build().await;

--- a/crates/sui-e2e-tests/tests/move_test_code/sources/accumulator_overflow.move
+++ b/crates/sui-e2e-tests/tests/move_test_code/sources/accumulator_overflow.move
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Test helpers that produce Move-native accumulator Merge/Split events of large amounts (up to
+/// `u64::MAX`) on a balance key, used to exercise the per-key accumulator representability guards.
+module move_test_code::accumulator_overflow;
+
+use sui::balance;
+use sui::coin::{Self, Coin};
+use sui::object::{Self, UID};
+use sui::sui::SUI;
+use sui::tx_context::{Self, TxContext};
+
+const U64_MAX: u64 = 18446744073709551615;
+
+/// Object-sourced withdrawals are checked for backing only at settlement (which runs after effects
+/// construction), so this withdraws `u64::MAX` and deposits it to the sender, yielding a single
+/// Move-native Merge of `u64::MAX` to `(sender, Balance<SUI>)`.
+public entry fun merge_u64_max(ctx: &mut TxContext) {
+    let sender = tx_context::sender(ctx);
+    let mut id = object::new(ctx);
+
+    let w = balance::withdraw_funds_from_object<SUI>(&mut id, U64_MAX);
+    let bal = balance::redeem_funds<SUI>(w);
+    balance::send_funds<SUI>(bal, sender);
+
+    object::delete(id);
+}
+
+/// Withdraw `amount` of SUI from a fresh object and return it as a `Coin<SUI>`. The per-object
+/// withdrawal emits a `Split` of `amount` on that object's accumulator key, which the supply guard
+/// bounds to `<= TOTAL_SUPPLY_MIST`. The returned `Coin` can be merged into `Argument::GasCoin` via
+/// a PTB `MergeCoins` command — not an accumulator event — so several such withdrawals can drive the
+/// gas coin's raw `u64` value up to `u64::MAX`, beyond what the supply guard permits for any single
+/// balance.
+public fun withdraw_sui_as_coin(amount: u64, ctx: &mut TxContext): Coin<SUI> {
+    let mut id = object::new(ctx);
+    let w = balance::withdraw_funds_from_object<SUI>(&mut id, amount);
+    let bal = balance::redeem_funds<SUI>(w);
+    object::delete(id);
+    coin::from_balance<SUI>(bal, ctx)
+}
+
+/// Deposit `u64::MAX` of `Balance<T>` to the sender twice via object-sourced withdrawals. Both
+/// deposits are Move-native Merges to `(sender, Balance<T>)`, so the second pushes the object-runtime
+/// per-key merge total past `u64::MAX` and is rejected with an arithmetic error. Unlike
+/// `Balance<SUI>`, an arbitrary `Balance<T>` has no uncapped gas-smash deposit path, so this per-key
+/// cap is the binding guard (and gas/conservation checking does not apply to non-SUI types).
+public entry fun double_merge_u64_max<T>(ctx: &mut TxContext) {
+    let sender = tx_context::sender(ctx);
+
+    let mut id1 = object::new(ctx);
+    let w1 = balance::withdraw_funds_from_object<T>(&mut id1, U64_MAX);
+    balance::send_funds<T>(balance::redeem_funds<T>(w1), sender);
+    object::delete(id1);
+
+    let mut id2 = object::new(ctx);
+    let w2 = balance::withdraw_funds_from_object<T>(&mut id2, U64_MAX);
+    balance::send_funds<T>(balance::redeem_funds<T>(w2), sender);
+    object::delete(id2);
+}

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -658,6 +658,24 @@ mod checked {
             ));
         }
 
+        // Reject transactions whose per-key accumulator totals are not representable *before*
+        // charging gas. For SUI this bounds each per-key gross Merge/Split total to the total supply;
+        // for other balances it bounds them to u64. Doing so here means the rejected PTB-emitted
+        // accumulator events are dropped during the gas reset on the error path (only the bounded gas
+        // events remain). Bounding SUI to the supply (which is ~8.4B SUI below u64::MAX) leaves enough
+        // headroom that the gas-smash deposit / gas-charge events emitted *after* this point cannot
+        // push any per-key total past u64::MAX, so the fold in AccumulatorWriteV1::merge cannot
+        // overflow even though those gas events are not re-checked here.
+        //
+        // Ungated: this only ever turns a would-be arithmetic failure into a deterministic abort,
+        // which produces no committed effects and so cannot diverge from any previously-committed
+        // result, and it applies uniformly across protocol versions.
+        if result.is_ok()
+            && let Err(e) = temporary_store.check_accumulator_amounts_representable()
+        {
+            result = Err(e.into());
+        }
+
         let cost_summary = gas_charger.charge_gas(temporary_store, protocol_config, &mut result);
         // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
         // information provided to check_sui_conserved, because we mint rewards, and burn

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -203,6 +203,83 @@ impl<'backing> TemporaryStore<'backing> {
         running_max_withdraws
     }
 
+    /// Ensure that, per accumulator object, the gross Merge total and gross Split total are
+    /// representable: bounded by the total SUI supply for `Balance<SUI>` keys, and by `u64::MAX`
+    /// otherwise.
+    ///
+    /// `AccumulatorWriteV1::merge` folds all writes for a key by summing Merge amounts and Split
+    /// amounts separately into `u64`s. The object runtime caps Move-native merges per key at
+    /// `u64::MAX`, but the gas charger emits additional, uncapped SUI deposit/withdraw events during
+    /// gas smashing and gas charging (e.g. a refund Merge to an address balance), so a per-key SUI
+    /// total could be pushed past `u64::MAX`, overflowing that fold (and the SUI-conservation sum).
+    /// Reaching such a total requires SUI from an object-sourced withdrawal whose backing is only
+    /// verified at settlement.
+    ///
+    /// Bounding SUI to `TOTAL_SUPPLY_MIST` rejects any such amount here, *before* gas is charged, so
+    /// the rejected PTB-emitted writes are dropped on gas reset and only the (bounded) gas events
+    /// remain. Crucially, `TOTAL_SUPPLY_MIST` is ~8.4B SUI below `u64::MAX`, so the gas events emitted
+    /// after this check (which move only real SUI) cannot push any per-key total past `u64::MAX` —
+    /// hence they need not be re-checked. Non-SUI balances have no uncapped gas path, so the
+    /// object-runtime per-key `u64::MAX` cap is the binding guard there and we only backstop u64
+    /// representability.
+    ///
+    /// The per-key limits are not sufficient on their own: withdrawn SUI can be spread across several
+    /// object keys (each withdrawal `<= TOTAL_SUPPLY_MIST`) and then recombined *outside* the
+    /// accumulator — e.g. each withdrawal redeemed to a `Coin<SUI>` and merged into the PTB gas coin
+    /// via `MergeCoins`, which is an object mutation, not an accumulator event. The recombined coin
+    /// can then reach `u64::MAX` and overflow `deduct_gas` on a refund. So we also bound the
+    /// *cross-key* total SUI withdrawn (gross Split) to the supply, capping the total SUI a single
+    /// transaction can withdraw regardless of how it is later recombined.
+    pub fn check_accumulator_amounts_representable(&self) -> Result<(), ExecutionError> {
+        let supply = sui_types::gas_coin::TOTAL_SUPPLY_MIST as u128;
+        let mut merge_totals: BTreeMap<AccumulatorObjId, u128> = BTreeMap::new();
+        let mut split_totals: BTreeMap<AccumulatorObjId, u128> = BTreeMap::new();
+        // Cross-key total of SUI withdrawn (gross Split), bounded to the supply (see above).
+        let mut total_sui_split: u128 = 0;
+        for event in &self.execution_results.accumulator_events {
+            let AccumulatorValue::Integer(amount) = event.write.value else {
+                continue;
+            };
+            let amount = amount as u128;
+            // SUI cannot exceed its total supply through any single balance. Bounding to the supply
+            // (rather than u64::MAX) leaves headroom for the not-yet-emitted gas events.
+            let is_sui = sui_types::gas_coin::GasCoin::is_gas_balance_type(&event.write.address.ty);
+            let limit = if is_sui { supply } else { u64::MAX as u128 };
+            let total = match event.write.operation {
+                AccumulatorOperation::Merge => {
+                    merge_totals.entry(event.accumulator_obj).or_default()
+                }
+                AccumulatorOperation::Split => {
+                    split_totals.entry(event.accumulator_obj).or_default()
+                }
+            };
+            *total += amount;
+            if *total > limit {
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::CoinBalanceOverflow,
+                    format!(
+                        "accumulator balance change for {:?} exceeds the representable limit \
+                         (gross total {}, limit {})",
+                        event.accumulator_obj, *total, limit
+                    ),
+                ));
+            }
+            if is_sui && matches!(event.write.operation, AccumulatorOperation::Split) {
+                total_sui_split += amount;
+                if total_sui_split > supply {
+                    return Err(ExecutionError::new_with_source(
+                        ExecutionErrorKind::CoinBalanceOverflow,
+                        format!(
+                            "total SUI withdrawn across all accumulators ({total_sui_split}) \
+                             exceeds the total supply ({supply})"
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Ensure that there is one entry for each accumulator object in the accumulator events.
     fn merge_accumulator_events(&mut self) {
         self.execution_results.accumulator_events = self
@@ -1385,20 +1462,25 @@ impl TemporaryStore<'_> {
         advance_epoch_gas_summary: Option<(u64, u64)>,
         layout_resolver: &mut impl LayoutResolver,
     ) -> Result<(), ExecutionError> {
+        // Accumulate in u128. The per-object SUI totals are bounded by the real supply, but the
+        // accumulator-event terms below are not: an object-sourced withdrawal/deposit (backing
+        // verified only at settlement) can contribute up to u64::MAX on each side, and a transaction
+        // can stack several across distinct keys, so a u64 running total could overflow. These
+        // amounts net out, so a u128 sum stays exact and conservation is decided correctly.
         // total amount of SUI in input objects, including both coins and storage rebates
-        let mut total_input_sui = 0;
+        let mut total_input_sui: u128 = 0;
         // total amount of SUI in output objects, including both coins and storage rebates
-        let mut total_output_sui = 0;
+        let mut total_output_sui: u128 = 0;
 
         // settlement input/output sui is used by the settlement transactions to account for
         // Sui that has been gathered from the accumulator writes of transactions which it is
         // settling.
-        total_input_sui += self.execution_results.settlement_input_sui;
-        total_output_sui += self.execution_results.settlement_output_sui;
+        total_input_sui += self.execution_results.settlement_input_sui as u128;
+        total_output_sui += self.execution_results.settlement_output_sui as u128;
 
         for (id, input, output) in self.get_modified_objects() {
             if let Some(input) = input {
-                total_input_sui += self.get_input_sui(&id, input.version, layout_resolver)?;
+                total_input_sui += self.get_input_sui(&id, input.version, layout_resolver)? as u128;
             }
             if let Some(object) = output {
                 total_output_sui += object.get_total_sui(layout_resolver).map_err(|e| {
@@ -1407,24 +1489,25 @@ impl TemporaryStore<'_> {
                          mutated type {:?}: {e:#?}",
                         object.struct_tag(),
                     )
-                })?;
+                })? as u128;
             }
         }
 
         for event in &self.execution_results.accumulator_events {
             let (input, output) = event.total_sui_in_event();
-            total_input_sui += input;
-            total_output_sui += output;
+            total_input_sui += input as u128;
+            total_output_sui += output as u128;
         }
 
         // note: storage_cost flows into the storage_rebate field of the output objects, which is
         // why it is not accounted for here.
         // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow
         // gets credited to the gas coin both computation costs and storage rebate inflow are
-        total_output_sui += gas_summary.computation_cost + gas_summary.non_refundable_storage_fee;
+        total_output_sui +=
+            gas_summary.computation_cost as u128 + gas_summary.non_refundable_storage_fee as u128;
         if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
-            total_input_sui += epoch_fees;
-            total_output_sui += epoch_rebates;
+            total_input_sui += epoch_fees as u128;
+            total_output_sui += epoch_rebates as u128;
         }
         if total_input_sui != total_output_sui {
             return Err(ExecutionError::invariant_violation(format!(


### PR DESCRIPTION
## Summary

- Reject transactions whose per-key accumulator totals are not representable before charging gas: SUI balance keys are bounded by the total SUI supply, other balances by `u64::MAX`
- Bound the cross-key total SUI withdrawn (gross Split) by the total supply, since withdrawn SUI can be recombined outside the accumulator (e.g. merged into the PTB gas coin)
- Accumulate SUI-conservation input/output totals in `u128` so intermediate sums stay exact regardless of individual event amounts
- The guard turns a would-be arithmetic failure into a deterministic `CoinBalanceOverflow` abort; it is ungated and applies uniformly across protocol versions

## Test plan

- [ ] Added e2e regression tests covering per-key SUI/custom-coin merges, single-withdrawal conservation, the gas-refund path, and gas-coin recombination via `MergeCoins`
- [ ] `cargo simtest -p sui-e2e-tests address_balance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)