### PR TITLE
docs: JSON-RPC deprecation banner and Playground analytics

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -381,9 +381,11 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       announcementBar: {
-        id: "skills_launch",
+        id: "json_rpc_deprecation",
         content:
-          'New: <a href="/skills">Sui Agent Skills</a> — drop pre-built skills into Claude Code, Cursor, Codex, and other AI coding agents.',
+          'JSON-RPC public endpoints shutting down: Testnet week of July 6, Mainnet week of July 20. <a href="/develop/accessing-data/json-rpc-migration">Migrate now</a>.',
+        backgroundColor: '#FFF3CD',
+        textColor: '#664D03',
         isCloseable: true,
       },
       image: "img/sui-doc-og.png",

--- a/docs/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
+++ b/docs/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
@@ -101,7 +101,7 @@ function OpenInPlayMoveButton({ className }: { className?: string }) {
         title="Open in Move Playground"
         className={clsx(
           className,
-          "!opacity-50 !hover:opacity-100 text-xs !pb-2 justify-center",
+          "!opacity-50 !hover:opacity-100 text-xs !pb-2 justify-center plausible-event-name=open+move+playground",
         )}
         onClick={handleClick}
       >


### PR DESCRIPTION
## Summary

- **JSON-RPC deprecation banner**: Replace the Skills launch announcement bar with a yellow warning banner about JSON-RPC public endpoint shutdowns (Testnet week of July 6, Mainnet week of July 20). Links to the migration guide at `/develop/accessing-data/json-rpc-migration`.
- **Plausible tracking**: Add `plausible-event-name=open+move+playground` CSS class to the "Open in Move Playground" button for click analytics.

## Test plan

- [ ] Verify yellow announcement bar appears at the top of all pages
- [ ] Verify "Migrate now" links to `/develop/accessing-data/json-rpc-migration`
- [ ] Verify banner is dismissible (X button)
- [ ] Verify Plausible tracks clicks on the Playground button (check Plausible dashboard or network tab for the event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)