### PR TITLE
Drop vestigial ParentSync impl from latest TemporaryStore

### DIFF
--- a/sui-execution/latest/sui-adapter/src/execution_value.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_value.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::storage::{BackingPackageStore, ChildObjectResolver, StorageView};
+use sui_types::storage::{BackingPackageStore, ChildObjectResolver, Storage};
 
 pub trait SuiResolver: BackingPackageStore {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
@@ -17,13 +17,13 @@ where
 }
 
 /// Interface with the store necessary to execute a programmable transaction
-pub trait ExecutionState: StorageView + SuiResolver {
+pub trait ExecutionState: Storage + ChildObjectResolver + SuiResolver {
     fn as_child_resolver(&self) -> &dyn ChildObjectResolver;
 }
 
 impl<T> ExecutionState for T
 where
-    T: StorageView,
+    T: Storage + ChildObjectResolver,
     T: SuiResolver,
 {
     fn as_child_resolver(&self) -> &dyn ChildObjectResolver {

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -34,7 +34,7 @@ use sui_types::{
     gas::GasCostSummary,
     object::Object,
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
+    storage::{BackingPackageStore, ChildObjectResolver, Storage},
     transaction::InputObjects,
 };
 use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, TypeTag, is_system_package};
@@ -1749,11 +1749,5 @@ impl BackingPackageStore for TemporaryStore<'_> {
                 }
             })
         }
-    }
-}
-
-impl ParentSync for TemporaryStore<'_> {
-    fn get_latest_parent_entry_ref_deprecated(&self, _object_id: ObjectID) -> Option<ObjectRef> {
-        unreachable!("Never called in newer protocol versions")
     }
 }


### PR DESCRIPTION
## Description

The latest `TemporaryStore`'s `ParentSync` impl was dead weight — its only method was `unreachable!()`, since `get_latest_parent_entry_ref_deprecated` is only ever called by the v0 adapter. It was forced onto `TemporaryStore` purely via the `ExecutionState: StorageView` supertrait chain (`StorageView: Storage + ParentSync + ChildObjectResolver`).

This decouples the latest adapter's `ExecutionState` from `StorageView`, requiring `Storage + ChildObjectResolver` directly instead, and drops the `ParentSync` impl. The shared `StorageView` in `sui-types` is untouched, so v0–v3 are unaffected.

## Test plan

No behavioral change — the removed impl was unreachable and the new trait bound is equivalent minus `ParentSync`. Covered by existing execution tests.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required. For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
