### PR TITLE
Remove deadcode from authority logic

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -131,7 +131,6 @@ mod test {
                 // Disable system overload checks for the test - during tests with crashes,
                 // it is possible for overload protection to trigger due to validators
                 // having queued certs which are missing dependencies.
-                check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })
@@ -154,7 +153,6 @@ mod test {
                 // Disable system overload checks for the test - during tests with crashes,
                 // it is possible for overload protection to trigger due to validators
                 // having queued certs which are missing dependencies.
-                check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })
@@ -983,7 +981,6 @@ mod test {
                 // Disable system overload checks for the test - during tests with crashes,
                 // it is possible for overload protection to trigger due to validators
                 // having queued certs which are missing dependencies.
-                check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 max_txn_age_in_queue: Duration::from_secs(10000),
                 max_transaction_manager_queue_length: 10000,
@@ -1027,7 +1024,6 @@ mod test {
                 // Disable system overload checks for the test - during tests with crashes,
                 // it is possible for overload protection to trigger due to validators
                 // having queued certs which are missing dependencies.
-                check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })
@@ -2007,7 +2003,6 @@ mod test {
 
         let mut test_cluster = init_test_cluster_builder(1, 0)
             .with_authority_overload_config(AuthorityOverloadConfig {
-                check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })
@@ -2170,7 +2165,6 @@ mod test {
         // Build a 4-node validator network with observer server enabled on all validators
         let mut test_cluster = init_test_cluster_builder(4, 40_000)
             .with_authority_overload_config(AuthorityOverloadConfig {
-                check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })
@@ -2342,7 +2336,6 @@ mod test {
             sui_framework_snapshot::load_bytecode_snapshot(target_version).unwrap();
         let test_cluster = init_test_cluster_builder(2, 10_000)
             .with_authority_overload_config(AuthorityOverloadConfig {
-                check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1412,11 +1412,6 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_check_system_overload_at_signing")]
     pub check_system_overload_at_signing: bool,
 
-    // When set to true, transaction execution may be rejected when the validator
-    // is overloaded.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub check_system_overload_at_execution: bool,
-
     // Reject a transaction if transaction manager queue length is above this threshold.
     // 100_000 = 10k TPS * 5s resident time in transaction manager (pending + executing) * 2.
     #[serde(default = "default_max_transaction_manager_queue_length")]
@@ -1521,7 +1516,6 @@ impl Default for AuthorityOverloadConfig {
                 default_min_load_shedding_percentage_above_hard_limit(),
             safe_transaction_ready_rate: default_safe_transaction_ready_rate(),
             check_system_overload_at_signing: true,
-            check_system_overload_at_execution: false,
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -105,7 +105,7 @@ use tracing::{debug, error, info, instrument, warn};
 
 use self::authority_store::ExecutionLockWriteGuard;
 use self::authority_store_pruner::{AuthorityStorePruningMetrics, PrunerWatermarks};
-pub use authority_store::{AuthorityStore, ResolverWrapper, UpdateType};
+pub use authority_store::{AuthorityStore, ResolverWrapper};
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 
 use crate::jsonrpc_index::IndexStore;
@@ -1280,12 +1280,6 @@ impl AuthorityState {
             .check_system_overload_at_signing
     }
 
-    pub fn check_system_overload_at_execution(&self) -> bool {
-        self.config
-            .authority_overload_config
-            .check_system_overload_at_execution
-    }
-
     pub(crate) fn check_system_overload(
         &self,
         tx_data: &SenderSignedData,
@@ -1631,25 +1625,6 @@ impl AuthorityState {
             assigned_shared_object_versions,
             epoch_store.epoch(),
         )
-    }
-
-    /// Test only wrapper for `try_execute_immediately()` above, useful for executing change epoch
-    /// transactions. Assumes execution will always succeed.
-    pub async fn try_execute_for_test(
-        &self,
-        certificate: &VerifiedCertificate,
-        execution_env: ExecutionEnv,
-    ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
-        let epoch_store = self.epoch_store_for_testing();
-        let (effects, execution_error_opt) = self
-            .try_execute_immediately(
-                &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
-                execution_env,
-                &epoch_store,
-            )
-            .unwrap();
-        let signed_effects = self.sign_effects(effects, &epoch_store).unwrap();
-        (signed_effects, execution_error_opt)
     }
 
     pub async fn try_execute_executable_for_test(
@@ -3747,12 +3722,6 @@ impl AuthorityState {
         &self.execution_cache_trait_pointers.object_store
     }
 
-    pub fn pending_post_processing(
-        &self,
-    ) -> &Arc<DashMap<TransactionDigest, oneshot::Receiver<PostProcessingOutput>>> {
-        &self.pending_post_processing
-    }
-
     pub async fn await_post_processing(
         &self,
         tx_digest: &TransactionDigest,
@@ -4472,30 +4441,6 @@ impl AuthorityState {
     /// Chain Identifier is the digest of the genesis checkpoint.
     pub fn get_chain_identifier(&self) -> ChainIdentifier {
         self.chain_identifier
-    }
-
-    pub fn get_fork_recovery_state(&self) -> Option<&ForkRecoveryState> {
-        self.fork_recovery_state.as_ref()
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    pub fn get_move_object<T>(&self, object_id: &ObjectID) -> SuiResult<T>
-    where
-        T: DeserializeOwned,
-    {
-        let o = self.get_object_read(object_id)?.into_object()?;
-        if let Some(move_object) = o.data.try_as_move() {
-            Ok(bcs::from_bytes(move_object.contents()).map_err(|e| {
-                SuiErrorKind::ObjectDeserializationError {
-                    error: format!("{e}"),
-                }
-            })?)
-        } else {
-            Err(SuiErrorKind::ObjectDeserializationError {
-                error: format!("Provided object : [{object_id}] is not a Move object."),
-            }
-            .into())
-        }
     }
 
     /// This function aims to serve rpc reads on past objects and
@@ -5245,8 +5190,7 @@ impl AuthorityState {
                     TransactionEvents::default()
                 };
                 // The cert_sig slot is permanently None: validators no longer aggregate or
-                // persist per-transaction quorum signatures (the transaction_cert_signatures
-                // table is deprecated and unwritten).
+                // persist per-transaction quorum signatures.
                 return Ok(Some((
                     (*transaction).clone().into_message(),
                     TransactionStatus::Executed(None, effects.into_inner(), events),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -468,6 +468,12 @@ pub struct AuthorityEpochTables {
     /// to disk.
     signed_effects_digests: DBMap<TransactionDigest, TransactionEffectsDigest>,
 
+    /// No longer used.
+    #[allow(dead_code)]
+    #[deprecated(note = "column family retained only for tidehunter backward compatibility")]
+    transaction_cert_signatures:
+        DBMap<TransactionDigest, sui_types::crypto::AuthorityStrongQuorumSignInfo>,
+
     /// Next available shared object versions for each shared object.
     next_shared_object_versions_v2: DBMap<ConsensusObjectSequenceKey, SequenceNumber>,
 
@@ -668,6 +674,16 @@ impl AuthorityEpochTables {
                     mutexes,
                     uniform_key,
                     bloom_config.clone(),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "transaction_cert_signatures".to_string(),
+                ThConfig::new_with_rm_prefix_indexing(
+                    tx_digest_indexing.clone(),
+                    mutexes,
+                    uniform_key,
+                    lru_bloom_config.clone(),
                     digest_prefix.clone(),
                 ),
             ),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -23,7 +23,6 @@ use move_bytecode_utils::module_cache::SyncModuleCache;
 use mysten_common::ZipDebugEqIteratorExt;
 use mysten_common::assert_reachable;
 use mysten_common::random_util::randomize_cache_capacity_in_tests;
-use mysten_common::sync::notify_once::NotifyOnce;
 use mysten_common::sync::notify_read::NotifyRead;
 use mysten_common::{debug_fatal, in_test_configuration};
 use mysten_metrics::monitored_scope;
@@ -43,7 +42,7 @@ use sui_types::base_types::{
 use sui_types::base_types::{ConciseableName, ObjectRef};
 use sui_types::committee::Committee;
 use sui_types::committee::CommitteeTrait;
-use sui_types::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound};
+use sui_types::crypto::{AuthoritySignInfo, RandomnessRound};
 use sui_types::digests::{ChainIdentifier, TransactionEffectsDigest};
 use sui_types::dynamic_field::get_dynamic_field_from_store;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
@@ -71,9 +70,9 @@ use sui_types::sui_system_state::epoch_start_sui_system_state::{
 };
 use sui_types::sui_system_state::{self, SuiSystemState};
 use sui_types::transaction::{
-    AuthenticatorStateUpdate, CertifiedTransaction, DeprecatedWithAliases, InputObjectKind,
-    ProgrammableTransaction, SenderSignedData, StoredExecutionTimeObservations, Transaction,
-    TransactionData, TransactionDataAPI, TransactionKey, TransactionKind, TxValidityCheckContext,
+    AuthenticatorStateUpdate, DeprecatedWithAliases, InputObjectKind, ProgrammableTransaction,
+    SenderSignedData, StoredExecutionTimeObservations, Transaction, TransactionData,
+    TransactionDataAPI, TransactionKey, TransactionKind, TxValidityCheckContext,
     VerifiedSignedTransaction, VerifiedTransaction, VerifiedTransactionWithAliases, WithAliases,
 };
 use tap::TapOptional;
@@ -180,30 +179,6 @@ type LocalExecutionTimeData = (
 pub enum CancelConsensusCertificateReason {
     CongestionOnObjects(Vec<ObjectID>),
     DkgFailed,
-}
-
-pub enum ConsensusCertificateResult {
-    /// The consensus message was ignored (e.g. because it has already been processed).
-    Ignored,
-    /// An executable transaction (can be a user tx or a system tx)
-    SuiTransaction(VerifiedExecutableTransaction),
-    /// The transaction should be re-processed at a future commit, specified by the DeferralKey
-    Deferred(DeferralKey),
-    /// A message was processed which updates randomness state.
-    RandomnessConsensusMessage,
-    /// Everything else, e.g. AuthorityCapabilities, CheckpointSignatures, etc.
-    ConsensusMessage,
-    /// A system message in consensus was ignored (e.g. because of end of epoch).
-    IgnoredSystem,
-    /// A will-be-cancelled transaction. It'll still go through execution engine (but not be executed),
-    /// unlock any owned objects, and return corresponding cancellation error according to
-    /// `CancelConsensusCertificateReason`.
-    Cancelled(
-        (
-            VerifiedExecutableTransaction,
-            CancelConsensusCertificateReason,
-        ),
-    ),
 }
 
 /// ConsensusStats is versioned because we may iterate on the struct, and it is
@@ -398,9 +373,6 @@ pub struct AuthorityPerEpochStore {
     /// Cancellation token used to signal epoch termination to all in-flight tasks.
     epoch_alive_token: CancellationToken,
 
-    /// Used to notify all epoch specific tasks that user certs are closed.
-    user_certs_closed_notify: NotifyOnce,
-
     /// This lock acts as a barrier for tasks that should not be executed in parallel with reconfiguration
     /// See comments in AuthorityPerEpochStore::epoch_terminated() on how this is used
     /// Crash recovery note: we write next epoch in the database first, and then use this lock to
@@ -495,11 +467,6 @@ pub struct AuthorityEpochTables {
     /// Entries are removed from this table after the transaction in question has been committed
     /// to disk.
     signed_effects_digests: DBMap<TransactionDigest, TransactionEffectsDigest>,
-
-    /// No longer used.
-    #[allow(dead_code)]
-    #[deprecated(note = "column family retained only for backward DB compatibility")]
-    transaction_cert_signatures: DBMap<TransactionDigest, AuthorityStrongQuorumSignInfo>,
 
     /// Next available shared object versions for each shared object.
     next_shared_object_versions_v2: DBMap<ConsensusObjectSequenceKey, SequenceNumber>,
@@ -705,16 +672,6 @@ impl AuthorityEpochTables {
                 ),
             ),
             (
-                "transaction_cert_signatures".to_string(),
-                ThConfig::new_with_rm_prefix_indexing(
-                    tx_digest_indexing.clone(),
-                    mutexes,
-                    uniform_key,
-                    lru_bloom_config.clone(),
-                    digest_prefix.clone(),
-                ),
-            ),
-            (
                 "next_shared_object_versions_v2".to_string(),
                 ThConfig::new_with_config(32 + 8, mutexes, uniform_key, lru_only_config.clone()),
             ),
@@ -914,13 +871,6 @@ impl AuthorityEpochTables {
         Ok(state)
     }
 
-    /// WARNING: This method is very subtle and can corrupt the database if used incorrectly.
-    /// It should only be used in one-off cases or tests after fully understanding the risk.
-    pub fn remove_executed_tx_subtle(&self, digest: &TransactionDigest) -> SuiResult {
-        self.executed_transactions_to_checkpoint.remove(digest)?;
-        Ok(())
-    }
-
     pub fn get_last_consensus_index(&self) -> SuiResult<Option<ExecutionIndices>> {
         Ok(self
             .last_consensus_stats
@@ -958,29 +908,6 @@ impl AuthorityEpochTables {
             .into_iter()
             .map(|l| l.map(|l| l.migrate().into_inner()))
             .collect())
-    }
-
-    pub fn write_transaction_locks(
-        &self,
-        signed_transaction: Option<VerifiedSignedTransaction>,
-        locks_to_write: impl Iterator<Item = (ObjectRef, LockDetails)>,
-    ) -> SuiResult {
-        let mut batch = self.owned_object_locked_transactions.batch();
-        batch.insert_batch(
-            &self.owned_object_locked_transactions,
-            locks_to_write.map(|(obj_ref, lock)| (obj_ref, LockDetailsWrapper::from(lock))),
-        )?;
-        if let Some(signed_transaction) = signed_transaction {
-            batch.insert_batch(
-                &self.signed_transactions,
-                std::iter::once((
-                    *signed_transaction.digest(),
-                    signed_transaction.serializable_ref(),
-                )),
-            )?;
-        }
-        batch.write()?;
-        Ok(())
     }
 
     fn get_all_deferred_transactions_v2(
@@ -1241,7 +1168,6 @@ impl AuthorityPerEpochStore {
             db_options,
             reconfig_state_mem: RwLock::new(reconfig_state),
             epoch_alive_token,
-            user_certs_closed_notify: NotifyOnce::new(),
             epoch_alive: tokio::sync::RwLock::new(true),
             consensus_notify_read: NotifyRead::new(),
             executed_transactions_to_checkpoint_notify_read: NotifyRead::new(),
@@ -1556,17 +1482,6 @@ impl AuthorityPerEpochStore {
             .running_root_state_hash
             .get(&checkpoint)
             .expect("db error"))
-    }
-
-    pub fn get_highest_running_root_state_hash(
-        &self,
-    ) -> SuiResult<Option<(CheckpointSequenceNumber, GlobalStateHash)>> {
-        Ok(self
-            .tables()?
-            .running_root_state_hash
-            .reversed_safe_iter_with_bounds(None, None)?
-            .next()
-            .transpose()?)
     }
 
     pub fn insert_running_root_state_hash(
@@ -2154,18 +2069,6 @@ impl AuthorityPerEpochStore {
             .unwrap_or_default())
     }
 
-    pub fn get_accumulators_in_checkpoint_range(
-        &self,
-        from_checkpoint: CheckpointSequenceNumber,
-        to_checkpoint: CheckpointSequenceNumber,
-    ) -> SuiResult<Vec<(CheckpointSequenceNumber, GlobalStateHash)>> {
-        self.tables()?
-            .state_hash_by_checkpoint
-            .safe_range_iter(from_checkpoint..=to_checkpoint)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
-    }
-
     /// Returns future containing the state accumulator for the given epoch
     /// once available.
     pub async fn notify_read_checkpoint_state_hasher(
@@ -2287,16 +2190,6 @@ impl AuthorityPerEpochStore {
             .tables()?
             .executed_transactions_to_checkpoint
             .contains_key(digest)?)
-    }
-
-    pub fn transactions_executed_in_checkpoint(
-        &self,
-        digests: impl Iterator<Item = TransactionDigest>,
-    ) -> SuiResult<Vec<bool>> {
-        Ok(self
-            .tables()?
-            .executed_transactions_to_checkpoint
-            .multi_contains_keys(digests)?)
     }
 
     pub fn get_transaction_checkpoint(
@@ -2583,35 +2476,6 @@ impl AuthorityPerEpochStore {
             .deferred_transactions
             .lock()
             .is_empty()
-    }
-
-    /// Check whether any certificates were processed by consensus.
-    /// This handles multiple certificates at once.
-    pub fn is_any_tx_certs_consensus_message_processed<'a>(
-        &self,
-        certificates: impl Iterator<Item = &'a CertifiedTransaction>,
-    ) -> SuiResult<bool> {
-        let keys = certificates.map(|cert| {
-            SequencedConsensusTransactionKey::External(ConsensusTransactionKey::Certificate(
-                *cert.digest(),
-            ))
-        });
-        Ok(self
-            .check_consensus_messages_processed(keys)?
-            .into_iter()
-            .any(|processed| processed))
-    }
-
-    /// Returns true if all messages with the given keys were processed by consensus.
-    pub fn all_external_consensus_messages_processed(
-        &self,
-        keys: impl Iterator<Item = ConsensusTransactionKey>,
-    ) -> SuiResult<bool> {
-        let keys = keys.map(SequencedConsensusTransactionKey::External);
-        Ok(self
-            .check_consensus_messages_processed(keys)?
-            .into_iter()
-            .all(|processed| processed))
     }
 
     pub fn is_consensus_message_processed(
@@ -3051,15 +2915,7 @@ impl AuthorityPerEpochStore {
         if epoch_close_time.is_none() {
             // Only update it the first time epoch is closed.
             *epoch_close_time = Some(Instant::now());
-
-            self.user_certs_closed_notify
-                .notify()
-                .expect("user_certs_closed_notify called twice on same epoch store");
         }
-    }
-
-    pub async fn user_certs_closed_notify(&self) {
-        self.user_certs_closed_notify.wait().await
     }
 
     /// Notify epoch is terminated, can only be called once on epoch store
@@ -3528,31 +3384,6 @@ impl AuthorityPerEpochStore {
             }
         }
         Ok(None)
-    }
-
-    pub fn builder_included_transactions_in_checkpoint<'a>(
-        &self,
-        digests: impl Iterator<Item = &'a TransactionDigest>,
-    ) -> SuiResult<Vec<bool>> {
-        let digests: Vec<_> = digests.cloned().collect();
-        let tables = self.tables()?;
-        Ok(do_fallback_lookup(
-            &digests,
-            |digest| {
-                let consensus_quarantine = self.consensus_quarantine.read();
-                if consensus_quarantine.included_transaction_in_checkpoint(digest) {
-                    CacheResult::Hit(true)
-                } else {
-                    CacheResult::Miss
-                }
-            },
-            |remaining| {
-                tables
-                    .builder_digest_to_checkpoint
-                    .multi_contains_keys(remaining)
-                    .expect("db error")
-            },
-        ))
     }
 
     pub(crate) fn record_epoch_pending_certs_process_time_metric(&self) {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -14,7 +14,6 @@ use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfigura
 use crate::global_state_hasher::GlobalStateHashStore;
 use crate::rpc_index::RpcIndexStore;
 use crate::transaction_outputs::TransactionOutputs;
-use either::Either;
 use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
 use futures::stream::FuturesUnordered;
 use move_core_types::account_address::AccountAddress;
@@ -310,14 +309,6 @@ impl AuthorityStore {
         Ok(self.perpetual_tables.effects.get(effects_digest)?)
     }
 
-    /// Returns true if we have an effects structure for this transaction digest
-    pub fn effects_exists(&self, effects_digest: &TransactionEffectsDigest) -> SuiResult<bool> {
-        self.perpetual_tables
-            .effects
-            .contains_key(effects_digest)
-            .map_err(|e| e.into())
-    }
-
     pub fn get_events(
         &self,
         digest: &TransactionDigest,
@@ -431,26 +422,6 @@ impl AuthorityStore {
             Some(Err(e)) => Err(e.into()),
             None => Ok(None),
         }
-    }
-
-    /// Returns future containing the state hash for the given epoch
-    /// once available
-    pub async fn notify_read_root_state_hash(
-        &self,
-        epoch: EpochId,
-    ) -> SuiResult<(CheckpointSequenceNumber, GlobalStateHash)> {
-        // We need to register waiters _before_ reading from the database to avoid race conditions
-        let registration = self.root_state_notify_read.register_one(&epoch);
-        let hash = self.perpetual_tables.root_state_hash_by_epoch.get(&epoch)?;
-
-        let result = match hash {
-            // Note that Some() clause also drops registration that is already fulfilled
-            Some(ready) => Either::Left(futures::future::ready(ready)),
-            None => Either::Right(registration),
-        }
-        .await;
-
-        Ok(result)
     }
 
     // DEPRECATED -- use function of same name in AuthorityPerEpochStore
@@ -1073,18 +1044,6 @@ impl AuthorityStore {
             .get_latest_object_ref_or_tombstone(object_id)
     }
 
-    /// Returns the latest object reference if and only if the object is still live (i.e. it does
-    /// not return tombstones)
-    pub fn get_latest_object_ref_if_alive(
-        &self,
-        object_id: ObjectID,
-    ) -> Result<Option<ObjectRef>, SuiError> {
-        match self.get_latest_object_ref_or_tombstone(object_id)? {
-            Some(objref) if objref.2.is_alive() => Ok(Some(objref)),
-            _ => Ok(None),
-        }
-    }
-
     /// Returns the latest object we have for this object_id in the objects table.
     ///
     /// If no entry for the object_id is found, return None.
@@ -1704,11 +1663,6 @@ impl ModuleResolver for ResolverWrapper {
     }
 }
 
-pub enum UpdateType {
-    Transaction(TransactionEffectsDigest),
-    Genesis,
-}
-
 pub type SuiLockResult = SuiResult<ObjectLockStatus>;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1723,35 +1677,6 @@ pub enum LockDetailsWrapperDeprecated {
     V1(LockDetailsV1Deprecated),
 }
 
-impl LockDetailsWrapperDeprecated {
-    pub fn migrate(self) -> Self {
-        // TODO: when there are multiple versions, we must iteratively migrate from version N to
-        // N+1 until we arrive at the latest version
-        self
-    }
-
-    // Always returns the most recent version. Older versions are migrated to the latest version at
-    // read time, so there is never a need to access older versions.
-    pub fn inner(&self) -> &LockDetailsDeprecated {
-        match self {
-            Self::V1(v1) => v1,
-
-            // can remove #[allow] when there are multiple versions
-            #[allow(unreachable_patterns)]
-            _ => panic!("lock details should have been migrated to latest version at read time"),
-        }
-    }
-    pub fn into_inner(self) -> LockDetailsDeprecated {
-        match self {
-            Self::V1(v1) => v1,
-
-            // can remove #[allow] when there are multiple versions
-            #[allow(unreachable_patterns)]
-            _ => panic!("lock details should have been migrated to latest version at read time"),
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LockDetailsV1Deprecated {
     pub epoch: EpochId,
@@ -1759,10 +1684,3 @@ pub struct LockDetailsV1Deprecated {
 }
 
 pub type LockDetailsDeprecated = LockDetailsV1Deprecated;
-
-impl From<LockDetailsDeprecated> for LockDetailsWrapperDeprecated {
-    fn from(details: LockDetailsDeprecated) -> Self {
-        // always use latest version.
-        LockDetailsWrapperDeprecated::V1(details)
-    }
-}

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -736,21 +736,6 @@ impl AuthorityPerpetualTables {
         Ok(self.executed_transactions_to_checkpoint.get(digest)?)
     }
 
-    pub fn get_newer_object_keys(
-        &self,
-        object: &(ObjectID, SequenceNumber),
-    ) -> SuiResult<Vec<ObjectKey>> {
-        let mut objects = vec![];
-        for result in self.objects.safe_iter_with_bounds(
-            Some(ObjectKey(object.0, object.1.next())),
-            Some(ObjectKey(object.0, VersionNumber::MAX)),
-        ) {
-            let (key, _) = result?;
-            objects.push(key);
-        }
-        Ok(objects)
-    }
-
     pub fn set_highest_pruned_checkpoint_without_wb(
         &self,
         checkpoint_number: CheckpointSequenceNumber,
@@ -794,13 +779,6 @@ impl AuthorityPerpetualTables {
     pub fn checkpoint_db(&self, path: &Path) -> SuiResult {
         // This checkpoints the entire db and not just objects table
         self.objects.checkpoint_db(path).map_err(Into::into)
-    }
-
-    pub fn get_root_state_hash(
-        &self,
-        epoch: EpochId,
-    ) -> SuiResult<Option<(CheckpointSequenceNumber, GlobalStateHash)>> {
-        Ok(self.root_state_hash_by_epoch.get(&epoch)?)
     }
 
     pub fn insert_root_state_hash(
@@ -901,13 +879,6 @@ impl LiveObject {
         match self {
             LiveObject::Normal(obj) => obj.compute_object_reference(),
             LiveObject::Wrapped(key) => (key.0, key.1, ObjectDigest::OBJECT_DIGEST_WRAPPED),
-        }
-    }
-
-    pub fn to_normal(self) -> Option<Object> {
-        match self {
-            LiveObject::Normal(object) => Some(object),
-            LiveObject::Wrapped(_) => None,
         }
     }
 }

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -801,10 +801,6 @@ impl ConsensusOutputQuarantine {
             .map(|(summary, _)| summary)
     }
 
-    pub(super) fn included_transaction_in_checkpoint(&self, digest: &TransactionDigest) -> bool {
-        self.builder_digest_to_checkpoint.contains_key(digest)
-    }
-
     pub(super) fn is_consensus_message_processed(
         &self,
         key: &SequencedConsensusTransactionKey,


### PR DESCRIPTION
## Description

Remove dead code that accumulated in the authority subsystem — unused methods, functions, types, fields, and enum variants across `AuthorityState`, `AuthorityStore`, `AuthorityPerEpochStore`, and the perpetual/epoch table holders. Every removed item had zero references repo-wide.

The one non-obvious removal is the deprecated `transaction_cert_signatures` column family: it has no accessors, and dropping the declaration is safe because typed_store reopens any on-disk column families the schema no longer declares.

## Test plan

Covered by existing tests. Verified the full workspace builds and lints clean (`cargo clippy --workspace --all-targets`) and that the `tidehunter` configuration still compiles.

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
