### PR TITLE
Carve legacy gas/execution into `mod legacy`

### DIFF
--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -14,7 +14,7 @@ mod checked {
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::runtime::MoveRuntime;
     use mysten_common::{assert_reachable, debug_fatal, in_test_configuration};
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
     use sui_types::balance::{
@@ -63,7 +63,7 @@ mod checked {
     };
     use sui_types::effects::TransactionEffects;
     use sui_types::error::{ExecutionError, ExecutionErrorTrait};
-    use sui_types::execution::{ExecutionTiming, ResultWithTimings};
+    use sui_types::execution::{ExecutionTiming, ResultWithTimings, SharedInput};
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
@@ -88,27 +88,6 @@ mod checked {
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     };
 
-    // MAGIC CONSTANTS -- these are all mainnet-only hardcoded constants and should not be changed
-    // (but can be removed in future execution cuts).
-
-    /// Mainnet recovery point: the fix replays for transactions at/above this accumulator root
-    /// version and keeps the old behavior below it. A compiled constant (not a protocol flag)
-    /// because it had to take effect mid-epoch during recovery, when the network can't reconfigure.
-    const ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION: SequenceNumber =
-        SequenceNumber::from_u64(692949576);
-
-    /// Mainnet settlement version at/above which an `InsufficientFundsForWithdraw` transaction
-    /// short-circuits execution entirely (zero-gas effects, mutable-input version bumps only),
-    /// superseding the address-balance gas-payment pruning hotfix. A compiled constant, not a
-    /// protocol flag, because it must take effect mid-epoch during recovery when the network cannot
-    /// reconfigure. Only consulted when an accumulator version is assigned (mainnet committed
-    /// execution); everywhere else the short-circuit is protocol gated (see
-    /// `should_short_circuit_insufficient_funds`).
-    ///
-    /// Value is the mainnet accumulator root version where the new binary was activated on the network.
-    const ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION: SequenceNumber =
-        SequenceNumber::from_u64(693531074);
-
     /// Whether the *head* early error is `InsufficientFundsForWithdraw`. Used to gate the first
     /// address-balance gas-payment pruning hotfix: the head error is the one surfaced as the
     /// failure status, so keying off it (rather than any occurrence) keeps the pruning bit-for-bit
@@ -122,62 +101,6 @@ mod checked {
                 ExecutionErrorKind::InsufficientFundsForWithdraw
             )
         })
-    }
-
-    /// Whether to prune the address-balance leg of gas smashing for an IFFW transaction. This is
-    /// the mainnet-only accumulator backfill that replays the pre-flag incident hotfix below the
-    /// short-circuit rollout point; once `early_exit_on_iffw` is set the short-circuit handles IFFW
-    /// upstream, so reaching here implies the flag is off (asserted below).
-    fn should_filter_address_balance_gas_smash(
-        execution_params: &ExecutionOrEarlyError,
-        protocol_config: &ProtocolConfig,
-    ) -> bool {
-        if !head_error_is_insufficient_funds_for_withdraw(execution_params) {
-            return false;
-        }
-        debug_assert!(
-            !protocol_config.early_exit_on_iffw(),
-            "Should not reach gas smashing filtering address balances if IFFW early exit is enabled"
-        );
-        // In test/debug builds, always apply the fix unconditionally to match the behaviour of
-        // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
-        in_test_configuration()
-            || protocol_config.early_exit_on_iffw()
-            || (protocol_config.chain() == Chain::Mainnet
-                && execution_params
-                    .accumulator_version()
-                    .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION))
-    }
-
-    /// Whether to short-circuit an IFFW transaction. When an accumulator version is assigned
-    /// (mainnet committed execution) it gates on the settlement-version rollout point; otherwise
-    /// (every other chain and non-committed paths, where no accumulator version is assigned) the
-    /// short-circuit applies based on `early_exit_on_iffw`.
-    fn should_short_circuit_insufficient_funds(
-        execution_params: &ExecutionOrEarlyError,
-        protocol_config: &ProtocolConfig,
-    ) -> bool {
-        // If no IFWWs, then does not apply
-        if !execution_params.early_errors().is_some_and(|errors| {
-            errors
-                .iter()
-                .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw))
-        }) {
-            return false;
-        }
-
-        // In test/debug builds, always short-circuit unconditionally to match the behaviour of
-        // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
-        if in_test_configuration() {
-            return true;
-        }
-
-        // otherwise gate by accumulator version (if present) or protocol flag
-        protocol_config.early_exit_on_iffw()
-            || (protocol_config.chain() == Chain::Mainnet
-                && execution_params.accumulator_version().is_some_and(|v| {
-                    v >= ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION
-                }))
     }
 
     fn payment_kind(
@@ -227,7 +150,7 @@ mod checked {
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
         input_objects: CheckedInputObjects,
-        mut gas_data: GasData,
+        gas_data: GasData,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         rewritten_inputs: Option<Vec<bool>>,
@@ -250,9 +173,9 @@ mod checked {
         };
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
-        let mut transaction_dependencies = input_objects.transaction_dependencies();
+        let transaction_dependencies = input_objects.transaction_dependencies();
 
-        let mut temporary_store = TemporaryStore::new(
+        let temporary_store = TemporaryStore::new(
             store,
             input_objects,
             receiving_objects,
@@ -261,179 +184,27 @@ mod checked {
             *epoch_id,
         );
 
-        // Short-circuit on InsufficientFundsForWithdraw: the transaction is guaranteed to fail
-        // and has nothing to execute, so skip the executor pipeline. Bump versions of mutable
-        // inputs (so locks advance) and emit effects with a zero gas cost summary. On mainnet
-        // committed execution this is gated on the settlement-version rollout point (below it we
-        // fall through to the address-balance gas-payment pruning hotfix instead); everywhere else
-        // it applies based on `early_exit_on_iffw`.
-        if should_short_circuit_insufficient_funds(&execution_params, protocol_config) {
-            assert_reachable!("IFFW short-circuit fired");
-            temporary_store.ensure_active_inputs_mutated();
-            transaction_dependencies.remove(&TransactionDigest::genesis_marker());
-
-            let execution_error: Mode::Error =
-                ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw).into();
-            let status = ExecutionStatus::new_failure(execution_error.to_execution_failure());
-            let gas_meter = GasCharger::new(
-                transaction_digest,
-                PaymentKind::gasless(),
-                gas_status,
-                &mut temporary_store,
-                protocol_config,
-            );
-
-            let gas_coin = gas_meter.gas_coin();
-            let (inner, effects) = temporary_store.into_effects(
-                shared_object_refs,
-                &transaction_digest,
-                transaction_dependencies,
-                GasCostSummary::default(),
-                status,
-                gas_coin,
-                *epoch_id,
-            );
-
-            return (
-                inner,
-                gas_meter.into_gas_status(),
-                effects,
-                vec![],
-                Err(execution_error),
-            );
-        }
-
-        let sponsor = {
-            let gas_owner = gas_data.owner;
-            if gas_owner == transaction_signer {
-                None
-            } else {
-                Some(gas_owner)
-            }
-        };
-        let gas_price = gas_status.gas_price();
-        let rgp = gas_status.reference_gas_price();
-
-        // On an IFFW abort, drop the address-balance gas payments (keeping real coins) so the
-        // pruned list flows into `payment_kind`/`compute_input_reservations` with no special
-        // handling. See `should_filter_address_balance_gas_smash` for when this applies.
-        if should_filter_address_balance_gas_smash(&execution_params, protocol_config)
-            && gas_data.payment.len() > 1
-            && ParsedDigest::try_from(gas_data.payment[0].2).is_err()
-        {
-            gas_data
-                .payment
-                .retain(|entry| ParsedDigest::try_from(entry.2).is_err());
-        }
-
-        let mut gas_charger = GasCharger::new(
-            transaction_digest,
-            payment_kind(&gas_data, &transaction_kind, protocol_config),
-            gas_status,
-            &mut temporary_store,
-            protocol_config,
-        );
-
-        let tx_ctx = TxContext::new_from_components(
-            &transaction_signer,
-            &transaction_digest,
-            epoch_id,
-            epoch_timestamp_ms,
-            rgp,
-            gas_price,
-            gas_data.budget,
-            sponsor,
-            protocol_config,
-        );
-        let tx_ctx = Rc::new(RefCell::new(tx_ctx));
-
-        let is_gasless = protocol_config.enable_gasless()
-            && is_gasless_transaction(&gas_data, &transaction_kind);
-        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
-
-        // Cache the transaction-derived invariant-check inputs (reservation budget, advance-epoch
-        // mint/burn, genesis flag) on the store, after the gas-smash filtering above. The
-        // conservation checks and the ownership-invariant check read them from there.
-        temporary_store.set_invariant_inputs(&transaction_kind, &gas_data, transaction_signer);
-
-        let (gas_cost_summary, mut execution_result, timings) = execute_transaction::<Mode>(
+        // TODO: remove all `legacy` code on the next execution version cut
+        legacy::execute_transaction_inner::<Mode>(
             store,
-            &mut temporary_store,
+            temporary_store,
+            gas_data,
+            gas_status,
             transaction_kind,
             rewritten_inputs,
-            &mut gas_charger,
-            tx_ctx,
-            move_vm,
-            protocol_config,
-            metrics.clone(),
-            execution_params,
-            trace_builder_opt,
-            is_gasless,
-        );
-
-        // Post-execution system-invariant checks, run after gas charging: SUI conservation
-        // (recoverable) followed by object-ownership authentication (panics on violation).
-        if let Err(e) = run_invariant_checks::<Mode>(
-            &mut temporary_store,
-            &mut gas_charger,
+            transaction_signer,
             transaction_digest,
             move_vm,
+            epoch_id,
+            epoch_timestamp_ms,
             protocol_config,
+            metrics,
             enable_expensive_checks,
-            &gas_cost_summary,
-            &transaction_signer,
-            &sponsor,
-            &mutable_inputs,
-            is_epoch_change,
-        ) {
-            // FIXME: we cannot fail the transaction if this is an epoch change transaction.
-            execution_result = Err(e);
-        }
-
-        let status = if let Err(error) = &execution_result {
-            ExecutionStatus::new_failure(error.to_execution_failure())
-        } else {
-            ExecutionStatus::Success
-        };
-
-        #[skip_checked_arithmetic]
-        trace!(
-            tx_digest = ?transaction_digest,
-            computation_gas_cost = gas_cost_summary.computation_cost,
-            storage_gas_cost = gas_cost_summary.storage_cost,
-            storage_gas_rebate = gas_cost_summary.storage_rebate,
-            "Finished execution of transaction with status {:?}",
-            status
-        );
-
-        // Genesis writes a special digest to indicate that an object was created during
-        // genesis and not written by any normal transaction - remove that from the
-        // dependencies
-        transaction_dependencies.remove(&TransactionDigest::genesis_marker());
-
-        let gas_coin = gas_charger.gas_coin();
-        let (inner, effects) = temporary_store.into_effects(
+            execution_params,
+            trace_builder_opt,
             shared_object_refs,
-            &transaction_digest,
             transaction_dependencies,
-            gas_cost_summary,
-            status,
-            gas_coin,
-            *epoch_id,
-        );
-
-        // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
-        // spun-up each time.
-        if !Mode::TRACK_EXECUTION {
-            update_vm_telemetry_metrics(&metrics, move_vm);
-        }
-
-        (
-            inner,
-            gas_charger.into_gas_status(),
-            effects,
-            timings,
-            execution_result,
+            mutable_inputs,
         )
     }
 
@@ -532,233 +303,518 @@ mod checked {
         Ok(temporary_store.into_inner(BTreeMap::new()))
     }
 
-    #[instrument(name = "tx_execute", level = "debug", skip_all)]
-    fn execute_transaction<Mode: ExecutionMode>(
-        store: &dyn BackingStore,
-        temporary_store: &mut TemporaryStore<'_>,
-        transaction_kind: TransactionKind,
-        rewritten_inputs: Option<Vec<bool>>,
-        gas_charger: &mut GasCharger,
-        tx_ctx: Rc<RefCell<TxContext>>,
-        move_vm: &Arc<MoveRuntime>,
-        protocol_config: &ProtocolConfig,
-        metrics: Arc<ExecutionMetrics>,
-        execution_params: ExecutionOrEarlyError,
-        trace_builder_opt: &mut Option<MoveTraceBuilder>,
-        is_gasless: bool,
-    ) -> (
-        GasCostSummary,
-        Result<Mode::ExecutionResults, Mode::Error>,
-        Vec<ExecutionTiming>,
-    ) {
-        // At this point no charges have been applied yet
-        debug_assert!(
-            gas_charger.no_charges(),
-            "No gas charges must be applied yet"
-        );
+    /// Frozen pre-v15 (`gas_model_version < 15`) execution, mirroring `origin/main`. Removed at the
+    /// next execution-version cut.
+    mod legacy {
+        use super::*;
 
-        let withdrawal_reservations =
-            if is_gasless && protocol_config.gasless_verify_remaining_balance() {
-                gasless_withdrawal_reservations(&transaction_kind, &tx_ctx.borrow())
+        // MAGIC CONSTANTS -- these are all mainnet-only hardcoded constants and should not be
+        // changed (but can be removed in future execution cuts).
+
+        /// Mainnet recovery point: the fix replays for transactions at/above this accumulator root
+        /// version and keeps the old behavior below it. A compiled constant (not a protocol flag)
+        /// because it had to take effect mid-epoch during recovery, when the network can't reconfigure.
+        pub(super) const ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION: SequenceNumber =
+            SequenceNumber::from_u64(692949576);
+
+        /// Mainnet settlement version at/above which an `InsufficientFundsForWithdraw` transaction
+        /// short-circuits execution entirely (zero-gas effects, mutable-input version bumps only),
+        /// superseding the address-balance gas-payment pruning hotfix. A compiled constant, not a
+        /// protocol flag, because it must take effect mid-epoch during recovery when the network cannot
+        /// reconfigure. Only consulted when an accumulator version is assigned (mainnet committed
+        /// execution); everywhere else the short-circuit is protocol gated (see
+        /// `should_short_circuit_insufficient_funds`).
+        ///
+        /// Value is the mainnet accumulator root version where the new binary was activated on the network.
+        pub(super) const ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION:
+            SequenceNumber = SequenceNumber::from_u64(693531074);
+
+        /// Whether to prune the address-balance leg of gas smashing for an IFFW transaction. This is
+        /// the mainnet-only accumulator backfill that replays the pre-flag incident hotfix below the
+        /// short-circuit rollout point; once `early_exit_on_iffw` is set the short-circuit handles IFFW
+        /// upstream, so reaching here implies the flag is off (asserted below).
+        pub(super) fn should_filter_address_balance_gas_smash(
+            execution_params: &ExecutionOrEarlyError,
+            protocol_config: &ProtocolConfig,
+        ) -> bool {
+            if !head_error_is_insufficient_funds_for_withdraw(execution_params) {
+                return false;
+            }
+            debug_assert!(
+                !protocol_config.early_exit_on_iffw(),
+                "Should not reach gas smashing filtering address balances if IFFW early exit is enabled"
+            );
+            // In test/debug builds, always apply the fix unconditionally to match the behaviour of
+            // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
+            in_test_configuration()
+                || protocol_config.early_exit_on_iffw()
+                || (protocol_config.chain() == Chain::Mainnet
+                    && execution_params
+                        .accumulator_version()
+                        .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION))
+        }
+
+        /// Whether to short-circuit an IFFW transaction. When an accumulator version is assigned
+        /// (mainnet committed execution) it gates on the settlement-version rollout point; otherwise
+        /// (every other chain and non-committed paths, where no accumulator version is assigned) the
+        /// short-circuit applies based on `early_exit_on_iffw`.
+        pub(super) fn should_short_circuit_insufficient_funds(
+            execution_params: &ExecutionOrEarlyError,
+            protocol_config: &ProtocolConfig,
+        ) -> bool {
+            // If no IFWWs, then does not apply
+            if !execution_params.early_errors().is_some_and(|errors| {
+                errors
+                    .iter()
+                    .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw))
+            }) {
+                return false;
+            }
+
+            // In test/debug builds, always short-circuit unconditionally to match the behaviour of
+            // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
+            if in_test_configuration() {
+                return true;
+            }
+
+            // otherwise gate by accumulator version (if present) or protocol flag
+            protocol_config.early_exit_on_iffw()
+                || (protocol_config.chain() == Chain::Mainnet
+                    && execution_params.accumulator_version().is_some_and(|v| {
+                        v >= ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION
+                    }))
+        }
+
+        /// Frozen pre-v15 (`gas_model_version < 15`) execution; mirrors `origin/main`.
+        #[allow(clippy::too_many_arguments)]
+        pub(super) fn execute_transaction_inner<Mode: ExecutionMode>(
+            store: &dyn BackingStore,
+            mut temporary_store: TemporaryStore<'_>,
+            mut gas_data: GasData,
+            gas_status: SuiGasStatus,
+            transaction_kind: TransactionKind,
+            rewritten_inputs: Option<Vec<bool>>,
+            transaction_signer: SuiAddress,
+            transaction_digest: TransactionDigest,
+            move_vm: &Arc<MoveRuntime>,
+            epoch_id: &EpochId,
+            epoch_timestamp_ms: u64,
+            protocol_config: &ProtocolConfig,
+            metrics: Arc<ExecutionMetrics>,
+            enable_expensive_checks: bool,
+            execution_params: ExecutionOrEarlyError,
+            trace_builder_opt: &mut Option<MoveTraceBuilder>,
+            shared_object_refs: Vec<SharedInput>,
+            mut transaction_dependencies: BTreeSet<TransactionDigest>,
+            mutable_inputs: HashSet<ObjectID>,
+        ) -> ExecutionOutput<Mode> {
+            // Short-circuit on InsufficientFundsForWithdraw: the transaction is guaranteed to fail
+            // and has nothing to execute, so skip the executor pipeline. Bump versions of mutable
+            // inputs (so locks advance) and emit effects with a zero gas cost summary. On mainnet
+            // committed execution this is gated on the settlement-version rollout point (below it we
+            // fall through to the address-balance gas-payment pruning hotfix instead); everywhere else
+            // it applies based on `early_exit_on_iffw`.
+            if should_short_circuit_insufficient_funds(&execution_params, protocol_config) {
+                assert_reachable!("IFFW short-circuit fired");
+                temporary_store.ensure_active_inputs_mutated();
+                transaction_dependencies.remove(&TransactionDigest::genesis_marker());
+
+                let execution_error: Mode::Error =
+                    ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw)
+                        .into();
+                let status = ExecutionStatus::new_failure(execution_error.to_execution_failure());
+                let gas_meter = GasCharger::new(
+                    transaction_digest,
+                    PaymentKind::gasless(),
+                    gas_status,
+                    &mut temporary_store,
+                    protocol_config,
+                );
+
+                let gas_coin = gas_meter.gas_coin();
+                let (inner, effects) = temporary_store.into_effects(
+                    shared_object_refs,
+                    &transaction_digest,
+                    transaction_dependencies,
+                    GasCostSummary::default(),
+                    status,
+                    gas_coin,
+                    *epoch_id,
+                );
+
+                return (
+                    inner,
+                    gas_meter.into_gas_status(),
+                    effects,
+                    vec![],
+                    Err(execution_error),
+                );
+            }
+
+            let sponsor = {
+                let gas_owner = gas_data.owner;
+                if gas_owner == transaction_signer {
+                    None
+                } else {
+                    Some(gas_owner)
+                }
+            };
+            let gas_price = gas_status.gas_price();
+            let rgp = gas_status.reference_gas_price();
+
+            // On an IFFW abort, drop the address-balance gas payments (keeping real coins) so the
+            // pruned list flows into `payment_kind`/`compute_input_reservations` with no special
+            // handling. See `should_filter_address_balance_gas_smash` for when this applies.
+            if should_filter_address_balance_gas_smash(&execution_params, protocol_config)
+                && gas_data.payment.len() > 1
+                && ParsedDigest::try_from(gas_data.payment[0].2).is_err()
+            {
+                gas_data
+                    .payment
+                    .retain(|entry| ParsedDigest::try_from(entry.2).is_err());
+            }
+
+            let mut gas_charger = GasCharger::new(
+                transaction_digest,
+                payment_kind(&gas_data, &transaction_kind, protocol_config),
+                gas_status,
+                &mut temporary_store,
+                protocol_config,
+            );
+
+            let tx_ctx = TxContext::new_from_components(
+                &transaction_signer,
+                &transaction_digest,
+                epoch_id,
+                epoch_timestamp_ms,
+                rgp,
+                gas_price,
+                gas_data.budget,
+                sponsor,
+                protocol_config,
+            );
+            let tx_ctx = Rc::new(RefCell::new(tx_ctx));
+
+            let is_gasless = protocol_config.enable_gasless()
+                && is_gasless_transaction(&gas_data, &transaction_kind);
+            let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
+
+            // Cache the transaction-derived invariant-check inputs (reservation budget, advance-epoch
+            // mint/burn, genesis flag) on the store, after the gas-smash filtering above. The
+            // conservation checks and the ownership-invariant check read them from there.
+            temporary_store.set_invariant_inputs(&transaction_kind, &gas_data, transaction_signer);
+
+            let (gas_cost_summary, mut execution_result, timings) = execute_transaction::<Mode>(
+                store,
+                &mut temporary_store,
+                transaction_kind,
+                rewritten_inputs,
+                &mut gas_charger,
+                tx_ctx,
+                move_vm,
+                protocol_config,
+                metrics.clone(),
+                execution_params,
+                trace_builder_opt,
+                is_gasless,
+            );
+
+            // Post-execution system-invariant checks, run after gas charging: SUI conservation
+            // (recoverable) followed by object-ownership authentication (panics on violation).
+            if let Err(e) = run_invariant_checks::<Mode>(
+                &mut temporary_store,
+                &mut gas_charger,
+                transaction_digest,
+                move_vm,
+                protocol_config,
+                enable_expensive_checks,
+                &gas_cost_summary,
+                &transaction_signer,
+                &sponsor,
+                &mutable_inputs,
+                is_epoch_change,
+            ) {
+                // FIXME: we cannot fail the transaction if this is an epoch change transaction.
+                execution_result = Err(e);
+            }
+
+            let status = if let Err(error) = &execution_result {
+                ExecutionStatus::new_failure(error.to_execution_failure())
             } else {
-                None
+                ExecutionStatus::Success
             };
 
-        // We must charge object read here during transaction execution, because if this fails
-        // we must still ensure an effect is committed and all objects versions incremented
-        let result = gas_charger.charge_input_objects(temporary_store);
+            #[skip_checked_arithmetic]
+            trace!(
+                tx_digest = ?transaction_digest,
+                computation_gas_cost = gas_cost_summary.computation_cost,
+                storage_gas_cost = gas_cost_summary.storage_cost,
+                storage_gas_rebate = gas_cost_summary.storage_rebate,
+                "Finished execution of transaction with status {:?}",
+                status
+            );
 
-        let result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> =
-            result.map_err(|e| (e.into(), vec![])).and_then(
-                |()| -> ResultWithTimings<Mode::ExecutionResults, Mode::Error> {
-                    let mut execution_result: ResultWithTimings<
-                        Mode::ExecutionResults,
-                        Mode::Error,
-                    > = match execution_params.into_early_errors() {
-                        Some(early_execution_errors) => {
-                            Err((Mode::Error::from_kind(early_execution_errors.head), vec![]))
-                        }
-                        None => execution_loop::<Mode>(
-                            store,
+            // Genesis writes a special digest to indicate that an object was created during
+            // genesis and not written by any normal transaction - remove that from the
+            // dependencies
+            transaction_dependencies.remove(&TransactionDigest::genesis_marker());
+
+            let gas_coin = gas_charger.gas_coin();
+            let (inner, effects) = temporary_store.into_effects(
+                shared_object_refs,
+                &transaction_digest,
+                transaction_dependencies,
+                gas_cost_summary,
+                status,
+                gas_coin,
+                *epoch_id,
+            );
+
+            // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
+            // spun-up each time.
+            if !Mode::TRACK_EXECUTION {
+                update_vm_telemetry_metrics(&metrics, move_vm);
+            }
+
+            (
+                inner,
+                gas_charger.into_gas_status(),
+                effects,
+                timings,
+                execution_result,
+            )
+        }
+
+        #[instrument(name = "tx_execute", level = "debug", skip_all)]
+        fn execute_transaction<Mode: ExecutionMode>(
+            store: &dyn BackingStore,
+            temporary_store: &mut TemporaryStore<'_>,
+            transaction_kind: TransactionKind,
+            rewritten_inputs: Option<Vec<bool>>,
+            gas_charger: &mut GasCharger,
+            tx_ctx: Rc<RefCell<TxContext>>,
+            move_vm: &Arc<MoveRuntime>,
+            protocol_config: &ProtocolConfig,
+            metrics: Arc<ExecutionMetrics>,
+            execution_params: ExecutionOrEarlyError,
+            trace_builder_opt: &mut Option<MoveTraceBuilder>,
+            is_gasless: bool,
+        ) -> (
+            GasCostSummary,
+            Result<Mode::ExecutionResults, Mode::Error>,
+            Vec<ExecutionTiming>,
+        ) {
+            // At this point no charges have been applied yet
+            debug_assert!(
+                gas_charger.no_charges(),
+                "No gas charges must be applied yet"
+            );
+
+            let withdrawal_reservations =
+                if is_gasless && protocol_config.gasless_verify_remaining_balance() {
+                    gasless_withdrawal_reservations(&transaction_kind, &tx_ctx.borrow())
+                } else {
+                    None
+                };
+
+            // We must charge object read here during transaction execution, because if this fails
+            // we must still ensure an effect is committed and all objects versions incremented
+            let result = gas_charger.charge_input_objects_legacy(temporary_store);
+
+            let result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> =
+                result.map_err(|e| (e.into(), vec![])).and_then(
+                    |()| -> ResultWithTimings<Mode::ExecutionResults, Mode::Error> {
+                        let mut execution_result: ResultWithTimings<
+                            Mode::ExecutionResults,
+                            Mode::Error,
+                        > = match execution_params.into_early_errors() {
+                            Some(early_execution_errors) => {
+                                Err((Mode::Error::from_kind(early_execution_errors.head), vec![]))
+                            }
+                            None => execution_loop::<Mode>(
+                                store,
+                                temporary_store,
+                                transaction_kind,
+                                rewritten_inputs,
+                                tx_ctx,
+                                move_vm,
+                                gas_charger,
+                                protocol_config,
+                                metrics.clone(),
+                                trace_builder_opt,
+                            ),
+                        };
+
+                        let meter_check = check_meter_limit::<Mode>(
                             temporary_store,
-                            transaction_kind,
-                            rewritten_inputs,
-                            tx_ctx,
-                            move_vm,
                             gas_charger,
                             protocol_config,
                             metrics.clone(),
-                            trace_builder_opt,
-                        ),
-                    };
-
-                    let meter_check = check_meter_limit::<Mode>(
-                        temporary_store,
-                        gas_charger,
-                        protocol_config,
-                        metrics.clone(),
-                    );
-                    if let Err(e) = meter_check {
-                        execution_result = Err((e, vec![]));
-                    }
-
-                    if execution_result.is_ok() {
-                        let gas_check = check_written_objects_limit::<Mode>(
-                            temporary_store,
-                            gas_charger,
-                            protocol_config,
-                            metrics,
                         );
-                        if let Err(e) = gas_check {
+                        if let Err(e) = meter_check {
                             execution_result = Err((e, vec![]));
                         }
-                    }
 
-                    execution_result
-                },
-            );
+                        if execution_result.is_ok() {
+                            let gas_check = check_written_objects_limit::<Mode>(
+                                temporary_store,
+                                gas_charger,
+                                protocol_config,
+                                metrics,
+                            );
+                            if let Err(e) = gas_check {
+                                execution_result = Err((e, vec![]));
+                            }
+                        }
 
-        let (mut result, timings) = match result {
-            Ok((r, t)) => (Ok(r), t),
-            Err((e, t)) => (Err(e), t),
-        };
-        if is_gasless
-            && result.is_ok()
-            && let Err(msg) = temporary_store
-                .check_gasless_execution_requirements(withdrawal_reservations.as_ref())
-        {
-            result = Err(Mode::Error::new_with_source(
-                ExecutionErrorKind::InsufficientGas,
-                msg,
-            ));
-        }
+                        execution_result
+                    },
+                );
 
-        // Reject transactions whose per-key accumulator totals are not representable *before*
-        // charging gas. For SUI this bounds each per-key gross Merge/Split total to the total supply;
-        // for other balances it bounds them to u64. Doing so here means the rejected PTB-emitted
-        // accumulator events are dropped during the gas reset on the error path (only the bounded gas
-        // events remain). Bounding SUI to the supply (which is ~8.4B SUI below u64::MAX) leaves enough
-        // headroom that the gas-smash deposit / gas-charge events emitted *after* this point cannot
-        // push any per-key total past u64::MAX, so the fold in AccumulatorWriteV1::merge cannot
-        // overflow even though those gas events are not re-checked here.
-        //
-        // Ungated: this only ever turns a would-be arithmetic failure into a deterministic abort,
-        // which produces no committed effects and so cannot diverge from any previously-committed
-        // result, and it applies uniformly across protocol versions.
-        if result.is_ok()
-            && let Err(e) = temporary_store.check_accumulator_amounts_representable()
-        {
-            result = Err(e.into());
-        }
+            let (mut result, timings) = match result {
+                Ok((r, t)) => (Ok(r), t),
+                Err((e, t)) => (Err(e), t),
+            };
+            if is_gasless
+                && result.is_ok()
+                && let Err(msg) = temporary_store
+                    .check_gasless_execution_requirements(withdrawal_reservations.as_ref())
+            {
+                result = Err(Mode::Error::new_with_source(
+                    ExecutionErrorKind::InsufficientGas,
+                    msg,
+                ));
+            }
 
-        let cost_summary = gas_charger.charge_gas(temporary_store, protocol_config, &mut result);
-        // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
-        // information provided to check_sui_conserved, because we mint rewards, and burn
-        // the rebates. We also need to pass in the unmetered_storage_rebate because storage
-        // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
-        // We could probably clean up the code a bit.
-        // Put all the storage rebate accumulated in the system transaction
-        // to the 0x5 object so that it's not lost.
-        temporary_store.conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
+            // Reject transactions whose per-key accumulator totals are not representable *before*
+            // charging gas. For SUI this bounds each per-key gross Merge/Split total to the total supply;
+            // for other balances it bounds them to u64. Doing so here means the rejected PTB-emitted
+            // accumulator events are dropped during the gas reset on the error path (only the bounded gas
+            // events remain). Bounding SUI to the supply (which is ~8.4B SUI below u64::MAX) leaves enough
+            // headroom that the gas-smash deposit / gas-charge events emitted *after* this point cannot
+            // push any per-key total past u64::MAX, so the fold in AccumulatorWriteV1::merge cannot
+            // overflow even though those gas events are not re-checked here.
+            //
+            // Ungated: this only ever turns a would-be arithmetic failure into a deterministic abort,
+            // which produces no committed effects and so cannot diverge from any previously-committed
+            // result, and it applies uniformly across protocol versions.
+            if result.is_ok()
+                && let Err(e) = temporary_store.check_accumulator_amounts_representable()
+            {
+                result = Err(e.into());
+            }
 
-        (cost_summary, result, timings)
-    }
-
-    /// Run all post-execution system-invariant checks against the finalized (gas-charged) store.
-    ///
-    /// Two families, with deliberately different failure handling:
-    /// - SUI conservation / balance-accumulator authorization, via [`run_conservation_checks`]. A
-    ///   violation is recoverable: the tx is aborted (and conserves SUI) rather than panicking.
-    /// - Object-ownership authentication (expensive-checks only, skipped under dev-inspect). This
-    ///   is a non-recoverable assertion, so it runs *after* conservation and *outside* its
-    ///   gas-charging recovery, and panics on violation. (Folding it into the recovery would let
-    ///   the recovery's `drop_writes` mask a real violation into a silent abort.)
-    ///
-    /// Returns the conservation result so the caller can fail the transaction on a violation; an
-    /// ownership violation panics directly.
-    #[allow(clippy::too_many_arguments)]
-    fn run_invariant_checks<Mode: ExecutionMode>(
-        temporary_store: &mut TemporaryStore<'_>,
-        gas_charger: &mut GasCharger,
-        tx_digest: TransactionDigest,
-        move_vm: &Arc<MoveRuntime>,
-        protocol_config: &ProtocolConfig,
-        enable_expensive_checks: bool,
-        cost_summary: &GasCostSummary,
-        sender: &SuiAddress,
-        sponsor: &Option<SuiAddress>,
-        mutable_inputs: &HashSet<ObjectID>,
-        is_epoch_change: bool,
-    ) -> Result<(), Mode::Error> {
-        let conservation = run_conservation_checks::<Mode>(
-            temporary_store,
-            gas_charger,
-            tx_digest,
-            move_vm,
-            protocol_config,
-            enable_expensive_checks,
-            cost_summary,
-        );
-        if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
+            let cost_summary =
+                gas_charger.legacy_charge_gas(temporary_store, protocol_config, &mut result);
+            // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
+            // information provided to check_sui_conserved, because we mint rewards, and burn
+            // the rebates. We also need to pass in the unmetered_storage_rebate because storage
+            // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
+            // We could probably clean up the code a bit.
+            // Put all the storage rebate accumulated in the system transaction
+            // to the 0x5 object so that it's not lost.
             temporary_store
-                .check_ownership_invariants(
-                    sender,
-                    sponsor,
-                    gas_charger,
-                    mutable_inputs,
-                    is_epoch_change,
-                )
-                .unwrap()
-        } // else, in dev inspect mode and anything goes--don't check
-        conservation
-    }
+                .conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
 
-    /// Run the SUI-conservation and balance-accumulator invariant checks
-    /// ([`TemporaryStore::check_conservation_invariants`]) against the finalized store. On a
-    /// violation, recover by dumping all writes, charging gas in
-    /// the aborted state, and re-checking; a surviving double failure means gas charging itself
-    /// mints or burns SUI, which is unrecoverable, so we panic. The checks themselves are read-only;
-    /// the recovery's gas-charging mutations are orchestrated here alongside the main-path charge.
-    #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
-    fn run_conservation_checks<Mode: ExecutionMode>(
-        temporary_store: &mut TemporaryStore<'_>,
-        gas_charger: &mut GasCharger,
-        tx_digest: TransactionDigest,
-        move_vm: &Arc<MoveRuntime>,
-        protocol_config: &ProtocolConfig,
-        enable_expensive_checks: bool,
-        cost_summary: &GasCostSummary,
-    ) -> Result<(), Mode::Error> {
-        let Err(conservation_err) = temporary_store.check_conservation_invariants::<Mode>(
-            move_vm,
-            enable_expensive_checks,
-            cost_summary,
-        ) else {
-            return Ok(());
-        };
-
-        // Conservation violated. Try to avoid a panic by dumping all writes, charging for gas in
-        // the aborted state, and re-checking; surface an aborted transaction with the invariant
-        // violation if that works.
-        let mut result: Result<(), Mode::Error> = Err(conservation_err.into());
-        gas_charger.reset(temporary_store);
-        gas_charger.charge_gas(temporary_store, protocol_config, &mut result);
-        if let Err(recovery_err) = temporary_store.check_conservation_invariants::<Mode>(
-            move_vm,
-            enable_expensive_checks,
-            cost_summary,
-        ) {
-            // If we still fail, it's a problem with gas charging that happens even in the
-            // "aborted" case — no other option but panic. We would create or destroy SUI
-            // otherwise (or admit an unauthorized accumulator Split).
-            panic!(
-                "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
-                tx_digest,
-                recovery_err,
-                gas_charger.summary()
-            )
+            (cost_summary, result, timings)
         }
-        result
+
+        /// Run all post-execution system-invariant checks against the finalized (gas-charged) store.
+        ///
+        /// Two families, with deliberately different failure handling:
+        /// - SUI conservation / balance-accumulator authorization, via [`run_conservation_checks`]. A
+        ///   violation is recoverable: the tx is aborted (and conserves SUI) rather than panicking.
+        /// - Object-ownership authentication (expensive-checks only, skipped under dev-inspect). This
+        ///   is a non-recoverable assertion, so it runs *after* conservation and *outside* its
+        ///   gas-charging recovery, and panics on violation. (Folding it into the recovery would let
+        ///   the recovery's `drop_writes` mask a real violation into a silent abort.)
+        ///
+        /// Returns the conservation result so the caller can fail the transaction on a violation; an
+        /// ownership violation panics directly.
+        #[allow(clippy::too_many_arguments)]
+        fn run_invariant_checks<Mode: ExecutionMode>(
+            temporary_store: &mut TemporaryStore<'_>,
+            gas_charger: &mut GasCharger,
+            tx_digest: TransactionDigest,
+            move_vm: &Arc<MoveRuntime>,
+            protocol_config: &ProtocolConfig,
+            enable_expensive_checks: bool,
+            cost_summary: &GasCostSummary,
+            sender: &SuiAddress,
+            sponsor: &Option<SuiAddress>,
+            mutable_inputs: &HashSet<ObjectID>,
+            is_epoch_change: bool,
+        ) -> Result<(), Mode::Error> {
+            let conservation = run_conservation_checks::<Mode>(
+                temporary_store,
+                gas_charger,
+                tx_digest,
+                move_vm,
+                protocol_config,
+                enable_expensive_checks,
+                cost_summary,
+            );
+            if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
+                temporary_store
+                    .check_ownership_invariants(
+                        sender,
+                        sponsor,
+                        gas_charger,
+                        mutable_inputs,
+                        is_epoch_change,
+                    )
+                    .unwrap()
+            } // else, in dev inspect mode and anything goes--don't check
+            conservation
+        }
+
+        /// Run the SUI-conservation and balance-accumulator invariant checks
+        /// ([`TemporaryStore::check_conservation_invariants`]) against the finalized store. On a
+        /// violation, recover by dumping all writes, charging gas in
+        /// the aborted state, and re-checking; a surviving double failure means gas charging itself
+        /// mints or burns SUI, which is unrecoverable, so we panic. The checks themselves are read-only;
+        /// the recovery's gas-charging mutations are orchestrated here alongside the main-path charge.
+        #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
+        fn run_conservation_checks<Mode: ExecutionMode>(
+            temporary_store: &mut TemporaryStore<'_>,
+            gas_charger: &mut GasCharger,
+            tx_digest: TransactionDigest,
+            move_vm: &Arc<MoveRuntime>,
+            protocol_config: &ProtocolConfig,
+            enable_expensive_checks: bool,
+            cost_summary: &GasCostSummary,
+        ) -> Result<(), Mode::Error> {
+            let Err(conservation_err) = temporary_store.check_conservation_invariants::<Mode>(
+                move_vm,
+                enable_expensive_checks,
+                cost_summary,
+            ) else {
+                return Ok(());
+            };
+
+            // Conservation violated. Try to avoid a panic by dumping all writes, charging for gas in
+            // the aborted state, and re-checking; surface an aborted transaction with the invariant
+            // violation if that works.
+            let mut result: Result<(), Mode::Error> = Err(conservation_err.into());
+            gas_charger.reset(temporary_store);
+            gas_charger.legacy_charge_gas(temporary_store, protocol_config, &mut result);
+            if let Err(recovery_err) = temporary_store.check_conservation_invariants::<Mode>(
+                move_vm,
+                enable_expensive_checks,
+                cost_summary,
+            ) {
+                // If we still fail, it's a problem with gas charging that happens even in the
+                // "aborted" case — no other option but panic. We would create or destroy SUI
+                // otherwise (or admit an unauthorized accumulator Split).
+                panic!(
+                    "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
+                    tx_digest,
+                    recovery_err,
+                    gas_charger.summary()
+                )
+            }
+            result
+        }
     }
 
     #[instrument(name = "check_meter_limit", level = "debug", skip_all)]
@@ -1828,7 +1884,7 @@ mod checked {
 
     #[cfg(test)]
     mod address_balance_smash_gate_tests {
-        use super::{
+        use super::legacy::{
             ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION,
             should_filter_address_balance_gas_smash,
         };
@@ -1911,7 +1967,7 @@ mod checked {
 
     #[cfg(test)]
     mod address_balance_smash_short_circuit_tests {
-        use super::{
+        use super::legacy::{
             ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION,
             should_short_circuit_insufficient_funds,
         };

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -289,24 +289,6 @@ pub mod checked {
             self.gas_status.charge_publish_package(size)
         }
 
-        pub fn charge_input_objects(
-            &mut self,
-            temporary_store: &TemporaryStore<'_>,
-        ) -> Result<(), ExecutionError> {
-            let objects = temporary_store.objects();
-            // TODO: Charge input object count.
-            let _object_count = objects.len();
-            // Charge bytes read
-            let total_size = temporary_store
-                .objects()
-                .iter()
-                // don't charge for loading Sui Framework or Move stdlib
-                .filter(|(id, _)| !is_system_package(**id))
-                .map(|(_, obj)| obj.object_size_for_gas_metering())
-                .sum();
-            self.gas_status.charge_storage_read(total_size)
-        }
-
         pub fn charge_coin_transfers(
             &mut self,
             protocol_config: &ProtocolConfig,
@@ -333,66 +315,96 @@ pub mod checked {
             self.smash_gas(temporary_store);
         }
 
-        /// Entry point for gas charging.
-        /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of
-        /// mutated objects
-        /// 2. Deduct computation gas costs and storage costs, credit storage rebates.
-        /// The happy path of this function follows (1) + (2) and is fairly simple.
-        /// Most of the complexity is in the unhappy paths:
-        /// - if execution aborted before calling this function, we have to dump all writes +
-        ///   re-smash gas, then charge for storage
-        /// - if we run out of gas while charging for storage, we have to dump all writes +
-        ///   re-smash gas, then charge for storage again
-        pub fn charge_gas<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            protocol_config: &ProtocolConfig,
-            execution_result: &mut Result<T, E>,
-        ) -> GasCostSummary {
-            // at this point, we have done *all* charging for computation,
-            // but have not yet set the storage rebate or storage gas units
-            debug_assert!(self.gas_status.storage_rebate() == 0);
-            debug_assert!(self.gas_status.storage_gas_units() == 0);
+        // === legacy methods below — see `mod legacy` for the full bodies ===
+    }
 
-            if !matches!(&self.payment, PaymentMetadata::Unmetered) {
-                // bucketize computation cost
-                let is_move_abort = execution_result
-                    .as_ref()
-                    .err()
-                    .map(|err| {
-                        matches!(
-                            err.kind(),
-                            sui_types::execution_status::ExecutionErrorKind::MoveAbort(_, _)
-                        )
-                    })
-                    .unwrap_or(false);
-                // bucketize computation cost
-                if let Err(err) = self.gas_status.bucketize_computation(Some(is_move_abort))
-                    && execution_result.is_ok()
-                {
-                    *execution_result = Err(err.into());
+    /// Frozen pre-v15 (`gas_model_version < 15`) gas charging, mirroring `origin/main` (incl. the
+    /// SUIPR-753 fix). Removed at the next execution-version cut.
+    mod legacy {
+        use super::*;
+
+        impl super::GasCharger {
+            /// Pre-v15 input charging: sum all input sizes and charge
+            /// `storage_read` once. Bit-for-bit identical to origin/main for
+            /// replay determinism; goes away when execution_version > 4.
+            pub fn charge_input_objects_legacy(
+                &mut self,
+                temporary_store: &TemporaryStore<'_>,
+            ) -> Result<(), ExecutionError> {
+                let objects = temporary_store.objects();
+                // TODO: Charge input object count.
+                let _object_count = objects.len();
+                // Charge bytes read
+                let total_size = temporary_store
+                    .objects()
+                    .iter()
+                    // don't charge for loading Sui Framework or Move stdlib
+                    .filter(|(id, _)| !is_system_package(**id))
+                    .map(|(_, obj)| obj.object_size_for_gas_metering())
+                    .sum();
+                self.gas_status.charge_storage_read(total_size)
+            }
+
+            /// Entry point for legacy gas charging.
+            /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field
+            /// of mutated objects
+            /// 2. Deduct computation gas costs and storage costs, credit storage rebates.
+            /// The happy path of this function follows (1) + (2) and is fairly simple.
+            /// Most of the complexity is in the unhappy paths:
+            /// - if execution aborted before calling this function, we have to dump all writes +
+            ///   re-smash gas, then charge for storage
+            /// - if we run out of gas while charging for storage, we have to dump all writes +
+            ///   re-smash gas, then charge for storage again
+            pub(crate) fn legacy_charge_gas<T, E: ExecutionErrorTrait>(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+                protocol_config: &ProtocolConfig,
+                execution_result: &mut Result<T, E>,
+            ) -> GasCostSummary {
+                // at this point, we have done *all* charging for computation,
+                // but have not yet set the storage rebate or storage gas units
+                debug_assert!(self.gas_status.storage_rebate() == 0);
+                debug_assert!(self.gas_status.storage_gas_units() == 0);
+
+                if !matches!(&self.payment, PaymentMetadata::Unmetered) {
+                    // bucketize computation cost
+                    let is_move_abort = execution_result
+                        .as_ref()
+                        .err()
+                        .map(|err| {
+                            matches!(
+                                err.kind(),
+                                sui_types::execution_status::ExecutionErrorKind::MoveAbort(_, _)
+                            )
+                        })
+                        .unwrap_or(false);
+                    // bucketize computation cost
+                    if let Err(err) = self.gas_status.bucketize_computation(Some(is_move_abort))
+                        && execution_result.is_ok()
+                    {
+                        *execution_result = Err(err.into());
+                    }
+
+                    // On error we need to dump writes, deletes, etc before charging storage gas
+                    if execution_result.is_err() {
+                        self.reset(temporary_store);
+                    }
                 }
 
-                // On error we need to dump writes, deletes, etc before charging storage gas
-                if execution_result.is_err() {
-                    self.reset(temporary_store);
+                // compute and collect storage charges
+                temporary_store.ensure_active_inputs_mutated();
+                temporary_store.collect_storage_and_rebate(self);
+
+                if matches!(&self.payment, PaymentMetadata::Unmetered) {
+                    return GasCostSummary::default();
                 }
-            }
+                let gas_payment_location = self.gas_payment_location();
+                if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
+                    #[skip_checked_arithmetic]
+                    trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+                }
 
-            // compute and collect storage charges
-            temporary_store.ensure_active_inputs_mutated();
-            temporary_store.collect_storage_and_rebate(self);
-
-            if matches!(&self.payment, PaymentMetadata::Unmetered) {
-                return GasCostSummary::default();
-            }
-            let gas_payment_location = self.gas_payment_location();
-            if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
-                #[skip_checked_arithmetic]
-                trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
-            }
-
-            if execution_result
+                if execution_result
                 .as_ref()
                 .err()
                 .map(|err| {
@@ -409,105 +421,107 @@ pub mod checked {
                     return GasCostSummary::default();
             }
 
-            self.compute_storage_and_rebate(temporary_store, execution_result);
+                self.compute_storage_and_rebate(temporary_store, execution_result);
 
-            let gas_payment_location = if refresh_gas_payment_location(self.gas_model_version) {
-                self.gas_payment_location()
-            } else {
-                gas_payment_location
-            };
-
-            let cost_summary = self.gas_status.summary();
-
-            let Some(gas_payment_location) = gas_payment_location else {
-                // Gasless: sender pays nothing.
-                assert!(
-                    matches!(self.payment, PaymentMetadata::Gasless),
-                    "Only gasless transactions should reach this point without a payment location"
-                );
-                if execution_result.is_err() {
-                    return GasCostSummary::default();
-                }
-                // Any storage rebate from destroyed input coins is absorbed as
-                // network fees, not returned to sender.
-                let storage_cost = cost_summary.storage_cost;
-                assert!(
-                    storage_cost == 0,
-                    "Gasless transaction must not incur storage cost, got {storage_cost}"
-                );
-                let sender_rebate = cost_summary.storage_rebate;
-                return GasCostSummary {
-                    computation_cost: sender_rebate,
-                    storage_cost: 0,
-                    storage_rebate: sender_rebate,
-                    non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
+                let gas_payment_location = if refresh_gas_payment_location(self.gas_model_version) {
+                    self.gas_payment_location()
+                } else {
+                    gas_payment_location
                 };
-            };
 
-            let net_change = cost_summary.net_gas_usage();
+                let cost_summary = self.gas_status.summary();
 
-            match gas_payment_location {
-                PaymentLocation::AddressBalance(payer_address) => {
-                    // TODO tracing?
-                    if net_change != 0 {
-                        let balance_type = sui_types::balance::Balance::type_tag(
-                            sui_types::gas_coin::GAS::type_tag(),
-                        );
-                        let event = AccumulatorEvent::from_balance_change(
-                            payer_address,
-                            balance_type,
-                            net_change.checked_neg().unwrap(),
-                        )
-                        .expect("Failed to create accumulator event for gas charging");
-                        temporary_store.add_accumulator_event(event);
+                let Some(gas_payment_location) = gas_payment_location else {
+                    // Gasless: sender pays nothing.
+                    assert!(
+                        matches!(self.payment, PaymentMetadata::Gasless),
+                        "Only gasless transactions should reach this point without a payment location"
+                    );
+                    if execution_result.is_err() {
+                        return GasCostSummary::default();
+                    }
+                    // Any storage rebate from destroyed input coins is absorbed as
+                    // network fees, not returned to sender.
+                    let storage_cost = cost_summary.storage_cost;
+                    assert!(
+                        storage_cost == 0,
+                        "Gasless transaction must not incur storage cost, got {storage_cost}"
+                    );
+                    let sender_rebate = cost_summary.storage_rebate;
+                    return GasCostSummary {
+                        computation_cost: sender_rebate,
+                        storage_cost: 0,
+                        storage_rebate: sender_rebate,
+                        non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
+                    };
+                };
+
+                let net_change = cost_summary.net_gas_usage();
+
+                match gas_payment_location {
+                    PaymentLocation::AddressBalance(payer_address) => {
+                        // TODO tracing?
+                        if net_change != 0 {
+                            let balance_type = sui_types::balance::Balance::type_tag(
+                                sui_types::gas_coin::GAS::type_tag(),
+                            );
+                            let event = AccumulatorEvent::from_balance_change(
+                                payer_address,
+                                balance_type,
+                                net_change.checked_neg().unwrap(),
+                            )
+                            .expect("Failed to create accumulator event for gas charging");
+                            temporary_store.add_accumulator_event(event);
+                        }
+                    }
+                    PaymentLocation::Coin(gas_object_id) => {
+                        let mut gas_object =
+                            temporary_store.read_object(&gas_object_id).unwrap().clone();
+                        deduct_gas(&mut gas_object, net_change);
+                        #[skip_checked_arithmetic]
+                        trace!(net_change, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+                        temporary_store.mutate_new_or_input_object(gas_object);
                     }
                 }
-                PaymentLocation::Coin(gas_object_id) => {
-                    let mut gas_object =
-                        temporary_store.read_object(&gas_object_id).unwrap().clone();
-                    deduct_gas(&mut gas_object, net_change);
-                    #[skip_checked_arithmetic]
-                    trace!(net_change, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
-                    temporary_store.mutate_new_or_input_object(gas_object);
-                }
+                cost_summary
             }
-            cost_summary
-        }
 
-        /// Calculate total gas cost considering storage and rebate.
-        ///
-        /// First, we net computation, storage, and rebate to determine total gas to charge.
-        ///
-        /// If we exceed gas_budget, we set execution_result to InsufficientGas, failing the tx.
-        /// If we have InsufficientGas, we determine how much gas to charge for the failed tx:
-        ///
-        /// we charge (computation + storage costs for input objects - storage_rebates)
-        /// if the gas balance is still insufficient, we fall back to set computation_cost = gas_budget
-        /// so we charge net (gas_budget - storage_rebates)
-        fn compute_storage_and_rebate<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) {
-            if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                // we run out of gas charging storage, reset and try charging for storage again.
-                // Input objects are touched and so they have a storage cost
-                // Attempt to charge just for computation + input object storage costs - storage_rebate
-                self.reset(temporary_store);
-                temporary_store.ensure_active_inputs_mutated();
-                temporary_store.collect_storage_and_rebate(self);
+            /// Calculate total gas cost considering storage and rebate.
+            ///
+            /// First, we net computation, storage, and rebate to determine total gas to charge.
+            ///
+            /// If we exceed gas_budget, we set execution_result to InsufficientGas, failing the tx.
+            /// If we have InsufficientGas, we determine how much gas to charge for the failed tx:
+            ///
+            /// v1: we set computation_cost = gas_budget, so we charge net (gas_budget - storage_rebates)
+            /// v2: we charge (computation + storage costs for input objects - storage_rebates)
+            ///     if the gas balance is still insufficient, we fall back to set computation_cost = gas_budget
+            ///     so we charge net (gas_budget - storage_rebates)
+            fn compute_storage_and_rebate<T, E: ExecutionErrorTrait>(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+                execution_result: &mut Result<T, E>,
+            ) {
                 if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                    // we run out of gas attempting to charge for the input objects exclusively,
-                    // deal with this edge case by not charging for storage: we charge (gas_budget - rebates).
+                    // we run out of gas charging storage, reset and try charging for storage again.
+                    // Input objects are touched and so they have a storage cost
+                    // Attempt to charge just for computation + input object storage costs - storage_rebate
                     self.reset(temporary_store);
-                    self.gas_status.adjust_computation_on_out_of_gas();
                     temporary_store.ensure_active_inputs_mutated();
-                    temporary_store.collect_rebate(self);
-                    if execution_result.is_ok() {
+                    temporary_store.collect_storage_and_rebate(self);
+                    if let Err(err) = self.gas_status.charge_storage_and_rebate() {
+                        // we run out of gas attempting to charge for the input objects exclusively,
+                        // deal with this edge case by not charging for storage: we charge (gas_budget - rebates).
+                        self.reset(temporary_store);
+                        self.gas_status.adjust_computation_on_out_of_gas();
+                        temporary_store.ensure_active_inputs_mutated();
+                        temporary_store.collect_rebate(self);
+                        if execution_result.is_ok() {
+                            *execution_result = Err(err.into());
+                        }
+                    } else if execution_result.is_ok() {
                         *execution_result = Err(err.into());
                     }
-                } else if execution_result.is_ok() {
-                    *execution_result = Err(err.into());
                 }
             }
         }


### PR DESCRIPTION
## Description
Pure code-motion: relocate the frozen legacy gas-charging and execution path into `mod legacy`, leaving the live path in `mod checked`. Behavior-preserving — the legacy path remains equivalent to main at runtime. Isolating the frozen pre-v15 path lets the new pipeline (PR 3/3) be added as almost-only-additive code.
Concrete "changes"
- the legacy_ gas-method rename (legacy_charge_gas is byte-identical to main's charge_gas; charge_input_objects_legacy ≡ charge_input_objects);
- the mod legacy { use super::*; … } wrapper + pub(super) visibility;
- fmt reflow (deeper indentation → a couple of line-wraps);
- the entry/body split (a behavior-preserving extract-method).

**Reviews options**:
- Review with move detection: `git show <sha> --color-moved=zebra --color-moved-ws=allow-indentation-change`. Not sure how clear that is
- Use SemanticDiff in vscode. Open the PR with GitLens find the files changed (2 files) and open the diff view. If you have SemanticDiff installed (it's a plug-in) it will show you code motion and it will look really really clear
- install difftastic and run git diff with. All command line, a colored diff, a bit more difficult to see but still very reasonable
- unleash your AI agent or dog on this. They should be able to give you an answer about whether the PR is sound and code motion only or not

Stacked PR 2/3 — based on #27041, next #27043 

## Test plan
Behavior-preserving carve; covered by existing gas/execution tests.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: