### PR TITLE
[gql] VM Error Visibility: simulateTransaction and transaction(digest)

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/graphql.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/graphql.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+
+use anyhow::Context;
+use prometheus::Registry;
+use reqwest::Client;
+use serde_json::Value;
+use serde_json::json;
+use sui_futures::service::Service;
+use sui_indexer_alt::config::IndexerConfig;
+use sui_indexer_alt::setup_indexer;
+use sui_indexer_alt_framework::IndexerArgs;
+use sui_indexer_alt_framework::ingestion::ClientArgs;
+use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
+use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
+use sui_indexer_alt_graphql::args::SubscriptionArgs;
+use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
+use sui_indexer_alt_graphql::start_rpc as start_graphql;
+use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
+use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
+use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
+use sui_pg_db::DbArgs;
+use sui_pg_db::temp::TempDb;
+use sui_pg_db::temp::get_available_port;
+use test_cluster::TestCluster;
+use url::Url;
+
+/// A lightweight indexed GraphQL test harness backed by a validator cluster and Postgres.
+///
+/// Unlike `FullCluster`, this only starts the indexer and GraphQL services needed by tests that
+/// execute against a validator cluster and then query indexed GraphQL state.
+pub struct IndexedGraphQlCluster {
+    url: Url,
+    client: Client,
+    /// Hold on to the service so it doesn't get dropped (and therefore aborted) until the cluster
+    /// goes out of scope.
+    #[allow(unused)]
+    service: Service,
+    /// Hold on to the database so it doesn't get dropped until the cluster is stopped.
+    #[allow(unused)]
+    database: TempDb,
+}
+
+impl IndexedGraphQlCluster {
+    pub async fn new(validator_cluster: &TestCluster) -> Self {
+        let graphql_port = get_available_port();
+        let graphql_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), graphql_port);
+
+        let database = TempDb::new().expect("Failed to create temp database");
+        let database_url = database.database().url().clone();
+
+        let fullnode_args = FullnodeArgs::new(validator_cluster.rpc_url().parse().unwrap());
+
+        let client_args = ClientArgs {
+            ingestion: IngestionClientArgs {
+                rpc_api_url: Some(
+                    Url::parse(validator_cluster.rpc_url()).expect("Invalid RPC URL"),
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let indexer = setup_indexer(
+            database_url.clone(),
+            DbArgs::default(),
+            IndexerArgs::default(),
+            client_args,
+            IndexerConfig::for_test(),
+            None,
+            &Registry::new(),
+        )
+        .await
+        .expect("Failed to setup indexer");
+
+        let pipelines: Vec<String> = indexer.pipelines().map(|s| s.to_string()).collect();
+        let s_indexer = indexer.run().await.expect("Failed to start indexer");
+
+        let s_graphql = start_graphql(
+            Some(database_url),
+            fullnode_args,
+            DbArgs::default(),
+            KvArgs::default(),
+            ConsistentReaderArgs::default(),
+            GraphQlArgs {
+                rpc_listen_address: graphql_listen_address,
+                no_ide: true,
+            },
+            SystemPackageTaskArgs::default(),
+            SubscriptionArgs::default(),
+            "0.0.0",
+            GraphQlConfig::default(),
+            pipelines,
+            &Registry::new(),
+        )
+        .await
+        .expect("Failed to start GraphQL server");
+
+        let url = Url::parse(&format!("http://{}/graphql", graphql_listen_address))
+            .expect("Failed to parse GraphQL URL");
+
+        Self {
+            url,
+            client: Client::new(),
+            service: s_graphql.merge(s_indexer),
+            database,
+        }
+    }
+
+    pub fn url(&self) -> Url {
+        self.url.clone()
+    }
+
+    /// Execute a GraphQL mutation or query.
+    pub async fn execute_graphql(&self, query: &str, variables: Value) -> anyhow::Result<Value> {
+        let request_body = json!({
+            "query": query,
+            "variables": variables
+        });
+
+        let response = self
+            .client
+            .post(self.url.clone())
+            .json(&request_body)
+            .send()
+            .await
+            .context("GraphQL request failed")?;
+
+        let body: Value = response
+            .json()
+            .await
+            .context("Failed to parse GraphQL response")?;
+
+        Ok(body)
+    }
+}

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -85,6 +85,7 @@ use url::Url;
 
 pub mod coin_registry;
 pub mod find;
+pub mod graphql;
 pub mod move_helpers;
 
 /// A simulation of the network, accompanied by off-chain services (database, indexer, RPC),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -1,43 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::IpAddr;
-use std::net::Ipv4Addr;
-use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use anyhow::Context;
 use fastcrypto::encoding::Base64;
 use fastcrypto::encoding::Encoding;
-use prometheus::Registry;
-use reqwest::Client;
 use serde::Deserialize;
 use serde_json::Value;
 use serde_json::json;
-use sui_futures::service::Service;
-use sui_indexer_alt::config::IndexerConfig;
-use sui_indexer_alt::setup_indexer;
-use sui_indexer_alt_framework::IndexerArgs;
-use sui_indexer_alt_framework::ingestion::ClientArgs;
-use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
-use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
-use sui_indexer_alt_graphql::args::SubscriptionArgs;
+use sui_indexer_alt_e2e_tests::graphql::IndexedGraphQlCluster;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
-use sui_indexer_alt_graphql::start_rpc as start_graphql;
-use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
-use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
-use sui_indexer_alt_reader::kv_loader::KvArgs;
-use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
-use sui_pg_db::DbArgs;
-use sui_pg_db::temp::TempDb;
-use sui_pg_db::temp::get_available_port;
 use sui_test_transaction_builder::make_transfer_sui_transaction;
 use sui_types::base_types::SuiAddress;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::gas_coin::GasCoin;
-use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
-use url::Url;
 
 // Structs for parsing command results
 #[derive(Debug, Deserialize)]
@@ -141,111 +118,11 @@ struct FieldLayout {
     layout: Value,
 }
 
-struct GraphQlTestCluster {
-    url: Url,
-    /// Hold on to the service so it doesn't get dropped (and therefore aborted) until the cluster
-    /// goes out of scope.
-    #[allow(unused)]
-    service: Service,
-    /// Hold on to the database so it doesn't get dropped until the cluster is stopped.
-    #[allow(unused)]
-    database: TempDb,
-}
-
-impl GraphQlTestCluster {
-    async fn new(validator_cluster: &TestCluster) -> Self {
-        let graphql_port = get_available_port();
-        let graphql_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), graphql_port);
-
-        let database = TempDb::new().expect("Failed to create temp database");
-        let database_url = database.database().url().clone();
-
-        let fullnode_args = FullnodeArgs::new(validator_cluster.rpc_url().parse().unwrap());
-
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                rpc_api_url: Some(
-                    Url::parse(validator_cluster.rpc_url()).expect("Invalid RPC URL"),
-                ),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let indexer = setup_indexer(
-            database_url.clone(),
-            DbArgs::default(),
-            IndexerArgs::default(),
-            client_args,
-            IndexerConfig::for_test(),
-            None,
-            &Registry::new(),
-        )
-        .await
-        .expect("Failed to setup indexer");
-
-        let pipelines: Vec<String> = indexer.pipelines().map(|s| s.to_string()).collect();
-        let s_indexer = indexer.run().await.expect("Failed to start indexer");
-
-        let s_graphql = start_graphql(
-            Some(database_url),
-            fullnode_args,
-            DbArgs::default(),
-            KvArgs::default(),
-            ConsistentReaderArgs::default(),
-            GraphQlArgs {
-                rpc_listen_address: graphql_listen_address,
-                no_ide: true,
-            },
-            SystemPackageTaskArgs::default(),
-            SubscriptionArgs::default(),
-            "0.0.0",
-            GraphQlConfig::default(),
-            pipelines,
-            &Registry::new(),
-        )
-        .await
-        .expect("Failed to start GraphQL server");
-
-        let url = Url::parse(&format!("http://{}/graphql", graphql_listen_address))
-            .expect("Failed to parse GraphQL URL");
-
-        Self {
-            url,
-            service: s_graphql.merge(s_indexer),
-            database,
-        }
-    }
-
-    /// Execute a GraphQL mutation or query
-    async fn execute_graphql(&self, query: &str, variables: Value) -> anyhow::Result<Value> {
-        let request_body = json!({
-            "query": query,
-            "variables": variables
-        });
-
-        let client = Client::new();
-        let response = client
-            .post(self.url.clone())
-            .json(&request_body)
-            .send()
-            .await
-            .context("GraphQL request failed")?;
-
-        let body: Value = response
-            .json()
-            .await
-            .context("Failed to parse GraphQL response")?;
-
-        Ok(body)
-    }
-}
-
 #[tokio::test]
 async fn test_simulate_transaction_basic() {
     let validator_cluster = TestClusterBuilder::new().build().await;
 
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Create a simple transfer transaction for simulation (no signatures needed!)
     let recipient = SuiAddress::random_for_testing_only();
@@ -307,7 +184,7 @@ async fn test_simulate_transaction_basic() {
 #[tokio::test]
 async fn test_simulate_transaction_with_events() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Publish our test package which emits events in its init function
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("packages/emit_event");
@@ -400,7 +277,7 @@ async fn test_simulate_transaction_with_events() {
 #[tokio::test]
 async fn test_simulate_transaction_input_validation() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Test invalid Base64 transaction data
     let result = graphql_cluster
@@ -430,7 +307,7 @@ async fn test_simulate_transaction_input_validation() {
 #[tokio::test]
 async fn test_simulate_transaction_object_changes() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Create a transfer transaction that will modify objects
     let recipient = SuiAddress::random_for_testing_only();
@@ -556,7 +433,7 @@ async fn test_simulate_transaction_object_changes() {
 #[tokio::test]
 async fn test_simulate_transaction_command_results() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // First, publish the command_results package
     let package_path =
@@ -766,7 +643,7 @@ async fn test_simulate_transaction_command_results() {
 #[tokio::test]
 async fn test_simulate_transaction_json_transfer() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     let sender = validator_cluster.get_address_0();
     let recipient = SuiAddress::random_for_testing_only();
@@ -871,7 +748,7 @@ async fn test_simulate_transaction_json_transfer() {
 #[tokio::test]
 async fn test_package_resolver_finds_newly_published_package() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Publish the test package
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -982,7 +859,7 @@ async fn test_package_resolver_finds_newly_published_package() {
 #[tokio::test]
 async fn test_simulate_transaction_balance_changes() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Create a transfer transaction that will cause balance changes
     let recipient = SuiAddress::random_for_testing_only();
@@ -1063,13 +940,86 @@ async fn test_simulate_transaction_balance_changes() {
     );
 }
 
+#[tokio::test]
+async fn test_simulate_transaction_insufficient_funds_error_metadata() {
+    let validator_cluster = TestClusterBuilder::new().build().await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
+
+    let recipient = SuiAddress::random_for_testing_only();
+    // Split more SUI than the gas coin can hold so execution fails with InsufficientCoinBalance.
+    let signed_tx =
+        make_transfer_sui_transaction(&validator_cluster.wallet, Some(recipient), Some(u64::MAX))
+            .await;
+    let (tx_bytes, _signatures) = signed_tx.to_tx_bytes_and_signatures();
+
+    let result = graphql_cluster
+        .execute_graphql(
+            r#"
+            query($txData: JSON!) {
+                simulateTransaction(transaction: $txData) {
+                    effects {
+                        status
+                        executionError {
+                            message
+                            metadata
+                        }
+                        effectsJson
+                    }
+                }
+            }
+        "#,
+            json!({
+                "txData": {
+                    "bcs": {
+                        "value": tx_bytes.encoded()
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("GraphQL request failed");
+
+    assert!(
+        result.get("errors").is_none(),
+        "Unexpected GraphQL errors: {result:#}"
+    );
+    assert_eq!(
+        result.pointer("/data/simulateTransaction/effects/status"),
+        Some(&json!("FAILURE"))
+    );
+
+    let metadata = result
+        .pointer("/data/simulateTransaction/effects/executionError/metadata")
+        .expect("executionError.metadata should be present");
+    let metadata_message = metadata
+        .pointer("/message")
+        .and_then(Value::as_str)
+        .expect("executionError.metadata.message should be present");
+
+    assert!(
+        metadata_message.contains("balance:"),
+        "unexpected metadata message: {metadata_message}"
+    );
+    assert!(
+        metadata_message.contains("required:"),
+        "unexpected metadata message: {metadata_message}"
+    );
+
+    assert_eq!(
+        result
+            .pointer("/data/simulateTransaction/effects/effectsJson/status/error/metadata")
+            .expect("effectsJson status error metadata should be present"),
+        metadata
+    );
+}
+
 /// Test that `doGasSelection: true` allows simulating a transaction without specifying gas_payment.
 /// The server auto-selects gas coins and estimates the budget.
 /// This E2E test verifies the simulation output can be signed, executed, and the transfer succeeds.
 #[tokio::test]
 async fn test_simulate_transaction_with_gas_selection() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     let sender = validator_cluster.get_address_0();
     let recipient = SuiAddress::random_for_testing_only();
@@ -1165,7 +1115,7 @@ async fn test_simulate_transaction_with_gas_selection() {
 #[tokio::test]
 async fn test_simulate_transaction_effects_json() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Create a transfer transaction
     let recipient = SuiAddress::random_for_testing_only();
@@ -1225,7 +1175,7 @@ async fn test_simulate_transaction_effects_json() {
 #[tokio::test]
 async fn test_simulate_transaction_payload_bypasses_query_limit() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     let mut tx_builder = validator_cluster.test_transaction_builder().await;
     let payload_size = GraphQlConfig::default().limits.max_query_payload_size;
@@ -1266,7 +1216,7 @@ async fn test_simulate_transaction_payload_bypasses_query_limit() {
 #[tokio::test]
 async fn test_simulate_transaction_transaction_json() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
 
     // Create a transfer transaction
     let recipient = SuiAddress::random_for_testing_only();

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_transaction_tests.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use serde_json::Value;
+use serde_json::json;
+use sui_indexer_alt_e2e_tests::graphql::IndexedGraphQlCluster;
+use sui_test_transaction_builder::make_transfer_sui_transaction;
+use sui_types::base_types::SuiAddress;
+use sui_types::effects::TransactionEffectsAPI;
+use test_cluster::TestClusterBuilder;
+
+#[tokio::test]
+async fn test_transaction_query_insufficient_funds_error_metadata() {
+    let validator_cluster = TestClusterBuilder::new().build().await;
+    let graphql_cluster = IndexedGraphQlCluster::new(&validator_cluster).await;
+
+    let recipient = SuiAddress::random_for_testing_only();
+    // Split more SUI than the gas coin can hold so execution fails with InsufficientCoinBalance.
+    let signed_tx =
+        make_transfer_sui_transaction(&validator_cluster.wallet, Some(recipient), Some(u64::MAX))
+            .await;
+    let executed_tx = validator_cluster
+        .wallet
+        .execute_transaction_may_fail(signed_tx)
+        .await
+        .expect("Failed to execute transaction");
+
+    assert!(
+        executed_tx.effects.status().is_err(),
+        "Transaction should fail with insufficient funds"
+    );
+
+    let digest = executed_tx.effects.transaction_digest().to_string();
+    let query = r#"
+        query($digest: String!) {
+            transaction(digest: $digest) {
+                effects {
+                    status
+                    executionError {
+                        message
+                        metadata
+                    }
+                    effectsJson
+                }
+            }
+        }
+    "#;
+
+    let result = tokio::time::timeout(Duration::from_secs(60), async {
+        let mut interval = tokio::time::interval(Duration::from_millis(200));
+        loop {
+            interval.tick().await;
+            let result = graphql_cluster
+                .execute_graphql(query, json!({ "digest": &digest }))
+                .await
+                .expect("GraphQL request failed");
+
+            if result.get("errors").is_some()
+                || result.pointer("/data/transaction/effects").is_some()
+            {
+                break result;
+            }
+        }
+    })
+    .await
+    .expect("Timed out waiting for GraphQL to index transaction");
+
+    assert!(
+        result.get("errors").is_none(),
+        "Unexpected GraphQL errors: {result:#}"
+    );
+    assert_eq!(
+        result.pointer("/data/transaction/effects/status"),
+        Some(&json!("FAILURE"))
+    );
+
+    let metadata = result
+        .pointer("/data/transaction/effects/executionError/metadata")
+        .expect("executionError.metadata should be present");
+    let metadata_message = metadata
+        .pointer("/message")
+        .and_then(Value::as_str)
+        .expect("executionError.metadata.message should be present");
+
+    assert!(
+        metadata_message.contains("balance:"),
+        "unexpected metadata message: {metadata_message}"
+    );
+    assert!(
+        metadata_message.contains("required:"),
+        "unexpected metadata message: {metadata_message}"
+    );
+
+    assert_eq!(
+        result
+            .pointer("/data/transaction/effects/effectsJson/status/error/metadata")
+            .expect("effectsJson status error metadata should be present"),
+        metadata
+    );
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1500,6 +1500,10 @@ type ExecutionError {
 	"""
 	message: String!
 	"""
+	Additional error metadata, when available.
+	"""
+	metadata: JSON
+	"""
 	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
 	"""
 	module: MoveModule

--- a/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
@@ -3,11 +3,13 @@
 
 use std::fmt::Write;
 
+use anyhow::Context as _;
 use async_graphql::Object;
 use fastcrypto::encoding::Base64;
 use fastcrypto::encoding::Encoding;
 use sui_package_resolver::CleverError;
 use sui_package_resolver::ErrorConstants;
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::execution_status::ExecutionErrorKind;
 use sui_types::execution_status::MoveLocation;
 use sui_types::execution_status::{ExecutionFailure, ExecutionStatus as NativeExecutionStatus};
@@ -15,6 +17,7 @@ use sui_types::transaction::ProgrammableTransaction;
 use tokio::sync::OnceCell;
 
 use crate::api::scalars::big_int::BigInt;
+use crate::api::scalars::json::Json;
 use crate::api::types::move_function::MoveFunction;
 use crate::api::types::move_module::MoveModule;
 use crate::api::types::move_package::MovePackage;
@@ -25,6 +28,7 @@ use crate::scope::Scope;
 pub(crate) struct ExecutionError {
     native: ExecutionErrorKind,
     command: Option<usize>,
+    metadata: Option<ExecutionErrorMetadata>,
     clever: OnceCell<Option<CleverError>>,
     scope: Scope,
 }
@@ -91,6 +95,17 @@ impl ExecutionError {
         }
     }
 
+    /// Additional error metadata, when available.
+    async fn metadata(&self) -> Option<Result<Json, RpcError>> {
+        let metadata = self.metadata.as_ref()?;
+        Some(
+            serde_json::to_value(metadata)
+                .context("Failed to serialize execution error metadata")
+                .map_err(RpcError::from)
+                .and_then(Json::try_from),
+        )
+    }
+
     /// The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
     async fn module(&self) -> Option<MoveModule> {
         let location = match &self.native {
@@ -144,6 +159,7 @@ impl ExecutionError {
         scope: &Scope,
         status: &NativeExecutionStatus,
         programmable_tx: Option<&ProgrammableTransaction>,
+        metadata: Option<ExecutionErrorMetadata>,
     ) -> Result<Option<Self>, RpcError> {
         let NativeExecutionStatus::Failure(ExecutionFailure { error, command }) = status else {
             return Ok(None);
@@ -160,6 +176,7 @@ impl ExecutionError {
         Ok(Some(Self {
             native: native_error,
             command: *command,
+            metadata,
             clever: OnceCell::new(),
             scope: scope.clone(),
         }))

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -629,6 +629,9 @@ ExecutionError.identifier
 ExecutionError.constant
   => {}
 
+ExecutionError.metadata
+  => {}
+
 ExecutionError.module
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -629,6 +629,9 @@ ExecutionError.identifier
 ExecutionError.constant
   => {}
 
+ExecutionError.metadata
+  => {}
+
 ExecutionError.module
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -406,7 +406,9 @@ impl TxBoundsCursor for CTransaction {
 
 impl From<TransactionEffects> for Transaction {
     fn from(fx: TransactionEffects) -> Self {
-        let EffectsContents { scope, contents } = fx.contents;
+        let EffectsContents {
+            scope, contents, ..
+        } = fx.contents;
 
         Self {
             digest: fx.digest,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -11,6 +11,7 @@ use async_graphql::connection::Connection;
 use async_graphql::dataloader::DataLoader;
 use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
+use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_indexer_alt_reader::kv_loader::BalanceChangeContents as KvBalanceChangeContents;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
@@ -22,6 +23,7 @@ use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffects as NativeTransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::execution_status::ExecutionStatus as NativeExecutionStatus;
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
@@ -68,6 +70,7 @@ pub(crate) struct TransactionEffects {
 pub(crate) struct EffectsContents {
     pub(crate) scope: Scope,
     pub(crate) contents: Option<Arc<NativeTransactionContents>>,
+    pub(crate) error_metadata: Option<ExecutionErrorMetadata>,
 }
 
 type CObjectChange = JsonCursor<usize>;
@@ -172,8 +175,13 @@ impl EffectsContents {
                         _ => None,
                     });
 
-            ExecutionError::from_execution_status(&self.scope, status, programmable_tx.as_ref())
-                .await
+            ExecutionError::from_execution_status(
+                &self.scope,
+                status,
+                programmable_tx.as_ref(),
+                self.error_metadata.clone(),
+            )
+            .await
         }
         .await;
 
@@ -363,6 +371,18 @@ impl EffectsContents {
         Some(
             async {
                 let mut proto_effects = content.proto_effects()?;
+                if let Some(metadata) = &self.error_metadata
+                    && let Some(error) = proto_effects
+                        .status
+                        .as_mut()
+                        .and_then(|status| status.error.as_mut())
+                    && error
+                        .metadata
+                        .as_ref()
+                        .is_none_or(|metadata| ExecutionErrorMetadata::from(metadata).is_empty())
+                {
+                    error.metadata = Some(metadata.into());
+                }
                 // Clear the bcs field as effectsJson is intended to provide a full structured output
                 proto_effects.bcs = None;
                 let json_value = serde_json::to_value(&proto_effects)
@@ -505,12 +525,14 @@ impl TransactionEffects {
         let digest = contents
             .digest()
             .context("Failed to get digest from transaction contents")?;
+        let error_metadata = contents.execution_error_metadata();
 
         Ok(Self {
             digest,
             contents: EffectsContents {
                 scope,
                 contents: Some(Arc::new(contents)),
+                error_metadata,
             },
         })
     }
@@ -543,6 +565,7 @@ impl EffectsContents {
         Self {
             scope,
             contents: None,
+            error_metadata: None,
         }
     }
 
@@ -555,15 +578,30 @@ impl EffectsContents {
         digest: TransactionDigest,
     ) -> Result<Self, RpcError> {
         if self.contents.is_some() {
-            return Ok(self.clone());
+            let mut contents = self.clone();
+            if contents.error_metadata.is_none()
+                && let Some(transaction) = &contents.contents
+            {
+                contents.error_metadata = transaction.execution_error_metadata();
+                if contents.error_metadata.is_none() && transaction.effects()?.status().is_err() {
+                    contents.error_metadata =
+                        execution_error_metadata_from_fullnode(ctx, digest).await;
+                }
+            }
+            return Ok(contents);
         }
 
         // Streaming fast path: if the scope is backed by a streamed checkpoint containing this
         // transaction, hydrate from the in-memory payload instead of hitting the DB.
         if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
+            let mut error_metadata = tx.contents.execution_error_metadata();
+            if error_metadata.is_none() && tx.contents.effects()?.status().is_err() {
+                error_metadata = execution_error_metadata_from_fullnode(ctx, digest).await;
+            }
             return Ok(Self {
                 scope: self.scope.clone(),
                 contents: Some(Arc::new(tx.contents.clone())),
+                error_metadata,
             });
         }
 
@@ -588,10 +626,34 @@ impl EffectsContents {
             return Ok(self.clone());
         }
 
+        let mut error_metadata = transaction.execution_error_metadata();
+        if error_metadata.is_none() && transaction.effects()?.status().is_err() {
+            error_metadata = execution_error_metadata_from_fullnode(ctx, digest).await;
+        }
+
         Ok(Self {
             scope: self.scope.clone(),
             contents: Some(Arc::new(transaction)),
+            error_metadata,
         })
+    }
+}
+
+async fn execution_error_metadata_from_fullnode(
+    ctx: &Context<'_>,
+    digest: TransactionDigest,
+) -> Option<ExecutionErrorMetadata> {
+    let fullnode_client = ctx.data_opt::<FullnodeClient>()?;
+
+    match fullnode_client.execution_error_metadata(digest).await {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            tracing::debug!(
+                ?digest,
+                "Failed to fetch execution error metadata from fullnode: {error}"
+            );
+            None
+        }
     }
 }
 
@@ -601,7 +663,11 @@ impl From<Transaction> for TransactionEffects {
 
         Self {
             digest: tx.digest,
-            contents: EffectsContents { scope, contents },
+            contents: EffectsContents {
+                scope,
+                contents,
+                error_metadata: None,
+            },
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1504,6 +1504,10 @@ type ExecutionError {
 	"""
 	message: String!
 	"""
+	Additional error metadata, when available.
+	"""
+	metadata: JSON
+	"""
 	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
 	"""
 	module: MoveModule

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1504,6 +1504,10 @@ type ExecutionError {
 	"""
 	message: String!
 	"""
+	Additional error metadata, when available.
+	"""
+	metadata: JSON
+	"""
 	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
 	"""
 	module: MoveModule

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -84,6 +84,7 @@ use sui_types::crypto::ToFromBytes;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::TransactionEvents;
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointSummary;
 use sui_types::object::Object as NativeObject;
@@ -482,6 +483,14 @@ fn process_transaction(
         .collect::<anyhow::Result<_>>()?;
 
     let digest = *effects.transaction_digest();
+    let execution_error_metadata = proto
+        .effects
+        .as_ref()
+        .and_then(|effects| effects.status.as_ref())
+        .and_then(|status| status.error.as_ref())
+        .and_then(|error| error.metadata.as_ref())
+        .map(ExecutionErrorMetadata::from)
+        .filter(|metadata| !metadata.is_empty());
 
     let contents = NativeTransactionContents::ExecutedTransaction(
         sui_indexer_alt_reader::kv_loader::ExecutedTransactionData {
@@ -491,6 +500,7 @@ fn process_transaction(
             signatures,
             balance_changes: proto.balance_changes.clone(),
             proto_effects: proto.effects.clone(),
+            execution_error_metadata,
             proto_transaction: proto.transaction.clone(),
             timestamp_ms: Some(timestamp_ms),
             cp_sequence_number: Some(cp_sequence_number),

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1500,6 +1500,10 @@ type ExecutionError {
 	"""
 	message: String!
 	"""
+	Additional error metadata, when available.
+	"""
+	metadata: JSON
+	"""
 	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
 	"""
 	module: MoveModule

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -8,8 +8,11 @@ use prometheus::Registry;
 use prost_types::FieldMask;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2 as proto;
+use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2::transaction_execution_service_client::TransactionExecutionServiceClient;
 use sui_sdk_types::Address;
+use sui_types::digests::TransactionDigest;
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::Transaction;
 use sui_types::transaction::TransactionData;
@@ -34,6 +37,7 @@ pub struct FullnodeArgs {
 #[derive(Clone)]
 pub struct FullnodeClient {
     execution_client: TransactionExecutionServiceClient<GrpcMetricsService<Channel>>,
+    ledger_client: LedgerServiceClient<GrpcMetricsService<Channel>>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -74,11 +78,16 @@ impl FullnodeClient {
 
         let channel = endpoint.connect_lazy();
 
-        let layered = GrpcMetricsLayer::new(prefix.unwrap_or("fullnode"), registry).layer(channel);
+        let layer = GrpcMetricsLayer::new(prefix.unwrap_or("fullnode"), registry);
 
-        let execution_client = TransactionExecutionServiceClient::new(layered);
+        let execution_client =
+            TransactionExecutionServiceClient::new(layer.clone().layer(channel.clone()));
+        let ledger_client = LedgerServiceClient::new(layer.layer(channel));
 
-        Ok(Some(Self { execution_client }))
+        Ok(Some(Self {
+            execution_client,
+            ledger_client,
+        }))
     }
 
     pub fn as_data_loader(&self) -> DataLoader<Self> {
@@ -123,6 +132,35 @@ impl FullnodeClient {
             .await
             .map(|r| r.into_inner())
             .map_err(Into::into)
+    }
+
+    /// Fetch execution error metadata from the full node ledger service.
+    #[instrument(skip(self), level = "debug")]
+    pub async fn execution_error_metadata(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<ExecutionErrorMetadata>, Error> {
+        let request = proto::GetTransactionRequest::default()
+            .with_digest(digest.to_string())
+            .with_read_mask(FieldMask::from_paths(["effects.status.error.metadata"]));
+
+        let response = self
+            .ledger_client
+            .clone()
+            .get_transaction(request)
+            .await?
+            .into_inner();
+
+        let metadata = response
+            .transaction
+            .and_then(|transaction| transaction.effects)
+            .and_then(|effects| effects.status)
+            .and_then(|status| status.error)
+            .and_then(|error| error.metadata)
+            .map(|metadata| ExecutionErrorMetadata::from(&metadata))
+            .filter(|metadata| !metadata.is_empty());
+
+        Ok(metadata)
     }
 
     /// Simulate a transaction on the Sui network via gRPC.

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -21,6 +21,7 @@ use sui_types::digests::TransactionEffectsDigest;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::TransactionEvents;
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::event::Event;
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::CheckpointContents;
@@ -120,6 +121,7 @@ pub struct ExecutedTransactionData {
     /// The proto TransactionEffects from gRPC, if available.
     /// Contains fully-rendered effects with object types and clever errors.
     pub proto_effects: Option<grpc::TransactionEffects>,
+    pub execution_error_metadata: Option<ExecutionErrorMetadata>,
     /// The proto Transaction from gRPC, if available.
     /// Contains the fully-rendered transaction.
     pub proto_transaction: Option<grpc::Transaction>,
@@ -441,6 +443,9 @@ impl TransactionContents {
 
         // Store the proto effects and transaction for JSON serialization
         let proto_effects = executed_transaction.effects.clone();
+        let execution_error_metadata = proto_effects
+            .as_ref()
+            .and_then(execution_error_metadata_from_proto_effects);
         let proto_transaction = executed_transaction.transaction.clone();
 
         Ok(Self::ExecutedTransaction(ExecutedTransactionData {
@@ -450,6 +455,7 @@ impl TransactionContents {
             signatures,
             balance_changes,
             proto_effects,
+            execution_error_metadata,
             proto_transaction,
             timestamp_ms: None,
             cp_sequence_number: None,
@@ -567,6 +573,15 @@ impl TransactionContents {
         }
     }
 
+    /// Returns execution error metadata when this source carried it.
+    pub fn execution_error_metadata(&self) -> Option<ExecutionErrorMetadata> {
+        match self {
+            Self::ExecutedTransaction(tx) => tx.execution_error_metadata.clone(),
+            Self::LedgerGrpc(txn) => txn.execution_error_metadata.clone(),
+            Self::Pg(_) | Self::Bigtable(_) => None,
+        }
+    }
+
     /// Returns the proto TransactionEffects.
     ///
     /// For ExecutedTransaction, returns the cached proto from gRPC (with object types, clever errors).
@@ -656,6 +671,13 @@ impl TransactionContents {
             Self::ExecutedTransaction(tx) => tx.cp_sequence_number,
         }
     }
+}
+
+fn execution_error_metadata_from_proto_effects(
+    effects: &grpc::TransactionEffects,
+) -> Option<ExecutionErrorMetadata> {
+    let metadata = ExecutionErrorMetadata::from(effects.status().error_opt()?.metadata());
+    (!metadata.is_empty()).then_some(metadata)
 }
 
 impl TransactionEventsContents {

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -9,6 +9,7 @@ use prometheus::Registry;
 use sui_rpc::proto::sui::rpc::v2 as grpc;
 use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
 use sui_types::effects::TransactionEffects;
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::event::Event;
 use sui_types::messages_checkpoint::CheckpointSummary;
 use sui_types::signature::GenericSignature;
@@ -43,6 +44,7 @@ pub struct CheckpointedTransaction {
     pub timestamp_ms: Option<u64>,
     pub cp_sequence_number: Option<u64>,
     pub balance_changes: Vec<grpc::BalanceChange>,
+    pub execution_error_metadata: Option<ExecutionErrorMetadata>,
 }
 
 /// A reader backed by gRPC LedgerService (sui-kv-rpc).

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -107,6 +107,7 @@ impl Loader<TransactionKey> for LedgerGrpcReader {
         request.read_mask = Some(FieldMask::from_paths([
             "transaction.bcs",
             "effects.bcs",
+            "effects.status.error.metadata",
             "events.bcs",
             "signatures.bcs",
             "checkpoint",
@@ -139,6 +140,7 @@ impl Loader<TransactionKey> for LedgerGrpcReader {
                     timestamp_ms,
                     cp_sequence_number: executed.checkpoint,
                     balance_changes: executed.balance_changes,
+                    execution_error_metadata: full_tx.execution_error_metadata,
                 };
                 results.insert(
                     TransactionKey(transaction.transaction_data.digest()),


### PR DESCRIPTION
## Description 

Optional field "metadata" on ExecutionError type in graphql schema provides improved error information for simulate and get transaction.

## Test plan 

sui-indexer-alt-e2e-tests
- test_transaction_query_insufficient_funds_error_metadata
- test_simulate_transaction_insufficient_funds_error_metadata

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: simulateTransaction and transaction(digest) now include error metadata
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
