### PR TITLE
retire signed_effects_digests write post-MFP

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5251,31 +5251,16 @@ impl AuthorityState {
         effects: TransactionEffects,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<VerifiedSignedTransactionEffects> {
-        let tx_digest = *effects.transaction_digest();
-        let signed_effects = match epoch_store.get_effects_signature(&tx_digest)? {
-            Some(sig) => {
-                debug_assert!(sig.epoch == epoch_store.epoch());
-                SignedTransactionEffects::new_from_data_and_sig(effects, sig)
-            }
-            _ => {
-                let sig = AuthoritySignInfo::new(
-                    epoch_store.epoch(),
-                    &effects,
-                    Intent::sui_app(IntentScope::TransactionEffects),
-                    self.name,
-                    &*self.secret,
-                );
-
-                let effects = SignedTransactionEffects::new_from_data_and_sig(effects, sig.clone());
-
-                epoch_store.insert_effects_signature(&tx_digest, &sig)?;
-
-                effects
-            }
-        };
+        let sig = AuthoritySignInfo::new(
+            epoch_store.epoch(),
+            &effects,
+            Intent::sui_app(IntentScope::TransactionEffects),
+            self.name,
+            &*self.secret,
+        );
 
         Ok(VerifiedSignedTransactionEffects::new_unchecked(
-            signed_effects,
+            SignedTransactionEffects::new_from_data_and_sig(effects, sig),
         ))
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1710,7 +1710,6 @@ impl AuthorityState {
         Option<ExecutionError>,
     )> {
         let _scope = monitored_scope("Execution::process_certificate");
-        let tx_digest = *certificate.digest();
 
         let input_objects = match self.read_objects_for_execution(
             tx_guard.as_lock_guard(),
@@ -1722,21 +1721,8 @@ impl AuthorityState {
             Err(e) => return ExecutionOutput::Fatal(e),
         };
 
-        let expected_effects_digest = match execution_env.expected_effects_digest {
-            Some(expected_effects_digest) => Some(expected_effects_digest),
-            None => {
-                // We could be re-executing a previously executed but uncommitted transaction, perhaps after
-                // restarting with a new binary. In this situation, if we have published an effects signature,
-                // we must be sure not to equivocate.
-                match epoch_store.get_signed_effects_digest(&tx_digest) {
-                    Ok(digest) => digest,
-                    Err(e) => return ExecutionOutput::Fatal(e),
-                }
-            }
-        };
-
         fail_point_if!("correlated-crash-process-certificate", || {
-            if sui_simulator::random::deterministic_probability_once(&tx_digest, 0.01) {
+            if sui_simulator::random::deterministic_probability_once(certificate.digest(), 0.01) {
                 sui_simulator::task::kill_current_node(None);
             }
         });
@@ -1749,7 +1735,6 @@ impl AuthorityState {
             execution_guard,
             certificate,
             input_objects,
-            expected_effects_digest,
             execution_env,
             epoch_store,
         )
@@ -1928,7 +1913,6 @@ impl AuthorityState {
         _execution_guard: &ExecutionLockReadGuard<'_>,
         certificate: &VerifiedExecutableTransaction,
         input_objects: InputObjects,
-        expected_effects_digest: Option<TransactionEffectsDigest>,
         execution_env: ExecutionEnv,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> ExecutionOutput<(
@@ -2047,7 +2031,7 @@ impl AuthorityState {
             return ExecutionOutput::RetryLater;
         }
 
-        if let Some(expected_effects_digest) = expected_effects_digest
+        if let Some(expected_effects_digest) = execution_env.expected_effects_digest
             && effects.digest() != expected_effects_digest
         {
             // We dont want to mask the original error, so we log it and continue.
@@ -2185,7 +2169,6 @@ impl AuthorityState {
                 &execution_guard,
                 certificate,
                 input_objects,
-                None,
                 ExecutionEnv::default(),
                 epoch_store,
             )
@@ -5285,11 +5268,7 @@ impl AuthorityState {
 
                 let effects = SignedTransactionEffects::new_from_data_and_sig(effects, sig.clone());
 
-                epoch_store.insert_effects_digest_and_signature(
-                    &tx_digest,
-                    effects.digest(),
-                    &sig,
-                )?;
+                epoch_store.insert_effects_signature(&tx_digest, &sig)?;
 
                 effects
             }
@@ -6234,7 +6213,6 @@ impl AuthorityState {
                 &execution_guard,
                 &executable_tx,
                 input_objects,
-                None,
                 ExecutionEnv::default(),
                 epoch_store,
             )

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use dashmap::DashMap;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -22,9 +21,9 @@ use moka::sync::SegmentedCache as MokaCache;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use mysten_common::ZipDebugEqIteratorExt;
 use mysten_common::assert_reachable;
+use mysten_common::debug_fatal;
 use mysten_common::random_util::randomize_cache_capacity_in_tests;
 use mysten_common::sync::notify_read::NotifyRead;
-use mysten_common::{debug_fatal, in_test_configuration};
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use parking_lot::{Mutex, RwLockReadGuard, RwLockWriteGuard};
@@ -365,11 +364,6 @@ pub struct AuthorityPerEpochStore {
 
     executed_digests_notify_read: NotifyRead<TransactionKey, TransactionDigest>,
 
-    /// In-memory cache of signed effects digests. Populated from disk at startup, updated on
-    /// insert, and pruned on checkpoint finalization. Avoids disk reads on the hot execution path
-    /// where the vast majority of lookups return None.
-    signed_effects_digests_cache: DashMap<TransactionDigest, TransactionEffectsDigest>,
-
     /// Cancellation token used to signal epoch termination to all in-flight tasks.
     epoch_alive_token: CancellationToken,
 
@@ -461,11 +455,8 @@ pub struct AuthorityEpochTables {
     /// signature is still epoch-specific and so is stored in the epoch store.
     effects_signatures: DBMap<TransactionDigest, AuthoritySignInfo>,
 
-    /// When we sign a TransactionEffects, we must record the digest of the effects in order
-    /// to detect and prevent equivocation when re-executing a transaction that may not have been
-    /// committed to disk.
-    /// Entries are removed from this table after the transaction in question has been committed
-    /// to disk.
+    #[allow(dead_code)]
+    #[deprecated(note = "column family retained only for backward compatibility")]
     signed_effects_digests: DBMap<TransactionDigest, TransactionEffectsDigest>,
 
     /// No longer used.
@@ -1025,12 +1016,6 @@ impl AuthorityPerEpochStore {
             .load_reconfig_state()
             .expect("Load reconfig state at initialization cannot fail");
 
-        let signed_effects_digests_cache = DashMap::new();
-        for item in tables.signed_effects_digests.safe_iter() {
-            let (tx_digest, effects_digest) = item?;
-            signed_effects_digests_cache.insert(tx_digest, effects_digest);
-        }
-
         let epoch_alive_token = CancellationToken::new();
 
         assert_eq!(
@@ -1191,7 +1176,6 @@ impl AuthorityPerEpochStore {
             checkpoint_state_notify_read: NotifyRead::new(),
             running_root_notify_read: NotifyRead::new(),
             executed_digests_notify_read: NotifyRead::new(),
-            signed_effects_digests_cache,
             end_of_publish: Mutex::new(end_of_publish),
             mutex_table: MutexTable::new(MUTEX_TABLE_SIZE),
             version_assignment_mutex_table: MutexTable::new(MUTEX_TABLE_SIZE),
@@ -1885,22 +1869,15 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    pub fn insert_effects_digest_and_signature(
+    pub fn insert_effects_signature(
         &self,
         tx_digest: &TransactionDigest,
-        effects_digest: &TransactionEffectsDigest,
         effects_signature: &AuthoritySignInfo,
     ) -> SuiResult {
         let tables = self.tables()?;
-        let mut batch = tables.effects_signatures.batch();
-        batch.insert_batch(&tables.effects_signatures, [(tx_digest, effects_signature)])?;
-        batch.insert_batch(
-            &tables.signed_effects_digests,
-            [(tx_digest, effects_digest)],
-        )?;
-        batch.write()?;
-        self.signed_effects_digests_cache
-            .insert(*tx_digest, *effects_digest);
+        tables
+            .effects_signatures
+            .insert(tx_digest, effects_signature)?;
         Ok(())
     }
 
@@ -1936,28 +1913,6 @@ impl AuthorityPerEpochStore {
     ) -> SuiResult<Option<AuthoritySignInfo>> {
         let tables = self.tables()?;
         Ok(tables.effects_signatures.get(tx_digest)?)
-    }
-
-    pub fn get_signed_effects_digest(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> SuiResult<Option<TransactionEffectsDigest>> {
-        let cached = self.signed_effects_digests_cache.get(tx_digest).map(|r| *r);
-        if in_test_configuration() {
-            let from_db = self.tables()?.signed_effects_digests.get(tx_digest)?;
-            if cached != from_db {
-                // Cache and DB writes are not atomic, so retry after a brief delay
-                // to allow eventual consistency before panicking.
-                std::thread::sleep(std::time::Duration::from_secs(1));
-                let from_db = self.tables()?.signed_effects_digests.get(tx_digest)?;
-                let cached = self.signed_effects_digests_cache.get(tx_digest).map(|r| *r);
-                assert_eq!(
-                    cached, from_db,
-                    "signed_effects_digests cache inconsistency for {tx_digest}"
-                );
-            }
-        }
-        Ok(cached)
     }
 
     /// Gets owned object locks, checking quarantine first then falling back to DB.
@@ -2137,21 +2092,13 @@ impl AuthorityPerEpochStore {
             Err(e) if matches!(e.as_inner(), SuiErrorKind::EpochEnded(_)) => return Ok(()),
             Err(e) => return Err(e),
         };
-        let mut batch = tables.signed_effects_digests.batch();
-
-        // Now that the transaction effects are committed, we will never re-execute, so we
-        // don't need to worry about equivocating.
-        batch.delete_batch(&tables.signed_effects_digests, digests)?;
+        let mut batch = tables.effects_signatures.batch();
 
         let seq = *checkpoint.sequence_number();
 
         let mut quarantine = self.consensus_quarantine.write();
         quarantine.update_highest_executed_checkpoint(seq, self, &mut batch)?;
         batch.write()?;
-
-        for digest in digests {
-            self.signed_effects_digests_cache.remove(digest);
-        }
 
         self.consensus_output_cache
             .remove_executed_in_epoch(digests);

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -448,11 +448,8 @@ pub struct AuthorityEpochTables {
     #[default_options_override_fn = "owned_object_transaction_locks_table_default_config"]
     owned_object_locked_transactions: DBMap<ObjectRef, LockDetailsWrapper>,
 
-    /// Signatures over transaction effects that we have signed and returned to users.
-    /// We store this to avoid re-signing the same effects twice.
-    /// Note that this may contain signatures for effects from previous epochs, in the case
-    /// that a user requests a signature for effects from a previous epoch. However, the
-    /// signature is still epoch-specific and so is stored in the epoch store.
+    #[allow(dead_code)]
+    #[deprecated(note = "column family retained only for backward compatibility")]
     effects_signatures: DBMap<TransactionDigest, AuthoritySignInfo>,
 
     #[allow(dead_code)]
@@ -1869,18 +1866,6 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    pub fn insert_effects_signature(
-        &self,
-        tx_digest: &TransactionDigest,
-        effects_signature: &AuthoritySignInfo,
-    ) -> SuiResult {
-        let tables = self.tables()?;
-        tables
-            .effects_signatures
-            .insert(tx_digest, effects_signature)?;
-        Ok(())
-    }
-
     pub fn transactions_executed_in_cur_epoch(
         &self,
         digests: &[TransactionDigest],
@@ -1905,14 +1890,6 @@ impl AuthorityPerEpochStore {
                     .expect("db error")
             },
         ))
-    }
-
-    pub fn get_effects_signature(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> SuiResult<Option<AuthoritySignInfo>> {
-        let tables = self.tables()?;
-        Ok(tables.effects_signatures.get(tx_digest)?)
     }
 
     /// Gets owned object locks, checking quarantine first then falling back to DB.
@@ -2092,7 +2069,7 @@ impl AuthorityPerEpochStore {
             Err(e) if matches!(e.as_inner(), SuiErrorKind::EpochEnded(_)) => return Ok(()),
             Err(e) => return Err(e),
         };
-        let mut batch = tables.effects_signatures.batch();
+        let mut batch = tables.last_consensus_stats.batch();
 
         let seq = *checkpoint.sequence_number();
 


### PR DESCRIPTION
`signed_effects_digests` was introduced in #18426 to prevent effects equivocation: with the writeback cache, a validator could lose uncommitted execution outputs on restart, re-execute on an upgraded binary, and produce effects contradicting ones it had already signed and returned to a user (whose signature fed the pre-MFP Quorum-Driver effects certificate). That precondition no longer holds, finality is established via WaitForEffects digest votes, not aggregated per-validator effects signatures, and there is a single post-consensus execution path.

This simplifies fork detection and recovery. After this change, a transaction fork can only occur when CheckpointExecutor executes a certified checkpoint transaction and the effects differ from what the certified checkpoint contains.