### PR TITLE
[releases/sui-v1.74.0-release] core: append TideHunter checkpoint watermark keyspace

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -121,20 +121,6 @@ pub struct AuthorityPerpetualTables {
     /// A singleton table that stores latest pruned checkpoint. Used to keep objects pruner progress
     pub(crate) pruned_checkpoint: DBMap<(), CheckpointSequenceNumber>,
 
-    /// A singleton table recording the highest checkpoint whose transaction
-    /// outputs (objects, effects, etc.) are durably committed to this store.
-    /// It is written in the *same* atomic batch as those outputs (see
-    /// `AuthorityStore::build_db_batch` and the checkpoint executor), so it is
-    /// always consistent with the live object set even after an unclean stop.
-    ///
-    /// This differs from the checkpoint store's `highest_executed` watermark,
-    /// which is bumped in a separate write after the outputs are committed: an
-    /// abrupt stop can leave the object writes durable while `highest_executed`
-    /// still lags. Consumers that read the live object set directly (e.g. the
-    /// embedded rpc-store's bulk restore) use this watermark instead, so they
-    /// never observe objects beyond the checkpoint they think they are at.
-    pub(crate) highest_committed_checkpoint: DBMap<(), CheckpointSequenceNumber>,
-
     /// Expected total amount of SUI in the network. This is expected to remain constant
     /// throughout the lifetime of the network. We check it at the end of each epoch if
     /// expensive checks are enabled. We cannot use 10B today because in tests we often
@@ -158,6 +144,23 @@ pub struct AuthorityPerpetualTables {
     /// Used to support address balance gas payments feature.
     /// This table uses epoch-prefixed keys to support efficient pruning via range delete.
     pub(crate) executed_transaction_digests: DBMap<(EpochId, TransactionDigest), ()>,
+
+    /// A singleton table recording the highest checkpoint whose transaction
+    /// outputs (objects, effects, etc.) are durably committed to this store.
+    /// It is written in the *same* atomic batch as those outputs (see
+    /// `AuthorityStore::build_db_batch` and the checkpoint executor), so it is
+    /// always consistent with the live object set even after an unclean stop.
+    ///
+    /// This differs from the checkpoint store's `highest_executed` watermark,
+    /// which is bumped in a separate write after the outputs are committed: an
+    /// abrupt stop can leave the object writes durable while `highest_executed`
+    /// still lags. Consumers that read the live object set directly (e.g. the
+    /// embedded rpc-store's bulk restore) use this watermark instead, so they
+    /// never observe objects beyond the checkpoint they think they are at.
+    ///
+    /// IMPORTANT: TideHunter keyspaces are order-sensitive once written to disk.
+    /// Keep new keyspaces append-only to preserve compatibility with existing DBs.
+    pub(crate) highest_committed_checkpoint: DBMap<(), CheckpointSequenceNumber>,
 }
 
 impl AuthorityPerpetualTables {
@@ -376,10 +379,6 @@ impl AuthorityPerpetualTables {
                 ThConfig::new(0, 1, KeyType::uniform(1)),
             ),
             (
-                "highest_committed_checkpoint".to_string(),
-                ThConfig::new(0, 1, KeyType::uniform(1)),
-            ),
-            (
                 "expected_network_sui_amount".to_string(),
                 ThConfig::new(0, 1, KeyType::uniform(1)),
             ),
@@ -429,6 +428,10 @@ impl AuthorityPerpetualTables {
                         true,
                     ),
                 ),
+            ),
+            (
+                "highest_committed_checkpoint".to_string(),
+                ThConfig::new(0, 1, KeyType::uniform(1)),
             ),
         ];
         Self::open_tables_read_write(


### PR DESCRIPTION
Backport of #27033 to `releases/sui-v1.74.0-release`.

## Problem
v1.74.0 added the `highest_committed_checkpoint` TideHunter keyspace but registered it **mid-list** (immediately after `pruned_checkpoint`), shifting `expected_network_sui_amount` and every keyspace after it down one slot. TideHunter control regions are order-sensitive and reject reordering, so any node with an existing TideHunter DB crash-loops on boot:

```
panicked at tidehunter/src/control.rs:263:21:
Keyspace mismatch at position 11: control region has keyspace 'expected_network_sui_amount',
but configuration has 'highest_committed_checkpoint'. Reordering or renaming keyspaces is not
supported. Only adding new keyspaces at the end is allowed.
```

During the v1.74.0 testnet rollout this took down **all 6 Mysten testnet validators** (TideHunter checkpoint DB). Non-TideHunter nodes were unaffected — testnet fullnodes and the RocksDB mainnet soak validator ran v1.74.0 cleanly.

## Fix
Move the `highest_committed_checkpoint` registration to the **end** of the keyspace list (append-only). This restores every pre-existing keyspace to its original position and adds the new one as a legal trailing append, so existing TideHunter DBs open cleanly. A guard comment is added to keep new keyspaces append-only.

Verified that `highest_committed_checkpoint` is the **only** keyspace whose order changed between v1.73.1 (`ff1fe0ec`) and v1.74.0 (`d034d564`), so this single move fully resolves the crash.

## Test plan
- Build this branch and deploy to one crash-looping testnet validator (`reset_db=false`); confirm it boots past the keyspace check and rejoins consensus against its on-disk DB.
- Then roll to the remaining testnet validators.
