### PR TITLE
Reliably report consistently-failing state-sync peers

### DIFF
--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -181,7 +181,11 @@ impl PeerScore {
         while self.successes.len() > Self::MAX_SAMPLES {
             self.successes.pop_front();
         }
-        self.failing_since = None;
+        // Note: a single success does NOT clear `failing_since`. Whether the peer is
+        // "consistently failing" is driven by the windowed failure RATE (see
+        // `update_failing_state`), so an occasional success while the rate stays high (e.g.
+        // a brief reconnect during connection churn) must not keep resetting the clock and
+        // prevent the peer from ever being reported.
     }
 
     pub(super) fn record_failure(&mut self) {
@@ -215,8 +219,16 @@ impl PeerScore {
     }
 
     pub(super) fn update_failing_state(&mut self) {
-        if self.is_failing() && self.failing_since.is_none() {
-            self.failing_since = Some(Instant::now());
+        if self.is_failing() {
+            // Start the consistently-failing clock when the windowed failure rate first
+            // crosses the threshold, and let it accumulate while the rate stays high.
+            if self.failing_since.is_none() {
+                self.failing_since = Some(Instant::now());
+            }
+        } else {
+            // The windowed failure rate dropped below the threshold: the peer is no longer
+            // failing, so clear the clock. Only an actual drop in the rate resets it.
+            self.failing_since = None;
         }
     }
 
@@ -1195,7 +1207,7 @@ async fn get_latest_from_peer(
         trace!(?info, "Peer {peer_id} not on same chain as us");
         return;
     }
-    let Some((highest_checkpoint, low_watermark)) =
+    let Ok(Some((highest_checkpoint, low_watermark))) =
         query_peer_for_latest_info(&mut client, timeout).await
     else {
         return;
@@ -1206,11 +1218,18 @@ async fn get_latest_from_peer(
         .update_peer_info(peer_id, highest_checkpoint, low_watermark);
 }
 
-/// Queries a peer for their highest_synced_checkpoint and low checkpoint watermark
+/// Queries a peer for their highest_synced_checkpoint and low checkpoint watermark.
+///
+/// Distinguishes three outcomes so callers can score the peer:
+/// - `Ok(Some(..))`: the peer answered with usable latest-checkpoint info.
+/// - `Ok(None)`: the peer answered but had nothing useful to report (e.g. a pre-upgrade peer
+///   that returns no latest summary). This is not a failure.
+/// - `Err(())`: the request itself failed (timeout / transport error). This is a failure: a
+///   peer that consistently fails these liveness queries is consistently unreachable.
 async fn query_peer_for_latest_info(
     client: &mut StateSyncClient<anemo::Peer>,
     timeout: Duration,
-) -> Option<(Checkpoint, Option<CheckpointSequenceNumber>)> {
+) -> Result<Option<(Checkpoint, Option<CheckpointSequenceNumber>)>, ()> {
     let request = Request::new(()).with_timeout(timeout);
     let response = client
         .get_checkpoint_availability(request)
@@ -1221,13 +1240,16 @@ async fn query_peer_for_latest_info(
             highest_synced_checkpoint,
             lowest_available_checkpoint,
         }) => {
-            return Some((highest_synced_checkpoint, Some(lowest_available_checkpoint)));
+            return Ok(Some((
+                highest_synced_checkpoint,
+                Some(lowest_available_checkpoint),
+            )));
         }
         Err(status) => {
             // If peer hasn't upgraded they would return 404 NotFound error
             if status.status() != anemo::types::response::StatusCode::NotFound {
                 trace!("get_checkpoint_availability request failed: {status:?}");
-                return None;
+                return Err(());
             }
         }
     };
@@ -1240,11 +1262,11 @@ async fn query_peer_for_latest_info(
         .await
         .map(Response::into_inner);
     match response {
-        Ok(Some(checkpoint)) => Some((checkpoint, None)),
-        Ok(None) => None,
+        Ok(Some(checkpoint)) => Ok(Some((checkpoint, None))),
+        Ok(None) => Ok(None),
         Err(status) => {
             trace!("get_checkpoint_summary (latest) request failed: {status:?}");
-            None
+            Err(())
         }
     }
 }
@@ -1268,14 +1290,32 @@ async fn query_peers_for_their_latest_checkpoint(
             let mut client = StateSyncClient::new(peer);
 
             async move {
+                let start = Instant::now();
                 let response = query_peer_for_latest_info(&mut client, timeout).await;
+                let elapsed = start.elapsed();
                 match response {
-                    Some((highest_checkpoint, low_watermark)) => peer_heights
-                        .write()
-                        .unwrap()
-                        .update_peer_info(peer_id, highest_checkpoint.clone(), low_watermark)
-                        .then_some(highest_checkpoint),
-                    None => None,
+                    Ok(Some((highest_checkpoint, low_watermark))) => {
+                        // A peer that answers our periodic liveness/discovery query is healthy;
+                        // record it so its success rate offsets occasional failures.
+                        let size = bcs::serialized_size(&highest_checkpoint).unwrap_or(0) as u64;
+                        let mut peer_heights = peer_heights.write().unwrap();
+                        peer_heights.record_success(peer_id, size, elapsed);
+                        peer_heights
+                            .update_peer_info(peer_id, highest_checkpoint.clone(), low_watermark)
+                            .then_some(highest_checkpoint)
+                    }
+                    // Peer responded but had nothing useful; neutral, do not score.
+                    Ok(None) => None,
+                    // Request failed (timeout / transport). A peer that consistently fails
+                    // these liveness queries is consistently unreachable, so record the
+                    // failure to feed the scorer even when we are not actively syncing from
+                    // it. Without this, an unreachable peer is only scored while there is
+                    // active sync traffic, so it can evade the consistently-failing-peer
+                    // disconnect logic indefinitely.
+                    Err(()) => {
+                        peer_heights.write().unwrap().record_failure(peer_id);
+                        None
+                    }
                 }
             }
         })

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -1352,27 +1352,21 @@ fn test_peer_score_failing_since_tracking() {
     score.update_failing_state();
     assert_eq!(score.failing_since.unwrap(), first_failing_since);
 
-    // Record a success - this should clear failing_since
+    // A single success does NOT clear failing_since while the windowed failure rate is still
+    // above the threshold (8 successes + 4 failures = 33% >= 30%, still failing).
     score.record_success(100, Duration::from_secs(1));
+    assert!(score.is_failing());
+    score.update_failing_state();
+    assert_eq!(score.failing_since.unwrap(), first_failing_since);
+
+    // failing_since is cleared only once the windowed failure rate drops back below the
+    // threshold (14 successes + 4 failures = ~22% < 30%), which update_failing_state detects.
+    for _ in 0..6 {
+        score.record_success(100, Duration::from_secs(1));
+    }
+    assert!(!score.is_failing());
+    score.update_failing_state();
     assert!(score.failing_since.is_none());
-
-    // Make failing again and verify update_failing_state doesn't clear it
-    // when is_failing() returns false due to lack of samples (not due to success)
-    let mut score2 = PeerScore::new(window, failure_rate);
-    for _ in 0..7 {
-        score2.record_success(100, Duration::from_secs(1));
-    }
-    for _ in 0..4 {
-        score2.record_failure();
-    }
-    score2.update_failing_state();
-    assert!(score2.failing_since.is_some());
-    let failing_since_before = score2.failing_since.unwrap();
-
-    // Simulate samples aging out by not adding new ones - update_failing_state
-    // should NOT clear failing_since (only record_success does that)
-    score2.update_failing_state();
-    assert_eq!(score2.failing_since, Some(failing_since_before));
 }
 
 #[test]


### PR DESCRIPTION
## Description

`state_sync_resilience_tests::test_disconnect_consistently_failing_peers` is flaky: under sustained latency the syncing node sometimes never reports any peer as failing. State-sync only scored a peer while actively fetching checkpoints from it, so a node that had already caught up scored nothing; and the "continuously failing" timer was reset by any single successful response, so a peer that failed most-but-not-all requests (e.g. flapping connections) never crossed the disconnect threshold.

Failed liveness/discovery queries now count as failures against the peer's score (distinguishing a genuine request failure from a peer that simply has nothing newer to report), and the "continuously failing" duration is derived from the windowed failure rate rather than reset on every success. A consistently-unreachable peer is now reported whether or not sync traffic is flowing.

## Test plan

The `failing_since` unit test in `sui-network` is updated for the rate-based semantics. Reproduced the flake locally with a fast-checkpoint-interval harness that fails 51/400 seeds without this change and passes 400/400 with it.

---

## Release notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): A node now reports and disconnects state-sync peers that are consistently unreachable even when it is not actively syncing from them; previously this could fail to happen. No operator action required.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
