### PR TITLE
[adapter] Add `PackagePayload` enum

### DIFF
--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -12,7 +12,10 @@ use crate::{
     static_programmable_transactions::{
         execution::context::subst_signature,
         linkage::{analysis::LinkageAnalyzer, resolved_linkage::ExecutableLinkage},
-        loading::ast::{self as L, Datatype, LoadedFunction, LoadedFunctionInstantiation, Type},
+        loading::ast::{
+            self as L, Datatype, DeserializedPackage, LoadedFunction, LoadedFunctionInstantiation,
+            Type,
+        },
     },
 };
 use move_binary_format::{
@@ -602,11 +605,11 @@ where
         self.load_vm_type_from_type_tag(Some(type_arg_idx), &tag)
     }
 
-    pub fn deserialize_modules(
+    pub fn deserialize_package(
         &self,
         module_bytes: &[Vec<u8>],
         dep_ids: &[ObjectID],
-    ) -> Result<(Vec<CompiledModule>, usize, [u8; 32]), Mode::Error> {
+    ) -> Result<DeserializedPackage, Mode::Error> {
         assert_invariant!(
             !module_bytes.is_empty(),
             "empty package is checked in transaction input checker"
@@ -615,7 +618,7 @@ where
         let total_bytes = module_bytes.iter().map(|v| v.len()).sum();
 
         let binary_config = self.protocol_config.binary_config(None);
-        let modules = module_bytes
+        let deserialized_modules = module_bytes
             .iter()
             .map(|b| {
                 CompiledModule::deserialize_with_config(b, &binary_config)
@@ -628,7 +631,11 @@ where
             dep_ids,
             /* hash_modules */ true,
         );
-        Ok((modules, total_bytes, computed_digest))
+        Ok(DeserializedPackage {
+            deserialized_modules,
+            total_bytes,
+            computed_digest,
+        })
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -16,7 +16,8 @@ use crate::{
     },
 };
 use move_binary_format::{
-    errors::VMError,
+    CompiledModule,
+    errors::{Location, VMError, VMResult},
     file_format::{Ability, AbilitySet, TypeParameterIndex},
 };
 use move_core_types::{
@@ -42,7 +43,7 @@ use sui_types::{
     execution_status::{ExecutionErrorKind, TypeArgumentError},
     funds_accumulator::RESOLVED_WITHDRAWAL_STRUCT,
     gas_coin::GasCoin,
-    move_package::{UpgradeCap, UpgradeReceipt, UpgradeTicket},
+    move_package::{MovePackage, UpgradeCap, UpgradeReceipt, UpgradeTicket},
     object::Object,
     type_input::{StructInput, TypeInput},
 };
@@ -599,6 +600,35 @@ where
         }
         let tag = to_type_tag_internal(self, type_arg_idx, ty)?;
         self.load_vm_type_from_type_tag(Some(type_arg_idx), &tag)
+    }
+
+    pub fn deserialize_modules(
+        &self,
+        module_bytes: &[Vec<u8>],
+        dep_ids: &[ObjectID],
+    ) -> Result<(Vec<CompiledModule>, usize, [u8; 32]), Mode::Error> {
+        assert_invariant!(
+            !module_bytes.is_empty(),
+            "empty package is checked in transaction input checker"
+        );
+
+        let total_bytes = module_bytes.iter().map(|v| v.len()).sum();
+
+        let binary_config = self.protocol_config.binary_config(None);
+        let modules = module_bytes
+            .iter()
+            .map(|b| {
+                CompiledModule::deserialize_with_config(b, &binary_config)
+                    .map_err(|e| e.finish(Location::Undefined))
+            })
+            .collect::<VMResult<Vec<CompiledModule>>>()
+            .map_err(|e| self.convert_vm_error(e))?;
+        let computed_digest = MovePackage::compute_digest_for_modules_and_deps(
+            module_bytes,
+            dep_ids,
+            /* hash_modules */ true,
+        );
+        Ok((modules, total_bytes, computed_digest))
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -15,7 +15,7 @@ use crate::{
             values::{Local, Locals, Value},
         },
         linkage::resolved_linkage::{ExecutableLinkage, ResolvedLinkage},
-        loading::ast::{Datatype, PackagePayload},
+        loading::ast::{Datatype, DeserializedPackage, PackagePayload},
         typing::ast::{self as T, Type},
     },
 };
@@ -1023,30 +1023,24 @@ where
     // Publish and Upgrade
     //
 
-    pub fn package_payload_modules(
+    pub fn deserialize_package(
         &mut self,
         package_payload: PackagePayload,
         dep_ids: &[ObjectID],
-    ) -> Result<(Vec<CompiledModule>, [u8; 32]), Mode::Error> {
+    ) -> Result<DeserializedPackage, Mode::Error> {
         Ok(match package_payload {
-            PackagePayload::Deserialized {
-                modules,
-                computed_digest,
-                ..
-            } => (modules, computed_digest),
+            PackagePayload::Deserialized(deserialized_pkg) => deserialized_pkg,
             PackagePayload::Serialized(module_bytes) => {
                 // This assertion is also checked in the call to `deserialize_modules`, but we
-                // want to check it here first to keep existing behavior.
+                // want to check it here first to keep existing behavior around checking this
+                // invariant before the charge on pre-existing pathways.
                 assert_invariant!(
                     !module_bytes.is_empty(),
                     "empty package is checked in transaction input checker"
                 );
                 let total_bytes = module_bytes.iter().map(|v| v.len()).sum();
                 self.gas_charger.charge_publish_package(total_bytes)?;
-
-                let (modules, _, computed_digest) =
-                    self.env.deserialize_modules(&module_bytes, dep_ids)?;
-                (modules, computed_digest)
+                self.env.deserialize_package(&module_bytes, dep_ids)?
             }
         })
     }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -15,7 +15,7 @@ use crate::{
             values::{Local, Locals, Value},
         },
         linkage::resolved_linkage::{ExecutableLinkage, ResolvedLinkage},
-        loading::ast::Datatype,
+        loading::ast::{Datatype, PackagePayload},
         typing::ast::{self as T, Type},
     },
 };
