### PR TITLE
[6/7] Generalize accumulator version to a system-object version map

### DIFF
--- a/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
@@ -188,7 +188,8 @@ impl ObjectFundsChecker {
         // for the epoch, and every production path that produces such a tx also
         // assigns an accumulator version. The `None` paths (accumulator-disabled
         // epoch, end-of-epoch tx) never produce withdraws and so never reach here.
-        let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version else {
+        let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version()
+        else {
             debug_fatal!("accumulator_version must be set for a tx with object withdraws");
             return false;
         };

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1513,7 +1513,7 @@ impl AuthorityState {
             return ExecutionOutput::EpochEnded;
         }
 
-        let accumulator_version = execution_env.assigned_versions.accumulator_version;
+        let accumulator_version = execution_env.assigned_versions.accumulator_version();
 
         let (transaction_outputs, timings, execution_error_opt) = match self.process_certificate(
             &tx_guard,
@@ -1969,17 +1969,15 @@ impl AuthorityState {
         // System object versions this transaction is allowed to read during execution. Currently
         // only the accumulator root, at the version this transaction was sequenced against (if
         // any), so the in-execution object-funds check can gate on settlement progress.
-        let system_object_versions: BTreeMap<ObjectID, SequenceNumber> = execution_env
+        let system_object_versions = execution_env
             .assigned_versions
-            .accumulator_version
-            .map(|v| (SUI_ACCUMULATOR_ROOT_OBJECT_ID, v))
-            .into_iter()
-            .collect();
+            .system_object_versions
+            .clone();
         // Mainnet-only: feed the accumulator (settlement) version so the address-balance gas-smash
         // short-circuit activates at its rollout version and replays bit-for-bit. Other chains pass
         // `None`, where the short-circuit applies unconditionally.
         let accumulator_version = if self.chain_identifier.chain() == Chain::Mainnet {
-            execution_env.assigned_versions.accumulator_version
+            execution_env.assigned_versions.accumulator_version()
         } else {
             None
         };
@@ -1996,7 +1994,7 @@ impl AuthorityState {
                 &*self.coin_reservation_resolver,
                 sender,
                 &mut kind,
-                execution_env.assigned_versions.accumulator_version,
+                execution_env.assigned_versions.accumulator_version(),
             )
             .expect("rewriting must succeed for a certified transaction")
         } else {
@@ -2046,8 +2044,10 @@ impl AuthorityState {
             // produced.
             Err(ExecutionRetryError::ObjectFundsNotSettled) => {
                 assert_reachable!("retry object withdraw later (in-execution)");
-                let accumulator_version =
-                    execution_env.assigned_versions.accumulator_version.expect(
+                let accumulator_version = execution_env
+                    .assigned_versions
+                    .accumulator_version()
+                    .expect(
                         "a tx requesting an object-funds retry must have an accumulator version",
                     );
                 if let Some(object_funds_checker) = object_funds_checker.as_ref() {
@@ -2090,7 +2090,7 @@ impl AuthorityState {
             }
         } else if effects.status().is_ok()
             && let Some(object_funds_checker) = object_funds_checker.as_ref()
-            && let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version
+            && let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version()
         {
             // In-execution flow: the VM confirmed sufficiency and the transaction succeeded. Record
             // its object withdrawals as unsettled so later transactions in this consensus commit,

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -14,6 +14,7 @@ use sui_types::SUI_ACCUMULATOR_ROOT_OBJECT_ID;
 use sui_types::SUI_CLOCK_OBJECT_ID;
 use sui_types::SUI_CLOCK_OBJECT_SHARED_VERSION;
 use sui_types::base_types::ConsensusObjectSequenceKey;
+use sui_types::base_types::ObjectID;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::EpochId;
 use sui_types::crypto::RandomnessRound;
@@ -36,15 +37,16 @@ pub struct SharedObjVerManager {}
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AssignedVersions {
     pub shared_object_versions: Vec<(ConsensusObjectSequenceKey, SequenceNumber)>,
-    /// Accumulator version number at the beginning of the consensus commit
-    /// that this transaction belongs to. It is used to determine the deterministic
-    /// balance state of the accounts involved in funds withdrawals.
+    /// Versions of system objects, keyed by object ID, that this transaction reads during execution
+    /// but that are not part of its declared shared inputs. They are recorded so the deterministic
+    /// state read during execution (e.g. the accumulator root version, used to settle object-funds
+    /// withdrawals) can be reproduced on replay.
     ///
-    /// `None` when no accumulator version applies to this transaction:
-    /// - accumulators are not enabled at the protocol level for this epoch, or
-    /// - the transaction is an end-of-epoch / change-epoch tx, which does not
-    ///   read or write the accumulator root.
-    pub accumulator_version: Option<SequenceNumber>,
+    /// Today this holds at most the accumulator root version (at the beginning of the consensus
+    /// commit this transaction belongs to), and is empty when accumulators are not enabled or the
+    /// transaction does not read the accumulator root (e.g. an end-of-epoch / change-epoch tx). More
+    /// system objects will be added over time.
+    pub system_object_versions: BTreeMap<ObjectID, SequenceNumber>,
 }
 
 impl AssignedVersions {
@@ -54,8 +56,23 @@ impl AssignedVersions {
     ) -> Self {
         Self {
             shared_object_versions,
-            accumulator_version,
+            system_object_versions: accumulator_version
+                .map(|v| (SUI_ACCUMULATOR_ROOT_OBJECT_ID, v))
+                .into_iter()
+                .collect(),
         }
+    }
+
+    /// The accumulator root version this transaction reads, if any.
+    pub fn accumulator_version(&self) -> Option<SequenceNumber> {
+        self.system_object_versions
+            .get(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
+            .copied()
+    }
+
+    /// Records the version at which `object_id` is read during execution.
+    pub fn set_system_object_version(&mut self, object_id: ObjectID, version: SequenceNumber) {
+        self.system_object_versions.insert(object_id, version);
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &(ConsensusObjectSequenceKey, SequenceNumber)> {
@@ -1184,20 +1201,14 @@ mod tests {
                 assigned_versions: AssignedTxAndVersions::new(vec![
                     (
                         withdraw_key,
-                        AssignedVersions {
-                            shared_object_versions: vec![],
-                            accumulator_version: Some(acc_version),
-                        }
+                        AssignedVersions::new(vec![], Some(acc_version))
                     ),
                     (
                         settlement_key,
-                        AssignedVersions {
-                            shared_object_versions: vec![(
-                                (SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version),
-                                acc_version
-                            )],
-                            accumulator_version: Some(acc_version),
-                        }
+                        AssignedVersions::new(
+                            vec![((SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version), acc_version)],
+                            Some(acc_version)
+                        )
                     ),
                 ]),
                 shared_input_next_versions: HashMap::from([(
@@ -1238,54 +1249,42 @@ mod tests {
                 assigned_versions: AssignedTxAndVersions::new(vec![
                     (
                         withdraw_key1,
-                        AssignedVersions {
-                            shared_object_versions: vec![],
-                            accumulator_version: Some(acc_version),
-                        }
+                        AssignedVersions::new(vec![], Some(acc_version))
                     ),
                     (
                         settlement_key1,
-                        AssignedVersions {
-                            shared_object_versions: vec![(
-                                (SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version),
-                                acc_version
-                            )],
-                            accumulator_version: Some(acc_version),
-                        }
+                        AssignedVersions::new(
+                            vec![((SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version), acc_version)],
+                            Some(acc_version)
+                        )
                     ),
                     (
                         withdraw_key2,
-                        AssignedVersions {
-                            shared_object_versions: vec![],
-                            accumulator_version: Some(acc_version.next()),
-                        }
+                        AssignedVersions::new(vec![], Some(acc_version.next()))
                     ),
                     (
                         settlement_key2,
-                        AssignedVersions {
-                            shared_object_versions: vec![(
+                        AssignedVersions::new(
+                            vec![(
                                 (SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version),
                                 acc_version.next()
                             )],
-                            accumulator_version: Some(acc_version.next()),
-                        }
+                            Some(acc_version.next())
+                        )
                     ),
                     (
                         withdraw_key3,
-                        AssignedVersions {
-                            shared_object_versions: vec![],
-                            accumulator_version: Some(acc_version.next().next()),
-                        }
+                        AssignedVersions::new(vec![], Some(acc_version.next().next()))
                     ),
                     (
                         settlement_key3,
-                        AssignedVersions {
-                            shared_object_versions: vec![(
+                        AssignedVersions::new(
+                            vec![(
                                 (SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version),
                                 acc_version.next().next()
                             )],
-                            accumulator_version: Some(acc_version.next().next()),
-                        }
+                            Some(acc_version.next().next())
+                        )
                     ),
                 ]),
                 shared_input_next_versions: HashMap::from([(
@@ -1321,23 +1320,17 @@ mod tests {
                 assigned_versions: AssignedTxAndVersions::new(vec![
                     (
                         withdraw_with_shared_key,
-                        AssignedVersions {
-                            shared_object_versions: vec![(
-                                (shared_obj_id, shared_obj_version),
-                                shared_obj_version
-                            )],
-                            accumulator_version: Some(acc_version),
-                        }
+                        AssignedVersions::new(
+                            vec![((shared_obj_id, shared_obj_version), shared_obj_version)],
+                            Some(acc_version)
+                        )
                     ),
                     (
                         settlement_key,
-                        AssignedVersions {
-                            shared_object_versions: vec![(
-                                (SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version),
-                                acc_version
-                            )],
-                            accumulator_version: Some(acc_version),
-                        }
+                        AssignedVersions::new(
+                            vec![((SUI_ACCUMULATOR_ROOT_OBJECT_ID, acc_version), acc_version)],
+                            Some(acc_version)
+                        )
                     ),
                 ]),
                 shared_input_next_versions: HashMap::from([

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -222,7 +222,7 @@ impl ExecutionScheduler {
         // (which create/update accumulator account objects) execute before coin reservation
         // transactions that depend on those objects.
         if tx_data.kind().has_coin_reservations()
-            && let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version
+            && let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version()
             && let Some(initial_shared_version) =
                 (**epoch_store.epoch_start_config()).accumulator_root_obj_initial_shared_version()
         {
@@ -365,7 +365,7 @@ impl ExecutionScheduler {
             assert!(!tx_withdraws.is_empty());
             let accumulator_version = env
                 .assigned_versions
-                .accumulator_version
+                .accumulator_version()
                 .expect("accumulator_version must be set when there are withdraws");
             if let Some(prev_version) = prev_version {
                 // Transactions must be in order.

--- a/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/e2e_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/e2e_tests.rs
@@ -137,7 +137,8 @@ impl TestEnv {
                 .iter()
                 .map(|tx| {
                     let mut env = ExecutionEnv::default();
-                    env.assigned_versions.accumulator_version = Some(version);
+                    env.assigned_versions
+                        .set_system_object_version(SUI_ACCUMULATOR_ROOT_OBJECT_ID, version);
                     (Schedulable::Transaction(tx.clone()), env)
                 })
                 .collect(),


### PR DESCRIPTION
## Description

Generalizes the version-passing framework that feeds system-object versions into execution. `AssignedVersions` carried a dedicated `accumulator_version: Option<SequenceNumber>` field; this replaces it with a generic `system_object_versions: BTreeMap<ObjectID, SequenceNumber>` so more system objects can be threaded over time (and so checkpoint replay can carry their versions, in the follow-up). Accumulator-specific consumers read the accumulator root version through an `accumulator_version()` accessor.

Pure refactor — no behavior change. The map currently holds at most the accumulator root version, exactly as before. A `BTreeMap` (not `HashMap`) is used to match the downstream temporary-store map and keep iteration deterministic.

## Stack
1. #27003, 2. #27019, 3. #27020, 4. #27022, 5. #27014 — object-funds-in-VM stack
6. this PR — generic system-object version map
7. (next) — record read system objects in effects for checkpoint replay

## Test plan

Covered by existing `shared_object_version_manager` assignment tests and the `object_funds_checker` suite (22 tests), which exercise version assignment and the accumulator-version reads through the new accessor.

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
