### PR TITLE
Enable Ristretto255 group ops and bulletproofs verification on testnet

### DIFF
--- a/crates/sui-framework/docs/sui/rangeproofs.md
+++ b/crates/sui-framework/docs/sui/rangeproofs.md
@@ -111,7 +111,7 @@ The number of commitments times <code>bits</code> can be at most 512.
 The <code>dst</code> is a domain separation tag that is bound into the proof transcript. Provers and
 verifiers must agree on the same <code>dst</code> for verification to succeed. It can be at most 64 bytes.
 
-Enabled only on devnet.
+Enabled only on devnet and testnet.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/rangeproofs.md#sui_rangeproofs_verify_bulletproofs_with_dst_ristretto255">verify_bulletproofs_with_dst_ristretto255</a>(proof: &vector&lt;u8&gt;, bits: u8, commitments: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">sui::ristretto255::G</a>&gt;&gt;, dst: &vector&lt;u8&gt;, version: u8): bool

--- a/crates/sui-framework/docs/sui/ristretto255.md
+++ b/crates/sui-framework/docs/sui/ristretto255.md
@@ -3,7 +3,7 @@ title: Module `sui::ristretto255`
 ---
 
 Group operations of BLS12-381.
-Only available in devnet.
+Only available in devnet and testnet.
 
 
 -  [Struct `Scalar`](#sui_ristretto255_Scalar)

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/rangeproofs.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/rangeproofs.move
@@ -33,7 +33,7 @@ const MAX_DST_LENGTH: u64 = 64;
 /// The `dst` is a domain separation tag that is bound into the proof transcript. Provers and
 /// verifiers must agree on the same `dst` for verification to succeed. It can be at most 64 bytes.
 ///
-/// Enabled only on devnet.
+/// Enabled only on devnet and testnet.
 public fun verify_bulletproofs_with_dst_ristretto255(
     proof: &vector<u8>,
     bits: u8,

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/ristretto255.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/ristretto255.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Group operations of BLS12-381.
-/// Only available in devnet.
+/// Only available in devnet and testnet.
 module sui::ristretto255;
 
 use sui::bcs;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -356,6 +356,7 @@ const MAINNET_USDB: &str =
 //              shipped to mainnet out-of-band in #26816).
 // Version 127: Enable always_advance_dkg_to_resolution.
 //              Update gas prices for range proofs and ristretto group operations.
+//              Enable Ristretto255 group operations and bulletproofs verification on testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -5018,6 +5019,11 @@ impl ProtocolConfig {
                     cfg.group_ops_ristretto_point_mul_cost = Some(1763);
                     cfg.group_ops_ristretto_scalar_div_cost = Some(557);
                     cfg.group_ops_ristretto_point_div_cost = Some(2244);
+
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags.enable_ristretto255_group_ops = true;
+                        cfg.feature_flags.enable_verify_bulletproofs_ristretto255 = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_127.snap
@@ -48,6 +48,8 @@ feature_flags:
   enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_ristretto255_group_ops: true
+  enable_verify_bulletproofs_ristretto255: true
   enable_nitro_attestation: true
   enable_nitro_attestation_upgraded_parsing: true
   enable_nitro_attestation_all_nonzero_pcrs_parsing: true


### PR DESCRIPTION
## Description

Ristretto255 group operations and bulletproofs range proof verification are currently enabled only on devnet. Enable both on testnet as well, keeping them disabled on mainnet.

## Test plan

N/A

## Release notes

Check each box that your change affects. If you leave all boxes unchecked, your PR will not be included in release notes.

- [x] Protocol: Enable Ristretto255 group operations and bulletproofs range proof verification on testnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
