### PR TITLE
[typed-store] Double WAL mmap window for perpetual tidehunter DB

### DIFF
--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -109,6 +109,11 @@ fn thdb_config(metric_conf: &MetricConf) -> Config {
     #[cfg(not(debug_assertions))]
     let max_maps = 8; // 8Gb of mapped space for prod
     let max_maps = parse_env_usize("TH_MAX_MAPS", 1).unwrap_or(max_maps);
+    let max_maps = if metric_conf.db_name.starts_with("perpetual") {
+        max_maps * 2
+    } else {
+        max_maps
+    };
     let max_index_maps = Some(parse_env_usize("TH_MAX_INDEX_MAPS", 3).unwrap_or(3));
     #[cfg(debug_assertions)]
     let commit_pool_size = 0;


### PR DESCRIPTION
## Description

The perpetual tidehunter DB is value-read-bound under sustained high load: object/tx/effects value reads dominate, and once their record-WAL frags age out of the mmap window they fall back to `pread` syscalls. Double `max_maps` (the record-WAL mmap window) for the perpetual DB only — the index is in memory, so `max_index_maps` is left unchanged.

## Test plan

Config-only change. Validated under load on private-testnet: at high TPS, `read{kind=record, type=syscall}` (value reads served by `pread` because the value's WAL frag was outside the mmap window) was eliminated after doubling the perpetual record-WAL mmap window, while `max_index_maps` (and the other DBs) were unaffected.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
