### PR TITLE
Add active address source metrics for discovery v3 rollout

### DIFF
--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -16,16 +16,20 @@ use consensus_core::{
     RandomnessSignatureHandler, storage::rocksdb_store::RocksDBStore,
 };
 use core::panic;
+use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::KeyPair as _;
 use mysten_metrics::{RegistryID, RegistryService};
 use mysten_network::Multiaddr;
-use prometheus::{IntGauge, Registry, register_int_gauge_with_registry};
+use prometheus::{
+    IntGauge, IntGaugeVec, Registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry,
+};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_config::{ConsensusConfig, NodeConfig};
-use sui_network::endpoint_manager::ConsensusAddressUpdater;
+use sui_network::endpoint_manager::{AddressSource, ConsensusAddressUpdater};
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::crypto::NetworkPublicKey;
 use sui_types::error::{SuiErrorKind, SuiResult};
@@ -93,14 +97,19 @@ impl AddressOverridesMap {
         }
     }
 
-    pub fn get_highest_priority_address(
+    /// Returns the highest-priority active override `(source, address)` for the
+    /// peer, or `None` when no override is installed (the on-chain committee
+    /// address is in use).
+    pub fn get_highest_priority_source_and_address(
         &self,
         network_pubkey: ConsensusNetworkPublicKey,
-    ) -> Option<Multiaddr> {
+    ) -> Option<(sui_network::endpoint_manager::AddressSource, Multiaddr)> {
         self.map
             .get(&network_pubkey)
             .and_then(|sources| sources.first_key_value())
-            .and_then(|(_, addresses)| addresses.first().cloned())
+            .and_then(|(source, addresses)| {
+                addresses.first().cloned().map(|address| (*source, address))
+            })
     }
 
     pub fn get_all_highest_priority_addresses(
@@ -474,8 +483,8 @@ impl ConsensusAddressUpdater for ConsensusManager {
         // Convert to consensus network public key once
         let network_pubkey = ConsensusNetworkPublicKey::new(network_pubkey.clone());
 
-        // Determine what address should be used after this update (if any)
-        let address_to_apply = {
+        // Determine which override (if any) should be used after this update.
+        let highest_priority = {
             let mut address_overrides = self.address_overrides.lock();
 
             if addresses.is_empty() {
@@ -484,10 +493,15 @@ impl ConsensusAddressUpdater for ConsensusManager {
                 address_overrides.insert(network_pubkey.clone(), source, addresses.clone());
             }
 
-            address_overrides.get_highest_priority_address(network_pubkey.clone())
+            address_overrides.get_highest_priority_source_and_address(network_pubkey.clone())
         };
+        self.metrics.set_active_address_source(
+            &Hex::encode(network_pubkey.to_bytes()),
+            highest_priority.as_ref().map(|(source, _)| *source),
+        );
 
         // Apply the update to running consensus if it exists
+        let address_to_apply = highest_priority.map(|(_, address)| address);
         if let Some(authority) = self.authority.load_full() {
             authority
                 .0
@@ -606,6 +620,7 @@ impl Clone for ReplayWaiter {
 pub struct ConsensusManagerMetrics {
     start_latency: IntGauge,
     shutdown_latency: IntGauge,
+    active_address_source: IntGaugeVec,
 }
 
 impl ConsensusManagerMetrics {
@@ -623,6 +638,34 @@ impl ConsensusManagerMetrics {
                 registry,
             )
             .unwrap(),
+            active_address_source: register_int_gauge_vec_with_registry!(
+                "consensus_active_address_source",
+                "Active consensus address source per committee peer, encoded as the gauge \
+                 value: 0=committee (no override active; the on-chain committee address is in \
+                 use), 1=admin, 2=config, 3=discovery, 4=seed, 5=chain (override priority \
+                 highest to lowest). One series per peer; `peer_id` is the full hex consensus \
+                 network public key.",
+                &["peer_id"],
+                registry,
+            )
+            .unwrap(),
         }
+    }
+
+    /// Records the active consensus address source for a committee peer as a single
+    /// per-peer gauge whose value is the source's `metric_code`. `active =
+    /// Some(source)` means an override is installed; `None` means no override.
+    fn set_active_address_source(
+        &self,
+        peer_id: &str,
+        active: Option<sui_network::endpoint_manager::AddressSource>,
+    ) {
+        let code = active.map_or(
+            AddressSource::DEFAULT_ADDRESS_SOURCE_CODE,
+            sui_network::endpoint_manager::AddressSource::metric_code,
+        );
+        self.active_address_source
+            .with_label_values(&[peer_id])
+            .set(code);
     }
 }

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -259,3 +259,87 @@ async fn test_consensus_manager_address_update() {
 
     manager.shutdown().await;
 }
+
+/// Reads the value of the single-series `consensus_active_address_source` gauge for
+/// a given `peer_id`, or `None` if that series is absent. The value is the active
+/// source's `metric_code` (or the committee code when no override is active).
+fn active_source_code(registry: &Registry, peer_id: &str) -> Option<i64> {
+    let families = registry.gather();
+    let family = families
+        .iter()
+        .find(|f| f.name() == "consensus_active_address_source")?;
+    family.get_metric().iter().find_map(|m| {
+        m.get_label()
+            .iter()
+            .any(|l| l.name() == "peer_id" && l.value() == peer_id)
+            .then(|| m.gauge.value() as i64)
+    })
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_consensus_active_address_source_metric() {
+    use fastcrypto::encoding::{Encoding, Hex};
+
+    let configs = ConfigBuilder::new_with_temp_dir()
+        .committee_size(4.try_into().unwrap())
+        .build();
+    let config = &configs.validator_configs()[0];
+    let consensus_config = config.consensus_config().unwrap();
+
+    // Registry clones share state, so gathering `registry` sees what ConsensusManager
+    // registers into `registry_service.default_registry()`.
+    let registry = Registry::new();
+    let registry_service = RegistryService::new(registry.clone());
+    let secret = Arc::pin(config.protocol_key_pair().copy());
+    let genesis = config.genesis().unwrap();
+
+    let state = TestAuthorityBuilder::new()
+        .with_genesis_and_keypair(genesis, &secret)
+        .build()
+        .await;
+    let epoch_store = state.epoch_store_for_testing();
+    let consensus_client = Arc::new(UpdatableConsensusClient::new());
+
+    let manager = ConsensusManager::new(
+        config,
+        consensus_config,
+        &registry_service,
+        consensus_client,
+        NodeRole::Validator,
+    );
+
+    // A committee peer's consensus network public key, and its metric label.
+    let committee = epoch_store.epoch_start_state().get_consensus_committee();
+    let (_idx, peer_authority) = committee.authorities().nth(1).unwrap();
+    let peer_network_key = peer_authority.network_key.clone();
+    let peer_label = Hex::encode(peer_network_key.to_bytes());
+    let peer_network_pubkey = peer_network_key.into_inner();
+
+    // Apply a Discovery override. Consensus isn't running, so update_address returns
+    // Err, but the active-source metric is recorded before the running check.
+    let discovery_addr: Multiaddr = "/ip4/10.0.0.1/udp/9001".parse().unwrap();
+    let _ = manager.update_address(
+        peer_network_pubkey.clone(),
+        AddressSource::Discovery,
+        vec![discovery_addr],
+    );
+
+    assert_eq!(
+        active_source_code(&registry, &peer_label),
+        Some(AddressSource::Discovery.metric_code()),
+        "Discovery override should be the active source"
+    );
+
+    // Clear the override: the peer falls back to the on-chain committee address.
+    let _ = manager.update_address(
+        peer_network_pubkey.clone(),
+        AddressSource::Discovery,
+        vec![],
+    );
+
+    assert_eq!(
+        active_source_code(&registry, &peer_label),
+        Some(AddressSource::DEFAULT_ADDRESS_SOURCE_CODE),
+        "with no override, the default address is in use"
+    );
+}

--- a/crates/sui-network/src/discovery/metrics.rs
+++ b/crates/sui-network/src/discovery/metrics.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{IntGauge, Registry, register_int_gauge_with_registry};
+use crate::endpoint_manager::AddressSource;
+use prometheus::{
+    IntGauge, IntGaugeVec, Registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry,
+};
 use std::sync::Arc;
 use tap::Pipe;
 
@@ -23,21 +27,30 @@ impl Metrics {
         Metrics(None)
     }
 
-    pub fn inc_num_peers_with_external_address(&self) {
+    /// Sets the gauge of distinct peers known to have an external address.
+    pub fn set_num_peers_with_external_address(&self, value: i64) {
         if let Some(inner) = &self.0 {
-            inner.num_peers_with_external_address.inc();
+            inner.num_peers_with_external_address.set(value);
         }
     }
 
-    pub fn dec_num_peers_with_external_address(&self) {
+    /// Records the currently-active P2P address source for a trusted peer as a
+    /// single per-peer gauge whose value is the source's `metric_code` (0 = no
+    /// address installed / all sources cleared).
+    pub fn set_active_p2p_address_source(&self, peer_id: &str, active: Option<AddressSource>) {
         if let Some(inner) = &self.0 {
-            inner.num_peers_with_external_address.dec();
+            let code = active.map_or(0, AddressSource::metric_code);
+            inner
+                .active_p2p_address_source
+                .with_label_values(&[peer_id])
+                .set(code);
         }
     }
 }
 
 struct Inner {
     num_peers_with_external_address: IntGauge,
+    active_p2p_address_source: IntGaugeVec,
 }
 
 impl Inner {
@@ -46,6 +59,16 @@ impl Inner {
             num_peers_with_external_address: register_int_gauge_with_registry!(
                 "num_peers_with_external_address",
                 "Number of peers with an external address configured for discovery",
+                registry
+            )
+            .unwrap(),
+            active_p2p_address_source: register_int_gauge_vec_with_registry!(
+                "discovery_active_p2p_address_source",
+                "Active P2P address source per trusted peer, encoded as the gauge value: \
+                 0=none (no address installed), 1=admin, 2=config, 3=discovery, 4=seed, \
+                 5=chain (highest to lowest priority). One series per peer; `peer_id` is the \
+                 full hex peer id.",
+                &["peer_id"],
                 registry
             )
             .unwrap(),

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -428,7 +428,6 @@ impl DiscoveryEventLoop {
             DiscoveryMessage::ReceivedNodeInfo { peer_info } => {
                 let changed = update_known_peers_versioned(
                     self.state.clone(),
-                    self.metrics.clone(),
                     vec![*peer_info],
                     self.configured_peers.clone(),
                     &self.chain_peers,
@@ -634,14 +633,29 @@ impl DiscoveryEventLoop {
     /// Reads the highest-priority addresses from `peer_addresses` for the given peer
     /// and updates `network.known_peers()` if they differ from the current addresses.
     fn reconfigure_peer_addresses(&mut self, peer_id: PeerId) {
-        let priority_addresses = self
+        let priority = self
             .state
             .read()
             .unwrap()
             .peer_addresses
             .get(&peer_id)
-            .and_then(|sources| sources.first_key_value().map(|(_, addrs)| addrs.clone()))
-            .unwrap_or_default();
+            .and_then(|sources| {
+                sources
+                    .first_key_value()
+                    .map(|(source, addrs)| (*source, addrs.clone()))
+            });
+
+        // Record the active P2P address source for trusted peers (one gauge per
+        // peer, value-encoded). Untrusted peers are skipped to bound metric
+        // cardinality. A `None` priority (no installed source) records 0.
+        if self.is_trusted_peer(&peer_id) {
+            self.metrics.set_active_p2p_address_source(
+                &peer_id.to_string(),
+                priority.as_ref().map(|(source, _)| *source),
+            );
+        }
+
+        let priority_addresses = priority.map(|(_, addrs)| addrs).unwrap_or_default();
         let current_addresses = self
             .network
             .known_peers()
@@ -688,7 +702,6 @@ impl DiscoveryEventLoop {
 
         update_known_peers_versioned(
             self.state.clone(),
-            self.metrics.clone(),
             entries,
             self.configured_peers.clone(),
             &self.chain_peers,
@@ -732,7 +745,6 @@ impl DiscoveryEventLoop {
                         peer,
                         self.discovery_config.clone(),
                         self.state.clone(),
-                        self.metrics.clone(),
                         self.configured_peers.clone(),
                         self.chain_peers.clone(),
                         self.endpoint_manager.clone(),
@@ -762,7 +774,6 @@ impl DiscoveryEventLoop {
                 self.network.clone(),
                 self.discovery_config.clone(),
                 self.state.clone(),
-                self.metrics.clone(),
                 self.configured_peers.clone(),
                 self.chain_peers.clone(),
                 self.endpoint_manager.clone(),
@@ -807,6 +818,24 @@ impl DiscoveryEventLoop {
         // Spawn some dials
         let state = self.state.read().unwrap();
         let our_peer_id = self.network.peer_id();
+
+        // Recompute the number of distinct peers with an external address from the
+        // deduped union of both known-peer maps. With v3 enabled a peer can appear
+        // in both maps, so a HashSet avoids double-counting; recomputing each tick
+        // (rather than inc/dec) also avoids drift when expired entries are culled.
+        let mut peers_with_external_address: HashSet<PeerId> = HashSet::new();
+        for (peer_id, info) in state.known_peers.iter() {
+            if !info.addresses.is_empty() {
+                peers_with_external_address.insert(*peer_id);
+            }
+        }
+        for (peer_id, info) in state.known_peers_v2.iter() {
+            if !info.p2p_addresses().is_empty() {
+                peers_with_external_address.insert(*peer_id);
+            }
+        }
+        self.metrics
+            .set_num_peers_with_external_address(peers_with_external_address.len() as i64);
 
         // Collect eligible peers from both known_peers (V2) and known_peers_v2 (V3),
         // preferring fresher timestamps when a peer appears in both maps.
@@ -1019,7 +1048,6 @@ async fn query_peer_for_their_known_peers(
     peer: Peer,
     discovery_config: Arc<DiscoveryConfig>,
     state: Arc<RwLock<State>>,
-    metrics: Metrics,
     configured_peers: Arc<HashMap<PeerId, PeerInfo>>,
     chain_peers: Arc<RwLock<HashSet<PeerId>>>,
     endpoint_manager: EndpointManager,
@@ -1058,7 +1086,6 @@ async fn query_peer_for_their_known_peers(
             if let Some(found_peers) = found_peers_v2 {
                 update_known_peers(
                     state.clone(),
-                    metrics.clone(),
                     found_peers,
                     configured_peers.clone(),
                     &chain_peers,
@@ -1067,7 +1094,6 @@ async fn query_peer_for_their_known_peers(
             if let Some(found_peers) = found_peers_v3 {
                 let changed = update_known_peers_versioned(
                     state,
-                    metrics,
                     found_peers,
                     configured_peers,
                     &chain_peers,
@@ -1083,7 +1109,7 @@ async fn query_peer_for_their_known_peers(
 
     // V3 not enabled or our_info_v2 not available - just run V2
     if let Some(found_peers) = query_peer_for_known_peers_v2(peer).await {
-        update_known_peers(state, metrics, found_peers, configured_peers, &chain_peers);
+        update_known_peers(state, found_peers, configured_peers, &chain_peers);
     }
 }
 
@@ -1091,7 +1117,6 @@ async fn query_connected_peers_for_their_known_peers(
     network: Network,
     config: Arc<DiscoveryConfig>,
     state: Arc<RwLock<State>>,
-    metrics: Metrics,
     configured_peers: Arc<HashMap<PeerId, PeerInfo>>,
     chain_peers: Arc<RwLock<HashSet<PeerId>>>,
     endpoint_manager: EndpointManager,
@@ -1187,14 +1212,12 @@ async fn query_connected_peers_for_their_known_peers(
 
             update_known_peers(
                 state.clone(),
-                metrics.clone(),
                 found_peers_v2,
                 configured_peers.clone(),
                 &chain_peers,
             );
             let changed = update_known_peers_versioned(
                 state,
-                metrics,
                 found_peers_v3,
                 configured_peers,
                 &chain_peers,
@@ -1209,18 +1232,11 @@ async fn query_connected_peers_for_their_known_peers(
 
     // V3 not enabled or our_info_v2 not available - just run V2
     let found_peers_v2 = v2_query.await;
-    update_known_peers(
-        state,
-        metrics,
-        found_peers_v2,
-        configured_peers,
-        &chain_peers,
-    );
+    update_known_peers(state, found_peers_v2, configured_peers, &chain_peers);
 }
 
 fn update_known_peers(
     state: Arc<RwLock<State>>,
-    metrics: Metrics,
     found_peers: Vec<SignedNodeInfo>,
     configured_peers: Arc<HashMap<PeerId, PeerInfo>>,
     chain_peers: &Arc<RwLock<HashSet<PeerId>>>,
@@ -1288,19 +1304,10 @@ fn update_known_peers(
         match known_peers.entry(peer.peer_id) {
             Entry::Occupied(mut o) => {
                 if peer.timestamp_ms > o.get().timestamp_ms {
-                    if o.get().addresses.is_empty() && !peer.addresses.is_empty() {
-                        metrics.inc_num_peers_with_external_address();
-                    }
-                    if !o.get().addresses.is_empty() && peer.addresses.is_empty() {
-                        metrics.dec_num_peers_with_external_address();
-                    }
                     o.insert(peer);
                 }
             }
             Entry::Vacant(v) => {
-                if !peer.addresses.is_empty() {
-                    metrics.inc_num_peers_with_external_address();
-                }
                 v.insert(peer);
             }
         }
@@ -1310,7 +1317,6 @@ fn update_known_peers(
 /// Returns true if any trusted peer was inserted or updated.
 fn update_known_peers_versioned(
     state: Arc<RwLock<State>>,
-    metrics: Metrics,
     found_peers: Vec<SignedVersionedNodeInfo>,
     configured_peers: Arc<HashMap<PeerId, PeerInfo>>,
     chain_peers: &Arc<RwLock<HashSet<PeerId>>>,
@@ -1375,18 +1381,9 @@ fn update_known_peers_versioned(
             }
         }
 
-        let peer_p2p_addresses = peer.p2p_addresses();
-
         match known_peers_v2.entry(peer_id) {
             Entry::Occupied(mut o) => {
                 if peer.timestamp_ms() > o.get().timestamp_ms() {
-                    let old_addresses = o.get().p2p_addresses();
-                    if old_addresses.is_empty() && !peer_p2p_addresses.is_empty() {
-                        metrics.inc_num_peers_with_external_address();
-                    }
-                    if !old_addresses.is_empty() && peer_p2p_addresses.is_empty() {
-                        metrics.dec_num_peers_with_external_address();
-                    }
                     o.insert(peer);
                     if is_trusted {
                         trusted_peer_changed = true;
@@ -1394,9 +1391,6 @@ fn update_known_peers_versioned(
                 }
             }
             Entry::Vacant(v) => {
-                if !peer_p2p_addresses.is_empty() {
-                    metrics.inc_num_peers_with_external_address();
-                }
                 v.insert(peer);
                 if is_trusted {
                     trusted_peer_changed = true;

--- a/crates/sui-network/src/discovery/tests.rs
+++ b/crates/sui-network/src/discovery/tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::endpoint_manager::ConsensusAddressUpdater;
 use crate::{
     endpoint_manager::{AddressSource, EndpointId},
     utils::{build_network_and_key, build_network_with_anemo_config},
@@ -11,7 +12,24 @@ use fastcrypto::ed25519::Ed25519PublicKey;
 use futures::stream::FuturesUnordered;
 use std::collections::HashSet;
 use sui_config::p2p::{AllowlistedPeer, DiscoveryConfig, SeedPeer};
+use sui_types::error::SuiResult;
 use tokio::time::timeout;
+
+/// Test `ConsensusAddressUpdater` that records every forwarded consensus update,
+/// for asserting which (source, address) reached the consensus endpoint.
+struct RecordingUpdater(std::sync::Mutex<Vec<(NetworkPublicKey, AddressSource, Vec<Multiaddr>)>>);
+
+impl ConsensusAddressUpdater for RecordingUpdater {
+    fn update_address(
+        &self,
+        pubkey: NetworkPublicKey,
+        source: AddressSource,
+        addrs: Vec<Multiaddr>,
+    ) -> SuiResult<()> {
+        self.0.lock().unwrap().push((pubkey, source, addrs));
+        Ok(())
+    }
+}
 
 #[tokio::test]
 async fn get_known_peers() -> Result<()> {
@@ -1475,24 +1493,6 @@ async fn test_discovery_address_cleared_on_expiry() -> Result<()> {
     // Verify Consensus Discovery address was also cleared.
     // The endpoint_manager buffers consensus updates when no updater is set.
     // Set a mock updater to drain the buffer and inspect the updates.
-    use crate::endpoint_manager::ConsensusAddressUpdater;
-    use sui_types::error::SuiResult;
-
-    struct RecordingUpdater(
-        std::sync::Mutex<Vec<(NetworkPublicKey, AddressSource, Vec<Multiaddr>)>>,
-    );
-    impl ConsensusAddressUpdater for RecordingUpdater {
-        fn update_address(
-            &self,
-            pubkey: NetworkPublicKey,
-            source: AddressSource,
-            addrs: Vec<Multiaddr>,
-        ) -> SuiResult<()> {
-            self.0.lock().unwrap().push((pubkey, source, addrs));
-            Ok(())
-        }
-    }
-
     let updater = Arc::new(RecordingUpdater(std::sync::Mutex::new(Vec::new())));
     event_loop
         .endpoint_manager
@@ -1619,7 +1619,6 @@ async fn test_discovery_only_peer_not_in_network_known_peers() -> Result<()> {
 
     update_known_peers_versioned(
         event_loop.state.clone(),
-        event_loop.metrics.clone(),
         vec![gossiped_info],
         event_loop.configured_peers.clone(),
         &event_loop.chain_peers,
@@ -1818,7 +1817,6 @@ async fn test_runtime_gossip_updates_configured_peer_address() -> Result<()> {
 
     update_known_peers_versioned(
         event_loop.state.clone(),
-        event_loop.metrics.clone(),
         vec![gossiped_info],
         event_loop.configured_peers.clone(),
         &event_loop.chain_peers,
@@ -2073,7 +2071,6 @@ async fn test_discovery_address_overrides_chain_for_chain_peer() -> Result<()> {
 
     update_known_peers_versioned(
         event_loop.state.clone(),
-        event_loop.metrics.clone(),
         vec![gossiped_info],
         event_loop.configured_peers.clone(),
         &event_loop.chain_peers,
@@ -2093,11 +2090,219 @@ async fn test_discovery_address_overrides_chain_for_chain_peer() -> Result<()> {
         "network.known_peers should use the Discovery address from gossip"
     );
 
-    // Both sources should be tracked.
+    // Both sources should be tracked, and the Chain address must remain available
+    // in peer_addresses as the lower-priority fallback (not overwritten by Discovery).
     let state = event_loop.state.read().unwrap();
     let sources = state.peer_addresses.get(&remote_peer_id).unwrap();
     assert!(sources.contains_key(&AddressSource::Discovery));
     assert!(sources.contains_key(&AddressSource::Chain));
+    let chain_anemo_addr = chain_multiaddr.to_anemo_address().unwrap();
+    assert_eq!(
+        sources.get(&AddressSource::Chain),
+        Some(&vec![chain_anemo_addr]),
+        "Chain address should be retained as the fallback under Discovery"
+    );
+
+    Ok(())
+}
+
+/// Reads the value of the single-series `discovery_active_p2p_address_source` gauge
+/// for a given `peer_id`, or `None` if that series is absent. The value is the
+/// active source's `metric_code` (0 = no address installed).
+fn active_p2p_source_code(registry: &prometheus::Registry, peer_id: &str) -> Option<i64> {
+    let families = registry.gather();
+    let family = families
+        .iter()
+        .find(|f| f.name() == "discovery_active_p2p_address_source")?;
+    family.get_metric().iter().find_map(|m| {
+        m.get_label()
+            .iter()
+            .any(|l| l.name() == "peer_id" && l.value() == peer_id)
+            .then(|| m.gauge.value() as i64)
+    })
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_active_p2p_address_source_metric() -> Result<()> {
+    // A gossiped Discovery address overriding a Chain address must change the
+    // value-encoded gauge from the Chain code to the Discovery code.
+    use fastcrypto::traits::KeyPair as _;
+
+    let remote_keypair = sui_types::crypto::NetworkKeyPair::generate(&mut rand::thread_rng());
+    let remote_peer_id = PeerId(
+        *fastcrypto::traits::KeyPair::public(&remote_keypair)
+            .0
+            .as_bytes(),
+    );
+
+    let registry = prometheus::Registry::new();
+    let config = P2pConfig::default();
+    let (builder, server, endpoint_manager) = Builder::new()
+        .config(config)
+        .with_metrics(&registry)
+        .build();
+    let (network, key) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network.clone(), key);
+
+    event_loop.construct_our_info();
+    event_loop.configure_preferred_peers();
+
+    let peer_label = remote_peer_id.to_string();
+
+    // Deliver a Chain address: the peer becomes trusted with Chain as the active source.
+    let chain_multiaddr: Multiaddr = "/ip4/172.16.0.1/udp/8080".parse().unwrap();
+    endpoint_manager
+        .update_endpoint(
+            EndpointId::P2p(remote_peer_id),
+            AddressSource::Chain,
+            vec![chain_multiaddr],
+        )
+        .unwrap();
+    while let Ok(msg) = event_loop.mailbox.try_recv() {
+        event_loop.handle_message(msg);
+    }
+
+    assert_eq!(
+        active_p2p_source_code(&registry, &peer_label),
+        Some(AddressSource::Chain.metric_code()),
+        "Chain should be the active source"
+    );
+
+    // Gossip a higher-priority Discovery address for the same (trusted) peer.
+    let discovery_multiaddr: Multiaddr = "/ip4/10.0.0.1/udp/9000".parse().unwrap();
+    let mut addresses = BTreeMap::new();
+    addresses.insert(EndpointId::P2p(remote_peer_id), vec![discovery_multiaddr]);
+    let gossiped_info = VersionedNodeInfo::V2(NodeInfoV2 {
+        addresses,
+        timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
+    })
+    .sign(&remote_keypair);
+
+    update_known_peers_versioned(
+        event_loop.state.clone(),
+        vec![gossiped_info],
+        event_loop.configured_peers.clone(),
+        &event_loop.chain_peers,
+        &event_loop.endpoint_manager,
+    );
+    while let Ok(msg) = event_loop.mailbox.try_recv() {
+        event_loop.handle_message(msg);
+    }
+
+    // Discovery now outranks Chain: the gauge value flips to the Discovery code.
+    assert_eq!(
+        active_p2p_source_code(&registry, &peer_label),
+        Some(AddressSource::Discovery.metric_code()),
+        "Discovery should now be the active source"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_divergent_discovery_consensus_address_applied() -> Result<()> {
+    // A trusted peer advertises a Discovery *consensus* address that differs from
+    // its on-chain Chain consensus address. The gossiped address must be forwarded
+    // to the consensus updater with AddressSource::Discovery, while the lower-priority
+    // Chain address is also forwarded (so consensus can retain it as a fallback).
+    use fastcrypto::traits::KeyPair as _;
+
+    let remote_keypair = sui_types::crypto::NetworkKeyPair::generate(&mut rand::thread_rng());
+    let remote_peer_id = PeerId(
+        *fastcrypto::traits::KeyPair::public(&remote_keypair)
+            .0
+            .as_bytes(),
+    );
+    let remote_network_pubkey =
+        NetworkPublicKey::from_bytes(&remote_peer_id.0).expect("PeerId is a valid public key");
+
+    let config = P2pConfig::default();
+    let (builder, server, endpoint_manager) = Builder::new().config(config).build();
+    let (network, key) = build_network_and_key(|router| router.add_rpc_service(server));
+    let (mut event_loop, _handle) = builder.build(network.clone(), key);
+
+    event_loop.construct_our_info();
+    event_loop.configure_preferred_peers();
+
+    // Mark the peer as trusted so its gossiped Consensus endpoint is forwarded.
+    event_loop
+        .chain_peers
+        .write()
+        .unwrap()
+        .insert(remote_peer_id);
+
+    let updater = Arc::new(RecordingUpdater(std::sync::Mutex::new(Vec::new())));
+    event_loop
+        .endpoint_manager
+        .set_consensus_address_updater(updater.clone());
+
+    // The peer's on-chain consensus address (lower priority than Discovery).
+    let chain_consensus_addr: Multiaddr = "/ip4/172.16.0.1/udp/8081".parse().unwrap();
+    endpoint_manager
+        .update_endpoint(
+            EndpointId::Consensus(remote_network_pubkey.clone()),
+            AddressSource::Chain,
+            vec![chain_consensus_addr.clone()],
+        )
+        .unwrap();
+
+    // Gossip a V2 NodeInfo whose Consensus address differs from the Chain address.
+    let discovery_consensus_addr: Multiaddr = "/ip4/10.0.0.1/udp/9001".parse().unwrap();
+    assert_ne!(
+        chain_consensus_addr, discovery_consensus_addr,
+        "test requires divergent Chain vs Discovery consensus addresses"
+    );
+    let mut addresses = BTreeMap::new();
+    addresses.insert(
+        EndpointId::P2p(remote_peer_id),
+        vec!["/ip4/10.0.0.1/udp/9000".parse().unwrap()],
+    );
+    addresses.insert(
+        EndpointId::Consensus(remote_network_pubkey.clone()),
+        vec![discovery_consensus_addr.clone()],
+    );
+    let gossiped_info = VersionedNodeInfo::V2(NodeInfoV2 {
+        addresses,
+        timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
+    })
+    .sign(&remote_keypair);
+
+    update_known_peers_versioned(
+        event_loop.state.clone(),
+        vec![gossiped_info],
+        event_loop.configured_peers.clone(),
+        &event_loop.chain_peers,
+        &event_loop.endpoint_manager,
+    );
+    while let Ok(msg) = event_loop.mailbox.try_recv() {
+        event_loop.handle_message(msg);
+    }
+
+    let updates = updater.0.lock().unwrap();
+
+    // The gossiped consensus address is forwarded with AddressSource::Discovery.
+    let discovery_update = updates
+        .iter()
+        .find(|(pubkey, source, _)| {
+            *pubkey == remote_network_pubkey && *source == AddressSource::Discovery
+        })
+        .expect("gossiped Consensus address should be forwarded with Discovery source");
+    assert_eq!(
+        discovery_update.2,
+        vec![discovery_consensus_addr.clone()],
+        "Discovery consensus address should be the gossiped (divergent) one"
+    );
+
+    // The Chain consensus address is also forwarded, available as a lower-priority fallback.
+    let chain_update = updates
+        .iter()
+        .find(|(pubkey, source, _)| {
+            *pubkey == remote_network_pubkey && *source == AddressSource::Chain
+        })
+        .expect("Chain consensus address should remain available as a fallback");
+    assert_eq!(chain_update.2, vec![chain_consensus_addr]);
 
     Ok(())
 }

--- a/crates/sui-network/src/endpoint_manager.rs
+++ b/crates/sui-network/src/endpoint_manager.rs
@@ -151,11 +151,21 @@ pub enum EndpointId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // NOTE: AddressSources are prioritized in order of the enum variants below.
 pub enum AddressSource {
-    Admin,     // override from admin server
-    Config,    // override from config file
-    Discovery, // address received from P2P peers via Discovery protocol
-    Seed,      // locally-configured seed address
-    Chain,     // public on-chain address
+    Admin = 1,     // override from admin server
+    Config = 2,    // override from config file
+    Discovery = 3, // address received from P2P peers via Discovery protocol
+    Seed = 4,      // locally-configured seed address
+    Chain = 5,     // public on-chain address
+}
+
+impl AddressSource {
+    /// Reserved metric value for the "no override" state.
+    pub const DEFAULT_ADDRESS_SOURCE_CODE: i64 = 0;
+
+    /// Used as the value of the active-address-source metrics.
+    pub const fn metric_code(self) -> i64 {
+        self as i64
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

Expose which address source is currently active for each trusted peer, so a gossiped Discovery override vs. the node's on-chain fallback is visible. No peer-selection or connection behavior changes.

Also replaces the drift-prone inc/dec of `num_peers_with_external_address` with a periodic recompute from a deduped union of the known-peer maps.

## Test plan

New unit tests in `sui-network` discovery and `sui-core` consensus_manager cover: the P2P gauge flipping from the Chain code to the Discovery code when a higher-priority address is gossiped; the consensus gauge moving between a Discovery override and the committee-default state; and a divergent Discovery-vs-Chain consensus address being applied with `AddressSource::Discovery`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
