### PR TITLE
docs(oidc): record Phase-4 decision — option A (all PRs read-only)

### DIFF
--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -40,7 +40,7 @@ The decision is the OIDC `sub` of the run, which depends on the event + ref:
 | `workflow_dispatch`| `main`, **no** `sui_repo_ref`        | `…:ref:refs/heads/main`        | **YES**                  | OIDC RW                               |
 | `workflow_dispatch`| `main` + `sui_repo_ref=<feature>`    | `…:ref:refs/heads/main`        | sub matches, but **gate OFF** | builds the override ref (untrusted code) → must NOT hold RW; gate requires `sui_repo_ref==''` → static/local |
 | `workflow_dispatch`| feature branch                       | `…:ref:refs/heads/<feat>`      | **NO**                   | local-cache fallback (expected)       |
-| `pull_request`     | any (same-repo **and** fork)         | `…:pull_request`               | **NO — by design**       | **blocked on A/B/C** (see roles doc)  |
+| `pull_request`     | any (same-repo **and** fork)         | `…:pull_request`               | **NO** (no RW)           | **RO role** (option A) once provisioned |
 
 > **Checkout-ref caveat (rust.yml / bridge.yml).** The OIDC `sub` (and thus role
 > assumability) is decided by `github.ref` — but these workflows check out
@@ -157,21 +157,21 @@ The `sui_repo_ref` guard is **conservative** for jobs that ignore that input
 static/local on an override dispatch rather than OIDC. That is the safe direction.
 
 - **Trusted push / dispatch-from-main** → OIDC RW (no static keys used).
-- **`pull_request`** → empty role → static-key fallback = **unchanged behavior**.
-- **Phase 4** then resolves the PR path per A/B/C (RO role, no-cache, or fork split).
+- **`pull_request`** → empty role → static-key fallback (until Phase 4 lands).
+- **Phase 4** then resolves the PR path: **option A — all PRs → RO role.**
 - **Phase 7** removes the static-key inputs once no event path needs them.
 
-**Decision required to finish the mixed callers (Phase 4):** pick PR-cache option
-**A** (all PRs → RO role), **B** (no PR cache), or **C** (same-repo RO, fork none)
-— see `AWS_OIDC_ROLES.md` §"PR read-only cache" for full trade-offs. Key facts for
-the decision: every PR (same-repo and fork) presents the same OIDC sub
-(`repo:MystenLabs/sui:pull_request`), so AWS trust alone cannot implement C —
-"fork = none" can only be enforced at the GitHub layer (fork PRs cannot get
-`id-token: write` under default repo settings, and C additionally requires the
-workflow to withhold that permission from fork-reachable jobs explicitly, not just
-gate the `role-to-assume` input). Recommendation on record: **A unless cache
-contents are considered sensitive** (simplest, robust, RO cannot poison the
-cache); **C with explicit workflow-layer enforcement** if preserving today's
-fork boundary outweighs fork CI speed; **B** if no PR cache is acceptable. The
-Phase-3 dual-pass above is the same regardless; A/B/C only changes the Phase-4
-follow-up and when static keys die.
+**Phase 4 decision: option A (2026-06-15).** All PRs, including forks, get
+**read-only** sccache access via a new RO role (`sui-sccache-ro-github`); no PR
+gets write access, so poisoning stays blocked. Chosen over C because the cache
+holds only public-source build artifacts (no identified sensitivity) and C's
+"fork = none" cannot be done in IAM — every PR presents the same sub
+`repo:MystenLabs/sui:pull_request`, so C would require ongoing workflow-layer
+enforcement (withholding `id-token: write` from fork-reachable jobs) that we
+declined to carry preemptively. See `AWS_OIDC_ROLES.md` §"PR read-only cache"
+for the RO role's trust + policy to provision.
+
+**Remaining Phase-4 work (mechanical, after the RO role is provisioned):** extend
+each `SCCACHE_ROLE` expression so `pull_request` resolves the RO ARN (trusted
+refs still → RW; override-dispatch still → empty), then drop the static-key
+inputs per Phase 7.

--- a/.github/AWS_OIDC_ROLES.md
+++ b/.github/AWS_OIDC_ROLES.md
@@ -63,11 +63,14 @@ not assume this role (they fall back to a local cache).
 > `repo:MystenLabs/sui:ref:refs/heads/{main,devnet,testnet,mainnet}` — `aud`
 > pinned, no wildcard.
 >
-> **Gap to close if needed:** the live trust does **not** yet include
-> `releases/sui-*-release` branches or `*-v*` tags. sccache callers that run on a
-> release branch or tag therefore cannot assume it today; add those `sub` entries
-> (per the "explicit refs" block) before flipping any release-branch/tag-triggered
-> sccache caller.
+> **Gap to close (Phase-5 release flip):** `releases/sui-*-release` branch trust
+> was added 2026-06-08, but the live trust does **not** yet include the release
+> **tags**. Add these three exact subjects (matching the workflow's dispatch guard
+> in `release.yml`, not a broad `*-v*`) before flipping the release.yml sccache
+> caller to OIDC:
+> `repo:MystenLabs/sui:ref:refs/tags/{devnet,testnet,mainnet}-v*`. The
+> dispatch path's `main` sub is already trusted and its chosen-ref hazard is
+> closed by the landed tag-prefix + `refs/tags/` checkout guards (PR #26953).
 
 ### Trust policy
 
@@ -102,7 +105,9 @@ Alternative (explicit refs — use if not adopting an environment):
       "repo:MystenLabs/sui:ref:refs/heads/testnet",
       "repo:MystenLabs/sui:ref:refs/heads/mainnet",
       "repo:MystenLabs/sui:ref:refs/heads/releases/sui-*-release",
-      "repo:MystenLabs/sui:ref:refs/tags/*-v*"
+      "repo:MystenLabs/sui:ref:refs/tags/devnet-v*",
+      "repo:MystenLabs/sui:ref:refs/tags/testnet-v*",
+      "repo:MystenLabs/sui:ref:refs/tags/mainnet-v*"
     ]
   }
 }

