### PR TITLE
fix(test): wait for address-balance deposit to settle on all nodes

### DIFF
--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -1294,6 +1294,16 @@ async fn authenticated_events_multiple_commits_per_checkpoint() {
     );
     test_cluster.sign_and_execute_transaction(&deposit_tx).await;
 
+    // The 6T deposit becomes spendable from the sender's address balance only after the
+    // per-checkpoint settlement transaction creates the account object on each node. Awaiting
+    // the deposit's execution above is not sufficient: the soft bundles below are submitted to
+    // a randomly chosen validator, and a validator that has not yet applied the settlement
+    // would see a zero balance in its pre-consensus funds check and reject the transaction
+    // with InvalidWithdrawReservation. Wait for the deposit to settle on every node first.
+    test_cluster
+        .wait_for_tx_settlement_all_nodes(&[deposit_tx.digest()])
+        .await;
+
     let event_count = 100;
 
     let tx_data_vec: Vec<_> = (0..event_count)

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -875,25 +875,50 @@ impl TestCluster {
     }
 
     pub async fn wait_for_tx_settlement(&self, digests: &[TransactionDigest]) {
-        self.fullnode_handle
-            .sui_node
-            .with_async(|node| async move {
+        Self::wait_for_tx_settlement_on_handles(
+            std::slice::from_ref(&self.fullnode_handle.sui_node),
+            digests,
+        )
+        .await;
+    }
+
+    /// Like `wait_for_tx_settlement`, but waits on every node (all validators and fullnodes)
+    /// instead of only the rpc fullnode. Nodes can execute the same checkpoint at different
+    /// times, so the rpc fullnode having settled a transaction does not imply every validator
+    /// has. Use this when a subsequent step may interact with an arbitrary validator (e.g. a
+    /// soft bundle is submitted to a randomly chosen validator) and that validator must have
+    /// already applied the settlement of `digests`.
+    pub async fn wait_for_tx_settlement_all_nodes(&self, digests: &[TransactionDigest]) {
+        let handles = self.all_node_handles();
+        Self::wait_for_tx_settlement_on_handles(&handles, digests).await;
+    }
+
+    /// Waits, concurrently across `handles`, until every transaction in `digests` has settled
+    /// on that node: the transaction's checkpoint is present in the node's store and that
+    /// checkpoint has been executed (which is when the transaction's settlement is visible).
+    async fn wait_for_tx_settlement_on_handles(
+        handles: &[SuiNodeHandle],
+        digests: &[TransactionDigest],
+    ) {
+        let waits = handles.iter().map(|handle| {
+            handle.with_async(|node| async move {
                 let state = node.state();
-                // wait until the transactions are in checkpoints
+                // wait until the transactions are in checkpoints on this node
                 let checkpoint_seqs = state
                     .epoch_store_for_testing()
                     .transactions_executed_in_checkpoint_notify(digests.to_vec())
                     .await
                     .unwrap();
 
-                // then wait until the highest of the checkpoints is executed
+                // then wait until the highest of those checkpoints is executed on this node
                 let max_checkpoint_seq = checkpoint_seqs.into_iter().max().unwrap();
                 state
                     .checkpoint_store
                     .notify_read_executed_checkpoint(max_checkpoint_seq)
                     .await;
             })
-            .await;
+        });
+        join_all(waits).await;
     }
 
     /// Execute a transaction on the network and wait for it to be executed on the rpc fullnode.


### PR DESCRIPTION
## Problem

`authenticated_events_multiple_commits_per_checkpoint` could flakily fail with `InvalidWithdrawReservation { "...is less than requested: 0 < 50000000000" }`.

The test deposits into the sender's address balance and awaits only the deposit transaction's **execution**, then immediately submits gas-by-address-balance transactions in soft bundles. Address-balance deposits become spendable only after an asynchronous, per-checkpoint settlement transaction creates the sender's account object — and that settlement reaches validators at slightly different times.

`execute_signed_txns_in_soft_bundle` submits each bundle to a **single randomly chosen validator with no retry**. When the chosen validator had not yet applied the deposit's settlement, its pre-consensus funds-availability check read a balance of `0` and rejected the transaction, which propagated to the client and failed the test. (Seed- and platform-dependent, which is why it surfaced intermittently in nightly simtest.)

## Fix

Add `TestCluster::wait_for_tx_settlement_all_nodes` (like `wait_for_tx_settlement`, but waits on every node rather than only the rpc fullnode) and call it on the deposit before spending, so whichever validator a bundle is routed to already has the sender's account object.

This is a test-only change; no production behavior is affected.

## Test plan

- `cargo simtest -p sui-e2e-tests authenticated_events_multiple_commits_per_checkpoint` passes.
- A local seed sweep under the nightly's mainnet protocol-config override: the previously-failing seed now passes, and 800/800 seeds pass.