### PR TITLE
[cli] Update the sui client balance to use gRPC list_balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14021,6 +14021,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tikv-jemalloc-ctl",
  "tokio",
+ "tokio-stream",
  "toml 0.7.4",
  "toml_edit 0.19.10",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -525,7 +525,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
   "tls12",
   "ring",
 ] }
-tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
+tokio-stream = { version = "0.1.14", features = ["sync", "net", "time"] }
 tokio-tungstenite = { version = "0.26.2", features = ["connect"] }
 tokio-util = "0.7.18"
 toml = { version = "0.7.4", features = ["preserve_order"] }

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -43,6 +43,7 @@ tabled.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-stream.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -16,6 +16,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 use sui_rpc::proto::sui::rpc::v2::{self as proto};
 
@@ -118,6 +119,8 @@ use tracing::{debug, info};
 
 /// Concurrency level for fetching coin metadata for balances.
 const NUM_CONCURRENCY_REQS: usize = 8;
+/// Rate limit for RPC calls to avoid being throttled by the server. This is equivalent to 20rps.
+const RATE_LIMIT_MILLIS: u64 = 50;
 
 pub(crate) static USER_AGENT: &str =
     concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -3004,18 +3007,21 @@ async fn balance_outputs_for_address(
         client.list_balances(address).try_collect().await?
     };
 