@@ -1022,27 +1022,33 @@ where
     //
     // Publish and Upgrade
     //
-    pub fn deserialize_modules(
-        &mut self,
-        module_bytes: &[Vec<u8>],
-    ) -> Result<Vec<CompiledModule>, Mode::Error> {
-        assert_invariant!(
-            !module_bytes.is_empty(),
-            "empty package is checked in transaction input checker"
-        );
-        let total_bytes = module_bytes.iter().map(|v| v.len()).sum();
-        self.gas_charger.charge_publish_package(total_bytes)?;
 
-        let binary_config = self.env.protocol_config.binary_config(None);
-        let modules = module_bytes
-            .iter()
-            .map(|b| {
-                CompiledModule::deserialize_with_config(b, &binary_config)
-                    .map_err(|e| e.finish(Location::Undefined))
-            })
-            .collect::<VMResult<Vec<CompiledModule>>>()
-            .map_err(|e| self.env.convert_vm_error(e))?;
-        Ok(modules)
+    pub fn package_payload_modules(
+        &mut self,
+        package_payload: PackagePayload,
+        dep_ids: &[ObjectID],
+    ) -> Result<(Vec<CompiledModule>, [u8; 32]), Mode::Error> {
+        Ok(match package_payload {
+            PackagePayload::Deserialized {
+                modules,
+                computed_digest,
+                ..
+            } => (modules, computed_digest),
+            PackagePayload::Serialized(module_bytes) => {
+                // This assertion is also checked in the call to `deserialize_modules`, but we
+                // want to check it here first to keep existing behavior.
+                assert_invariant!(
+                    !module_bytes.is_empty(),
+                    "empty package is checked in transaction input checker"
+                );
+                let total_bytes = module_bytes.iter().map(|v| v.len()).sum();
+                self.gas_charger.charge_publish_package(total_bytes)?;
+
+                let (modules, _, computed_digest) =
+                    self.env.deserialize_modules(&module_bytes, dep_ids)?;
+                (modules, computed_digest)
+            }
+        })
     }
 
     fn fetch_package(&mut self, dependency_id: &ObjectID) -> Result<Rc<MovePackage>, Mode::Error> {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -11,6 +11,7 @@ use crate::{
             context::{Context, CtxValue, GasCoinTransfer},
             trace_utils,
         },
+        loading::ast::DeserializedPackage,
         typing::{ast as T, verify::input_arguments::is_coin_send_funds},
     },
 };
