### PR TITLE
json-rpc: add config flag to disable the JSON-RPC HTTP service

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -111,6 +111,16 @@ pub struct NodeConfig {
     /// - 'both' for both a websocket and http based service (deprecated)
     pub jsonrpc_server_type: Option<ServerType>,
 
+    /// When true, the JSON-RPC HTTP service is not started. This only stops the
+    /// node from serving JSON-RPC requests; it is independent of JSON-RPC
+    /// indexing (see `enable_index_processing`), which continues to run. This
+    /// lets a node keep indexing while no longer exposing the JSON-RPC service,
+    /// and it does not affect the gRPC/REST service served on the same address.
+    /// Defaults to false so the service stays enabled unless explicitly turned
+    /// off.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub disable_json_rpc: bool,
+
     #[serde(default)]
     pub grpc_load_shed: Option<bool>,
 
@@ -966,6 +976,13 @@ impl NodeConfig {
 
     pub fn jsonrpc_server_type(&self) -> ServerType {
         self.jsonrpc_server_type.unwrap_or(ServerType::Http)
+    }
+
+    /// Whether the JSON-RPC HTTP service should be served. This gates only the
+    /// JSON-RPC endpoints; the gRPC/REST service and JSON-RPC indexing are
+    /// unaffected.
+    pub fn json_rpc_enabled(&self) -> bool {
+        !self.disable_json_rpc
     }
 
     pub fn rpc(&self) -> Option<&crate::RpcConfig> {

--- a/crates/sui-e2e-tests/tests/jsonrpc_disabled_tests.rs
+++ b/crates/sui-e2e-tests/tests/jsonrpc_disabled_tests.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Verifies the `disable_json_rpc` node config flag: it turns off the JSON-RPC
+//! HTTP service while leaving the gRPC/REST service served on the same address
+//! enabled. JSON-RPC is enabled by default, so disabling it is strictly
+//! opt-in.
+
+use std::time::Duration;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::rpc_params;
+use rand::rngs::OsRng;
+use sui_macros::sim_test;
+use sui_rpc_api::Client;
+use test_cluster::TestClusterBuilder;
+
+#[sim_test]
+async fn disabling_json_rpc_keeps_grpc_enabled() {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+
+    // The cluster's default fullnode keeps JSON-RPC enabled and acts as a
+    // control: the same request must succeed there.
+    let enabled_url = test_cluster.rpc_url().to_owned();
+
+    // Spawn an additional fullnode with the JSON-RPC service disabled. We spawn
+    // it directly through the swarm rather than through
+    // `start_fullnode_from_config`, because the latter eagerly builds a JSON-RPC
+    // client to handshake with the node, which would fail when the service is
+    // turned off.
+    let config = test_cluster
+        .fullnode_config_builder()
+        .with_disable_json_rpc(true)
+        .build(&mut OsRng, test_cluster.swarm.config());
+    assert!(config.disable_json_rpc);
+    let rpc_url = format!("http://{}", config.json_rpc_address);
+    let _handle = test_cluster.swarm.spawn_new_node(config).await;
+
+    // gRPC is served on the same address and must stay available even though
+    // JSON-RPC is disabled. The node is freshly spawned and still syncing, so we
+    // poll until it has caught up enough to answer; a successful response proves
+    // the gRPC service is enabled and reachable.
+    let grpc_client = Client::new(&rpc_url).unwrap();
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            if grpc_client.get_chain_identifier().await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .expect("grpc service should be enabled and reachable when json-rpc is disabled");
+
+    // JSON-RPC requests to the disabled node must fail: the endpoints are never
+    // registered, so there is nothing to answer the request.
+    let disabled_client = HttpClientBuilder::default().build(&rpc_url).unwrap();
+    let disabled_resp: Result<String, _> = disabled_client
+        .request("sui_getChainIdentifier", rpc_params![])
+        .await;
+    assert!(
+        disabled_resp.is_err(),
+        "json-rpc should be disabled, but the request succeeded: {disabled_resp:?}"
+    );
+
+    // Control: the same JSON-RPC request succeeds against the default fullnode,
+    // confirming the request itself is well-formed and that disabling is opt-in.
+    let enabled_client = HttpClientBuilder::default().build(&enabled_url).unwrap();
+    let enabled_resp: Result<String, _> = enabled_client
+        .request("sui_getChainIdentifier", rpc_params![])
+        .await;
+    assert!(
+        enabled_resp.is_ok(),
+        "json-rpc should be enabled on the default fullnode, got: {enabled_resp:?}"
+    );
+}

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -2510,6 +2510,83 @@ fn build_kv_store(
     )))
 }
 
+async fn build_json_rpc_router(
+    state: &Arc<AuthorityState>,
+    transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
+    config: &NodeConfig,
+    prometheus_registry: &Registry,
+) -> Result<axum::Router> {
+    let traffic_controller = state.traffic_controller.clone();
+    let mut server = JsonRpcServerBuilder::new(
+        env!("CARGO_PKG_VERSION"),
+        prometheus_registry,
+        traffic_controller,
+        config.policy_config.clone(),
+    );
+
+    let kv_store = build_kv_store(state, config, prometheus_registry)?;
+
+    let metrics = Arc::new(JsonRpcMetrics::new(prometheus_registry));
+    server.register_module(ReadApi::new(
+        state.clone(),
+        kv_store.clone(),
+        metrics.clone(),
+    ))?;
+    server.register_module(CoinReadApi::new(
+        state.clone(),
+        kv_store.clone(),
+        metrics.clone(),
+    ))?;
+
+    // if run_with_range is enabled we want to prevent any transactions
+    // run_with_range = None is normal operating conditions
+    if config.run_with_range.is_none() {
+        server.register_module(TransactionBuilderApi::new(state.clone()))?;
+    }
+    server.register_module(GovernanceReadApi::new(state.clone(), metrics.clone()))?;
+    server.register_module(BridgeReadApi::new(state.clone(), metrics.clone()))?;
+
+    if let Some(transaction_orchestrator) = transaction_orchestrator {
+        server.register_module(TransactionExecutionApi::new(
+            state.clone(),
+            transaction_orchestrator.clone(),
+            metrics.clone(),
+        ))?;
+    }
+
+    let name_service_config = if let (
+        Some(package_address),
+        Some(registry_id),
+        Some(reverse_registry_id),
+    ) = (
+        config.name_service_package_address,
+        config.name_service_registry_id,
+        config.name_service_reverse_registry_id,
+    ) {
+        sui_name_service::NameServiceConfig::new(package_address, registry_id, reverse_registry_id)
+    } else {
+        match state.get_chain_identifier().chain() {
+            Chain::Mainnet => sui_name_service::NameServiceConfig::mainnet(),
+            Chain::Testnet => sui_name_service::NameServiceConfig::testnet(),
+            Chain::Unknown => sui_name_service::NameServiceConfig::default(),
+        }
+    };
+
+    server.register_module(IndexerApi::new(
+        state.clone(),
+        ReadApi::new(state.clone(), kv_store.clone(), metrics.clone()),
+        kv_store,
+        name_service_config,
+        metrics,
+        config.indexer_max_subscriptions,
+    ))?;
+    server.register_module(MoveUtils::new(state.clone()))?;
+
+    let server_type = config.jsonrpc_server_type();
+
+    Ok(server.to_router(server_type).await?)
+}
+
 async fn build_http_servers(
     state: Arc<AuthorityState>,
     store: RocksDbStore,
@@ -2528,80 +2605,22 @@ async fn build_http_servers(
 
     let mut router = axum::Router::new();
 
-    let json_rpc_router = {
-        let traffic_controller = state.traffic_controller.clone();
-        let mut server = JsonRpcServerBuilder::new(
-            env!("CARGO_PKG_VERSION"),
-            prometheus_registry,
-            traffic_controller,
-            config.policy_config.clone(),
+    // The JSON-RPC service can be disabled independently of the gRPC/REST
+    // service and of JSON-RPC indexing, so that a node can keep indexing
+    // without exposing the JSON-RPC endpoints.
+    if config.json_rpc_enabled() {
+        router = router.merge(
+            build_json_rpc_router(
+                &state,
+                transaction_orchestrator,
+                config,
+                prometheus_registry,
+            )
+            .await?,
         );
-
-        let kv_store = build_kv_store(&state, config, prometheus_registry)?;
-
-        let metrics = Arc::new(JsonRpcMetrics::new(prometheus_registry));
-        server.register_module(ReadApi::new(
-            state.clone(),
-            kv_store.clone(),
-            metrics.clone(),
-        ))?;
-        server.register_module(CoinReadApi::new(
-            state.clone(),
-            kv_store.clone(),
-            metrics.clone(),
-        ))?;
-
-        // if run_with_range is enabled we want to prevent any transactions
-        // run_with_range = None is normal operating conditions
-        if config.run_with_range.is_none() {
-            server.register_module(TransactionBuilderApi::new(state.clone()))?;
-        }
-        server.register_module(GovernanceReadApi::new(state.clone(), metrics.clone()))?;
-        server.register_module(BridgeReadApi::new(state.clone(), metrics.clone()))?;
-
-        if let Some(transaction_orchestrator) = transaction_orchestrator {
-            server.register_module(TransactionExecutionApi::new(
-                state.clone(),
-                transaction_orchestrator.clone(),
-                metrics.clone(),
-            ))?;
-        }
-
-        let name_service_config =
-            if let (Some(package_address), Some(registry_id), Some(reverse_registry_id)) = (
-                config.name_service_package_address,
-                config.name_service_registry_id,
-                config.name_service_reverse_registry_id,
-            ) {
-                sui_name_service::NameServiceConfig::new(
-                    package_address,
-                    registry_id,
-                    reverse_registry_id,
-                )
-            } else {
-                match state.get_chain_identifier().chain() {
-                    Chain::Mainnet => sui_name_service::NameServiceConfig::mainnet(),
-                    Chain::Testnet => sui_name_service::NameServiceConfig::testnet(),
-                    Chain::Unknown => sui_name_service::NameServiceConfig::default(),
-                }
-            };
-
-        server.register_module(IndexerApi::new(
-            state.clone(),
-            ReadApi::new(state.clone(), kv_store.clone(), metrics.clone()),
-            kv_store,
-            name_service_config,
-            metrics,
-            config.indexer_max_subscriptions,
-        ))?;
-        server.register_module(MoveUtils::new(state.clone()))?;
-
-        let server_type = config.jsonrpc_server_type();
-
-        server.to_router(server_type).await?
-    };
-
-    router = router.merge(json_rpc_router);
+    } else {
+        info!("json-rpc service is disabled");
+    }
 
     let (subscription_service_checkpoint_sender, subscription_service_handle) =
         SubscriptionService::build(prometheus_registry);

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -274,6 +274,7 @@ impl ValidatorConfigBuilder {
             execution_cache: self.execution_cache_config.unwrap_or_default(),
             run_with_range: None,
             jsonrpc_server_type: None,
+            disable_json_rpc: false,
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
             state_accumulator_v2: self.global_state_hash_v2,
@@ -324,6 +325,7 @@ pub struct FullnodeConfigBuilder {
     fw_config: Option<RemoteFirewallConfig>,
     data_ingestion_dir: Option<PathBuf>,
     disable_pruning: bool,
+    disable_json_rpc: bool,
     sync_post_process_one_tx: bool,
     chain_override: Option<Chain>,
     transaction_driver_config: Option<TransactionDriverConfig>,
@@ -377,6 +379,11 @@ impl FullnodeConfigBuilder {
 
     pub fn with_disable_pruning(mut self, disable_pruning: bool) -> Self {
         self.disable_pruning = disable_pruning;
+        self
+    }
+
+    pub fn with_disable_json_rpc(mut self, disable_json_rpc: bool) -> Self {
+        self.disable_json_rpc = disable_json_rpc;
         self
     }
 
@@ -657,6 +664,7 @@ impl FullnodeConfigBuilder {
             authority_overload_config: Default::default(),
             run_with_range: self.run_with_range,
             jsonrpc_server_type: None,
+            disable_json_rpc: self.disable_json_rpc,
             policy_config: self.policy_config,
             firewall_config: self.fw_config,
             execution_cache: ExecutionCacheConfig::default(),


### PR DESCRIPTION
Adds a new `disable_json_rpc` flag to the node config that turns off the JSON-RPC HTTP service. The flag is independent of JSON-RPC indexing (see `enable_index_processing`) and of the gRPC/REST service served on the same address, so a node can keep indexing and serving gRPC while no longer exposing the JSON-RPC endpoints.

The flag defaults to false so the service stays enabled unless explicitly turned off, making it strictly opt-in. It uses `skip_serializing_if` so existing serialized configs are unchanged when the flag is left at its default.

In `build_http_servers`, the JSON-RPC router construction is factored out into `build_json_rpc_router` and only built and merged when the flag leaves the service enabled; the gRPC/REST router and subscription service are unaffected.

Also adds a sui-e2e-tests test that spawns a fullnode with the flag set and verifies the JSON-RPC service is off while the gRPC service stays on, using the cluster's default fullnode as a control that JSON-RPC is on by default.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
