### PR TITLE
docs: fix self-referencing link in migration-strategies.mdx

### DIFF
--- a/docs/content/sui-stack/suiplay0x1/migration-strategies.mdx
+++ b/docs/content/sui-stack/suiplay0x1/migration-strategies.mdx
@@ -34,7 +34,7 @@ The Playtron wallet is portable and can connect to any app using the Sui dApp Ki
 
 ## Off-device ⇒ on-device
 
-If a user starts playing your game off-device first, their primary wallet depends on what wallet architecture you choose in your game design (custodial, self-custody, or game-specific zkLogin). Depending on what kind of wallet interactions your game requires during gameplay, you have different options for supporting cross-device gameplay. To learn more about wallet options, see [Wallet Integration Options](/sui-stack/suiplay0x1/migration-strategies).
+If a user starts playing your game off-device first, their primary wallet depends on what wallet architecture you choose in your game design (custodial, self-custody, or game-specific zkLogin). Depending on what kind of wallet interactions your game requires during gameplay, you have different options for supporting cross-device gameplay. To learn more about wallet options, see [Wallet Integration Options](/sui-stack/suiplay0x1/wallet-integration).
 
 ### Read-only asset access
 


### PR DESCRIPTION
## Description

Fixes the self-referencing link issue in the migration-strategies.mdx file where the 'Wallet Integration Options' link was incorrectly pointing back to itself instead of the wallet-integration.mdx file.

## Changes
- Updated the link target from `/sui-stack/suiplay0x1/migration-strategies` to `/sui-stack/suiplay0x1/wallet-integration`

## Testing
- Verified that wallet-integration.mdx exists in the same directory
- Confirmed the link now points to the correct file

Fixes #26039

## Note
The other two issues mentioned in #26039 regarding GraphQL RPC links appear to have been resolved in a previous IA restructure commit (#26241). The current codebase already has the correct links pointing to `/develop/accessing-data/graphql/graphql-rpc`.