### PR TITLE
Enable Ristretto255 group ops and bulletproofs verification on testnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -356,6 +356,7 @@ const MAINNET_USDB: &str =
 //              shipped to mainnet out-of-band in #26816).
 // Version 127: Enable always_advance_dkg_to_resolution.
 //              Update gas prices for range proofs and ristretto group operations.
+//              Enable Ristretto255 group operations and bulletproofs verification on testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -5018,6 +5019,14 @@ impl ProtocolConfig {
                     cfg.group_ops_ristretto_point_mul_cost = Some(1763);
                     cfg.group_ops_ristretto_scalar_div_cost = Some(557);
                     cfg.group_ops_ristretto_point_div_cost = Some(2244);
+
+                    // Enable Ristretto255 group operations and bulletproofs range proof
+                    // verification on testnet (already enabled on devnet). Keep both
+                    // disabled on mainnet.
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags.enable_ristretto255_group_ops = true;
+                        cfg.feature_flags.enable_verify_bulletproofs_ristretto255 = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
@@ -48,6 +48,8 @@ feature_flags:
   enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_ristretto255_group_ops: true
+  enable_verify_bulletproofs_ristretto255: true
   enable_nitro_attestation: true
   enable_nitro_attestation_upgraded_parsing: true
   enable_nitro_attestation_all_nonzero_pcrs_parsing: true


### PR DESCRIPTION
## Description

Ristretto255 group operations and bulletproofs range proof verification are currently enabled only on devnet. Enable both on testnet as well, keeping them disabled on mainnet. The feature flags are set under protocol version 127, which is not yet in any release branch (latest release is at version 126), so no new version bump is needed.

## Test plan

Covered by the protocol-config snapshot tests; the testnet v127 snapshot now shows both flags enabled while the mainnet snapshot leaves them off.

## Release notes

Check each box that your change affects. If you leave all boxes unchecked, your PR will not be included in release notes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
