### PR TITLE
Refactor archival resolution & rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15874,7 +15874,6 @@ dependencies = [
  "sui-rpc",
  "sui-rpc-api",
  "sui-sdk-types",
- "sui-storage",
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -862,14 +862,10 @@ async fn start_archival(
         .await
         .context("Failed to start BigTable indexer")?;
 
-    let kv_rpc_server = KvRpcServer::new_local(
-        emulator.host().to_string(),
-        INSTANCE_ID.to_string(),
-        None,
-        None,
-    )
-    .await
-    .context("Failed to create KvRpcServer")?;
+    let kv_rpc_server =
+        KvRpcServer::new_local(emulator.host().to_string(), INSTANCE_ID.to_string(), None)
+            .await
+            .context("Failed to create KvRpcServer")?;
     let kv_rpc_service = kv_rpc_server
         .start_service(
             kv_rpc_address,

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -7,8 +7,10 @@ use move_core_types::ident_str;
 use sui_indexer_alt_e2e_tests::FullCluster;
 use sui_rpc::field::FieldMask;
 use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
 use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
 use sui_rpc::proto::sui::rpc::v2::GetTransactionRequest;
+use sui_rpc::proto::sui::rpc::v2::get_checkpoint_request::CheckpointId;
 use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2alpha::AffectedAddressFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::AffectedObjectFilter;
@@ -3554,6 +3556,68 @@ async fn test_list_checkpoints_with_objects_read_mask() {
     assert!(
         any_transactions,
         "expected at least one tx.digest populated"
+    );
+}
+
+// GetCheckpoint hydrates transactions and objects from BigTable (the GCS
+// checkpoint-bucket dependency was removed). Without it, a `transactions`/
+// `objects` read mask silently returned empty.
+#[tokio::test]
+async fn test_get_checkpoint_with_transactions_and_objects() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    let (sender, kp, gas) = cluster.funded_account(10 * DEFAULT_GAS_BUDGET).unwrap();
+    let gas_id_string = gas.0.to_canonical_string(true);
+
+    let (digest, _new_gas) = transfer_self(&mut cluster, sender, &kp, gas).await;
+    let checkpoint = cluster.create_checkpoint().await;
+    let seq = checkpoint.sequence_number;
+
+    let mut client = LedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+
+    let mut req = GetCheckpointRequest::default();
+    req.checkpoint_id = Some(CheckpointId::SequenceNumber(seq));
+    req.read_mask = Some(FieldMask::from_paths([
+        "sequence_number",
+        "transactions.digest",
+        "objects.objects.object_id",
+        "objects.objects.version",
+    ]));
+
+    let cp = client
+        .get_checkpoint(req)
+        .await
+        .unwrap()
+        .into_inner()
+        .checkpoint
+        .expect("checkpoint populated");
+    assert_eq!(cp.sequence_number, Some(seq));
+
+    // Transactions hydrated from BigTable.
+    let returned: std::collections::HashSet<String> = cp
+        .transactions
+        .iter()
+        .filter_map(|tx| tx.digest.clone())
+        .collect();
+    assert!(
+        returned.contains(&digest.to_string()),
+        "expected tx digest {digest} in transactions[].digest, got {returned:?}"
+    );
+
+    // Objects hydrated from BigTable: the transfer's mutated gas object appears.
+    let saw_gas_object = cp
+        .objects
+        .as_ref()
+        .map(|os| {
+            os.objects
+                .iter()
+                .any(|o| o.object_id.as_deref() == Some(gas_id_string.as_str()))
+        })
+        .unwrap_or(false);
+    assert!(
+        saw_gas_object,
+        "expected gas object {gas_id_string} in checkpoint objects[]"
     );
 }
 

--- a/crates/sui-kv-rpc/Cargo.toml
+++ b/crates/sui-kv-rpc/Cargo.toml
@@ -37,7 +37,6 @@ sui-protocol-config.workspace = true
 sui-rpc.workspace = true
 sui-rpc-api.workspace = true
 sui-sdk-types.workspace = true
-sui-storage.workspace = true
 sui-types.workspace = true
 telemetry-subscribers.workspace = true
 thiserror.workspace = true
@@ -47,3 +46,7 @@ tonic-prost.workspace = true
 tonic-reflection.workspace = true
 prost.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+# `test-util` powers `#[tokio::test(start_paused = true)]` in the limiter tests.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -168,6 +168,13 @@ impl StagesConfig {
             PipelineStage::Checkpoints => self.checkpoints.as_ref(),
         }
     }
+
+    /// Resolved tunables for one pipeline stage. Unset stages fall back to the
+    /// built-in chunk size (`100`) and stage concurrency (`10`); the latter is
+    /// independent of `request_bigtable_concurrency`.
+    pub fn stage(&self, stage: PipelineStage) -> ResolvedStageConfig {
+        StageConfig::resolve(self.get(stage))
+    }
 }
 
 /// Tunables for the v2alpha ledger-history list APIs. Per-endpoint knobs live in
@@ -218,20 +225,6 @@ pub struct LedgerHistoryConfig {
     /// Defaults to `10` if not specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_bitmap_filter_literals: Option<usize>,
-
-    /// Per-request semaphore capacity gating downstream BigTable reads. Bitmap
-    /// scans are not gated by this; their fanout is bounded by
-    /// `max_bitmap_filter_literals`.
-    ///
-    /// Defaults to `10` if not specified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_bigtable_concurrency: Option<usize>,
-
-    /// Per-table-stage pipeline tunables (chunk size and fan-out concurrency).
-    /// Bounded by `request_bigtable_concurrency` at runtime, which remains the
-    /// request-wide read ceiling.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stages: Option<StagesConfig>,
 }
 
 impl LedgerHistoryConfig {
@@ -268,18 +261,6 @@ impl LedgerHistoryConfig {
             .unwrap_or(DEFAULT_MAX_BITMAP_FILTER_LITERALS)
     }
 
-    pub fn request_bigtable_concurrency(&self) -> usize {
-        self.request_bigtable_concurrency
-            .unwrap_or(DEFAULT_REQUEST_BIGTABLE_CONCURRENCY)
-    }
-
-    /// Resolved tunables for one pipeline stage. Unset stages fall back to the
-    /// built-in chunk size (`100`) and stage concurrency (`10`); the latter is
-    /// independent of `request_bigtable_concurrency`.
-    pub fn stage(&self, stage: PipelineStage) -> ResolvedStageConfig {
-        StageConfig::resolve(self.stages.as_ref().and_then(|s| s.get(stage)))
-    }
-
     /// Reject configurations that cannot make forward progress. Each filter
     /// literal becomes one bitmap leaf that must fetch at least one bucket to
     /// emit its first watermark; if a per-request budget is below the literal
@@ -287,10 +268,6 @@ impl LedgerHistoryConfig {
     /// leaving the client a cursorless `QueryEnd` it cannot resume from. Mirrors
     /// the fullnode side's `LedgerHistoryConfig::validate`.
     pub fn validate(&self) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            self.request_bigtable_concurrency() > 0,
-            "ledger_history.request_bigtable_concurrency must be greater than zero",
-        );
         anyhow::ensure!(
             self.max_bitmap_filter_literals() > 0,
             "ledger_history.max_bitmap_filter_literals must be greater than zero",
@@ -311,22 +288,6 @@ impl LedgerHistoryConfig {
             self.bitmap_bucket_budget_event(),
             self.max_bitmap_filter_literals(),
         );
-        for stage in [
-            PipelineStage::TxSeqDigest,
-            PipelineStage::Transactions,
-            PipelineStage::Objects,
-            PipelineStage::Checkpoints,
-        ] {
-            let resolved = self.stage(stage);
-            anyhow::ensure!(
-                resolved.chunk_size > 0,
-                "ledger_history.stages.{stage:?} chunk_size must be greater than zero",
-            );
-            anyhow::ensure!(
-                resolved.concurrency > 0,
-                "ledger_history.stages.{stage:?} concurrency must be greater than zero",
-            );
-        }
         Ok(())
     }
 }
@@ -354,9 +315,6 @@ pub struct KvRpcConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub app_profile_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub checkpoint_bucket: Option<String>,
 
     /// Path to a GCP service account JSON key file. If unset, Application
     /// Default Credentials are used.
@@ -409,6 +367,21 @@ pub struct KvRpcConfig {
     /// Tunables for the v2alpha ledger-history list APIs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ledger_history: Option<LedgerHistoryConfig>,
+
+    /// Per-request semaphore capacity gating downstream BigTable reads, shared by
+    /// the point-get and list APIs. Bitmap scans are not gated by this; their
+    /// fanout is bounded by `ledger_history.max_bitmap_filter_literals`.
+    ///
+    /// Defaults to `10` if not specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_bigtable_concurrency: Option<usize>,
+
+    /// Per-table-stage read pipeline tunables (chunk size and fan-out
+    /// concurrency), shared by the point-get and list APIs. Bounded by
+    /// `request_bigtable_concurrency` at runtime, which remains the request-wide
+    /// read ceiling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stages: Option<StagesConfig>,
 }
 
 impl KvRpcConfig {
@@ -496,6 +469,43 @@ impl KvRpcConfig {
     pub fn ledger_history(&self) -> LedgerHistoryConfig {
         self.ledger_history.clone().unwrap_or_default()
     }
+
+    pub fn request_bigtable_concurrency(&self) -> usize {
+        self.request_bigtable_concurrency
+            .unwrap_or(DEFAULT_REQUEST_BIGTABLE_CONCURRENCY)
+    }
+
+    pub fn stages(&self) -> StagesConfig {
+        self.stages.clone().unwrap_or_default()
+    }
+
+    /// Reject configurations that cannot make forward progress. Validates the
+    /// shared read-pipeline knobs (concurrency and per-stage chunk/fan-out) and
+    /// delegates to [`LedgerHistoryConfig::validate`] for the list-API knobs.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.request_bigtable_concurrency() > 0,
+            "request_bigtable_concurrency must be greater than zero",
+        );
+        let stages = self.stages();
+        for stage in [
+            PipelineStage::TxSeqDigest,
+            PipelineStage::Transactions,
+            PipelineStage::Objects,
+            PipelineStage::Checkpoints,
+        ] {
+            let resolved = stages.stage(stage);
+            anyhow::ensure!(
+                resolved.chunk_size > 0,
+                "stages.{stage:?} chunk_size must be greater than zero",
+            );
+            anyhow::ensure!(
+                resolved.concurrency > 0,
+                "stages.{stage:?} concurrency must be greater than zero",
+            );
+        }
+        self.ledger_history().validate()
+    }
 }
 
 #[cfg(test)]
