### PR TITLE
ci(release): flip release-build sccache to the OIDC RW role (Phase 5)

### DIFF
--- a/.github/AWS_OIDC_MIGRATION_INVENTORY.md
+++ b/.github/AWS_OIDC_MIGRATION_INVENTORY.md
@@ -26,7 +26,7 @@ Keep any new `SCCACHE_ROLE` gate in sync with this exact set.
 | `rust.yml`           | 11         | push, pull_request, workflow_dispatch        | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
 | `external.yml`       | 2          | push, pull_request                           | **dual-pass ✅** (OIDC trusted / static PRs) | 3 ✅ → 4 |
 | `bridge.yml`         | 2          | push, pull_request, workflow_dispatch        | **dual-pass ✅** (PR #26927)                 | 3 ✅ → 4 |
-| `release.yml`        | 1          | release, workflow_dispatch                   | sccache static; **S3 ops OIDC ✅** (release env) | 5 (S3 ✅) |
+| `release.yml`        | 1          | release, workflow_dispatch                   | **OIDC ✅** (sccache RW + S3 ops release env) | 5 ✅     |
 
 ## How each event/ref classifies
 
@@ -68,38 +68,32 @@ Note `extensions` push is **not** trusted (branch is 404 → excluded) → local
 
 `clippy` (L85), `test` (L111). Prefix `ubuntu-ghcloud`.
 
-### `release.yml` — 1 site — **Phase 5: S3 done (job split), sccache remains**
+### `release.yml` — 1 site — **Phase 5: S3 + sccache both OIDC ✅**
 
 `release-build`, prefix `${{ matrix.os }}`. Triggers on `release: created`
 (tag) + `workflow_dispatch`.
 
-**Done — option (b), the job split.** `release-build` no longer holds any
-`sui-releases` credentials (its only remaining AWS credentials are the static
-sccache keys passed to `setup-sccache`): the existing-archive download uses the
-bucket's public read access, and all `sui-releases` writes moved to
-`upload-release-archives-to-s3`,
-which declares `environment: release` and assumes the `release-s3` role via OIDC
-(roles doc, Role 2). The `release` GitHub Environment exists with a custom
-deployment branch policy (`main` + `devnet-v*`/`testnet-v*`/`mainnet-v*` tags).
+**S3 ops — option (b) job split.** `release-build` holds no `sui-releases`
+credentials: the existing-archive download uses the bucket's public read access,
+and all `sui-releases` writes moved to `upload-release-archives-to-s3`, which
+declares `environment: release` and assumes the `release-s3` role via OIDC (roles
+doc, Role 2). The `release` GitHub Environment exists with a custom deployment
+branch policy (`main` + `devnet-v*`/`testnet-v*`/`mainnet-v*` tags).
 
-**Remaining — the sccache call site.** Because of the split, `release-build`'s
-OIDC sub is now a plain tag/branch ref (no environment), so giving sccache OIDC
-needs role #1 to trust the release tag subs:
-`refs/tags/{devnet,testnet,mainnet}-v*` for `release:` events.
+**sccache — flipped to OIDC RW.** Role 1 now trusts the release tag subs
+`refs/tags/{devnet,testnet,mainnet}-v*` (for `release:` events) in addition to
+`refs/heads/main` (for dispatch). `release-build` declares
+`permissions: {contents: write, id-token: write}` (contents:write is for the GH
+release attach, not new — it had it via the default token) and passes the RW ARN
+to `setup-sccache`. The role is unconditional here: there is no `pull_request`
+trigger, and both event paths run under trusted subs.
 
-**Dispatch hazard — same trusted-sub / chosen-ref problem as rust.yml.** A
-`workflow_dispatch` of this workflow runs with sub `refs/heads/main` (which
-role #1 already trusts) while checking out `inputs.sui_tag` — arbitrary
-attacker-chosen code holding the RW cache role. Before flipping this call site
-to OIDC, BOTH guards are required:
-1. the checkout must use `refs/tags/${sui_tag}` explicitly (never a bare ref
-   that could resolve to a branch), and
-2. the tag-name validation step must reject anything not matching
-   `{devnet,testnet,mainnet}-v*` BEFORE `setup-sccache` runs.
-With those in place, dispatch builds only published release tags (trusted
-lineage), and assuming the RW role under the `main` sub is sound. Until then,
-sccache keeps static keys here — it must stay working through Phase 7 or
-release builds lose the S3 cache.
+**Dispatch hazard — closed.** A `workflow_dispatch` runs with sub
+`refs/heads/main` (trusted) while checking out `inputs.sui_tag`. The two guards
+that make this sound landed in PR #26953: the checkout uses `refs/tags/${sui_tag}`
+explicitly, and the tag-name validation rejects anything not matching
+`{devnet,testnet,mainnet}-v*` before `setup-sccache` runs — so dispatch only ever
+builds published release tags. Static-key inputs are retained until Phase 7.
 
 ## Trust-policy gaps — status
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,20 +64,25 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Clean up and validate ${{ env.TAG_NAME }} tag name
+      - name: Validate the release tag
         shell: bash
         run: |
-          export sui_tag=$(echo ${{ env.TAG_NAME }} | sed s/'refs\/tags\/'//)
-          # only published release tags may be built: a workflow_dispatch runs
-          # with a trusted main OIDC sub while building this input, so an
-          # unconstrained ref here would let arbitrary code run under that sub
-          if [[ ! "${sui_tag}" =~ ^(devnet|testnet|mainnet)-v ]]; then
-            echo "sui_tag must be a release tag (devnet-v*/testnet-v*/mainnet-v*), got: ${sui_tag}"
+          # Read TAG_NAME as a shell variable (it is a workflow-level env, above).
+          # NEVER interpolate the raw input into the script via ${{ }}: a
+          # workflow_dispatch sui_tag is attacker-controllable, and this job holds
+          # id-token: write for the trusted `main` sub, so injected shell here
+          # could mint the RW cache token before the guard below runs.
+          sui_tag="${TAG_NAME#refs/tags/}"
+          # Only published release tags may be built. Fully anchored (^...$) with a
+          # restricted charset so the value also cannot smuggle a newline into the
+          # GITHUB_ENV writes below.
+          if [[ ! "$sui_tag" =~ ^(devnet|testnet|mainnet)-v[0-9A-Za-z.-]+$ ]]; then
+            echo "sui_tag must be a release tag (devnet-v*/testnet-v*/mainnet-v*), got: $sui_tag"
             exit 1
           fi
-          echo "sui_tag=${sui_tag}" >> $GITHUB_ENV
-          export sui_version=$(echo ${sui_tag} | sed -e 's/mainnet-v//' -e 's/testnet-v//')
-          echo "sui_version=${sui_version}" >> $GITHUB_ENV
+          echo "sui_tag=$sui_tag" >> "$GITHUB_ENV"
+          sui_version=$(echo "$sui_tag" | sed -e 's/mainnet-v//' -e 's/testnet-v//')
+          echo "sui_version=$sui_version" >> "$GITHUB_ENV"
 
       - name: Check out ${{ env.sui_tag }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,20 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   TMP_BUILD_DIR: './tmp/release'
+  # release.yml only runs trusted release builds: `release: created` (OIDC sub =
+  # the release tag, trusted via refs/tags/{devnet,testnet,mainnet}-v*) and
+  # workflow_dispatch (sub = refs/heads/main, trusted; the tag-prefix + refs/tags
+  # checkout guards restrict it to published release tags). There is no
+  # pull_request trigger, so sccache always uses the RW role.
+  SCCACHE_ROLE: arn:aws:iam::011083325127:role/sui-sccache-rw-github
 
 jobs:
   release-build:
     name: Build & Publish Binaries
     timeout-minutes: 240
+    permissions:
+      contents: write # attach built archives to the GitHub release
+      id-token: write # OIDC token to assume the sccache RW role
     strategy:
       matrix:
         os:
@@ -157,6 +166,7 @@ jobs:
       - uses: ./.github/actions/setup-sccache
         if: ${{ env.s3_existing_archive == '' }}
         with:
+          role-to-assume: ${{ env.SCCACHE_ROLE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Completes Phase 5: the last static-key sccache call site, `release.yml`'s `release-build`, now assumes the RW cache role via OIDC. Both prerequisites are in place — Role 1 trusts the release tag subjects `refs/tags/{devnet,testnet,mainnet}-v*`, and the dispatch chosen-ref guards landed in #26953.

Changes:
- **`SCCACHE_ROLE`** workflow env set to the RW ARN (constant). This workflow only runs trusted release builds — `release: created` (sub = the release tag) and `workflow_dispatch` (sub = `refs/heads/main`, guard-restricted to published release tags). No `pull_request` trigger, so there's no RO/empty branch to gate.
- **`release-build` permissions** block added: `contents: write` (for the existing `softprops/action-gh-release` attach — not a new privilege, it had this via the default token) + `id-token: write` (for OIDC).
- **`role-to-assume: ${{ env.SCCACHE_ROLE }}`** passed to `setup-sccache`.

The separate `upload-release-archives-to-s3` job (Role 2, `environment: release`) is unchanged. Static-key inputs are retained until Phase 7.

## Why the dispatch path is sound

A `workflow_dispatch` runs under the trusted `main` sub while checking out `inputs.sui_tag`. The #26953 guards make this safe: the checkout uses `refs/tags/${sui_tag}` explicitly (can't resolve to a branch) and the tag-name validation rejects anything not matching `{devnet,testnet,mainnet}-v*` before `setup-sccache` runs. So the only code that ever builds under the RW role is a published release tag.

## Test plan

- [x] `actionlint`: identical finding count to main (33/33 pre-existing); zero new
- [x] Confirmed `release-build`'s only elevated-GITHUB_TOKEN step is the GH release attach (`contents: write`); walrus dispatch uses a PAT, Chocolatey uses `CHOCO_API_KEY` — so `{contents: write, id-token: write}` is sufficient and not over-scoped
- [x] Role 1 trust now includes the three release tag subjects (verified in IAM)
- [ ] **Post-merge:** `workflow_dispatch` with an already-released mainnet tag (fast-path build via public download won't exercise sccache; use a tag whose archive is absent, or accept that the existing-archive short-circuit skips the build) → confirm `release-build`'s sccache step shows `Assuming role with OIDC` for `sui-sccache-rw-github`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: