### PR TITLE
[1/5] Add ExecutionRetryError plumbing from execution to authority

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -169,7 +169,8 @@ impl EpochState {
                 signer,
                 tx_digest,
                 &mut None,
-            );
+            )
+            .expect("simulacrum execution does not produce retry errors");
         Ok((inner_temp_store, gas_status, effects, result))
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -69,6 +69,7 @@ use std::{
 use sui_config::NodeConfig;
 use sui_config::node::{AuthorityOverloadConfig, StateDebugDumpConfig};
 use sui_execution::Executor;
+use sui_execution::executor::TransactionEffectsOutput;
 use sui_protocol_config::Chain;
 use sui_protocol_config::PerObjectCongestionControlMode;
 use sui_types::accumulator_root::AccumulatorObjId;
@@ -1877,13 +1878,7 @@ impl AuthorityState {
         rewritten_inputs: Option<Vec<bool>>,
         signer: SuiAddress,
         tx_digest: TransactionDigest,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
-    ) {
+    ) -> TransactionEffectsOutput<ExecutionError> {
         let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
             // TODO only run this function on FullNodes, use `execute_transaction_to_effects` on validators.
             .execute_transaction_to_effects_and_execution_error(
@@ -1902,7 +1897,9 @@ impl AuthorityState {
                 signer,
                 tx_digest,
                 &mut None,
-            );
+            )
+            // TODO: handle the retry request here. No native produces one yet, so assume it never trips.
+            .expect("transaction retry is not yet handled");
 
         (
             inner_temp_store,

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -936,7 +936,8 @@ fn create_genesis_transaction(
                 signer,
                 genesis_digest,
                 &mut None,
-            );
+            )
+            .expect("genesis execution does not produce retry errors");
         assert!(inner_temp_store.input_objects.is_empty());
         assert!(inner_temp_store.mutable_inputs.is_empty());
         assert!(effects.mutated().is_empty());

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -147,7 +147,8 @@ pub fn execute_transaction_to_effects(
             txn_data.sender(),
             digest,
             trace_builder_opt,
-        );
+        )
+        .expect("replay execution does not produce retry errors");
     let ReplayStore {
         object_cache,
         checkpoint: _,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -809,7 +809,8 @@ impl LocalExec {
                 tx_info.sender,
                 *tx_digest,
                 &mut None,
-            );
+            )
+            .expect("replay execution does not produce retry errors");
 
         if let Err(err) = self.pretty_print_for_tracing(
             &gas_status,
@@ -1005,7 +1006,8 @@ impl LocalExec {
                 signer,
                 *executable.digest(),
                 &mut None,
-            );
+            )
+            .expect("replay execution does not produce retry errors");
 
         let effects =
             SuiTransactionBlockEffects::try_from(effects).map_err(ReplayEngineError::from)?;

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -207,8 +207,10 @@ impl SingleValidator {
         )
         .unwrap();
         let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
-        let (inner_temp_store, _, effects, _timings, _) =
-            self.epoch_store.executor().execute_transaction_to_effects(
+        let (inner_temp_store, _, effects, _timings, _) = self
+            .epoch_store
+            .executor()
+            .execute_transaction_to_effects(
                 &store,
                 self.epoch_store.protocol_config(),
                 self.get_validator().metrics.execution_metrics.clone(),
@@ -224,7 +226,8 @@ impl SingleValidator {
                 signer,
                 *executable.digest(),
                 &mut None,
-            );
+            )
+            .expect("benchmark execution does not produce retry errors");
         assert!(effects.status().is_ok());
         store.commit_objects(inner_temp_store);
         effects

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -740,7 +740,8 @@ mod test {
                 signer,
                 genesis_digest,
                 &mut None,
-            );
+            )
+            .expect("genesis execution does not produce retry errors");
 
         assert_eq!(&effects, genesis.effects());
     }

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -384,6 +384,31 @@ impl ExecutionTiming {
 
 pub type ResultWithTimings<R, E> = Result<(R, Vec<ExecutionTiming>), (E, Vec<ExecutionTiming>)>;
 
+/// Signals that transaction execution should be retried later rather than committed. Unlike
+/// `ExecutionError` it produces no effects; an enum so more retry reasons can be added.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionRetryError {
+    /// A system object the transaction needs to read was not yet available at the version this
+    /// transaction requires (its latest committed version had not caught up). The transaction
+    /// should be retried once that object reaches the required version.
+    SystemObjectUnavailable { object_id: ObjectID },
+}
+
+impl std::fmt::Display for ExecutionRetryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExecutionRetryError::SystemObjectUnavailable { object_id } => {
+                write!(
+                    f,
+                    "system object {object_id} not yet available; retry requested"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ExecutionRetryError {}
+
 /// Captures the output of executing a transaction in the execution driver.
 #[derive(Debug)]
 pub enum ExecutionOutput<T> {

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -14,7 +14,7 @@ use crate::base_types::{
 use crate::committee::EpochId;
 use crate::effects::{TransactionEffects, TransactionEffectsAPI};
 use crate::error::{ExecutionError, SuiError, SuiErrorKind};
-use crate::execution::{DynamicallyLoadedObjectMetadata, ExecutionResults};
+use crate::execution::{DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionRetryError};
 use crate::full_checkpoint_content::ObjectSet;
 use crate::message_envelope::Message;
 use crate::move_package::MovePackage;
@@ -244,6 +244,18 @@ pub trait Storage {
     ) -> DenyListResult;
 
     fn record_generated_object_ids(&mut self, generated_ids: BTreeSet<ObjectID>);
+
+    /// The retry request recorded during execution, if any. Defaults to `None`. Only the latest
+    /// `TemporaryStore` records one; the v0..=v3 stores never request a retry, so the default lets
+    /// them satisfy this trait without touching those adapters.
+    fn take_retry_request(&mut self) -> Option<ExecutionRetryError> {
+        None
+    }
+
+    /// Non-consuming peek for the commit-path assertion. Defaults to `false`.
+    fn has_retry_request(&self) -> bool {
+        false
+    }
 }
 
 pub type PackageFetchResults<Package> = Result<Vec<Package>, Vec<ObjectID>>;

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -63,13 +63,13 @@ mod checked {
     };
     use sui_types::effects::TransactionEffects;
     use sui_types::error::{ExecutionError, ExecutionErrorTrait};
-    use sui_types::execution::{ExecutionTiming, ResultWithTimings};
+    use sui_types::execution::{ExecutionRetryError, ExecutionTiming, ResultWithTimings};
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
     use sui_types::id::UID;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
-    use sui_types::storage::BackingStore;
+    use sui_types::storage::{BackingStore, Storage};
     #[cfg(msim)]
     use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result_for;
     use sui_types::sui_system_state::{ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME, AdvanceEpochParams};
@@ -281,13 +281,16 @@ mod checked {
         enable_expensive_checks: bool,
         execution_params: ExecutionOrEarlyError,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<Mode::ExecutionResults, Mode::Error>,
-    ) {
+    ) -> Result<
+        (
+            InnerTemporaryStore,
+            SuiGasStatus,
+            TransactionEffects,
+            Vec<ExecutionTiming>,
+            Result<Mode::ExecutionResults, Mode::Error>,
+        ),
+        ExecutionRetryError,
+    > {
         let input_objects = input_objects.into_inner();
         let mutable_inputs = if enable_expensive_checks {
             input_objects.all_mutable_inputs().keys().copied().collect()
@@ -339,13 +342,13 @@ mod checked {
                 *epoch_id,
             );
 
-            return (
+            return Ok((
                 inner,
                 gas_meter.into_gas_status(),
                 effects,
                 vec![],
                 Err(execution_error),
-            );
+            ));
         }
 
         let sponsor = {
@@ -414,6 +417,13 @@ mod checked {
             trace_builder_opt,
             is_gasless,
             &input_reservations,
+        )?;
+
+        // Defense in depth: `execute_transaction` returns early on a retry, so none can be
+        // outstanding here.
+        debug_assert!(
+            !temporary_store.has_retry_request(),
+            "retry request must be consumed before building effects"
         );
 
         let status = if let Err(error) = &execution_result {
@@ -521,13 +531,13 @@ mod checked {
             });
         }
 
-        (
+        Ok((
             inner,
             gas_charger.into_gas_status(),
             effects,
             timings,
             execution_result,
-        )
+        ))
     }
 
     pub fn execute_genesis_state_update(
@@ -566,6 +576,14 @@ mod checked {
         Ok(temporary_store.into_inner(BTreeMap::new()))
     }
 
+    /// The non-retry output of `execute_transaction`: the gas cost summary, the execution status,
+    /// and the per-command execution timings.
+    type GasAndExecutionResult<Mode> = (
+        GasCostSummary,
+        Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
+        Vec<ExecutionTiming>,
+    );
+
     #[instrument(name = "tx_execute", level = "debug", skip_all)]
     fn execute_transaction<Mode: ExecutionMode>(
         store: &dyn BackingStore,
@@ -582,11 +600,7 @@ mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         is_gasless: bool,
         input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
-    ) -> (
-        GasCostSummary,
-        Result<Mode::ExecutionResults, Mode::Error>,
-        Vec<ExecutionTiming>,
-    ) {
+    ) -> Result<GasAndExecutionResult<Mode>, ExecutionRetryError> {
         // At this point no charges have been applied yet
         debug_assert!(
             gas_charger.no_charges(),
@@ -605,15 +619,13 @@ mod checked {
 
         // We must charge object read here during transaction execution, because if this fails
         // we must still ensure an effect is committed and all objects versions incremented
-        let result = gas_charger.charge_input_objects(temporary_store);
+        let charge_result = gas_charger.charge_input_objects(temporary_store);
 
-        let result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> =
-            result.map_err(|e| (e.into(), vec![])).and_then(
-                |()| -> ResultWithTimings<Mode::ExecutionResults, Mode::Error> {
-                    let mut execution_result: ResultWithTimings<
-                        Mode::ExecutionResults,
-                        Mode::Error,
-                    > = match execution_params.into_early_errors() {
+        let result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> = match charge_result {
+            Err(e) => Err((e.into(), vec![])),
+            Ok(()) => {
+                let mut execution_result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> =
+                    match execution_params.into_early_errors() {
                         Some(early_execution_errors) => {
                             Err((Mode::Error::from_kind(early_execution_errors.head), vec![]))
                         }
@@ -631,31 +643,37 @@ mod checked {
                         ),
                     };
 
-                    let meter_check = check_meter_limit::<Mode>(
+                // If a native requested a retry, bail out here — before any gas, metering, or
+                // effects — so nothing is committed and the transaction is rescheduled.
+                if let Some(reason) = temporary_store.take_retry_request() {
+                    return Err(reason);
+                }
+
+                let meter_check = check_meter_limit::<Mode>(
+                    temporary_store,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                );
+                if let Err(e) = meter_check {
+                    execution_result = Err((e, vec![]));
+                }
+
+                if execution_result.is_ok() {
+                    let gas_check = check_written_objects_limit::<Mode>(
                         temporary_store,
                         gas_charger,
                         protocol_config,
-                        metrics.clone(),
+                        metrics,
                     );
-                    if let Err(e) = meter_check {
+                    if let Err(e) = gas_check {
                         execution_result = Err((e, vec![]));
                     }
+                }
 
-                    if execution_result.is_ok() {
-                        let gas_check = check_written_objects_limit::<Mode>(
-                            temporary_store,
-                            gas_charger,
-                            protocol_config,
-                            metrics,
-                        );
-                        if let Err(e) = gas_check {
-                            execution_result = Err((e, vec![]));
-                        }
-                    }
-
-                    execution_result
-                },
-            );
+                execution_result
+            }
+        };
 
         let (mut result, timings) = match result {
             Ok((r, t)) => (Ok(r), t),
@@ -716,7 +734,7 @@ mod checked {
             result = Err(e);
         }
 
-        (cost_summary, result, timings)
+        Ok((cost_summary, result, timings))
     }
 
     #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -6,6 +6,7 @@ use crate::gas_charger::{GasCharger, PaymentLocation};
 use mysten_common::{ZipDebugEqIteratorExt, debug_fatal};
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::accumulator_event::AccumulatorEvent;
@@ -18,7 +19,8 @@ use sui_types::effects::{
     TransactionEvents,
 };
 use sui_types::execution::{
-    DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV2, SharedInput,
+    DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV2, ExecutionRetryError,
+    SharedInput,
 };
 use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
 use sui_types::inner_temporary_store::InnerTemporaryStore;
@@ -96,6 +98,12 @@ pub struct TemporaryStore<'backing> {
     /// underlying events are also cleared. A `Vec` is sufficient because real transactions run
     /// the PTB at most a handful of times.
     ptb_emitted_accumulator_event_ranges: Vec<std::ops::Range<usize>>,
+
+    /// Recorded when execution determines the transaction must be retried later rather than
+    /// committed; checked before gas finalization. A `RefCell` rather than a lock: execution is
+    /// single-threaded, but the condition is detected behind `&self` (`ChildObjectResolver`) so the
+    /// field must be interior-mutable.
+    retry_request: RefCell<Option<ExecutionRetryError>>,
 }
 
 impl<'backing> TemporaryStore<'backing> {
@@ -150,6 +158,7 @@ impl<'backing> TemporaryStore<'backing> {
             cur_epoch,
             loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
             ptb_emitted_accumulator_event_ranges: Vec::new(),
+            retry_request: RefCell::new(None),
         }
     }
 
@@ -1717,6 +1726,14 @@ impl Storage for TemporaryStore<'_> {
 
     fn record_generated_object_ids(&mut self, generated_ids: BTreeSet<ObjectID>) {
         TemporaryStore::save_generated_object_ids(self, generated_ids)
+    }
+
+    fn take_retry_request(&mut self) -> Option<ExecutionRetryError> {
+        self.retry_request.borrow_mut().take()
+    }
+
+    fn has_retry_request(&self) -> bool {
+        self.retry_request.borrow().is_some()
     }
 }
 

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -14,7 +14,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::ExecutionError,
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionRetryError, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -22,6 +22,16 @@ use sui_types::{
     metrics::ExecutionMetrics,
     transaction::{CheckedInputObjects, ProgrammableTransaction, TransactionKind},
 };
+
+/// Output of executing a transaction to effects: temporary store, gas status, effects, per-command
+/// timings, and the execution status (`E` is the error detail type).
+pub type TransactionEffectsOutput<E> = (
+    InnerTemporaryStore,
+    SuiGasStatus,
+    TransactionEffects,
+    Vec<ExecutionTiming>,
+    Result<(), E>,
+);
 
 /// Abstracts over access to the VM across versions of the execution layer.
 pub trait Executor {
@@ -47,13 +57,7 @@ pub trait Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionFailure>,
-    );
+    ) -> Result<TransactionEffectsOutput<ExecutionFailure>, ExecutionRetryError>;
 
     /// Execution mode returns greater error information, primarily used in fullnode execution
     /// as opposed to `execute_transaction_to_effects` which only includes basic `ExecutionFailure` error.
@@ -74,13 +78,7 @@ pub trait Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
-    );
+    ) -> Result<TransactionEffectsOutput<ExecutionError>, ExecutionRetryError>;
 
     fn dev_inspect_transaction(
         &self,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -6,7 +6,6 @@ use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
-use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
@@ -15,7 +14,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, ExecutionErrorTrait, SuiError, SuiResult},
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionRetryError, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -80,13 +79,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionFailure>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionFailure>, ExecutionRetryError> {
         let (store_out, gas_status_out, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
                 store,
@@ -105,11 +98,11 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
                 trace_builder_opt,
-            );
+            )?;
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        (store_out, gas_status_out, effects, timings, result)
+        Ok((store_out, gas_status_out, effects, timings, result))
     }
 
     fn execute_transaction_to_effects_and_execution_error(
@@ -129,13 +122,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionError>, ExecutionRetryError> {
         let (store_out, gas_status_out, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
                 store,
@@ -154,11 +141,11 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
                 trace_builder_opt,
-            );
+            )?;
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        (store_out, gas_status_out, effects, timings, result)
+        Ok((store_out, gas_status_out, effects, timings, result))
     }
 
     fn dev_inspect_transaction(
@@ -222,7 +209,8 @@ impl executor::Executor for Executor {
                 execution_params,
                 &mut None,
             )
-        };
+        }
+        .expect("dev-inspect execution does not produce retry errors");
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -7,7 +7,6 @@ use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use sui_protocol_config::ProtocolConfig;
-use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
@@ -16,7 +15,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, SuiError, SuiResult},
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionRetryError, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -80,13 +79,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         _trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionFailure>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionFailure>, ExecutionRetryError> {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -109,13 +102,13 @@ impl executor::Executor for Executor {
             log_execution_error(transaction_digest, error);
         }
         // note: old versions do not report timings.
-        (
+        Ok((
             inner_temp_store,
             gas_status,
             effects,
             vec![],
             result.map_err(ExecutionFailure::from),
-        )
+        ))
     }
 
     fn dev_inspect_transaction(
@@ -200,13 +193,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         _trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionError>, ExecutionRetryError> {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -228,7 +215,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        (inner_temp_store, gas_status, effects, vec![], result)
+        Ok((inner_temp_store, gas_status, effects, vec![], result))
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -7,7 +7,6 @@ use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use sui_protocol_config::ProtocolConfig;
-use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
@@ -16,7 +15,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, SuiError, SuiResult},
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionRetryError, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -80,13 +79,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         _trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionFailure>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionFailure>, ExecutionRetryError> {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -109,13 +102,13 @@ impl executor::Executor for Executor {
             log_execution_error(transaction_digest, error);
         }
         // note: old versions do not report timings.
-        (
+        Ok((
             inner_temp_store,
             gas_status,
             effects,
             vec![],
             result.map_err(ExecutionFailure::from),
-        )
+        ))
     }
 
     fn dev_inspect_transaction(
@@ -200,13 +193,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         _trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionError>, ExecutionRetryError> {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -228,7 +215,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        (inner_temp_store, gas_status, effects, vec![], result)
+        Ok((inner_temp_store, gas_status, effects, vec![], result))
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -7,7 +7,6 @@ use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use sui_protocol_config::ProtocolConfig;
-use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
@@ -16,7 +15,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, SuiError, SuiResult},
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionRetryError, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -80,13 +79,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         _trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionFailure>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionFailure>, ExecutionRetryError> {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -109,13 +102,13 @@ impl executor::Executor for Executor {
             log_execution_error(transaction_digest, error);
         }
         // note: old versions do not report timings.
-        (
+        Ok((
             inner_temp_store,
             gas_status,
             effects,
             vec![],
             result.map_err(ExecutionFailure::from),
-        )
+        ))
     }
 
     fn dev_inspect_transaction(
@@ -200,13 +193,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         _trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionError>, ExecutionRetryError> {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -228,7 +215,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        (inner_temp_store, gas_status, effects, vec![], result)
+        Ok((inner_temp_store, gas_status, effects, vec![], result))
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -6,7 +6,6 @@ use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
-use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
@@ -15,7 +14,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, SuiError, SuiResult},
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionRetryError, TypeLayoutStore},
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     layout_resolver::LayoutResolver,
@@ -80,13 +79,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionFailure>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionFailure>, ExecutionRetryError> {
         let (inner_temp_store, gas_status, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
                 store,
@@ -108,13 +101,13 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
-        (
+        Ok((
             inner_temp_store,
             gas_status,
             effects,
             timings,
             result.map_err(ExecutionFailure::from),
-        )
+        ))
     }
 
     fn execute_transaction_to_effects_and_execution_error(
@@ -134,13 +127,7 @@ impl executor::Executor for Executor {
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
-    ) {
+    ) -> Result<executor::TransactionEffectsOutput<ExecutionError>, ExecutionRetryError> {
         let (inner_temp_store, gas_status, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
                 store,
@@ -162,7 +149,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
-        (inner_temp_store, gas_status, effects, timings, result)
+        Ok((inner_temp_store, gas_status, effects, timings, result))
     }
 
     fn dev_inspect_transaction(


### PR DESCRIPTION
## Description

Base of the stack. Threads a transaction-retry signal out of execution to the authority, so a native can later request that a transaction be retried later rather than committed.

Plumbing only — nothing requests a retry on this branch. The temporary store owns an interior-mutable retry flag (`ExecutionRetryError::SystemObjectUnavailable { object_id }`); execution checks it before any gas or effects, so the transaction bails without side effects, and the error is threaded out of the executor to the authority (which `expect()`s it for now — generic handling arrives in 3/5).

## Stack

1/5 #27003 — `ExecutionRetryError` plumbing from execution to authority
2/5 #27019 — rename `ChildObjectResolver` → `RuntimeObjectResolver`
3/5 #27036 — waitable system object framework
4/5 #27037 — record read system objects in effects
5/5 #27038 — check object funds withdraw sufficiency in the Move VM

## Test plan

No behavior change: the retry flag is never set on this branch, so the early bail-out is unreachable. The executor signature change is exercised by existing execution paths across `sui-core`, `sui-replay`, `simulacrum`, and genesis.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
