### PR TITLE
[feat] detect owned-object double-spend contention and emit metrics

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -327,6 +327,9 @@ pub struct AuthorityMetrics {
     pub consensus_handler_deferred_transactions: IntCounter,
     pub consensus_handler_congested_transactions: IntCounter,
     pub consensus_handler_unpaid_amplification_deferrals: IntCounter,
+    pub consensus_handler_double_spend_deferrals: IntCounter,
+    pub consensus_handler_double_spend_conflict_count: HistogramVec,
+    pub consensus_handler_double_spend_conflicting_authority: IntCounterVec,
     pub consensus_handler_cancelled_transactions: IntCounter,
     pub consensus_handler_max_object_costs: IntGaugeVec,
     pub consensus_committed_subdags: IntCounterVec,
@@ -662,6 +665,26 @@ impl AuthorityMetrics {
             consensus_handler_unpaid_amplification_deferrals: register_int_counter_with_registry!(
                 "consensus_handler_unpaid_amplification_deferrals",
                 "Number of transactions deferred due to unpaid consensus amplification",
+                registry,
+            ).unwrap(),
+            consensus_handler_double_spend_deferrals: register_int_counter_with_registry!(
+                "consensus_handler_double_spend_deferrals",
+                "Number of transactions deferred due to owned object double-spend contention",
+                registry,
+            ).unwrap(),
+            consensus_handler_double_spend_conflict_count: register_histogram_vec_with_registry!(
+                "consensus_handler_double_spend_conflict_count",
+                "Number of conflicting transactions per double-spend winner, by object type",
+                &["object_type"],
+                POSITIVE_INT_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            consensus_handler_double_spend_conflicting_authority: register_int_counter_vec_with_registry!(
+                "consensus_handler_double_spend_conflicting_authority",
+                "Number of transactions involved in owned object double-spend contention, by the \
+                 block authority that sequenced the transaction and its role in the conflict \
+                 (winner = won the lock, loser = dropped)",
+                &["authority", "role"],
                 registry,
             ).unwrap(),
             consensus_handler_cancelled_transactions: register_int_counter_with_registry!(

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -94,11 +94,25 @@ use crate::{
     traffic_controller::{TrafficController, policies::TrafficTally},
 };
 
+/// Tracks the nature of intra-commit owned object lock conflicts for a winning transaction.
+#[derive(Default)]
+struct ConflictInfo {
+    /// Number of conflicts on gas payment objects.
+    gas_object_conflicts: u64,
+    /// Number of conflicts on non-gas owned objects.
+    non_gas_object_conflicts: u64,
+    /// Index of the block authority that sequenced the winning (lock holder) transaction.
+    winner_author: usize,
+}
+
 /// Output from filtering consensus transactions.
 /// Contains the filtered transactions and any owned object locks acquired post-consensus.
 struct FilteredConsensusOutput {
     transactions: Vec<(SequencedConsensusTransactionKind, u32)>,
     owned_object_locks: HashMap<ObjectRef, TransactionDigest>,
+    // When multiple transactions in the same commit try to lock the same owned object, the transaction
+    // that managed to lock it first is tracked here with the conflict info.
+    contested_transaction_digests: HashMap<TransactionDigest, ConflictInfo>,
 }
 
 pub struct ConsensusHandlerInitializer {
@@ -1000,6 +1014,9 @@ struct CommitHandlerState {
     initial_reconfig_state: ReconfigState,
     // Occurrence counts for user transactions, used for unpaid amplification detection.
     occurrence_counts: HashMap<TransactionDigest, u32>,
+    // Transactions involved in same commit owned object lock contention (double-spend),
+    // mapped to conflict info (gas vs non-gas breakdown).
+    contested_transaction_digests: HashMap<TransactionDigest, ConflictInfo>,
 }
 
 impl CommitHandlerState {
@@ -1166,16 +1183,19 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 .get_reconfig_state_read_lock_guard()
                 .clone(),
             occurrence_counts: HashMap::new(),
+            contested_transaction_digests: HashMap::new(),
         };
 
         let FilteredConsensusOutput {
             transactions,
             owned_object_locks,
+            contested_transaction_digests,
         } = self.filter_consensus_txns(
             state.initial_reconfig_state.clone(),
             &commit_info,
             &consensus_commit,
         );
+        state.contested_transaction_digests = contested_transaction_digests;
         // Buffer owned object locks for batch write.
         if !owned_object_locks.is_empty() {
             state.output.set_owned_object_locks(owned_object_locks);
@@ -2111,6 +2131,34 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             }
         }
 
+        // Detect owned object double-spend: if this transaction won an owned object
+        // lock while another transaction in the same commit tried to lock the same
+        // object, record metrics so we can measure contention on mainnet before
+        // enabling the deferral penalty.
+        if let Some(conflict_info) = state
+            .contested_transaction_digests
+            .get(transaction.tx().digest())
+        {
+            self.metrics.consensus_handler_double_spend_deferrals.inc();
+            self.metrics
+                .consensus_handler_double_spend_conflict_count
+                .with_label_values(&["gas_object"])
+                .observe(conflict_info.gas_object_conflicts as f64);
+            self.metrics
+                .consensus_handler_double_spend_conflict_count
+                .with_label_values(&["non_gas_object"])
+                .observe(conflict_info.non_gas_object_conflicts as f64);
+            // Attribute the winning side of the conflict to the authority that sequenced the
+            // contested holder transaction.
+            self.metrics
+                .consensus_handler_double_spend_conflicting_authority
+                .with_label_values(&[
+                    self.authority_hostname(conflict_info.winner_author),
+                    "winner",
+                ])
+                .inc();
+        }
+
         let tx_cost = shared_object_congestion_tracker.get_tx_cost(
             execution_time_estimator,
             transaction.tx(),
@@ -2684,6 +2732,15 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         }
     }
 
+    // Returns the hostname of the block author at the given committee index, used as a metric
+    // label. Falls back to "unknown" if the index is out of bounds.
+    fn authority_hostname(&self, author: usize) -> &str {
+        self.committee
+            .to_authority_index(author)
+            .map(|index| self.committee.authority(index).hostname.as_str())
+            .unwrap_or("unknown")
+    }
+
     // Filters out rejected or deprecated transactions.
     // Returns FilteredConsensusOutput containing transactions and owned_object_locks.
     #[instrument(level = "trace", skip_all)]
@@ -2695,6 +2752,12 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     ) -> FilteredConsensusOutput {
         let mut transactions = Vec::new();
         let mut owned_object_locks = HashMap::new();
+        let mut contested_transaction_digests: HashMap<TransactionDigest, ConflictInfo> =
+            HashMap::new();
+        // Block author for each transaction that successfully acquired owned object locks, so we
+        // can attribute the winning side of a double-spend conflict to the authority that
+        // sequenced it.
+        let mut lock_holder_authors: HashMap<TransactionDigest, usize> = HashMap::new();
         let epoch = self.epoch_store.epoch();
         let mut num_finalized_user_transactions = vec![0; self.committee.size()];
         let mut num_rejected_user_transactions = vec![0; self.committee.size()];
@@ -2890,12 +2953,49 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         ) {
                         Ok(new_locks) => {
                             owned_object_locks.extend(new_locks.into_iter());
+                            lock_holder_authors.insert(*tx.digest(), author);
                             // Lock acquisition succeeded - now set Finalized status
                             self.epoch_store
                                 .set_consensus_tx_status(position, ConsensusTxStatus::Finalized);
                             num_finalized_user_transactions[author] += 1;
                         }
                         Err(e) => {
+                            // Flag intra-commit double-spend: if the conflict is with
+                            // a transaction in this commit (in owned_object_locks), the
+                            // holder should be deferred as penalty.
+                            let gas_object_ids: HashSet<ObjectID> = tx
+                                .transaction_data()
+                                .gas()
+                                .iter()
+                                .map(|obj_ref| obj_ref.0)
+                                .collect();
+                            let mut is_intra_commit_conflict = false;
+                            for obj_ref in &owned_object_refs {
+                                if let Some(holder_digest) = owned_object_locks.get(obj_ref) {
+                                    is_intra_commit_conflict = true;
+                                    let info = contested_transaction_digests
+                                        .entry(*holder_digest)
+                                        .or_default();
+                                    info.winner_author = lock_holder_authors
+                                        .get(holder_digest)
+                                        .copied()
+                                        .unwrap_or(author);
+                                    if gas_object_ids.contains(&obj_ref.0) {
+                                        info.gas_object_conflicts += 1;
+                                    } else {
+                                        info.non_gas_object_conflicts += 1;
+                                    }
+                                }
+                            }
+                            // Attribute the losing side of the conflict to the authority that
+                            // sequenced this dropped transaction. Counted once per loser, even
+                            // if it conflicted on multiple objects.
+                            if is_intra_commit_conflict {
+                                self.metrics
+                                    .consensus_handler_double_spend_conflicting_authority
+                                    .with_label_values(&[self.authority_hostname(author), "loser"])
+                                    .inc();
+                            }
                             debug!("Dropping transaction {}: {}", tx.digest(), e);
                             self.epoch_store
                                 .set_consensus_tx_status(position, ConsensusTxStatus::Dropped);
@@ -2937,6 +3037,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         FilteredConsensusOutput {
             transactions,
             owned_object_locks,
+            contested_transaction_digests,
         }
     }
 

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -60,6 +60,9 @@ mod congestion_control_tests;
 #[path = "unit_tests/consensus_test_utils.rs"]
 pub mod consensus_test_utils;
 #[cfg(test)]
+#[path = "unit_tests/double_spend_deferral_tests.rs"]
+mod double_spend_deferral_tests;
+#[cfg(test)]
 #[path = "unit_tests/move_package_publish_tests.rs"]
 mod move_package_publish_tests;
 #[cfg(test)]

--- a/crates/sui-core/src/unit_tests/consensus_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/consensus_test_utils.rs
@@ -133,6 +133,7 @@ impl ConsensusCommitAPI for TestConsensusCommit {
 pub struct TestConsensusHandlerSetup<C> {
     pub consensus_handler: ConsensusHandler<C>,
     pub captured_transactions: CapturedTransactions,
+    pub metrics: Arc<AuthorityMetrics>,
 }
 
 pub fn make_consensus_adapter_for_test(
@@ -332,7 +333,7 @@ where
         consensus_adapter,
         authority.get_object_cache_reader().clone(),
         consensus_committee,
-        metrics,
+        metrics.clone(),
         Arc::new(throughput_calculator),
         backpressure_manager.subscribe(),
         authority.traffic_controller.clone(),
@@ -342,6 +343,7 @@ where
     TestConsensusHandlerSetup {
         consensus_handler,
         captured_transactions,
+        metrics,
     }
 }
 

--- a/crates/sui-core/src/unit_tests/double_spend_deferral_tests.rs
+++ b/crates/sui-core/src/unit_tests/double_spend_deferral_tests.rs
@@ -1,0 +1,204 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::authority::AuthorityMetrics;
+use crate::authority::AuthorityState;
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::checkpoints::CheckpointServiceNoop;
+use crate::consensus_adapter::consensus_tests::test_user_transaction;
+use crate::consensus_test_utils::{
+    self, CapturedTransactions, TestConsensusCommit, TestConsensusHandlerSetup,
+};
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::crypto::{AccountKeyPair, deterministic_random_account_key};
+use sui_types::messages_consensus::ConsensusTransaction;
+use sui_types::object::Object;
+use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
+
+use crate::consensus_handler::ConsensusHandler;
+
+struct DoubleSpendTestSetup {
+    authority_state: Arc<AuthorityState>,
+    consensus_handler: ConsensusHandler<CheckpointServiceNoop>,
+    captured_transactions: CapturedTransactions,
+    metrics: Arc<AuthorityMetrics>,
+    sender: SuiAddress,
+    keypair: AccountKeyPair,
+    contested_object: Object,
+    gas_objects: Vec<Object>,
+}
+
+impl DoubleSpendTestSetup {
+    async fn new(protocol_config: ProtocolConfig, num_gas_objects: usize) -> Self {
+        let (sender, keypair): (_, AccountKeyPair) = deterministic_random_account_key();
+
+        let gas_objects: Vec<Object> = (0..num_gas_objects)
+            .map(|_| Object::with_id_owner_for_testing(ObjectID::random(), sender))
+            .collect();
+        let contested_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+
+        let mut genesis_objects = gas_objects.clone();
+        genesis_objects.push(contested_object.clone());
+
+        let authority_state = TestAuthorityBuilder::new()
+            .with_reference_gas_price(1000)
+            .with_protocol_config(protocol_config)
+            .build()
+            .await;
+        authority_state.insert_genesis_objects(&genesis_objects);
+
+        let TestConsensusHandlerSetup {
+            consensus_handler,
+            captured_transactions,
+            metrics,
+        } = consensus_test_utils::setup_consensus_handler_for_testing(&authority_state).await;
+
+        Self {
+            authority_state,
+            consensus_handler,
+            captured_transactions,
+            metrics,
+            sender,
+            keypair,
+            contested_object,
+            gas_objects,
+        }
+    }
+
+    /// Build consensus transactions where each gas object produces a transaction
+    /// that uses the contested owned object.
+    async fn build_competing_consensus_txns(&self) -> Vec<ConsensusTransaction> {
+        let mut consensus_txns = Vec::new();
+        for gas_object in &self.gas_objects {
+            let tx = test_user_transaction(
+                &self.authority_state,
+                self.sender,
+                &self.keypair,
+                gas_object.clone(),
+                vec![self.contested_object.clone()],
+            )
+            .await;
+            consensus_txns.push(ConsensusTransaction::new_user_transaction_v2_message(
+                &self.authority_state.name,
+                tx.into(),
+            ));
+        }
+        consensus_txns
+    }
+
+    /// Submit a commit and return the number of scheduled transactions.
+    async fn submit_commit_and_count_scheduled(&mut self, commit: TestConsensusCommit) -> usize {
+        self.consensus_handler.handle_consensus_commit(commit).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut captured = self.captured_transactions.lock();
+        assert!(
+            !captured.is_empty(),
+            "Expected at least one scheduler message"
+        );
+        let (scheduled_txns, _) = captured.remove(0);
+        scheduled_txns.len()
+    }
+}
+
+fn base_protocol_config() -> ProtocolConfig {
+    ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown)
+}
+
+/// Two transactions in the same commit compete for the same owned object. The first
+/// to acquire the lock wins and is scheduled; the second is dropped (failed lock).
+/// Deferral is not yet enabled on this branch, so the winner runs immediately - but
+/// the contention must be detected and surfaced through the double-spend metrics.
+#[tokio::test]
+async fn test_double_spend_detection_emits_metrics() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut setup = DoubleSpendTestSetup::new(base_protocol_config(), 2).await;
+    let consensus_txns = setup.build_competing_consensus_txns().await;
+
+    let count = setup
+        .submit_commit_and_count_scheduled(TestConsensusCommit::new(consensus_txns, 1, 0, 0))
+        .await;
+
+    // prologue + winner (loser dropped due to lock conflict). No deferral on this branch.
+    assert_eq!(count, 2, "Expected prologue + winner (detection only)");
+
+    // The winner that contested an owned object is counted exactly once.
+    assert_eq!(
+        setup.metrics.consensus_handler_double_spend_deferrals.get(),
+        1,
+        "Expected one detected double-spend winner"
+    );
+
+    // The contested object is a non-gas owned object, so the non-gas histogram records
+    // the conflict while the gas histogram records a zero observation.
+    let non_gas = setup
+        .metrics
+        .consensus_handler_double_spend_conflict_count
+        .with_label_values(&["non_gas_object"]);
+    assert_eq!(non_gas.get_sample_count(), 1);
+    assert_eq!(non_gas.get_sample_sum(), 1.0);
+
+    let gas = setup
+        .metrics
+        .consensus_handler_double_spend_conflict_count
+        .with_label_values(&["gas_object"]);
+    assert_eq!(gas.get_sample_count(), 1);
+    assert_eq!(gas.get_sample_sum(), 0.0);
+
+    // Both transactions are sequenced in author 0's block, so the winner and the loser
+    // are both attributed to that authority's hostname, once each.
+    let consensus_committee = setup
+        .authority_state
+        .epoch_store_for_testing()
+        .epoch_start_state()
+        .get_consensus_committee();
+    let author0_hostname = consensus_committee
+        .authority(consensus_committee.to_authority_index(0).unwrap())
+        .hostname
+        .clone();
+    assert_eq!(
+        setup
+            .metrics
+            .consensus_handler_double_spend_conflicting_authority
+            .with_label_values(&[author0_hostname.as_str(), "winner"])
+            .get(),
+        1,
+        "Expected one double-spend winner attributed to author 0"
+    );
+    assert_eq!(
+        setup
+            .metrics
+            .consensus_handler_double_spend_conflicting_authority
+            .with_label_values(&[author0_hostname.as_str(), "loser"])
+            .get(),
+        1,
+        "Expected one double-spend loser attributed to author 0"
+    );
+}
+
+/// When only one transaction uses an owned object there is no contention, so no
+/// double-spend metrics should be recorded.
+#[tokio::test]
+async fn test_no_contention_no_metrics() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut setup = DoubleSpendTestSetup::new(base_protocol_config(), 1).await;
+    let consensus_txns = setup.build_competing_consensus_txns().await;
+
+    let count = setup
+        .submit_commit_and_count_scheduled(TestConsensusCommit::new(consensus_txns, 1, 0, 0))
+        .await;
+
+    // prologue + the single transaction (no contention).
+    assert_eq!(count, 2, "Expected prologue + user tx (no contention)");
+    assert_eq!(
+        setup.metrics.consensus_handler_double_spend_deferrals.get(),
+        0,
+        "Expected no detected double-spend without contention"
+    );
+}


### PR DESCRIPTION
## Description 

Detect when multiple transactions in the same consensus commit attempt to lock the same owned object. The transaction that wins the lock is tracked together with a gas/non-gas conflict breakdown, and surfaced through two new metrics:

- consensus_handler_double_spend_deferrals: count of contested winners
- consensus_handler_double_spend_conflict_count: per-winner conflict histogram, labelled by object type

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