@@ -539,36 +549,35 @@ mod tests {
     #[test]
     fn stage_override_wins_and_siblings_default() {
         let yaml = r#"
-ledger-history:
-  stages:
-    objects:
-      concurrency: 4
-    transactions:
-      chunk-size: 25
+stages:
+  objects:
+    concurrency: 4
+  transactions:
+    chunk-size: 25
 "#;
         let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
-        let lh = cfg.ledger_history();
+        let stages = cfg.stages();
 
-        let objects = lh.stage(PipelineStage::Objects);
+        let objects = stages.stage(PipelineStage::Objects);
         assert_eq!(objects.concurrency, 4);
         // Unset sibling field on the same stage falls back to its default.
         assert_eq!(objects.chunk_size, 100);
 
-        let transactions = lh.stage(PipelineStage::Transactions);
+        let transactions = stages.stage(PipelineStage::Transactions);
         assert_eq!(transactions.chunk_size, 25);
         assert_eq!(transactions.concurrency, 10);
 
         // Untouched stage is fully default.
-        let checkpoints = lh.stage(PipelineStage::Checkpoints);
+        let checkpoints = stages.stage(PipelineStage::Checkpoints);
         assert_eq!(checkpoints.chunk_size, 100);
         assert_eq!(checkpoints.concurrency, 10);
 
-        lh.validate().unwrap();
+        cfg.validate().unwrap();
     }
 
     #[test]
     fn validate_rejects_zero_stage_knob() {
-        let cfg = LedgerHistoryConfig {
+        let cfg = KvRpcConfig {
             stages: Some(StagesConfig {
                 objects: Some(StageConfig {
                     chunk_size: Some(0),
@@ -581,7 +590,7 @@ ledger-history:
         let err = cfg.validate().expect_err("zero chunk_size must fail");
         assert!(err.to_string().contains("chunk_size"), "{err}");
 
-        let cfg = LedgerHistoryConfig {
+        let cfg = KvRpcConfig {
             stages: Some(StagesConfig {
                 transactions: Some(StageConfig {
                     chunk_size: None,

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -40,6 +40,8 @@ mod object_cache;
 mod operation;
 mod package_store;
 mod pipeline;
+mod render;
+mod resolve;
 mod v2;
 mod v2alpha;
 
@@ -134,12 +136,13 @@ pub struct KvRpcServer {
     chain_id: ChainIdentifier,
     client: BigTableClient,
     server_version: Option<ServerVersion>,
-    checkpoint_bucket: Option<String>,
     service_info_watermark_pipelines: Vec<&'static str>,
     cache: Arc<RwLock<Option<GetServiceInfoResponse>>>,
     package_resolver: PackageResolver,
     metrics: Arc<KvRpcMetrics>,
     pub(crate) ledger_history: LedgerHistoryConfig,
+    pub(crate) request_bigtable_concurrency: usize,
+    pub(crate) stages: StagesConfig,
 }
 
 /// Optional configuration for the gRPC server (TLS, metrics, reflection).
@@ -156,7 +159,6 @@ impl KvRpcServer {
         instance_id: String,
         project_id: Option<String>,
         app_profile_id: Option<String>,
-        checkpoint_bucket: Option<String>,
         channel_timeout: Option<Duration>,
         server_version: Option<ServerVersion>,
         registry: &Registry,
@@ -164,6 +166,8 @@ impl KvRpcServer {
         pool_config: PoolConfig,
         service_info_watermark_pipelines: Vec<&'static str>,
         ledger_history: LedgerHistoryConfig,
+        request_bigtable_concurrency: usize,
+        stages: StagesConfig,
     ) -> anyhow::Result<Self> {
         ledger_history.validate()?;
         let mut client = BigTableClient::new_remote_with_credentials(
@@ -191,10 +195,11 @@ impl KvRpcServer {
             client,
             chain_id,
             server_version,
-            checkpoint_bucket,
             service_info_watermark_pipelines,
             metrics,
             ledger_history,
+            request_bigtable_concurrency,
+            stages,
         )
     }
 
@@ -203,7 +208,6 @@ impl KvRpcServer {
         host: String,
         instance_id: String,
         server_version: Option<ServerVersion>,
-        checkpoint_bucket: Option<String>,
     ) -> anyhow::Result<Self> {
         let client = BigTableClient::new_local(host, instance_id).await?;
         // Emulator/test path: metrics are inert (no scrape endpoint), but the
@@ -213,10 +217,11 @@ impl KvRpcServer {
             client,
             ChainIdentifier::from(sui_types::digests::CheckpointDigest::default()),
             server_version,
-            checkpoint_bucket,
             default_service_info_watermark_pipelines(false),
             metrics,
             LedgerHistoryConfig::default(),
+            KvRpcConfig::default().request_bigtable_concurrency(),
+            StagesConfig::default(),
         )
     }
 
@@ -224,10 +229,11 @@ impl KvRpcServer {
         client: BigTableClient,
         chain_id: ChainIdentifier,
         server_version: Option<ServerVersion>,
-        checkpoint_bucket: Option<String>,
         service_info_watermark_pipelines: Vec<&'static str>,
         metrics: Arc<KvRpcMetrics>,
         ledger_history: LedgerHistoryConfig,
+        request_bigtable_concurrency: usize,
+        stages: StagesConfig,
     ) -> anyhow::Result<Self> {
         ensure!(
             !service_info_watermark_pipelines.is_empty(),
@@ -246,12 +252,13 @@ impl KvRpcServer {
             chain_id,
             client,
             server_version,
-            checkpoint_bucket,
             service_info_watermark_pipelines,
             cache,
             package_resolver,
             metrics,
             ledger_history,
+            request_bigtable_concurrency,
+            stages,
         };
 
         let server_clone = server.clone();

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -57,9 +57,6 @@ struct App {
     /// (deprecated)
     #[clap(long = "app-profile-id")]
     app_profile_id: Option<String>,
-    /// (deprecated)
-    #[clap(long = "checkpoint-bucket")]
-    checkpoint_bucket: Option<String>,
     /// (deprecated) Pipeline watermark to include in GetServiceInfo checkpoint
     /// height. Repeat to include multiple pipelines.
     #[clap(
@@ -121,11 +118,6 @@ fn apply_deprecated_overrides(app: App, config: &mut KvRpcConfig) {
         &mut config.app_profile_id,
     );
     override_field(
-        "--checkpoint-bucket",
-        app.checkpoint_bucket,
-        &mut config.checkpoint_bucket,
-    );
-    override_field(
         "--bigtable-channel-timeout-ms",
         app.bigtable_channel_timeout_ms,
         &mut config.bigtable_channel_timeout_ms,
@@ -178,6 +170,7 @@ async fn main() -> Result<()> {
         None => KvRpcConfig::default(),
     };
     apply_deprecated_overrides(app, &mut config);
+    config.validate()?;
 
     let instance_id = config.instance_id.clone().context(
         "instance_id must be set via the config file (--config-path) or the \
@@ -194,7 +187,6 @@ async fn main() -> Result<()> {
         instance_id,
         config.bigtable_project.clone(),
         config.app_profile_id.clone(),
-        config.checkpoint_bucket.clone(),
         config.channel_timeout(),
         server_version,
         &registry,
@@ -202,6 +194,8 @@ async fn main() -> Result<()> {
         config.pool_config(),
         config.service_info_watermark_pipelines()?,
         config.ledger_history(),
+        config.request_bigtable_concurrency(),
+        config.stages(),
     )
     .await?;
 

--- a/crates/sui-kv-rpc/src/operation.rs
+++ b/crates/sui-kv-rpc/src/operation.rs
@@ -19,7 +19,7 @@ use crate::KvRpcMetrics;
 use crate::KvRpcServer;
 use crate::PackageResolver;
 use crate::bigtable_client::BigTableClient;
-use crate::config::LedgerHistoryConfig;
+use crate::config::{LedgerHistoryConfig, PipelineStage, ResolvedStageConfig, StagesConfig};
 use sui_rpc_api::ledger_history::filter::event_filter_to_query;
 use sui_rpc_api::ledger_history::filter::transaction_filter_to_query;
 
@@ -43,6 +43,8 @@ pub(crate) struct QueryContext {
     method: &'static str,
     checkpoint_hi_exclusive: u64,
     ledger_history: LedgerHistoryConfig,
+    request_bigtable_concurrency: usize,
+    stages: StagesConfig,
 }
 
 impl QueryContext {
@@ -53,6 +55,8 @@ impl QueryContext {
         method: &'static str,
         checkpoint_hi_exclusive: u64,
         ledger_history: LedgerHistoryConfig,
+        request_bigtable_concurrency: usize,
+        stages: StagesConfig,
     ) -> Self {
         Self {
             client,
@@ -61,11 +65,18 @@ impl QueryContext {
             method,
             checkpoint_hi_exclusive,
             ledger_history,
+            request_bigtable_concurrency,
+            stages,
         }
     }
 
     pub(crate) fn ledger_history(&self) -> &LedgerHistoryConfig {
         &self.ledger_history
+    }
+
+    /// Resolved tunables for one read pipeline stage (chunk size + fan-out).
+    pub(crate) fn stage(&self, stage: PipelineStage) -> ResolvedStageConfig {
+        self.stages.stage(stage)
     }
 
     pub(crate) fn client(&self) -> &BigTableClient {
@@ -81,7 +92,7 @@ impl QueryContext {
     }
 
     pub(crate) fn request_bigtable_concurrency(&self) -> usize {
-        self.ledger_history.request_bigtable_concurrency()
+        self.request_bigtable_concurrency
     }
 
     /// Per-request evaluated-bucket budget for `spec`. Handlers pass this
@@ -141,10 +152,10 @@ impl QueryContext {
 }
 
 impl KvRpcServer {
-    fn limited_client(&self, operation: &'static str) -> BigTableClient {
+    pub(crate) fn limited_client(&self, operation: &'static str) -> BigTableClient {
         BigTableClient::new(
             self.client.clone(),
-            self.ledger_history.request_bigtable_concurrency(),
+            self.request_bigtable_concurrency,
             self.metrics.bigtable_limiter.clone(),
             operation,
         )
@@ -178,6 +189,8 @@ impl KvRpcServer {
             operation,
             self.cached_checkpoint_hi_exclusive().await?,
             self.ledger_history.clone(),
+            self.request_bigtable_concurrency,
+            self.stages.clone(),
         ))
     }
 

--- a/crates/sui-kv-rpc/src/render.rs
+++ b/crates/sui-kv-rpc/src/render.rs
@@ -1,0 +1,400 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared proto-rendering layer: turns resolved BigTable data
+//! (`CheckpointData`/`TransactionData` + object maps) into the `sui.rpc.v2`
+//! proto messages, honoring a `FieldMaskTree`. Used by both the v2 point-get
+//! handlers and the v2alpha list handlers so rendering is identical across
+//! them.
+
+use std::collections::HashMap;
+
+use move_core_types::language_storage::StructTag;
+use mysten_common::ZipDebugEqIteratorExt;
+use sui_kvstore::{CheckpointData, TransactionData};
+use sui_rpc::field::FieldMaskTree;
+use sui_rpc::merge::Merge;
+use sui_rpc::proto::sui::rpc::v2::{
+    Checkpoint, Event, ExecutedTransaction, Transaction, TransactionEffects, TransactionEvents,
+    UserSignature,
+};
+use sui_rpc_api::RpcError;
+use sui_rpc_api::proto::timestamp_ms_to_proto;
+use sui_types::TypeTag;
+use sui_types::base_types::ObjectID;
+use sui_types::full_checkpoint_content::Checkpoint as FullCheckpoint;
+use sui_types::full_checkpoint_content::ExecutedTransaction as FullExecutedTransaction;
+use sui_types::full_checkpoint_content::ObjectSet;
+use sui_types::messages_checkpoint::CertifiedCheckpointSummary;
+use sui_types::object::Object;
+use sui_types::object::rpc_visitor::proto::ProtoVisitor;
+use sui_types::storage::ObjectKey;
+use tracing::warn;
+
+use crate::PackageResolver;
+
+/// Maximum size in bytes for JSON-rendered Move values (1 MiB).
+const MAX_JSON_MOVE_VALUE_SIZE: usize = 1024 * 1024;
+
+/// Render a Move value as JSON using the package resolver for type layout.
+pub(crate) async fn render_json(
+    resolver: &PackageResolver,
+    struct_tag: &StructTag,
+    contents: &[u8],
+) -> Option<prost_types::Value> {
+    let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
+    let layout = resolver.type_layout(type_tag).await.ok()?;
+    ProtoVisitor::new(MAX_JSON_MOVE_VALUE_SIZE)
+        .deserialize_value(contents, &layout)
+        .ok()
+}
+
+/// Render a summary-only `CheckpointData` into the proto `Checkpoint` (the fast
+/// path: read mask requests neither transactions nor objects).
+pub(crate) fn checkpoint_to_response(
+    checkpoint: CheckpointData,
+    read_mask: &FieldMaskTree,
+) -> Result<Checkpoint, RpcError> {
+    let summary = checkpoint
+        .summary
+        .ok_or_else(|| anyhow::anyhow!("checkpoint summary missing"))?;
+    let mut message = Checkpoint::default();
+    let summary: sui_sdk_types::CheckpointSummary = summary.try_into()?;
+    message.merge(&summary, read_mask);
+
+    if read_mask.contains(Checkpoint::SIGNATURE_FIELD) {
+        let signatures = checkpoint
+            .signatures
+            .ok_or_else(|| anyhow::anyhow!("checkpoint signatures missing"))?;
+        let signatures: sui_sdk_types::ValidatorAggregatedSignature = signatures.into();
+        message.merge(signatures, read_mask);
+    }
+
+    if read_mask.contains(Checkpoint::CONTENTS_FIELD.name) {
+        let contents = checkpoint
+            .contents
+            .ok_or_else(|| anyhow::anyhow!("checkpoint contents missing"))?;
+        message.merge(
+            sui_sdk_types::CheckpointContents::try_from(contents)?,
+            read_mask,
+        );
+    }
+
+    Ok(message)
+}
+
+/// Build the full proto `Checkpoint` (summary + signatures + contents +
+/// transactions + objects) from resolved BigTable data. `objects` must contain
+/// exactly the objects referenced by this checkpoint's transactions — the whole
+/// map is folded into the rendered `ObjectSet`.
+pub(crate) fn render_full_checkpoint(
+    checkpoint: CheckpointData,
+    txs: Vec<TransactionData>,
+    objects: &HashMap<ObjectKey, Object>,
+    read_mask: &FieldMaskTree,
+) -> Result<Checkpoint, RpcError> {
+    let summary = checkpoint
+        .summary
+        .ok_or_else(|| RpcError::new(tonic::Code::Internal, "checkpoint summary column missing"))?;
+    let cp_seq = summary.sequence_number;
+    let signatures = checkpoint.signatures.ok_or_else(|| {
+        RpcError::new(
+            tonic::Code::Internal,
+            format!("checkpoint {cp_seq} signatures column missing"),
+        )
+    })?;
+    let contents = checkpoint.contents.ok_or_else(|| {
+        RpcError::new(
+            tonic::Code::Internal,
+            format!("checkpoint {cp_seq} contents column missing"),
+        )
+    })?;
+
+    let executed_transactions = txs
+        .into_iter()
+        .map(|tx| {
+            let transaction = tx.transaction_data.ok_or_else(|| {
+                RpcError::new(
+                    tonic::Code::Internal,
+                    format!("transaction {} data column missing", tx.digest),
+                )
+            })?;
+            let effects = tx.effects.ok_or_else(|| {
+                RpcError::new(
+                    tonic::Code::Internal,
+                    format!("transaction {} effects column missing", tx.digest),
+                )
+            })?;
+            Ok::<_, RpcError>(FullExecutedTransaction {
+                transaction,
+                signatures: tx.signatures.unwrap_or_default(),
+                effects,
+                events: tx.events,
+                unchanged_loaded_runtime_objects: tx.unchanged_loaded_runtime_objects,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut object_set = ObjectSet::default();
+    for (_, obj) in objects.iter() {
+        object_set.insert(obj.clone());
+    }
+
+    let full_checkpoint = FullCheckpoint {
+        summary: CertifiedCheckpointSummary::new_from_data_and_sig(summary, signatures),
+        contents,
+        transactions: executed_transactions,
+        object_set,
+    };
+
+    let mut message = Checkpoint::default();
+    message.merge(&full_checkpoint, read_mask);
+    Ok(message)
+}
+
+/// Render a `TransactionData` into the proto `ExecutedTransaction`. `objects`
+/// supplies the object types for the transaction's changed/unchanged-consensus
+/// objects (keyed by `(id, version)`); keys absent from the map are simply not
+/// annotated.
+pub(crate) async fn transaction_to_response(
+    source: TransactionData,
+    mask: &FieldMaskTree,
+    objects: &HashMap<ObjectKey, Object>,
+    resolver: &PackageResolver,
+) -> Result<ExecutedTransaction, RpcError> {
+    let mut message = ExecutedTransaction::default();
+
+    if mask.contains(ExecutedTransaction::DIGEST_FIELD.name) {
+        message.digest = Some(source.digest.to_string());
+    }
+
+    if let Some(submask) = mask.subtree(ExecutedTransaction::TRANSACTION_FIELD.name)
+        && let Some(tx_data) = &source.transaction_data
+    {
+        let transaction = sui_sdk_types::Transaction::try_from(tx_data.clone())?;
+        message.transaction = Some(Transaction::merge_from(transaction, &submask));
+    }
+
+    if let Some(submask) = mask.subtree(ExecutedTransaction::SIGNATURES_FIELD.name)
+        && let Some(sigs) = &source.signatures
+    {
+        message.signatures = sigs
+            .iter()
+            .map(|s| {
+                sui_sdk_types::UserSignature::try_from(s.clone())
+                    .map(|s| UserSignature::merge_from(s, &submask))
+            })
+            .collect::<Result<_, _>>()?;
+    }
+
+    if let Some(submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name)
+        && let Some(effects) = source.effects
+    {
+        let mut effects = TransactionEffects::merge_from(
+            &sui_sdk_types::TransactionEffects::try_from(effects)?,
+            &submask,
+        );
+        if submask.contains(TransactionEffects::UNCHANGED_LOADED_RUNTIME_OBJECTS_FIELD.name) {
+            effects.unchanged_loaded_runtime_objects = source
+                .unchanged_loaded_runtime_objects
+                .iter()
+                .map(Into::into)
+                .collect();
+        }
+        for changed_object in effects.changed_objects.iter_mut() {
+            let Ok(object_id) = changed_object.object_id().parse::<ObjectID>() else {
+                warn!(
+                    object_id = changed_object.object_id(),
+                    "failed to parse object_id in changed_objects"
+                );
+                continue;
+            };
+            let version = changed_object
+                .input_version_opt()
+                .unwrap_or_else(|| changed_object.output_version());
+            if let Some(object) = objects.get(&ObjectKey(object_id, version.into())) {
+                changed_object.set_object_type(object_type_to_string(object.into()));
+            }
+        }
+
+        for unchanged in effects.unchanged_consensus_objects.iter_mut() {
+            let Ok(object_id) = unchanged.object_id().parse::<ObjectID>() else {
+                warn!(
+                    object_id = unchanged.object_id(),
+                    "failed to parse object_id in unchanged_consensus_objects"
+                );
+                continue;
+            };
+            if let Some(object) = objects.get(&ObjectKey(object_id, unchanged.version().into())) {
+                unchanged.set_object_type(object_type_to_string(object.into()));
+            }
+        }
+
+        message.effects = Some(effects);
+    }
+
+    if let Some(submask) = mask.subtree(ExecutedTransaction::EVENTS_FIELD.name)
+        && let Some(events) = &source.events
+    {
+        message.events = Some(TransactionEvents::merge_from(events, &submask));
+
+        if let Some(event_mask) = submask.subtree(TransactionEvents::EVENTS_FIELD.name)
+            && event_mask.contains(Event::JSON_FIELD.name)
+            && let Some(proto_events) = message.events.as_mut()
+        {
+            for (proto_event, sui_event) in
+                proto_events.events.iter_mut().zip_debug_eq(&events.data)
+            {
+                proto_event.json = render_json(resolver, &sui_event.type_, &sui_event.contents)
+                    .await
+                    .map(Box::new);
+            }
+        }
+    }
+    if mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name) {
+        message.checkpoint = Some(source.checkpoint_number);
+    }
+    if mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name) {
+        message.timestamp = Some(timestamp_ms_to_proto(source.timestamp));
+    }
+
+    if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name) {
+        message.balance_changes = source.balance_changes.into_iter().map(Into::into).collect();
+    }
+
+    Ok(message)
+}
+
+fn object_type_to_string(object_type: sui_types::base_types::ObjectType) -> String {
+    match object_type {
+        sui_types::base_types::ObjectType::Package => "package".to_owned(),
+        sui_types::base_types::ObjectType::Struct(move_object_type) => {
+            move_object_type.to_canonical_string(true)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_core_types::account_address::AccountAddress;
+    use std::sync::Arc;
+    use sui_kvstore::TransactionData as KvTransactionData;
+    use sui_package_resolver::{Package, PackageStore, Resolver};
+    use sui_rpc::field::{FieldMask, FieldMaskUtil};
+    use sui_rpc::proto::sui::rpc::v2::BalanceChange as ProtoBalanceChange;
+    use sui_rpc::proto::sui::rpc::v2::ObjectReference;
+    use sui_types::TypeTag;
+    use sui_types::balance_change::BalanceChange;
+    use sui_types::base_types::{ObjectID, SuiAddress};
+    use sui_types::effects::TestEffectsBuilder;
+    use sui_types::object::Object;
+    use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+    use sui_types::storage::ObjectKey;
+    use sui_types::transaction::{
+        SenderSignedData, Transaction, TransactionData as SuiTransactionData,
+    };
+
+    use sui_types::digests::TransactionDigest;
+
+    fn test_tx_data() -> (TransactionDigest, SuiTransactionData) {
+        let sender = SuiAddress::random_for_testing_only();
+        let gas = Object::immutable_with_id_for_testing(ObjectID::random());
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.transfer_sui(SuiAddress::random_for_testing_only(), None);
+            builder.finish()
+        };
+        let data = SuiTransactionData::new_programmable(
+            sender,
+            vec![gas.compute_object_reference()],
+            pt,
+            1_000_000,
+            1,
+        );
+        let tx = Transaction::new(SenderSignedData::new(data.clone(), vec![]));
+        (*tx.digest(), data)
+    }
+
+    /// Empty package store for tests that don't exercise JSON rendering.
+    struct EmptyPackageStore;
+
+    #[async_trait::async_trait]
+    impl PackageStore for EmptyPackageStore {
+        async fn fetch(&self, id: AccountAddress) -> sui_package_resolver::Result<Arc<Package>> {
+            Err(sui_package_resolver::error::Error::PackageNotFound(id))
+        }
+    }
+
+    fn test_resolver() -> PackageResolver {
+        let store: Arc<dyn PackageStore> = Arc::new(EmptyPackageStore);
+        Arc::new(Resolver::new(store))
+    }
+
+    #[tokio::test]
+    async fn transaction_to_response_returns_balance_changes_when_requested() {
+        let (digest, tx_data) = test_tx_data();
+        let tx = Transaction::new(SenderSignedData::new(tx_data.clone(), vec![]));
+        let effects = TestEffectsBuilder::new(tx.data()).build();
+        let balance_change = BalanceChange {
+            address: SuiAddress::random_for_testing_only(),
+            coin_type: TypeTag::U64,
+            amount: 42,
+        };
+        let source = KvTransactionData {
+            digest,
+            transaction_data: Some(tx_data),
+            signatures: Some(vec![]),
+            effects: Some(effects),
+            events: None,
+            checkpoint_number: 7,
+            timestamp: 42,
+            balance_changes: vec![balance_change.clone()],
+            unchanged_loaded_runtime_objects: vec![],
+        };
+        let mask = FieldMaskTree::from(FieldMask::from_str("balance_changes"));
+        let resolver = test_resolver();
+
+        let response = transaction_to_response(source, &mask, &HashMap::new(), &resolver)
+            .await
+            .expect("render should succeed");
+
+        assert_eq!(
+            response.balance_changes,
+            vec![ProtoBalanceChange::from(balance_change)]
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_to_response_returns_unchanged_loaded_runtime_objects_when_requested() {
+        let (digest, tx_data) = test_tx_data();
+        let tx = Transaction::new(SenderSignedData::new(tx_data.clone(), vec![]));
+        let effects = TestEffectsBuilder::new(tx.data()).build();
+        let obj_key = ObjectKey(ObjectID::random(), 3.into());
+        let source = KvTransactionData {
+            digest,
+            transaction_data: Some(tx_data),
+            signatures: Some(vec![]),
+            effects: Some(effects),
+            events: None,
+            checkpoint_number: 7,
+            timestamp: 42,
+            balance_changes: vec![],
+            unchanged_loaded_runtime_objects: vec![obj_key],
+        };
+        let mask = FieldMaskTree::from(FieldMask::from_str(
+            "effects.unchanged_loaded_runtime_objects",
+        ));
+        let resolver = test_resolver();
+
+        let response = transaction_to_response(source, &mask, &HashMap::new(), &resolver)
+            .await
+            .expect("render should succeed");
+
+        let effects = response.effects.expect("effects should be present");
+        assert_eq!(
+            effects.unchanged_loaded_runtime_objects,
+            vec![ObjectReference::from(&obj_key)]
+        );
+    }
+}

--- a/crates/sui-kv-rpc/src/resolve.rs
+++ b/crates/sui-kv-rpc/src/resolve.rs
@@ -1,0 +1,503 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared BigTable resolution layer: turns streams (or bounded sets) of
+//! checkpoint/transaction identifiers into fully-resolved entities — their
+//! transactions and objects — using the chunked, concurrency-limited pipeline
+//! primitives. Both the v2 point-get handlers and the v2alpha list handlers
+//! build on these so request-size chunking, stage overlap, and object
+//! deduplication are identical across them.
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+
+use futures::StreamExt;
+use futures::TryStreamExt;
+use futures::stream;
+use futures::stream::BoxStream;
+use sui_kvstore::tables;
+use sui_kvstore::{CheckpointData, TransactionData};
+use sui_rpc::field::FieldMaskTree;
+use sui_rpc::proto::sui::rpc::v2::{Checkpoint, ExecutedTransaction, TransactionEffects};
+use sui_rpc_api::RpcError;
+use sui_types::digests::TransactionDigest;
+use sui_types::storage::ObjectKey;
+
+use crate::bigtable_client::BigTableClient;
+use crate::config::ResolvedStageConfig;
+use crate::object_cache::{BigTableObjectFetcher, ObjectCache, ObjectMap};
+use crate::pipeline::{InputOrderEmitter, Watermarked, pipelined_chunks, pipelined_keyed_batches};
+
+pub(crate) type CpWithTxs = (u64, CheckpointData, Vec<TransactionData>);
+pub(crate) type ResolvedCp = (u64, CheckpointData, Vec<TransactionData>, ObjectMap);
+
+/// Attach a per-item `ObjectMap` to each item in `upstream`. When
+/// `needs_objects` is false every item is paired with an empty map (no
+/// BigTable read); otherwise object keys are derived per item via `keys_of`
+/// and fetched through `pipelined_keyed_batches` — chunk-bounded, concurrent,
+/// and deduplicated by a request-scoped `ObjectCache`, overlapping with the
+/// still-arriving upstream. The cache is owned by the returned stream, so its
+/// in-flight dispatches abort if the consumer drops the stream.
+pub(crate) fn with_object_maps<I>(
+    upstream: BoxStream<'static, Result<Watermarked<I>, anyhow::Error>>,
+    client: BigTableClient,
+    objects_stage: ResolvedStageConfig,
+    needs_objects: bool,
+    keys_of: impl Fn(&I) -> Vec<ObjectKey> + Send + 'static,
+) -> BoxStream<'static, Result<Watermarked<(I, ObjectMap)>, anyhow::Error>>
+where
+    I: Send + 'static,
+{
+    if needs_objects {
+        let object_cache = ObjectCache::new(Arc::new(BigTableObjectFetcher::new(client)));
+        let with_keys = upstream
+            .map_ok(move |m| {
+                m.map_item(|item| {
+                    let keys = keys_of(&item);
+                    (item, keys)
+                })
+            })
+            .boxed();
+        pipelined_keyed_batches(
+            with_keys,
+            objects_stage.chunk_size,
+            objects_stage.chunk_size,
+            objects_stage.concurrency,
+            move |keys| {
+                let object_cache = object_cache.clone();
+                async move {
+                    object_cache
+                        .get_many(keys)
+                        .await
+                        .map_err(anyhow::Error::new)
+                }
+            },
+        )
+        .boxed()
+    } else {
+        let empty: ObjectMap = Arc::new(HashMap::new());
+        upstream
+            .map_ok(move |m| {
+                let empty = empty.clone();
+                m.map_item(move |item| (item, empty.clone()))
+            })
+            .boxed()
+    }
+}
+
+/// Resolve a stream of `(cp_seq, CheckpointData)` into
+/// `(cp_seq, cp_data, txs, objects)`. Stage C fetches each chunk's
+/// transactions; stage D attaches their objects. Shared by `get_checkpoint`
+/// (single lookup) and the list-checkpoints handler (range scan).
+pub(crate) fn resolve_checkpoints(
+    client: BigTableClient,
+    read_mask: &FieldMaskTree,
+    transactions_stage: ResolvedStageConfig,
+    objects_stage: ResolvedStageConfig,
+    cp_data_stream: BoxStream<'static, Result<Watermarked<(u64, CheckpointData)>, anyhow::Error>>,
+) -> BoxStream<'static, Result<Watermarked<ResolvedCp>, anyhow::Error>> {
+    let tx_columns: Arc<[&'static str]> = list_transactions_columns(read_mask).into();
+    let needs_objects = read_mask.contains(Checkpoint::OBJECTS_FIELD);
+
+    // Stage C: (cp_seq, CheckpointData) -> + Vec<TransactionData>. Batched
+    // across the chunk: gather ALL tx_digests across all cps in the chunk into
+    // one multi_get, route results back per-cp, then emit in input cp_seq order
+    // after the chunk drains.
+    let cp_with_txs_stream = pipelined_chunks(
+        cp_data_stream,
+        transactions_stage.chunk_size,
+        transactions_stage.concurrency,
+        {
+            let client = client.clone();
+            let columns = tx_columns.clone();
+            move |items| fetch_transactions_for_cps(client.clone(), columns.clone(), items)
+        },
+    );
+
+    // Stage D: each cp must see only its own object keys, since
+    // `render_full_checkpoint` folds the whole map into an `ObjectSet`.
+    with_object_maps(
+        cp_with_txs_stream,
+        client,
+        objects_stage,
+        needs_objects,
+        |(_, _, txs): &CpWithTxs| {
+            txs.iter()
+                .flat_map(compute_object_keys)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect()
+        },
+    )
+    .map_ok(|m| m.map_item(|((cp_seq, cp_data, txs), objects)| (cp_seq, cp_data, txs, objects)))
+    .boxed()
+}
+
+/// Resolve a single already-fetched checkpoint (the point-get path): drive
+/// `resolve_checkpoints` over a one-item stream and return the sole result.
+/// `resolve_checkpoints` emits exactly one item per input checkpoint (empty
+/// checkpoints are pre-emitted) or propagates a fetch error, so the stream is
+/// never empty — hence no "missing result" failure mode.
+pub(crate) async fn resolve_checkpoint(
+    client: BigTableClient,
+    read_mask: &FieldMaskTree,
+    transactions_stage: ResolvedStageConfig,
+    objects_stage: ResolvedStageConfig,
+    cp_seq: u64,
+    cp_data: CheckpointData,
+) -> Result<ResolvedCp, RpcError> {
+    let cp_stream =
+        stream::once(async move { Ok::<_, anyhow::Error>(Watermarked::Item((cp_seq, cp_data))) })
+            .boxed();
+    let stream = resolve_checkpoints(
+        client,
+        read_mask,
+        transactions_stage,
+        objects_stage,
+        cp_stream,
+    );
+    futures::pin_mut!(stream);
+    while let Some(item) = stream.next().await {
+        if let Watermarked::Item(resolved) = item.map_err(RpcError::from)? {
+            return Ok(resolved);
+        }
+    }
+    unreachable!("resolve_checkpoints emits exactly one item per input checkpoint")
+}
+
+/// Resolve `digests` into their transactions and (when the mask needs object
+/// types) objects, keyed by digest for request-order reconstruction. Tx rows
+/// stream in by chunk and their objects fetch concurrently, overlapping the tx
+/// fetch. An empty `digests` issues no BigTable read.
+pub(crate) async fn resolve_transactions(
+    client: BigTableClient,
+    digests: Vec<TransactionDigest>,
+    read_mask: &FieldMaskTree,
+    transactions_stage: ResolvedStageConfig,
+    objects_stage: ResolvedStageConfig,
+) -> Result<HashMap<TransactionDigest, (TransactionData, ObjectMap)>, RpcError> {
+    if digests.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let columns: Arc<[&'static str]> = transaction_columns(read_mask).into();
+    let needs_objects = needs_object_types(read_mask);
+
+    let digest_stream = stream::iter(
+        digests
+            .into_iter()
+            .map(|d| Ok::<_, anyhow::Error>(Watermarked::Item(d))),
+    )
+    .boxed();
+
+    // Stage A: digests -> (digest, TransactionData), chunked & concurrent.
+    let tx_stream = pipelined_chunks(
+        digest_stream,
+        transactions_stage.chunk_size,
+        transactions_stage.concurrency,
+        {
+            let client = client.clone();
+            let columns = columns.clone();
+            move |chunk| fetch_transaction_rows(client.clone(), columns.clone(), chunk)
+        },
+    );
+
+    // Stage B: attach each tx's own objects.
+    let with_objects = with_object_maps(
+        tx_stream,
+        client,
+        objects_stage,
+        needs_objects,
+        |(_, tx): &(TransactionDigest, TransactionData)| {
+            compute_object_keys(tx).into_iter().collect()
+        },
+    );
+    futures::pin_mut!(with_objects);
+
+    let mut out = HashMap::new();
+    while let Some(item) = with_objects.next().await {
+        if let Watermarked::Item(((digest, tx), objects)) = item.map_err(RpcError::from)? {
+            out.insert(digest, (tx, objects));
+        }
+    }
+    Ok(out)
+}
+
+/// Stage-A/C fetch: fetch one chunk of transaction rows as a stream. An empty
+/// chunk issues no read (see the empty-RowSet full-scan trap guarded in
+/// `sui-kvstore`).
+async fn fetch_transaction_rows(
+    client: BigTableClient,
+    columns: Arc<[&'static str]>,
+    digests: Vec<TransactionDigest>,
+) -> Result<
+    BoxStream<'static, Result<(TransactionDigest, TransactionData), anyhow::Error>>,
+    anyhow::Error,
+> {
+    if digests.is_empty() {
+        return Ok(stream::empty().boxed());
+    }
+    let column_filter = BigTableClient::column_filter(&columns);
+    Ok(client
+        .get_transactions_stream(digests, Some(column_filter))
+        .await?
+        .boxed())
+}
+
+/// Fetch the transactions for a chunk of checkpoints in a single batched
+/// multi_get, routing rows back per-cp and emitting in input cp_seq order once
+/// each cp's full set has arrived.
+async fn fetch_transactions_for_cps(
+    client: BigTableClient,
+    columns: Arc<[&'static str]>,
+    items: Vec<(u64, CheckpointData)>,
+) -> Result<BoxStream<'static, Result<CpWithTxs, anyhow::Error>>, anyhow::Error> {
+    if items.is_empty() {
+        return Ok(stream::empty().boxed());
+    }
+
+    let mut input_order: Vec<u64> = Vec::with_capacity(items.len());
+    let mut cp_data_by_seq: HashMap<u64, CheckpointData> = HashMap::with_capacity(items.len());
+    let mut expected_count: HashMap<u64, usize> = HashMap::with_capacity(items.len());
+    let mut digest_to_cp: HashMap<TransactionDigest, u64> = HashMap::new();
+    let mut txs_by_seq: HashMap<u64, Vec<TransactionData>> = HashMap::with_capacity(items.len());
+    let mut flat_digests: Vec<TransactionDigest> = Vec::new();
+
+    for (cp_seq, cp_data) in items {
+        let contents = cp_data
+            .contents
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("checkpoint {cp_seq} contents column missing"))?;
+        let cp_digests: Vec<_> = contents.iter().map(|d| d.transaction).collect();
+        expected_count.insert(cp_seq, cp_digests.len());
+        txs_by_seq.insert(cp_seq, Vec::with_capacity(cp_digests.len()));
+        for digest in &cp_digests {
+            digest_to_cp.insert(*digest, cp_seq);
+        }
+        flat_digests.extend(cp_digests);
+        input_order.push(cp_seq);
+        cp_data_by_seq.insert(cp_seq, cp_data);
+    }
+
+    // Empty checkpoints (zero transactions) generate no BigTable rows, so
+    // pre-collect them and release through the emitter before draining the
+    // tx stream — otherwise they'd never get emitted.
+    let empty_cps: Vec<u64> = input_order
+        .iter()
+        .copied()
+        .filter(|cp_seq| expected_count[cp_seq] == 0)
+        .collect();
+
+    // CRITICAL: never call `get_transactions_stream` with an empty digest list
+    // (an empty `RowSet` is read as a full transactions-table scan). When every
+    // cp in this chunk is empty, fall back to an empty stream and let the
+    // pre-emit loop alone drive emission.
+    let tx_stream: BoxStream<'static, Result<(TransactionDigest, TransactionData), anyhow::Error>> =
+        if flat_digests.is_empty() {
+            stream::empty().boxed()
+        } else {
+            let column_filter = BigTableClient::column_filter(&columns);
+            client
+                .get_transactions_stream(flat_digests, Some(column_filter))
+                .await?
+                .boxed()
+        };
+
+    Ok(async_stream::try_stream! {
+        let mut emitter: InputOrderEmitter<u64, CpWithTxs> = InputOrderEmitter::new(input_order);
+        for cp_seq in empty_cps {
+            let cp_data = cp_data_by_seq.remove(&cp_seq).expect("cp_data entry present");
+            for v in emitter.push(
+                cp_seq,
+                (cp_seq, cp_data, Vec::new()),
+                "resolve_checkpoints: checkpoint transaction lookup",
+            )? {
+                yield v;
+            }
+        }
+        futures::pin_mut!(tx_stream);
+        while let Some(row) = tx_stream.next().await {
+            let (digest, tx) = row?;
+            let cp_seq = digest_to_cp.remove(&digest).ok_or_else(|| {
+                anyhow::anyhow!("resolve_checkpoints: unexpected transaction body row {digest}")
+            })?;
+            let cp_txs = txs_by_seq
+                .get_mut(&cp_seq)
+                .expect("txs_by_seq entry present");
+            cp_txs.push(tx);
+            if cp_txs.len() == expected_count[&cp_seq] {
+                let txs = txs_by_seq.remove(&cp_seq).expect("txs_by_seq entry");
+                let cp_data = cp_data_by_seq
+                    .remove(&cp_seq)
+                    .expect("cp_data entry present");
+                for v in emitter.push(
+                    cp_seq,
+                    (cp_seq, cp_data, txs),
+                    "resolve_checkpoints: checkpoint transaction lookup",
+                )? {
+                    yield v;
+                }
+            }
+        }
+        // Defensive: if BigTable returned fewer rows than requested, surface
+        // the missing digests as an internal error rather than emit a partial
+        // checkpoint downstream.
+        if !cp_data_by_seq.is_empty() {
+            let mut incomplete: Vec<(u64, usize, usize)> = cp_data_by_seq
+                .keys()
+                .map(|cp_seq| {
+                    let got = txs_by_seq.get(cp_seq).map(|v| v.len()).unwrap_or(0);
+                    let expected = expected_count.get(cp_seq).copied().unwrap_or(0);
+                    (*cp_seq, got, expected)
+                })
+                .collect();
+            incomplete.sort_unstable();
+            tracing::warn!(
+                incomplete_count = incomplete.len(),
+                ?incomplete,
+                "resolve_checkpoints: BigTable returned fewer transactions than requested (cp_seq, got, expected)"
+            );
+            Err(RpcError::new(
+                tonic::Code::Internal,
+                format!(
+                    "resolve_checkpoints: BigTable returned fewer transactions than requested for {} checkpoint(s)",
+                    incomplete.len()
+                ),
+            ))?;
+        }
+        for v in emitter.finish("resolve_checkpoints: missing selected checkpoint transactions")? {
+            yield v;
+        }
+    }
+    .boxed())
+}
+
+// --- Read-mask -> column / fetch planning ---
+
+/// Whether the checkpoint read mask requests transactions or objects (the heavy
+/// path that needs `resolve_checkpoints`).
+pub(crate) fn needs_transactions_or_objects(mask: &FieldMaskTree) -> bool {
+    mask.contains(Checkpoint::TRANSACTIONS_FIELD) || mask.contains(Checkpoint::OBJECTS_FIELD)
+}
+
+/// Whether a transaction read mask needs object types resolved (i.e. requests
+/// `effects.changed_objects` or `effects.unchanged_consensus_objects`).
+pub(crate) fn needs_object_types(mask: &FieldMaskTree) -> bool {
+    mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name)
+        .is_some_and(|submask| {
+            submask.contains(TransactionEffects::CHANGED_OBJECTS_FIELD.name)
+                || submask.contains(TransactionEffects::UNCHANGED_CONSENSUS_OBJECTS_FIELD.name)
+        })
+}
+
+/// Object keys (id, version) referenced by a transaction's inputs/effects —
+/// i.e. the objects to fetch to annotate its `changed_objects` types.
+pub(crate) fn compute_object_keys(source: &TransactionData) -> BTreeSet<ObjectKey> {
+    match (&source.transaction_data, &source.effects) {
+        (Some(tx_data), Some(effects)) => sui_types::storage::get_transaction_object_set(
+            tx_data,
+            effects,
+            &source.unchanged_loaded_runtime_objects,
+        ),
+        _ => BTreeSet::new(),
+    }
+}
+
+/// Checkpoint-table columns needed for `mask`. Always includes `s` (summary);
+/// adds `sg` (signatures) and `c` (contents) when requested.
+pub(crate) fn checkpoint_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
+    use tables::checkpoints::col;
+    let mut columns = vec![col::SUMMARY];
+    if mask.contains(Checkpoint::SIGNATURE_FIELD) {
+        columns.push(col::SIGNATURES);
+    }
+    if mask.contains(Checkpoint::CONTENTS_FIELD) {
+        columns.push(col::CONTENTS);
+    }
+    columns
+}
+
+/// Checkpoint-table columns for the list/get checkpoint handlers. The heavy
+/// (transactions/objects) path additionally needs `signatures` (to reconstruct
+/// `CertifiedCheckpointSummary`) and `contents` (to enumerate tx digests).
+pub(crate) fn list_checkpoint_columns(mask: &FieldMaskTree, needs_full: bool) -> Vec<&'static str> {
+    use tables::checkpoints::col;
+    let mut columns = checkpoint_columns(mask);
+    if needs_full {
+        if !columns.contains(&col::CONTENTS) {
+            columns.push(col::CONTENTS);
+        }
+        if !columns.contains(&col::SIGNATURES) {
+            columns.push(col::SIGNATURES);
+        }
+    }
+    columns
+}
+
+/// Transaction-table columns needed for `mask`. Always includes `cn`/`ts`
+/// (small metadata); adds `td`, `sg`, `ef`, `ev`, `bc`, `ul` as the mask
+/// requires (and `td`/`ul` when object types must be resolved).
+pub(crate) fn transaction_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
+    use tables::transactions::col;
+    let mut columns = vec![col::CHECKPOINT_NUMBER, col::TIMESTAMP];
+
+    if mask
+        .subtree(ExecutedTransaction::TRANSACTION_FIELD.name)
+        .is_some()
+    {
+        columns.push(col::DATA);
+    }
+    if mask
+        .subtree(ExecutedTransaction::SIGNATURES_FIELD.name)
+        .is_some()
+    {
+        columns.push(col::SIGNATURES);
+    }
+    if let Some(effects_submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name) {
+        columns.push(col::EFFECTS);
+        let needs_objects = needs_object_types(mask);
+        if effects_submask.contains(TransactionEffects::UNCHANGED_LOADED_RUNTIME_OBJECTS_FIELD.name)
+            || needs_objects
+        {
+            columns.push(col::UNCHANGED_LOADED);
+        }
+        if needs_objects {
+            columns.push(col::DATA);
+        }
+    }
+    if mask
+        .subtree(ExecutedTransaction::EVENTS_FIELD.name)
+        .is_some()
+    {
+        columns.push(col::EVENTS);
+    }
+    if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name) {
+        columns.push(col::BALANCE_CHANGES);
+    }
+
+    columns
+}
+
+/// Transaction-table columns needed to resolve a checkpoint's transactions. The
+/// merge target (`full_checkpoint_content::ExecutedTransaction`) has non-Option
+/// `transaction`/`effects`, so `td`+`ef` are always fetched; object resolution
+/// also needs `ul`.
+pub(crate) fn list_transactions_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
+    use tables::transactions::col;
+    let mut columns = if let Some(submask) = mask.subtree(Checkpoint::TRANSACTIONS_FIELD.name) {
+        transaction_columns(&submask)
+    } else {
+        // Baseline metadata columns even if the proto `transactions` field
+        // isn't requested; we still need the rows to compute object keys.
+        vec![col::CHECKPOINT_NUMBER, col::TIMESTAMP]
+    };
+    // Required to construct the merge target faithfully.
+    for c in [col::DATA, col::EFFECTS] {
+        if !columns.contains(&c) {
+            columns.push(c);
+        }
+    }
+    if mask.contains(Checkpoint::OBJECTS_FIELD) && !columns.contains(&col::UNCHANGED_LOADED) {
+        columns.push(col::UNCHANGED_LOADED);
+    }
+    columns
+}

--- a/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
+++ b/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
@@ -1,25 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_kvstore::CheckpointData;
-use sui_kvstore::tables::checkpoints::col;
-use sui_kvstore::{BigTableClient, CHECKPOINTS_PIPELINE, KeyValueStoreReader};
+use sui_kvstore::{BigTableClient, CHECKPOINTS_PIPELINE, CheckpointData, KeyValueStoreReader};
 use sui_rpc::field::{FieldMask, FieldMaskTree, FieldMaskUtil};
-use sui_rpc::merge::Merge;
 use sui_rpc::proto::sui::rpc::v2::get_checkpoint_request::CheckpointId;
 use sui_rpc::proto::sui::rpc::v2::{Checkpoint, GetCheckpointRequest, GetCheckpointResponse};
 use sui_rpc_api::{
     CheckpointNotFoundError, ErrorReason, RpcError, proto::google::rpc::bad_request::FieldViolation,
 };
-use sui_storage::object_store::util::{build_object_store, fetch_checkpoint};
 use sui_types::digests::CheckpointDigest;
+
+use crate::bigtable_client::BigTableClient as LimitedBigTableClient;
+use crate::config::{PipelineStage, ResolvedStageConfig, StagesConfig};
+use crate::render;
+use crate::resolve;
 
 pub const READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::CHECKPOINT;
 
 pub async fn get_checkpoint(
     mut client: BigTableClient,
+    limited_client: LimitedBigTableClient,
+    stages: &StagesConfig,
     request: GetCheckpointRequest,
-    checkpoint_bucket: Option<String>,
 ) -> Result<GetCheckpointResponse, RpcError> {
     let read_mask = {
         let read_mask = request
@@ -32,7 +34,8 @@ pub async fn get_checkpoint(
         })?;
         FieldMaskTree::from(read_mask)
     };
-    let columns = checkpoint_columns(&read_mask);
+    let needs_full = resolve::needs_transactions_or_objects(&read_mask);
+    let columns = resolve::list_checkpoint_columns(&read_mask, needs_full);
     let checkpoint = match request.checkpoint_id {
         Some(CheckpointId::Digest(digest)) => {
             let digest = digest.parse::<CheckpointDigest>().map_err(|e| {
@@ -64,70 +67,47 @@ pub async fn get_checkpoint(
         }
     };
 
-    let message =
-        checkpoint_to_response(checkpoint, &read_mask, checkpoint_bucket.as_deref()).await?;
+    let message = if needs_full {
+        let transactions_stage = stages.stage(PipelineStage::Transactions);
+        let objects_stage = stages.stage(PipelineStage::Objects);
+        resolve_full_checkpoint(
+            limited_client,
+            checkpoint,
+            &read_mask,
+            transactions_stage,
+            objects_stage,
+        )
+        .await?
+    } else {
+        render::checkpoint_to_response(checkpoint, &read_mask)?
+    };
     Ok(GetCheckpointResponse::new(message))
 }
 
-/// Render a `CheckpointData` into the proto `Checkpoint`, populating fields
-/// according to `read_mask`. Shared by `get_checkpoint` and the
-/// v2alpha list-checkpoints handler.
-pub(crate) async fn checkpoint_to_response(
+/// Heavy path: resolve the checkpoint's transactions and (when requested)
+/// objects from BigTable, then render the full proto `Checkpoint`.
+async fn resolve_full_checkpoint(
+    limited_client: LimitedBigTableClient,
     checkpoint: CheckpointData,
     read_mask: &FieldMaskTree,
-    checkpoint_bucket: Option<&str>,
+    transactions_stage: ResolvedStageConfig,
+    objects_stage: ResolvedStageConfig,
 ) -> Result<Checkpoint, RpcError> {
-    let summary = checkpoint
+    let cp_seq = checkpoint
         .summary
-        .ok_or_else(|| anyhow::anyhow!("checkpoint summary missing"))?;
-    let sequence_number = summary.sequence_number;
-    let mut message = Checkpoint::default();
-    let summary: sui_sdk_types::CheckpointSummary = summary.try_into()?;
-    message.merge(&summary, read_mask);
+        .as_ref()
+        .map(|s| s.sequence_number)
+        .ok_or_else(|| RpcError::new(tonic::Code::Internal, "checkpoint summary column missing"))?;
 
-    if read_mask.contains(Checkpoint::SIGNATURE_FIELD) {
-        let signatures = checkpoint
-            .signatures
-            .ok_or_else(|| anyhow::anyhow!("checkpoint signatures missing"))?;
-        let signatures: sui_sdk_types::ValidatorAggregatedSignature = signatures.into();
-        message.merge(signatures, read_mask);
-    }
+    let (_, cp_data, txs, objects) = resolve::resolve_checkpoint(
+        limited_client,
+        read_mask,
+        transactions_stage,
+        objects_stage,
+        cp_seq,
+        checkpoint,
+    )
+    .await?;
 
-    if read_mask.contains(Checkpoint::CONTENTS_FIELD.name) {
-        let contents = checkpoint
-            .contents
-            .ok_or_else(|| anyhow::anyhow!("checkpoint contents missing"))?;
-        message.merge(
-            sui_sdk_types::CheckpointContents::try_from(contents)?,
-            read_mask,
-        );
-    }
-
-    if (read_mask.contains(Checkpoint::TRANSACTIONS_FIELD)
-        || read_mask.contains(Checkpoint::OBJECTS_FIELD))
-        && let Some(url) = checkpoint_bucket
-    {
-        let store = build_object_store(url, vec![]);
-        let checkpoint = fetch_checkpoint(&store, sequence_number).await?;
-
-        message.merge(&checkpoint, read_mask);
-    }
-
-    Ok(message)
-}
-
-/// Compute the set of BigTable columns needed for the given read mask.
-/// Always includes `s` (summary) since it provides sequence_number, digest, etc.
-/// Only includes `sg` (signatures) and `c` (contents) when needed.
-pub(crate) fn checkpoint_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
-    let mut columns = vec![col::SUMMARY];
-
-    if mask.contains(Checkpoint::SIGNATURE_FIELD) {
-        columns.push(col::SIGNATURES);
-    }
-    if mask.contains(Checkpoint::CONTENTS_FIELD) {
-        columns.push(col::CONTENTS);
-    }
-
-    columns
+    render::render_full_checkpoint(cp_data, txs, objects.as_ref(), read_mask)
 }

--- a/crates/sui-kv-rpc/src/v2/get_object.rs
+++ b/crates/sui-kv-rpc/src/v2/get_object.rs
@@ -15,8 +15,8 @@ use sui_rpc_api::{
 };
 use sui_types::storage::ObjectKey;
 
-use super::render_json;
 use crate::PackageResolver;
+use crate::render::render_json;
 
 pub const MAX_BATCH_REQUESTS: usize = 1000;
 

--- a/crates/sui-kv-rpc/src/v2/get_transaction.rs
+++ b/crates/sui-kv-rpc/src/v2/get_transaction.rs
@@ -1,29 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use mysten_common::ZipDebugEqIteratorExt;
-use std::collections::{BTreeSet, HashMap};
 use std::str::FromStr;
-use sui_kvstore::tables::transactions::col;
-use sui_kvstore::{BigTableClient, KeyValueStoreReader, TransactionData};
 use sui_rpc::field::{FieldMask, FieldMaskTree, FieldMaskUtil};
-use sui_rpc::merge::Merge;
 use sui_rpc::proto::sui::rpc::v2::{
-    BatchGetTransactionsRequest, BatchGetTransactionsResponse, Event, ExecutedTransaction,
-    GetTransactionRequest, GetTransactionResponse, GetTransactionResult, Transaction,
-    TransactionEffects, TransactionEvents, UserSignature,
+    BatchGetTransactionsRequest, BatchGetTransactionsResponse, ExecutedTransaction,
+    GetTransactionRequest, GetTransactionResponse, GetTransactionResult,
 };
 use sui_rpc_api::{
     ErrorReason, RpcError, TransactionNotFoundError,
-    proto::google::rpc::bad_request::FieldViolation, proto::timestamp_ms_to_proto,
+    proto::google::rpc::bad_request::FieldViolation,
 };
-use sui_types::base_types::{ObjectID, TransactionDigest};
-use sui_types::object::Object;
-use sui_types::storage::ObjectKey;
-use tracing::warn;
+use sui_types::base_types::TransactionDigest;
 
-use super::render_json;
-use crate::PackageResolver;
+use crate::bigtable_client::BigTableClient;
+use crate::config::{PipelineStage, StagesConfig};
+use crate::render::transaction_to_response;
+use crate::{PackageResolver, resolve};
 
 pub const MAX_BATCH_REQUESTS: usize = 200;
 pub const READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::TRANSACTION;
@@ -41,7 +34,8 @@ pub(crate) fn validate_read_mask(read_mask: Option<FieldMask>) -> Result<FieldMa
 }
 
 pub async fn get_transaction(
-    mut client: BigTableClient,
+    client: BigTableClient,
+    stages: &StagesConfig,
     request: GetTransactionRequest,
     resolver: &PackageResolver,
 ) -> Result<GetTransactionResponse, RpcError> {
@@ -61,25 +55,27 @@ pub async fn get_transaction(
 
     let read_mask = validate_read_mask(request.read_mask)?;
 
-    let columns = transaction_columns(&read_mask);
-    let mut response = client
-        .get_transactions_filtered(&[transaction_digest], Some(&columns))
-        .await?;
-    let transaction = response
-        .pop()
+    let transactions_stage = stages.stage(PipelineStage::Transactions);
+    let objects_stage = stages.stage(PipelineStage::Objects);
+    let mut resolved = resolve::resolve_transactions(
+        client,
+        vec![transaction_digest],
+        &read_mask,
+        transactions_stage,
+        objects_stage,
+    )
+    .await?;
+    let (transaction, objects) = resolved
+        .remove(&transaction_digest)
         .ok_or(TransactionNotFoundError(transaction_digest.into()))?;
-    let objects = if needs_object_types(&read_mask) {
-        fetch_object_map(&mut client, std::iter::once(&transaction)).await?
-    } else {
-        HashMap::new()
-    };
     Ok(GetTransactionResponse::new(
-        transaction_to_response(transaction, &read_mask, &objects, resolver).await?,
+        transaction_to_response(transaction, &read_mask, objects.as_ref(), resolver).await?,
     ))
 }
 
 pub async fn batch_get_transactions(
-    mut client: BigTableClient,
+    client: BigTableClient,
+    stages: &StagesConfig,
     BatchGetTransactionsRequest {
         digests, read_mask, ..
     }: BatchGetTransactionsRequest,
@@ -98,24 +94,22 @@ pub async fn batch_get_transactions(
         .iter()
         .map(|digest| TransactionDigest::from_str(digest))
         .collect::<Result<Vec<_>, _>>()?;
-    let columns = transaction_columns(&read_mask);
-    let response: HashMap<_, _> = client
-        .get_transactions_filtered(&digests, Some(&columns))
-        .await?
-        .into_iter()
-        .map(|tx| (tx.digest, tx))
-        .collect();
-
-    let objects = if needs_object_types(&read_mask) {
-        fetch_object_map(&mut client, response.values()).await?
-    } else {
-        HashMap::new()
-    };
+    let transactions_stage = stages.stage(PipelineStage::Transactions);
+    let objects_stage = stages.stage(PipelineStage::Objects);
+    let resolved = resolve::resolve_transactions(
+        client,
+        digests.clone(),
+        &read_mask,
+        transactions_stage,
+        objects_stage,
+    )
+    .await?;
 
     let mut transactions = Vec::with_capacity(digests.len());
     for digest in digests {
-        if let Some(tx) = response.get(&digest) {
-            match transaction_to_response(tx.clone(), &read_mask, &objects, resolver).await {
+        if let Some((tx, objects)) = resolved.get(&digest) {
+            match transaction_to_response(tx.clone(), &read_mask, objects.as_ref(), resolver).await
+            {
                 Ok(tx) => transactions.push(GetTransactionResult::new_transaction(tx)),
                 Err(err) => {
                     transactions.push(GetTransactionResult::new_error(err.into_status_proto()))
@@ -127,326 +121,4 @@ pub async fn batch_get_transactions(
         }
     }
     Ok(BatchGetTransactionsResponse::new(transactions))
-}
-
-pub(crate) async fn transaction_to_response(
-    source: TransactionData,
-    mask: &FieldMaskTree,
-    objects: &HashMap<ObjectKey, Object>,
-    resolver: &PackageResolver,
-) -> Result<ExecutedTransaction, RpcError> {
-    let mut message = ExecutedTransaction::default();
-
-    if mask.contains(ExecutedTransaction::DIGEST_FIELD.name) {
-        message.digest = Some(source.digest.to_string());
-    }
-
-    if let Some(submask) = mask.subtree(ExecutedTransaction::TRANSACTION_FIELD.name)
-        && let Some(tx_data) = &source.transaction_data
-    {
-        let transaction = sui_sdk_types::Transaction::try_from(tx_data.clone())?;
-        message.transaction = Some(Transaction::merge_from(transaction, &submask));
-    }
-
-    if let Some(submask) = mask.subtree(ExecutedTransaction::SIGNATURES_FIELD.name)
-        && let Some(sigs) = &source.signatures
-    {
-        message.signatures = sigs
-            .iter()
-            .map(|s| {
-                sui_sdk_types::UserSignature::try_from(s.clone())
-                    .map(|s| UserSignature::merge_from(s, &submask))
-            })
-            .collect::<Result<_, _>>()?;
-    }
-
-    if let Some(submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name)
-        && let Some(effects) = source.effects
-    {
-        let mut effects = TransactionEffects::merge_from(
-            &sui_sdk_types::TransactionEffects::try_from(effects)?,
-            &submask,
-        );
-        if submask.contains(TransactionEffects::UNCHANGED_LOADED_RUNTIME_OBJECTS_FIELD.name) {
-            effects.unchanged_loaded_runtime_objects = source
-                .unchanged_loaded_runtime_objects
-                .iter()
-                .map(Into::into)
-                .collect();
-        }
-        for changed_object in effects.changed_objects.iter_mut() {
-            let Ok(object_id) = changed_object.object_id().parse::<ObjectID>() else {
-                warn!(
-                    object_id = changed_object.object_id(),
-                    "failed to parse object_id in changed_objects"
-                );
-                continue;
-            };
-            let version = changed_object
-                .input_version_opt()
-                .unwrap_or_else(|| changed_object.output_version());
-            if let Some(object) = objects.get(&ObjectKey(object_id, version.into())) {
-                changed_object.set_object_type(object_type_to_string(object.into()));
-            }
-        }
-
-        for unchanged in effects.unchanged_consensus_objects.iter_mut() {
-            let Ok(object_id) = unchanged.object_id().parse::<ObjectID>() else {
-                warn!(
-                    object_id = unchanged.object_id(),
-                    "failed to parse object_id in unchanged_consensus_objects"
-                );
-                continue;
-            };
-            if let Some(object) = objects.get(&ObjectKey(object_id, unchanged.version().into())) {
-                unchanged.set_object_type(object_type_to_string(object.into()));
-            }
-        }
-
-        message.effects = Some(effects);
-    }
-
-    if let Some(submask) = mask.subtree(ExecutedTransaction::EVENTS_FIELD.name)
-        && let Some(events) = &source.events
-    {
-        message.events = Some(TransactionEvents::merge_from(events, &submask));
-
-        if let Some(event_mask) = submask.subtree(TransactionEvents::EVENTS_FIELD.name)
-            && event_mask.contains(Event::JSON_FIELD.name)
-            && let Some(proto_events) = message.events.as_mut()
-        {
-            for (proto_event, sui_event) in
-                proto_events.events.iter_mut().zip_debug_eq(&events.data)
-            {
-                proto_event.json = render_json(resolver, &sui_event.type_, &sui_event.contents)
-                    .await
-                    .map(Box::new);
-            }
-        }
-    }
-    if mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name) {
-        message.checkpoint = Some(source.checkpoint_number);
-    }
-    if mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name) {
-        message.timestamp = Some(timestamp_ms_to_proto(source.timestamp));
-    }
-
-    if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name) {
-        message.balance_changes = source.balance_changes.into_iter().map(Into::into).collect();
-    }
-
-    Ok(message)
-}
-
-/// Compute the set of BigTable columns needed for the given read mask.
-/// Always includes `cn` and `ts` (small metadata).
-/// Only includes `td`, `sg`, `ef`, `ev`, `bc`, and `ul` when the corresponding fields
-/// are in the mask.
-pub(crate) fn transaction_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
-    let mut columns = vec![col::CHECKPOINT_NUMBER, col::TIMESTAMP];
-
-    if mask
-        .subtree(ExecutedTransaction::TRANSACTION_FIELD.name)
-        .is_some()
-    {
-        columns.push(col::DATA);
-    }
-    if mask
-        .subtree(ExecutedTransaction::SIGNATURES_FIELD.name)
-        .is_some()
-    {
-        columns.push(col::SIGNATURES);
-    }
-    if let Some(effects_submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name) {
-        columns.push(col::EFFECTS);
-        let needs_objects = needs_object_types(mask);
-        if effects_submask.contains(TransactionEffects::UNCHANGED_LOADED_RUNTIME_OBJECTS_FIELD.name)
-            || needs_objects
-        {
-            columns.push(col::UNCHANGED_LOADED);
-        }
-        if needs_objects {
-            columns.push(col::DATA);
-        }
-    }
-    if mask
-        .subtree(ExecutedTransaction::EVENTS_FIELD.name)
-        .is_some()
-    {
-        columns.push(col::EVENTS);
-    }
-    if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name) {
-        columns.push(col::BALANCE_CHANGES);
-    }
-
-    columns
-}
-
-pub(crate) fn needs_object_types(mask: &FieldMaskTree) -> bool {
-    mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name)
-        .is_some_and(|submask| {
-            submask.contains(TransactionEffects::CHANGED_OBJECTS_FIELD.name)
-                || submask.contains(TransactionEffects::UNCHANGED_CONSENSUS_OBJECTS_FIELD.name)
-        })
-}
-
-pub(crate) fn compute_object_keys(source: &TransactionData) -> BTreeSet<ObjectKey> {
-    match (&source.transaction_data, &source.effects) {
-        (Some(tx_data), Some(effects)) => sui_types::storage::get_transaction_object_set(
-            tx_data,
-            effects,
-            &source.unchanged_loaded_runtime_objects,
-        ),
-        _ => BTreeSet::new(),
-    }
-}
-
-pub(crate) async fn fetch_object_map<'a>(
-    client: &mut BigTableClient,
-    transactions: impl Iterator<Item = &'a TransactionData>,
-) -> Result<HashMap<ObjectKey, Object>, RpcError> {
-    let keys: Vec<_> = transactions
-        .flat_map(compute_object_keys)
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect();
-    Ok(client
-        .get_objects(&keys)
-        .await?
-        .into_iter()
-        .map(|o| (ObjectKey(o.id(), o.version()), o))
-        .collect())
-}
-
-fn object_type_to_string(object_type: sui_types::base_types::ObjectType) -> String {
-    match object_type {
-        sui_types::base_types::ObjectType::Package => "package".to_owned(),
-        sui_types::base_types::ObjectType::Struct(move_object_type) => {
-            move_object_type.to_canonical_string(true)
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use move_core_types::account_address::AccountAddress;
-    use std::sync::Arc;
-    use sui_kvstore::TransactionData as KvTransactionData;
-    use sui_package_resolver::{Package, PackageStore, Resolver};
-    use sui_rpc::proto::sui::rpc::v2::BalanceChange as ProtoBalanceChange;
-    use sui_rpc::proto::sui::rpc::v2::ObjectReference;
-    use sui_types::TypeTag;
-    use sui_types::balance_change::BalanceChange;
-    use sui_types::base_types::{ObjectID, SuiAddress};
-    use sui_types::effects::TestEffectsBuilder;
-    use sui_types::object::Object;
-    use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-    use sui_types::storage::ObjectKey;
-    use sui_types::transaction::{
-        SenderSignedData, Transaction, TransactionData as SuiTransactionData,
-    };
-
-    use sui_types::digests::TransactionDigest;
-
-    fn test_tx_data() -> (TransactionDigest, SuiTransactionData) {
-        let sender = SuiAddress::random_for_testing_only();
-        let gas = Object::immutable_with_id_for_testing(ObjectID::random());
-        let pt = {
-            let mut builder = ProgrammableTransactionBuilder::new();
-            builder.transfer_sui(SuiAddress::random_for_testing_only(), None);
-            builder.finish()
-        };
-        let data = SuiTransactionData::new_programmable(
-            sender,
-            vec![gas.compute_object_reference()],
-            pt,
-            1_000_000,
-            1,
-        );
-        let tx = Transaction::new(SenderSignedData::new(data.clone(), vec![]));
-        (*tx.digest(), data)
-    }
-
-    /// Empty package store for tests that don't exercise JSON rendering.
-    struct EmptyPackageStore;
-
-    #[async_trait::async_trait]
-    impl PackageStore for EmptyPackageStore {
-        async fn fetch(&self, id: AccountAddress) -> sui_package_resolver::Result<Arc<Package>> {
-            Err(sui_package_resolver::error::Error::PackageNotFound(id))
-        }
-    }
-
-    fn test_resolver() -> PackageResolver {
-        let store: Arc<dyn PackageStore> = Arc::new(EmptyPackageStore);
-        Arc::new(Resolver::new(store))
-    }
-
-    #[tokio::test]
-    async fn transaction_to_response_returns_balance_changes_when_requested() {
-        let (digest, tx_data) = test_tx_data();
-        let tx = Transaction::new(SenderSignedData::new(tx_data.clone(), vec![]));
-        let effects = TestEffectsBuilder::new(tx.data()).build();
-        let balance_change = BalanceChange {
-            address: SuiAddress::random_for_testing_only(),
-            coin_type: TypeTag::U64,
-            amount: 42,
-        };
-        let source = KvTransactionData {
-            digest,
-            transaction_data: Some(tx_data),
-            signatures: Some(vec![]),
-            effects: Some(effects),
-            events: None,
-            checkpoint_number: 7,
-            timestamp: 42,
-            balance_changes: vec![balance_change.clone()],
-            unchanged_loaded_runtime_objects: vec![],
-        };
-        let mask = FieldMaskTree::from(FieldMask::from_str("balance_changes"));
-        let resolver = test_resolver();
-
-        let response = transaction_to_response(source, &mask, &HashMap::new(), &resolver)
-            .await
-            .expect("render should succeed");
-
-        assert_eq!(
-            response.balance_changes,
-            vec![ProtoBalanceChange::from(balance_change)]
-        );
-    }
-
-    #[tokio::test]
-    async fn transaction_to_response_returns_unchanged_loaded_runtime_objects_when_requested() {
-        let (digest, tx_data) = test_tx_data();
-        let tx = Transaction::new(SenderSignedData::new(tx_data.clone(), vec![]));
-        let effects = TestEffectsBuilder::new(tx.data()).build();
-        let obj_key = ObjectKey(ObjectID::random(), 3.into());
-        let source = KvTransactionData {
-            digest,
-            transaction_data: Some(tx_data),
-            signatures: Some(vec![]),
-            effects: Some(effects),
-            events: None,
-            checkpoint_number: 7,
-            timestamp: 42,
-            balance_changes: vec![],
-            unchanged_loaded_runtime_objects: vec![obj_key],
-        };
-        let mask = FieldMaskTree::from(FieldMask::from_str(
-            "effects.unchanged_loaded_runtime_objects",
-        ));
-        let resolver = test_resolver();
-
-        let response = transaction_to_response(source, &mask, &HashMap::new(), &resolver)
-            .await
-            .expect("render should succeed");
-
-        let effects = response.effects.expect("effects should be present");
-        assert_eq!(
-            effects.unchanged_loaded_runtime_objects,
-            vec![ObjectReference::from(&obj_key)]
-        );
-    }
 }

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::language_storage::StructTag;
 use sui_kvstore::{BigTableClient, KeyValueStoreReader};
 use sui_rpc::proto::sui::rpc::v2::{
     BatchGetObjectsRequest, BatchGetObjectsResponse, BatchGetTransactionsRequest,
@@ -13,32 +12,14 @@ use sui_rpc::proto::sui::rpc::v2::{
 use sui_rpc_api::proto::timestamp_ms_to_proto;
 use sui_rpc_api::{CheckpointNotFoundError, RpcError, ServerVersion};
 use sui_sdk_types::Digest;
-use sui_types::TypeTag;
 use sui_types::digests::ChainIdentifier;
-use sui_types::object::rpc_visitor::proto::ProtoVisitor;
 
-use crate::{KvRpcServer, PackageResolver};
+use crate::KvRpcServer;
 
 pub(crate) mod get_checkpoint;
 mod get_epoch;
 mod get_object;
 pub(crate) mod get_transaction;
-
-/// Maximum size in bytes for JSON-rendered Move values (1 MiB).
-const MAX_JSON_MOVE_VALUE_SIZE: usize = 1024 * 1024;
-
-/// Render a Move value as JSON using the package resolver for type layout.
-pub(crate) async fn render_json(
-    resolver: &PackageResolver,
-    struct_tag: &StructTag,
-    contents: &[u8],
-) -> Option<prost_types::Value> {
-    let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
-    let layout = resolver.type_layout(type_tag).await.ok()?;
-    ProtoVisitor::new(MAX_JSON_MOVE_VALUE_SIZE)
-        .deserialize_value(contents, &layout)
-        .ok()
-}
 
 #[tonic::async_trait]
 impl LedgerService for KvRpcServer {
@@ -97,7 +78,8 @@ impl LedgerService for KvRpcServer {
         request: tonic::Request<GetTransactionRequest>,
     ) -> Result<tonic::Response<GetTransactionResponse>, tonic::Status> {
         get_transaction::get_transaction(
-            self.client.clone(),
+            self.limited_client("GetTransaction"),
+            &self.stages,
             request.into_inner(),
             &self.package_resolver,
         )
@@ -111,7 +93,8 @@ impl LedgerService for KvRpcServer {
         request: tonic::Request<BatchGetTransactionsRequest>,
     ) -> Result<tonic::Response<BatchGetTransactionsResponse>, tonic::Status> {
         get_transaction::batch_get_transactions(
-            self.client.clone(),
+            self.limited_client("BatchGetTransactions"),
+            &self.stages,
             request.into_inner(),
             &self.package_resolver,
         )
@@ -126,8 +109,9 @@ impl LedgerService for KvRpcServer {
     ) -> Result<tonic::Response<GetCheckpointResponse>, tonic::Status> {
         get_checkpoint::get_checkpoint(
             self.client.clone(),
+            self.limited_client("GetCheckpoint"),
+            &self.stages,
             request.into_inner(),
-            self.checkpoint_bucket.clone(),
         )
         .await
         .map(tonic::Response::new)

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -13,22 +11,14 @@ use futures::stream;
 use futures::stream::BoxStream;
 use sui_kvstore::BitmapIndexSpec;
 use sui_kvstore::CheckpointData;
-use sui_kvstore::TransactionData;
 use sui_kvstore::tables;
 use sui_rpc::field::FieldMask;
 use sui_rpc::field::FieldMaskTree;
 use sui_rpc::field::FieldMaskUtil;
-use sui_rpc::merge::Merge;
 use sui_rpc::proto::sui::rpc::v2::Checkpoint;
 use sui_rpc_api::ErrorReason;
 use sui_rpc_api::RpcError;
 use sui_rpc_api::proto::google::rpc::bad_request::FieldViolation;
-use sui_types::digests::TransactionDigest;
-use sui_types::full_checkpoint_content::Checkpoint as FullCheckpoint;
-use sui_types::full_checkpoint_content::ExecutedTransaction as FullExecutedTransaction;
-use sui_types::full_checkpoint_content::ObjectSet;
-use sui_types::messages_checkpoint::CertifiedCheckpointSummary;
-use sui_types::storage::ObjectKey;
 use tracing::Instrument;
 use tracing::debug_span;
 use tracing::info;
@@ -36,20 +26,17 @@ use tracing::info;
 use crate::bigtable_client::BigTableClient;
 use crate::bigtable_client::stage;
 use crate::config::PipelineStage;
-use crate::object_cache::BigTableObjectFetcher;
-use crate::object_cache::ObjectCache;
-use crate::object_cache::ObjectMap;
 use crate::operation::QueryContext;
 use crate::pipeline::InputOrderEmitter;
 use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
 use crate::pipeline::pipelined_chunks;
-use crate::pipeline::pipelined_keyed_batches;
 use crate::pipeline::resolve_watermarks;
 use crate::pipeline::take_items;
-use crate::v2::get_checkpoint::checkpoint_columns;
-use crate::v2::get_transaction::compute_object_keys;
-use crate::v2::get_transaction::transaction_columns;
+use crate::render::render_full_checkpoint;
+use crate::resolve;
+use crate::resolve::list_checkpoint_columns;
+use crate::resolve::needs_transactions_or_objects;
 use sui_inverted_index::BitmapScanLimitExceeded;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::error_contains;
@@ -73,9 +60,6 @@ use sui_rpc::proto::sui::rpc::v2alpha::list_checkpoints_response;
 
 const READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::CHECKPOINT;
 
-type CpWithTxs = (u64, CheckpointData, Vec<TransactionData>);
-type ResolvedCp = (u64, CheckpointData, Vec<TransactionData>, ObjectMap);
-
 pub(crate) type ListCheckpointsStream =
     BoxStream<'static, Result<ListCheckpointsResponse, RpcError>>;
 
@@ -89,9 +73,9 @@ pub(crate) async fn list_checkpoints(
     let checkpoint_hi_exclusive = ctx.checkpoint_hi_exclusive();
     let lh = ctx.ledger_history();
     let endpoint = lh.list_checkpoints();
-    let checkpoints_stage = lh.stage(PipelineStage::Checkpoints);
-    let transactions_stage = lh.stage(PipelineStage::Transactions);
-    let objects_stage = lh.stage(PipelineStage::Objects);
+    let checkpoints_stage = ctx.stage(PipelineStage::Checkpoints);
+    let transactions_stage = ctx.stage(PipelineStage::Transactions);
+    let objects_stage = ctx.stage(PipelineStage::Objects);
 
     let checkpoint_range = CheckpointRange::from_request(
         request.start_checkpoint,
@@ -201,8 +185,7 @@ pub(crate) async fn list_checkpoints(
     };
 
     // Fast path: read_mask doesn't request transactions or objects → render
-    // directly from CheckpointData via the existing `checkpoint_to_response`
-    // (with `checkpoint_bucket = None`, the GCS branch is a no-op).
+    // directly from CheckpointData via the existing `checkpoint_to_response`.
     if !needs_full {
         let cp_data_stream = resolve_watermarks(cp_data_stream, client.tx_wm_resolver(direction));
         return Ok(async_stream::try_stream! {
@@ -217,8 +200,7 @@ pub(crate) async fn list_checkpoints(
                         let wm = item_watermark(&options, cp_seq, cp_seq, checkpoint_boundary);
                         emitted += 1;
                         let message =
-                            crate::v2::get_checkpoint::checkpoint_to_response(cp_data, &read_mask, None)
-                                .await?;
+                            crate::render::checkpoint_to_response(cp_data, &read_mask)?;
                         yield response_for(wm, message);
                     }
                     Ok(ResolvedWatermarked::Watermark { position: _, cp: raw_cp }) => {
@@ -275,85 +257,18 @@ pub(crate) async fn list_checkpoints(
     }
 
     // Heavy path: needs transactions and/or objects.
-    let tx_columns: Arc<[&'static str]> = list_transactions_columns(&read_mask).into();
-    let needs_objects = read_mask.contains(Checkpoint::OBJECTS_FIELD);
-
-    // Stage C: (cp_seq, CheckpointData) -> + Vec<TransactionData>. Batched
-    // across the chunk: gather ALL tx_digests across all cps in the chunk
-    // into one multi_get, route results back per-cp, then emit in input
-    // cp_seq order after the chunk drains.
-    let cp_with_txs_stream = pipelined_chunks(
+    let cp_full_stream = resolve::resolve_checkpoints(
+        client.clone(),
+        &read_mask,
+        transactions_stage,
+        objects_stage,
         cp_data_stream,
-        transactions_stage.chunk_size,
-        transactions_stage.concurrency,
-        {
-            let client = client.clone();
-            let columns = tx_columns.clone();
-            move |items| fetch_transactions_for_cps(client.clone(), columns.clone(), items)
-        },
     );
-
-    // Stage D: + ObjectMap. Per-cp object refs are precomputed, then
-    // `pipelined_keyed_batches` packs consecutive cps into batches whose
-    // deduped key union fits within `chunk_max`. The helper splits the per-batch fetch result back out
-    // per cp — `render_full_checkpoint` builds an `ObjectSet` by
-    // iterating the whole map, so each cp must see only its own keys.
-    let object_cache = ObjectCache::new(Arc::new(BigTableObjectFetcher::new(client.clone())));
-    let cp_full_stream: BoxStream<'static, Result<Watermarked<ResolvedCp>, anyhow::Error>> =
-        if needs_objects {
-            let cp_with_keys = cp_with_txs_stream
-                .map_ok(|m: Watermarked<CpWithTxs>| {
-                    m.map_item(|(cp_seq, cp_data, txs)| {
-                        let keys: Vec<ObjectKey> = txs
-                            .iter()
-                            .flat_map(compute_object_keys)
-                            .collect::<BTreeSet<_>>()
-                            .into_iter()
-                            .collect();
-                        ((cp_seq, cp_data, txs), keys)
-                    })
-                })
-                .boxed();
-            pipelined_keyed_batches(
-                cp_with_keys,
-                objects_stage.chunk_size,
-                objects_stage.chunk_size,
-                objects_stage.concurrency,
-                {
-                    let object_cache = object_cache.clone();
-                    move |keys| {
-                        let object_cache = object_cache.clone();
-                        async move {
-                            object_cache
-                                .get_many(keys)
-                                .await
-                                .map_err(anyhow::Error::new)
-                        }
-                    }
-                },
-            )
-            .map_ok(|m| {
-                m.map_item(|((cp_seq, cp_data, txs), objects)| (cp_seq, cp_data, txs, objects))
-            })
-            .boxed()
-        } else {
-            let empty: ObjectMap = Arc::new(HashMap::new());
-            cp_with_txs_stream
-                .map_ok(move |m: Watermarked<CpWithTxs>| {
-                    let empty = empty.clone();
-                    m.map_item(move |(cp_seq, cp_data, txs)| (cp_seq, cp_data, txs, empty.clone()))
-                })
-                .boxed()
-        };
-
     let cp_full_stream = resolve_watermarks(cp_full_stream, client.tx_wm_resolver(direction));
 
     // Stage E: sync render — build full_checkpoint_content::Checkpoint and
     // merge into the proto Checkpoint (CPU-only, no further IO).
     Ok(async_stream::try_stream! {
-        // Hold the cache for the lifetime of the response stream so in-flight
-        // object dispatches are aborted if the consumer drops the stream.
-        let _object_cache = object_cache;
         futures::pin_mut!(cp_full_stream);
         let mut emitted = 0usize;
         let mut checkpoint_boundary: Option<u64> = None;
@@ -363,13 +278,10 @@ pub(crate) async fn list_checkpoints(
                 Ok(ResolvedWatermarked::Item((cp_seq, cp_data, txs, objects))) => {
                     checkpoint_boundary = advance_checkpoint_boundary(checkpoint_boundary, cp_seq, &options);
                     let wm = item_watermark(&options, cp_seq, cp_seq, checkpoint_boundary);
-                    let response = render_full_checkpoint(
-                        (cp_seq, cp_data, txs, objects),
-                        &read_mask,
-                        wm,
-                    )?;
+                    let message =
+                        render_full_checkpoint(cp_data, txs, objects.as_ref(), &read_mask)?;
                     emitted += 1;
-                    yield response;
+                    yield response_for(wm, message);
                 }
                 Ok(ResolvedWatermarked::Watermark { position: _, cp: raw_cp }) => {
                     // See light-path arm — same clamp + boundary logic.
@@ -510,206 +422,6 @@ async fn fetch_checkpoint_data(
     .boxed())
 }
 
-async fn fetch_transactions_for_cps(
-    client: BigTableClient,
-    columns: Arc<[&'static str]>,
-    items: Vec<(u64, CheckpointData)>,
-) -> Result<BoxStream<'static, Result<CpWithTxs, anyhow::Error>>, anyhow::Error> {
-    if items.is_empty() {
-        return Ok(stream::empty().boxed());
-    }
-
-    let mut input_order: Vec<u64> = Vec::with_capacity(items.len());
-    let mut cp_data_by_seq: HashMap<u64, CheckpointData> = HashMap::with_capacity(items.len());
-    let mut expected_count: HashMap<u64, usize> = HashMap::with_capacity(items.len());
-    let mut digest_to_cp: HashMap<TransactionDigest, u64> = HashMap::new();
-    let mut txs_by_seq: HashMap<u64, Vec<TransactionData>> = HashMap::with_capacity(items.len());
-    let mut flat_digests: Vec<TransactionDigest> = Vec::new();
-
-    for (cp_seq, cp_data) in items {
-        let contents = cp_data
-            .contents
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("checkpoint {cp_seq} contents column missing"))?;
-        let cp_digests: Vec<_> = contents.iter().map(|d| d.transaction).collect();
-        expected_count.insert(cp_seq, cp_digests.len());
-        txs_by_seq.insert(cp_seq, Vec::with_capacity(cp_digests.len()));
-        for digest in &cp_digests {
-            digest_to_cp.insert(*digest, cp_seq);
-        }
-        flat_digests.extend(cp_digests);
-        input_order.push(cp_seq);
-        cp_data_by_seq.insert(cp_seq, cp_data);
-    }
-
-    // Empty checkpoints (zero transactions) generate no BigTable rows, so
-    // pre-collect them and release through the emitter before draining the
-    // tx stream — otherwise they'd never get emitted.
-    let empty_cps: Vec<u64> = input_order
-        .iter()
-        .copied()
-        .filter(|cp_seq| expected_count[cp_seq] == 0)
-        .collect();
-
-    // CRITICAL: never call `get_transactions_stream` with an empty digest
-    // list. `multi_get_stream` builds a ReadRowsRequest with
-    // `rows_limit = keys.len()`, and BigTable interprets `rows_limit = 0`
-    // as "no limit" — i.e. a full transactions-table scan. When every cp
-    // in this chunk is empty, fall back to an empty stream and let the
-    // pre-emit loop alone drive emission.
-    let tx_stream: BoxStream<'static, Result<(TransactionDigest, TransactionData), anyhow::Error>> =
-        if flat_digests.is_empty() {
-            stream::empty().boxed()
-        } else {
-            let column_filter = BigTableClient::column_filter(&columns);
-            client
-                .get_transactions_stream(flat_digests, Some(column_filter))
-                .await?
-                .boxed()
-        };
-
-    Ok(async_stream::try_stream! {
-        let mut emitter: InputOrderEmitter<u64, CpWithTxs> = InputOrderEmitter::new(input_order);
-        for cp_seq in empty_cps {
-            let cp_data = cp_data_by_seq.remove(&cp_seq).expect("cp_data entry present");
-            for v in emitter.push(
-                cp_seq,
-                (cp_seq, cp_data, Vec::new()),
-                "list_checkpoints: checkpoint transaction lookup",
-            )? {
-                yield v;
-            }
-        }
-        futures::pin_mut!(tx_stream);
-        while let Some(row) = tx_stream.next().await {
-            let (digest, tx) = row?;
-            let cp_seq = digest_to_cp.remove(&digest).ok_or_else(|| {
-                anyhow::anyhow!("list_checkpoints: unexpected transaction body row {digest}")
-            })?;
-            let cp_txs = txs_by_seq
-                .get_mut(&cp_seq)
-                .expect("txs_by_seq entry present");
-            cp_txs.push(tx);
-            if cp_txs.len() == expected_count[&cp_seq] {
-                let txs = txs_by_seq.remove(&cp_seq).expect("txs_by_seq entry");
-                let cp_data = cp_data_by_seq
-                    .remove(&cp_seq)
-                    .expect("cp_data entry present");
-                for v in emitter.push(
-                    cp_seq,
-                    (cp_seq, cp_data, txs),
-                    "list_checkpoints: checkpoint transaction lookup",
-                )? {
-                    yield v;
-                }
-            }
-        }
-        // Defensive: if BigTable returned fewer rows than requested, surface
-        // the missing digests as an internal error rather than emit a
-        // partial checkpoint downstream. cp_data_by_seq still containing
-        // entries means at least one cp's tx set was incomplete.
-        if !cp_data_by_seq.is_empty() {
-            // Build a per-cp report (got vs expected) to make production
-            // triage tractable — without it the error message alone gives
-            // no signal about which cps or how big the gap was.
-            let mut incomplete: Vec<(u64, usize, usize)> = cp_data_by_seq
-                .keys()
-                .map(|cp_seq| {
-                    let got = txs_by_seq.get(cp_seq).map(|v| v.len()).unwrap_or(0);
-                    let expected = expected_count.get(cp_seq).copied().unwrap_or(0);
-                    (*cp_seq, got, expected)
-                })
-                .collect();
-            incomplete.sort_unstable();
-            tracing::warn!(
-                incomplete_count = incomplete.len(),
-                ?incomplete,
-                "list_checkpoints: BigTable returned fewer transactions than requested (cp_seq, got, expected)"
-            );
-            Err(RpcError::new(
-                tonic::Code::Internal,
-                format!(
-                    "list_checkpoints: BigTable returned fewer transactions than requested for {} checkpoint(s)",
-                    incomplete.len()
-                ),
-            ))?;
-        }
-        for v in emitter.finish("list_checkpoints: missing selected checkpoint transactions")? {
-            yield v;
-        }
-    }
-    .boxed())
-}
-
-fn render_full_checkpoint(
-    item: ResolvedCp,
-    read_mask: &FieldMaskTree,
-    watermark: Watermark,
-) -> Result<ListCheckpointsResponse, RpcError> {
-    let (cp_seq, cp_data, txs, objects) = item;
-
-    let summary = cp_data.summary.ok_or_else(|| {
-        RpcError::new(
-            tonic::Code::Internal,
-            format!("checkpoint {cp_seq} summary column missing"),
-        )
-    })?;
-    let signatures = cp_data.signatures.ok_or_else(|| {
-        RpcError::new(
-            tonic::Code::Internal,
-            format!("checkpoint {cp_seq} signatures column missing"),
-        )
-    })?;
-    let contents = cp_data.contents.ok_or_else(|| {
-        RpcError::new(
-            tonic::Code::Internal,
-            format!("checkpoint {cp_seq} contents column missing"),
-        )
-    })?;
-
-    let executed_transactions = txs
-        .into_iter()
-        .map(|tx| {
-            let transaction = tx.transaction_data.ok_or_else(|| {
-                RpcError::new(
-                    tonic::Code::Internal,
-                    format!("transaction {} data column missing", tx.digest),
-                )
-            })?;
-            let effects = tx.effects.ok_or_else(|| {
-                RpcError::new(
-                    tonic::Code::Internal,
-                    format!("transaction {} effects column missing", tx.digest),
-                )
-            })?;
-            Ok::<_, RpcError>(FullExecutedTransaction {
-                transaction,
-                signatures: tx.signatures.unwrap_or_default(),
-                effects,
-                events: tx.events,
-                unchanged_loaded_runtime_objects: tx.unchanged_loaded_runtime_objects,
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let mut object_set = ObjectSet::default();
-    for (_, obj) in objects.iter() {
-        object_set.insert(obj.clone());
-    }
-
-    let full_checkpoint = FullCheckpoint {
-        summary: CertifiedCheckpointSummary::new_from_data_and_sig(summary, signatures),
-        contents,
-        transactions: executed_transactions,
-        object_set,
-    };
-
-    let mut message = Checkpoint::default();
-    message.merge(&full_checkpoint, read_mask);
-
-    Ok(response_for(watermark, message))
-}
-
 fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {
     let mut item = CheckpointItem::default();
     item.checkpoint = Some(message);
@@ -727,64 +439,6 @@ fn end_response(reason: QueryEndReason) -> ListCheckpointsResponse {
     let mut response = ListCheckpointsResponse::default();
     response.response = Some(list_checkpoints_response::Response::End(end));
     response
-}
-
-fn needs_transactions_or_objects(mask: &FieldMaskTree) -> bool {
-    mask.contains(Checkpoint::TRANSACTIONS_FIELD) || mask.contains(Checkpoint::OBJECTS_FIELD)
-}
-
-/// Columns to fetch from the checkpoints table. When transactions or
-/// objects are in the read mask we additionally need `signatures` (to
-/// reconstruct `CertifiedCheckpointSummary`) and `contents` (to enumerate
-/// each checkpoint's transaction digests).
-fn list_checkpoint_columns(mask: &FieldMaskTree, needs_full: bool) -> Vec<&'static str> {
-    let mut columns = checkpoint_columns(mask);
-    if needs_full {
-        if !columns.contains(&tables::checkpoints::col::CONTENTS) {
-            columns.push(tables::checkpoints::col::CONTENTS);
-        }
-        if !columns.contains(&tables::checkpoints::col::SIGNATURES) {
-            columns.push(tables::checkpoints::col::SIGNATURES);
-        }
-    }
-    columns
-}
-
-/// Columns to fetch from the transactions table for the heavy path. The
-/// merge target is `full_checkpoint_content::ExecutedTransaction`, whose
-/// `transaction: TransactionData` and `effects: TransactionEffects` fields
-/// are non-`Option` — even when the read mask only asks for
-/// `transactions.digest`, the merge reads `source.transaction.digest()` to
-/// produce the response, so we must always have data + effects available.
-/// Object resolution likewise needs data + effects + unchanged_loaded to
-/// derive `compute_object_keys`. Optional source fields (signatures,
-/// events, unchanged_loaded) are gated by the mask.
-fn list_transactions_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
-    let mut columns = if let Some(submask) = mask.subtree(Checkpoint::TRANSACTIONS_FIELD.name) {
-        transaction_columns(&submask)
-    } else {
-        // Baseline metadata columns even if the proto `transactions` field
-        // isn't requested; we still need the rows to compute object keys.
-        vec![
-            tables::transactions::col::CHECKPOINT_NUMBER,
-            tables::transactions::col::TIMESTAMP,
-        ]
-    };
-    // Required to construct the merge target faithfully — see fn doc.
-    for col in [
-        tables::transactions::col::DATA,
-        tables::transactions::col::EFFECTS,
-    ] {
-        if !columns.contains(&col) {
-            columns.push(col);
-        }
-    }
-    if mask.contains(Checkpoint::OBJECTS_FIELD)
-        && !columns.contains(&tables::transactions::col::UNCHANGED_LOADED)
-    {
-        columns.push(tables::transactions::col::UNCHANGED_LOADED);
-    }
-    columns
 }
 
 /// Filtered cp_seq discovery for `ListCheckpoints`. The tx-bitmap scan and
@@ -810,10 +464,7 @@ async fn filtered_checkpoint_seq_stream(
 
     let client = ctx.client();
     let query = ctx.transaction_filter_query(filter)?;
-    let chunk_max = ctx
-        .ledger_history()
-        .stage(PipelineStage::TxSeqDigest)
-        .chunk_size;
+    let chunk_max = ctx.stage(PipelineStage::TxSeqDigest).chunk_size;
 
     let tx_seq_stream = client.eval_bitmap_query_stream(
         query,

--- a/crates/sui-kv-rpc/src/v2alpha/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_events.rs
@@ -36,7 +36,7 @@ use crate::pipeline::Watermarked;
 use crate::pipeline::pipelined_chunks;
 use crate::pipeline::resolve_watermarks;
 use crate::pipeline::take_items;
-use crate::v2::render_json;
+use crate::render::render_json;
 use sui_inverted_index::BitmapScanLimitExceeded;
 use sui_inverted_index::error_contains;
 use sui_rpc_api::ledger_history::query_options::CheckpointRange;
@@ -73,8 +73,8 @@ pub(crate) async fn list_events(
     let checkpoint_hi_exclusive = ctx.checkpoint_hi_exclusive();
     let lh = ctx.ledger_history();
     let endpoint = lh.list_events();
-    let tx_seq_digest_stage = lh.stage(PipelineStage::TxSeqDigest);
-    let transactions_stage = lh.stage(PipelineStage::Transactions);
+    let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
+    let transactions_stage = ctx.stage(PipelineStage::Transactions);
 
     let checkpoint_range = CheckpointRange::from_request(
         request.start_checkpoint,

--- a/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
@@ -15,28 +15,25 @@ use sui_rpc::field::FieldMaskTree;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_rpc_api::RpcError;
 use sui_types::digests::TransactionDigest;
-use sui_types::storage::ObjectKey;
 use tracing::Instrument;
 use tracing::debug_span;
 use tracing::info;
 
 use crate::bigtable_client::BigTableClient;
 use crate::config::PipelineStage;
-use crate::object_cache::BigTableObjectFetcher;
-use crate::object_cache::ObjectCache;
 use crate::object_cache::ObjectMap;
 use crate::operation::QueryContext;
 use crate::pipeline::InputOrderEmitter;
 use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
 use crate::pipeline::pipelined_chunks;
-use crate::pipeline::pipelined_keyed_batches;
 use crate::pipeline::resolve_watermarks;
 use crate::pipeline::take_items;
-use crate::v2::get_transaction::compute_object_keys;
-use crate::v2::get_transaction::needs_object_types;
-use crate::v2::get_transaction::transaction_columns;
-use crate::v2::get_transaction::transaction_to_response;
+use crate::render::transaction_to_response;
+use crate::resolve;
+use crate::resolve::compute_object_keys;
+use crate::resolve::needs_object_types;
+use crate::resolve::transaction_columns;
 use crate::v2::get_transaction::validate_read_mask;
 use sui_inverted_index::BitmapScanLimitExceeded;
 use sui_inverted_index::error_contains;
@@ -73,9 +70,9 @@ pub(crate) async fn list_transactions(
     let checkpoint_hi_exclusive = ctx.checkpoint_hi_exclusive();
     let lh = ctx.ledger_history();
     let endpoint = lh.list_transactions();
-    let tx_seq_digest_stage = lh.stage(PipelineStage::TxSeqDigest);
-    let transactions_stage = lh.stage(PipelineStage::Transactions);
-    let objects_stage = lh.stage(PipelineStage::Objects);
+    let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
+    let transactions_stage = ctx.stage(PipelineStage::Transactions);
+    let objects_stage = ctx.stage(PipelineStage::Objects);
 
     let checkpoint_range = CheckpointRange::from_request(
         request.start_checkpoint,
@@ -236,44 +233,15 @@ pub(crate) async fn list_transactions(
     let txn_with_objects_stream: BoxStream<
         'static,
         Result<Watermarked<TransactionWithObjectsStreamItem>, anyhow::Error>,
-    > = if needs_objects {
-        let object_cache = ObjectCache::new(Arc::new(BigTableObjectFetcher::new(client.clone())));
-        let tx_with_keys = tx_stream
-            .map_ok(|m| {
-                m.map_item(|(seq, offset, tx)| {
-                    let keys: Vec<ObjectKey> = compute_object_keys(&tx).into_iter().collect();
-                    ((seq, offset, tx), keys)
-                })
-            })
-            .boxed();
-
-        pipelined_keyed_batches(
-            tx_with_keys,
-            objects_stage.chunk_size,
-            objects_stage.chunk_size,
-            objects_stage.concurrency,
-            move |keys| {
-                let object_cache = object_cache.clone();
-                async move {
-                    object_cache
-                        .get_many(keys)
-                        .await
-                        .map_err(anyhow::Error::new)
-                }
-            },
-        )
-        .map_ok(|m| m.map_item(|((seq, offset, tx), objects)| (seq, offset, tx, objects)))
-        .boxed()
-    } else {
-        // No object lookup needed — emit each tx with an empty ObjectMap.
-        tx_stream
-            .map_ok(|m| {
-                m.map_item(|(seq, offset, tx)| {
-                    (seq, offset, tx, Arc::new(HashMap::new()) as ObjectMap)
-                })
-            })
-            .boxed()
-    };
+    > = resolve::with_object_maps(
+        tx_stream,
+        client.clone(),
+        objects_stage,
+        needs_objects,
+        |(_, _, tx): &(u64, u32, TransactionData)| compute_object_keys(tx).into_iter().collect(),
+    )
+    .map_ok(|m| m.map_item(|((seq, offset, tx), objects)| (seq, offset, tx, objects)))
+    .boxed();
 
     let txn_with_objects_stream =
         resolve_watermarks(txn_with_objects_stream, client.tx_wm_resolver(direction));

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -886,6 +886,12 @@ impl BigTableClient {
         keys: Vec<Vec<u8>>,
         filter: Option<RowFilter>,
     ) -> Result<Vec<(Bytes, Vec<(Bytes, Bytes)>)>> {
+        // An empty key set must never reach `build_multi_get_request`: it would
+        // produce a `RowSet` with no keys/ranges and `rows_limit = 0`, which
+        // BigTable interprets as an unbounded full-table scan. Short-circuit.
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
         let request = self.build_multi_get_request(table_name, keys, filter);
         self.read_rows(request, table_name).await
     }
@@ -911,6 +917,12 @@ impl BigTableClient {
         keys: Vec<Vec<u8>>,
         filter: Option<RowFilter>,
     ) -> Result<futures::stream::BoxStream<'static, Result<(Bytes, Vec<(Bytes, Bytes)>)>>> {
+        // See `multi_get_internal`: an empty key set would be read as a
+        // full-table scan, so emit an empty stream instead of building a
+        // request.
+        if keys.is_empty() {
+            return Ok(futures::stream::empty().boxed());
+        }
         let request = self.build_multi_get_request(table_name, keys, filter);
         let stream = self.read_rows_stream(request, table_name).await?;
         Ok(stream.boxed())


### PR DESCRIPTION
## Description 

This migrates the point-get APIs to use the streaming, pipelined bigtable resolution code I wrote for the list_\* APIs. I am doing this for a few reasons.

1. The GetCheckpoint API was originally written to read full checkpoints from GCS instead of bigtable if txn/object contents read masks were set. None of the archival instances actually have wired this GCS dependency up, so these read masks were effectively unsupported. Since the pipelined code path has request-level concurrency limits and deduplicated object fetches, I feel like it's reasonable to just use bigtable as the only data source. 
2. The GetTransaction API had a bug where if a txn had no objects to resolve, it would do a full table scan of the object table instead of skipping the object resolution step. My pipelined implementation didn't have this bug. Plus reducing the code maintenance surface is just good. I also added a defensive check in the bigtable client code to no-op if someone passes an empty key slice into the multi-get method, because that was genuinely surprising/confusing behavior. If we ever want to support a full table scan for some reason, we should make it an explicit method on the client.


## Test plan 

There are lots of unit tests, and the latency of the streaming code should be strictly better than the old implementation (which we have more or less verified with our graphql integration work).
