### PR TITLE
[tx-timestamp 1/4] Add commit timestamp to ExecutionEnv and source it from consensus

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -166,8 +166,9 @@ use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemS
 use sui_types::sui_system_state::{SuiSystemState, get_sui_system_state};
 use sui_types::supported_protocol_versions::{ProtocolConfig, SupportedProtocolVersions};
 use sui_types::{
-    SUI_SYSTEM_ADDRESS,
+    SUI_CLOCK_OBJECT_ID, SUI_SYSTEM_ADDRESS,
     base_types::*,
+    clock::Clock,
     committee::Committee,
     crypto::AuthoritySignature,
     error::{SuiError, SuiResult},
@@ -791,6 +792,15 @@ pub struct ExecutionEnv {
     /// Transactions that must finish before this transaction can be executed.
     /// Used to schedule barrier transactions after non-exclusive writes.
     pub barrier_dependencies: Vec<TransactionDigest>,
+    /// Timestamp in milliseconds of the consensus commit that included the transaction.
+    /// This value will be used for reading timestamp in Move directly from TxContext without involving
+    /// Clock object.
+    ///
+    /// For almost all transactions, this value will be the same as if the transaction reads
+    /// the Clock object according to the consensus ordering. The only exception is the prologue
+    /// transaction itself, which reads the old Clock object that still contains the previous
+    /// commit's timestamp.
+    pub tx_timestamp_ms: Option<u64>,
 }
 
 impl Default for ExecutionEnv {
@@ -800,6 +810,7 @@ impl Default for ExecutionEnv {
             expected_effects_digest: None,
             funds_withdraw_status: FundsWithdrawStatus::MaybeSufficient,
             barrier_dependencies: Default::default(),
+            tx_timestamp_ms: None,
         }
     }
 }
@@ -832,6 +843,11 @@ impl ExecutionEnv {
         barrier_dependencies: BTreeSet<TransactionDigest>,
     ) -> Self {
         self.barrier_dependencies = barrier_dependencies.into_iter().collect();
+        self
+    }
+
+    pub fn with_tx_timestamp_ms(mut self, tx_timestamp_ms: u64) -> Self {
+        self.tx_timestamp_ms = Some(tx_timestamp_ms);
         self
     }
 }
@@ -1989,6 +2005,13 @@ impl AuthorityState {
             return ExecutionOutput::Fatal(e);
         }
         let tx_digest = *certificate.digest();
+
+        check_clock_timestamp_matches_commit(
+            &tx_digest,
+            &input_objects,
+            execution_env.tx_timestamp_ms,
+        );
+
         let protocol_config = epoch_store.protocol_config();
         let transaction_data = &certificate.data().intent_message().value;
         let sender = transaction_data.sender();
@@ -6795,5 +6818,41 @@ impl NodeStateDump {
     pub fn read_from_file(path: &PathBuf) -> Result<Self, anyhow::Error> {
         let file = File::open(path)?;
         serde_json::from_reader(file).map_err(|e| anyhow::anyhow!(e))
+    }
+}
+
+/// The consensus commit timestamp threaded through the execution env is sourced from the consensus
+/// commit prologue, which is also the transaction that writes the Clock object. Hence any
+/// transaction that reads the Clock must observe a matching timestamp. This guards the wiring while
+/// nothing reads the value yet.
+///
+/// The prologue itself is excluded: it takes the Clock as a *mutable* input still holding the
+/// previous commit's timestamp and overwrites it, so only immutable Clock reads are checked.
+fn check_clock_timestamp_matches_commit(
+    tx_digest: &TransactionDigest,
+    input_objects: &CheckedInputObjects,
+    tx_timestamp_ms: Option<u64>,
+) {
+    let Some(tx_timestamp_ms) = tx_timestamp_ms else {
+        return;
+    };
+    let Some(clock_timestamp_ms) = input_objects
+        .inner()
+        .iter()
+        .find(|obj| obj.id() == SUI_CLOCK_OBJECT_ID && !obj.is_mutable())
+        .and_then(|obj| obj.as_object())
+        .and_then(|obj| obj.data.try_as_move())
+        .and_then(|move_obj| bcs::from_bytes::<Clock>(move_obj.contents()).ok())
+        .map(|clock| clock.timestamp_ms)
+    else {
+        return;
+    };
+    if clock_timestamp_ms != tx_timestamp_ms {
+        debug_fatal!(
+            "Clock timestamp {} does not match consensus commit timestamp {} for tx {:?}",
+            clock_timestamp_ms,
+            tx_timestamp_ms,
+            tx_digest
+        );
     }
 }

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -431,7 +431,7 @@ where
             !captured.is_empty(),
             "Expected transactions to be scheduled"
         );
