### PR TITLE
Remove checkpoint timestamp clamping in CheckpointBuilder

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1953,22 +1953,16 @@ impl CheckpointBuilder {
         let last_checkpoint_of_epoch = details.last_of_epoch;
 
         let sequence_number = details.checkpoint_seq;
-        let mut timestamp_ms = details.timestamp_ms;
+        let timestamp_ms = details.timestamp_ms;
         if let Some((_, last_checkpoint)) = &last_checkpoint
             && last_checkpoint.timestamp_ms > timestamp_ms
         {
-            // First consensus commit of an epoch can have zero timestamp.
-            debug!(
-                "Decrease of checkpoint timestamp, possibly due to epoch change. Sequence: {}, previous: {}, current: {}",
-                sequence_number, last_checkpoint.timestamp_ms, timestamp_ms,
+            debug_fatal!(
+                "Decrease of checkpoint timestamp. Sequence: {}, previous: {}, current: {}",
+                sequence_number,
+                last_checkpoint.timestamp_ms,
+                timestamp_ms
             );
-            if self
-                .epoch_store
-                .protocol_config()
-                .enforce_checkpoint_timestamp_monotonicity()
-            {
-                timestamp_ms = last_checkpoint.timestamp_ms;
-            }
         }
 
         let mut effects = all_effects;


### PR DESCRIPTION
## Description

Consensus commit timestamps are now guaranteed monotonic even across epoch boundaries, so the CheckpointBuilder no longer needs to clamp a decreasing checkpoint timestamp to the previous checkpoint's. A decrease now signals a real invariant violation, so it is reported via `debug_fatal!` instead of being silently corrected.

## Test plan

Covered by existing checkpoint-building tests in `sui-core`; the removed branch is now unreachable under the monotonicity guarantee.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: