### PR TITLE
fix(ci): release.yml startup failure (empty ${{ }} in a run-block comment)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,11 @@ jobs:
         shell: bash
         run: |
           # Read TAG_NAME as a shell variable (it is a workflow-level env, above).
-          # NEVER interpolate the raw input into the script via ${{ }}: a
-          # workflow_dispatch sui_tag is attacker-controllable, and this job holds
-          # id-token: write for the trusted `main` sub, so injected shell here
-          # could mint the RW cache token before the guard below runs.
+          # NEVER splice the raw input into this script through GitHub Actions
+          # expression interpolation: a workflow_dispatch sui_tag is
+          # attacker-controllable, and this job holds id-token: write for the
+          # trusted `main` sub, so injected shell here could mint the RW cache
+          # token before the guard below runs.
           sui_tag="${TAG_NAME#refs/tags/}"
           # Only published release tags may be built. Fully anchored (^...$) with a
           # restricted charset so the value also cannot smuggle a newline into the


### PR DESCRIPTION
## Summary

**release.yml is currently unparseable on `main`** — every push since #26963 produces a startup-failure run (e.g. [27573500321](https://github.com/MystenLabs/sui/actions/runs/27573500321)), and, more importantly, **the next real `release: created` event would also startup-fail and never build/attach the release binaries.**

Root cause: a shell comment **inside the `run:` block** of release-build's "Validate the release tag" step literally contained the token `${{ }}` (an *empty* GitHub Actions expression):

```
# NEVER interpolate the raw input into the script via ${{ }}: a
```

GitHub scans every `run:` body for `${{ … }}` templates (it doesn't know the line is a shell comment) and fails to parse the empty expression — which invalidates the **whole workflow file**, so GitHub can no longer read the `on:` triggers and emits startup-failures on every event evaluation. Ironically the comment warning *against* `${{ }}` interpolation is what broke the parser by writing it literally. Introduced in #26963.

Fix: reword the comment to drop the literal token (same meaning, no `${{`). No behavior change.

## Why actionlint's gate didn't catch it earlier

`actionlint` **does** flag it (`release.yml:69:145: unexpected end of input while parsing variable access … [expression]`), but the project's super-linter run only checks changed files and this is on `main`; the per-PR actionlint count I'd eyeballed during #26963 had it buried under pre-existing shellcheck/runner-label noise. This PR's actionlint count drops from 29 → 28 — exactly the removed startup error.

## Test plan

- [x] `grep '\${{' release.yml` in comments → none remain
- [x] `actionlint release.yml` → the `[expression] unexpected end of input` error is **gone** (count 29 → 28; remaining are pre-existing shellcheck/runner-label)
- [ ] Post-merge: confirm pushes no longer create release.yml startup-failure runs

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: