### PR TITLE
Downgrade MVCC root-version stabilization check to non-invariant

### DIFF
--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -55,9 +55,9 @@ use dashmap::mapref::entry::Entry as DashMapEntry;
 use futures::{FutureExt, future::BoxFuture};
 use moka::sync::SegmentedCache as MokaCache;
 use mysten_common::ZipDebugEqIteratorExt;
-use mysten_common::debug_fatal;
 use mysten_common::random_util::randomize_cache_capacity_in_tests;
 use mysten_common::sync::notify_read::NotifyRead;
+use mysten_common::{debug_fatal, debug_fatal_no_invariant};
 use parking_lot::Mutex;
 use rayon::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -1439,7 +1439,7 @@ impl AccountFundsRead for WritebackCache {
                     .version();
             if pre_root_version == post_root_version {
                 if loop_iter > 3 {
-                    debug_fatal!(
+                    debug_fatal_no_invariant!(
                         "Root version stabilized after {} iterations during MVCC read",
                         loop_iter
                     );


### PR DESCRIPTION
## Description

The `loop_iter > 3` warning in the accumulator MVCC read loop is a should-not-happen condition, but a high number of root-version retries reflects contention rather than a broken system invariant. Switch it to `debug_fatal_no_invariant!` so it still crashes in debug/test builds but is not counted against the `system_invariant_violations` metric in production.

## Test plan

Covered by existing `sui-core` execution-cache tests; behavior is unchanged outside of the production metric/log path.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: