### PR TITLE
Return 404 on pruned epoch

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_epoch.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_epoch.rs
@@ -57,6 +57,15 @@ async fn get_epoch() {
         .epoch
         .unwrap();
     assert!(epoch.system_state.is_some());
+
+    let status = client
+        .get_epoch(
+            GetEpochRequest::new(latest_epoch.epoch.unwrap() + 1000)
+                .with_read_mask(FieldMask::from_str("*")),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::NotFound);
 }
 
 #[sim_test]

--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -413,3 +413,28 @@ impl From<CheckpointNotFoundError> for crate::RpcError {
         Self::new(tonic::Code::NotFound, value.to_string())
     }
 }
+
+#[derive(Debug)]
+pub struct EpochNotFoundError {
+    epoch: sui_sdk_types::EpochId,
+}
+
+impl EpochNotFoundError {
+    pub fn new(epoch: sui_sdk_types::EpochId) -> Self {
+        Self { epoch }
+    }
+}
+
+impl std::fmt::Display for EpochNotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Epoch {} not found", self.epoch)
+    }
+}
+
+impl std::error::Error for EpochNotFoundError {}
+
+impl From<EpochNotFoundError> for crate::RpcError {
+    fn from(value: EpochNotFoundError) -> Self {
+        Self::new(tonic::Code::NotFound, value.to_string())
+    }
+}

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_epoch.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_epoch.rs
@@ -4,6 +4,7 @@
 use crate::ErrorReason;
 use crate::Result;
 use crate::RpcService;
+use crate::error::EpochNotFoundError;
 use prost_types::FieldMask;
 use sui_rpc::field::FieldMaskTree;
 use sui_rpc::field::FieldMaskUtil;
@@ -40,16 +41,22 @@ pub fn get_epoch(service: &RpcService, request: GetEpochRequest) -> Result<GetEp
 
     let epoch = request.epoch.unwrap_or(current_epoch);
 
-    if read_mask.contains(Epoch::EPOCH_FIELD.name) {
-        message.set_epoch(epoch);
-    }
-
     // Fetch epoch info, if indexing is available.
     let mut epoch_info = service
         .reader
         .inner()
         .indexes()
-        .and_then(|indexes| indexes.get_epoch_info(epoch).ok().flatten());
+        .map(|indexes| indexes.get_epoch_info(epoch))
+        .transpose()?
+        .flatten();
+
+    if epoch != current_epoch && epoch_info.is_none() {
+        return Err(EpochNotFoundError::new(epoch).into());
+    }
+
+    if read_mask.contains(Epoch::EPOCH_FIELD.name) {
+        message.set_epoch(epoch);
+    }
 
     let system_state = if epoch == current_epoch {
         Some(current_system_state)


### PR DESCRIPTION
## Description

Returning a 404 instead of a stub on pruned and future epochs