-    futures::stream::iter(balances)
-        .map(|balance| async move {
-            let metadata = coin_metadata_for_balance(client, &balance).await?;
-            Ok(BalanceOutput {
-                metadata,
-                balance,
-                coins: Vec::new(),
-            })
+    tokio_stream::StreamExt::throttle(
+        futures::stream::iter(balances),
+        Duration::from_millis(RATE_LIMIT_MILLIS),
+    )
+    .map(|balance| async move {
+        let metadata = coin_metadata_for_balance(client, &balance).await?;
+        Ok(BalanceOutput {
+            metadata,
+            balance,
+            coins: Vec::new(),
         })
-        .buffered(NUM_CONCURRENCY_REQS)
-        .try_collect()
-        .await
+    })
+    .buffered(NUM_CONCURRENCY_REQS)
+    .try_collect()
+    .await
 }
 
 /// Best-effort metadata lookup for a balance returned by the balance API.

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use futures::TryStreamExt;
 use std::{
-    collections::{BTreeMap, BTreeSet, btree_map::Entry},
+    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Display, Formatter, Write},
     fs,
     path::{Path, PathBuf},
@@ -866,68 +866,17 @@ impl SuiClientCommands {
                 let _ = context.cache_chain_id().await?;
 
                 let client = context.grpc_client()?;
-                let coin_type = if let Some(ty) = coin_type {
-                    let ty = ty.parse::<TypeTag>()?;
-                    sui_types::coin::Coin::type_(ty)
-                } else {
-                    StructTag {
-                        address: SUI_FRAMEWORK_ADDRESS,
-                        name: COIN_STRUCT_NAME.to_owned(),
-                        module: COIN_MODULE_NAME.to_owned(),
-                        type_params: vec![],
-                    }
-                };
+                let coin_type = coin_type.map(parse_coin_type_arg).transpose()?;
+                let mut balances =
+                    balance_outputs_for_address(&client, address, coin_type.as_ref()).await?;
 
-                let objects: Vec<Coin> = client
-                    .list_owned_objects(address, Some(coin_type))
-                    .try_filter_map(|o| async move {
-                        let Ok(Some((coin_type, balance))) =
-                            sui_types::coin::Coin::extract_balance_if_coin(&o)
-                        else {
-                            return Ok(None);
-                        };
-                        Ok(Some(Coin {
-                            coin_type: coin_type.to_canonical_string(true),
-                            coin_object_id: o.id(),
-                            version: o.version(),
-                            digest: o.digest(),
-                            balance,
-                            previous_transaction: o.previous_transaction,
-                        }))
-                    })
-                    .try_collect()
-                    .await?;
-
-                fn canonicalize_type(type_: &str) -> Result<String, anyhow::Error> {
-                    Ok(TypeTag::from_str(type_)
-                        .context("Cannot parse coin type")?
-                        .to_canonical_string(/* with_prefix */ true))
+                if with_coins {
+                    attach_owned_coin_objects(&client, address, coin_type.as_ref(), &mut balances)
+                        .await?;
                 }
 
-                let mut coins_by_type = BTreeMap::new();
-                for c in objects {
-                    let coins = match coins_by_type.entry(canonicalize_type(&c.coin_type)?) {
-                        Entry::Vacant(entry) => {
-                            let ty = StructTag::from_str(&c.coin_type)?;
-                            let metadata = client.get_coin_info(&ty).await.ok();
-
-                            &mut entry.insert((metadata, vec![])).1
-                        }
-                        Entry::Occupied(entry) => &mut entry.into_mut().1,
-                    };
-
-                    coins.push(c);
-                }
-                let sui_type_tag = canonicalize_type(SUI_COIN_TYPE)?;
-
-                // show SUI first
-                let ordered_coins_sui_first = coins_by_type
-                    .remove(&sui_type_tag)
-                    .into_iter()
-                    .chain(coins_by_type.into_values())
-                    .collect();
-
-                SuiClientCommandResult::Balance(ordered_coins_sui_first, with_coins)
+                order_balance_outputs_sui_first(&mut balances)?;
+                SuiClientCommandResult::Balance(balances, with_coins)
             }
 
             SuiClientCommands::DynamicFieldQuery { id, cursor, limit } => {
@@ -2212,14 +2161,14 @@ impl Display for SuiClientCommandResult {
                 table.with(style);
                 write!(f, "{}", table)?
             }
-            SuiClientCommandResult::Balance(coins, with_coins) => {
-                if coins.is_empty() {
-                    return write!(f, "No coins found for this address.");
+            SuiClientCommandResult::Balance(balances, with_coins) => {
+                if balances.is_empty() {
+                    return write!(f, "No balances found for this address.");
                 }
                 let mut builder = TableBuilder::default();
-                pretty_print_balance(coins, &mut builder, *with_coins);
+                pretty_print_balance(balances, &mut builder, *with_coins);
                 let mut table = builder.build();
-                table.with(TablePanel::header("Balance of coins owned by this address"));
+                table.with(TablePanel::header("Balances owned by this address"));
                 table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
                     1,
                     TableStyle::modern().get_horizontal(),
@@ -2820,6 +2769,15 @@ pub struct AddressesOutput {
     pub addresses: Vec<(String, SuiAddress)>,
 }
 
+/// Balance data prepared for both human-readable and JSON CLI output.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceOutput {
+    pub metadata: Option<proto::GetCoinInfoResponse>,
+    pub balance: proto::Balance,
+    pub coins: Vec<Coin>,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NewAddressOutput {
@@ -2923,7 +2881,7 @@ pub enum SuiClientCommandResult {
     ActiveAddress(Option<SuiAddress>),
     ActiveEnv(Option<String>),
     Addresses(AddressesOutput),
-    Balance(Vec<(Option<proto::GetCoinInfoResponse>, Vec<Coin>)>, bool),
+    Balance(Vec<BalanceOutput>, bool),
     ChainIdentifier(String),
     ComputeTransactionDigest(TransactionData),
     DynamicFieldQuery(proto::ListDynamicFieldsResponse),
@@ -3029,18 +2987,166 @@ pub async fn request_tokens_from_faucet(
     Ok(())
 }
 
-fn pretty_print_balance(
-    coins_by_type: &Vec<(Option<proto::GetCoinInfoResponse>, Vec<Coin>)>,
-    builder: &mut TableBuilder,
-    with_coins: bool,
-) {
-    let format_decmials = 2;
+/// Parse the CLI coin type argument as the inner type `T`, not as `Coin<T>`.
+fn parse_coin_type_arg(coin_type: String) -> Result<StructTag, anyhow::Error> {
+    match coin_type.parse::<TypeTag>()? {
+        TypeTag::Struct(coin_type) => Ok(*coin_type),
+        coin_type => bail!("coin type must be a struct type, got {coin_type}"),
+    }
+}
+
+/// Fetch aggregate balances from gRPC and attach coin metadata for display.
+async fn balance_outputs_for_address(
+    client: &Client,
+    address: SuiAddress,
+    coin_type: Option<&StructTag>,
+) -> Result<Vec<BalanceOutput>, anyhow::Error> {
+    let balances = if let Some(coin_type) = coin_type {
+        vec![client.get_balance(address, coin_type).await?]
+    } else {
+        client.list_balances(address).try_collect().await?
+    };
+
+    let mut outputs = Vec::with_capacity(balances.len());
+    for balance in balances {
+        let metadata = coin_metadata_for_balance(client, &balance).await?;
+        outputs.push(BalanceOutput {
+            metadata,
+            balance,
+            coins: Vec::new(),
+        });
+    }
+
+    Ok(outputs)
+}
+
+/// Best-effort metadata lookup for a balance returned by the balance API.
+async fn coin_metadata_for_balance(
+    client: &Client,
+    balance: &proto::Balance,
+) -> Result<Option<proto::GetCoinInfoResponse>, anyhow::Error> {
+    let ty = StructTag::from_str(balance.coin_type()).with_context(|| {
+        format!(
+            "Cannot parse coin type returned by balance API: {}",
+            balance.coin_type()
+        )
+    })?;
+    Ok(client.get_coin_info(&ty).await.ok())
+}
+
+/// Add owned coin object details without changing aggregate balance totals.
+async fn attach_owned_coin_objects(
+    client: &Client,
+    address: SuiAddress,
+    coin_type: Option<&StructTag>,
+    balances: &mut Vec<BalanceOutput>,
+) -> Result<(), anyhow::Error> {
+    let coin_object_type = coin_object_type_filter(coin_type);
+    let coins: Vec<Coin> = client
+        .list_owned_objects(address, Some(coin_object_type))
+        .try_filter_map(|o| async move {
+            let Ok(Some((coin_type, balance))) = sui_types::coin::Coin::extract_balance_if_coin(&o)
+            else {
+                return Ok(None);
+            };
+            Ok(Some(Coin {
+                coin_type: coin_type.to_canonical_string(true),
+                coin_object_id: o.id(),
+                version: o.version(),
+                digest: o.digest(),
+                balance,
+                previous_transaction: o.previous_transaction,
+            }))
+        })
+        .try_collect()
+        .await?;
+
+    let mut coins_by_type: BTreeMap<String, Vec<Coin>> = BTreeMap::new();
+    for coin in coins {
+        coins_by_type
+            .entry(canonicalize_type(&coin.coin_type)?)
+            .or_default()
+            .push(coin);
+    }
+
+    for balance in balances.iter_mut() {
+        if let Some(coins) = coins_by_type.remove(balance.balance.coin_type()) {
+            balance.coins = coins;
+        }
+    }
+
+    for (coin_type, coins) in coins_by_type {
+        let metadata = if let Ok(ty) = StructTag::from_str(&coin_type) {
+            client.get_coin_info(&ty).await.ok()
+        } else {
+            None
+        };
+        balances.push(BalanceOutput {
+            metadata,
+            balance: balance_from_coins(coin_type, &coins),
+            coins,
+        });
+    }
+
+    Ok(())
+}
+
+/// Build the object type filter expected by `list_owned_objects`.
+fn coin_object_type_filter(coin_type: Option<&StructTag>) -> StructTag {
+    if let Some(coin_type) = coin_type {
+        sui_types::coin::Coin::type_(TypeTag::Struct(Box::new(coin_type.clone())))
+    } else {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            name: COIN_STRUCT_NAME.to_owned(),
+            module: COIN_MODULE_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+/// Reconstruct an aggregate balance for coin objects missing from `list_balances`.
+fn balance_from_coins(coin_type: String, coins: &[Coin]) -> proto::Balance {
+    let coin_balance = coins
+        .iter()
+        .fold(0u64, |total, coin| total.saturating_add(coin.balance));
+    let mut balance = proto::Balance::default()
+        .with_coin_type(coin_type)
+        .with_balance(coin_balance);
+    if coin_balance != 0 {
+        balance.set_coin_balance(coin_balance);
+    }
+    balance
+}
+
+/// Normalize equivalent type strings before grouping and ordering balances.
+fn canonicalize_type(type_: &str) -> Result<String, anyhow::Error> {
+    Ok(TypeTag::from_str(type_)
+        .context("Cannot parse coin type")?
+        .to_canonical_string(/* with_prefix */ true))
+}
+
+/// Keep SUI first while preserving the balance API's order for other coin types.
+fn order_balance_outputs_sui_first(balances: &mut Vec<BalanceOutput>) -> Result<(), anyhow::Error> {
+    let sui_type_tag = canonicalize_type(SUI_COIN_TYPE)?;
+    if let Some(index) = balances
+        .iter()
+        .position(|balance| balance.balance.coin_type() == sui_type_tag.as_str())
+    {
+        let sui_balance = balances.remove(index);
+        balances.insert(0, sui_balance);
+    }
+    Ok(())
+}
+
+fn pretty_print_balance(balances: &[BalanceOutput], builder: &mut TableBuilder, with_coins: bool) {
+    let format_decimals = 2;
     let mut table_builder = TableBuilder::default();
     if !with_coins {
-        table_builder.set_header(vec!["coin", "balance (raw)", "balance", ""]);
+        table_builder.set_header(vec!["coin", "balance (raw)", "balance"]);
     }
-    for (metadata, coins) in coins_by_type {
-        let (name, symbol, coin_decimals) = if let Some(metadata) = metadata {
+    for balance_output in balances {
+        let (name, symbol, coin_decimals) = if let Some(metadata) = &balance_output.metadata {
             (
                 metadata.metadata().name(),
                 metadata.metadata().symbol(),
@@ -3050,32 +3156,50 @@ fn pretty_print_balance(
             ("unknown", "unknown_symbol", 9)
         };
 
-        let balance = coins.iter().map(|x| x.balance as u128).sum::<u128>();
+        let balance = balance_output.balance.balance() as u128;
+        let address_balance = balance_output.balance.address_balance();
         let mut inner_table = TableBuilder::default();
-        inner_table.set_header(vec!["coinId", "balance (raw)", "balance", ""]);
+        inner_table.set_header(vec!["coinId", "balance (raw)", "balance"]);
 
         if with_coins {
-            let coin_numbers = if coins.len() != 1 { "coins" } else { "coin" };
+            let coin_numbers = if balance_output.coins.len() != 1 {
+                "coins"
+            } else {
+                "coin"
+            };
             let balance_formatted = format!(
                 "({} {})",
-                format_balance(balance, coin_decimals, format_decmials, Some(symbol)),
+                format_balance(balance, coin_decimals, format_decimals, Some(symbol)),
                 symbol
             );
             let summary = format!(
                 "{}: {} {coin_numbers}, Balance: {} {}",
                 name,
-                coins.len(),
+                balance_output.coins.len(),
                 balance,
                 balance_formatted
             );
-            for c in coins {
+            for c in &balance_output.coins {
                 inner_table.push_record(vec![
                     c.coin_object_id.to_string().as_str(),
                     c.balance.to_string().as_str(),
                     format_balance(
                         c.balance as u128,
                         coin_decimals,
-                        format_decmials,
+                        format_decimals,
+                        Some(symbol),
+                    )
+                    .as_str(),
+                ]);
+            }
+            if address_balance != 0 {
+                inner_table.push_record(vec![
+                    "address balance",
+                    address_balance.to_string().as_str(),
+                    format_balance(
+                        address_balance as u128,
+                        coin_decimals,
+                        format_decimals,
                         Some(symbol),
                     )
                     .as_str(),
@@ -3097,7 +3221,7 @@ fn pretty_print_balance(
             table_builder.push_record(vec![
                 name,
                 balance.to_string().as_str(),
-                format_balance(balance, coin_decimals, format_decmials, Some(symbol)).as_str(),
+                format_balance(balance, coin_decimals, format_decimals, Some(symbol)).as_str(),
             ]);
         }
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -48,7 +48,7 @@ use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use shared_crypto::intent::Intent;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    BalanceChange as RpcBalanceChange, BcsEvent, Coin, DryRunTransactionBlockResponse,
+    BalanceChange as RpcBalanceChange, BcsEvent, Coin as RpcCoin, DryRunTransactionBlockResponse,
     ObjectChange as RpcObjectChange, SuiEvent, SuiTransactionBlock, SuiTransactionBlockEffects,
     SuiTransactionBlockEvents, SuiTransactionBlockResponse,
 };
@@ -69,7 +69,7 @@ use sui_sdk::{
 use sui_types::{
     SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID,
     base_types::{FullObjectID, ObjectID, ObjectRef, ObjectType, SequenceNumber, SuiAddress},
-    coin::{COIN_MODULE_NAME, COIN_STRUCT_NAME},
+    coin::{COIN_MODULE_NAME, COIN_STRUCT_NAME, Coin},
     crypto::{EmptySignInfo, SignatureScheme},
     digests::TransactionDigest,
     effects::TransactionEffectsAPI,
@@ -866,7 +866,9 @@ impl SuiClientCommands {
                 let _ = context.cache_chain_id().await?;
 
                 let client = context.grpc_client()?;
-                let coin_type = coin_type.map(parse_coin_type_arg).transpose()?;
+                let coin_type = coin_type
+                    .map(|coin_type| coin_type.parse::<StructTag>())
+                    .transpose()?;
                 let mut balances =
                     balance_outputs_for_address(&client, address, coin_type.as_ref()).await?;
 
@@ -875,7 +877,7 @@ impl SuiClientCommands {
                         .await?;
                 }
 
-                order_balance_outputs_sui_first(&mut balances)?;
+                order_balance_outputs_sui_first(&mut balances);
                 SuiClientCommandResult::Balance(balances, with_coins)
             }
 
@@ -2775,7 +2777,7 @@ pub struct AddressesOutput {
 pub struct BalanceOutput {
     pub metadata: Option<proto::GetCoinInfoResponse>,
     pub balance: proto::Balance,
-    pub coins: Vec<Coin>,
+    pub coins: Vec<RpcCoin>,
 }
 
 #[derive(Serialize)]
@@ -2987,14 +2989,6 @@ pub async fn request_tokens_from_faucet(
     Ok(())
 }
 
-/// Parse the CLI coin type argument as the inner type `T`, not as `Coin<T>`.
-fn parse_coin_type_arg(coin_type: String) -> Result<StructTag, anyhow::Error> {
-    match coin_type.parse::<TypeTag>()? {
-        TypeTag::Struct(coin_type) => Ok(*coin_type),
-        coin_type => bail!("coin type must be a struct type, got {coin_type}"),
-    }
-}
-
 /// Fetch aggregate balances from gRPC and attach coin metadata for display.
 async fn balance_outputs_for_address(
     client: &Client,
@@ -3039,17 +3033,16 @@ async fn attach_owned_coin_objects(
     client: &Client,
     address: SuiAddress,
     coin_type: Option<&StructTag>,
-    balances: &mut Vec<BalanceOutput>,
+    balances: &mut [BalanceOutput],
 ) -> Result<(), anyhow::Error> {
     let coin_object_type = coin_object_type_filter(coin_type);
-    let coins: Vec<Coin> = client
+    let coins: Vec<RpcCoin> = client
         .list_owned_objects(address, Some(coin_object_type))
         .try_filter_map(|o| async move {
-            let Ok(Some((coin_type, balance))) = sui_types::coin::Coin::extract_balance_if_coin(&o)
-            else {
+            let Ok(Some((coin_type, balance))) = Coin::extract_balance_if_coin(&o) else {
                 return Ok(None);
             };
-            Ok(Some(Coin {
+            Ok(Some(RpcCoin {
                 coin_type: coin_type.to_canonical_string(true),
                 coin_object_id: o.id(),
                 version: o.version(),
@@ -3061,10 +3054,10 @@ async fn attach_owned_coin_objects(
         .try_collect()
         .await?;
 
-    let mut coins_by_type: BTreeMap<String, Vec<Coin>> = BTreeMap::new();
+    let mut coins_by_type: BTreeMap<String, Vec<RpcCoin>> = BTreeMap::new();
     for coin in coins {
         coins_by_type
-            .entry(canonicalize_type(&coin.coin_type)?)
+            .entry(coin.coin_type.clone())
             .or_default()
             .push(coin);
     }
@@ -3075,26 +3068,13 @@ async fn attach_owned_coin_objects(
         }
     }
 
-    for (coin_type, coins) in coins_by_type {
-        let metadata = if let Ok(ty) = StructTag::from_str(&coin_type) {
-            client.get_coin_info(&ty).await.ok()
-        } else {
-            None
-        };
-        balances.push(BalanceOutput {
-            metadata,
-            balance: balance_from_coins(coin_type, &coins),
-            coins,
-        });
-    }
-
     Ok(())
 }
 
 /// Build the object type filter expected by `list_owned_objects`.
 fn coin_object_type_filter(coin_type: Option<&StructTag>) -> StructTag {
     if let Some(coin_type) = coin_type {
-        sui_types::coin::Coin::type_(TypeTag::Struct(Box::new(coin_type.clone())))
+        Coin::type_(coin_type.clone().into())
     } else {
         StructTag {
             address: SUI_FRAMEWORK_ADDRESS,
@@ -3105,30 +3085,9 @@ fn coin_object_type_filter(coin_type: Option<&StructTag>) -> StructTag {
     }
 }
 
-/// Reconstruct an aggregate balance for coin objects missing from `list_balances`.
-fn balance_from_coins(coin_type: String, coins: &[Coin]) -> proto::Balance {
-    let coin_balance = coins
-        .iter()
-        .fold(0u64, |total, coin| total.saturating_add(coin.balance));
-    let mut balance = proto::Balance::default()
-        .with_coin_type(coin_type)
-        .with_balance(coin_balance);
-    if coin_balance != 0 {
-        balance.set_coin_balance(coin_balance);
-    }
-    balance
-}
-
-/// Normalize equivalent type strings before grouping and ordering balances.
-fn canonicalize_type(type_: &str) -> Result<String, anyhow::Error> {
-    Ok(TypeTag::from_str(type_)
-        .context("Cannot parse coin type")?
-        .to_canonical_string(/* with_prefix */ true))
-}
-
 /// Keep SUI first while preserving the balance API's order for other coin types.
-fn order_balance_outputs_sui_first(balances: &mut Vec<BalanceOutput>) -> Result<(), anyhow::Error> {
-    let sui_type_tag = canonicalize_type(SUI_COIN_TYPE)?;
+fn order_balance_outputs_sui_first(balances: &mut Vec<BalanceOutput>) {
+    let sui_type_tag = GasCoin::type_().to_canonical_string(/* with_prefix */ true);
     if let Some(index) = balances
         .iter()
         .position(|balance| balance.balance.coin_type() == sui_type_tag.as_str())
@@ -3136,7 +3095,6 @@ fn order_balance_outputs_sui_first(balances: &mut Vec<BalanceOutput>) -> Result<
         let sui_balance = balances.remove(index);
         balances.insert(0, sui_balance);
     }
-    Ok(())
 }
 
 fn pretty_print_balance(balances: &[BalanceOutput], builder: &mut TableBuilder, with_coins: bool) {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -8,7 +8,7 @@ use crate::{
     upgrade_compatibility::check_compatibility,
     verifier_meter::{AccumulatingMeter, Accumulator},
 };
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Display, Formatter, Write},
@@ -115,6 +115,9 @@ use sui_package_alt::{BuildParams, SuiFlavor, find_environment};
 use sui_source_validation::{BytecodeSourceVerifier, ValidationMode};
 use sui_types::digests::ChainIdentifier;
 use tracing::{debug, info};
+
+/// Concurrency level for fetching coin metadata for balances.
+const NUM_CONCURRENCY_REQS: usize = 8;
 
 pub(crate) static USER_AGENT: &str =
     concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -3001,17 +3004,18 @@ async fn balance_outputs_for_address(
         client.list_balances(address).try_collect().await?
     };
 
-    let mut outputs = Vec::with_capacity(balances.len());
-    for balance in balances {
-        let metadata = coin_metadata_for_balance(client, &balance).await?;
-        outputs.push(BalanceOutput {
-            metadata,
-            balance,
-            coins: Vec::new(),
-        });
-    }
-
-    Ok(outputs)
+    futures::stream::iter(balances)
+        .map(|balance| async move {
+            let metadata = coin_metadata_for_balance(client, &balance).await?;
+            Ok(BalanceOutput {
+                metadata,
+                balance,
+                coins: Vec::new(),
+            })
+        })
+        .buffered(NUM_CONCURRENCY_REQS)
+        .try_collect()
+        .await
 }
 
 /// Best-effort metadata lookup for a balance returned by the balance API.

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3556,6 +3556,36 @@ async fn test_send_funds_sui() -> Result<(), anyhow::Error> {
     assert_eq!(balance.address_balance(), amount);
     assert_eq!(balance.coin_balance(), 0);
 
+    let balance_output = SuiClientCommands::Balance {
+        address: Some(recipient1.clone()),
+        coin_type: None,
+        with_coins: false,
+    }
+    .execute(context)
+    .await?
+    .to_string();
+    assert!(
+        balance_output.contains(&amount.to_string()),
+        "{balance_output}"
+    );
+
+    let balance_with_coins_output = SuiClientCommands::Balance {
+        address: Some(recipient1.clone()),
+        coin_type: None,
+        with_coins: true,
+    }
+    .execute(context)
+    .await?
+    .to_string();
+    assert!(
+        balance_with_coins_output.contains("address balance"),
+        "{balance_with_coins_output}"
+    );
+    assert!(
+        balance_with_coins_output.contains(&amount.to_string()),
+        "{balance_with_coins_output}"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description 

I realized that the CLI `balance` command does not use the gRPC `list_balances` so it does not properly support address balances. This change moves to using `list_balances` for these two cases.
```
sui client balance
sui client balance --coin-type
```

When `--with-coins` is passed, we still need to fetch all the owned objects and then display those. For this case, it also makes sure that the address balance is taken into account.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
