### PR TITLE
ci(sccache): same-repo PRs assume the read-only OIDC role (Phase 4, option A)

### DIFF
--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -23,9 +23,9 @@ Keep any new `SCCACHE_ROLE` gate in sync with this exact set.
 | -------------------- | ---------- | -------------------------------------------- | -------------------------------------------- | -------- |
 | `sccache-warmup.yml` | 2          | schedule, workflow_dispatch                  | **OIDC ✅**                                  | 1 ✅     |
 | `nightly.yml`        | 1          | schedule, workflow_dispatch (disabled)       | **OIDC ✅**                                  | 2 ✅     |
-| `rust.yml`           | 11         | push, pull_request, workflow_dispatch        | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
-| `external.yml`       | 2          | push, pull_request                           | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
-| `bridge.yml`         | 2          | push, pull_request, workflow_dispatch        | **dual-pass ✅** (PR #26927)                 | 3 ✅ → 4 |
+| `rust.yml`           | 11         | push, pull_request, workflow_dispatch        | **OIDC ✅** (RW trusted / RO same-repo PR / local fork) | 3 ✅ 4 ✅ |
+| `external.yml`       | 2          | push, pull_request                           | **OIDC ✅** (RW trusted / RO same-repo PR / local fork) | 3 ✅ 4 ✅ |
+| `bridge.yml`         | 2          | push, pull_request, workflow_dispatch        | **OIDC ✅** (RW trusted / RO same-repo PR / local fork) | 3 ✅ 4 ✅ |
 | `release.yml`        | 1          | release, workflow_dispatch                   | **OIDC ✅** (sccache RW + S3 ops release env) | 5 ✅     |
 
 ## How each event/ref classifies
@@ -40,7 +40,8 @@ The decision is the OIDC `sub` of the run, which depends on the event + ref:
 | `workflow_dispatch`| `main`, **no** `sui_repo_ref`        | `…:ref:refs/heads/main`        | **YES**                  | OIDC RW                               |
 | `workflow_dispatch`| `main` + `sui_repo_ref=<feature>`    | `…:ref:refs/heads/main`        | sub matches, but **gate OFF** | builds the override ref (untrusted code) → must NOT hold RW; gate requires `sui_repo_ref==''` → static/local |
 | `workflow_dispatch`| feature branch                       | `…:ref:refs/heads/<feat>`      | **NO**                   | local-cache fallback (expected)       |
-| `pull_request`     | any (same-repo **and** fork)         | `…:pull_request`               | **NO** (no RW)           | **RO role** (option A) once provisioned |
+| `pull_request` (same-repo) | PR merge ref                 | `…:pull_request`               | **NO** (RO, not RW)      | **RO role ✅** (option A)              |
+| `pull_request` (fork)      | PR merge ref                 | `…:pull_request`               | **NO**                   | empty → local cache (fork `id-token` capped to none; gate skips to avoid a hard-fail — fail-safe, not a security boundary) |
 
 > **Checkout-ref caveat (rust.yml / bridge.yml).** The OIDC `sub` (and thus role
 > assumability) is decided by `github.ref` — but these workflows check out
@@ -155,17 +156,21 @@ static/local on an override dispatch rather than OIDC. That is the safe directio
 - **Phase 4** then resolves the PR path: **option A — all PRs → RO role.**
 - **Phase 7** removes the static-key inputs once no event path needs them.
 
-**Phase 4 decision: option A (2026-06-15).** All PRs, including forks, get
-**read-only** sccache access via a new RO role (`sui-sccache-ro-github`); no PR
-gets write access, so poisoning stays blocked. Chosen over C because the cache
-holds only public-source build artifacts (no identified sensitivity) and C's
-"fork = none" cannot be done in IAM — every PR presents the same sub
-`repo:MystenLabs/sui:pull_request`, so C would require ongoing workflow-layer
-enforcement (withholding `id-token: write` from fork-reachable jobs) that we
-declined to carry preemptively. See `AWS_OIDC_ROLES.md` §"PR read-only cache"
-for the RO role's trust + policy to provision.
+**Phase 4 decision: option A (2026-06-15) — IMPLEMENTED.** The security decision:
+PRs get **read-only** sccache via the RO role (`sui-sccache-ro-github`, trust
+`repo:MystenLabs/sui:pull_request`); no PR gets write access, so poisoning stays
+blocked. Chosen over C because the cache holds only public-source build artifacts
+(no identified sensitivity) and C's "fork = none" cannot be done in IAM — every PR
+presents the same sub `repo:MystenLabs/sui:pull_request`.
 
-**Remaining Phase-4 work (mechanical, after the RO role is provisioned):** extend
-each `SCCACHE_ROLE` expression so `pull_request` resolves the RO ARN (trusted
-refs still → RW; override-dispatch still → empty), then drop the static-key
-inputs per Phase 7.
+**Implementation (the fork nuance).** GitHub caps fork-PR `id-token` to `none`, so
+a fork cannot mint the OIDC token, and `setup-sccache`'s OIDC step has no
+`continue-on-error` — setting `role-to-assume` on a fork would hard-fail the job.
+So each `SCCACHE_ROLE` gate resolves the RO ARN only for **same-repo** PRs
+(`github.event.pull_request.head.repo.fork == false`); **fork** PRs get empty →
+local cache, exactly as before. This fork skip is a **fail-safe accommodation, not
+a security boundary**: the RO role still trusts `pull_request`, so if GitHub
+settings ever let forks mint `id-token`, a fork assuming the RO role is still
+acceptable under Decision A — fork-local must NOT be relied on as a durable
+guarantee. Static-key inputs are retained on all call sites until Phase 7 (the
+RO/RW OIDC paths are verified first, then the static fallback is removed).

--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -172,5 +172,17 @@ local cache, exactly as before. This fork skip is a **fail-safe accommodation, n
 a security boundary**: the RO role still trusts `pull_request`, so if GitHub
 settings ever let forks mint `id-token`, a fork assuming the RO role is still
 acceptable under Decision A — fork-local must NOT be relied on as a durable
-guarantee. Static-key inputs are retained on all call sites until Phase 7 (the
-RO/RW OIDC paths are verified first, then the static fallback is removed).
+guarantee.
+
+**Static keys removed from these three workflows (not deferred to Phase 7).**
+`rust.yml`/`external.yml`/`bridge.yml` no longer pass `aws-access-key-id` /
+`aws-secret-access-key` to `setup-sccache`. Keeping them would have been an active
+hole, not just dead weight: (1) `setup-sccache` is a **local** action loaded from
+the checked-out workspace, so a same-repo PR could edit it to consume the RW
+static keys directly, defeating the RO boundary; and (2) on an override dispatch
+(`sui_repo_ref` set, `SCCACHE_ROLE` empty) the static-key path would have handed
+**RW** creds to the untrusted override build. With the keys gone, forks and
+override dispatches get a local cache (no creds). The RW/RO OIDC paths are
+verified (RO: same-repo PR 100% hit; RW: protected-push soak). `release.yml` still
+passes static keys (no `pull_request` trigger → not PR-exposed); the repo secrets
+themselves are deleted in Phase 7 once release.yml is also off them.

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -101,11 +101,10 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
-          # Dual-pass: OIDC on trusted refs (SCCACHE_ROLE non-empty); static-key
-          # fallback on same-repo PRs / untrusted refs until Phase 4 sets PR cache.
+          # OIDC only: RW on trusted refs, RO on same-repo PRs, empty (→ local
+          # cache) on forks / override dispatches. No static-key fallback — those
+          # were removed so a PR-controlled local action cannot reach the RW keys.
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
       - name: cargo clippy
@@ -133,11 +132,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - uses: ./.github/actions/setup-sccache
         with:
-          # Dual-pass: OIDC on trusted refs (SCCACHE_ROLE non-empty); static-key
-          # fallback on same-repo PRs / untrusted refs until Phase 4 sets PR cache.
+          # OIDC only: RW on trusted refs, RO on same-repo PRs, empty (→ local
+          # cache) on forks / override dispatches. No static-key fallback — those
+          # were removed so a PR-controlled local action cannot reach the RW keys.
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -101,9 +101,6 @@ jobs:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: ./.github/actions/setup-sccache
         with:
-          # OIDC only: RW on trusted refs, RO on same-repo PRs, empty (→ local
-          # cache) on forks / override dispatches. No static-key fallback — those
-          # were removed so a PR-controlled local action cannot reach the RW keys.
           role-to-assume: ${{ env.SCCACHE_ROLE }}
           key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
@@ -132,9 +129,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - uses: ./.github/actions/setup-sccache
         with:
-          # OIDC only: RW on trusted refs, RO on same-repo PRs, empty (→ local
-          # cache) on forks / override dispatches. No static-key fallback — those
-          # were removed so a PR-controlled local action cannot reach the RW keys.
           role-to-assume: ${{ env.SCCACHE_ROLE }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -50,13 +50,17 @@ env:
   RUST_LOG: error
   # RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
-  # sccache RW role on trusted refs only (protected branches + release branches),
-  # AND only when not building an override ref: a workflow_dispatch with a non-empty
-  # sui_repo_ref checks out arbitrary code, so it must NOT hold the RW cache even
-  # though github.ref (and the OIDC sub) is main. Empty elsewhere → setup-sccache
-  # falls back to static keys (same-repo PRs) or a local cache (forks / overrides).
-  # Keep in sync with the sui-sccache-rw-github trust policy.
-  SCCACHE_ROLE: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.sui_repo_ref == '') && (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
+  # sccache role selection:
+  #   trusted refs (protected + release branches), NOT a workflow_dispatch building
+  #     an override sui_repo_ref → RW role (read/write cache).
+  #   same-repo pull_request → RO role (read-only; a PR cannot poison the cache).
+  #   forks / overrides / everything else → empty → setup-sccache falls back to a
+  #     local cache. Forks are skipped here because GitHub caps fork id-token to
+  #     none, so role-to-assume would hard-fail the OIDC step. This fork skip is a
+  #     fail-safe accommodation, NOT a security boundary — the RO role still trusts
+  #     pull_request, so a fork reading the cache is acceptable (Decision A).
+  # Keep in sync with the sui-sccache-{rw,ro}-github trust policies.
+  SCCACHE_ROLE: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.sui_repo_ref == '') && (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) && 'arn:aws:iam::011083325127:role/sui-sccache-ro-github' || '' }}
 
 jobs:
   diff:

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -36,12 +36,15 @@ env:
   RUST_BACKTRACE: short
   # RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
