### PR TITLE
graphql: generalize Address.asTransactionObject

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.move
@@ -22,6 +22,17 @@
     }
   }
 
+  # Same resolver called directly on an Object (an IAddressable implementor).
+  objectDirect: object(address: "@{obj_1_0}") {
+    asTransactionObject(transactionDigest: "@{digest_1}") {
+      __typename
+      ... on ObjectChange {
+        idCreated
+        outputState { address }
+      }
+    }
+  }
+
   # No `transactionDigest` argument outside subscription scope → null.
   noArg: address(address: "@{obj_1_0}") {
     asTransactionObject {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.snap
@@ -18,11 +18,20 @@ task 2, line 10:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 3, lines 12-40:
+task 3, lines 12-51:
 //# run-graphql
 Response: {
   "data": {
     "changed": {
+      "asTransactionObject": {
+        "__typename": "ObjectChange",
+        "idCreated": true,
+        "outputState": {
+          "address": "0xb97536b48e93de1f9c1d06619490683304fdf3423dadd0e409bd99d116a1c80c"
+        }
+      }
+    },
+    "objectDirect": {
       "asTransactionObject": {
         "__typename": "ObjectChange",
         "idCreated": true,
@@ -40,17 +49,17 @@ Response: {
   }
 }
 
-task 4, lines 42-65:
+task 4, lines 53-76:
 //# publish
 created: object(4,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 6680400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 5, line 67:
+task 5, line 78:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 6, lines 69-71:
+task 6, lines 80-82:
 //# programmable --sender A --inputs 7u64 @A
 //> 0: P::M::create_object(Input(0));
 //> 1: TransferObjects([Result(0)], Input(1));
@@ -58,22 +67,22 @@ created: object(6,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 7, line 73:
+task 7, line 84:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 8, lines 75-76:
+task 8, lines 86-87:
 //# programmable --sender A --inputs object(6,0) 99u64
 //> 0: P::M::mutate_and_emit(Input(0), Input(1));
 events: Event { package_id: P, transaction_module: Identifier("M"), sender: A, type_: StructTag { address: P, module: Identifier("M"), name: Identifier("TestAddressEvent"), type_params: [] }, contents: [62, 219, 117, 132, 227, 135, 32, 1, 102, 151, 41, 1, 101, 98, 132, 247, 88, 218, 211, 19, 164, 9, 23, 115, 161, 29, 20, 131, 114, 1, 203, 163] }
 mutated: object(0,0), object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 2302344, non_refundable_storage_fee: 23256
 
-task 9, line 78:
+task 9, line 89:
 //# create-checkpoint
 Checkpoint created: 4
 
-task 10, lines 80-105:
+task 10, lines 91-116:
 //# run-graphql
 Response: {
   "data": {
@@ -117,7 +126,7 @@ Response: {
   }
 }
 
-task 11, lines 107-134:
+task 11, lines 118-145:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -115,7 +115,7 @@ async fn test_event_subscription_transaction_fields() {
     });
 }
 
-/// Verifies the `Address.asTransactionObject` resolver in streaming mode for the
+/// Verifies the `IAddressable.asTransactionObject` resolver in streaming mode for the
 /// `ObjectChange` variant.
 #[tokio::test]
 async fn test_event_subscription_as_transaction_object_change() {
@@ -169,7 +169,7 @@ async fn test_event_subscription_as_transaction_object_change() {
     });
 }
 
-/// Verifies the `Address.asTransactionObject` resolver in streaming mode for the
+/// Verifies the `IAddressable.asTransactionObject` resolver in streaming mode for the
 /// `ConsensusObjectRead` variant. The test tx takes the (read-only) shared clock as a
 /// consensus input and emits a `TestAddressEvent` whose payload is the clock's address.
 #[tokio::test]

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -627,7 +627,7 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1006,7 +1006,7 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1671,7 +1671,7 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this addressable entity was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2315,7 +2315,7 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2484,7 +2484,7 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -3015,7 +3015,7 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asMovePackage: MovePackage
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -627,6 +627,16 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -995,6 +1005,16 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -1651,6 +1671,16 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2285,6 +2315,16 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2443,6 +2483,16 @@ type MovePackage implements Node & IAddressable & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -2964,6 +3014,16 @@ type Object implements Node & IAddressable & IObject {
 	Attempts to convert the object into a MovePackage.
 	"""
 	asMovePackage: MovePackage
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -82,7 +82,7 @@ pub(crate) enum AddressTransactionRelationship {
         name = "as_transaction_object",
         arg(name = "transaction_digest", ty = "Option<Digest>"),
         ty = "Option<Result<TransactionObject, RpcError>>",
-        desc = "How this address (interpreted as an object ID) was referenced by a specific transaction.\n\nReturns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).\n\nThe `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.\n\nPassing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.",
+        desc = "How this addressable entity was referenced by a specific transaction.\n\nReturns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).\n\nThe `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.\n\nPassing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.",
     ),
     field(
         name = "balance",

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -79,6 +79,12 @@ pub(crate) enum AddressTransactionRelationship {
         desc = "Fetch the address as it was at a different root version, or checkpoint.\n\nIf no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.",
     ),
     field(
+        name = "as_transaction_object",
+        arg(name = "transaction_digest", ty = "Option<Digest>"),
+        ty = "Option<Result<TransactionObject, RpcError>>",
+        desc = "How this address (interpreted as an object ID) was referenced by a specific transaction.\n\nReturns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).\n\nThe `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.\n\nPassing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.",
+    ),
+    field(
         name = "balance",
         arg(name = "coin_type", ty = "TypeInput"),
         ty = "Option<Result<Balance, RpcError<balance::Error>>>",

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -233,7 +233,7 @@ macro_rules! delegate {
 // - `=> OtherType.field(.., "filterName")`: delegate and add filter constraint
 // - `|pipelines, filters| { ... }`: block of statements operating on pipelines and filters to execute
 collect_pipelines! {
-    Address.[address, addressAt] => IAddressable.*;
+    Address.[address, addressAt, asTransactionObject] => IAddressable.*;
     Address.[asObject] => IObject.objectAt();
     Address.[transactions] => Query.transactions(.., "affectedAddress");
     Address.[balance, balances, multiGetBalances, objects] => IAddressable.*;
@@ -242,7 +242,7 @@ collect_pipelines! {
 
     Checkpoint.[transactions] => Query.transactions(.., "atCheckpoint");
 
-    CoinMetadata.[address, addressAt] => IAddressable.*;
+    CoinMetadata.[address, addressAt, asTransactionObject] => IAddressable.*;
     CoinMetadata.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     CoinMetadata.[defaultNameRecord] => IAddressable.defaultNameRecord();
     CoinMetadata.[contents, hasPublicTransfer, moveObjectBcs] => IMoveObject.*;
@@ -255,7 +255,7 @@ collect_pipelines! {
         pipelines.insert("consistent".to_string());
     };
 
-    DynamicField.[address, addressAt] => IAddressable.*;
+    DynamicField.[address, addressAt, asTransactionObject] => IAddressable.*;
     DynamicField.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     DynamicField.[defaultNameRecord] => IAddressable.defaultNameRecord();
     DynamicField.[contents, hasPublicTransfer, moveObjectBcs] => IMoveObject.*;
@@ -308,7 +308,7 @@ collect_pipelines! {
         pipelines.insert("obj_versions".to_string());
     };
 
-    MoveObject.[address, addressAt] => IAddressable.*;
+    MoveObject.[address, addressAt, asTransactionObject] => IAddressable.*;
     MoveObject.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     MoveObject.[defaultNameRecord] => IAddressable.defaultNameRecord();
     MoveObject.[contents, hasPublicTransfer, moveObjectBcs] => IMoveObject.*;
@@ -318,7 +318,7 @@ collect_pipelines! {
     MoveObject.[digest, objectBcs, owner, previousTransaction, storageRebate, version] => IObject.*;
     MoveObject.[receivedTransactions] => IObject.receivedTransactions();
 
-    MovePackage.[address, addressAt] => IAddressable.*;
+    MovePackage.[address, addressAt, asTransactionObject] => IAddressable.*;
     MovePackage.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     MovePackage.[defaultNameRecord] => IAddressable.defaultNameRecord();
     MovePackage.[objectAt, objectVersionsAfter, objectVersionsBefore] => IObject.*;
@@ -331,7 +331,7 @@ collect_pipelines! {
         pipelines.insert("obj_versions".to_string());
     };
 
-    Object.[address, addressAt] => IAddressable.*;
+    Object.[address, addressAt, asTransactionObject] => IAddressable.*;
     Object.[balance, balances, multiGetBalances, objects] => IAddressable.*;
     Object.[defaultNameRecord] => IAddressable.defaultNameRecord();
     Object.[dynamicField, dynamicObjectField, multiGetDynamicFields, multiGetDynamicObjectFields] => IMoveObject.*;

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -27,6 +27,7 @@ use tokio::sync::OnceCell;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::big_int::BigInt;
+use crate::api::scalars::digest::Digest;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::scalars::type_filter::TypeInput;
 use crate::api::scalars::uint53::UInt53;
@@ -52,6 +53,7 @@ use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
+use crate::api::types::transaction_object::TransactionObject;
 use crate::error::RpcError;
 use crate::error::upcast;
 use crate::scope::Scope;
@@ -144,6 +146,24 @@ impl CoinMetadata {
     /// 32-byte hash that identifies the object's contents, encoded in Base58.
     pub(crate) async fn digest(&self, ctx: &Context<'_>) -> Option<Result<String, RpcError>> {
         self.super_.digest(ctx).await.ok()?
+    }
+
+    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    ///
+    /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+    ///
+    /// The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+    ///
+    /// Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    pub(crate) async fn as_transaction_object(
+        &self,
+        ctx: &Context<'_>,
+        transaction_digest: Option<Digest>,
+    ) -> Option<Result<TransactionObject, RpcError>> {
+        self.super_
+            .as_transaction_object(ctx, transaction_digest)
+            .await
+            .ok()?
     }
 
     /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -148,7 +148,7 @@ impl CoinMetadata {
         self.super_.digest(ctx).await.ok()?
     }
 
-    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    /// How this object was referenced by a specific transaction.
     ///
     /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -176,7 +176,7 @@ impl DynamicField {
         self.super_.digest(ctx).await.ok()?
     }
 
-    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    /// How this object was referenced by a specific transaction.
     ///
     /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -25,6 +25,7 @@ use tokio::sync::OnceCell;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::big_int::BigInt;
+use crate::api::scalars::digest::Digest;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::owner_kind::OwnerKind;
 use crate::api::scalars::sui_address::SuiAddress;
@@ -51,6 +52,7 @@ use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
+use crate::api::types::transaction_object::TransactionObject;
 use crate::config::Limits;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
@@ -172,6 +174,24 @@ impl DynamicField {
     /// 32-byte hash that identifies the object's contents, encoded in Base58.
     pub(crate) async fn digest(&self, ctx: &Context<'_>) -> Option<Result<String, RpcError>> {
         self.super_.digest(ctx).await.ok()?
+    }
+
+    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    ///
+    /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+    ///
+    /// The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+    ///
+    /// Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    pub(crate) async fn as_transaction_object(
+        &self,
+        ctx: &Context<'_>,
+        transaction_digest: Option<Digest>,
+    ) -> Option<Result<TransactionObject, RpcError>> {
+        self.super_
+            .as_transaction_object(ctx, transaction_digest)
+            .await
+            .ok()?
     }
 
     /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -15,6 +15,7 @@ use tokio::sync::OnceCell;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::big_int::BigInt;
+use crate::api::scalars::digest::Digest;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::scalars::type_filter::TypeInput;
@@ -42,6 +43,7 @@ use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
+use crate::api::types::transaction_object::TransactionObject;
 use crate::error::RpcError;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
@@ -172,6 +174,24 @@ impl MoveObject {
         ctx: &Context<'_>,
     ) -> Result<Option<DynamicField>, RpcError> {
         DynamicField::from_move_object(self, ctx).await
+    }
+
+    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    ///
+    /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+    ///
+    /// The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+    ///
+    /// Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    pub(crate) async fn as_transaction_object(
+        &self,
+        ctx: &Context<'_>,
+        transaction_digest: Option<Digest>,
+    ) -> Option<Result<TransactionObject, RpcError>> {
+        self.super_
+            .as_transaction_object(ctx, transaction_digest)
+            .await
+            .ok()?
     }
 
     /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -176,7 +176,7 @@ impl MoveObject {
         DynamicField::from_move_object(self, ctx).await
     }
 
-    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    /// How this object was referenced by a specific transaction.
     ///
     /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -35,6 +35,7 @@ use crate::api::scalars::base64::Base64;
 use crate::api::scalars::big_int::BigInt;
 use crate::api::scalars::cursor::BcsCursor;
 use crate::api::scalars::cursor::JsonCursor;
+use crate::api::scalars::digest::Digest;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::scalars::type_filter::TypeInput;
@@ -59,6 +60,7 @@ use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
+use crate::api::types::transaction_object::TransactionObject;
 use crate::api::types::type_origin::TypeOrigin;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
@@ -173,6 +175,24 @@ impl MovePackage {
     /// 32-byte hash that identifies the package's contents, encoded in Base58.
     pub(crate) async fn digest(&self, ctx: &Context<'_>) -> Option<Result<String, RpcError>> {
         self.super_.digest(ctx).await.ok()?
+    }
+
+    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    ///
+    /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+    ///
+    /// The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+    ///
+    /// Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    pub(crate) async fn as_transaction_object(
+        &self,
+        ctx: &Context<'_>,
+        transaction_digest: Option<Digest>,
+    ) -> Option<Result<TransactionObject, RpcError>> {
+        self.super_
+            .as_transaction_object(ctx, transaction_digest)
+            .await
+            .ok()?
     }
 
     /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -177,7 +177,7 @@ impl MovePackage {
         self.super_.digest(ctx).await.ok()?
     }
 
-    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    /// How this object was referenced by a specific transaction.
     ///
     /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -45,6 +45,7 @@ use crate::api::scalars::base64::Base64;
 use crate::api::scalars::big_int::BigInt;
 use crate::api::scalars::cursor::BcsCursor;
 use crate::api::scalars::cursor::JsonCursor;
+use crate::api::scalars::digest::Digest;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::owner_kind::OwnerKind;
 use crate::api::scalars::sui_address::SuiAddress;
@@ -69,6 +70,7 @@ use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionConnection;
 use crate::api::types::transaction::filter::TransactionFilter;
+use crate::api::types::transaction_object::TransactionObject;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
 use crate::error::feature_unavailable;
@@ -309,6 +311,24 @@ impl Object {
     /// Attempts to convert the object into a MovePackage.
     async fn as_move_package(&self, ctx: &Context<'_>) -> Option<Result<MovePackage, RpcError>> {
         MovePackage::from_object(self, ctx).await.transpose()
+    }
+
+    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    ///
+    /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+    ///
+    /// The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+    ///
+    /// Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    pub(crate) async fn as_transaction_object(
+        &self,
+        ctx: &Context<'_>,
+        transaction_digest: Option<Digest>,
+    ) -> Option<Result<TransactionObject, RpcError>> {
+        self.super_
+            .as_transaction_object(ctx, transaction_digest)
+            .await
+            .ok()?
     }
 
     /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -313,7 +313,7 @@ impl Object {
         MovePackage::from_object(self, ctx).await.transpose()
     }
 
-    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    /// How this object was referenced by a specific transaction.
     ///
     /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -269,6 +269,9 @@ CoinMetadata.version
 CoinMetadata.digest
   => {}
 
+CoinMetadata.asTransactionObject
+  => {}
+
 CoinMetadata.balance
   => {"consistent"}
 
@@ -432,6 +435,9 @@ DynamicField.version
   => {}
 
 DynamicField.digest
+  => {}
+
+DynamicField.asTransactionObject
   => {}
 
 DynamicField.balance
@@ -690,6 +696,9 @@ IAddressable.address
   => {}
 
 IAddressable.addressAt
+  => {}
+
+IAddressable.asTransactionObject
   => {}
 
 IAddressable.balance
@@ -959,6 +968,9 @@ MoveObject.asCoinMetadata
 MoveObject.asDynamicField
   => {}
 
+MoveObject.asTransactionObject
+  => {}
+
 MoveObject.balance
   => {"consistent"}
 
@@ -1035,6 +1047,9 @@ MovePackage.version
   => {}
 
 MovePackage.digest
+  => {}
+
+MovePackage.asTransactionObject
   => {}
 
 MovePackage.balance
@@ -1221,6 +1236,9 @@ Object.asMoveObject
   => {}
 
 Object.asMovePackage
+  => {}
+
+Object.asTransactionObject
   => {}
 
 Object.balance

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -269,6 +269,9 @@ CoinMetadata.version
 CoinMetadata.digest
   => {}
 
+CoinMetadata.asTransactionObject
+  => {}
+
 CoinMetadata.balance
   => {"consistent"}
 
@@ -432,6 +435,9 @@ DynamicField.version
   => {}
 
 DynamicField.digest
+  => {}
+
+DynamicField.asTransactionObject
   => {}
 
 DynamicField.balance
@@ -690,6 +696,9 @@ IAddressable.address
   => {}
 
 IAddressable.addressAt
+  => {}
+
+IAddressable.asTransactionObject
   => {}
 
 IAddressable.balance
@@ -959,6 +968,9 @@ MoveObject.asCoinMetadata
 MoveObject.asDynamicField
   => {}
 
+MoveObject.asTransactionObject
+  => {}
+
 MoveObject.balance
   => {"consistent"}
 
@@ -1035,6 +1047,9 @@ MovePackage.version
   => {}
 
 MovePackage.digest
+  => {}
+
+MovePackage.asTransactionObject
   => {}
 
 MovePackage.balance
@@ -1221,6 +1236,9 @@ Object.asMoveObject
   => {}
 
 Object.asMovePackage
+  => {}
+
+Object.asTransactionObject
   => {}
 
 Object.balance

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -223,7 +223,7 @@ impl EffectsContents {
                 let transaction_digest = content.digest()?;
                 let timestamp_ms = content.timestamp_ms();
                 // Anchor the parent transaction (with hydrated contents) onto each yielded
-                // Event's scope, so descendant resolvers like `Address.asTransactionObject`
+                // Event's scope, so descendant resolvers like `IAddressable.asTransactionObject`
                 // default to it and `*Contents::fetch` short-circuits via the scope.
                 let event_scope = self
                     .scope

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -64,8 +64,8 @@ pub(crate) enum DataSource {
 }
 
 /// Identifies the transaction whose effects are currently in view. Descendant resolvers default
-/// fields like `Address.asTransactionObject` to this transaction, and `*Contents::fetch` consults
-/// `contents` as a hit before falling back to streaming/kv_loader.
+/// fields like `IAddressable.asTransactionObject` to this transaction, and `*Contents::fetch`
+/// consults `contents` as a hit before falling back to streaming/kv_loader.
 ///
 /// `contents` is `Some` when the anchoring caller already had them in hand (e.g. when navigating
 /// `Transaction.effects` on a hydrated `Transaction`). `None` for digest-only anchors (e.g.
@@ -110,11 +110,11 @@ pub(crate) struct Scope {
     checkpoint_viewed_at: Option<u64>,
 
     /// The transaction whose effects descendant resolvers default to (e.g.
-    /// `Address.asTransactionObject` without an explicit `transactionDigest`). Set when a
+    /// `IAddressable.asTransactionObject` without an explicit `transactionDigest`). Set when a
     /// resolver brings a single transaction into view: indexed paths that already hold the
-    /// `TransactionContents` anchor with contents (so `*Contents::fetch` can short-circuit
-    /// via `active_transaction_contents_for`); subscription resolvers anchor digest-only and
-    /// rely on the [`DataSource::Streamed`] checkpoint for content lookups.
+    /// `TransactionContents` anchor with contents (so `*Contents::fetch` can short-circuit via
+    /// `active_transaction_contents_for`); subscription resolvers anchor digest-only and rely on
+    /// the [`DataSource::Streamed`] checkpoint for content lookups.
     ///
     /// This is *not* a "view bound" up to and including a transaction; it identifies one
     /// transaction. Object visibility is end-of-checkpoint regardless of this field.
@@ -189,7 +189,7 @@ impl Scope {
 
     /// Anchor a nested scope to a transaction whose contents the caller already holds. Lets
     /// downstream resolvers reuse the contents instead of re-fetching via kv_loader, and lets
-    /// fields like `Address.asTransactionObject` default to this transaction. Does not change
+    /// fields like `IAddressable.asTransactionObject` default to this transaction. Does not change
     /// object visibility.
     pub(crate) fn with_active_transaction_contents(
         &self,

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -631,7 +631,7 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1010,7 +1010,7 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1675,7 +1675,7 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this addressable entity was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2319,7 +2319,7 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2488,7 +2488,7 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -3019,7 +3019,7 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asMovePackage: MovePackage
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -631,6 +631,16 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -999,6 +1009,16 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -1655,6 +1675,16 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2289,6 +2319,16 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2447,6 +2487,16 @@ type MovePackage implements Node & IAddressable & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -2968,6 +3018,16 @@ type Object implements Node & IAddressable & IObject {
 	Attempts to convert the object into a MovePackage.
 	"""
 	asMovePackage: MovePackage
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -631,7 +631,7 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1010,7 +1010,7 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1675,7 +1675,7 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this addressable entity was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2319,7 +2319,7 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2488,7 +2488,7 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -3019,7 +3019,7 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asMovePackage: MovePackage
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -631,6 +631,16 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -999,6 +1009,16 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -1655,6 +1675,16 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2289,6 +2319,16 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2447,6 +2487,16 @@ type MovePackage implements Node & IAddressable & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -2968,6 +3018,16 @@ type Object implements Node & IAddressable & IObject {
 	Attempts to convert the object into a MovePackage.
 	"""
 	asMovePackage: MovePackage
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -627,7 +627,7 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1006,7 +1006,7 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -1671,7 +1671,7 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this addressable entity was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2315,7 +2315,7 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -2484,7 +2484,7 @@ type MovePackage implements Node & IAddressable & IObject {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
@@ -3015,7 +3015,7 @@ type Object implements Node & IAddressable & IObject {
 	"""
 	asMovePackage: MovePackage
 	"""
-	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	How this object was referenced by a specific transaction.
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -627,6 +627,16 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	allowGlobalPause: Boolean
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -995,6 +1005,16 @@ type DynamicField implements Node & IAddressable & IMoveObject & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -1651,6 +1671,16 @@ interface IAddressable {
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2285,6 +2315,16 @@ type MoveObject implements Node & IAddressable & IMoveObject & IObject {
 	"""
 	asDynamicField: DynamicField
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.
@@ -2443,6 +2483,16 @@ type MovePackage implements Node & IAddressable & IObject {
 	If no additional bound is provided, the address is fetched at the latest checkpoint known to the RPC.
 	"""
 	addressAt(rootVersion: UInt53, checkpoint: UInt53): Address
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -2964,6 +3014,16 @@ type Object implements Node & IAddressable & IObject {
 	Attempts to convert the object into a MovePackage.
 	"""
 	asMovePackage: MovePackage
+	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
+	
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	


### PR DESCRIPTION
Promote this field to the `IAddressable` interface, so that it can be called directly on any entity that has an address.

## Test plan

Updated E2E test:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- as_transaction_object
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Introduce `IAddressable.asTransactionObject` as a generalization of `Address.asTransactionObject`.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
