### PR TITLE
[tx-timestamp 2/4] Add commit timestamp to effects

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -916,6 +916,10 @@ impl CheckpointExecutor {
                             env = env.with_insufficient_funds();
                         }
 
+                        if let Some(timestamp) = effects.consensus_commit_timestamp() {
+                            env = env.with_tx_timestamp_ms(timestamp);
+                        }
+
                         Some((tx_digest, (txn.clone(), env)))
                     }
                 },

--- a/crates/sui-indexer-alt-graphql/src/api/types/unchanged_consensus_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/unchanged_consensus_object.rs
@@ -177,6 +177,9 @@ impl UnchangedConsensusObject {
                 object_id,
                 epoch,
             }),
+            // The consensus commit timestamp is not an object; exposing it through GraphQL is
+            // deferred until the timestamp surface is designed.
+            NativeUnchangedConsensusKind::ConsensusCommitTimestamp(_) => todo!(),
         }
     }
 }

--- a/crates/sui-replay-2/src/replay_txn.rs
+++ b/crates/sui-replay-2/src/replay_txn.rs
@@ -533,7 +533,7 @@ fn load_objects(
     object_store: &dyn ObjectStore,
 ) -> Result<
     (
-        BTreeMap<ObjectID, BTreeMap<ObjectVersion, Object>>, // objets loaded
+        BTreeMap<ObjectID, BTreeMap<ObjectVersion, Object>>, // objects loaded
         BTreeSet<ObjectID>,                                  // packages referenced
     ),
     Error,
@@ -696,7 +696,8 @@ fn get_effects_ids(effects: &TransactionEffects) -> Result<BTreeSet<ObjectKey>, 
             UnchangedConsensusKind::MutateConsensusStreamEnded(_)
             | UnchangedConsensusKind::ReadConsensusStreamEnded(_)
             | UnchangedConsensusKind::Cancelled(_)
-            | UnchangedConsensusKind::PerEpochConfig => {
+            | UnchangedConsensusKind::PerEpochConfig
+            | UnchangedConsensusKind::ConsensusCommitTimestamp(_) => {
                 trace!("Ignored `UnchangedConsensusKind`: {:?}", kind);
             }
         });

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -347,6 +347,10 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         vec![]
     }
 
+    fn consensus_commit_timestamp(&self) -> Option<u64> {
+        None
+    }
+
     fn status_mut_for_testing(&mut self) -> &mut ExecutionStatus {
         &mut self.status
     }

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -149,6 +149,8 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
                         // since it does not require sequencing, and hence shall not be considered
                         // as a normal input consensus object.
                         UnchangedConsensusKind::PerEpochConfig => None,
+                        // The consensus commit timestamp is not tied to an input object.
+                        UnchangedConsensusKind::ConsensusCommitTimestamp(_) => None,
                     }),
             )
             .collect()
@@ -491,6 +493,16 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
             .collect()
     }
 
+    fn consensus_commit_timestamp(&self) -> Option<u64> {
+        self.unchanged_consensus_objects
+            .iter()
+            .filter_map(|(_, kind)| match kind {
+                UnchangedConsensusKind::ConsensusCommitTimestamp(timestamp) => Some(*timestamp),
+                _ => None,
+            })
+            .next()
+    }
+
     fn status_mut_for_testing(&mut self) -> &mut ExecutionStatus {
         &mut self.status
     }
@@ -796,4 +808,7 @@ pub enum UnchangedConsensusKind {
     Cancelled(SequenceNumber),
     /// Read of a per-epoch config object that should remain the same during an epoch.
     PerEpochConfig,
+    /// Timestamp of the consensus commit that included the transaction. This entry is added
+    /// when the transaction reads the timestamp directly from the TxContext.
+    ConsensusCommitTimestamp(u64),
 }

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -382,6 +382,11 @@ pub trait TransactionEffectsAPI {
     /// Returns all accumulator updates in the transaction.
     fn accumulator_updates(&self) -> Vec<(ObjectID, AccumulatorWriteV1)>;
 
+    /// Returns the timestamp of the consensus commit that included the transaction.
+    /// This is available only if during transaction execution, the transaction reads the timestamp
+    /// directly from the TxContext without involving the Clock object.
+    fn consensus_commit_timestamp(&self) -> Option<u64>;
+
     // All of these should be #[cfg(test)], but they are used by tests in other crates, and
     // dependencies don't get built with cfg(test) set as far as I can tell.
     fn status_mut_for_testing(&mut self) -> &mut ExecutionStatus;

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -3395,6 +3395,8 @@ impl From<crate::effects::UnchangedConsensusKind> for UnchangedConsensusObject {
                 UnchangedConsensusObjectKind::Canceled
             }
             K::PerEpochConfig => UnchangedConsensusObjectKind::PerEpochConfig,
+            // Requires a new variant in the external rust sdk proto definitions.
+            K::ConsensusCommitTimestamp(_) => todo!(),
             // PerEpochConfigWithSequenceNumber { version } => {
             //     message.version = Some(version);
             //     UnchangedSharedObjectKind::PerEpochConfig

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -609,6 +609,8 @@ impl From<crate::effects::UnchangedConsensusKind> for UnchangedConsensusKind {
                 version: version.into(),
             },
             crate::effects::UnchangedConsensusKind::PerEpochConfig => Self::PerEpochConfig,
+            // Requires a new variant in the external rust sdk types.
+            crate::effects::UnchangedConsensusKind::ConsensusCommitTimestamp(_) => todo!(),
         }
     }
 }

--- a/crates/sui-types/tests/snapshots/format__sui.yaml.snap
+++ b/crates/sui-types/tests/snapshots/format__sui.yaml.snap
@@ -1440,6 +1440,9 @@ UnchangedConsensusKind:
           TYPENAME: SequenceNumber
     4:
       PerEpochConfig: UNIT
+    5:
+      ConsensusCommitTimestamp:
+        NEWTYPE: U64
 UpgradeInfo:
   STRUCT:
     - upgraded_id:


### PR DESCRIPTION
## Description

Part 2 of the `tx_timestamp_ms` stack (below); stacked on #26982.

PR1 sources the commit timestamp into `ExecutionEnv` on the live consensus path, but checkpoint execution and replay rebuild `ExecutionEnv` from a transaction's effects, where it isn't recorded. This persists it in effects (v2) so it survives into re-execution.

A trailing `UnchangedConsensusKind::ConsensusCommitTimestamp(u64)` variant carries the value, exposed via a new `consensus_commit_timestamp()` accessor on the effects API; the checkpoint executor reads it back into `ExecutionEnv`. No transaction produces the variant yet, so this is behavior-preserving. RPC/SDK/GraphQL rendering of the new variant is left as `todo!()` pending the corresponding variants in the external rust-sdk repo and a dedicated timestamp surface.

### Stack
Feeds the consensus commit timestamp through execution so Move can read it (merge in order):
1. #26982 — `tx_timestamp_ms` on `ExecutionEnv`, sourced from consensus
2. #26994 — record / recover it in transaction effects
3. #26984 — thread it into `TxContext`
4. #27000 — write path + gated `tx_context::timestamp_ms` native

## Test plan

Behavior-preserving plumbing with no producer yet, so it's exercised by existing effects and checkpoint-execution tests. The new effects variant is captured in the BCS format snapshot (`format__sui.yaml.snap`); it's appended in last position and therefore wire-compatible.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