-  # sccache RW role on trusted refs only. Empty elsewhere → setup-sccache falls
-  # back to static keys (same-repo PRs) or a local cache (forks). The extensions
-  # branch is deliberately not in the role trust (dormant; see
-  # AWS_OIDC_MIGRATION_INVENTORY.md). No workflow_dispatch here, so no
-  # override-ref clause. Keep in sync with the sui-sccache-rw-github trust policy.
-  SCCACHE_ROLE: ${{ (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
+  # sccache role selection: trusted refs → RW role; same-repo pull_request → RO
+  # role (read-only, cannot poison the cache); forks / extensions / everything else
+  # → empty → setup-sccache falls back to a local cache. Forks are skipped because
+  # GitHub caps fork id-token to none (role-to-assume would hard-fail OIDC); this
+  # skip is a fail-safe, NOT a security boundary — the RO role still trusts
+  # pull_request (Decision A). The extensions branch is deliberately untrusted
+  # (dormant; see AWS_OIDC_MIGRATION_INVENTORY.md). No workflow_dispatch here, so no
+  # override-ref clause. Keep in sync with the sui-sccache-{rw,ro}-github trusts.
+  SCCACHE_ROLE: ${{ (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) && 'arn:aws:iam::011083325127:role/sui-sccache-ro-github' || '' }}
 
 jobs:
   diff:

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -81,8 +81,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
@@ -126,8 +124,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,13 +51,17 @@ env:
   # Set log level in CI to error. If you need more information to debug a CI
   # failure, change this temporarily and rerun your tests
   RUST_LOG: error
-  # sccache RW role on trusted refs only (protected branches + release branches),
-  # AND only when not building an override ref: a workflow_dispatch with a non-empty
-  # sui_repo_ref checks out arbitrary code, so it must NOT hold the RW cache even
-  # though github.ref (and the OIDC sub) is main. Empty elsewhere → setup-sccache
-  # falls back to static keys (same-repo PRs) or a local cache (forks / overrides).
-  # Keep in sync with the sui-sccache-rw-github trust policy.
-  SCCACHE_ROLE: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.sui_repo_ref == '') && (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || '' }}
+  # sccache role selection:
+  #   trusted refs (protected + release branches), NOT a workflow_dispatch building
+  #     an override sui_repo_ref → RW role (read/write cache).
+  #   same-repo pull_request → RO role (read-only; a PR cannot poison the cache).
+  #   forks / overrides / everything else → empty → setup-sccache falls back to a
+  #     local cache. Forks are skipped here because GitHub caps fork id-token to
+  #     none, so role-to-assume would hard-fail the OIDC step. This fork skip is a
+  #     fail-safe accommodation, NOT a security boundary — the RO role still trusts
+  #     pull_request, so a fork reading the cache is acceptable (Decision A).
+  # Keep in sync with the sui-sccache-{rw,ro}-github trust policies.
+  SCCACHE_ROLE: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.sui_repo_ref == '') && (contains(fromJSON('["refs/heads/main","refs/heads/devnet","refs/heads/testnet","refs/heads/mainnet"]'), github.ref) || (startsWith(github.ref, 'refs/heads/releases/sui-') && endsWith(github.ref, '-release'))) && 'arn:aws:iam::011083325127:role/sui-sccache-rw-github' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) && 'arn:aws:iam::011083325127:role/sui-sccache-ro-github' || '' }}
 
 jobs:
   diff:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,8 +114,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
@@ -167,8 +165,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
@@ -236,8 +232,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
@@ -305,8 +299,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
@@ -367,8 +359,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: windows-ghcloud
 
       - uses: taiki-e/install-action@nextest
@@ -398,8 +388,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: windows-ghcloud
 
       - uses: taiki-e/install-action@nextest
@@ -427,8 +415,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
@@ -467,8 +453,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
@@ -507,8 +491,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - name: Run move tests
@@ -607,8 +589,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
       # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
@@ -692,8 +672,6 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
       - name: Install cargo-hakari, and cache the binary
         uses: baptiste0928/cargo-install@1cd874a5478fdca35d868ccc74640c5aabbb8f1b # pin@v3.0.0


### PR DESCRIPTION
## Summary

Implements **Phase 4, decision A** (recorded in #26960). Now that `sui-sccache-ro-github` is provisioned, each `SCCACHE_ROLE` gate in `rust.yml` / `external.yml` / `bridge.yml` resolves the **read-only** role for same-repo PRs, and the static-key inputs are removed from these workflows entirely.

Role selection after this PR:

| Context | Role | Cache |
|---|---|---|
| trusted push / dispatch-from-main (no override) | `sui-sccache-rw-github` | read/write |
| **same-repo `pull_request`** | **`sui-sccache-ro-github`** | **read-only (new)** |
| fork `pull_request` | — (empty) | local |
| override dispatch (`sui_repo_ref` set) | — (empty) | local |

The RO role grants `s3:GetObject` + `s3:ListBucket` only — **no `PutObject`** — so a PR can read the shared cache but cannot poison it.

## The fork nuance (why same-repo only)

GitHub caps fork-PR `id-token` to `none`, so a fork cannot mint the OIDC token — and `setup-sccache`'s `Configure AWS credentials (OIDC)` step has no `continue-on-error`, so setting `role-to-assume` on a fork would **hard-fail the job**. The gate therefore resolves the RO ARN only when `github.event.pull_request.head.repo.fork == false`; fork PRs stay empty → local cache, exactly as today.

**This fork skip is a fail-safe accommodation, not a security boundary.** The RO role still trusts `pull_request`, so if GitHub settings ever permit fork `id-token`, a fork assuming the RO role remains acceptable under Decision A. We are not relying on fork-local as a durable guarantee (that would require withholding `id-token: write` from fork-reachable jobs — the option-C complexity we declined).

**Static-key inputs are removed from these three workflows** (not deferred to Phase 7). Keeping them would have been an active hole, not dead weight: `setup-sccache` is a **local** action loaded from the checked-out workspace, so a same-repo PR could edit it to consume the RW static keys directly — defeating the RO boundary — and an override dispatch (`SCCACHE_ROLE` empty) would have fed RW static keys to the untrusted override build. With them gone, forks and override dispatches get a local cache (no creds). `release.yml` still passes static keys (no `pull_request` trigger → not PR-exposed); the repo secrets are deleted in Phase 7.

## Test plan

- [x] Expression traced for every event/ref: trusted push/dispatch → RW; same-repo PR → RO; fork PR → empty; override dispatch → empty. The `github.event_name == 'pull_request'` guard short-circuits before the `fork == false` comparison on non-PR events (avoids GitHub's null→0 coercion making `fork == false` spuriously true).
- [x] `actionlint`: identical finding count to main on all three files (11/0/5, all pre-existing shellcheck/isSolidity); zero new.
- [ ] **Post-merge:** confirm a same-repo PR's sccache step shows `Assuming role with OIDC` for `sui-sccache-ro-github`; confirm a trusted push still assumes the RW role; confirm a fork PR (or simulated empty role) degrades to local cache without failing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
