### PR TITLE
Don't panic when randomness receiver channel is closed during shutdown

### DIFF
--- a/crates/sui-network/src/randomness/mod.rs
+++ b/crates/sui-network/src/randomness/mod.rs
@@ -777,9 +777,18 @@ impl RandomnessEventLoop {
         }
 
         let sig_bytes = bcs::to_bytes(&sig).expect("signature serialization should not fail");
-        self.randomness_tx
-            .try_send((epoch, round, sig_bytes))
-            .expect("RandomnessRoundReceiver mailbox should not overflow or be closed");
+        if let Err(e) = self.randomness_tx.try_send((epoch, round, sig_bytes)) {
+            match e {
+                // Receiver is torn down during node shutdown; dropping the round is harmless.
+                mpsc::error::TrySendError::Closed(_) => {
+                    info!("dropping completed randomness round {round}: receiver channel closed");
+                }
+                // Mailbox capacity is huge (default 1M); a full mailbox means a real bug.
+                mpsc::error::TrySendError::Full(_) => {
+                    panic!("RandomnessRoundReceiver mailbox should not overflow");
+                }
+            }
+        }
     }
 
     fn maybe_ignore_byzantine_peer(&mut self, epoch: EpochId, peer_id: PeerId) {


### PR DESCRIPTION
## Description

Completed randomness rounds are forwarded to the node-lifetime `RandomnessRoundReceiver`, which runs in a separate task with no shutdown ordering relative to the randomness network event loop, so it can be torn down first and close the channel. Treat a closed channel as benign shutdown and only panic on a full mailbox (which still indicates a real bug).

## Test plan

Covered by existing `randomness::tests` in `sui-network`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fixes a spurious panic that could occur during a normal node shutdown/restart. No action required.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
