### PR TITLE
fix(graphql): unexpected unicode in SuiAddress

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
@@ -72,8 +72,15 @@ impl FromStr for SuiAddress {
 
         // Parse a single hexadecimal character from the string, or return an error pointing to the
         // bad character in the source string.
+        let bytes = s.as_bytes();
         let hex = |i: usize| -> Result<u8, Error> {
-            u8::from_str_radix(&s[i..=i], 16).map_err(|_| Error::BadHex(i + 2))
+            let b = bytes[i];
+            match b {
+                b'0'..=b'9' => Ok(b - b'0'),
+                b'a'..=b'f' => Ok(b - b'a' + 10),
+                b'A'..=b'F' => Ok(b - b'A' + 10),
+                _ => Err(Error::BadHex(i + 2)),
+            }
         };
 
         let mut arr = [0u8; SUI_ADDRESS_LENGTH];
@@ -243,6 +250,12 @@ mod tests {
     #[test]
     fn test_unicode_gibberish() {
         let parsed = SuiAddress::from_str("aAௗ0㌀0");
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn test_unicode_char_boundary() {
+        let parsed = SuiAddress::from_str("0x…0123");
         assert!(parsed.is_err());
     }
 


### PR DESCRIPTION
Make `SuiAddress` parsing in GraphQL robust to the presence of unicode characters. The previous approach did not correctly handle multi-byte UTF8 characters (it assumed each byte offset in the string was a valid character boundary) and attempted to slice out each character as a single byte string to pass to `u8::from_str_radix` -- this slice operation can panic when fed a string containing a multi-byte character (although GraphQL has a panic handler installed so in practice this turns a user error into an internal error).

## Test plan

Introduced a regression test for this case:

```
$ cargo nextest run                \
  -p sui-indexer-alt-graphql --lib \
  -- test_unicode_char_boundary
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
