### PR TITLE
[telemetry-subscribers] add RUST_LOG_TAILS for per-target log file tails

### DIFF
--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -15,7 +15,8 @@ use opentelemetry_sdk::{
     trace::{BatchSpanProcessor, ShouldSample, TracerProvider},
 };
 use span_latency_prom::PrometheusSpanLatencyLayer;
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{
     env,
@@ -29,7 +30,8 @@ use tracing::{Level, error, info};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
-    EnvFilter, Layer, Registry, filter,
+    EnvFilter, Layer, Registry,
+    filter::{self, FilterExt},
     fmt::{self, format::Pretty},
     layer::SubscriberExt,
     reload,
@@ -123,9 +125,44 @@ impl<S: tracing::Subscriber> Layer<S> for GlobalLevelFilter {
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// Output format for a per-target log route (see [`TelemetryConfig::log_tails`]). Inferred
+/// from the route's file extension.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum LogFormat {
+    Json,
+    #[default]
+    Text,
+}
+
+impl LogFormat {
+    /// Infer the output format from a log file's extension: the common newline-delimited
+    /// JSON extensions `jsonl` and `ndjson` (case-insensitive) select [`LogFormat::Json`];
+    /// every other extension (including `.json` and `.log`) and none default to
+    /// [`LogFormat::Text`].
+    fn from_path(path: &Path) -> Self {
+        if let Some(ext) = path.extension().and_then(|ext| ext.to_str())
+            && (ext.eq_ignore_ascii_case("jsonl") || ext.eq_ignore_ascii_case("ndjson"))
+        {
+            LogFormat::Json
+        } else {
+            LogFormat::Text
+        }
+    }
+}
+
+/// A per-target output route: *additionally* write `target`'s logs to `file`. Configured via
+/// the `RUST_LOG_TAILS` env var, e.g. `graphql_request=/var/log/sui/graphql_request.jsonl`.
+#[derive(Clone, Debug)]
+pub struct LogTail {
+    pub target: String,
+    pub format: LogFormat,
+    pub file: PathBuf,
+}
+
 /// Configuration for different logging/tracing options
 /// ===
 /// - json_log_output: Output JSON logs to stdout only.
+/// - log_tails: Additional per-target log files via RUST_LOG_TAILS.
 /// - log_file: If defined, write output to a file starting with this name, ex app.log
 /// - log_level: error/warn/info/debug/trace, defaults to info
 #[derive(Default, Clone, Debug)]
@@ -155,6 +192,10 @@ pub struct TelemetryConfig {
     pub trace_target: Option<Vec<String>>,
     /// Print unadorned logs from the target on standard error if this is a tty
     pub user_info_target: Vec<String>,
+    /// Per-target output routing — one [`LogTail`] per entry — populated from the
+    /// `RUST_LOG_TAILS` env var. See [`TelemetryConfig::with_log_tail`] for how each tail
+    /// is emitted.
+    pub log_tails: Vec<LogTail>,
     // Sets the subscriber created by this config to be the global default. Defaults to true if not set.
     pub set_global_default: bool,
     // Add error layer to capture trace spans. Defaults to false if not set.
@@ -167,6 +208,9 @@ pub struct TelemetryConfig {
 #[allow(dead_code)]
 pub struct TelemetryGuards {
     worker_guard: WorkerGuard,
+    /// Flush guards for any per-target log files (`RUST_LOG_TAILS`). Held so the
+    /// background writer threads keep flushing until the guards are dropped.
+    file_guards: Vec<WorkerGuard>,
     provider: Option<TracerProvider>,
     subscriber: Option<DefaultGuard>,
 }
@@ -175,6 +219,7 @@ impl TelemetryGuards {
     fn new(
         config: TelemetryConfig,
         worker_guard: WorkerGuard,
+        file_guards: Vec<WorkerGuard>,
         provider: Option<TracerProvider>,
         subscriber: Option<DefaultGuard>,
     ) -> Self {
@@ -184,6 +229,7 @@ impl TelemetryGuards {
         }
         Self {
             worker_guard,
+            file_guards,
             provider,
             subscriber,
         }
@@ -302,6 +348,24 @@ fn get_output(log_file: Option<String>) -> (NonBlocking, WorkerGuard) {
     }
 }
 
+/// Open a per-target log file (`RUST_LOG_TAILS`), pre-creating its parent directory.
+/// Panics `init()` if the directory cannot be created, rather than silently dropping the
+/// target's file sink.
+fn open_tail_file(path: &Path) -> (NonBlocking, WorkerGuard) {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).unwrap_or_else(|e| {
+            panic!(
+                "telemetry: cannot create directory for RUST_LOG_TAILS file {}: {e}",
+                path.display()
+            )
+        });
+    }
+    let file_appender = tracing_appender::rolling::daily("", path);
+    tracing_appender::non_blocking(file_appender)
+}
+
 // NOTE: this function is copied from tracing's panic_hook example
 fn set_panic_hook(crash_on_panic: bool) {
     let default_panic_handler = std::panic::take_hook();
@@ -361,6 +425,33 @@ pub fn get_global_telemetry_config() -> Option<TelemetryConfig> {
     global_config.clone()
 }
 
+fn parse_log_tails(spec: &str) -> Vec<LogTail> {
+    spec.split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(parse_log_tail_entry)
+        .collect()
+}
+
+fn parse_log_tail_entry(entry: &str) -> LogTail {
+    if let Some((target, file)) = entry.split_once('=') {
+        let (target, file) = (target.trim(), file.trim());
+        if !target.is_empty() && !file.is_empty() {
+            let file = PathBuf::from(file);
+            let format = LogFormat::from_path(&file);
+            return LogTail {
+                target: target.to_owned(),
+                format,
+                file,
+            };
+        }
+    }
+    panic!(
+        "telemetry: invalid RUST_LOG_TAILS entry {entry:?}: a `=file` path is \
+         required, e.g. `graphql_request=/var/log/sui/graphql_request.jsonl`"
+    )
+}
+
 impl TelemetryConfig {
     pub fn new() -> Self {
         Self {
@@ -377,6 +468,7 @@ impl TelemetryConfig {
             sample_rate: 1.0,
             trace_target: None,
             user_info_target: Vec::new(),
+            log_tails: Vec::new(),
             set_global_default: true,
             enable_error_layer: false,
             enable_test_layer: false,
@@ -434,6 +526,19 @@ impl TelemetryConfig {
         self
     }
 
+    /// Adds a `RUST_LOG_TAILS`-style routing rule: *additionally* write `target`'s logs to
+    /// `file`, in a format inferred from its extension.
+    pub fn with_log_tail(mut self, target: &str, file: impl Into<PathBuf>) -> Self {
+        let file = file.into();
+        let format = LogFormat::from_path(&file);
+        self.log_tails.push(LogTail {
+            target: target.to_owned(),
+            format,
+            file,
+        });
+        self
+    }
+
     pub fn with_set_global_default(mut self, set_global_default: bool) -> Self {
         self.set_global_default = set_global_default;
         self
@@ -460,6 +565,10 @@ impl TelemetryConfig {
 
         if env::var("RUST_LOG_JSON").is_ok() {
             self.json_log_output = true;
+        }
+
+        if let Ok(spec) = env::var("RUST_LOG_TAILS") {
+            self.log_tails = parse_log_tails(&spec);
         }
 
         if env::var("TOKIO_CONSOLE").is_ok() {
@@ -502,8 +611,8 @@ impl TelemetryConfig {
                 directives.push_str(&format!(",{}=trace", target));
             }
         }
-        let env_filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(directives));
+        let env_filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new(directives.clone()));
         // When the test layer is enabled, it accepts events at any level without a
         // per-layer filter, so global event-level filtering would hide events the
         // test wants to capture. Disable it by pinning max_event_level to TRACE
@@ -629,6 +738,8 @@ impl TelemetryConfig {
         }
 
         let (nb_output, worker_guard) = get_output(config.log_file.clone());
+        // Flush guards for any per-target files opened below; kept alive in TelemetryGuards.
+        let mut file_guards: Vec<WorkerGuard> = Vec::new();
         if config.json_log_output {
             // Output to file or to stderr in a newline-delimited JSON format
             let json_layer = fmt::layer()
@@ -640,13 +751,15 @@ impl TelemetryConfig {
                 .boxed();
             layers.push(json_layer);
         } else {
-            // Output to file or to stderr with ANSI colors
+            let with_ansi = config.log_file.is_none() && stderr().is_tty();
+
+            // Main human-readable layer — always emits everything permitted by the env
+            // filter (`RUST_LOG`).
             let fmt_layer = fmt::layer()
-                .with_ansi(config.log_file.is_none() && stderr().is_tty())
+                .with_ansi(with_ansi)
                 .with_writer(nb_output.clone())
                 .with_filter(log_filter)
                 .boxed();
-
             layers.push(fmt_layer);
 
             if config.log_file.is_none() && stderr().is_tty() && !config.user_info_target.is_empty()
@@ -670,6 +783,49 @@ impl TelemetryConfig {
                     .boxed();
 
                 layers.push(fmt_layer);
+            }
+        }
+
+        if !config.log_tails.is_empty() {
+            // One non-blocking writer per unique file, shared by that file's layers.
+            let mut file_writers: HashMap<PathBuf, NonBlocking> = HashMap::new();
+            for path in config.log_tails.iter().map(|t| &t.file) {
+                if !file_writers.contains_key(path) {
+                    let (writer, guard) = open_tail_file(path);
+                    file_writers.insert(path.clone(), writer);
+                    file_guards.push(guard);
+                }
+            }
+
+            // One layer per routed target: its format, written to its file.
+            for log_tail in &config.log_tails {
+                let writer = file_writers
+                    .get(&log_tail.file)
+                    .cloned()
+                    .expect("a writer was created above for every target's file");
+                // Target restriction (matches this target at any level) ANDed with an EnvFilter
+                // (built like the main one) so `RUST_LOG`'s per-target level is the binding gate.
+                let target_filter = filter::Targets::new()
+                    .with_target(log_tail.target.clone(), LevelFilter::TRACE)
+                    .and(
+                        EnvFilter::try_from_default_env()
+                            .unwrap_or_else(|_| EnvFilter::new(directives.clone())),
+                    );
+                let layer = match log_tail.format {
+                    LogFormat::Json => fmt::layer()
+                        .with_file(true)
+                        .with_line_number(true)
+                        .json()
+                        .with_writer(writer)
+                        .with_filter(target_filter)
+                        .boxed(),
+                    LogFormat::Text => fmt::layer()
+                        .with_ansi(false)
+                        .with_writer(writer)
+                        .with_filter(target_filter)
+                        .boxed(),
+                };
+                layers.push(layer);
             }
         }
 
@@ -717,7 +873,13 @@ impl TelemetryConfig {
 
         // The guard must be returned and kept in the main fn of the app, as when it's dropped then the output
         // gets flushed and closed. If this is dropped too early then no output will appear!
-        let guards = TelemetryGuards::new(config_clone, worker_guard, provider, subscriber_guard);
+        let guards = TelemetryGuards::new(
+            config_clone,
+            worker_guard,
+            file_guards,
+            provider,
+            subscriber_guard,
+        );
 
         (
             guards,
@@ -853,5 +1015,84 @@ mod tests {
     #[test]
     fn testing_logger_2() {
         init_for_testing();
+    }
+
+    #[test]
+    fn with_log_tail_appends() {
+        // Format is inferred from the file extension.
+        let config = TelemetryConfig::new()
+            .with_log_tail("graphql_request", "/var/log/x.ndjson")
+            .with_log_tail("foo", "/var/log/foo.log");
+        assert_eq!(config.log_tails.len(), 2);
+        assert_eq!(config.log_tails[0].target, "graphql_request");
+        assert_eq!(config.log_tails[0].format, LogFormat::Json);
+        assert_eq!(config.log_tails[0].file, PathBuf::from("/var/log/x.ndjson"));
+        assert_eq!(config.log_tails[1].target, "foo");
+        assert_eq!(config.log_tails[1].format, LogFormat::Text);
+        assert_eq!(config.log_tails[1].file, PathBuf::from("/var/log/foo.log"));
+    }
+
+    #[test]
+    fn parse_log_tails_infers_format_from_extension() {
+        // `target=file`, comma-separated, with surrounding whitespace; the file extension
+        // selects the format.
+        let t = parse_log_tails(
+            "a=/var/log/a.jsonl, b=/var/log/b.ndjson , c=/var/log/c.log, d=/var/log/d.JSONL, e=/var/log/e.json",
+        );
+        assert_eq!(t.len(), 5);
+        let got: Vec<_> = t
+            .iter()
+            .map(|lt| (&*lt.target, lt.format, lt.file.clone()))
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                ("a", LogFormat::Json, PathBuf::from("/var/log/a.jsonl")),
+                ("b", LogFormat::Json, PathBuf::from("/var/log/b.ndjson")),
+                ("c", LogFormat::Text, PathBuf::from("/var/log/c.log")),
+                // Extension match is case-insensitive.
+                ("d", LogFormat::Json, PathBuf::from("/var/log/d.JSONL")),
+                // `.json` is a single JSON document, not newline-delimited → text.
+                ("e", LogFormat::Text, PathBuf::from("/var/log/e.json")),
+            ]
+        );
+
+        // Empty / whitespace-only entries are skipped (they are absent, not malformed).
+        assert!(parse_log_tails("").is_empty());
+        assert!(parse_log_tails("  ,  , ").is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid RUST_LOG_TAILS entry")]
+    fn parse_log_tails_panics_without_file() {
+        // A non-empty entry without a `=file` is a misconfiguration → hard-fail init.
+        let _ = parse_log_tails("graphql_request");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid RUST_LOG_TAILS entry")]
+    fn parse_log_tails_panics_on_empty_file() {
+        let _ = parse_log_tails("a=");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid RUST_LOG_TAILS entry")]
+    fn parse_log_tails_panics_on_empty_target() {
+        let _ = parse_log_tails("=/var/log/x.log");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid RUST_LOG_TAILS entry")]
+    fn parse_log_tails_panics_on_one_bad_entry_among_valid() {
+        // A single malformed entry fails the whole parse, even alongside valid ones.
+        let _ = parse_log_tails("bare, ok=/var/log/ok.jsonl");
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot create directory for RUST_LOG_TAILS file")]
+    fn open_tail_file_panics_on_uncreatable_dir() {
+        // `/dev/null` is not a directory, so create_dir_all under it fails deterministically —
+        // a bad RUST_LOG_TAILS file path must hard-fail init rather than silently degrade.
+        let _ = open_tail_file(Path::new("/dev/null/x/test.log"));
     }
 }


### PR DESCRIPTION
## Description

Adds `RUST_LOG_TAILS` to `telemetry-subscribers` (with a `with_log_tail` builder / `log_tails` config) that *additionally* writes individual tracing targets to dedicated files, on top of the normal log output. A "tail" is an extra file sink: matching events are **duplicated** to the file, not moved off the console/JSON stream.

**Syntax** — comma-separated `target=file` entries (mirroring `RUST_LOG`'s `target=level`, but assigning a file instead of a level):

- `=file` is a daily-rolling file (like `RUST_LOG_FILE`) and is **mandatory** — `RUST_LOG_TAILS` only adds file sinks, it never routes to the stream.
- The output **format is inferred from the file extension**: `.jsonl` / `.ndjson` (case-insensitive) → newline-delimited JSON; everything else (including `.json` and `.log`) → text.

| Entry | Result |
| --- | --- |
| `graphql_request=/var/log/sui/gql.log` | `graphql_request` → text in that file |
| `graphql_request=/var/log/sui/gql.jsonl` | `graphql_request` → NDJSON in that file (replay corpus) |
| `a=/x.jsonl,b=/y.log` | two tails, each to its own file |

Behavior:

- Tails are **additional** sinks — the events still appear on the normal stream as well, **including when `RUST_LOG_JSON` (global JSON output) is set**.
- Each tail honors **`RUST_LOG`'s per-target level** (its layer filter is the target restriction ANDed with an `EnvFilter`): e.g. with `RUST_LOG=warn` a `bar` tail captures only `warn`+, while `RUST_LOG=warn,bar=debug` also captures `bar` debug. Targets are matched by prefix (like `RUST_LOG`).
- A malformed entry (missing target or `=file`) or a file whose directory cannot be created **hard-fails `init()`** rather than silently degrading.

Example — capture `graphql_request` as a JSON replay corpus in its own file while normal logs stay human-readable:

```
RUST_LOG="info,graphql_request=trace" RUST_LOG_TAILS="graphql_request=/var/log/sui/graphql_request.jsonl"
```

## Test plan

Added unit tests (entry parsing, extension→format inference, malformed-entry panics, builder). `cargo test -p telemetry-subscribers`, `cargo xclippy`, and `cargo fmt -- --check` all pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): New optional `RUST_LOG_TAILS` env var additionally writes individual tracing targets to dedicated files (format inferred from the file extension — `.jsonl`/`.ndjson` for JSON, otherwise text), leaving normal log output unchanged. Backward-compatible — unset by default, so log output is unchanged and no action is required.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] Indexing Framework: The same `RUST_LOG_TAILS` env var is available to indexer binaries (e.g. `sui-indexer-alt-graphql`). Set it alongside `RUST_LOG` (e.g. `RUST_LOG="info,graphql_request=trace"` with `RUST_LOG_TAILS="graphql_request=/var/log/sui/graphql_request.jsonl"`) to capture that target as NDJSON for replay while normal logs stay readable. Opt-in; no action required otherwise.