--- a/.github/AWS_OIDC_ROLES.md
+++ b/.github/AWS_OIDC_ROLES.md
@@ -133,18 +133,56 @@ so they are covered by the branch subjects above.)
 }
 ```
 
-### PR read-only cache (follow-up, not this PR)
+### PR read-only cache — **DECISION: option A (2026-06-15)**
 
-Today same-repo PRs get **read/write** cache via the static key. The goal is to
-demote PRs to **read-only** so a PR can't poison the shared cache, using a second
-role `sui-github-actions-sccache-ro` (trust on `pull_request`, policy granting
-only `s3:GetObject` + `s3:ListBucket`, **no `PutObject`**).
+> **Decided: option A.** Allow all PRs, including forks, **read-only** access to
+> the sccache cache through a new RO OIDC role. The cache holds compiled
+> artifacts built from public `sui` source with no identified sensitive material,
+> and PRs get **no write access** so cache poisoning stays blocked. If concrete
+> sensitivity is ever identified in cache contents, revisit option C — but we do
+> not carry the workflow capability-split complexity preemptively. Options B/C
+> are retained below for the record.
 
-**Caveat — "fork = none" is not enforceable by the trust policy.** GitHub's OIDC
-`sub` for *every* PR — same-repo and fork alike — is the same value
-`repo:MystenLabs/sui:pull_request`. AWS cannot tell a fork PR from a same-repo PR
-from that claim, so the trust alone cannot grant RO to same-repo PRs while
-denying forks. Pick one:
+Today same-repo PRs get **read/write** cache via the static key. Option A demotes
+PRs to **read-only** so a PR can't poison the shared cache, using a second role
+**`sui-sccache-ro-github`** (naming parallels the existing
+`sui-sccache-rw-github`; trust on `pull_request`, policy granting only
+`s3:GetObject` + `s3:ListBucket`, **no `PutObject`**).
+
+**To provision (AWS account `011083325127`):**
+
+```json
+// Trust policy — RO role
+"Condition": {
+  "StringEquals": {
+    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+    "token.actions.githubusercontent.com:sub": "repo:MystenLabs/sui:pull_request"
+  }
+}
+```
+
+```json
+// Permission policy — bucket mystenlabs-sccache, read-only (NO PutObject)
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Sid": "SccacheObjectRO", "Effect": "Allow",
+      "Action": "s3:GetObject", "Resource": "arn:aws:s3:::mystenlabs-sccache/*" },
+    { "Sid": "SccacheListBucket", "Effect": "Allow",
+      "Action": "s3:ListBucket", "Resource": "arn:aws:s3:::mystenlabs-sccache" }
+  ]
+}
+```
+
+Under option A this trust is intentionally PR-wide; no fork/same-repo distinction
+is attempted (it is not expressible in IAM — see below). The workflow flip then
+extends each `SCCACHE_ROLE` expression to resolve the RO ARN on `pull_request`.
+
+**For the record — "fork = none" is not enforceable by the trust policy** (the
+reason A was chosen over C). GitHub's OIDC `sub` for *every* PR — same-repo and
+fork alike — is the same value `repo:MystenLabs/sui:pull_request`. AWS cannot tell
+a fork PR from a same-repo PR from that claim, so the trust alone cannot grant RO
+to same-repo PRs while denying forks. The rejected alternatives:
 
 - **(A) All PRs → read-only** (incl. forks): trust `pull_request` on the RO role.
   Simplest; a read-only cache is low-risk (no poisoning, no exfil beyond cache


### PR DESCRIPTION
## Summary

Docs-only. Records the **Phase-4 decision: option A** in the canonical OIDC docs, unblocking the remaining mechanical migration work.

> **Decision:** Allow all PRs, including forks, **read-only** access to the sccache cache through a new RO OIDC role. The cache holds compiled artifacts from public `sui` source with no identified sensitive material, and PRs get **no write access** so cache poisoning stays blocked. If concrete sensitivity in cache contents is ever identified, we can revisit C — but we do not carry the workflow capability-split complexity preemptively.

Changes:
- `AWS_OIDC_ROLES.md` §"PR read-only cache": marks A as decided and adds the concrete provisioning spec for `sui-sccache-ro-github` (trust on `repo:MystenLabs/sui:pull_request`, RO policy: `s3:GetObject` + `s3:ListBucket`, **no `PutObject`**). B/C retained for the record as rejected alternatives.
- `AWS_OIDC_MIGRATION_INVENTORY.md`: decision paragraph rewritten from "decision required" to "decision: A", `pull_request` classification row updated to "RO role (option A)", and the remaining mechanical gate-flip work spelled out.

## Why A over C

The cache contains only public-source build artifacts. C's "fork = none" is **not expressible in IAM** — every PR (same-repo and fork) presents the identical sub `repo:MystenLabs/sui:pull_request`, so C would require ongoing workflow-layer enforcement (withholding `id-token: write` from fork-reachable jobs) that becomes a standing maintenance liability for no concrete security gain here.

## What's unblocked next (not in this PR)

1. **AWS:** provision `sui-sccache-ro-github` per the spec (account `011083325127`).
2. **Workflow:** extend each `SCCACHE_ROLE` expression so `pull_request` → RO ARN (trusted refs still → RW; override-dispatch still → empty). Mechanical, one PR.
3. **Phase 7:** drop static-key inputs + delete repo secrets once RO and RW paths both have successful runs on record.

## Test plan

- [x] Docs-only; no workflow behavior changes

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:

---

## IAM handoff (this PR is the spec for both)

**1. Provision `sui-sccache-ro-github`**
- Trust: `repo:MystenLabs/sui:pull_request`
- Permissions: `s3:GetObject` + `s3:ListBucket` on the sccache bucket/prefix; **no** `s3:PutObject`/write/delete
- Return the role ARN for workflow wiring

**2. Add Role 1 (`sui-sccache-rw-github`) release-tag trust**
- `repo:MystenLabs/sui:ref:refs/tags/devnet-v*`
- `repo:MystenLabs/sui:ref:refs/tags/testnet-v*`
- `repo:MystenLabs/sui:ref:refs/tags/mainnet-v*`
- (Three exact prefixes, matching release.yml's dispatch guard — not a broad `*-v*`. Release-branch trust `releases/sui-*-release` already landed 2026-06-08.)

The two are independent and can be provisioned in either order; each unblocks one mechanical workflow PR.