-        let (paired, _) = captured.remove(0);
+        let (paired, _, _) = captured.remove(0);
         let (schedulables, versions): (Vec<_>, Vec<_>) = paired.into_iter().unzip();
         let assigned_versions = schedulables
             .iter()

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -726,7 +726,7 @@ impl CheckpointQueue {
         });
 
         self.execution_scheduler_sender
-            .send(schedulables, settlement_info);
+            .send(schedulables, settlement_info, timestamp);
 
         self.pending_tx_count += user_tx_count;
         self.pending_roots.push_back(QueuedCheckpointRoots {
@@ -2953,6 +2953,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 pub(crate) type SchedulerMessage = (
     Vec<(Schedulable, AssignedVersions)>,
     Option<SettlementBatchInfo>,
+    // Timestamp in milliseconds of the consensus commit that ordered these transactions.
+    u64,
 );
 
 #[derive(Clone)]
@@ -2980,8 +2982,11 @@ impl ExecutionSchedulerSender {
         &self,
         transactions: Vec<(Schedulable, AssignedVersions)>,
         settlement: Option<SettlementBatchInfo>,
+        commit_timestamp_ms: u64,
     ) {
-        let _ = self.sender.send((transactions, settlement));
+        let _ = self
+            .sender
+            .send((transactions, settlement, commit_timestamp_ms));
     }
 
     async fn run(
@@ -2989,11 +2994,18 @@ impl ExecutionSchedulerSender {
         settlement_scheduler: SettlementScheduler,
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) {
-        while let Some((transactions, settlement)) = recv.recv().await {
+        while let Some((transactions, settlement, commit_timestamp_ms)) = recv.recv().await {
             let _guard = monitored_scope("ConsensusHandler::enqueue");
             let txns = transactions
                 .into_iter()
-                .map(|(txn, versions)| (txn, ExecutionEnv::new().with_assigned_versions(versions)))
+                .map(|(txn, versions)| {
+                    (
+                        txn,
+                        ExecutionEnv::new()
+                            .with_assigned_versions(versions)
+                            .with_tx_timestamp_ms(commit_timestamp_ms),
+                    )
+                })
                 .collect();
             if let Some(settlement) = settlement {
                 settlement_scheduler.enqueue_v2(txns, settlement, &epoch_store);

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5802,7 +5802,7 @@ where
         (vec![], HashMap::new())
     } else {
         // Remove and return the first batch of captured transactions
-        let (mut paired, _) = captured.remove(0);
+        let (mut paired, _, _) = captured.remove(0);
 
         // Filter out consensus commit prologue transactions if requested
         if filter_prologue {

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -317,7 +317,7 @@ async fn test_congestion_control_execution_cancellation() {
             !captured.is_empty(),
             "Expected transactions to be scheduled"
         );
-        let (scheduled_txns, _) = captured.remove(0);
+        let (scheduled_txns, _, _) = captured.remove(0);
         scheduled_txns
     };
 


### PR DESCRIPTION
## Description

Part 1 of a 4-PR stack (below) that feeds the consensus commit timestamp through execution so it can eventually be read from Move.

Adds `tx_timestamp_ms: Option<u64>` to `ExecutionEnv` (`None` when a transaction is not scheduled from a consensus commit) and populates it on the consensus execution path from the commit timestamp that ordered the transaction (threaded from `ConsensusHandler` through the execution-scheduler message). Also adds a debug assertion that, when a transaction reads the `Clock` as an immutable input and a commit timestamp is present, the two agree — guarding the invariant the rest of the stack relies on.

Nothing reads the value yet, so this is behavior-preserving.

### Stack
Feeds the consensus commit timestamp through execution so Move can read it (merge in order):
1. #26982 — `tx_timestamp_ms` on `ExecutionEnv`, sourced from consensus
2. #26994 — record / recover it in transaction effects
3. #26984 — thread it into `TxContext`
4. #27000 — write path + gated `tx_context::timestamp_ms` native

## Test plan

Covered by existing `sui-core` consensus/scheduler tests, which exercise the scheduler message and the test helpers updated here. Nothing downstream to assert yet because the value is unused until later PRs.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
