### PR TITLE
test-cluster: retry submit_and_execute on transient post-reconfiguration consensus timeouts

### DIFF
--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -935,69 +935,112 @@ impl TestCluster {
         tx: Transaction,
         client_addr: Option<SocketAddr>,
     ) -> anyhow::Result<(TransactionEffects, TransactionEvents)> {
-        let agg = self.authority_aggregator();
-        // Pick a validator to submit to using seeded RNG for deterministic simtest selection
-        let clients = &agg.authority_clients;
-        let index = rand::thread_rng().gen_range(0..clients.len());
-        let (_, client) = clients
-            .iter()
-            .nth(index)
-            .ok_or_else(|| anyhow::anyhow!("No authority clients available"))?;
+        // The consensus position handed back on submission is the *first* one, even when the
+        // consensus adapter internally retries (e.g. the block was garbage-collected before being
+        // sequenced, which is most likely right after a reconfiguration). If we wait for effects on
+        // that stale position, the validator can neither produce effects nor expire the position
+        // within its wait window, surfacing as a timeout/`Expired`. The consensus adapter documents
+        // that clients must retry in that case, and the production `TransactionDriver` does exactly
+        // that. Mirror it here with a bounded resubmit loop so tests don't flake on this transient
+        // condition. Definite outcomes (executed / rejected) return immediately.
+        const MAX_ATTEMPTS: usize = 5;
+        let mut last_transient_err: Option<anyhow::Error> = None;
+        for attempt in 0..MAX_ATTEMPTS {
+            if attempt > 0 {
+                // Brief backoff before resubmitting to obtain a fresh consensus position.
+                sleep(Duration::from_secs(1)).await;
+            }
 
-        // Submit the transaction
-        let submit_request = SubmitTxRequest::new_transaction(tx.clone());
-        let submit_response = client
-            .submit_transaction(submit_request, client_addr)
-            .await?;
+            let agg = self.authority_aggregator();
+            // Pick a validator to submit to using seeded RNG for deterministic simtest selection
+            let clients = &agg.authority_clients;
+            let index = rand::thread_rng().gen_range(0..clients.len());
+            let (_, client) = clients
+                .iter()
+                .nth(index)
+                .ok_or_else(|| anyhow::anyhow!("No authority clients available"))?;
 
-        let mut consensus_position = None;
-        for result in submit_response.results {
-            match result {
-                SubmitTxResult::Executed { details, .. } => {
+            // Submit the transaction
+            let submit_request = SubmitTxRequest::new_transaction(tx.clone());
+            let submit_response = match client.submit_transaction(submit_request, client_addr).await
+            {
+                Ok(response) => response,
+                // Retry only transient submission failures (e.g. validator overloaded, or
+                // consensus not yet ready right after reconfiguration); surface definite errors
+                // (invalid transaction, lock conflict, internal) immediately.
+                Err(err) if err.as_inner().categorize().is_submission_retriable() => {
+                    last_transient_err = Some(err.into());
+                    continue;
+                }
+                Err(err) => return Err(err.into()),
+            };
+
+            let mut consensus_position = None;
+            for result in submit_response.results {
+                match result {
+                    SubmitTxResult::Executed { details, .. } => {
+                        let data =
+                            details.ok_or_else(|| anyhow::anyhow!("Expected execution details"))?;
+                        let events = data.events.unwrap_or_default();
+                        return Ok((data.effects, events));
+                    }
+                    SubmitTxResult::Rejected { error } => {
+                        return Err(error.into());
+                    }
+                    SubmitTxResult::Submitted {
+                        consensus_position: position,
+                    } => {
+                        consensus_position = Some(position);
+                    }
+                }
+            }
+
+            let consensus_position = consensus_position
+                .ok_or_else(|| anyhow::anyhow!("Expected submitted transaction result"))?;
+
+            // Wait for effects
+            let wait_request = WaitForEffectsRequest {
+                transaction_digest: Some(*tx.digest()),
+                consensus_position: Some(consensus_position),
+                include_details: true,
+                ping_type: None,
+            };
+
+            match client.wait_for_effects(wait_request, client_addr).await {
+                Ok(WaitForEffectsResponse::Executed { details, .. }) => {
                     let data =
                         details.ok_or_else(|| anyhow::anyhow!("Expected execution details"))?;
                     let events = data.events.unwrap_or_default();
                     return Ok((data.effects, events));
                 }
-                SubmitTxResult::Rejected { error } => {
-                    return Err(error.into());
+                Ok(WaitForEffectsResponse::Rejected { error }) => {
+                    return Err(error
+                        .unwrap_or_else(|| {
+                            SuiErrorKind::GenericAuthorityError {
+                                error: "Transaction was rejected".to_string(),
+                            }
+                            .into()
+                        })
+                        .into());
                 }
-                SubmitTxResult::Submitted {
-                    consensus_position: position,
-                } => {
-                    consensus_position = Some(position);
+                // The position we waited on was garbage-collected before being sequenced; resubmit
+                // to obtain a fresh position.
+                Ok(WaitForEffectsResponse::Expired { .. }) => {
+                    last_transient_err = Some(SuiErrorKind::TransactionExpired.into());
                 }
+                // A transient wait failure (e.g. the validator's "Timeout waiting for effects")
+                // means the watched position never resolved; resubmit for a fresh one. Surface
+                // definite errors immediately.
+                Err(err) if err.as_inner().categorize().is_submission_retriable() => {
+                    last_transient_err = Some(err.into());
+                }
+                Err(err) => return Err(err.into()),
             }
         }
 
-        let consensus_position = consensus_position
-            .ok_or_else(|| anyhow::anyhow!("Expected submitted transaction result"))?;
-
-        // Wait for effects
-        let wait_request = WaitForEffectsRequest {
-            transaction_digest: Some(*tx.digest()),
-            consensus_position: Some(consensus_position),
-            include_details: true,
-            ping_type: None,
-        };
-
-        let response = client.wait_for_effects(wait_request, client_addr).await?;
-        match response {
-            WaitForEffectsResponse::Executed { details, .. } => {
-                let data = details.ok_or_else(|| anyhow::anyhow!("Expected execution details"))?;
-                let events = data.events.unwrap_or_default();
-                Ok((data.effects, events))
-            }
-            WaitForEffectsResponse::Rejected { error } => Err(error
-                .unwrap_or_else(|| {
-                    SuiErrorKind::GenericAuthorityError {
-                        error: "Transaction was rejected".to_string(),
-                    }
-                    .into()
-                })
-                .into()),
-            WaitForEffectsResponse::Expired { .. } => Err(SuiErrorKind::TransactionExpired.into()),
-        }
+        Err(last_transient_err.unwrap_or_else(|| {
+            anyhow::anyhow!("submit_and_execute exhausted retries without a result")
+        }))
     }
 
     /// This call sends some funds from the seeded address to the funding


### PR DESCRIPTION
## Problem

`receive_of_object_with_reconfiguration_receive_after_reconfig` and similar e2e tests flake (~0.5% of simtest seeds) with `Internal error - Timeout waiting for effects`.

Right after a reconfiguration, a transaction's initial consensus block can be garbage-collected before it is sequenced. The consensus adapter resubmits it internally, and the re-committed copy may be reject-voted (so it produces no effects) — but the consensus position handed back to, and awaited by, the client is the original, now-GC'd one. The validator's `wait_for_effects` on that stale position can neither return effects, nor surface the rejection (recorded against the *new* position), nor expire the position within its 20s window (a position only expires once the committed leader round advances `CONSENSUS_STATUS_RETENTION_ROUNDS = 400` rounds, while only ~100 occur in that window). The result is a hard timeout that the test unwraps into a panic.

## Fix

`TestCluster::submit_and_execute` now wraps submit+wait in a bounded (5-attempt) resubmit loop: transient wait outcomes (timeout / `Expired`) resubmit to obtain a fresh consensus position, while definite outcomes (executed / rejected) return immediately. This mirrors the production `TransactionDriver` and the consensus adapter's documented contract that clients must retry when the original position is garbage-collected.

## Validation

- The previously-failing seed now passes — resubmission re-commits the transaction, which is then finalized and executed.
- 500/500 seeds pass for the affected test (baseline flake rate ~0.5%).
- `party_objects_tests` (10/10) and `shared_objects_tests` (8/8) — equivocation/conflict callers of the same helper — pass unchanged.