@@ -348,10 +349,17 @@ fn execute_command<Mode: ExecutionMode>(
         }
         T::Command__::Publish(payload, dep_ids, linkage) => {
             trace_utils::trace_publish_event(trace_builder_opt)?;
-            let (modules, _) = context.package_payload_modules(payload, &dep_ids)?;
+            let DeserializedPackage {
+                deserialized_modules,
+                ..
+            } = context.deserialize_package(payload, &dep_ids)?;
 
-            let original_id =
-                context.publish_and_init_package(modules, &dep_ids, linkage, trace_builder_opt)?;
+            let original_id = context.publish_and_init_package(
+                deserialized_modules,
+                &dep_ids,
+                linkage,
+                trace_builder_opt,
+            )?;
 
             if <Mode>::packages_are_predefined() {
                 // no upgrade cap for genesis modules
@@ -377,7 +385,11 @@ fn execute_command<Mode: ExecutionMode>(
                 ));
             }
             // deserialize modules and charge gas
-            let (modules, computed_digest) = context.package_payload_modules(payload, &dep_ids)?;
+            let DeserializedPackage {
+                deserialized_modules,
+                computed_digest,
+                ..
+            } = context.deserialize_package(payload, &dep_ids)?;
             let computed_digest = computed_digest.to_vec();
 
             if computed_digest != upgrade_ticket.digest {
@@ -391,7 +403,7 @@ fn execute_command<Mode: ExecutionMode>(
             }
 
             let upgraded_package_id = context.upgrade(
-                modules,
+                deserialized_modules,
                 &dep_ids,
                 current_package_id,
                 upgrade_ticket.policy,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -30,7 +30,6 @@ use sui_types::{
     execution::{ExecutionTiming, ResultWithTimings},
     execution_status::{ExecutionErrorKind, PackageUpgradeError},
     metrics::ExecutionMetrics,
-    move_package::MovePackage,
     object::Owner,
 };
 use tracing::instrument;
@@ -347,9 +346,9 @@ fn execute_command<Mode: ExecutionMode>(
             trace_utils::trace_make_move_vec(context, trace_builder_opt, &items, &ty)?;
             vec![CtxValue::vec_pack(ty, items)?]
         }
-        T::Command__::Publish(module_bytes, dep_ids, linkage) => {
+        T::Command__::Publish(payload, dep_ids, linkage) => {
             trace_utils::trace_publish_event(trace_builder_opt)?;
-            let modules = context.deserialize_modules(&module_bytes)?;
+            let (modules, _) = context.package_payload_modules(payload, &dep_ids)?;
 
             let original_id =
                 context.publish_and_init_package(modules, &dep_ids, linkage, trace_builder_opt)?;
@@ -361,13 +360,7 @@ fn execute_command<Mode: ExecutionMode>(
                 std::vec![context.new_upgrade_cap(original_id)?]
             }
         }
-        T::Command__::Upgrade(
-            module_bytes,
-            dep_ids,
-            current_package_id,
-            upgrade_ticket,
-            linkage,
-        ) => {
+        T::Command__::Upgrade(payload, dep_ids, current_package_id, upgrade_ticket, linkage) => {
             trace_utils::trace_upgrade_event(trace_builder_opt)?;
             let upgrade_ticket = context
                 .argument::<CtxValue>(upgrade_ticket)?
@@ -384,14 +377,9 @@ fn execute_command<Mode: ExecutionMode>(
                 ));
             }
             // deserialize modules and charge gas
-            let modules = context.deserialize_modules(&module_bytes)?;
+            let (modules, computed_digest) = context.package_payload_modules(payload, &dep_ids)?;
+            let computed_digest = computed_digest.to_vec();
 
-            let computed_digest = MovePackage::compute_digest_for_modules_and_deps(
-                &module_bytes,
-                &dep_ids,
-                /* hash_modules */ true,
-            )
-            .to_vec();
             if computed_digest != upgrade_ticket.digest {
                 return Err(Mode::Error::from_kind(
                     ExecutionErrorKind::PackageUpgradeError {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
@@ -10,6 +10,7 @@ use crate::{
     execution_mode::ExecutionMode,
     static_programmable_transactions::{
         execution::context::{Context, CtxValue},
+        loading::ast::DeserializedPackage,
         typing::ast::{Command__, Commands, Type},
     },
 };
@@ -117,8 +118,11 @@ pub fn trace_ptb_summary<Mode: ExecutionMode>(
                     events.push(PTBCommandInfo::ExternalEvent("Publish".to_string()));
                     // Not ideal but it only runs when tracing is enabled so overhead
                     // should be insignificant
-                    let (modules, _) = context.package_payload_modules(payload.clone(), dep_ids)?;
-                    events.extend(modules.into_iter().find_map(|m| {
+                    let DeserializedPackage {
+                        deserialized_modules,
+                        ..
+                    } = context.deserialize_package(payload.clone(), dep_ids)?;
+                    events.extend(deserialized_modules.into_iter().find_map(|m| {
                         for fdef in &m.function_defs {
                             let fhandle = m.function_handle_at(fdef.function);
                             let fname = m.identifier_at(fhandle.name);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
@@ -112,12 +112,12 @@ pub fn trace_ptb_summary<Mode: ExecutionMode>(
                 Command__::MergeCoins(..) => Ok(vec![PTBCommandInfo::ExternalEvent(
                     "MergeCoins".to_string(),
                 )]),
-                Command__::Publish(module_bytes, _, _) => {
+                Command__::Publish(payload, dep_ids, _) => {
                     let mut events = vec![];
                     events.push(PTBCommandInfo::ExternalEvent("Publish".to_string()));
                     // Not ideal but it only runs when tracing is enabled so overhead
                     // should be insignificant
-                    let modules = context.deserialize_modules(module_bytes)?;
+                    let (modules, _) = context.package_payload_modules(payload.clone(), dep_ids)?;
                     events.extend(modules.into_iter().find_map(|m| {
                         for fdef in &m.function_defs {
                             let fhandle = m.function_handle_at(fdef.function);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -141,15 +141,19 @@ pub enum Command {
 #[derive(Debug, Clone)]
 pub enum PackagePayload {
     Serialized(Vec<Vec<u8>>),
-    Deserialized {
-        // NB: Modules are deserialized but not yet verified.
-        modules: Vec<CompiledModule>,
-        // Sum of the sizes of all modules in (serialized) bytes, used for metering
-        total_bytes: usize,
-        // The computed digest of the package --
-        // `MovePackage::compute_digest_for_modules_and_deps` with `hash_modules` set to `true`.
-        computed_digest: [u8; 32],
-    },
+    Deserialized(DeserializedPackage),
+}
+
+// A Deserialized but not yet verified package created as part of loading.
+#[derive(Debug, Clone)]
+pub struct DeserializedPackage {
+    // NB: Modules are deserialized but not yet verified. They _are_ bounds checked though.
+    pub deserialized_modules: Vec<CompiledModule>,
+    // Sum of the sizes of all modules in (serialized) bytes, used for metering
+    pub total_bytes: usize,
+    // The computed digest of the package --
+    // `MovePackage::compute_digest_for_modules_and_deps` with `hash_modules` set to `true`.
+    pub computed_digest: [u8; 32],
 }
 
 #[derive(Debug)]

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -8,8 +8,9 @@ use crate::{
     },
 };
 use indexmap::IndexSet;
-use move_binary_format::file_format::{
-    AbilitySet, CodeOffset, FunctionDefinitionIndex, Visibility,
+use move_binary_format::{
+    CompiledModule,
+    file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, Visibility},
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -127,14 +128,28 @@ pub enum Command {
     SplitCoins(Argument, Vec<Argument>),
     MergeCoins(Argument, Vec<Argument>),
     MakeMoveVec(/* T for vector<T> */ Option<Type>, Vec<Argument>),
-    Publish(Vec<Vec<u8>>, Vec<ObjectID>, ResolvedLinkage),
+    Publish(PackagePayload, Vec<ObjectID>, ResolvedLinkage),
     Upgrade(
-        Vec<Vec<u8>>,
+        PackagePayload,
         Vec<ObjectID>,
         ObjectID,
         Argument,
         ResolvedLinkage,
     ),
+}
+
+#[derive(Debug, Clone)]
+pub enum PackagePayload {
+    Serialized(Vec<Vec<u8>>),
+    Deserialized {
+        // NB: Modules are deserialized but not yet verified.
+        modules: Vec<CompiledModule>,
+        // Sum of the sizes of all modules in (serialized) bytes, used for metering
+        total_bytes: usize,
+        // The computed digest of the package --
+        // `MovePackage::compute_digest_for_modules_and_deps` with `hash_modules` set to `true`.
+        computed_digest: [u8; 32],
+    },
 }
 
 #[derive(Debug)]

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -6,7 +6,7 @@ use crate::{
     gas_charger::GasPayment,
     static_programmable_transactions::{
         env::Env,
-        loading::ast as L,
+        loading::ast::{self as L, PackagePayload},
         metering::{self, translation_meter::TranslationMeter},
     },
 };
@@ -274,17 +274,19 @@ fn command<Mode: ExecutionMode>(
         }
         P::Command::SplitCoins(coin, amounts) => L::Command::SplitCoins(coin, amounts),
         P::Command::MergeCoins(target, coins) => L::Command::MergeCoins(target, coins),
-        P::Command::Publish(items, object_ids) => {
+        P::Command::Publish(items, dep_ids) => {
             let resolved_linkage = env
                 .linkage_analysis
-                .compute_publication_linkage::<Mode::Error>(&object_ids, env.linkable_store)?;
-            L::Command::Publish(items, object_ids, resolved_linkage)
+                .compute_publication_linkage::<Mode::Error>(&dep_ids, env.linkable_store)?;
+            let payload = PackagePayload::Serialized(items);
+            L::Command::Publish(payload, dep_ids, resolved_linkage)
         }
-        P::Command::Upgrade(items, object_ids, object_id, argument) => {
+        P::Command::Upgrade(items, dep_ids, object_id, argument) => {
             let resolved_linkage = env
                 .linkage_analysis
-                .compute_publication_linkage::<Mode::Error>(&object_ids, env.linkable_store)?;
-            L::Command::Upgrade(items, object_ids, object_id, argument, resolved_linkage)
+                .compute_publication_linkage::<Mode::Error>(&dep_ids, env.linkable_store)?;
+            let payload = PackagePayload::Serialized(items);
+            L::Command::Upgrade(payload, dep_ids, object_id, argument, resolved_linkage)
         }
     })
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -4,7 +4,9 @@
 use crate::{
     gas_charger::GasPayment,
     static_programmable_transactions::{
-        linkage::resolved_linkage::ResolvedLinkage, loading::ast as L, spanned::Spanned,
+        linkage::resolved_linkage::ResolvedLinkage,
+        loading::ast::{self as L, PackagePayload},
+        spanned::Spanned,
     },
 };
 use indexmap::{IndexMap, IndexSet};
@@ -132,9 +134,9 @@ pub enum Command__ {
     SplitCoins(/* Coin<T> */ Type, Argument, Vec<Argument>),
     MergeCoins(/* Coin<T> */ Type, Argument, Vec<Argument>),
     MakeMoveVec(/* T for vector<T> */ Type, Vec<Argument>),
-    Publish(Vec<Vec<u8>>, Vec<ObjectID>, ResolvedLinkage),
+    Publish(PackagePayload, Vec<ObjectID>, ResolvedLinkage),
     Upgrade(
-        Vec<Vec<u8>>,
+        PackagePayload,
         Vec<ObjectID>,
         ObjectID,
         Argument,


### PR DESCRIPTION
## Description 
Add a `PackagePayload` from the loaded SPTB AST on-down, but do not create the `PackagePayload::Deserialized` variant yet.

Plumbing for future work in the PR stacked on this that adds unified linkage.

## Test plan 

CI
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
