### PR TITLE
Tidy existing gas code: thread gas coin through into_effects, abstract gas status

### DIFF
--- a/crates/sui-replay/src/displays/gas_status_displays.rs
+++ b/crates/sui-replay/src/displays/gas_status_displays.rs
@@ -3,8 +3,9 @@
 
 use crate::displays::Pretty;
 use std::fmt::{Display, Formatter};
-use sui_types::gas::SuiGasStatus;
-use sui_types::gas_model::gas_v2::SuiGasStatus as GasStatusV2;
+use sui_types::base_types::ObjectID;
+use sui_types::gas::{SuiGasStatus, SuiGasStatusAPI};
+use sui_types::gas_model::gas_v2::PerObjectStorage;
 use tabled::{
     builder::Builder as TableBuilder,
     settings::{Style as TableStyle, style::HorizontalLine},
@@ -13,20 +14,19 @@ use tabled::{
 impl Display for Pretty<'_, SuiGasStatus> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(sui_gas_status) = self;
-        match sui_gas_status {
-            SuiGasStatus::V2(s) => {
-                display_info(f, s)?;
-                per_object_storage_table(f, s)?;
-            }
-        };
+        display_info(f, *sui_gas_status)?;
+        display_per_object_storage_table(f, sui_gas_status.per_object_storage())?;
         Ok(())
     }
 }
 
-fn per_object_storage_table(f: &mut Formatter, sui_gas_status: &GasStatusV2) -> std::fmt::Result {
+fn display_per_object_storage_table(
+    f: &mut Formatter,
+    per_object_storage: &[(ObjectID, PerObjectStorage)],
+) -> std::fmt::Result {
     let mut builder = TableBuilder::default();
     builder.push_record(vec!["Object ID", "Bytes", "Old Rebate", "New Rebate"]);
-    for (object_id, per_obj_storage) in sui_gas_status.per_object_storage() {
+    for (object_id, per_obj_storage) in per_object_storage {
         builder.push_record(vec![
             object_id.to_string(),
             per_obj_storage.new_size.to_string(),
@@ -43,31 +43,29 @@ fn per_object_storage_table(f: &mut Formatter, sui_gas_status: &GasStatusV2) -> 
     write!(f, "\n{}\n", table)
 }
 
-fn display_info(f: &mut Formatter<'_>, sui_gas_status: &GasStatusV2) -> std::fmt::Result {
+fn display_info(f: &mut Formatter<'_>, sui_gas_status: &dyn SuiGasStatusAPI) -> std::fmt::Result {
+    let move_gas_status = sui_gas_status.move_gas_status();
     let mut builder = TableBuilder::default();
     builder.push_record(vec!["Gas Info".to_string()]);
     builder.push_record(vec![format!(
         "Reference Gas Price: {}",
         sui_gas_status.reference_gas_price()
     )]);
-    builder.push_record(vec![format!(
-        "Gas Price: {}",
-        sui_gas_status.gas_status.gas_price()
-    )]);
+    builder.push_record(vec![format!("Gas Price: {}", move_gas_status.gas_price())]);
 
     builder.push_record(vec![format!(
         "Max Gas Stack Height: {}",
-        sui_gas_status.gas_status.stack_height_high_water_mark()
+        move_gas_status.stack_height_high_water_mark()
     )]);
 
     builder.push_record(vec![format!(
         "Max Gas Stack Size: {}",
-        sui_gas_status.gas_status.stack_size_high_water_mark()
+        move_gas_status.stack_size_high_water_mark()
     )]);
 
     builder.push_record(vec![format!(
         "Number of Bytecode Instructions Executed: {}",
-        sui_gas_status.gas_status.instructions_executed()
+        move_gas_status.instructions_executed()
     )]);
 
     let mut table = builder.build();

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -14,6 +14,7 @@ mod checked {
     use sui_types::base_types::{ObjectID, ObjectRef};
     use sui_types::error::{SuiResult, UserInputError, UserInputResult};
     use sui_types::executable_transaction::VerifiedExecutableTransaction;
+    use sui_types::gas::SuiGasStatusAPI;
     use sui_types::metrics::BytecodeVerifierMetrics;
     use sui_types::object::ObjectPermission;
     use sui_types::transaction::{

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -12,6 +12,7 @@ pub mod checked {
 
     use crate::gas::GasUsageReport;
     use crate::gas_model::gas_predicates::check_for_gas_price_too_high;
+    use crate::gas_model::gas_v2::PerObjectStorage;
     use crate::{
         ObjectID,
         effects::{TransactionEffects, TransactionEffectsAPI},
@@ -54,6 +55,14 @@ pub mod checked {
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
         fn adjust_computation_on_out_of_gas(&mut self);
         fn gas_usage_report(&self) -> GasUsageReport;
+        fn check_gas_balance(
+            &self,
+            gas_objs: &[&ObjectReadResult],
+            gas_budget: u64,
+            available_address_balance_gas: u64,
+        ) -> UserInputResult;
+        fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult;
+        fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)>;
     }
 
     /// Version aware enum for gas status.
@@ -102,31 +111,6 @@ pub mod checked {
 
         pub fn new_unmetered() -> Self {
             Self::V2(SuiGasStatusV2::new_unmetered())
-        }
-
-        pub fn check_gas_balance(
-            &self,
-            gas_objs: &[&ObjectReadResult],
-            gas_budget: u64,
-            available_address_balance_gas: u64,
-        ) -> UserInputResult {
-            match self {
-                Self::V2(status) => {
-                    status.check_gas_balance(gas_objs, gas_budget, available_address_balance_gas)
-                }
-            }
-        }
-
-        pub fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult {
-            match self {
-                Self::V2(status) => status.check_gas_objects(gas_objs),
-            }
-        }
-
-        pub fn gas_price(&self) -> u64 {
-            match self {
-                Self::V2(status) => status.gas_price(),
-            }
         }
     }
 

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -311,44 +311,8 @@ mod checked {
             self.reference_gas_price
         }
 
-        // Check whether gas arguments are legit:
-        // 1. Gas object has an address owner.
-        // 2. Gas budget is between min and max budget allowed
-        // 3. Gas balance (all gas coins together) is bigger or equal to budget
-        pub(crate) fn check_gas_balance(
-            &self,
-            gas_objs: &[&ObjectReadResult],
-            gas_budget: u64,
-            available_address_balance_gas: u64,
-        ) -> UserInputResult {
-            self.check_gas_objects(gas_objs)?;
-            self.check_gas_data(gas_objs, gas_budget, available_address_balance_gas)
-        }
-
-        // Check gas objects have an address owner.
-        pub(crate) fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult {
-            // All gas objects have an address owner
-            // Note: because of address balance payments, gas_objs may be empty.
-            for gas_object in gas_objs {
-                // if as_object() returns None, it means the object has been deleted (and therefore
-                // must be a shared object).
-                if let Some(obj) = gas_object.as_object() {
-                    if !obj.is_address_owned() {
-                        return Err(UserInputError::GasObjectNotOwnedObject {
-                            owner: obj.owner.clone(),
-                        });
-                    }
-                } else {
-                    // This case should never happen (because gas can't be a shared object), but we
-                    // handle this case for future-proofing
-                    return Err(UserInputError::MissingGasPayment);
-                }
-            }
-            Ok(())
-        }
-
         // Gas data is consistent
-        pub(crate) fn check_gas_data(
+        fn check_gas_data(
             &self,
             gas_objs: &[&ObjectReadResult],
             gas_budget: u64,
@@ -389,10 +353,6 @@ mod checked {
 
         fn storage_cost(&self) -> u64 {
             self.storage_gas_units()
-        }
-
-        pub fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
-            &self.per_object_storage
         }
     }
 
@@ -603,6 +563,46 @@ mod checked {
                 storage_gas_price: self.storage_gas_price,
                 rebate_rate: self.rebate_rate,
             }
+        }
+
+        // Check whether gas arguments are legit:
+        // 1. Gas object has an address owner.
+        // 2. Gas budget is between min and max budget allowed
+        // 3. Gas balance (all gas coins together) is bigger or equal to budget
+        fn check_gas_balance(
+            &self,
+            gas_objs: &[&ObjectReadResult],
+            gas_budget: u64,
+            available_address_balance_gas: u64,
+        ) -> UserInputResult {
+            self.check_gas_objects(gas_objs)?;
+            self.check_gas_data(gas_objs, gas_budget, available_address_balance_gas)
+        }
+
+        // Check gas objects have an address owner.
+        fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult {
+            // All gas objects have an address owner
+            // Note: because of address balance payments, gas_objs may be empty.
+            for gas_object in gas_objs {
+                // if as_object() returns None, it means the object has been deleted (and therefore
+                // must be a shared object).
+                if let Some(obj) = gas_object.as_object() {
+                    if !obj.is_address_owned() {
+                        return Err(UserInputError::GasObjectNotOwnedObject {
+                            owner: obj.owner.clone(),
+                        });
+                    }
+                } else {
+                    // This case should never happen (because gas can't be a shared object), but we
+                    // handle this case for future-proofing
+                    return Err(UserInputError::MissingGasPayment);
+                }
+            }
+            Ok(())
+        }
+
+        fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
+            &self.per_object_storage
         }
     }
 

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -216,7 +216,13 @@ mod checked {
         }
     }
 
-    #[allow(clippy::type_complexity)]
+    type ExecutionOutput<Mode> = (
+        InnerTemporaryStore,
+        SuiGasStatus,
+        TransactionEffects,
+        Vec<ExecutionTiming>,
+        Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
+    );
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
@@ -235,13 +241,7 @@ mod checked {
         enable_expensive_checks: bool,
         execution_params: ExecutionOrEarlyError,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<Mode::ExecutionResults, Mode::Error>,
-    ) {
+    ) -> ExecutionOutput<Mode> {
         let input_objects = input_objects.into_inner();
         let mutable_inputs = if enable_expensive_checks {
             input_objects.all_mutable_inputs().keys().copied().collect()
@@ -275,7 +275,7 @@ mod checked {
             let execution_error: Mode::Error =
                 ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw).into();
             let status = ExecutionStatus::new_failure(execution_error.to_execution_failure());
-            let mut gas_meter = GasCharger::new(
+            let gas_meter = GasCharger::new(
                 transaction_digest,
                 PaymentKind::gasless(),
                 gas_status,
@@ -283,13 +283,14 @@ mod checked {
                 protocol_config,
             );
 
+            let gas_coin = gas_meter.gas_coin();
             let (inner, effects) = temporary_store.into_effects(
                 shared_object_refs,
                 &transaction_digest,
                 transaction_dependencies,
                 GasCostSummary::default(),
                 status,
-                &mut gas_meter,
+                gas_coin,
                 *epoch_id,
             );
 
@@ -410,75 +411,21 @@ mod checked {
         // dependencies
         transaction_dependencies.remove(&TransactionDigest::genesis_marker());
 
+        let gas_coin = gas_charger.gas_coin();
         let (inner, effects) = temporary_store.into_effects(
             shared_object_refs,
             &transaction_digest,
             transaction_dependencies,
             gas_cost_summary,
             status,
-            &mut gas_charger,
+            gas_coin,
             *epoch_id,
         );
 
         // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
         // spun-up each time.
         if !Mode::TRACK_EXECUTION {
-            metrics.vm_telemetry_metrics.try_update(|vm_metrics| {
-                let t = move_vm.get_telemetry_report();
-                vm_metrics
-                    .move_vm_package_cache_count
-                    .set(t.package_cache_count as i64);
-                vm_metrics
-                    .move_vm_total_arena_size_bytes
-                    .set(t.total_arena_size as i64);
-                vm_metrics.move_vm_module_count.set(t.module_count as i64);
-                vm_metrics
-                    .move_vm_function_count
-                    .set(t.function_count as i64);
-                vm_metrics.move_vm_type_count.set(t.type_count as i64);
-                vm_metrics.move_vm_interner_size.set(t.interner_size as i64);
-                vm_metrics
-                    .move_vm_vtable_cache_count
-                    .set(t.vtable_cache_count as i64);
-                vm_metrics
-                    .move_vm_vtable_cache_hits
-                    .set(t.vtable_cache_hits as i64);
-                vm_metrics
-                    .move_vm_vtable_cache_misses
-                    .set(t.vtable_cache_misses as i64);
-                vm_metrics
-                    .move_vm_load_time_ms
-                    .set(t.total_load_time as i64);
-                vm_metrics.move_vm_load_count.set(t.load_count as i64);
-                vm_metrics
-                    .move_vm_validation_time_ms
-                    .set(t.total_validation_time as i64);
-                vm_metrics
-                    .move_vm_validation_count
-                    .set(t.validation_count as i64);
-                vm_metrics.move_vm_jit_time_ms.set(t.total_jit_time as i64);
-                vm_metrics.move_vm_jit_count.set(t.jit_count as i64);
-                vm_metrics
-                    .move_vm_execution_time_ms
-                    .set(t.total_execution_time as i64);
-                vm_metrics
-                    .move_vm_execution_count
-                    .set(t.execution_count as i64);
-                vm_metrics
-                    .move_vm_interpreter_time_ms
-                    .set(t.total_interpreter_time as i64);
-                vm_metrics
-                    .move_vm_interpreter_count
-                    .set(t.interpreter_count as i64);
-                vm_metrics
-                    .move_vm_max_callstack_size
-                    .set(t.max_callstack_size as i64);
-                vm_metrics
-                    .move_vm_max_valuestack_size
-                    .set(t.max_valuestack_size as i64);
-                vm_metrics.move_vm_total_time_ms.set(t.total_time as i64);
-                vm_metrics.move_vm_total_count.set(t.total_count as i64);
-            });
+            update_vm_telemetry_metrics(&metrics, move_vm);
         }
 
         (
@@ -488,6 +435,65 @@ mod checked {
             timings,
             execution_result,
         )
+    }
+
+    fn update_vm_telemetry_metrics(metrics: &ExecutionMetrics, move_vm: &MoveRuntime) {
+        metrics.vm_telemetry_metrics.try_update(|vm_metrics| {
+            let t = move_vm.get_telemetry_report();
+            vm_metrics
+                .move_vm_package_cache_count
+                .set(t.package_cache_count as i64);
+            vm_metrics
+                .move_vm_total_arena_size_bytes
+                .set(t.total_arena_size as i64);
+            vm_metrics.move_vm_module_count.set(t.module_count as i64);
+            vm_metrics
+                .move_vm_function_count
+                .set(t.function_count as i64);
+            vm_metrics.move_vm_type_count.set(t.type_count as i64);
+            vm_metrics.move_vm_interner_size.set(t.interner_size as i64);
+            vm_metrics
+                .move_vm_vtable_cache_count
+                .set(t.vtable_cache_count as i64);
+            vm_metrics
+                .move_vm_vtable_cache_hits
+                .set(t.vtable_cache_hits as i64);
+            vm_metrics
+                .move_vm_vtable_cache_misses
+                .set(t.vtable_cache_misses as i64);
+            vm_metrics
+                .move_vm_load_time_ms
+                .set(t.total_load_time as i64);
+            vm_metrics.move_vm_load_count.set(t.load_count as i64);
+            vm_metrics
+                .move_vm_validation_time_ms
+                .set(t.total_validation_time as i64);
+            vm_metrics
+                .move_vm_validation_count
+                .set(t.validation_count as i64);
+            vm_metrics.move_vm_jit_time_ms.set(t.total_jit_time as i64);
+            vm_metrics.move_vm_jit_count.set(t.jit_count as i64);
+            vm_metrics
+                .move_vm_execution_time_ms
+                .set(t.total_execution_time as i64);
+            vm_metrics
+                .move_vm_execution_count
+                .set(t.execution_count as i64);
+            vm_metrics
+                .move_vm_interpreter_time_ms
+                .set(t.total_interpreter_time as i64);
+            vm_metrics
+                .move_vm_interpreter_count
+                .set(t.interpreter_count as i64);
+            vm_metrics
+                .move_vm_max_callstack_size
+                .set(t.max_callstack_size as i64);
+            vm_metrics
+                .move_vm_max_valuestack_size
+                .set(t.max_valuestack_size as i64);
+            vm_metrics.move_vm_total_time_ms.set(t.total_time as i64);
+            vm_metrics.move_vm_total_count.set(t.total_count as i64);
+        });
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -57,7 +57,7 @@ pub mod checked {
     /// Tracks the combined balance (`total_smashed`), the target location where the
     /// smashed value lives, and the original payment methods for bookkeeping.
     /// Note that the target location (`gas_charge_location`) may differ from the first payment
-    /// method in the list if it has ben overridden during execution.
+    /// method in the list if it has been overridden during execution.
     #[derive(Debug)]
     struct SmashMetadata {
         /// The location to charge gas from at the end of execution. Starts with the primary
@@ -90,7 +90,7 @@ pub mod checked {
         Smash(IndexMap<PaymentLocation, PaymentMethod>),
     }
 
-    /// A single source of SUI used to pay for gas: either an coin object or a withdrawal
+    /// A single source of SUI used to pay for gas: either a coin object or a withdrawal
     /// reservation from an address balance.
     #[derive(Debug)]
     pub enum PaymentMethod {
@@ -199,6 +199,15 @@ pub mod checked {
                     amount: metadata.total_smashed,
                 }),
             }
+        }
+
+        /// The coin that receives the final gas charge, or `None` when gas is paid from an address
+        /// balance (or there is no payment, e.g. unmetered/gasless).
+        pub fn gas_coin(&self) -> Option<ObjectID> {
+            self.gas_payment_amount().and_then(|gp| match gp.location {
+                PaymentLocation::Coin(coin_id) => Some(coin_id),
+                PaymentLocation::AddressBalance(_) => None,
+            })
         }
 
         pub(crate) fn gas_payment_location(&self) -> Option<PaymentLocation> {

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::execution_mode::ExecutionMode;
-use crate::gas_charger::{GasCharger, PaymentLocation};
+use crate::gas_charger::GasCharger;
 use move_vm_runtime::runtime::MoveRuntime;
 use mysten_common::ZipDebugEqIteratorExt;
 use mysten_metrics::monitored_scope;
@@ -389,7 +389,7 @@ impl<'backing> TemporaryStore<'backing> {
         mut transaction_dependencies: BTreeSet<TransactionDigest>,
         gas_cost_summary: GasCostSummary,
         status: ExecutionStatus,
-        gas_charger: &mut GasCharger,
+        gas_coin: Option<ObjectID>,
         epoch: EpochId,
     ) -> (InnerTemporaryStore, TransactionEffects) {
         // Defense-in-depth: Owner::Party is not yet supported as an effect output. There are
@@ -426,17 +426,6 @@ impl<'backing> TemporaryStore<'backing> {
         }
 
         assert!(self.protocol_config.enable_effects_v2());
-
-        // In the case of special transactions that don't require a gas object,
-        // we don't really care about the effects to gas, just use the input for it.
-        // Gas coins are guaranteed to be at least size 1 and if more than 1
-        // the first coin is where all the others are merged.
-        let gas_coin = gas_charger
-            .gas_payment_amount()
-            .and_then(|gp| match gp.location {
-                PaymentLocation::Coin(coin_id) => Some(coin_id),
-                PaymentLocation::AddressBalance(_) => None,
-            });
 
         let object_changes = self.get_object_changes();
 


### PR DESCRIPTION
## Description
Behavior-neutral cleanup of existing gas code, preparing for the v15+ step-by-step gas pipeline (stacked PRs on top).

Stacked PR 1/3 — #27042 and #27043 

## Test plan
Behavior-neutral; covered by existing gas/execution tests.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: