### PR TITLE
[cli] Rename forking_mode to skip_signing

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -713,10 +713,10 @@ pub struct TxProcessingArgs {
     /// private key corresponding to this address is not in keystore.
     #[arg(long, required = false, value_parser)]
     pub sender: Option<SuiAddress>,
-    /// Submit the transaction without signatures for forked networks that support sender
-    /// impersonation. This is only intended for local forked-network testing.
+    /// Do not sign the transaction. This is only intended for local forked networks that
+    /// support sender impersonation.
     #[arg(long)]
-    pub forking_mode: bool,
+    pub skip_signing: bool,
 }
 
 #[derive(Args, Debug, Default)]
@@ -3326,7 +3326,7 @@ async fn dry_run_or_execute_or_serialize_impl(
         serialize_unsigned_transaction,
         serialize_signed_transaction,
         sender,
-        forking_mode,
+        skip_signing,
     } = processing;
 
     ensure!(
@@ -3450,7 +3450,7 @@ async fn dry_run_or_execute_or_serialize_impl(
     } else if tx_digest {
         Ok(SuiClientCommandResult::ComputeTransactionDigest(tx_data))
     } else {
-        let signatures = if forking_mode {
+        let signatures = if skip_signing {
             vec![]
         } else {
             let mut signatures = vec![

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -221,7 +221,7 @@ impl PTB {
             serialize_unsigned_transaction: program_metadata.serialize_unsigned_set,
             serialize_signed_transaction: program_metadata.serialize_signed_set,
             sender: program_metadata.sender.map(|x| x.value.into_inner().into()),
-            forking_mode: false,
+            skip_signing: false,
         };
 
         let gas_payment = client.transaction_builder().input_refs(&gas).await?;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2905,7 +2905,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
     .execute(context)
     .await?;
 
-    let forking_mode_tx = SuiClientCommands::TransferSui {
+    let skip_signing_tx = SuiClientCommands::TransferSui {
         to: KeyIdentity::Address(address1),
         sui_coin_object_id: coin,
         amount: Some(1),
@@ -2915,14 +2915,14 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         },
         processing: TxProcessingArgs {
             serialize_signed_transaction: true,
-            forking_mode: true,
+            skip_signing: true,
             ..Default::default()
         },
     }
     .execute(context)
     .await?;
 
-    let SuiClientCommandResult::SerializedSignedTransaction(sender_signed_data) = forking_mode_tx
+    let SuiClientCommandResult::SerializedSignedTransaction(sender_signed_data) = skip_signing_tx
     else {
         panic!("Expected SerializedSignedTransaction result");
     };


### PR DESCRIPTION
## Description 

This PR fixes the weird flag name from a previous PR, as @amnn suggested: `forking-mode` is now `skip-signing`.

## Test plan 

Existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Renamed the `--forking-mode` flag to `--skip-signing` to more correctly represent what it does.
- [ ] Rust SDK:
- [ ] Indexing Framework:
