### PR TITLE
Fork execute_transaction_to_effects to eliminate a bunch of obsolete checks

### DIFF
--- a/crates/mysten-common/src/logging.rs
+++ b/crates/mysten-common/src/logging.rs
@@ -70,14 +70,12 @@ macro_rules! register_debug_fatal_handler {
     };
 }
 
-/// Like `debug_fatal!`, but records `$location` (a `&str`) as the
-/// `system_invariant_violations` metric label instead of the macro's own
-/// `file!():line!()`. Use this when forwarding a caller-supplied location
-/// (e.g. from `#[track_caller]` + `Location::caller()`) so the metric points
-/// at the user's call site rather than the wrapper.
+/// Like `debug_fatal!`, but records the violation on a metric of the caller's choosing instead of
+/// `system_invariant_violations`: `$record` is invoked with `&mysten_metrics::Metrics` when metrics
+/// are initialized. Use this when a violation has its own counter, and its own alert.
 #[macro_export]
-macro_rules! debug_fatal_at {
-    ($location:expr, $msg:literal $(, $arg:expr)*) => {{
+macro_rules! debug_fatal_with_metric {
+    ($record:expr, $msg:literal $(, $arg:expr)*) => {{
         loop {
             #[cfg(msim)]
             {
@@ -98,9 +96,8 @@ macro_rules! debug_fatal_at {
             } else {
                 let stacktrace = std::backtrace::Backtrace::capture();
                 tracing::error!(debug_fatal = true, stacktrace = ?stacktrace, $msg $(, $arg)*);
-                let location: &str = $location;
                 if let Some(metrics) = mysten_metrics::get_metrics() {
-                    metrics.system_invariant_violations.with_label_values(&[location]).inc();
+                    ($record)(metrics);
                 }
                 if $crate::in_antithesis() {
                     // antithesis requires a literal for first argument. pass the formatted argument
@@ -112,6 +109,24 @@ macro_rules! debug_fatal_at {
             }
             break;
         }
+    }};
+}
+
+/// Like `debug_fatal!`, but records `$location` (a `&str`) as the
+/// `system_invariant_violations` metric label instead of the macro's own
+/// `file!():line!()`. Use this when forwarding a caller-supplied location
+/// (e.g. from `#[track_caller]` + `Location::caller()`) so the metric points
+/// at the user's call site rather than the wrapper.
+#[macro_export]
+macro_rules! debug_fatal_at {
+    ($location:expr, $msg:literal $(, $arg:expr)*) => {{
+        $crate::debug_fatal_with_metric!(
+            |metrics: &mysten_metrics::Metrics| {
+                let location: &str = $location;
+                metrics.system_invariant_violations.with_label_values(&[location]).inc();
+            },
+            $msg $(, $arg)*
+        );
     }};
 }
 

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -161,9 +161,9 @@ impl Metrics {
             ).unwrap(),
             execution_bump_only_exits: register_int_counter_vec_with_registry!(
                 "execution_bump_only_exits",
-                "Number of transactions that bailed to the BumpOnly (recorded no-op) execution exit, \
+                "Number of transactions that bailed to the BumpOnly execution exit, \
                  excluding the expected InsufficientFundsForWithdraw short-circuit. Labelled by the \
-                 stage that bailed. Any non-zero value is an execution bug.",
+                 stage that bailed. Any non-zero value is an execution invariant failure.",
                 &["reason"],
                 registry,
             ).unwrap(),

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -78,6 +78,7 @@ pub struct Metrics {
     pub scope_entrance: IntGaugeVec,
     pub thread_stall_duration_sec: Histogram,
     pub system_invariant_violations: IntCounterVec,
+    pub execution_bump_only_exits: IntCounterVec,
 }
 
 impl Metrics {
@@ -156,6 +157,14 @@ impl Metrics {
                 "system_invariant_violations",
                 "Number of system invariant violations",
                 &["name"],
+                registry,
+            ).unwrap(),
+            execution_bump_only_exits: register_int_counter_vec_with_registry!(
+                "execution_bump_only_exits",
+                "Number of transactions that bailed to the BumpOnly (recorded no-op) execution exit, \
+                 excluding the expected InsufficientFundsForWithdraw short-circuit. Labelled by the \
+                 stage that bailed. Any non-zero value is an execution bug.",
+                &["reason"],
                 registry,
             ).unwrap(),
         }

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -931,7 +931,7 @@ fn create_genesis_transaction(
                 input_objects,
                 std::collections::BTreeMap::new(),
                 gas_data,
-                SuiGasStatus::new_unmetered(),
+                SuiGasStatus::new_unmetered(protocol_config),
                 kind,
                 None, // compat_args
                 signer,

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -101,7 +101,7 @@ pub fn execute_transaction_to_effects(
         .ok_or_else(|| anyhow!(format!("Epoch {} not found", epoch)))?;
     let epoch_start_timestamp = epoch_data.start_timestamp;
     let gas_status = if txn_data.kind().is_system_tx() {
-        SuiGasStatus::new_unmetered()
+        SuiGasStatus::new_unmetered(protocol_config)
     } else {
         SuiGasStatus::new(
             txn_data.gas_data().budget,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -764,7 +764,7 @@ impl LocalExec {
         let expensive_checks = true;
         let transaction_kind = override_transaction_kind.unwrap_or(tx_info.kind.clone());
         let gas_status = if tx_info.kind.is_system_tx() {
-            SuiGasStatus::new_unmetered()
+            SuiGasStatus::new_unmetered(protocol_config)
         } else {
             SuiGasStatus::new(
                 tx_info.gas_budget,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -769,7 +769,7 @@ mod test {
                 input_objects,
                 std::collections::BTreeMap::new(),
                 gas_data,
-                SuiGasStatus::new_unmetered(),
+                SuiGasStatus::new_unmetered(&protocol_config),
                 kind,
                 None, // compat_args
                 signer,

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -18,7 +18,7 @@ mod checked {
     use sui_types::metrics::BytecodeVerifierMetrics;
     use sui_types::object::ObjectPermission;
     use sui_types::transaction::{
-        CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
+        CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResultKind,
         ReceivingObjectReadResult, ReceivingObjects, SharedObjectMutability, TransactionData,
         TransactionDataAPI, TransactionKind,
     };
@@ -61,7 +61,7 @@ mod checked {
         gas_ownership_checks: bool,
     ) -> SuiResult<SuiGasStatus> {
         if transaction.kind().is_system_tx() {
-            Ok(SuiGasStatus::new_unmetered())
+            Ok(SuiGasStatus::new_unmetered(protocol_config))
         } else {
             let is_gasless =
                 protocol_config.enable_gasless() && transaction.is_gasless_transaction();
@@ -95,38 +95,6 @@ mod checked {
             &[],
         )?;
         check_receiving_objects(&input_objects, receiving_objects)?;
-        // Runs verifier, which could be expensive.
-        check_non_system_packages_to_be_published(
-            transaction,
-            protocol_config,
-            metrics,
-            verifier_signing_config,
-        )?;
-
-        Ok((gas_status, input_objects.into_checked()))
-    }
-
-    pub fn check_transaction_input_with_given_gas(
-        protocol_config: &ProtocolConfig,
-        reference_gas_price: u64,
-        transaction: &TransactionData,
-        mut input_objects: InputObjects,
-        receiving_objects: ReceivingObjects,
-        gas_object: Object,
-        metrics: &Arc<BytecodeVerifierMetrics>,
-        verifier_signing_config: &VerifierSigningConfig,
-    ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
-        let gas_object_ref = gas_object.compute_object_reference();
-        input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
-
-        let gas_status = check_transaction_input_inner(
-            protocol_config,
-            reference_gas_price,
-            transaction,
-            &input_objects,
-            &[gas_object_ref],
-        )?;
-        check_receiving_objects(&input_objects, &receiving_objects)?;
         // Runs verifier, which could be expensive.
         check_non_system_packages_to_be_published(
             transaction,

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -17,7 +17,10 @@ pub mod checked {
         ObjectID,
         effects::{TransactionEffects, TransactionEffectsAPI},
         error::{ExecutionError, SuiResult, UserInputError, UserInputResult},
-        gas_model::{gas_v2::SuiGasStatus as SuiGasStatusV2, tables::GasStatus},
+        gas_model::{
+            gas_v2::SuiGasStatus as SuiGasStatusV2, gas_v3::SuiGasStatus as SuiGasStatusV3,
+            tables::GasStatus,
+        },
         object::Object,
         sui_serde::{BigInt, Readable},
         transaction::ObjectReadResult,
@@ -51,7 +54,7 @@ pub mod checked {
             object_id: ObjectID,
             new_size: usize,
             storage_rebate: u64,
-        ) -> u64;
+        ) -> Option<u64>;
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
         fn adjust_computation_on_out_of_gas(&mut self);
         fn gas_usage_report(&self) -> GasUsageReport;
@@ -65,13 +68,15 @@ pub mod checked {
         fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)>;
     }
 
-    /// Version aware enum for gas status.
+    /// Version-aware gas status: `V2` is the legacy model (`gas_model_version < 15`, incl. replay),
+    /// `V3` is the v15+ pipeline. Dispatched by `gas_model_version() >= 15`.
     #[enum_dispatch(SuiGasStatusAPI)]
     #[derive(Debug)]
     pub enum SuiGasStatus {
         // V1 does not exists any longer as it was a pre mainnet version.
         // So we start the enum from V2
         V2(SuiGasStatusV2),
+        V3(SuiGasStatusV3),
     }
 
     impl SuiGasStatus {
@@ -101,16 +106,30 @@ pub mod checked {
                 .into());
             }
 
-            Ok(Self::V2(SuiGasStatusV2::new_with_budget(
-                gas_budget,
-                gas_price,
-                reference_gas_price,
-                config,
-            )))
+            // Dispatch by gas model version: v15+ uses the clean gas_v3 pipeline;
+            // everything older keeps the legacy gas_v2 path so replay determinism holds.
+            if config.gas_model_version() >= 15 {
+                Ok(Self::V3(SuiGasStatusV3::new_with_budget(
+                    gas_budget,
+                    gas_price,
+                    reference_gas_price,
+                    config,
+                )))
+            } else {
+                Ok(Self::V2(SuiGasStatusV2::new_with_budget(
+                    gas_budget,
+                    gas_price,
+                    reference_gas_price,
+                    config,
+                )))
+            }
         }
 
         pub fn new_unmetered() -> Self {
-            Self::V2(SuiGasStatusV2::new_unmetered())
+            // Unmetered txs (system, dev-inspect, dry-run) never trigger metering, so the
+            // pipeline choice doesn't matter for their semantics — pick gas_v3 to match the
+            // current execution layer.
+            Self::V3(SuiGasStatusV3::new_unmetered())
         }
     }
 

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -17,7 +17,10 @@ pub mod checked {
         ObjectID,
         effects::{TransactionEffects, TransactionEffectsAPI},
         error::{ExecutionError, SuiResult, UserInputError, UserInputResult},
-        gas_model::{gas_v2::SuiGasStatus as SuiGasStatusV2, tables::GasStatus},
+        gas_model::{
+            gas_v2::SuiGasStatus as SuiGasStatusV2, gas_v3::SuiGasStatus as SuiGasStatusV3,
+            tables::GasStatus,
+        },
         object::Object,
         sui_serde::{BigInt, Readable},
         transaction::ObjectReadResult,
@@ -51,7 +54,7 @@ pub mod checked {
             object_id: ObjectID,
             new_size: usize,
             storage_rebate: u64,
-        ) -> u64;
+        ) -> Option<u64>;
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
         fn adjust_computation_on_out_of_gas(&mut self);
         fn gas_usage_report(&self) -> GasUsageReport;
@@ -65,13 +68,15 @@ pub mod checked {
         fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)>;
     }
 
-    /// Version aware enum for gas status.
+    /// Version-aware gas status: `V2` is the legacy model (`gas_model_version < 15`, incl. replay),
+    /// `V3` is the v15+ pipeline. Dispatched by `gas_model_version() >= 15`.
     #[enum_dispatch(SuiGasStatusAPI)]
     #[derive(Debug)]
     pub enum SuiGasStatus {
         // V1 does not exists any longer as it was a pre mainnet version.
         // So we start the enum from V2
         V2(SuiGasStatusV2),
+        V3(SuiGasStatusV3),
     }
 
     impl SuiGasStatus {
@@ -101,16 +106,33 @@ pub mod checked {
                 .into());
             }
 
-            Ok(Self::V2(SuiGasStatusV2::new_with_budget(
-                gas_budget,
-                gas_price,
-                reference_gas_price,
-                config,
-            )))
+            // Dispatch by gas model version: v15+ uses the clean gas_v3 pipeline;
+            // everything older keeps the legacy gas_v2 path so replay determinism holds.
+            if config.gas_model_version() >= 15 {
+                Ok(Self::V3(SuiGasStatusV3::new_with_budget(
+                    gas_budget,
+                    gas_price,
+                    reference_gas_price,
+                    config,
+                )))
+            } else {
+                Ok(Self::V2(SuiGasStatusV2::new_with_budget(
+                    gas_budget,
+                    gas_price,
+                    reference_gas_price,
+                    config,
+                )))
+            }
         }
 
-        pub fn new_unmetered() -> Self {
-            Self::V2(SuiGasStatusV2::new_unmetered())
+        pub fn new_unmetered(config: &ProtocolConfig) -> Self {
+            // Same dispatch as `new`: v15+ uses gas_v3, everything older keeps gas_v2 so
+            // replay determinism holds.
+            if config.gas_model_version() >= 15 {
+                Self::V3(SuiGasStatusV3::new_unmetered())
+            } else {
+                Self::V2(SuiGasStatusV2::new_unmetered())
+            }
         }
     }
 

--- a/crates/sui-types/src/gas_model/gas_common.rs
+++ b/crates/sui-types/src/gas_model/gas_common.rs
@@ -1,0 +1,226 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub use checked::*;
+
+mod checked {
+    use crate::error::{UserInputError, UserInputResult};
+    use crate::transaction::ObjectReadResult;
+    use crate::{ObjectID, gas};
+    use serde::{Deserialize, Serialize};
+
+    pub fn check_gas_objects(gas_objs: &[&ObjectReadResult]) -> UserInputResult {
+        // All gas objects have an address owner
+        // Note: because of address balance payments, gas_objs may be empty.
+        for gas_object in gas_objs {
+            // if as_object() returns None, it means the object has been deleted (and therefore
+            // must be a shared object).
+            if let Some(obj) = gas_object.as_object() {
+                if !obj.is_address_owned() {
+                    return Err(UserInputError::GasObjectNotOwnedObject {
+                        owner: obj.owner.clone(),
+                    });
+                }
+            } else {
+                // This case should never happen (because gas can't be a shared object), but we
+                // handle this case for future-proofing
+                return Err(UserInputError::MissingGasPayment);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn check_gas_data(
+        gas_objs: &[&ObjectReadResult],
+        gas_budget: u64,
+        available_address_balance_gas: u64,
+        min_transaction_cost: u64,
+        max_gas_budget: u64,
+    ) -> UserInputResult {
+        // Gas budget is between min and max budget allowed
+        if gas_budget > max_gas_budget {
+            return Err(UserInputError::GasBudgetTooHigh {
+                gas_budget,
+                max_budget: max_gas_budget,
+            });
+        }
+        if gas_budget < min_transaction_cost {
+            return Err(UserInputError::GasBudgetTooLow {
+                gas_budget,
+                min_budget: min_transaction_cost,
+            });
+        }
+
+        // Gas balance (all gas coins + address balance together) is bigger or equal to budget
+        let mut gas_balance = available_address_balance_gas as u128;
+        for gas_obj in gas_objs {
+            gas_balance += gas::get_gas_balance(gas_obj.as_object().ok_or(
+                UserInputError::InvalidGasObject {
+                    object_id: gas_obj.id(),
+                },
+            )?)? as u128;
+        }
+        if gas_balance < gas_budget as u128 {
+            Err(UserInputError::GasBalanceTooLow {
+                gas_balance,
+                needed_gas_amount: gas_budget as u128,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
+    /// will be burned, then re-minted + added to the storage fund at the next epoch change
+    pub fn sender_rebate(storage_rebate: u64, storage_rebate_rate: u64) -> u64 {
+        // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
+        // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
+        const BASIS_POINTS: u128 = 10000;
+        (((storage_rebate as u128 * storage_rebate_rate as u128)
+        + (BASIS_POINTS / 2)) // integer rounding adds half of the BASIS_POINTS (denominator)
+        / BASIS_POINTS) as u64
+    }
+
+    pub fn half_digits_rounding(n: u64) -> u64 {
+        if n < 1000 {
+            return 1000;
+        }
+        let digits = n.ilog10();
+        let drop = digits / 2;
+        let base = 10u64.pow(drop);
+        n.div_ceil(base).saturating_mul(base)
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct PerObjectStorage {
+        /// The new "value" for this object storage. Computed
+        /// at the end of execution while determining storage charges.
+        /// This will be the new storage rebate.
+        pub storage_cost: u64,
+        /// storage_rebate is the value of this object.
+        /// This is computed at the end of execution while determining storage charges.
+        /// The value is in Sui.
+        pub storage_rebate: u64,
+        /// The object size post-transaction in bytes
+        pub new_size: u64,
+    }
+
+    /// Per-object storage-gas accumulator, shared by both gas models. Pure data + arithmetic; the Move
+    /// meter stays on the outer `SuiGasStatus`, which passes the `unmetered` flag into `track_mutation`.
+    #[derive(Debug)]
+    pub struct StorageGas {
+        /// Per-object storage cost + rebate, accumulated during execution.
+        per_object_storage: Vec<(ObjectID, PerObjectStorage)>,
+        /// Running total of per-object storage cost. Metered path only.
+        total_storage_cost: u64,
+        /// Running total of per-object storage rebate. Metered path only.
+        total_storage_rebate: u64,
+        /// Storage rebate accrued while running unmetered (system transactions), retained in effects
+        /// and parked onto 0x5. Kept separate from `total_storage_rebate`: it must read 0 on metered
+        /// txns (its consumer `conserve_unmetered_storage_rebate` runs unconditionally).
+        unmetered_storage_rebate: u64,
+        /// Multiplier applied to the storage byte cost (`ProtocolConfig::storage_gas_price`).
+        pub storage_gas_price: u64,
+        /// Refundable per-byte storage cost (`ProtocolConfig::obj_data_cost_refundable`).
+        storage_per_byte_cost: u64,
+    }
+
+    impl StorageGas {
+        pub fn new(storage_gas_price: u64, storage_per_byte_cost: u64) -> Self {
+            Self {
+                per_object_storage: Vec::new(),
+                total_storage_cost: 0,
+                total_storage_rebate: 0,
+                unmetered_storage_rebate: 0,
+                storage_gas_price,
+                storage_per_byte_cost,
+            }
+        }
+
+        pub fn storage_gas_units(&self) -> u64 {
+            self.total_storage_cost
+        }
+
+        pub fn storage_rebate(&self) -> u64 {
+            self.total_storage_rebate
+        }
+
+        pub fn unmetered_storage_rebate(&self) -> u64 {
+            self.unmetered_storage_rebate
+        }
+
+        pub fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
+            &self.per_object_storage
+        }
+
+        pub fn reset(&mut self) {
+            self.per_object_storage = Vec::new();
+            self.total_storage_cost = 0;
+            self.total_storage_rebate = 0;
+            self.unmetered_storage_rebate = 0;
+        }
+
+        /// Update the running storage cost/rebate totals for the object.
+        /// Returns the new object storage cost (based on `new_size`), or `None` on overflow.
+        pub fn track_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+            unmetered: bool,
+        ) -> Option<u64> {
+            if unmetered {
+                return self
+                    .unmetered_storage_rebate
+                    .checked_add(storage_rebate)
+                    .map(|total| {
+                        self.unmetered_storage_rebate = total;
+                        0
+                    });
+            }
+
+            let new_size = new_size as u64;
+            let storage_cost = new_size
+                .checked_mul(self.storage_per_byte_cost)?
+                .checked_mul(self.storage_gas_price)?;
+            self.total_storage_cost = self.total_storage_cost.checked_add(storage_cost)?;
+            self.total_storage_rebate = self.total_storage_rebate.checked_add(storage_rebate)?;
+            self.per_object_storage.push((
+                object_id,
+                PerObjectStorage {
+                    storage_cost,
+                    storage_rebate,
+                    new_size,
+                },
+            ));
+            Some(storage_cost)
+        }
+    }
+
+    #[test]
+    fn test_half_digits_rounding() {
+        assert_eq!(half_digits_rounding(0), 1000);
+        assert_eq!(half_digits_rounding(1), 1000);
+        assert_eq!(half_digits_rounding(999), 1000);
+        assert_eq!(half_digits_rounding(1000), 1000);
+        assert_eq!(half_digits_rounding(1001), 1010);
+        assert_eq!(half_digits_rounding(1050), 1050);
+        assert_eq!(half_digits_rounding(1999), 2000);
+        assert_eq!(half_digits_rounding(20_000), 20_000);
+        assert_eq!(half_digits_rounding(20_001), 20_100);
+        assert_eq!(half_digits_rounding(20_500), 20_500);
+        assert_eq!(half_digits_rounding(29_999), 30_000);
+        assert_eq!(half_digits_rounding(300_000), 300_000);
+        assert_eq!(half_digits_rounding(300_001), 300_100);
+        assert_eq!(half_digits_rounding(305_500), 305_500);
+        assert_eq!(half_digits_rounding(305_501), 305_600);
+        assert_eq!(half_digits_rounding(999_999), 1_000_000);
+        assert_eq!(half_digits_rounding(1_000_000), 1_000_000);
+        assert_eq!(half_digits_rounding(1_000_001), 1_001_000);
+        assert_eq!(half_digits_rounding(1_005_000), 1_005_000);
+        assert_eq!(half_digits_rounding(1_005_001), 1_006_000);
+        assert_eq!(half_digits_rounding(1_999_999), 2_000_000);
+        assert_eq!(half_digits_rounding(10_000_001), 10_001_000);
+        assert_eq!(half_digits_rounding(100_000_001), 100_010_000);
+    }
+}

--- a/crates/sui-types/src/gas_model/gas_common.rs
+++ b/crates/sui-types/src/gas_model/gas_common.rs
@@ -1,0 +1,232 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(clippy::arithmetic_side_effects)]
+
+pub use checked::*;
+
+mod checked {
+    use crate::error::{UserInputError, UserInputResult};
+    use crate::transaction::ObjectReadResult;
+    use crate::{ObjectID, gas};
+    use serde::{Deserialize, Serialize};
+
+    pub fn check_gas_objects(gas_objs: &[&ObjectReadResult]) -> UserInputResult {
+        // All gas objects have an address owner
+        // Note: because of address balance payments, gas_objs may be empty.
+        for gas_object in gas_objs {
+            // if as_object() returns None, it means the object has been deleted (and therefore
+            // must be a shared object).
+            if let Some(obj) = gas_object.as_object() {
+                if !obj.is_address_owned() {
+                    return Err(UserInputError::GasObjectNotOwnedObject {
+                        owner: obj.owner.clone(),
+                    });
+                }
+            } else {
+                // This case should never happen (because gas can't be a shared object), but we
+                // handle this case for future-proofing
+                return Err(UserInputError::MissingGasPayment);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn check_gas_data(
+        gas_objs: &[&ObjectReadResult],
+        gas_budget: u64,
+        available_address_balance_gas: u64,
+        min_transaction_cost: u64,
+        max_gas_budget: u64,
+    ) -> UserInputResult {
+        // Gas budget is between min and max budget allowed
+        if gas_budget > max_gas_budget {
+            return Err(UserInputError::GasBudgetTooHigh {
+                gas_budget,
+                max_budget: max_gas_budget,
+            });
+        }
+        if gas_budget < min_transaction_cost {
+            return Err(UserInputError::GasBudgetTooLow {
+                gas_budget,
+                min_budget: min_transaction_cost,
+            });
+        }
+
+        // Gas balance (all gas coins + address balance together) is bigger or equal to budget
+        let mut gas_balance = available_address_balance_gas as u128;
+        for gas_obj in gas_objs {
+            // Saturation is unreachable: a sum of u64 coin balances cannot overflow u128.
+            gas_balance =
+                gas_balance.saturating_add(gas::get_gas_balance(gas_obj.as_object().ok_or(
+                    UserInputError::InvalidGasObject {
+                        object_id: gas_obj.id(),
+                    },
+                )?)? as u128);
+        }
+        if gas_balance < gas_budget as u128 {
+            Err(UserInputError::GasBalanceTooLow {
+                gas_balance,
+                needed_gas_amount: gas_budget as u128,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
+    /// will be burned, then re-minted + added to the storage fund at the next epoch change
+    // Cannot overflow: u64::MAX * u64::MAX leaves ~2^65 of u128 headroom for the `+ 5000`.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn sender_rebate(storage_rebate: u64, storage_rebate_rate: u64) -> u64 {
+        // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
+        // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
+        const BASIS_POINTS: u128 = 10000;
+        (((storage_rebate as u128 * storage_rebate_rate as u128)
+        + (BASIS_POINTS / 2)) // integer rounding adds half of the BASIS_POINTS (denominator)
+        / BASIS_POINTS) as u64
+    }
+
+    pub fn half_digits_rounding(n: u64) -> u64 {
+        if n < 1000 {
+            return 1000;
+        }
+        let digits = n.ilog10();
+        let drop = digits / 2;
+        let base = 10u64.pow(drop);
+        n.div_ceil(base).saturating_mul(base)
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct PerObjectStorage {
+        /// The new "value" for this object storage. Computed
+        /// at the end of execution while determining storage charges.
+        /// This will be the new storage rebate.
+        pub storage_cost: u64,
+        /// storage_rebate is the value of this object.
+        /// This is computed at the end of execution while determining storage charges.
+        /// The value is in Sui.
+        pub storage_rebate: u64,
+        /// The object size post-transaction in bytes
+        pub new_size: u64,
+    }
+
+    /// Per-object storage-gas accumulator, shared by both gas models. Pure data + arithmetic; the Move
+    /// meter stays on the outer `SuiGasStatus`, which passes the `unmetered` flag into `track_mutation`.
+    #[derive(Debug)]
+    pub struct StorageGas {
+        /// Per-object storage cost + rebate, accumulated during execution.
+        per_object_storage: Vec<(ObjectID, PerObjectStorage)>,
+        /// Running total of per-object storage cost. Metered path only.
+        total_storage_cost: u64,
+        /// Running total of per-object storage rebate. Metered path only.
+        total_storage_rebate: u64,
+        /// Storage rebate accrued while running unmetered (system transactions), retained in effects
+        /// and parked onto 0x5. Kept separate from `total_storage_rebate`: it must read 0 on metered
+        /// txns (its consumer `conserve_unmetered_storage_rebate` runs unconditionally).
+        unmetered_storage_rebate: u64,
+        /// Multiplier applied to the storage byte cost (`ProtocolConfig::storage_gas_price`).
+        pub storage_gas_price: u64,
+        /// Refundable per-byte storage cost (`ProtocolConfig::obj_data_cost_refundable`).
+        storage_per_byte_cost: u64,
+    }
+
+    impl StorageGas {
+        pub fn new(storage_gas_price: u64, storage_per_byte_cost: u64) -> Self {
+            Self {
+                per_object_storage: Vec::new(),
+                total_storage_cost: 0,
+                total_storage_rebate: 0,
+                unmetered_storage_rebate: 0,
+                storage_gas_price,
+                storage_per_byte_cost,
+            }
+        }
+
+        pub fn storage_gas_units(&self) -> u64 {
+            self.total_storage_cost
+        }
+
+        pub fn storage_rebate(&self) -> u64 {
+            self.total_storage_rebate
+        }
+
+        pub fn unmetered_storage_rebate(&self) -> u64 {
+            self.unmetered_storage_rebate
+        }
+
+        pub fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
+            &self.per_object_storage
+        }
+
+        pub fn reset(&mut self) {
+            self.per_object_storage = Vec::new();
+            self.total_storage_cost = 0;
+            self.total_storage_rebate = 0;
+            self.unmetered_storage_rebate = 0;
+        }
+
+        /// Update the running storage cost/rebate totals for the object.
+        /// Returns the new object storage cost (based on `new_size`), or `None` on overflow.
+        pub fn track_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+            unmetered: bool,
+        ) -> Option<u64> {
+            if unmetered {
+                return self
+                    .unmetered_storage_rebate
+                    .checked_add(storage_rebate)
+                    .map(|total| {
+                        self.unmetered_storage_rebate = total;
+                        0
+                    });
+            }
+
+            let new_size = new_size as u64;
+            let storage_cost = new_size
+                .checked_mul(self.storage_per_byte_cost)?
+                .checked_mul(self.storage_gas_price)?;
+            self.total_storage_cost = self.total_storage_cost.checked_add(storage_cost)?;
+            self.total_storage_rebate = self.total_storage_rebate.checked_add(storage_rebate)?;
+            self.per_object_storage.push((
+                object_id,
+                PerObjectStorage {
+                    storage_cost,
+                    storage_rebate,
+                    new_size,
+                },
+            ));
+            Some(storage_cost)
+        }
+    }
+
+    #[test]
+    fn test_half_digits_rounding() {
+        assert_eq!(half_digits_rounding(0), 1000);
+        assert_eq!(half_digits_rounding(1), 1000);
+        assert_eq!(half_digits_rounding(999), 1000);
+        assert_eq!(half_digits_rounding(1000), 1000);
+        assert_eq!(half_digits_rounding(1001), 1010);
+        assert_eq!(half_digits_rounding(1050), 1050);
+        assert_eq!(half_digits_rounding(1999), 2000);
+        assert_eq!(half_digits_rounding(20_000), 20_000);
+        assert_eq!(half_digits_rounding(20_001), 20_100);
+        assert_eq!(half_digits_rounding(20_500), 20_500);
+        assert_eq!(half_digits_rounding(29_999), 30_000);
+        assert_eq!(half_digits_rounding(300_000), 300_000);
+        assert_eq!(half_digits_rounding(300_001), 300_100);
+        assert_eq!(half_digits_rounding(305_500), 305_500);
+        assert_eq!(half_digits_rounding(305_501), 305_600);
+        assert_eq!(half_digits_rounding(999_999), 1_000_000);
+        assert_eq!(half_digits_rounding(1_000_000), 1_000_000);
+        assert_eq!(half_digits_rounding(1_000_001), 1_001_000);
+        assert_eq!(half_digits_rounding(1_005_000), 1_005_000);
+        assert_eq!(half_digits_rounding(1_005_001), 1_006_000);
+        assert_eq!(half_digits_rounding(1_999_999), 2_000_000);
+        assert_eq!(half_digits_rounding(10_000_001), 10_001_000);
+        assert_eq!(half_digits_rounding(100_000_001), 100_010_000);
+    }
+}

--- a/crates/sui-types/src/gas_model/gas_common.rs
+++ b/crates/sui-types/src/gas_model/gas_common.rs
@@ -4,6 +4,8 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(clippy::indexing_slicing)]
+#![deny(clippy::cast_possible_wrap)]
+#![deny(clippy::cast_sign_loss)]
 
 use crate::error::{UserInputError, UserInputResult};
 use crate::transaction::ObjectReadResult;

--- a/crates/sui-types/src/gas_model/gas_common.rs
+++ b/crates/sui-types/src/gas_model/gas_common.rs
@@ -2,231 +2,224 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(clippy::arithmetic_side_effects)]
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::indexing_slicing)]
 
-pub use checked::*;
+use crate::error::{UserInputError, UserInputResult};
+use crate::transaction::ObjectReadResult;
+use crate::{ObjectID, gas};
+use serde::{Deserialize, Serialize};
 
-mod checked {
-    use crate::error::{UserInputError, UserInputResult};
-    use crate::transaction::ObjectReadResult;
-    use crate::{ObjectID, gas};
-    use serde::{Deserialize, Serialize};
-
-    pub fn check_gas_objects(gas_objs: &[&ObjectReadResult]) -> UserInputResult {
-        // All gas objects have an address owner
-        // Note: because of address balance payments, gas_objs may be empty.
-        for gas_object in gas_objs {
-            // if as_object() returns None, it means the object has been deleted (and therefore
-            // must be a shared object).
-            if let Some(obj) = gas_object.as_object() {
-                if !obj.is_address_owned() {
-                    return Err(UserInputError::GasObjectNotOwnedObject {
-                        owner: obj.owner.clone(),
-                    });
-                }
-            } else {
-                // This case should never happen (because gas can't be a shared object), but we
-                // handle this case for future-proofing
-                return Err(UserInputError::MissingGasPayment);
+pub fn check_gas_objects(gas_objs: &[&ObjectReadResult]) -> UserInputResult {
+    // All gas objects have an address owner
+    // Note: because of address balance payments, gas_objs may be empty.
+    for gas_object in gas_objs {
+        // if as_object() returns None, it means the object has been deleted (and therefore
+        // must be a shared object).
+        if let Some(obj) = gas_object.as_object() {
+            if !obj.is_address_owned() {
+                return Err(UserInputError::GasObjectNotOwnedObject {
+                    owner: obj.owner.clone(),
+                });
             }
+        } else {
+            // This case should never happen (because gas can't be a shared object), but we
+            // handle this case for future-proofing
+            return Err(UserInputError::MissingGasPayment);
         }
+    }
+    Ok(())
+}
+
+pub fn check_gas_data(
+    gas_objs: &[&ObjectReadResult],
+    gas_budget: u64,
+    available_address_balance_gas: u64,
+    min_transaction_cost: u64,
+    max_gas_budget: u64,
+) -> UserInputResult {
+    // Gas budget is between min and max budget allowed
+    if gas_budget > max_gas_budget {
+        return Err(UserInputError::GasBudgetTooHigh {
+            gas_budget,
+            max_budget: max_gas_budget,
+        });
+    }
+    if gas_budget < min_transaction_cost {
+        return Err(UserInputError::GasBudgetTooLow {
+            gas_budget,
+            min_budget: min_transaction_cost,
+        });
+    }
+
+    // Gas balance (all gas coins + address balance together) is bigger or equal to budget
+    let mut gas_balance = available_address_balance_gas as u128;
+    for gas_obj in gas_objs {
+        // Saturation is unreachable: a sum of u64 coin balances cannot overflow u128.
+        gas_balance = gas_balance.saturating_add(gas::get_gas_balance(gas_obj.as_object().ok_or(
+            UserInputError::InvalidGasObject {
+                object_id: gas_obj.id(),
+            },
+        )?)? as u128);
+    }
+    if gas_balance < gas_budget as u128 {
+        Err(UserInputError::GasBalanceTooLow {
+            gas_balance,
+            needed_gas_amount: gas_budget as u128,
+        })
+    } else {
         Ok(())
     }
+}
 
-    pub fn check_gas_data(
-        gas_objs: &[&ObjectReadResult],
-        gas_budget: u64,
-        available_address_balance_gas: u64,
-        min_transaction_cost: u64,
-        max_gas_budget: u64,
-    ) -> UserInputResult {
-        // Gas budget is between min and max budget allowed
-        if gas_budget > max_gas_budget {
-            return Err(UserInputError::GasBudgetTooHigh {
-                gas_budget,
-                max_budget: max_gas_budget,
-            });
-        }
-        if gas_budget < min_transaction_cost {
-            return Err(UserInputError::GasBudgetTooLow {
-                gas_budget,
-                min_budget: min_transaction_cost,
-            });
-        }
+/// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
+/// will be burned, then re-minted + added to the storage fund at the next epoch change
+pub fn sender_rebate(storage_rebate: u64, storage_rebate_rate: u64) -> u64 {
+    // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
+    // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
+    const BASIS_POINTS: u128 = 10000;
+    let rebate = (storage_rebate as u128)
+        .saturating_mul(storage_rebate_rate as u128)
+        .saturating_add(BASIS_POINTS / 2) // integer rounding adds half of the denominator
+        / BASIS_POINTS;
+    u64::try_from(rebate).unwrap_or(u64::MAX)
+}
 
-        // Gas balance (all gas coins + address balance together) is bigger or equal to budget
-        let mut gas_balance = available_address_balance_gas as u128;
-        for gas_obj in gas_objs {
-            // Saturation is unreachable: a sum of u64 coin balances cannot overflow u128.
-            gas_balance =
-                gas_balance.saturating_add(gas::get_gas_balance(gas_obj.as_object().ok_or(
-                    UserInputError::InvalidGasObject {
-                        object_id: gas_obj.id(),
-                    },
-                )?)? as u128);
-        }
-        if gas_balance < gas_budget as u128 {
-            Err(UserInputError::GasBalanceTooLow {
-                gas_balance,
-                needed_gas_amount: gas_budget as u128,
-            })
-        } else {
-            Ok(())
+pub fn half_digits_rounding(n: u64) -> u64 {
+    if n < 1000 {
+        return 1000;
+    }
+    let digits = n.ilog10();
+    let drop = digits / 2;
+    let base = 10u64.pow(drop);
+    n.div_ceil(base).saturating_mul(base)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerObjectStorage {
+    /// The new "value" for this object storage. Computed
+    /// at the end of execution while determining storage charges.
+    /// This will be the new storage rebate.
+    pub storage_cost: u64,
+    /// storage_rebate is the value of this object.
+    /// This is computed at the end of execution while determining storage charges.
+    /// The value is in Sui.
+    pub storage_rebate: u64,
+    /// The object size post-transaction in bytes
+    pub new_size: u64,
+}
+
+/// Per-object storage-gas accumulator, shared by both gas models. Pure data + arithmetic; the Move
+/// meter stays on the outer `SuiGasStatus`, which passes the `unmetered` flag into `track_mutation`.
+#[derive(Debug)]
+pub struct StorageGas {
+    /// Per-object storage cost + rebate, accumulated during execution.
+    per_object_storage: Vec<(ObjectID, PerObjectStorage)>,
+    /// Running total of per-object storage cost. Metered path only.
+    total_storage_cost: u64,
+    /// Running total of per-object storage rebate. Metered path only.
+    total_storage_rebate: u64,
+    /// Storage rebate accrued while running unmetered (system transactions), retained in effects
+    /// and parked onto 0x5. Kept separate from `total_storage_rebate`: it must read 0 on metered
+    /// txns (its consumer `conserve_unmetered_storage_rebate` runs unconditionally).
+    unmetered_storage_rebate: u64,
+    /// Multiplier applied to the storage byte cost (`ProtocolConfig::storage_gas_price`).
+    pub storage_gas_price: u64,
+    /// Refundable per-byte storage cost (`ProtocolConfig::obj_data_cost_refundable`).
+    storage_per_byte_cost: u64,
+}
+
+impl StorageGas {
+    pub fn new(storage_gas_price: u64, storage_per_byte_cost: u64) -> Self {
+        Self {
+            per_object_storage: Vec::new(),
+            total_storage_cost: 0,
+            total_storage_rebate: 0,
+            unmetered_storage_rebate: 0,
+            storage_gas_price,
+            storage_per_byte_cost,
         }
     }
 
-    /// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
-    /// will be burned, then re-minted + added to the storage fund at the next epoch change
-    // Cannot overflow: u64::MAX * u64::MAX leaves ~2^65 of u128 headroom for the `+ 5000`.
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn sender_rebate(storage_rebate: u64, storage_rebate_rate: u64) -> u64 {
-        // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
-        // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
-        const BASIS_POINTS: u128 = 10000;
-        (((storage_rebate as u128 * storage_rebate_rate as u128)
-        + (BASIS_POINTS / 2)) // integer rounding adds half of the BASIS_POINTS (denominator)
-        / BASIS_POINTS) as u64
+    pub fn storage_gas_units(&self) -> u64 {
+        self.total_storage_cost
     }
 
-    pub fn half_digits_rounding(n: u64) -> u64 {
-        if n < 1000 {
-            return 1000;
-        }
-        let digits = n.ilog10();
-        let drop = digits / 2;
-        let base = 10u64.pow(drop);
-        n.div_ceil(base).saturating_mul(base)
+    pub fn storage_rebate(&self) -> u64 {
+        self.total_storage_rebate
     }
 
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct PerObjectStorage {
-        /// The new "value" for this object storage. Computed
-        /// at the end of execution while determining storage charges.
-        /// This will be the new storage rebate.
-        pub storage_cost: u64,
-        /// storage_rebate is the value of this object.
-        /// This is computed at the end of execution while determining storage charges.
-        /// The value is in Sui.
-        pub storage_rebate: u64,
-        /// The object size post-transaction in bytes
-        pub new_size: u64,
+    pub fn unmetered_storage_rebate(&self) -> u64 {
+        self.unmetered_storage_rebate
     }
 
-    /// Per-object storage-gas accumulator, shared by both gas models. Pure data + arithmetic; the Move
-    /// meter stays on the outer `SuiGasStatus`, which passes the `unmetered` flag into `track_mutation`.
-    #[derive(Debug)]
-    pub struct StorageGas {
-        /// Per-object storage cost + rebate, accumulated during execution.
-        per_object_storage: Vec<(ObjectID, PerObjectStorage)>,
-        /// Running total of per-object storage cost. Metered path only.
-        total_storage_cost: u64,
-        /// Running total of per-object storage rebate. Metered path only.
-        total_storage_rebate: u64,
-        /// Storage rebate accrued while running unmetered (system transactions), retained in effects
-        /// and parked onto 0x5. Kept separate from `total_storage_rebate`: it must read 0 on metered
-        /// txns (its consumer `conserve_unmetered_storage_rebate` runs unconditionally).
-        unmetered_storage_rebate: u64,
-        /// Multiplier applied to the storage byte cost (`ProtocolConfig::storage_gas_price`).
-        pub storage_gas_price: u64,
-        /// Refundable per-byte storage cost (`ProtocolConfig::obj_data_cost_refundable`).
-        storage_per_byte_cost: u64,
+    pub fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
+        &self.per_object_storage
     }
 
-    impl StorageGas {
-        pub fn new(storage_gas_price: u64, storage_per_byte_cost: u64) -> Self {
-            Self {
-                per_object_storage: Vec::new(),
-                total_storage_cost: 0,
-                total_storage_rebate: 0,
-                unmetered_storage_rebate: 0,
-                storage_gas_price,
-                storage_per_byte_cost,
-            }
-        }
-
-        pub fn storage_gas_units(&self) -> u64 {
-            self.total_storage_cost
-        }
-
-        pub fn storage_rebate(&self) -> u64 {
-            self.total_storage_rebate
-        }
-
-        pub fn unmetered_storage_rebate(&self) -> u64 {
-            self.unmetered_storage_rebate
-        }
-
-        pub fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
-            &self.per_object_storage
-        }
-
-        pub fn reset(&mut self) {
-            self.per_object_storage = Vec::new();
-            self.total_storage_cost = 0;
-            self.total_storage_rebate = 0;
-            self.unmetered_storage_rebate = 0;
-        }
-
-        /// Update the running storage cost/rebate totals for the object.
-        /// Returns the new object storage cost (based on `new_size`), or `None` on overflow.
-        pub fn track_mutation(
-            &mut self,
-            object_id: ObjectID,
-            new_size: usize,
-            storage_rebate: u64,
-            unmetered: bool,
-        ) -> Option<u64> {
-            if unmetered {
-                return self
-                    .unmetered_storage_rebate
-                    .checked_add(storage_rebate)
-                    .map(|total| {
-                        self.unmetered_storage_rebate = total;
-                        0
-                    });
-            }
-
-            let new_size = new_size as u64;
-            let storage_cost = new_size
-                .checked_mul(self.storage_per_byte_cost)?
-                .checked_mul(self.storage_gas_price)?;
-            self.total_storage_cost = self.total_storage_cost.checked_add(storage_cost)?;
-            self.total_storage_rebate = self.total_storage_rebate.checked_add(storage_rebate)?;
-            self.per_object_storage.push((
-                object_id,
-                PerObjectStorage {
-                    storage_cost,
-                    storage_rebate,
-                    new_size,
-                },
-            ));
-            Some(storage_cost)
-        }
+    pub fn reset(&mut self) {
+        self.per_object_storage = Vec::new();
+        self.total_storage_cost = 0;
+        self.total_storage_rebate = 0;
+        self.unmetered_storage_rebate = 0;
     }
 
-    #[test]
-    fn test_half_digits_rounding() {
-        assert_eq!(half_digits_rounding(0), 1000);
-        assert_eq!(half_digits_rounding(1), 1000);
-        assert_eq!(half_digits_rounding(999), 1000);
-        assert_eq!(half_digits_rounding(1000), 1000);
-        assert_eq!(half_digits_rounding(1001), 1010);
-        assert_eq!(half_digits_rounding(1050), 1050);
-        assert_eq!(half_digits_rounding(1999), 2000);
-        assert_eq!(half_digits_rounding(20_000), 20_000);
-        assert_eq!(half_digits_rounding(20_001), 20_100);
-        assert_eq!(half_digits_rounding(20_500), 20_500);
-        assert_eq!(half_digits_rounding(29_999), 30_000);
-        assert_eq!(half_digits_rounding(300_000), 300_000);
-        assert_eq!(half_digits_rounding(300_001), 300_100);
-        assert_eq!(half_digits_rounding(305_500), 305_500);
-        assert_eq!(half_digits_rounding(305_501), 305_600);
-        assert_eq!(half_digits_rounding(999_999), 1_000_000);
-        assert_eq!(half_digits_rounding(1_000_000), 1_000_000);
-        assert_eq!(half_digits_rounding(1_000_001), 1_001_000);
-        assert_eq!(half_digits_rounding(1_005_000), 1_005_000);
-        assert_eq!(half_digits_rounding(1_005_001), 1_006_000);
-        assert_eq!(half_digits_rounding(1_999_999), 2_000_000);
-        assert_eq!(half_digits_rounding(10_000_001), 10_001_000);
-        assert_eq!(half_digits_rounding(100_000_001), 100_010_000);
+    /// Update the running storage cost/rebate totals for the object.
+    /// Returns the new object storage cost (based on `new_size`), or `None` on overflow.
+    pub fn track_mutation(
+        &mut self,
+        object_id: ObjectID,
+        new_size: usize,
+        storage_rebate: u64,
+        unmetered: bool,
+    ) -> Option<u64> {
+        if unmetered {
+            let total = self.unmetered_storage_rebate.checked_add(storage_rebate)?;
+            self.unmetered_storage_rebate = total;
+            return Some(0);
+        }
+
+        let new_size = new_size as u64;
+        let storage_cost = new_size
+            .checked_mul(self.storage_per_byte_cost)?
+            .checked_mul(self.storage_gas_price)?;
+        self.total_storage_cost = self.total_storage_cost.checked_add(storage_cost)?;
+        self.total_storage_rebate = self.total_storage_rebate.checked_add(storage_rebate)?;
+        self.per_object_storage.push((
+            object_id,
+            PerObjectStorage {
+                storage_cost,
+                storage_rebate,
+                new_size,
+            },
+        ));
+        Some(storage_cost)
     }
+}
+
+#[test]
+fn test_half_digits_rounding() {
+    assert_eq!(half_digits_rounding(0), 1000);
+    assert_eq!(half_digits_rounding(1), 1000);
+    assert_eq!(half_digits_rounding(999), 1000);
+    assert_eq!(half_digits_rounding(1000), 1000);
+    assert_eq!(half_digits_rounding(1001), 1010);
+    assert_eq!(half_digits_rounding(1050), 1050);
+    assert_eq!(half_digits_rounding(1999), 2000);
+    assert_eq!(half_digits_rounding(20_000), 20_000);
+    assert_eq!(half_digits_rounding(20_001), 20_100);
+    assert_eq!(half_digits_rounding(20_500), 20_500);
+    assert_eq!(half_digits_rounding(29_999), 30_000);
+    assert_eq!(half_digits_rounding(300_000), 300_000);
+    assert_eq!(half_digits_rounding(300_001), 300_100);
+    assert_eq!(half_digits_rounding(305_500), 305_500);
+    assert_eq!(half_digits_rounding(305_501), 305_600);
+    assert_eq!(half_digits_rounding(999_999), 1_000_000);
+    assert_eq!(half_digits_rounding(1_000_000), 1_000_000);
+    assert_eq!(half_digits_rounding(1_000_001), 1_001_000);
+    assert_eq!(half_digits_rounding(1_005_000), 1_005_000);
+    assert_eq!(half_digits_rounding(1_005_001), 1_006_000);
+    assert_eq!(half_digits_rounding(1_999_999), 2_000_000);
+    assert_eq!(half_digits_rounding(10_000_001), 10_001_000);
+    assert_eq!(half_digits_rounding(100_000_001), 100_010_000);
 }

--- a/crates/sui-types/src/gas_model/gas_predicates.rs
+++ b/crates/sui-types/src/gas_model/gas_predicates.rs
@@ -85,3 +85,7 @@ pub fn native_function_threshold_exceeded(gas_model_version: u64, num_native_cal
 pub fn refresh_gas_payment_location(gas_model_version: u64) -> bool {
     gas_model_version >= 13
 }
+
+pub fn use_step_gas_charging(gas_model_version: u64) -> bool {
+    gas_model_version >= 15
+}

--- a/crates/sui-types/src/gas_model/gas_predicates.rs
+++ b/crates/sui-types/src/gas_model/gas_predicates.rs
@@ -64,7 +64,7 @@ pub fn cost_table_for_version(gas_model: u64) -> CostTable {
 }
 
 // In gas model versions <= 13, charge_native_function_before_execution pops
-// args that were already popped by charge_call — a double-pop. The resulting
+// args that were already popped by charge_call - a double-pop. The resulting
 // negative stack heights were masked by saturating_sub in pop_stack.
 // Version 14+ fixes the double-pop so charge_native_function_before_execution
 // no longer pops args.

--- a/crates/sui-types/src/gas_model/gas_predicates.rs
+++ b/crates/sui-types/src/gas_model/gas_predicates.rs
@@ -85,3 +85,7 @@ pub fn native_function_threshold_exceeded(gas_model_version: u64, num_native_cal
 pub fn refresh_gas_payment_location(gas_model_version: u64) -> bool {
     gas_model_version >= 13
 }
+
+pub fn bump_only_enabled(gas_model_version: u64) -> bool {
+    gas_model_version >= 15
+}

--- a/crates/sui-types/src/gas_model/gas_v3.rs
+++ b/crates/sui-types/src/gas_model/gas_v3.rs
@@ -4,15 +4,13 @@
 
 pub use checked::*;
 
-#[sui_macros::with_checked_arithmetic]
 mod checked {
     use crate::error::UserInputResult;
     use crate::gas::{GasCostSummary, GasUsageReport, SuiGasStatusAPI};
-    pub use crate::gas_model::gas_common::PerObjectStorage;
     use crate::gas_model::gas_common::{
         StorageGas, check_gas_data, check_gas_objects, half_digits_rounding, sender_rebate,
     };
-    use crate::gas_model::gas_predicates::{cost_table_for_version, txn_base_cost_as_multiplier};
+    use crate::gas_model::gas_predicates::cost_table_for_version;
     use crate::gas_model::units_types::CostTable;
     use crate::transaction::ObjectReadResult;
     use crate::{
@@ -24,78 +22,21 @@ mod checked {
     use move_core_types::vm_status::StatusCode;
     use sui_protocol_config::*;
 
-    /// A bucket defines a range of units that will be priced the same.
-    /// After execution a call to `GasStatus::bucketize` will round the computation
-    /// cost to `cost` for the bucket ([`min`, `max`]) the gas used falls into.
-    #[allow(dead_code)]
-    pub(crate) struct ComputationBucket {
-        min: u64,
-        max: u64,
-        cost: u64,
-    }
-
-    impl ComputationBucket {
-        fn new(min: u64, max: u64, cost: u64) -> Self {
-            ComputationBucket { min, max, cost }
-        }
-
-        fn simple(min: u64, max: u64) -> Self {
-            Self::new(min, max, max)
-        }
-    }
-
-    fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
-        for bucket in table {
-            if bucket.max >= computation_cost {
-                return bucket.cost;
-            }
-        }
-        match table.last() {
-            // maybe not a literal here could be better?
-            None => 5_000_000,
-            Some(bucket) => bucket.cost,
-        }
-    }
-
-    // define the bucket table for computation charging
-    // If versioning defines multiple functions and
-    fn computation_bucket(max_bucket_cost: u64) -> Vec<ComputationBucket> {
-        assert!(max_bucket_cost >= 5_000_000);
-        vec![
-            ComputationBucket::simple(0, 1_000),
-            ComputationBucket::simple(1_000, 5_000),
-            ComputationBucket::simple(5_000, 10_000),
-            ComputationBucket::simple(10_000, 20_000),
-            ComputationBucket::simple(20_000, 50_000),
-            ComputationBucket::simple(50_000, 200_000),
-            ComputationBucket::simple(200_000, 1_000_000),
-            ComputationBucket::simple(1_000_000, max_bucket_cost),
-        ]
-    }
-
     /// A list of constant costs of various operations in Sui.
     pub struct SuiCostTable {
-        /// A flat fee charged for every transaction. This is also the minimum amount of
-        /// gas charged for a transaction.
+        /// A flat fee charged for every transaction.
         pub(crate) min_transaction_cost: u64,
         /// Maximum allowable budget for a transaction.
         pub(crate) max_gas_budget: u64,
-        /// Computation cost per byte charged for package publish. This cost is primarily
-        /// determined by the cost to verify and link a package. Note that this does not
-        /// include the cost of writing the package to the store.
+        /// Computation cost per byte charged for package publish.
         package_publish_per_byte_cost: u64,
-        /// Per byte cost to read objects from the store. This is computation cost instead of
-        /// storage cost because it does not change the amount of data stored on the db.
+        /// Per byte cost to read objects from the store.
         object_read_per_byte_cost: u64,
-        /// Unit cost of a byte in the storage. This will be used both for charging for
-        /// new storage as well as rebating for deleting storage. That is, we expect users to
-        /// get full refund on the object storage when it's deleted.
+        /// Unit cost of a byte in the storage.
         storage_per_byte_cost: u64,
         /// Execution cost table to be used.
         pub execution_cost_table: CostTable,
-        /// Computation buckets to cost transaction in price groups
-        computation_bucket: Vec<ComputationBucket>,
-        /// Max gas price for aborted transactions.
+        /// RGP-multiplier cap on the effective gas price for aborted transactions.
         max_gas_price_rgp_factor_for_aborted_transactions: Option<u64>,
     }
 
@@ -110,11 +51,10 @@ mod checked {
         pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
             // gas_price here is the Reference Gas Price, however we may decide
             // to change it to be the price passed in the transaction
-            let min_transaction_cost = if txn_base_cost_as_multiplier(c) {
-                c.base_tx_cost_fixed() * gas_price
-            } else {
-                c.base_tx_cost_fixed()
-            };
+            let min_transaction_cost = c
+                .base_tx_cost_fixed()
+                .checked_mul(gas_price)
+                .expect("base tx cost cannot overflow: gas_price is bounded by max_gas_price");
             Self {
                 min_transaction_cost,
                 max_gas_budget: c.max_tx_gas(),
@@ -122,7 +62,6 @@ mod checked {
                 object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
                 storage_per_byte_cost: c.obj_data_cost_refundable(),
                 execution_cost_table: cost_table_for_version(c.gas_model_version()),
-                computation_bucket: computation_bucket(c.max_gas_computation_bucket()),
                 max_gas_price_rgp_factor_for_aborted_transactions: c
                     .max_gas_price_rgp_factor_for_aborted_transactions_as_option(),
             }
@@ -136,22 +75,12 @@ mod checked {
                 object_read_per_byte_cost: 0,
                 storage_per_byte_cost: 0,
                 execution_cost_table: ZERO_COST_SCHEDULE.clone(),
-                // should not matter
-                computation_bucket: computation_bucket(5_000_000),
                 max_gas_price_rgp_factor_for_aborted_transactions: None,
             }
         }
     }
 
-    #[derive(Debug, Clone, Copy)]
-    enum GasRoundingMode {
-        /// Bucketize the computation cost according to predefined buckets.
-        Bucketize,
-        /// Rounding value to round up gas charges.
-        Stepped(u64),
-        /// Round by keeping just over half digits
-        KeepHalfDigits,
-    }
+    pub use crate::gas_model::gas_common::PerObjectStorage;
 
     #[allow(dead_code)]
     #[derive(Debug)]
@@ -161,29 +90,22 @@ mod checked {
         // Cost table contains a set of constant/config for the gas model/charging
         cost_table: SuiCostTable,
         // Gas budget for this gas status instance.
-        // Typically the gas budget as defined in the `TransactionData::GasData`
         gas_budget: u64,
-        // Computation cost after execution. This is the result of the gas used by the `GasStatus`
-        // properly bucketized.
-        // Starts at 0 and it is assigned in `bucketize_computation`.
-        computation_cost: u64,
         // Whether to charge or go unmetered
         charge: bool,
-        // Gas price for computation.
-        // This is a multiplier on the final charge as related to the RGP (reference gas price).
-        // Checked at signing: `gas_price >= reference_gas_price`
-        // and then conceptually
-        // `final_computation_cost = total_computation_cost * gas_price / reference_gas_price`
-        gas_price: u64,
+        // Price used to convert gas units to MIST; starts at `user_gas_price`, lowered to the abort cap
+        // by `bucketize_computation` on a Move abort.
+        effective_gas_price: u64,
+        // The gas price the user signed for (>= reference_gas_price).
+        user_gas_price: u64,
         // RGP as defined in the protocol config.
         reference_gas_price: u64,
         // storage rebate rate as defined in the ProtocolConfig
         rebate_rate: u64,
-        /// Per-object storage accounting (accumulated costs/rebates + the storage config it needs),
-        /// shared with gas_v3 via `gas_common::StorageGas`.
+        /// Per-object storage accounting .
         storage: StorageGas,
-        /// Rounding mode for gas charges.
-        gas_rounding_mode: GasRoundingMode,
+        /// When set, computation cost is reported as exactly `gas_budget`.
+        force_computation_cost_to_budget: bool,
     }
 
     impl SuiGasStatus {
@@ -191,29 +113,23 @@ mod checked {
             move_gas_status: GasStatus,
             gas_budget: u64,
             charge: bool,
-            gas_price: u64,
+            user_gas_price: u64,
             reference_gas_price: u64,
             storage_gas_price: u64,
             rebate_rate: u64,
-            gas_rounding_mode: GasRoundingMode,
             cost_table: SuiCostTable,
         ) -> SuiGasStatus {
-            let gas_rounding_mode = match gas_rounding_mode {
-                GasRoundingMode::Bucketize => GasRoundingMode::Bucketize,
-                GasRoundingMode::Stepped(val) => GasRoundingMode::Stepped(val.max(1)),
-                GasRoundingMode::KeepHalfDigits => GasRoundingMode::KeepHalfDigits,
-            };
             SuiGasStatus {
                 gas_status: move_gas_status,
                 gas_budget,
                 charge,
-                computation_cost: 0,
-                gas_price,
+                effective_gas_price: user_gas_price,
+                user_gas_price,
                 reference_gas_price,
                 rebate_rate,
                 storage: StorageGas::new(storage_gas_price, cost_table.storage_per_byte_cost),
-                gas_rounding_mode,
                 cost_table,
+                force_computation_cost_to_budget: false,
             }
         }
 
@@ -224,20 +140,18 @@ mod checked {
             config: &ProtocolConfig,
         ) -> SuiGasStatus {
             let storage_gas_price = config.storage_gas_price();
-            let max_computation_budget = config.max_gas_computation_bucket() * gas_price;
+            let max_computation_budget = config
+                .max_gas_computation_bucket()
+                .checked_mul(gas_price)
+                .expect(
+                    "computation budget cannot overflow: gas_price is bounded by max_gas_price",
+                );
             let computation_budget = if gas_budget > max_computation_budget {
                 max_computation_budget
             } else {
                 gas_budget
             };
             let sui_cost_table = SuiCostTable::new(config, gas_price);
-            let gas_rounding_mode = if config.gas_rounding_halve_digits() {
-                GasRoundingMode::KeepHalfDigits
-            } else if let Some(step) = config.gas_rounding_step_as_option() {
-                GasRoundingMode::Stepped(step)
-            } else {
-                GasRoundingMode::Bucketize
-            };
             Self::new(
                 GasStatus::new(
                     sui_cost_table.execution_cost_table.clone(),
@@ -251,7 +165,6 @@ mod checked {
                 reference_gas_price,
                 storage_gas_price,
                 config.storage_rebate_rate(),
-                gas_rounding_mode,
                 sui_cost_table,
             )
         }
@@ -265,13 +178,34 @@ mod checked {
                 0,
                 0,
                 0,
-                GasRoundingMode::Bucketize,
                 SuiCostTable::unmetered(),
             )
         }
 
         pub fn reference_gas_price(&self) -> u64 {
             self.reference_gas_price
+        }
+
+        /// Meter-derived computation cost in MIST (bucketed units × effective_gas_price).
+        fn uncapped_computation_cost(&self) -> u64 {
+            if self.force_computation_cost_to_budget {
+                return self.gas_budget;
+            }
+            let raw_units = self.gas_status.gas_used_pre_gas_price();
+            let bucketed_units = half_digits_rounding(raw_units);
+            bucketed_units.saturating_mul(self.effective_gas_price)
+        }
+
+        /// Computation cost reported in `summary()`, capped so
+        /// `computation + storage_cost - sender_rebate ≤ gas_budget`
+        /// storage charges stick, computation absorbs whatever budget remains.
+        fn derived_computation_cost(&self) -> u64 {
+            let uncapped_cost = self.uncapped_computation_cost();
+            let storage_rebate = self.storage_rebate();
+            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+            let net_storage = self.storage_cost().saturating_sub(sender_rebate);
+            let max_computation = self.gas_budget.saturating_sub(net_storage);
+            uncapped_cost.min(max_computation)
         }
 
         fn storage_cost(&self) -> u64 {
@@ -293,60 +227,34 @@ mod checked {
         }
 
         fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
-            let gas_used = self.gas_status.gas_used_pre_gas_price();
-            let effective_gas_price = if let Some(max_gas_price_rgp_factor_for_aborted_transactions) =
-                self.cost_table
-                    .max_gas_price_rgp_factor_for_aborted_transactions
-                && aborted.unwrap_or(false)
+            self.effective_gas_price = match self
+                .cost_table
+                .max_gas_price_rgp_factor_for_aborted_transactions
             {
-                // For aborts, cap at max but don't exceed user's price
-                // This minimizes the risk of competing for priority execution in the case that the txn may be aborted.
-                let max_gas_price_for_aborted_txns =
-                    max_gas_price_rgp_factor_for_aborted_transactions * self.reference_gas_price;
-                self.gas_price.min(max_gas_price_for_aborted_txns)
-            } else {
-                // For all other cases, use the user's gas price
-                self.gas_price
+                Some(factor) if aborted.unwrap_or(false) => {
+                    let cap = factor
+                        .checked_mul(self.reference_gas_price)
+                        .ok_or_else(|| {
+                            ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation)
+                        })?;
+                    self.user_gas_price.min(cap)
+                }
+                _ => self.user_gas_price,
             };
-            let gas_used = match self.gas_rounding_mode {
-                GasRoundingMode::KeepHalfDigits => {
-                    half_digits_rounding(gas_used) * effective_gas_price
-                }
-                GasRoundingMode::Stepped(gas_rounding) => {
-                    if gas_used > 0 && gas_used % gas_rounding == 0 {
-                        gas_used * effective_gas_price
-                    } else {
-                        ((gas_used / gas_rounding) + 1) * gas_rounding * effective_gas_price
-                    }
-                }
-                GasRoundingMode::Bucketize => {
-                    let bucket_cost =
-                        get_bucket_cost(&self.cost_table.computation_bucket, gas_used);
-                    // charge extra on top of `computation_cost` to make the total computation
-                    // cost a bucket value
-                    bucket_cost * effective_gas_price
-                }
-            };
-            if self.gas_budget <= gas_used {
-                self.computation_cost = self.gas_budget;
-                Err(ExecutionErrorKind::InsufficientGas.into())
-            } else {
-                self.computation_cost = gas_used;
-                Ok(())
+            if self.uncapped_computation_cost() >= self.gas_budget {
+                return Err(ExecutionErrorKind::InsufficientGas.into());
             }
+            Ok(())
         }
 
-        /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
-        /// We use initial budget, combined with remaining gas and storage cost to derive
-        /// computation cost.
+        /// Returns the gas cost summary for the transaction.
         fn summary(&self) -> GasCostSummary {
-            // compute storage rebate, both rebate and non refundable fee
             let storage_rebate = self.storage_rebate();
             let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
             assert!(sender_rebate <= storage_rebate);
             let non_refundable_storage_fee = storage_rebate - sender_rebate;
             GasCostSummary {
-                computation_cost: self.computation_cost,
+                computation_cost: self.derived_computation_cost(),
                 storage_cost: self.storage_cost(),
                 storage_rebate: sender_rebate,
                 non_refundable_storage_fee,
@@ -358,7 +266,7 @@ mod checked {
         }
 
         fn gas_price(&self) -> u64 {
-            self.gas_price
+            self.user_gas_price
         }
 
         fn reference_gas_price(&self) -> u64 {
@@ -404,9 +312,8 @@ mod checked {
         }
 
         /// Update `storage_rebate` and `storage_gas_units` for each object in the transaction.
-        /// There is no charge in this function. Charges will all be applied together at the end
-        /// (`track_storage_mutation`).
-        /// Return the new storage rebate (cost of object storage) according to `new_size`.
+        /// Return the new storage rebate (cost of object storage) according to `new_size` or
+        /// `None` on arithmetic errors.
         fn track_storage_mutation(
             &mut self,
             object_id: ObjectID,
@@ -419,31 +326,24 @@ mod checked {
         }
 
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
-            let storage_rebate = self.storage_rebate();
-            let storage_cost = self.storage_cost();
+            let storage_rebate = self.storage.storage_rebate();
+            let storage_cost = self.storage.storage_gas_units();
             let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
             assert!(sender_rebate <= storage_rebate);
-            if sender_rebate >= storage_cost {
-                // there is more rebate than cost, when deducting gas we are adding
-                // to whatever is the current amount charged so we are `Ok`
-                Ok(())
-            } else {
-                let gas_left = self.gas_budget - self.computation_cost;
-                // we have to charge for storage and may go out of gas, check
-                if gas_left < storage_cost - sender_rebate {
-                    // Running out of gas would cause the temporary store to reset
-                    // and zero storage and rebate.
-                    // The remaining_gas will be 0 and we will charge all in computation
-                    Err(ExecutionErrorKind::InsufficientGas.into())
-                } else {
-                    Ok(())
-                }
+            let net_storage_cost = storage_cost.saturating_sub(sender_rebate);
+            let gas_left = self
+                .gas_budget
+                .saturating_sub(self.uncapped_computation_cost());
+            if net_storage_cost > gas_left {
+                return Err(ExecutionErrorKind::InsufficientGas.into());
             }
+            Ok(())
         }
 
+        /// Drop accumulated storage and force `summary()` to report `computation_cost == gas_budget`
         fn adjust_computation_on_out_of_gas(&mut self) {
             self.storage.reset();
-            self.computation_cost = self.gas_budget;
+            self.force_computation_cost_to_budget = true;
         }
 
         fn gas_usage_report(&self) -> GasUsageReport {

--- a/crates/sui-types/src/gas_model/gas_v3.rs
+++ b/crates/sui-types/src/gas_model/gas_v3.rs
@@ -2,17 +2,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![deny(clippy::arithmetic_side_effects)]
+
 pub use checked::*;
 
-#[sui_macros::with_checked_arithmetic]
 mod checked {
     use crate::error::UserInputResult;
     use crate::gas::{GasCostSummary, GasUsageReport, SuiGasStatusAPI};
-    pub use crate::gas_model::gas_common::PerObjectStorage;
     use crate::gas_model::gas_common::{
         StorageGas, check_gas_data, check_gas_objects, half_digits_rounding, sender_rebate,
     };
-    use crate::gas_model::gas_predicates::{cost_table_for_version, txn_base_cost_as_multiplier};
+    use crate::gas_model::gas_predicates::cost_table_for_version;
     use crate::gas_model::units_types::CostTable;
     use crate::transaction::ObjectReadResult;
     use crate::{
@@ -24,78 +24,21 @@ mod checked {
     use move_core_types::vm_status::StatusCode;
     use sui_protocol_config::*;
 
-    /// A bucket defines a range of units that will be priced the same.
-    /// After execution a call to `GasStatus::bucketize` will round the computation
-    /// cost to `cost` for the bucket ([`min`, `max`]) the gas used falls into.
-    #[allow(dead_code)]
-    pub(crate) struct ComputationBucket {
-        min: u64,
-        max: u64,
-        cost: u64,
-    }
-
-    impl ComputationBucket {
-        fn new(min: u64, max: u64, cost: u64) -> Self {
-            ComputationBucket { min, max, cost }
-        }
-
-        fn simple(min: u64, max: u64) -> Self {
-            Self::new(min, max, max)
-        }
-    }
-
-    fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
-        for bucket in table {
-            if bucket.max >= computation_cost {
-                return bucket.cost;
-            }
-        }
-        match table.last() {
-            // maybe not a literal here could be better?
-            None => 5_000_000,
-            Some(bucket) => bucket.cost,
-        }
-    }
-
-    // define the bucket table for computation charging
-    // If versioning defines multiple functions and
-    fn computation_bucket(max_bucket_cost: u64) -> Vec<ComputationBucket> {
-        assert!(max_bucket_cost >= 5_000_000);
-        vec![
-            ComputationBucket::simple(0, 1_000),
-            ComputationBucket::simple(1_000, 5_000),
-            ComputationBucket::simple(5_000, 10_000),
-            ComputationBucket::simple(10_000, 20_000),
-            ComputationBucket::simple(20_000, 50_000),
-            ComputationBucket::simple(50_000, 200_000),
-            ComputationBucket::simple(200_000, 1_000_000),
-            ComputationBucket::simple(1_000_000, max_bucket_cost),
-        ]
-    }
-
     /// A list of constant costs of various operations in Sui.
     pub struct SuiCostTable {
-        /// A flat fee charged for every transaction. This is also the minimum amount of
-        /// gas charged for a transaction.
+        /// A flat fee charged for every transaction.
         pub(crate) min_transaction_cost: u64,
         /// Maximum allowable budget for a transaction.
         pub(crate) max_gas_budget: u64,
-        /// Computation cost per byte charged for package publish. This cost is primarily
-        /// determined by the cost to verify and link a package. Note that this does not
-        /// include the cost of writing the package to the store.
+        /// Computation cost per byte charged for package publish.
         package_publish_per_byte_cost: u64,
-        /// Per byte cost to read objects from the store. This is computation cost instead of
-        /// storage cost because it does not change the amount of data stored on the db.
+        /// Per byte cost to read objects from the store.
         object_read_per_byte_cost: u64,
-        /// Unit cost of a byte in the storage. This will be used both for charging for
-        /// new storage as well as rebating for deleting storage. That is, we expect users to
-        /// get full refund on the object storage when it's deleted.
+        /// Unit cost of a byte in the storage.
         storage_per_byte_cost: u64,
         /// Execution cost table to be used.
         pub execution_cost_table: CostTable,
-        /// Computation buckets to cost transaction in price groups
-        computation_bucket: Vec<ComputationBucket>,
-        /// Max gas price for aborted transactions.
+        /// RGP-multiplier cap on the effective gas price for aborted transactions.
         max_gas_price_rgp_factor_for_aborted_transactions: Option<u64>,
     }
 
@@ -110,11 +53,10 @@ mod checked {
         pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
             // gas_price here is the Reference Gas Price, however we may decide
             // to change it to be the price passed in the transaction
-            let min_transaction_cost = if txn_base_cost_as_multiplier(c) {
-                c.base_tx_cost_fixed() * gas_price
-            } else {
-                c.base_tx_cost_fixed()
-            };
+            let min_transaction_cost = c
+                .base_tx_cost_fixed()
+                .checked_mul(gas_price)
+                .expect("base tx cost cannot overflow: gas_price is bounded by max_gas_price");
             Self {
                 min_transaction_cost,
                 max_gas_budget: c.max_tx_gas(),
@@ -122,7 +64,6 @@ mod checked {
                 object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
                 storage_per_byte_cost: c.obj_data_cost_refundable(),
                 execution_cost_table: cost_table_for_version(c.gas_model_version()),
-                computation_bucket: computation_bucket(c.max_gas_computation_bucket()),
                 max_gas_price_rgp_factor_for_aborted_transactions: c
                     .max_gas_price_rgp_factor_for_aborted_transactions_as_option(),
             }
@@ -136,22 +77,12 @@ mod checked {
                 object_read_per_byte_cost: 0,
                 storage_per_byte_cost: 0,
                 execution_cost_table: ZERO_COST_SCHEDULE.clone(),
-                // should not matter
-                computation_bucket: computation_bucket(5_000_000),
                 max_gas_price_rgp_factor_for_aborted_transactions: None,
             }
         }
     }
 
-    #[derive(Debug, Clone, Copy)]
-    enum GasRoundingMode {
-        /// Bucketize the computation cost according to predefined buckets.
-        Bucketize,
-        /// Rounding value to round up gas charges.
-        Stepped(u64),
-        /// Round by keeping just over half digits
-        KeepHalfDigits,
-    }
+    pub use crate::gas_model::gas_common::PerObjectStorage;
 
     #[allow(dead_code)]
     #[derive(Debug)]
@@ -161,29 +92,22 @@ mod checked {
         // Cost table contains a set of constant/config for the gas model/charging
         cost_table: SuiCostTable,
         // Gas budget for this gas status instance.
-        // Typically the gas budget as defined in the `TransactionData::GasData`
         gas_budget: u64,
-        // Computation cost after execution. This is the result of the gas used by the `GasStatus`
-        // properly bucketized.
-        // Starts at 0 and it is assigned in `bucketize_computation`.
-        computation_cost: u64,
         // Whether to charge or go unmetered
         charge: bool,
-        // Gas price for computation.
-        // This is a multiplier on the final charge as related to the RGP (reference gas price).
-        // Checked at signing: `gas_price >= reference_gas_price`
-        // and then conceptually
-        // `final_computation_cost = total_computation_cost * gas_price / reference_gas_price`
-        gas_price: u64,
+        // Price used to convert gas units to MIST; starts at `user_gas_price`, lowered to the abort cap
+        // by `bucketize_computation` on a Move abort.
+        effective_gas_price: u64,
+        // The gas price the user signed for (>= reference_gas_price).
+        user_gas_price: u64,
         // RGP as defined in the protocol config.
         reference_gas_price: u64,
         // storage rebate rate as defined in the ProtocolConfig
         rebate_rate: u64,
-        /// Per-object storage accounting (accumulated costs/rebates + the storage config it needs),
-        /// shared with gas_v3 via `gas_common::StorageGas`.
+        /// Per-object storage accounting .
         storage: StorageGas,
-        /// Rounding mode for gas charges.
-        gas_rounding_mode: GasRoundingMode,
+        /// When set, computation cost is reported as exactly `gas_budget`.
+        force_computation_cost_to_budget: bool,
     }
 
     impl SuiGasStatus {
@@ -191,29 +115,23 @@ mod checked {
             move_gas_status: GasStatus,
             gas_budget: u64,
             charge: bool,
-            gas_price: u64,
+            user_gas_price: u64,
             reference_gas_price: u64,
             storage_gas_price: u64,
             rebate_rate: u64,
-            gas_rounding_mode: GasRoundingMode,
             cost_table: SuiCostTable,
         ) -> SuiGasStatus {
-            let gas_rounding_mode = match gas_rounding_mode {
-                GasRoundingMode::Bucketize => GasRoundingMode::Bucketize,
-                GasRoundingMode::Stepped(val) => GasRoundingMode::Stepped(val.max(1)),
-                GasRoundingMode::KeepHalfDigits => GasRoundingMode::KeepHalfDigits,
-            };
             SuiGasStatus {
                 gas_status: move_gas_status,
                 gas_budget,
                 charge,
-                computation_cost: 0,
-                gas_price,
+                effective_gas_price: user_gas_price,
+                user_gas_price,
                 reference_gas_price,
                 rebate_rate,
                 storage: StorageGas::new(storage_gas_price, cost_table.storage_per_byte_cost),
-                gas_rounding_mode,
                 cost_table,
+                force_computation_cost_to_budget: false,
             }
         }
 
@@ -224,20 +142,18 @@ mod checked {
             config: &ProtocolConfig,
         ) -> SuiGasStatus {
             let storage_gas_price = config.storage_gas_price();
-            let max_computation_budget = config.max_gas_computation_bucket() * gas_price;
+            let max_computation_budget = config
+                .max_gas_computation_bucket()
+                .checked_mul(gas_price)
+                .expect(
+                    "computation budget cannot overflow: gas_price is bounded by max_gas_price",
+                );
             let computation_budget = if gas_budget > max_computation_budget {
                 max_computation_budget
             } else {
                 gas_budget
             };
             let sui_cost_table = SuiCostTable::new(config, gas_price);
-            let gas_rounding_mode = if config.gas_rounding_halve_digits() {
-                GasRoundingMode::KeepHalfDigits
-            } else if let Some(step) = config.gas_rounding_step_as_option() {
-                GasRoundingMode::Stepped(step)
-            } else {
-                GasRoundingMode::Bucketize
-            };
             Self::new(
                 GasStatus::new(
                     sui_cost_table.execution_cost_table.clone(),
@@ -251,7 +167,6 @@ mod checked {
                 reference_gas_price,
                 storage_gas_price,
                 config.storage_rebate_rate(),
-                gas_rounding_mode,
                 sui_cost_table,
             )
         }
@@ -265,13 +180,34 @@ mod checked {
                 0,
                 0,
                 0,
-                GasRoundingMode::Bucketize,
                 SuiCostTable::unmetered(),
             )
         }
 
         pub fn reference_gas_price(&self) -> u64 {
             self.reference_gas_price
+        }
+
+        /// Meter-derived computation cost in MIST (bucketed units × effective_gas_price).
+        fn uncapped_computation_cost(&self) -> u64 {
+            if self.force_computation_cost_to_budget {
+                return self.gas_budget;
+            }
+            let raw_units = self.gas_status.gas_used_pre_gas_price();
+            let bucketed_units = half_digits_rounding(raw_units);
+            bucketed_units.saturating_mul(self.effective_gas_price)
+        }
+
+        /// Computation cost reported in `summary()`, capped so
+        /// `computation + storage_cost - sender_rebate ≤ gas_budget`
+        /// storage charges stick, computation absorbs whatever budget remains.
+        fn derived_computation_cost(&self) -> u64 {
+            let uncapped_cost = self.uncapped_computation_cost();
+            let storage_rebate = self.storage_rebate();
+            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+            let net_storage = self.storage_cost().saturating_sub(sender_rebate);
+            let max_computation = self.gas_budget.saturating_sub(net_storage);
+            uncapped_cost.min(max_computation)
         }
 
         fn storage_cost(&self) -> u64 {
@@ -293,60 +229,35 @@ mod checked {
         }
 
         fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
-            let gas_used = self.gas_status.gas_used_pre_gas_price();
-            let effective_gas_price = if let Some(max_gas_price_rgp_factor_for_aborted_transactions) =
-                self.cost_table
-                    .max_gas_price_rgp_factor_for_aborted_transactions
-                && aborted.unwrap_or(false)
+            self.effective_gas_price = match self
+                .cost_table
+                .max_gas_price_rgp_factor_for_aborted_transactions
             {
-                // For aborts, cap at max but don't exceed user's price
-                // This minimizes the risk of competing for priority execution in the case that the txn may be aborted.
-                let max_gas_price_for_aborted_txns =
-                    max_gas_price_rgp_factor_for_aborted_transactions * self.reference_gas_price;
-                self.gas_price.min(max_gas_price_for_aborted_txns)
-            } else {
-                // For all other cases, use the user's gas price
-                self.gas_price
+                Some(factor) if aborted.unwrap_or(false) => {
+                    let cap = factor
+                        .checked_mul(self.reference_gas_price)
+                        .ok_or_else(|| {
+                            ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation)
+                        })?;
+                    self.user_gas_price.min(cap)
+                }
+                _ => self.user_gas_price,
             };
-            let gas_used = match self.gas_rounding_mode {
-                GasRoundingMode::KeepHalfDigits => {
-                    half_digits_rounding(gas_used) * effective_gas_price
-                }
-                GasRoundingMode::Stepped(gas_rounding) => {
-                    if gas_used > 0 && gas_used % gas_rounding == 0 {
-                        gas_used * effective_gas_price
-                    } else {
-                        ((gas_used / gas_rounding) + 1) * gas_rounding * effective_gas_price
-                    }
-                }
-                GasRoundingMode::Bucketize => {
-                    let bucket_cost =
-                        get_bucket_cost(&self.cost_table.computation_bucket, gas_used);
-                    // charge extra on top of `computation_cost` to make the total computation
-                    // cost a bucket value
-                    bucket_cost * effective_gas_price
-                }
-            };
-            if self.gas_budget <= gas_used {
-                self.computation_cost = self.gas_budget;
-                Err(ExecutionErrorKind::InsufficientGas.into())
-            } else {
-                self.computation_cost = gas_used;
-                Ok(())
+            if self.uncapped_computation_cost() >= self.gas_budget {
+                return Err(ExecutionErrorKind::InsufficientGas.into());
             }
+            Ok(())
         }
 
-        /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
-        /// We use initial budget, combined with remaining gas and storage cost to derive
-        /// computation cost.
+        /// Returns the gas cost summary for the transaction.
         fn summary(&self) -> GasCostSummary {
-            // compute storage rebate, both rebate and non refundable fee
             let storage_rebate = self.storage_rebate();
             let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
-            assert!(sender_rebate <= storage_rebate);
-            let non_refundable_storage_fee = storage_rebate - sender_rebate;
+            let non_refundable_storage_fee = storage_rebate
+                .checked_sub(sender_rebate)
+                .expect("sender rebate must not exceed storage rebate");
             GasCostSummary {
-                computation_cost: self.computation_cost,
+                computation_cost: self.derived_computation_cost(),
                 storage_cost: self.storage_cost(),
                 storage_rebate: sender_rebate,
                 non_refundable_storage_fee,
@@ -358,7 +269,7 @@ mod checked {
         }
 
         fn gas_price(&self) -> u64 {
-            self.gas_price
+            self.user_gas_price
         }
 
         fn reference_gas_price(&self) -> u64 {
@@ -404,9 +315,8 @@ mod checked {
         }
 
         /// Update `storage_rebate` and `storage_gas_units` for each object in the transaction.
-        /// There is no charge in this function. Charges will all be applied together at the end
-        /// (`track_storage_mutation`).
-        /// Return the new storage rebate (cost of object storage) according to `new_size`.
+        /// Return the new storage rebate (cost of object storage) according to `new_size` or
+        /// `None` on arithmetic errors.
         fn track_storage_mutation(
             &mut self,
             object_id: ObjectID,
@@ -419,31 +329,24 @@ mod checked {
         }
 
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
-            let storage_rebate = self.storage_rebate();
-            let storage_cost = self.storage_cost();
+            let storage_rebate = self.storage.storage_rebate();
+            let storage_cost = self.storage.storage_gas_units();
             let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
             assert!(sender_rebate <= storage_rebate);
-            if sender_rebate >= storage_cost {
-                // there is more rebate than cost, when deducting gas we are adding
-                // to whatever is the current amount charged so we are `Ok`
-                Ok(())
-            } else {
-                let gas_left = self.gas_budget - self.computation_cost;
-                // we have to charge for storage and may go out of gas, check
-                if gas_left < storage_cost - sender_rebate {
-                    // Running out of gas would cause the temporary store to reset
-                    // and zero storage and rebate.
-                    // The remaining_gas will be 0 and we will charge all in computation
-                    Err(ExecutionErrorKind::InsufficientGas.into())
-                } else {
-                    Ok(())
-                }
+            let net_storage_cost = storage_cost.saturating_sub(sender_rebate);
+            let gas_left = self
+                .gas_budget
+                .saturating_sub(self.uncapped_computation_cost());
+            if net_storage_cost > gas_left {
+                return Err(ExecutionErrorKind::InsufficientGas.into());
             }
+            Ok(())
         }
 
+        /// Drop accumulated storage and force `summary()` to report `computation_cost == gas_budget`
         fn adjust_computation_on_out_of_gas(&mut self) {
             self.storage.reset();
-            self.computation_cost = self.gas_budget;
+            self.force_computation_cost_to_budget = true;
         }
 
         fn gas_usage_report(&self) -> GasUsageReport {

--- a/crates/sui-types/src/gas_model/gas_v3.rs
+++ b/crates/sui-types/src/gas_model/gas_v3.rs
@@ -5,6 +5,8 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(clippy::indexing_slicing)]
+#![deny(clippy::cast_possible_wrap)]
+#![deny(clippy::cast_sign_loss)]
 
 use crate::error::UserInputResult;
 use crate::gas::{GasCostSummary, GasUsageReport, SuiGasStatusAPI};
@@ -185,7 +187,7 @@ impl SuiGasStatus {
         self.reference_gas_price
     }
 
-    /// Meter-derived computation cost in MIST (bucketed units × effective_gas_price).
+    /// Meter-derived computation cost in MIST (bucketed units * effective_gas_price).
     fn uncapped_computation_cost(&self) -> u64 {
         if self.force_computation_cost_to_budget {
             return self.gas_budget;
@@ -196,7 +198,7 @@ impl SuiGasStatus {
     }
 
     /// Computation cost reported in `summary()`, capped so
-    /// `computation + storage_cost - sender_rebate ≤ gas_budget`
+    /// `computation + storage_cost - sender_rebate <= gas_budget`
     /// storage charges stick, computation absorbs whatever budget remains.
     fn derived_computation_cost(&self) -> u64 {
         let uncapped_cost = self.uncapped_computation_cost();

--- a/crates/sui-types/src/gas_model/gas_v3.rs
+++ b/crates/sui-types/src/gas_model/gas_v3.rs
@@ -3,391 +3,387 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(clippy::arithmetic_side_effects)]
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::indexing_slicing)]
 
-pub use checked::*;
+use crate::error::UserInputResult;
+use crate::gas::{GasCostSummary, GasUsageReport, SuiGasStatusAPI};
+use crate::gas_model::gas_common::{
+    StorageGas, check_gas_data, check_gas_objects, half_digits_rounding, sender_rebate,
+};
+use crate::gas_model::gas_predicates::cost_table_for_version;
+use crate::gas_model::units_types::CostTable;
+use crate::transaction::ObjectReadResult;
+use crate::{
+    ObjectID,
+    error::ExecutionError,
+    execution_status::ExecutionErrorKind,
+    gas_model::tables::{GasStatus, ZERO_COST_SCHEDULE},
+};
+use move_core_types::vm_status::StatusCode;
+use sui_protocol_config::*;
 
-mod checked {
-    use crate::error::UserInputResult;
-    use crate::gas::{GasCostSummary, GasUsageReport, SuiGasStatusAPI};
-    use crate::gas_model::gas_common::{
-        StorageGas, check_gas_data, check_gas_objects, half_digits_rounding, sender_rebate,
-    };
-    use crate::gas_model::gas_predicates::cost_table_for_version;
-    use crate::gas_model::units_types::CostTable;
-    use crate::transaction::ObjectReadResult;
-    use crate::{
-        ObjectID,
-        error::ExecutionError,
-        execution_status::ExecutionErrorKind,
-        gas_model::tables::{GasStatus, ZERO_COST_SCHEDULE},
-    };
-    use move_core_types::vm_status::StatusCode;
-    use sui_protocol_config::*;
+/// A list of constant costs of various operations in Sui.
+pub struct SuiCostTable {
+    /// A flat fee charged for every transaction.
+    pub(crate) min_transaction_cost: u64,
+    /// Maximum allowable budget for a transaction.
+    pub(crate) max_gas_budget: u64,
+    /// Computation cost per byte charged for package publish.
+    package_publish_per_byte_cost: u64,
+    /// Per byte cost to read objects from the store.
+    object_read_per_byte_cost: u64,
+    /// Unit cost of a byte in the storage.
+    storage_per_byte_cost: u64,
+    /// Execution cost table to be used.
+    pub execution_cost_table: CostTable,
+    /// RGP-multiplier cap on the effective gas price for aborted transactions.
+    max_gas_price_rgp_factor_for_aborted_transactions: Option<u64>,
+}
 
-    /// A list of constant costs of various operations in Sui.
-    pub struct SuiCostTable {
-        /// A flat fee charged for every transaction.
-        pub(crate) min_transaction_cost: u64,
-        /// Maximum allowable budget for a transaction.
-        pub(crate) max_gas_budget: u64,
-        /// Computation cost per byte charged for package publish.
-        package_publish_per_byte_cost: u64,
-        /// Per byte cost to read objects from the store.
-        object_read_per_byte_cost: u64,
-        /// Unit cost of a byte in the storage.
-        storage_per_byte_cost: u64,
-        /// Execution cost table to be used.
-        pub execution_cost_table: CostTable,
-        /// RGP-multiplier cap on the effective gas price for aborted transactions.
-        max_gas_price_rgp_factor_for_aborted_transactions: Option<u64>,
+impl std::fmt::Debug for SuiCostTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: dump the fields.
+        write!(f, "SuiCostTable(...)")
     }
+}
 
-    impl std::fmt::Debug for SuiCostTable {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            // TODO: dump the fields.
-            write!(f, "SuiCostTable(...)")
+impl SuiCostTable {
+    pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
+        // gas_price here is the Reference Gas Price, however we may decide
+        // to change it to be the price passed in the transaction
+        let min_transaction_cost = c
+            .base_tx_cost_fixed()
+            .checked_mul(gas_price)
+            .expect("base tx cost cannot overflow: gas_price is bounded by max_gas_price");
+        Self {
+            min_transaction_cost,
+            max_gas_budget: c.max_tx_gas(),
+            package_publish_per_byte_cost: c.package_publish_cost_per_byte(),
+            object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
+            storage_per_byte_cost: c.obj_data_cost_refundable(),
+            execution_cost_table: cost_table_for_version(c.gas_model_version()),
+            max_gas_price_rgp_factor_for_aborted_transactions: c
+                .max_gas_price_rgp_factor_for_aborted_transactions_as_option(),
         }
     }
 
-    impl SuiCostTable {
-        pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
-            // gas_price here is the Reference Gas Price, however we may decide
-            // to change it to be the price passed in the transaction
-            let min_transaction_cost = c
-                .base_tx_cost_fixed()
-                .checked_mul(gas_price)
-                .expect("base tx cost cannot overflow: gas_price is bounded by max_gas_price");
-            Self {
-                min_transaction_cost,
-                max_gas_budget: c.max_tx_gas(),
-                package_publish_per_byte_cost: c.package_publish_cost_per_byte(),
-                object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
-                storage_per_byte_cost: c.obj_data_cost_refundable(),
-                execution_cost_table: cost_table_for_version(c.gas_model_version()),
-                max_gas_price_rgp_factor_for_aborted_transactions: c
-                    .max_gas_price_rgp_factor_for_aborted_transactions_as_option(),
-            }
-        }
-
-        pub(crate) fn unmetered() -> Self {
-            Self {
-                min_transaction_cost: 0,
-                max_gas_budget: u64::MAX,
-                package_publish_per_byte_cost: 0,
-                object_read_per_byte_cost: 0,
-                storage_per_byte_cost: 0,
-                execution_cost_table: ZERO_COST_SCHEDULE.clone(),
-                max_gas_price_rgp_factor_for_aborted_transactions: None,
-            }
+    pub(crate) fn unmetered() -> Self {
+        Self {
+            min_transaction_cost: 0,
+            max_gas_budget: u64::MAX,
+            package_publish_per_byte_cost: 0,
+            object_read_per_byte_cost: 0,
+            storage_per_byte_cost: 0,
+            execution_cost_table: ZERO_COST_SCHEDULE.clone(),
+            max_gas_price_rgp_factor_for_aborted_transactions: None,
         }
     }
+}
 
-    pub use crate::gas_model::gas_common::PerObjectStorage;
+pub use crate::gas_model::gas_common::PerObjectStorage;
 
-    #[allow(dead_code)]
-    #[derive(Debug)]
-    pub struct SuiGasStatus {
-        // GasStatus as used by the VM, that is all the VM sees
-        pub gas_status: GasStatus,
-        // Cost table contains a set of constant/config for the gas model/charging
-        cost_table: SuiCostTable,
-        // Gas budget for this gas status instance.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct SuiGasStatus {
+    // GasStatus as used by the VM, that is all the VM sees
+    pub gas_status: GasStatus,
+    // Cost table contains a set of constant/config for the gas model/charging
+    cost_table: SuiCostTable,
+    // Gas budget for this gas status instance.
+    gas_budget: u64,
+    // Whether to charge or go unmetered
+    charge: bool,
+    // Price used to convert gas units to MIST; starts at `user_gas_price`, lowered to the abort cap
+    // by `bucketize_computation` on a Move abort.
+    effective_gas_price: u64,
+    // The gas price the user signed for (>= reference_gas_price).
+    user_gas_price: u64,
+    // RGP as defined in the protocol config.
+    reference_gas_price: u64,
+    // storage rebate rate as defined in the ProtocolConfig
+    rebate_rate: u64,
+    /// Per-object storage accounting .
+    storage: StorageGas,
+    /// When set, computation cost is reported as exactly `gas_budget`.
+    force_computation_cost_to_budget: bool,
+}
+
+impl SuiGasStatus {
+    fn new(
+        move_gas_status: GasStatus,
         gas_budget: u64,
-        // Whether to charge or go unmetered
         charge: bool,
-        // Price used to convert gas units to MIST; starts at `user_gas_price`, lowered to the abort cap
-        // by `bucketize_computation` on a Move abort.
-        effective_gas_price: u64,
-        // The gas price the user signed for (>= reference_gas_price).
         user_gas_price: u64,
-        // RGP as defined in the protocol config.
         reference_gas_price: u64,
-        // storage rebate rate as defined in the ProtocolConfig
+        storage_gas_price: u64,
         rebate_rate: u64,
-        /// Per-object storage accounting .
-        storage: StorageGas,
-        /// When set, computation cost is reported as exactly `gas_budget`.
-        force_computation_cost_to_budget: bool,
+        cost_table: SuiCostTable,
+    ) -> SuiGasStatus {
+        SuiGasStatus {
+            gas_status: move_gas_status,
+            gas_budget,
+            charge,
+            effective_gas_price: user_gas_price,
+            user_gas_price,
+            reference_gas_price,
+            rebate_rate,
+            storage: StorageGas::new(storage_gas_price, cost_table.storage_per_byte_cost),
+            cost_table,
+            force_computation_cost_to_budget: false,
+        }
     }
 
-    impl SuiGasStatus {
-        fn new(
-            move_gas_status: GasStatus,
-            gas_budget: u64,
-            charge: bool,
-            user_gas_price: u64,
-            reference_gas_price: u64,
-            storage_gas_price: u64,
-            rebate_rate: u64,
-            cost_table: SuiCostTable,
-        ) -> SuiGasStatus {
-            SuiGasStatus {
-                gas_status: move_gas_status,
-                gas_budget,
-                charge,
-                effective_gas_price: user_gas_price,
-                user_gas_price,
-                reference_gas_price,
-                rebate_rate,
-                storage: StorageGas::new(storage_gas_price, cost_table.storage_per_byte_cost),
-                cost_table,
-                force_computation_cost_to_budget: false,
-            }
-        }
-
-        pub(crate) fn new_with_budget(
-            gas_budget: u64,
-            gas_price: u64,
-            reference_gas_price: u64,
-            config: &ProtocolConfig,
-        ) -> SuiGasStatus {
-            let storage_gas_price = config.storage_gas_price();
-            let max_computation_budget = config
-                .max_gas_computation_bucket()
-                .checked_mul(gas_price)
-                .expect(
-                    "computation budget cannot overflow: gas_price is bounded by max_gas_price",
-                );
-            let computation_budget = if gas_budget > max_computation_budget {
-                max_computation_budget
-            } else {
-                gas_budget
-            };
-            let sui_cost_table = SuiCostTable::new(config, gas_price);
-            Self::new(
-                GasStatus::new(
-                    sui_cost_table.execution_cost_table.clone(),
-                    computation_budget,
-                    gas_price,
-                    config.gas_model_version(),
-                ),
-                gas_budget,
-                true,
+    pub(crate) fn new_with_budget(
+        gas_budget: u64,
+        gas_price: u64,
+        reference_gas_price: u64,
+        config: &ProtocolConfig,
+    ) -> SuiGasStatus {
+        let storage_gas_price = config.storage_gas_price();
+        let max_computation_budget = config
+            .max_gas_computation_bucket()
+            .checked_mul(gas_price)
+            .expect("computation budget cannot overflow: gas_price is bounded by max_gas_price");
+        let computation_budget = if gas_budget > max_computation_budget {
+            max_computation_budget
+        } else {
+            gas_budget
+        };
+        let sui_cost_table = SuiCostTable::new(config, gas_price);
+        Self::new(
+            GasStatus::new(
+                sui_cost_table.execution_cost_table.clone(),
+                computation_budget,
                 gas_price,
-                reference_gas_price,
-                storage_gas_price,
-                config.storage_rebate_rate(),
-                sui_cost_table,
-            )
-        }
+                config.gas_model_version(),
+            ),
+            gas_budget,
+            true,
+            gas_price,
+            reference_gas_price,
+            storage_gas_price,
+            config.storage_rebate_rate(),
+            sui_cost_table,
+        )
+    }
 
-        pub fn new_unmetered() -> SuiGasStatus {
-            Self::new(
-                GasStatus::new_unmetered(),
-                0,
-                false,
-                0,
-                0,
-                0,
-                0,
-                SuiCostTable::unmetered(),
-            )
-        }
+    pub fn new_unmetered() -> SuiGasStatus {
+        Self::new(
+            GasStatus::new_unmetered(),
+            0,
+            false,
+            0,
+            0,
+            0,
+            0,
+            SuiCostTable::unmetered(),
+        )
+    }
 
-        pub fn reference_gas_price(&self) -> u64 {
-            self.reference_gas_price
-        }
+    pub fn reference_gas_price(&self) -> u64 {
+        self.reference_gas_price
+    }
 
-        /// Meter-derived computation cost in MIST (bucketed units × effective_gas_price).
-        fn uncapped_computation_cost(&self) -> u64 {
-            if self.force_computation_cost_to_budget {
-                return self.gas_budget;
+    /// Meter-derived computation cost in MIST (bucketed units × effective_gas_price).
+    fn uncapped_computation_cost(&self) -> u64 {
+        if self.force_computation_cost_to_budget {
+            return self.gas_budget;
+        }
+        let raw_units = self.gas_status.gas_used_pre_gas_price();
+        let bucketed_units = half_digits_rounding(raw_units);
+        bucketed_units.saturating_mul(self.effective_gas_price)
+    }
+
+    /// Computation cost reported in `summary()`, capped so
+    /// `computation + storage_cost - sender_rebate ≤ gas_budget`
+    /// storage charges stick, computation absorbs whatever budget remains.
+    fn derived_computation_cost(&self) -> u64 {
+        let uncapped_cost = self.uncapped_computation_cost();
+        let storage_rebate = self.storage_rebate();
+        let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+        let net_storage = self.storage_cost().saturating_sub(sender_rebate);
+        let max_computation = self.gas_budget.saturating_sub(net_storage);
+        uncapped_cost.min(max_computation)
+    }
+
+    fn storage_cost(&self) -> u64 {
+        self.storage_gas_units()
+    }
+}
+
+impl SuiGasStatusAPI for SuiGasStatus {
+    fn is_unmetered(&self) -> bool {
+        !self.charge
+    }
+
+    fn move_gas_status(&self) -> &GasStatus {
+        &self.gas_status
+    }
+
+    fn move_gas_status_mut(&mut self) -> &mut GasStatus {
+        &mut self.gas_status
+    }
+
+    fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
+        self.effective_gas_price = match self
+            .cost_table
+            .max_gas_price_rgp_factor_for_aborted_transactions
+        {
+            Some(factor) if aborted.unwrap_or(false) => {
+                let cap = factor
+                    .checked_mul(self.reference_gas_price)
+                    .ok_or_else(|| {
+                        ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation)
+                    })?;
+                self.user_gas_price.min(cap)
             }
-            let raw_units = self.gas_status.gas_used_pre_gas_price();
-            let bucketed_units = half_digits_rounding(raw_units);
-            bucketed_units.saturating_mul(self.effective_gas_price)
+            _ => self.user_gas_price,
+        };
+        if self.uncapped_computation_cost() >= self.gas_budget {
+            return Err(ExecutionErrorKind::InsufficientGas.into());
         }
+        Ok(())
+    }
 
-        /// Computation cost reported in `summary()`, capped so
-        /// `computation + storage_cost - sender_rebate ≤ gas_budget`
-        /// storage charges stick, computation absorbs whatever budget remains.
-        fn derived_computation_cost(&self) -> u64 {
-            let uncapped_cost = self.uncapped_computation_cost();
-            let storage_rebate = self.storage_rebate();
-            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
-            let net_storage = self.storage_cost().saturating_sub(sender_rebate);
-            let max_computation = self.gas_budget.saturating_sub(net_storage);
-            uncapped_cost.min(max_computation)
-        }
-
-        fn storage_cost(&self) -> u64 {
-            self.storage_gas_units()
+    /// Returns the gas cost summary for the transaction.
+    fn summary(&self) -> GasCostSummary {
+        let storage_rebate = self.storage_rebate();
+        let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+        let non_refundable_storage_fee = storage_rebate
+            .checked_sub(sender_rebate)
+            .expect("sender rebate must not exceed storage rebate");
+        GasCostSummary {
+            computation_cost: self.derived_computation_cost(),
+            storage_cost: self.storage_cost(),
+            storage_rebate: sender_rebate,
+            non_refundable_storage_fee,
         }
     }
 
-    impl SuiGasStatusAPI for SuiGasStatus {
-        fn is_unmetered(&self) -> bool {
-            !self.charge
-        }
+    fn gas_budget(&self) -> u64 {
+        self.gas_budget
+    }
 
-        fn move_gas_status(&self) -> &GasStatus {
-            &self.gas_status
-        }
+    fn gas_price(&self) -> u64 {
+        self.user_gas_price
+    }
 
-        fn move_gas_status_mut(&mut self) -> &mut GasStatus {
-            &mut self.gas_status
-        }
+    fn reference_gas_price(&self) -> u64 {
+        self.reference_gas_price
+    }
 
-        fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
-            self.effective_gas_price = match self
-                .cost_table
-                .max_gas_price_rgp_factor_for_aborted_transactions
-            {
-                Some(factor) if aborted.unwrap_or(false) => {
-                    let cap = factor
-                        .checked_mul(self.reference_gas_price)
-                        .ok_or_else(|| {
-                            ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation)
-                        })?;
-                    self.user_gas_price.min(cap)
-                }
-                _ => self.user_gas_price,
-            };
-            if self.uncapped_computation_cost() >= self.gas_budget {
-                return Err(ExecutionErrorKind::InsufficientGas.into());
-            }
-            Ok(())
-        }
+    fn storage_gas_units(&self) -> u64 {
+        self.storage.storage_gas_units()
+    }
 
-        /// Returns the gas cost summary for the transaction.
-        fn summary(&self) -> GasCostSummary {
-            let storage_rebate = self.storage_rebate();
-            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
-            let non_refundable_storage_fee = storage_rebate
-                .checked_sub(sender_rebate)
-                .expect("sender rebate must not exceed storage rebate");
-            GasCostSummary {
-                computation_cost: self.derived_computation_cost(),
-                storage_cost: self.storage_cost(),
-                storage_rebate: sender_rebate,
-                non_refundable_storage_fee,
-            }
-        }
+    fn storage_rebate(&self) -> u64 {
+        self.storage.storage_rebate()
+    }
 
-        fn gas_budget(&self) -> u64 {
-            self.gas_budget
-        }
+    fn unmetered_storage_rebate(&self) -> u64 {
+        self.storage.unmetered_storage_rebate()
+    }
 
-        fn gas_price(&self) -> u64 {
-            self.user_gas_price
-        }
+    fn gas_used(&self) -> u64 {
+        self.gas_status.gas_used_pre_gas_price()
+    }
 
-        fn reference_gas_price(&self) -> u64 {
-            self.reference_gas_price
-        }
+    fn reset_storage_cost_and_rebate(&mut self) {
+        self.storage.reset();
+    }
 
-        fn storage_gas_units(&self) -> u64 {
-            self.storage.storage_gas_units()
-        }
+    fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
+        self.gas_status
+            .charge_bytes(size, self.cost_table.object_read_per_byte_cost)
+            .map_err(|e| {
+                debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+                ExecutionErrorKind::InsufficientGas.into()
+            })
+    }
 
-        fn storage_rebate(&self) -> u64 {
-            self.storage.storage_rebate()
-        }
+    fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
+        self.gas_status
+            .charge_bytes(size, self.cost_table.package_publish_per_byte_cost)
+            .map_err(|e| {
+                debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+                ExecutionErrorKind::InsufficientGas.into()
+            })
+    }
 
-        fn unmetered_storage_rebate(&self) -> u64 {
-            self.storage.unmetered_storage_rebate()
-        }
+    /// Update `storage_rebate` and `storage_gas_units` for each object in the transaction.
+    /// Return the new storage rebate (cost of object storage) according to `new_size` or
+    /// `None` on arithmetic errors.
+    fn track_storage_mutation(
+        &mut self,
+        object_id: ObjectID,
+        new_size: usize,
+        storage_rebate: u64,
+    ) -> Option<u64> {
+        let unmetered = self.is_unmetered();
+        self.storage
+            .track_mutation(object_id, new_size, storage_rebate, unmetered)
+    }
 
-        fn gas_used(&self) -> u64 {
-            self.gas_status.gas_used_pre_gas_price()
+    fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
+        let storage_rebate = self.storage.storage_rebate();
+        let storage_cost = self.storage.storage_gas_units();
+        let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+        assert!(sender_rebate <= storage_rebate);
+        let net_storage_cost = storage_cost.saturating_sub(sender_rebate);
+        let gas_left = self
+            .gas_budget
+            .saturating_sub(self.uncapped_computation_cost());
+        if net_storage_cost > gas_left {
+            return Err(ExecutionErrorKind::InsufficientGas.into());
         }
+        Ok(())
+    }
 
-        fn reset_storage_cost_and_rebate(&mut self) {
-            self.storage.reset();
-        }
+    /// Drop accumulated storage and force `summary()` to report `computation_cost == gas_budget`
+    fn adjust_computation_on_out_of_gas(&mut self) {
+        self.storage.reset();
+        self.force_computation_cost_to_budget = true;
+    }
 
-        fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
-            self.gas_status
-                .charge_bytes(size, self.cost_table.object_read_per_byte_cost)
-                .map_err(|e| {
-                    debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
-                    ExecutionErrorKind::InsufficientGas.into()
-                })
+    fn gas_usage_report(&self) -> GasUsageReport {
+        GasUsageReport {
+            cost_summary: self.summary(),
+            gas_used: self.gas_used(),
+            gas_price: self.gas_price(),
+            reference_gas_price: self.reference_gas_price(),
+            per_object_storage: self.per_object_storage().clone(),
+            gas_budget: self.gas_budget(),
+            storage_gas_price: self.storage.storage_gas_price,
+            rebate_rate: self.rebate_rate,
         }
+    }
 
-        fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
-            self.gas_status
-                .charge_bytes(size, self.cost_table.package_publish_per_byte_cost)
-                .map_err(|e| {
-                    debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
-                    ExecutionErrorKind::InsufficientGas.into()
-                })
-        }
+    // Check whether gas arguments are legit:
+    // 1. Gas object has an address owner.
+    // 2. Gas budget is between min and max budget allowed
+    // 3. Gas balance (all gas coins together) is bigger or equal to budget
+    fn check_gas_balance(
+        &self,
+        gas_objs: &[&ObjectReadResult],
+        gas_budget: u64,
+        available_address_balance_gas: u64,
+    ) -> UserInputResult {
+        self.check_gas_objects(gas_objs)?;
+        check_gas_data(
+            gas_objs,
+            gas_budget,
+            available_address_balance_gas,
+            self.cost_table.min_transaction_cost,
+            self.cost_table.max_gas_budget,
+        )
+    }
 
-        /// Update `storage_rebate` and `storage_gas_units` for each object in the transaction.
-        /// Return the new storage rebate (cost of object storage) according to `new_size` or
-        /// `None` on arithmetic errors.
-        fn track_storage_mutation(
-            &mut self,
-            object_id: ObjectID,
-            new_size: usize,
-            storage_rebate: u64,
-        ) -> Option<u64> {
-            let unmetered = self.is_unmetered();
-            self.storage
-                .track_mutation(object_id, new_size, storage_rebate, unmetered)
-        }
+    fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult {
+        check_gas_objects(gas_objs)
+    }
 
-        fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
-            let storage_rebate = self.storage.storage_rebate();
-            let storage_cost = self.storage.storage_gas_units();
-            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
-            assert!(sender_rebate <= storage_rebate);
-            let net_storage_cost = storage_cost.saturating_sub(sender_rebate);
-            let gas_left = self
-                .gas_budget
-                .saturating_sub(self.uncapped_computation_cost());
-            if net_storage_cost > gas_left {
-                return Err(ExecutionErrorKind::InsufficientGas.into());
-            }
-            Ok(())
-        }
-
-        /// Drop accumulated storage and force `summary()` to report `computation_cost == gas_budget`
-        fn adjust_computation_on_out_of_gas(&mut self) {
-            self.storage.reset();
-            self.force_computation_cost_to_budget = true;
-        }
-
-        fn gas_usage_report(&self) -> GasUsageReport {
-            GasUsageReport {
-                cost_summary: self.summary(),
-                gas_used: self.gas_used(),
-                gas_price: self.gas_price(),
-                reference_gas_price: self.reference_gas_price(),
-                per_object_storage: self.per_object_storage().clone(),
-                gas_budget: self.gas_budget(),
-                storage_gas_price: self.storage.storage_gas_price,
-                rebate_rate: self.rebate_rate,
-            }
-        }
-
-        // Check whether gas arguments are legit:
-        // 1. Gas object has an address owner.
-        // 2. Gas budget is between min and max budget allowed
-        // 3. Gas balance (all gas coins together) is bigger or equal to budget
-        fn check_gas_balance(
-            &self,
-            gas_objs: &[&ObjectReadResult],
-            gas_budget: u64,
-            available_address_balance_gas: u64,
-        ) -> UserInputResult {
-            self.check_gas_objects(gas_objs)?;
-            check_gas_data(
-                gas_objs,
-                gas_budget,
-                available_address_balance_gas,
-                self.cost_table.min_transaction_cost,
-                self.cost_table.max_gas_budget,
-            )
-        }
-
-        fn check_gas_objects(&self, gas_objs: &[&ObjectReadResult]) -> UserInputResult {
-            check_gas_objects(gas_objs)
-        }
-
-        fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
-            self.storage.per_object_storage()
-        }
+    fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
+        self.storage.per_object_storage()
     }
 }

--- a/crates/sui-types/src/gas_model/mod.rs
+++ b/crates/sui-types/src/gas_model/mod.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod gas_common;
 pub mod gas_predicates;
 pub mod gas_v2;
+pub mod gas_v3;
 pub mod tables;
 pub mod units_types;

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -15,7 +15,7 @@ pub(crate) mod checked {
     use move_vm_runtime::runtime::MoveRuntime;
     use mysten_common::{assert_reachable, debug_fatal, in_test_configuration};
     use std::collections::{BTreeMap, BTreeSet};
-    use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
+    use std::{cell::RefCell, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
     use sui_types::balance::{
         BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
@@ -24,6 +24,7 @@ pub(crate) mod checked {
     use sui_types::coin_reservation::ParsedDigest;
     use sui_types::execution_params::ExecutionOrEarlyError;
     use sui_types::gas_coin::GAS;
+    use sui_types::gas_model::gas_predicates::use_step_gas_charging;
     use sui_types::messages_checkpoint::CheckpointTimestamp;
     use sui_types::metrics::ExecutionMetrics;
     use sui_types::object::OBJECT_START_VERSION;
@@ -88,10 +89,7 @@ pub(crate) mod checked {
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     };
 
-    /// Whether the *head* early error is `InsufficientFundsForWithdraw`. Used to gate the first
-    /// address-balance gas-payment pruning hotfix: the head error is the one surfaced as the
-    /// failure status, so keying off it (rather than any occurrence) keeps the pruning bit-for-bit
-    /// with the original single-error hotfix.
+    /// Whether the *head* early error is `InsufficientFundsForWithdraw`.
     fn head_error_is_insufficient_funds_for_withdraw(
         execution_params: &ExecutionOrEarlyError,
     ) -> bool {
@@ -103,7 +101,80 @@ pub(crate) mod checked {
         })
     }
 
+    /// Whether `InsufficientFundsForWithdraw` appears anywhere in the early-error list.
+    fn any_error_is_insufficient_funds_for_withdraw(
+        execution_params: &ExecutionOrEarlyError,
+    ) -> bool {
+        execution_params.early_errors().is_some_and(|errors| {
+            errors
+                .iter()
+                .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw))
+        })
+    }
+
+    /// Whether to short-circuit an IFFW transaction.
+    fn should_short_circuit_insufficient_funds(
+        execution_params: &ExecutionOrEarlyError,
+        _gas_data: &GasData,
+    ) -> bool {
+        // REVIEW AND DELETE COMMENT AFTER: this is a slightly different condition
+        // than latest. latest has `head_error_is_insufficient_funds_for_withdraw` an which
+        // is the only condition today.
+        // Commented is an alternative which may or may not work.
+        // If some better filter than the one below please comment
+        any_error_is_insufficient_funds_for_withdraw(execution_params)
+        // if !any_error_is_insufficient_funds_for_withdraw(execution_params) {
+        //     return false;
+        // }
+        // gas_data
+        //     .payment
+        //     .iter()
+        //     .any(|entry| ParsedDigest::try_from(entry.2).is_ok())
+    }
+
     fn payment_kind(
+        gas_data: &GasData,
+        transaction_kind: &TransactionKind,
+        protocol_config: &ProtocolConfig,
+        transaction_signer: SuiAddress,
+    ) -> PaymentKind {
+        if gas_data.is_unmetered() || transaction_kind.is_system_tx() {
+            PaymentKind::unmetered()
+        } else if protocol_config.enable_gasless()
+            && is_gasless_transaction(gas_data, transaction_kind)
+        {
+            let sponsor = (gas_data.owner != transaction_signer).then_some(gas_data.owner);
+            let reservations =
+                compute_gasless_reservations(transaction_kind, transaction_signer, sponsor)
+                    .unwrap_or_default();
+            PaymentKind::gasless_with_reservations(reservations)
+        } else if gas_data.payment.is_empty() {
+            PaymentKind::smash(vec![PaymentMethod::AddressBalance(
+                gas_data.owner,
+                gas_data.budget,
+            )])
+            .expect("unable to create a payment kind with a single address balance")
+        } else {
+            let payment_methods = gas_data
+                .payment
+                .iter()
+                .map(|entry| {
+                    if let Ok(parsed) = ParsedDigest::try_from(entry.2) {
+                        PaymentMethod::AddressBalance(gas_data.owner, parsed.reservation_amount())
+                    } else {
+                        PaymentMethod::Coin(*entry)
+                    }
+                })
+                .collect();
+            PaymentKind::smash(payment_methods).expect(
+                "unable to create a payment kind from payment methods. \
+                 Should not be possible wit ha non-empty vector",
+            )
+        }
+    }
+
+    // Legacy (gas_model < 15) payment classification (delete at execution version cut)
+    fn legacy_payment_kind(
         gas_data: &GasData,
         transaction_kind: &TransactionKind,
         protocol_config: &ProtocolConfig,
@@ -146,6 +217,13 @@ pub(crate) mod checked {
         Vec<ExecutionTiming>,
         Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
     );
+
+    /// Gas summary, execution result, and timings produced by `execute_transaction`.
+    type ExecutionOutcome<Mode> = (
+        GasCostSummary,
+        Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
+        Vec<ExecutionTiming>,
+    );
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
@@ -167,16 +245,11 @@ pub(crate) mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> ExecutionOutput<Mode> {
         let input_objects = input_objects.into_inner();
-        let mutable_inputs = if enable_expensive_checks {
-            input_objects.all_mutable_inputs().keys().copied().collect()
-        } else {
-            HashSet::new()
-        };
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
-        let transaction_dependencies = input_objects.transaction_dependencies();
+        let mut transaction_dependencies = input_objects.transaction_dependencies();
 
-        let temporary_store = TemporaryStore::new(
+        let mut temporary_store = TemporaryStore::new(
             store,
             input_objects,
             receiving_objects,
@@ -186,28 +259,176 @@ pub(crate) mod checked {
             system_object_versions,
         );
 
-        // TODO: remove all `legacy` code on the next execution version cut
-        legacy::execute_transaction_inner::<Mode>(
-            store,
+        if use_step_gas_charging(protocol_config.gas_model_version()) {
+            let Finalized {
+                gas,
+                status,
+                timings,
+                execution_result,
+            }: Finalized<Mode> = match execute_transaction_to_outcome::<Mode>(
+                store,
+                &mut temporary_store,
+                gas_data,
+                gas_status,
+                transaction_kind,
+                rewritten_inputs,
+                transaction_signer,
+                transaction_digest,
+                move_vm,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics.clone(),
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+            ) {
+                Outcome::Proceed {
+                    gas_charger,
+                    gas_cost_summary,
+                    execution_result,
+                    timings,
+                } => {
+                    let status = if let Err(error) = &execution_result {
+                        ExecutionStatus::new_failure(error.to_execution_failure())
+                    } else {
+                        ExecutionStatus::Success
+                    };
+                    let coin = gas_charger.gas_coin();
+                    Finalized {
+                        gas: GasOutcome {
+                            cost_summary: gas_cost_summary,
+                            coin,
+                            status: gas_charger.into_gas_status(),
+                        },
+                        status,
+                        timings,
+                        execution_result,
+                    }
+                }
+                Outcome::BumpOnly { gas_status, error } => {
+                    // Recorded no-op: consume the dropped store and rebuild from its inputs, keeping only
+                    // the input version bumps.
+                    temporary_store = temporary_store.into_recorded_noop();
+                    Finalized {
+                        gas: GasOutcome {
+                            cost_summary: GasCostSummary::default(),
+                            coin: None,
+                            status: gas_status,
+                        },
+                        status: ExecutionStatus::new_failure(error.to_execution_failure()),
+                        timings: vec![],
+                        execution_result: Err(error),
+                    }
+                }
+            };
+
+            // Shared infallible tail: trim the genesis dependency, build effects, telemetry.
+            let GasOutcome {
+                cost_summary,
+                coin,
+                status: gas_status,
+            } = gas;
+            #[skip_checked_arithmetic]
+            trace!(
+                tx_digest = ?transaction_digest,
+                computation_gas_cost = cost_summary.computation_cost,
+                storage_gas_cost = cost_summary.storage_cost,
+                storage_gas_rebate = cost_summary.storage_rebate,
+                "Finished execution of transaction with status {:?}",
+                status
+            );
+            transaction_dependencies.remove(&TransactionDigest::genesis_marker());
+            let (inner, effects) = temporary_store.into_effects(
+                shared_object_refs,
+                &transaction_digest,
+                transaction_dependencies,
+                cost_summary,
+                status,
+                coin,
+                *epoch_id,
+            );
+            // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
+            // spun-up each time.
+            if !Mode::TRACK_EXECUTION {
+                update_vm_telemetry_metrics(&metrics, move_vm);
+            }
+            (inner, gas_status, effects, timings, execution_result)
+        } else {
+            // TODO: remove all `legacy` code on the next execution version cut
+            legacy::execute_transaction_inner::<Mode>(
+                store,
+                temporary_store,
+                gas_data,
+                gas_status,
+                transaction_kind,
+                rewritten_inputs,
+                transaction_signer,
+                transaction_digest,
+                move_vm,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+                shared_object_refs,
+                transaction_dependencies,
+            )
+        }
+    }
+
+    /// Post-execution consistency: SUI conservation + the expensive ownership invariants. `Err` means
+    /// an invariant was violated unrecoverably — no panic, no recovery; the caller bails to the
+    /// recorded no-op reporting the error.
+    #[allow(clippy::too_many_arguments)]
+    fn check_consistency<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &GasCharger,
+        gas_cost_summary: &GasCostSummary,
+        move_vm: &Arc<MoveRuntime>,
+        enable_expensive_checks: bool,
+        transaction_signer: SuiAddress,
+        sponsor: Option<SuiAddress>,
+        is_epoch_change: bool,
+        transaction_digest: TransactionDigest,
+    ) -> Result<(), Mode::Error> {
+        // FIXME: we cannot fail the transaction if this is an epoch change transaction.
+        // Conservation + ownership read the cached invariant inputs from the store
+        // (`set_invariant_inputs`); genesis flag, advance-epoch summary and the reservation budget
+        // are no longer threaded here (#27051).
+        run_conservation_checks::<Mode>(
             temporary_store,
-            gas_data,
-            gas_status,
-            transaction_kind,
-            rewritten_inputs,
-            transaction_signer,
+            gas_charger,
             transaction_digest,
             move_vm,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
             enable_expensive_checks,
-            execution_params,
-            trace_builder_opt,
-            shared_object_refs,
-            transaction_dependencies,
-            mutable_inputs,
-        )
+            gas_cost_summary,
+        )?;
+
+        // Ownership invariants — only under expensive checks + non-arbitrary mode; a violation is a
+        // real bug that should never fire.
+        if enable_expensive_checks
+            && !Mode::allow_arbitrary_function_calls()
+            && let Err(err) = temporary_store.check_ownership_invariants(
+                &transaction_signer,
+                &sponsor,
+                gas_charger,
+                is_epoch_change,
+            )
+        {
+            #[skip_checked_arithmetic]
+            tracing::error!(
+                tx_digest = ?transaction_digest,
+                error = %err,
+                "ownership invariants violated; falling back to the no-op exit (State 2): \
+                 dropping all writes and charging nothing",
+            );
+            return Err(ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation).into());
+        }
+
+        Ok(())
     }
 
     fn update_vm_telemetry_metrics(metrics: &ExecutionMetrics, move_vm: &MoveRuntime) {
@@ -304,6 +525,304 @@ pub(crate) mod checked {
         .map_err(|(e, _)| e)?;
         temporary_store.update_object_version_and_prev_tx();
         Ok(temporary_store.into_inner(BTreeMap::new()))
+    }
+
+    #[allow(clippy::large_enum_variant)]
+    enum Outcome<Mode: ExecutionMode> {
+        Proceed {
+            gas_charger: GasCharger,
+            gas_cost_summary: GasCostSummary,
+            execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+            timings: Vec<ExecutionTiming>,
+        },
+        BumpOnly {
+            gas_status: SuiGasStatus,
+            error: Mode::Error,
+        },
+    }
+
+    struct GasOutcome {
+        cost_summary: GasCostSummary,
+        coin: Option<ObjectID>,
+        status: SuiGasStatus,
+    }
+
+    struct Finalized<Mode: ExecutionMode> {
+        gas: GasOutcome,
+        status: ExecutionStatus,
+        timings: Vec<ExecutionTiming>,
+        execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+    }
+
+    fn execute_transaction_to_outcome<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_data: GasData,
+        gas_status: SuiGasStatus,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        move_vm: &Arc<MoveRuntime>,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        enable_expensive_checks: bool,
+        execution_params: ExecutionOrEarlyError,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> Outcome<Mode> {
+        // Short-circuit insufficient_funds. No execution, `Outcome::BumpOnly`
+        if should_short_circuit_insufficient_funds(&execution_params, &gas_data) {
+            assert_reachable!("IFFW short-circuit fired");
+            let iffw: Mode::Error =
+                ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw).into();
+            return Outcome::BumpOnly {
+                gas_status,
+                error: iffw,
+            };
+        }
+
+        let sponsor = {
+            let gas_owner = gas_data.owner;
+            if gas_owner == transaction_signer {
+                None
+            } else {
+                Some(gas_owner)
+            }
+        };
+        let gas_price = gas_status.gas_price();
+        let rgp = gas_status.reference_gas_price();
+        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
+
+        let tx_ctx = TxContext::new_from_components(
+            &transaction_signer,
+            &transaction_digest,
+            epoch_id,
+            epoch_timestamp_ms,
+            rgp,
+            gas_price,
+            gas_data.budget,
+            sponsor,
+            protocol_config,
+        );
+        let tx_ctx = Rc::new(RefCell::new(tx_ctx));
+
+        // Cache transaction-derived invariant inputs
+        temporary_store.set_invariant_inputs(&transaction_kind, &gas_data, transaction_signer);
+
+        let mut gas_charger = GasCharger::new(
+            transaction_digest,
+            payment_kind(
+                &gas_data,
+                &transaction_kind,
+                protocol_config,
+                transaction_signer,
+            ),
+            gas_status,
+            temporary_store,
+            protocol_config,
+        );
+        let (gas_cost_summary, execution_result, timings) = match execute_transaction::<Mode>(
+            store,
+            temporary_store,
+            transaction_kind,
+            rewritten_inputs,
+            &mut gas_charger,
+            tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics,
+            execution_params,
+            trace_builder_opt,
+        ) {
+            Err(error) => {
+                return Outcome::BumpOnly {
+                    gas_status: gas_charger.into_gas_status(),
+                    error,
+                };
+            }
+            Ok((gas_cost_summary, execution_result, timings)) => {
+                (gas_cost_summary, execution_result, timings)
+            }
+        };
+
+        // Post-execution consistency (conservation + ownership): on violation bail to `BumpOnly` with
+        // the gas_status recovered from the charger
+        match check_consistency::<Mode>(
+            temporary_store,
+            &gas_charger,
+            &gas_cost_summary,
+            move_vm,
+            enable_expensive_checks,
+            transaction_signer,
+            sponsor,
+            is_epoch_change,
+            transaction_digest,
+        ) {
+            Ok(()) => Outcome::Proceed {
+                gas_charger,
+                gas_cost_summary,
+                execution_result,
+                timings,
+            },
+            Err(error) => Outcome::BumpOnly {
+                gas_status: gas_charger.into_gas_status(),
+                error,
+            },
+        }
+    }
+
+    #[instrument(name = "tx_execute", level = "debug", skip_all)]
+    fn execute_transaction<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        gas_charger: &mut GasCharger,
+        tx_ctx: Rc<RefCell<TxContext>>,
+        move_vm: &Arc<MoveRuntime>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        execution_params: ExecutionOrEarlyError,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> Result<ExecutionOutcome<Mode>, Mode::Error> {
+        debug_assert!(
+            gas_charger.no_charges(),
+            "No gas charges must be applied yet"
+        );
+
+        let mut timings: Vec<ExecutionTiming> = vec![];
+
+        let result = gas_charger
+            .charge_input_objects(temporary_store)
+            .map_err(Into::into)
+            // Early errors fail without running the VM
+            .and_then(|()| match execution_params.into_early_errors() {
+                Some(early_execution_errors) => {
+                    Err(ExecutionError::new(early_execution_errors.head, None).into())
+                }
+                None => execute_ptb::<Mode>(
+                    store,
+                    temporary_store,
+                    transaction_kind,
+                    rewritten_inputs,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                    trace_builder_opt,
+                    &mut timings,
+                ),
+            })
+            .and_then(|v| {
+                gas_charger
+                    .charge_storage(temporary_store)
+                    .map_err(Into::into)
+                    .map(|_| v)
+            });
+
+        let checks = check_effects::<Mode>(temporary_store, gas_charger, protocol_config, metrics);
+        // Execution error wins; otherwise a failed effects check fails the tx.
+        let result = result.and_then(|v| checks.map(|()| v));
+
+        if result.is_err() {
+            gas_charger.reset_writes(temporary_store)?;
+        }
+        let cost_summary = gas_charger.charge(temporary_store, &result);
+        Ok((cost_summary, result, timings))
+    }
+
+    /// Execute the PTB, then bucketize computation via `round_computation`. Timings are written to
+    /// `timings_out` regardless of Ok/Err.
+    fn execute_ptb<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        tx_ctx: Rc<RefCell<TxContext>>,
+        move_vm: &Arc<MoveRuntime>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        timings_out: &mut Vec<ExecutionTiming>,
+    ) -> Result<Mode::ExecutionResults, Mode::Error> {
+        let result = match execution_loop::<Mode>(
+            store,
+            temporary_store,
+            transaction_kind,
+            rewritten_inputs,
+            tx_ctx,
+            move_vm,
+            gas_charger,
+            protocol_config,
+            metrics,
+            trace_builder_opt,
+        ) {
+            Ok((v, t)) => {
+                *timings_out = t;
+                Ok(v)
+            }
+            Err((e, t)) => {
+                *timings_out = t;
+                Err(e)
+            }
+        };
+        gas_charger.round_computation(result)
+    }
+
+    fn check_effects<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+    ) -> Result<(), Mode::Error> {
+        let meter = check_meter_limit::<Mode>(
+            temporary_store,
+            gas_charger,
+            protocol_config,
+            metrics.clone(),
+        );
+        let written = check_written_objects_limit::<Mode>(
+            temporary_store,
+            gas_charger,
+            protocol_config,
+            metrics,
+        );
+        let representable = temporary_store
+            .check_accumulator_amounts_representable()
+            .map_err(Into::into);
+        meter.and(written).and(representable)
+    }
+
+    #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
+    fn run_conservation_checks<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &GasCharger,
+        tx_digest: TransactionDigest,
+        move_vm: &Arc<MoveRuntime>,
+        enable_expensive_checks: bool,
+        cost_summary: &GasCostSummary,
+    ) -> Result<(), Mode::Error> {
+        if let Err(conservation_err) = temporary_store.check_conservation_invariants::<Mode>(
+            move_vm,
+            enable_expensive_checks,
+            cost_summary,
+        ) {
+            #[skip_checked_arithmetic]
+            tracing::error!(
+                tx_digest = ?tx_digest,
+                conservation_error = %conservation_err,
+                gas_status = %gas_charger.summary(),
+                "SUI conservation check failed; falling back to the no-op exit (State 2): \
+                 dropping all writes and charging nothing",
+            );
+            return Err(conservation_err.into());
+        }
+
+        Ok(())
     }
 
     /// Frozen pre-v15 (`gas_model_version < 15`) execution, mirroring `origin/main`. Removed at the
@@ -409,7 +928,6 @@ pub(crate) mod checked {
             trace_builder_opt: &mut Option<MoveTraceBuilder>,
             shared_object_refs: Vec<SharedInput>,
             mut transaction_dependencies: BTreeSet<TransactionDigest>,
-            mutable_inputs: HashSet<ObjectID>,
         ) -> ExecutionOutput<Mode> {
             // Short-circuit on InsufficientFundsForWithdraw: the transaction is guaranteed to fail
             // and has nothing to execute, so skip the executor pipeline. Bump versions of mutable
@@ -479,7 +997,7 @@ pub(crate) mod checked {
 
             let mut gas_charger = GasCharger::new(
                 transaction_digest,
-                payment_kind(&gas_data, &transaction_kind, protocol_config),
+                legacy_payment_kind(&gas_data, &transaction_kind, protocol_config),
                 gas_status,
                 &mut temporary_store,
                 protocol_config,
@@ -534,7 +1052,6 @@ pub(crate) mod checked {
                 &gas_cost_summary,
                 &transaction_signer,
                 &sponsor,
-                &mutable_inputs,
                 is_epoch_change,
             ) {
                 // FIXME: we cannot fail the transaction if this is an epoch change transaction.
@@ -602,11 +1119,7 @@ pub(crate) mod checked {
             execution_params: ExecutionOrEarlyError,
             trace_builder_opt: &mut Option<MoveTraceBuilder>,
             is_gasless: bool,
-        ) -> (
-            GasCostSummary,
-            Result<Mode::ExecutionResults, Mode::Error>,
-            Vec<ExecutionTiming>,
-        ) {
+        ) -> ExecutionOutcome<Mode> {
             // At this point no charges have been applied yet
             debug_assert!(
                 gas_charger.no_charges(),
@@ -722,6 +1235,40 @@ pub(crate) mod checked {
             (cost_summary, result, timings)
         }
 
+        fn gasless_withdrawal_reservations(
+            transaction_kind: &TransactionKind,
+            tx_ctx: &TxContext,
+        ) -> Option<BTreeMap<(SuiAddress, TypeTag), u64>> {
+            let TransactionKind::ProgrammableTransaction(pt) = transaction_kind else {
+                debug_fatal!("Gasless transaction must be a ProgrammableTransaction");
+                return None;
+            };
+            let sender = tx_ctx.sender();
+            let mut reservations = BTreeMap::<(SuiAddress, TypeTag), u64>::new();
+            for input in &pt.inputs {
+                let CallArg::FundsWithdrawal(fw) = input else {
+                    continue;
+                };
+                let Some(coin_type) = fw.type_arg.get_balance_type_param() else {
+                    debug_fatal!("expected Balance type for withdrawal");
+                    continue;
+                };
+                let owner = match fw.withdraw_from {
+                    WithdrawFrom::Sender => sender,
+                    WithdrawFrom::Sponsor => {
+                        debug_fatal!(
+                            "WithdrawFrom::Sponsor is not expected in gasless transactions"
+                        );
+                        tx_ctx.sponsor().unwrap_or(sender)
+                    }
+                };
+                let Reservation::MaxAmountU64(amount) = fw.reservation;
+                let entry = reservations.entry((owner, coin_type)).or_insert(0);
+                *entry = entry.saturating_add(amount);
+            }
+            Some(reservations)
+        }
+
         /// Run all post-execution system-invariant checks against the finalized (gas-charged) store.
         ///
         /// Two families, with deliberately different failure handling:
@@ -745,7 +1292,6 @@ pub(crate) mod checked {
             cost_summary: &GasCostSummary,
             sender: &SuiAddress,
             sponsor: &Option<SuiAddress>,
-            mutable_inputs: &HashSet<ObjectID>,
             is_epoch_change: bool,
         ) -> Result<(), Mode::Error> {
             let conservation = run_conservation_checks::<Mode>(
@@ -759,13 +1305,7 @@ pub(crate) mod checked {
             );
             if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
                 temporary_store
-                    .check_ownership_invariants(
-                        sender,
-                        sponsor,
-                        gas_charger,
-                        mutable_inputs,
-                        is_epoch_change,
-                    )
+                    .check_ownership_invariants(sender, sponsor, gas_charger, is_epoch_change)
                     .unwrap()
             } // else, in dev inspect mode and anything goes--don't check
             conservation
@@ -901,15 +1441,15 @@ pub(crate) mod checked {
         Ok(())
     }
 
-    fn gasless_withdrawal_reservations(
+    fn compute_gasless_reservations(
         transaction_kind: &TransactionKind,
-        tx_ctx: &TxContext,
+        sender: SuiAddress,
+        sponsor: Option<SuiAddress>,
     ) -> Option<BTreeMap<(SuiAddress, TypeTag), u64>> {
         let TransactionKind::ProgrammableTransaction(pt) = transaction_kind else {
             debug_fatal!("Gasless transaction must be a ProgrammableTransaction");
             return None;
         };
-        let sender = tx_ctx.sender();
         let mut reservations = BTreeMap::<(SuiAddress, TypeTag), u64>::new();
         for input in &pt.inputs {
             let CallArg::FundsWithdrawal(fw) = input else {
@@ -923,7 +1463,7 @@ pub(crate) mod checked {
                 WithdrawFrom::Sender => sender,
                 WithdrawFrom::Sponsor => {
                     debug_fatal!("WithdrawFrom::Sponsor is not expected in gasless transactions");
-                    tx_ctx.sponsor().unwrap_or(sender)
+                    sponsor.unwrap_or(sender)
                 }
             };
             let Reservation::MaxAmountU64(amount) = fw.reservation;

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -123,39 +123,45 @@ pub(crate) mod checked {
     fn payment_kind(
         gas_data: &GasData,
         transaction_kind: &TransactionKind,
-        protocol_config: &ProtocolConfig,
-    ) -> PaymentKind {
-        if gas_data.is_unmetered() || transaction_kind.is_system_tx() {
-            PaymentKind::unmetered()
-        } else if protocol_config.enable_gasless()
-            && is_gasless_transaction(gas_data, transaction_kind)
-        {
-            // The gasless withdrawal reservations are cached on the store by
-            // `set_invariant_inputs`, under the same gasless predicate as here.
-            PaymentKind::gasless()
-        } else if gas_data.payment.is_empty() {
-            PaymentKind::smash(vec![PaymentMethod::AddressBalance(
-                gas_data.owner,
-                gas_data.budget,
-            )])
-            .expect("unable to create a payment kind with a single address balance")
-        } else {
-            let payment_methods = gas_data
-                .payment
-                .iter()
-                .map(|entry| {
-                    if let Ok(parsed) = ParsedDigest::try_from(entry.2) {
-                        PaymentMethod::AddressBalance(gas_data.owner, parsed.reservation_amount())
-                    } else {
-                        PaymentMethod::Coin(*entry)
-                    }
-                })
-                .collect();
-            PaymentKind::smash(payment_methods).expect(
-                "unable to create a payment kind from payment methods. \
-                 Should not be possible with a non-empty vector",
-            )
-        }
+    ) -> Result<PaymentKind, ExecutionError> {
+        Ok(
+            if gas_data.is_unmetered() || transaction_kind.is_system_tx() {
+                PaymentKind::unmetered()
+            } else if is_gasless_transaction(gas_data, transaction_kind) {
+                PaymentKind::gasless()
+            } else if gas_data.payment.is_empty() {
+                PaymentKind::smash(vec![PaymentMethod::AddressBalance(
+                    gas_data.owner,
+                    gas_data.budget,
+                )])
+                .ok_or_else(|| {
+                    ExecutionError::invariant_violation(
+                        "unable to create a payment kind with a single address balance",
+                    )
+                })?
+            } else {
+                let payment_methods = gas_data
+                    .payment
+                    .iter()
+                    .map(|entry| {
+                        if let Ok(parsed) = ParsedDigest::try_from(entry.2) {
+                            PaymentMethod::AddressBalance(
+                                gas_data.owner,
+                                parsed.reservation_amount(),
+                            )
+                        } else {
+                            PaymentMethod::Coin(*entry)
+                        }
+                    })
+                    .collect();
+                PaymentKind::smash(payment_methods).ok_or_else(|| {
+                    ExecutionError::invariant_violation(
+                        "unable to create a payment kind from the gas payment: \
+                     duplicate gas coin or reservation overflow",
+                    )
+                })?
+            },
+        )
     }
 
     // Legacy (gas_model < 15) payment classification (delete at execution version cut)
@@ -195,20 +201,21 @@ pub(crate) mod checked {
         }
     }
 
-    type ExecutionOutput<Mode> = (
-        InnerTemporaryStore,
-        SuiGasStatus,
-        TransactionEffects,
-        Vec<ExecutionTiming>,
-        Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
-    );
+    /// Everything `execute_transaction_to_effects` hands back to the executor layer.
+    pub struct ExecutionOutput<Mode: ExecutionMode> {
+        pub inner_store: InnerTemporaryStore,
+        pub gas_status: SuiGasStatus,
+        pub effects: TransactionEffects,
+        pub timings: Vec<ExecutionTiming>,
+        pub execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+    }
 
     /// Gas summary, execution result, and timings produced by `execute_transaction`.
-    type ExecutionOutcome<Mode> = (
-        GasCostSummary,
-        Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
-        Vec<ExecutionTiming>,
-    );
+    struct ExecutionOutcome<Mode: ExecutionMode> {
+        cost_summary: GasCostSummary,
+        execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+        timings: Vec<ExecutionTiming>,
+    }
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
@@ -297,9 +304,8 @@ pub(crate) mod checked {
                     reason,
                 } => {
                     report_bump_only::<Mode>(reason, &transaction_digest, &error);
-                    // Recorded no-op: consume the dropped store and rebuild from its inputs, keeping only
-                    // the input version bumps.
-                    temporary_store = temporary_store.into_recorded_noop();
+                    // Rebuild the store from its inputs, keeping only the input version bumps.
+                    temporary_store = temporary_store.into_bump_only();
                     Finalized {
                         gas: GasOutcome {
                             cost_summary: GasCostSummary::default(),
@@ -343,7 +349,13 @@ pub(crate) mod checked {
             if !Mode::TRACK_EXECUTION {
                 update_vm_telemetry_metrics(&metrics, move_vm);
             }
-            (inner, gas_status, effects, timings, execution_result)
+            ExecutionOutput {
+                inner_store: inner,
+                gas_status,
+                effects,
+                timings,
+                execution_result,
+            }
         } else {
             // TODO: remove all `legacy` code on the next execution version cut
             legacy::execute_transaction_inner::<Mode>(
@@ -370,8 +382,8 @@ pub(crate) mod checked {
     }
 
     /// Post-execution consistency: SUI conservation + the expensive ownership invariants. `Err` means
-    /// an invariant was violated unrecoverably — no panic, no recovery; the caller bails to the
-    /// recorded no-op reporting the error.
+    /// an invariant was violated unrecoverably — no panic, no recovery; the caller bails to
+    /// `BumpOnly` reporting the error.
     #[allow(clippy::too_many_arguments)]
     fn check_consistency<Mode: ExecutionMode>(
         temporary_store: &mut TemporaryStore<'_>,
@@ -537,13 +549,13 @@ pub(crate) mod checked {
         },
     }
 
-    /// Which stage bailed to the `BumpOnly` (recorded no-op) exit. `InsufficientFundsForWithdraw` is
+    /// Which stage bailed to the `BumpOnly` exit. `InsufficientFundsForWithdraw` is
     /// the one expected reason; every other variant is an execution bug and is reported to
     /// `execution_bump_only_exits`, whose `reason` label is `Self::label`.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum BumpOnlyReason {
         InsufficientFundsForWithdraw,
-        /// Resetting writes after a failed execution could not charge even input-only storage.
+        GasSmash,
         WriteReset,
         Conservation,
         Ownership,
@@ -554,6 +566,7 @@ pub(crate) mod checked {
         fn label(self) -> &'static str {
             match self {
                 Self::InsufficientFundsForWithdraw => "insufficient_funds_for_withdraw",
+                Self::GasSmash => "gas_smash",
                 Self::WriteReset => "write_reset",
                 Self::Conservation => "conservation",
                 Self::Ownership => "ownership",
@@ -563,6 +576,19 @@ pub(crate) mod checked {
         fn is_expected(self) -> bool {
             matches!(self, Self::InsufficientFundsForWithdraw)
         }
+    }
+
+    struct GasOutcome {
+        cost_summary: GasCostSummary,
+        coin: Option<ObjectID>,
+        status: SuiGasStatus,
+    }
+
+    struct Finalized<Mode: ExecutionMode> {
+        gas: GasOutcome,
+        status: ExecutionStatus,
+        timings: Vec<ExecutionTiming>,
+        execution_result: Result<Mode::ExecutionResults, Mode::Error>,
     }
 
     /// Report an unexpected `BumpOnly` exit: a transaction whose writes were all dropped and which
@@ -587,25 +613,12 @@ pub(crate) mod checked {
                     .with_label_values(&[reason.label()])
                     .inc();
             },
-            "BumpOnly exit (recorded no-op): all writes dropped, no gas charged. \
+            "BumpOnly exit: all writes dropped, no gas charged. \
              reason={}, tx_digest={:?}, error={:?}",
             reason.label(),
             transaction_digest,
             error
         );
-    }
-
-    struct GasOutcome {
-        cost_summary: GasCostSummary,
-        coin: Option<ObjectID>,
-        status: SuiGasStatus,
-    }
-
-    struct Finalized<Mode: ExecutionMode> {
-        gas: GasOutcome,
-        status: ExecutionStatus,
-        timings: Vec<ExecutionTiming>,
-        execution_result: Result<Mode::ExecutionResults, Mode::Error>,
     }
 
     fn execute_transaction_to_outcome<Mode: ExecutionMode>(
@@ -666,14 +679,28 @@ pub(crate) mod checked {
         // Cache transaction-derived invariant inputs
         temporary_store.set_invariant_inputs(&transaction_kind, &gas_data, transaction_signer);
 
+        let payment_kind = match payment_kind(&gas_data, &transaction_kind) {
+            Ok(payment_kind) => payment_kind,
+            Err(error) => {
+                return Outcome::BumpOnly {
+                    gas_status,
+                    error: error.into(),
+                    reason: BumpOnlyReason::GasSmash,
+                };
+            }
+        };
         let mut gas_charger = GasCharger::new(
             transaction_digest,
-            payment_kind(&gas_data, &transaction_kind, protocol_config),
+            payment_kind,
             gas_status,
             temporary_store,
             protocol_config,
         );
-        let (gas_cost_summary, execution_result, timings) = match execute_transaction::<Mode>(
+        let ExecutionOutcome {
+            cost_summary: gas_cost_summary,
+            execution_result,
+            timings,
+        } = match execute_transaction::<Mode>(
             store,
             temporary_store,
             transaction_kind,
@@ -693,9 +720,7 @@ pub(crate) mod checked {
                     reason,
                 };
             }
-            Ok((gas_cost_summary, execution_result, timings)) => {
-                (gas_cost_summary, execution_result, timings)
-            }
+            Ok(outcome) => outcome,
         };
 
         // Post-execution consistency (conservation + ownership): on violation bail to `BumpOnly` with
@@ -770,7 +795,7 @@ pub(crate) mod checked {
             })
             .and_then(|v| {
                 gas_charger
-                    .charge_storage(temporary_store)
+                    .meter_storage(temporary_store)
                     .map_err(Into::into)
                     .map(|_| v)
             });
@@ -781,11 +806,15 @@ pub(crate) mod checked {
 
         if result.is_err() {
             gas_charger
-                .reset_writes(temporary_store)
+                .handle_error(temporary_store)
                 .map_err(|error| (error.into(), BumpOnlyReason::WriteReset))?;
         }
         let cost_summary = gas_charger.charge(temporary_store, &result);
-        Ok((cost_summary, result, timings))
+        Ok(ExecutionOutcome {
+            cost_summary,
+            execution_result: result,
+            timings,
+        })
     }
 
     /// Execute the PTB, then bucketize computation via `round_computation`. Timings are written to
@@ -1017,13 +1046,13 @@ pub(crate) mod checked {
                     *epoch_id,
                 );
 
-                return (
-                    inner,
-                    gas_meter.into_gas_status(),
+                return ExecutionOutput {
+                    inner_store: inner,
+                    gas_status: gas_meter.into_gas_status(),
                     effects,
-                    vec![],
-                    Err(execution_error),
-                );
+                    timings: vec![],
+                    execution_result: Err(execution_error),
+                };
             }
 
             let sponsor = {
@@ -1079,7 +1108,11 @@ pub(crate) mod checked {
             // conservation checks and the ownership-invariant check read them from there.
             temporary_store.set_invariant_inputs(&transaction_kind, &gas_data, transaction_signer);
 
-            let (gas_cost_summary, mut execution_result, timings) = execute_transaction::<Mode>(
+            let ExecutionOutcome {
+                cost_summary: gas_cost_summary,
+                mut execution_result,
+                timings,
+            } = execute_transaction::<Mode>(
                 store,
                 &mut temporary_store,
                 transaction_kind,
@@ -1151,13 +1184,13 @@ pub(crate) mod checked {
                 update_vm_telemetry_metrics(&metrics, move_vm);
             }
 
-            (
-                inner,
-                gas_charger.into_gas_status(),
+            ExecutionOutput {
+                inner_store: inner,
+                gas_status: gas_charger.into_gas_status(),
                 effects,
                 timings,
                 execution_result,
-            )
+            }
         }
 
         #[instrument(name = "tx_execute", level = "debug", skip_all)]
@@ -1289,7 +1322,11 @@ pub(crate) mod checked {
             temporary_store
                 .conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
 
-            (cost_summary, result, timings)
+            ExecutionOutcome {
+                cost_summary,
+                execution_result: result,
+                timings,
+            }
         }
 
         fn gasless_withdrawal_reservations(

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -12,9 +12,11 @@ pub(crate) mod checked {
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::runtime::MoveRuntime;
-    use mysten_common::{assert_reachable, debug_fatal, in_test_configuration};
+    use mysten_common::{
+        assert_reachable, debug_fatal, debug_fatal_with_metric, in_test_configuration,
+    };
     use std::collections::{BTreeMap, BTreeSet};
-    use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
+    use std::{cell::RefCell, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
     use sui_types::balance::{
         BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
@@ -23,6 +25,7 @@ pub(crate) mod checked {
     use sui_types::coin_reservation::ParsedDigest;
     use sui_types::execution_params::ExecutionOrEarlyError;
     use sui_types::gas_coin::GAS;
+    use sui_types::gas_model::gas_predicates::bump_only_enabled;
     use sui_types::messages_checkpoint::CheckpointTimestamp;
     use sui_types::metrics::ExecutionMetrics;
     use sui_types::object::OBJECT_START_VERSION;
@@ -87,10 +90,7 @@ pub(crate) mod checked {
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     };
 
-    /// Whether the *head* early error is `InsufficientFundsForWithdraw`. Used to gate the first
-    /// address-balance gas-payment pruning hotfix: the head error is the one surfaced as the
-    /// failure status, so keying off it (rather than any occurrence) keeps the pruning bit-for-bit
-    /// with the original single-error hotfix.
+    /// Whether the *head* early error is `InsufficientFundsForWithdraw`.
     fn head_error_is_insufficient_funds_for_withdraw(
         execution_params: &ExecutionOrEarlyError,
     ) -> bool {
@@ -102,7 +102,64 @@ pub(crate) mod checked {
         })
     }
 
+    /// Whether `InsufficientFundsForWithdraw` appears anywhere in the early-error list.
+    fn any_error_is_insufficient_funds_for_withdraw(
+        execution_params: &ExecutionOrEarlyError,
+    ) -> bool {
+        execution_params.early_errors().is_some_and(|errors| {
+            errors
+                .iter()
+                .any(|e| matches!(e, ExecutionErrorKind::InsufficientFundsForWithdraw))
+        })
+    }
+
+    /// Whether to short-circuit an IFFW transaction. Matches the legacy short-circuit once
+    /// `early_exit_on_iffw` is on (constant at gas model v15+): any IFFW among the early errors
+    /// short-circuits, even when it is not the head error.
+    fn should_short_circuit_insufficient_funds(execution_params: &ExecutionOrEarlyError) -> bool {
+        any_error_is_insufficient_funds_for_withdraw(execution_params)
+    }
+
     fn payment_kind(
+        gas_data: &GasData,
+        transaction_kind: &TransactionKind,
+        protocol_config: &ProtocolConfig,
+    ) -> PaymentKind {
+        if gas_data.is_unmetered() || transaction_kind.is_system_tx() {
+            PaymentKind::unmetered()
+        } else if protocol_config.enable_gasless()
+            && is_gasless_transaction(gas_data, transaction_kind)
+        {
+            // The gasless withdrawal reservations are cached on the store by
+            // `set_invariant_inputs`, under the same gasless predicate as here.
+            PaymentKind::gasless()
+        } else if gas_data.payment.is_empty() {
+            PaymentKind::smash(vec![PaymentMethod::AddressBalance(
+                gas_data.owner,
+                gas_data.budget,
+            )])
+            .expect("unable to create a payment kind with a single address balance")
+        } else {
+            let payment_methods = gas_data
+                .payment
+                .iter()
+                .map(|entry| {
+                    if let Ok(parsed) = ParsedDigest::try_from(entry.2) {
+                        PaymentMethod::AddressBalance(gas_data.owner, parsed.reservation_amount())
+                    } else {
+                        PaymentMethod::Coin(*entry)
+                    }
+                })
+                .collect();
+            PaymentKind::smash(payment_methods).expect(
+                "unable to create a payment kind from payment methods. \
+                 Should not be possible with a non-empty vector",
+            )
+        }
+    }
+
+    // Legacy (gas_model < 15) payment classification (delete at execution version cut)
+    fn legacy_payment_kind(
         gas_data: &GasData,
         transaction_kind: &TransactionKind,
         protocol_config: &ProtocolConfig,
@@ -145,6 +202,13 @@ pub(crate) mod checked {
         Vec<ExecutionTiming>,
         Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
     );
+
+    /// Gas summary, execution result, and timings produced by `execute_transaction`.
+    type ExecutionOutcome<Mode> = (
+        GasCostSummary,
+        Result<<Mode as ExecutionMode>::ExecutionResults, <Mode as ExecutionMode>::Error>,
+        Vec<ExecutionTiming>,
+    );
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
@@ -166,16 +230,11 @@ pub(crate) mod checked {
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> ExecutionOutput<Mode> {
         let input_objects = input_objects.into_inner();
-        let mutable_inputs = if enable_expensive_checks {
-            input_objects.all_mutable_inputs().keys().copied().collect()
-        } else {
-            HashSet::new()
-        };
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
-        let transaction_dependencies = input_objects.transaction_dependencies();
+        let mut transaction_dependencies = input_objects.transaction_dependencies();
 
-        let temporary_store = TemporaryStore::new(
+        let mut temporary_store = TemporaryStore::new(
             store,
             input_objects,
             receiving_objects,
@@ -185,28 +244,185 @@ pub(crate) mod checked {
             system_object_versions,
         );
 
-        // TODO: remove all `legacy` code on the next execution version cut
-        legacy::execute_transaction_inner::<Mode>(
-            store,
+        if bump_only_enabled(protocol_config.gas_model_version()) {
+            let Finalized {
+                gas,
+                status,
+                timings,
+                execution_result,
+            }: Finalized<Mode> = match execute_transaction_to_outcome::<Mode>(
+                store,
+                &mut temporary_store,
+                gas_data,
+                gas_status,
+                transaction_kind,
+                rewritten_inputs,
+                transaction_signer,
+                transaction_digest,
+                move_vm,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics.clone(),
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+            ) {
+                Outcome::Proceed {
+                    gas_charger,
+                    gas_cost_summary,
+                    execution_result,
+                    timings,
+                } => {
+                    let status = if let Err(error) = &execution_result {
+                        ExecutionStatus::new_failure(error.to_execution_failure())
+                    } else {
+                        ExecutionStatus::Success
+                    };
+                    let coin = gas_charger.gas_coin();
+                    Finalized {
+                        gas: GasOutcome {
+                            cost_summary: gas_cost_summary,
+                            coin,
+                            status: gas_charger.into_gas_status(),
+                        },
+                        status,
+                        timings,
+                        execution_result,
+                    }
+                }
+                Outcome::BumpOnly {
+                    gas_status,
+                    error,
+                    reason,
+                } => {
+                    report_bump_only::<Mode>(reason, &transaction_digest, &error);
+                    // Recorded no-op: consume the dropped store and rebuild from its inputs, keeping only
+                    // the input version bumps.
+                    temporary_store = temporary_store.into_recorded_noop();
+                    Finalized {
+                        gas: GasOutcome {
+                            cost_summary: GasCostSummary::default(),
+                            coin: None,
+                            status: gas_status,
+                        },
+                        status: ExecutionStatus::new_failure(error.to_execution_failure()),
+                        timings: vec![],
+                        execution_result: Err(error),
+                    }
+                }
+            };
+
+            // Shared infallible tail: trim the genesis dependency, build effects, telemetry.
+            let GasOutcome {
+                cost_summary,
+                coin,
+                status: gas_status,
+            } = gas;
+            #[skip_checked_arithmetic]
+            trace!(
+                tx_digest = ?transaction_digest,
+                computation_gas_cost = cost_summary.computation_cost,
+                storage_gas_cost = cost_summary.storage_cost,
+                storage_gas_rebate = cost_summary.storage_rebate,
+                "Finished execution of transaction with status {:?}",
+                status
+            );
+            transaction_dependencies.remove(&TransactionDigest::genesis_marker());
+            let (inner, effects) = temporary_store.into_effects(
+                shared_object_refs,
+                &transaction_digest,
+                transaction_dependencies,
+                cost_summary,
+                status,
+                coin,
+                *epoch_id,
+            );
+            // Skip VM telemetry on simulation paths (dev-inspect / dry-run) since a new runtime is
+            // spun-up each time.
+            if !Mode::TRACK_EXECUTION {
+                update_vm_telemetry_metrics(&metrics, move_vm);
+            }
+            (inner, gas_status, effects, timings, execution_result)
+        } else {
+            // TODO: remove all `legacy` code on the next execution version cut
+            legacy::execute_transaction_inner::<Mode>(
+                store,
+                temporary_store,
+                gas_data,
+                gas_status,
+                transaction_kind,
+                rewritten_inputs,
+                transaction_signer,
+                transaction_digest,
+                move_vm,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+                shared_object_refs,
+                transaction_dependencies,
+            )
+        }
+    }
+
+    /// Post-execution consistency: SUI conservation + the expensive ownership invariants. `Err` means
+    /// an invariant was violated unrecoverably — no panic, no recovery; the caller bails to the
+    /// recorded no-op reporting the error.
+    #[allow(clippy::too_many_arguments)]
+    fn check_consistency<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &GasCharger,
+        gas_cost_summary: &GasCostSummary,
+        move_vm: &Arc<MoveRuntime>,
+        enable_expensive_checks: bool,
+        transaction_signer: SuiAddress,
+        sponsor: Option<SuiAddress>,
+        is_epoch_change: bool,
+        transaction_digest: TransactionDigest,
+    ) -> Result<(), (Mode::Error, BumpOnlyReason)> {
+        // FIXME: we cannot fail the transaction if this is an epoch change transaction.
+        // Conservation + ownership read the cached invariant inputs from the store
+        // (`set_invariant_inputs`); genesis flag, advance-epoch summary and the reservation budget
+        // are no longer threaded here (#27051).
+        run_conservation_checks::<Mode>(
             temporary_store,
-            gas_data,
-            gas_status,
-            transaction_kind,
-            rewritten_inputs,
-            transaction_signer,
+            gas_charger,
             transaction_digest,
             move_vm,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
             enable_expensive_checks,
-            execution_params,
-            trace_builder_opt,
-            shared_object_refs,
-            transaction_dependencies,
-            mutable_inputs,
+            gas_cost_summary,
         )
+        .map_err(|error| (error, BumpOnlyReason::Conservation))?;
+
+        // Ownership invariants — only under expensive checks + non-arbitrary mode; a violation is a
+        // real bug that should never fire.
+        if enable_expensive_checks
+            && !Mode::allow_arbitrary_function_calls()
+            && let Err(err) = temporary_store.check_ownership_invariants(
+                &transaction_signer,
+                &sponsor,
+                gas_charger,
+                is_epoch_change,
+            )
+        {
+            #[skip_checked_arithmetic]
+            tracing::error!(
+                tx_digest = ?transaction_digest,
+                error = %err,
+                "ownership invariants violated; falling back to the no-op exit (State 2): \
+                 dropping all writes and charging nothing",
+            );
+            return Err((
+                ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation).into(),
+                BumpOnlyReason::Ownership,
+            ));
+        }
+
+        Ok(())
     }
 
     fn update_vm_telemetry_metrics(metrics: &ExecutionMetrics, move_vm: &MoveRuntime) {
@@ -287,7 +503,8 @@ pub(crate) mod checked {
             0,
             BTreeMap::new(),
         );
-        let mut gas_charger = GasCharger::new_unmetered(tx_context.borrow().digest());
+        let mut gas_charger =
+            GasCharger::new_unmetered(tx_context.borrow().digest(), protocol_config);
         SPT::execute::<execution_mode::Genesis>(
             protocol_config,
             metrics,
@@ -303,6 +520,363 @@ pub(crate) mod checked {
         .map_err(|(e, _)| e)?;
         temporary_store.update_object_version_and_prev_tx();
         Ok(temporary_store.into_inner(BTreeMap::new()))
+    }
+
+    #[allow(clippy::large_enum_variant)]
+    enum Outcome<Mode: ExecutionMode> {
+        Proceed {
+            gas_charger: GasCharger,
+            gas_cost_summary: GasCostSummary,
+            execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+            timings: Vec<ExecutionTiming>,
+        },
+        BumpOnly {
+            gas_status: SuiGasStatus,
+            error: Mode::Error,
+            reason: BumpOnlyReason,
+        },
+    }
+
+    /// Which stage bailed to the `BumpOnly` (recorded no-op) exit. `InsufficientFundsForWithdraw` is
+    /// the one expected reason; every other variant is an execution bug and is reported to
+    /// `execution_bump_only_exits`, whose `reason` label is `Self::label`.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum BumpOnlyReason {
+        InsufficientFundsForWithdraw,
+        /// Resetting writes after a failed execution could not charge even input-only storage.
+        WriteReset,
+        Conservation,
+        Ownership,
+    }
+
+    impl BumpOnlyReason {
+        /// Metric label. Alerts select on these, so keep the values stable.
+        fn label(self) -> &'static str {
+            match self {
+                Self::InsufficientFundsForWithdraw => "insufficient_funds_for_withdraw",
+                Self::WriteReset => "write_reset",
+                Self::Conservation => "conservation",
+                Self::Ownership => "ownership",
+            }
+        }
+
+        fn is_expected(self) -> bool {
+            matches!(self, Self::InsufficientFundsForWithdraw)
+        }
+    }
+
+    /// Report an unexpected `BumpOnly` exit: a transaction whose writes were all dropped and which
+    /// was charged nothing because a stage of the pipeline failed. `debug_fatal` semantics — panics
+    /// under `crash_on_debug()`, counts + logs in production.
+    ///
+    /// Skipped for the expected IFFW short-circuit, and for the simulation paths
+    /// (`Mode::TRACK_EXECUTION`: dev-inspect / dry-run / simulate), where an arbitrary user-supplied
+    /// transaction must not be able to crash a debug node or raise an alert.
+    fn report_bump_only<Mode: ExecutionMode>(
+        reason: BumpOnlyReason,
+        transaction_digest: &TransactionDigest,
+        error: &Mode::Error,
+    ) {
+        if reason.is_expected() || Mode::TRACK_EXECUTION {
+            return;
+        }
+        debug_fatal_with_metric!(
+            |metrics: &mysten_metrics::Metrics| {
+                metrics
+                    .execution_bump_only_exits
+                    .with_label_values(&[reason.label()])
+                    .inc();
+            },
+            "BumpOnly exit (recorded no-op): all writes dropped, no gas charged. \
+             reason={}, tx_digest={:?}, error={:?}",
+            reason.label(),
+            transaction_digest,
+            error
+        );
+    }
+
+    struct GasOutcome {
+        cost_summary: GasCostSummary,
+        coin: Option<ObjectID>,
+        status: SuiGasStatus,
+    }
+
+    struct Finalized<Mode: ExecutionMode> {
+        gas: GasOutcome,
+        status: ExecutionStatus,
+        timings: Vec<ExecutionTiming>,
+        execution_result: Result<Mode::ExecutionResults, Mode::Error>,
+    }
+
+    fn execute_transaction_to_outcome<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_data: GasData,
+        gas_status: SuiGasStatus,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        move_vm: &Arc<MoveRuntime>,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        enable_expensive_checks: bool,
+        execution_params: ExecutionOrEarlyError,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> Outcome<Mode> {
+        // Short-circuit insufficient_funds. No execution, `Outcome::BumpOnly`
+        if should_short_circuit_insufficient_funds(&execution_params) {
+            assert_reachable!("IFFW short-circuit fired");
+            let iffw: Mode::Error =
+                ExecutionError::from_kind(ExecutionErrorKind::InsufficientFundsForWithdraw).into();
+            return Outcome::BumpOnly {
+                gas_status,
+                error: iffw,
+                reason: BumpOnlyReason::InsufficientFundsForWithdraw,
+            };
+        }
+
+        let sponsor = {
+            let gas_owner = gas_data.owner;
+            if gas_owner == transaction_signer {
+                None
+            } else {
+                Some(gas_owner)
+            }
+        };
+        let gas_price = gas_status.gas_price();
+        let rgp = gas_status.reference_gas_price();
+        let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
+
+        let tx_ctx = TxContext::new_from_components(
+            &transaction_signer,
+            &transaction_digest,
+            epoch_id,
+            epoch_timestamp_ms,
+            rgp,
+            gas_price,
+            gas_data.budget,
+            sponsor,
+            protocol_config,
+        );
+        let tx_ctx = Rc::new(RefCell::new(tx_ctx));
+
+        // Cache transaction-derived invariant inputs
+        temporary_store.set_invariant_inputs(&transaction_kind, &gas_data, transaction_signer);
+
+        let mut gas_charger = GasCharger::new(
+            transaction_digest,
+            payment_kind(&gas_data, &transaction_kind, protocol_config),
+            gas_status,
+            temporary_store,
+            protocol_config,
+        );
+        let (gas_cost_summary, execution_result, timings) = match execute_transaction::<Mode>(
+            store,
+            temporary_store,
+            transaction_kind,
+            rewritten_inputs,
+            &mut gas_charger,
+            tx_ctx,
+            move_vm,
+            protocol_config,
+            metrics,
+            execution_params,
+            trace_builder_opt,
+        ) {
+            Err((error, reason)) => {
+                return Outcome::BumpOnly {
+                    gas_status: gas_charger.into_gas_status(),
+                    error,
+                    reason,
+                };
+            }
+            Ok((gas_cost_summary, execution_result, timings)) => {
+                (gas_cost_summary, execution_result, timings)
+            }
+        };
+
+        // Post-execution consistency (conservation + ownership): on violation bail to `BumpOnly` with
+        // the gas_status recovered from the charger
+        match check_consistency::<Mode>(
+            temporary_store,
+            &gas_charger,
+            &gas_cost_summary,
+            move_vm,
+            enable_expensive_checks,
+            transaction_signer,
+            sponsor,
+            is_epoch_change,
+            transaction_digest,
+        ) {
+            Ok(()) => Outcome::Proceed {
+                gas_charger,
+                gas_cost_summary,
+                execution_result,
+                timings,
+            },
+            Err((error, reason)) => Outcome::BumpOnly {
+                gas_status: gas_charger.into_gas_status(),
+                error,
+                reason,
+            },
+        }
+    }
+
+    #[instrument(name = "tx_execute", level = "debug", skip_all)]
+    fn execute_transaction<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        gas_charger: &mut GasCharger,
+        tx_ctx: Rc<RefCell<TxContext>>,
+        move_vm: &Arc<MoveRuntime>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        execution_params: ExecutionOrEarlyError,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> Result<ExecutionOutcome<Mode>, (Mode::Error, BumpOnlyReason)> {
+        debug_assert!(
+            gas_charger.no_charges(),
+            "No gas charges must be applied yet"
+        );
+
+        let mut timings: Vec<ExecutionTiming> = vec![];
+
+        let result = gas_charger
+            .charge_input_objects(temporary_store)
+            .map_err(Into::into)
+            // Early errors fail without running the VM
+            .and_then(|()| match execution_params.into_early_errors() {
+                Some(early_execution_errors) => {
+                    Err(ExecutionError::new(early_execution_errors.head, None).into())
+                }
+                None => execute_ptb::<Mode>(
+                    store,
+                    temporary_store,
+                    transaction_kind,
+                    rewritten_inputs,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                    trace_builder_opt,
+                    &mut timings,
+                ),
+            })
+            .and_then(|v| {
+                gas_charger
+                    .charge_storage(temporary_store)
+                    .map_err(Into::into)
+                    .map(|_| v)
+            });
+
+        let checks = check_effects::<Mode>(temporary_store, gas_charger, protocol_config, metrics);
+        // Execution error wins; otherwise a failed effects check fails the tx.
+        let result = result.and_then(|v| checks.map(|()| v));
+
+        if result.is_err() {
+            gas_charger
+                .reset_writes(temporary_store)
+                .map_err(|error| (error.into(), BumpOnlyReason::WriteReset))?;
+        }
+        let cost_summary = gas_charger.charge(temporary_store, &result);
+        Ok((cost_summary, result, timings))
+    }
+
+    /// Execute the PTB, then bucketize computation via `round_computation`. Timings are written to
+    /// `timings_out` regardless of Ok/Err.
+    fn execute_ptb<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        tx_ctx: Rc<RefCell<TxContext>>,
+        move_vm: &Arc<MoveRuntime>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        timings_out: &mut Vec<ExecutionTiming>,
+    ) -> Result<Mode::ExecutionResults, Mode::Error> {
+        let result = match execution_loop::<Mode>(
+            store,
+            temporary_store,
+            transaction_kind,
+            rewritten_inputs,
+            tx_ctx,
+            move_vm,
+            gas_charger,
+            protocol_config,
+            metrics,
+            trace_builder_opt,
+        ) {
+            Ok((v, t)) => {
+                *timings_out = t;
+                Ok(v)
+            }
+            Err((e, t)) => {
+                *timings_out = t;
+                Err(e)
+            }
+        };
+        gas_charger.round_computation(result)
+    }
+
+    fn check_effects<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+    ) -> Result<(), Mode::Error> {
+        let meter = check_meter_limit::<Mode>(
+            temporary_store,
+            gas_charger,
+            protocol_config,
+            metrics.clone(),
+        );
+        let written = check_written_objects_limit::<Mode>(
+            temporary_store,
+            gas_charger,
+            protocol_config,
+            metrics,
+        );
+        let representable = temporary_store
+            .check_accumulator_amounts_representable()
+            .map_err(Into::into);
+        meter.and(written).and(representable)
+    }
+
+    #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
+    fn run_conservation_checks<Mode: ExecutionMode>(
+        temporary_store: &mut TemporaryStore<'_>,
+        gas_charger: &GasCharger,
+        tx_digest: TransactionDigest,
+        move_vm: &Arc<MoveRuntime>,
+        enable_expensive_checks: bool,
+        cost_summary: &GasCostSummary,
+    ) -> Result<(), Mode::Error> {
+        if let Err(conservation_err) = temporary_store.check_conservation_invariants::<Mode>(
+            move_vm,
+            enable_expensive_checks,
+            cost_summary,
+        ) {
+            #[skip_checked_arithmetic]
+            tracing::error!(
+                tx_digest = ?tx_digest,
+                conservation_error = %conservation_err,
+                gas_status = %gas_charger.summary(),
+                "SUI conservation check failed; falling back to the no-op exit (State 2): \
+                 dropping all writes and charging nothing",
+            );
+            return Err(conservation_err.into());
+        }
+
+        Ok(())
     }
 
     /// Frozen pre-v15 (`gas_model_version < 15`) execution, mirroring `origin/main`. Removed at the
@@ -408,7 +982,6 @@ pub(crate) mod checked {
             trace_builder_opt: &mut Option<MoveTraceBuilder>,
             shared_object_refs: Vec<SharedInput>,
             mut transaction_dependencies: BTreeSet<TransactionDigest>,
-            mutable_inputs: HashSet<ObjectID>,
         ) -> ExecutionOutput<Mode> {
             // Short-circuit on InsufficientFundsForWithdraw: the transaction is guaranteed to fail
             // and has nothing to execute, so skip the executor pipeline. Bump versions of mutable
@@ -478,7 +1051,7 @@ pub(crate) mod checked {
 
             let mut gas_charger = GasCharger::new(
                 transaction_digest,
-                payment_kind(&gas_data, &transaction_kind, protocol_config),
+                legacy_payment_kind(&gas_data, &transaction_kind, protocol_config),
                 gas_status,
                 &mut temporary_store,
                 protocol_config,
@@ -533,7 +1106,6 @@ pub(crate) mod checked {
                 &gas_cost_summary,
                 &transaction_signer,
                 &sponsor,
-                &mutable_inputs,
                 is_epoch_change,
                 execution_result.is_ok(),
             ) {
@@ -602,11 +1174,7 @@ pub(crate) mod checked {
             execution_params: ExecutionOrEarlyError,
             trace_builder_opt: &mut Option<MoveTraceBuilder>,
             is_gasless: bool,
-        ) -> (
-            GasCostSummary,
-            Result<Mode::ExecutionResults, Mode::Error>,
-            Vec<ExecutionTiming>,
-        ) {
+        ) -> ExecutionOutcome<Mode> {
             // At this point no charges have been applied yet
             debug_assert!(
                 gas_charger.no_charges(),
@@ -681,7 +1249,9 @@ pub(crate) mod checked {
             if is_gasless
                 && result.is_ok()
                 && let Err(msg) = temporary_store
-                    .check_gasless_execution_requirements(withdrawal_reservations.as_ref())
+                    .check_gasless_execution_requirements_with_reservations(
+                        withdrawal_reservations.as_ref(),
+                    )
             {
                 result = Err(Mode::Error::new_with_source(
                     ExecutionErrorKind::InsufficientGas,
@@ -722,6 +1292,40 @@ pub(crate) mod checked {
             (cost_summary, result, timings)
         }
 
+        fn gasless_withdrawal_reservations(
+            transaction_kind: &TransactionKind,
+            tx_ctx: &TxContext,
+        ) -> Option<BTreeMap<(SuiAddress, TypeTag), u64>> {
+            let TransactionKind::ProgrammableTransaction(pt) = transaction_kind else {
+                debug_fatal!("Gasless transaction must be a ProgrammableTransaction");
+                return None;
+            };
+            let sender = tx_ctx.sender();
+            let mut reservations = BTreeMap::<(SuiAddress, TypeTag), u64>::new();
+            for input in &pt.inputs {
+                let CallArg::FundsWithdrawal(fw) = input else {
+                    continue;
+                };
+                let Some(coin_type) = fw.type_arg.get_balance_type_param() else {
+                    debug_fatal!("expected Balance type for withdrawal");
+                    continue;
+                };
+                let owner = match fw.withdraw_from {
+                    WithdrawFrom::Sender => sender,
+                    WithdrawFrom::Sponsor => {
+                        debug_fatal!(
+                            "WithdrawFrom::Sponsor is not expected in gasless transactions"
+                        );
+                        tx_ctx.sponsor().unwrap_or(sender)
+                    }
+                };
+                let Reservation::MaxAmountU64(amount) = fw.reservation;
+                let entry = reservations.entry((owner, coin_type)).or_insert(0);
+                *entry = entry.saturating_add(amount);
+            }
+            Some(reservations)
+        }
+
         /// Run all post-execution system-invariant checks against the finalized (gas-charged) store.
         ///
         /// Two families, with deliberately different failure handling:
@@ -745,7 +1349,6 @@ pub(crate) mod checked {
             cost_summary: &GasCostSummary,
             sender: &SuiAddress,
             sponsor: &Option<SuiAddress>,
-            mutable_inputs: &HashSet<ObjectID>,
             is_epoch_change: bool,
             execution_succeeded: bool,
         ) -> Result<(), Mode::Error> {
@@ -760,13 +1363,7 @@ pub(crate) mod checked {
             );
             if enable_expensive_checks && !Mode::allow_arbitrary_function_calls() {
                 temporary_store
-                    .check_ownership_invariants(
-                        sender,
-                        sponsor,
-                        gas_charger,
-                        mutable_inputs,
-                        is_epoch_change,
-                    )
+                    .check_ownership_invariants(sender, sponsor, gas_charger, is_epoch_change)
                     .unwrap()
             } // else, in dev inspect mode and anything goes--don't check
 
@@ -904,38 +1501,6 @@ pub(crate) mod checked {
         }
 
         Ok(())
-    }
-
-    fn gasless_withdrawal_reservations(
-        transaction_kind: &TransactionKind,
-        tx_ctx: &TxContext,
-    ) -> Option<BTreeMap<(SuiAddress, TypeTag), u64>> {
-        let TransactionKind::ProgrammableTransaction(pt) = transaction_kind else {
-            debug_fatal!("Gasless transaction must be a ProgrammableTransaction");
-            return None;
-        };
-        let sender = tx_ctx.sender();
-        let mut reservations = BTreeMap::<(SuiAddress, TypeTag), u64>::new();
-        for input in &pt.inputs {
-            let CallArg::FundsWithdrawal(fw) = input else {
-                continue;
-            };
-            let Some(coin_type) = fw.type_arg.get_balance_type_param() else {
-                debug_fatal!("expected Balance type for withdrawal");
-                continue;
-            };
-            let owner = match fw.withdraw_from {
-                WithdrawFrom::Sender => sender,
-                WithdrawFrom::Sponsor => {
-                    debug_fatal!("WithdrawFrom::Sponsor is not expected in gasless transactions");
-                    tx_ctx.sponsor().unwrap_or(sender)
-                }
-            };
-            let Reservation::MaxAmountU64(amount) = fw.reservation;
-            let entry = reservations.entry((owner, coin_type)).or_insert(0);
-            *entry = entry.saturating_add(amount);
-        }
-        Some(reservations)
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -381,9 +381,10 @@ pub(crate) mod checked {
         }
     }
 
-    /// Post-execution consistency: SUI conservation + the expensive ownership invariants. `Err` means
-    /// an invariant was violated unrecoverably - no panic, no recovery; the caller bails to
-    /// `BumpOnly` reporting the error.
+    /// Post-execution consistency: SUI conservation, the expensive ownership invariants, and (on
+    /// successful execution) the published-packages invariant. `Err` means an invariant was
+    /// violated unrecoverably - no panic, no recovery; the caller bails to `BumpOnly` reporting
+    /// the error.
     #[allow(clippy::too_many_arguments)]
     fn check_consistency<Mode: ExecutionMode>(
         temporary_store: &mut TemporaryStore<'_>,
@@ -395,6 +396,7 @@ pub(crate) mod checked {
         sponsor: Option<SuiAddress>,
         is_epoch_change: bool,
         transaction_digest: TransactionDigest,
+        execution_succeeded: bool,
     ) -> Result<(), (Mode::Error, BumpOnlyReason)> {
         // FIXME: we cannot fail the transaction if this is an epoch change transaction.
         // Conservation + ownership read the cached invariant inputs from the store
@@ -432,6 +434,14 @@ pub(crate) mod checked {
                 ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation).into(),
                 BumpOnlyReason::Ownership,
             ));
+        }
+
+        // Written packages must match the PTB's publish/upgrade commands; only meaningful when
+        // execution succeeded (on failure the writes were dropped).
+        if execution_succeeded {
+            temporary_store
+                .check_published_packages()
+                .map_err(|error| (error.into(), BumpOnlyReason::PublishedPackages))?;
         }
 
         Ok(())
@@ -559,6 +569,7 @@ pub(crate) mod checked {
         WriteReset,
         Conservation,
         Ownership,
+        PublishedPackages,
     }
 
     impl BumpOnlyReason {
@@ -570,6 +581,7 @@ pub(crate) mod checked {
                 Self::WriteReset => "write_reset",
                 Self::Conservation => "conservation",
                 Self::Ownership => "ownership",
+                Self::PublishedPackages => "published_packages",
             }
         }
 
@@ -723,8 +735,8 @@ pub(crate) mod checked {
             Ok(outcome) => outcome,
         };
 
-        // Post-execution consistency (conservation + ownership): on violation bail to `BumpOnly` with
-        // the gas_status recovered from the charger
+        // Post-execution consistency (conservation + ownership + published packages): on violation
+        // bail to `BumpOnly` with the gas_status recovered from the charger
         match check_consistency::<Mode>(
             temporary_store,
             &gas_charger,
@@ -735,6 +747,7 @@ pub(crate) mod checked {
             sponsor,
             is_epoch_change,
             transaction_digest,
+            execution_result.is_ok(),
         ) {
             Ok(()) => Outcome::Proceed {
                 gas_charger,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -382,7 +382,7 @@ pub(crate) mod checked {
     }
 
     /// Post-execution consistency: SUI conservation + the expensive ownership invariants. `Err` means
-    /// an invariant was violated unrecoverably — no panic, no recovery; the caller bails to
+    /// an invariant was violated unrecoverably - no panic, no recovery; the caller bails to
     /// `BumpOnly` reporting the error.
     #[allow(clippy::too_many_arguments)]
     fn check_consistency<Mode: ExecutionMode>(
@@ -410,7 +410,7 @@ pub(crate) mod checked {
         )
         .map_err(|error| (error, BumpOnlyReason::Conservation))?;
 
-        // Ownership invariants — only under expensive checks + non-arbitrary mode; a violation is a
+        // Ownership invariants - only under expensive checks + non-arbitrary mode; a violation is a
         // real bug that should never fire.
         if enable_expensive_checks
             && !Mode::allow_arbitrary_function_calls()
@@ -592,7 +592,7 @@ pub(crate) mod checked {
     }
 
     /// Report an unexpected `BumpOnly` exit: a transaction whose writes were all dropped and which
-    /// was charged nothing because a stage of the pipeline failed. `debug_fatal` semantics — panics
+    /// was charged nothing because a stage of the pipeline failed. `debug_fatal` semantics - panics
     /// under `crash_on_debug()`, counts + logs in production.
     ///
     /// Skipped for the expected IFFW short-circuit, and for the simulation paths
@@ -1446,7 +1446,7 @@ pub(crate) mod checked {
                 cost_summary,
             ) {
                 // If we still fail, it's a problem with gas charging that happens even in the
-                // "aborted" case — no other option but panic. We would create or destroy SUI
+                // "aborted" case - no other option but panic. We would create or destroy SUI
                 // otherwise (or admit an unauthorized accumulator Split).
                 panic!(
                     "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -13,7 +13,9 @@ pub(crate) mod checked {
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::runtime::MoveRuntime;
-    use mysten_common::{assert_reachable, debug_fatal, in_test_configuration};
+    use mysten_common::{
+        assert_reachable, debug_fatal, debug_fatal_with_metric, in_test_configuration,
+    };
     use std::collections::{BTreeMap, BTreeSet};
     use std::{cell::RefCell, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
@@ -306,7 +308,12 @@ pub(crate) mod checked {
                         execution_result,
                     }
                 }
-                Outcome::BumpOnly { gas_status, error } => {
+                Outcome::BumpOnly {
+                    gas_status,
+                    error,
+                    reason,
+                } => {
+                    report_bump_only::<Mode>(reason, &transaction_digest, &error);
                     // Recorded no-op: consume the dropped store and rebuild from its inputs, keeping only
                     // the input version bumps.
                     temporary_store = temporary_store.into_recorded_noop();
@@ -393,7 +400,7 @@ pub(crate) mod checked {
         sponsor: Option<SuiAddress>,
         is_epoch_change: bool,
         transaction_digest: TransactionDigest,
-    ) -> Result<(), Mode::Error> {
+    ) -> Result<(), (Mode::Error, BumpOnlyReason)> {
         // FIXME: we cannot fail the transaction if this is an epoch change transaction.
         // Conservation + ownership read the cached invariant inputs from the store
         // (`set_invariant_inputs`); genesis flag, advance-epoch summary and the reservation budget
@@ -405,7 +412,8 @@ pub(crate) mod checked {
             move_vm,
             enable_expensive_checks,
             gas_cost_summary,
-        )?;
+        )
+        .map_err(|error| (error, BumpOnlyReason::Conservation))?;
 
         // Ownership invariants — only under expensive checks + non-arbitrary mode; a violation is a
         // real bug that should never fire.
@@ -425,7 +433,10 @@ pub(crate) mod checked {
                 "ownership invariants violated; falling back to the no-op exit (State 2): \
                  dropping all writes and charging nothing",
             );
-            return Err(ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation).into());
+            return Err((
+                ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation).into(),
+                BumpOnlyReason::Ownership,
+            ));
         }
 
         Ok(())
@@ -538,7 +549,66 @@ pub(crate) mod checked {
         BumpOnly {
             gas_status: SuiGasStatus,
             error: Mode::Error,
+            reason: BumpOnlyReason,
         },
+    }
+
+    /// Which stage bailed to the `BumpOnly` (recorded no-op) exit. `InsufficientFundsForWithdraw` is
+    /// the one expected reason; every other variant is an execution bug and is reported to
+    /// `execution_bump_only_exits`, whose `reason` label is `Self::label`.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum BumpOnlyReason {
+        InsufficientFundsForWithdraw,
+        /// Resetting writes after a failed execution could not charge even input-only storage.
+        WriteReset,
+        Conservation,
+        Ownership,
+    }
+
+    impl BumpOnlyReason {
+        /// Metric label. Alerts select on these, so keep the values stable.
+        fn label(self) -> &'static str {
+            match self {
+                Self::InsufficientFundsForWithdraw => "insufficient_funds_for_withdraw",
+                Self::WriteReset => "write_reset",
+                Self::Conservation => "conservation",
+                Self::Ownership => "ownership",
+            }
+        }
+
+        fn is_expected(self) -> bool {
+            matches!(self, Self::InsufficientFundsForWithdraw)
+        }
+    }
+
+    /// Report an unexpected `BumpOnly` exit: a transaction whose writes were all dropped and which
+    /// was charged nothing because a stage of the pipeline failed. `debug_fatal` semantics — panics
+    /// under `crash_on_debug()`, counts + logs in production.
+    ///
+    /// Skipped for the expected IFFW short-circuit, and for the simulation paths
+    /// (`Mode::TRACK_EXECUTION`: dev-inspect / dry-run / simulate), where an arbitrary user-supplied
+    /// transaction must not be able to crash a debug node or raise an alert.
+    fn report_bump_only<Mode: ExecutionMode>(
+        reason: BumpOnlyReason,
+        transaction_digest: &TransactionDigest,
+        error: &Mode::Error,
+    ) {
+        if reason.is_expected() || Mode::TRACK_EXECUTION {
+            return;
+        }
+        debug_fatal_with_metric!(
+            |metrics: &mysten_metrics::Metrics| {
+                metrics
+                    .execution_bump_only_exits
+                    .with_label_values(&[reason.label()])
+                    .inc();
+            },
+            "BumpOnly exit (recorded no-op): all writes dropped, no gas charged. \
+             reason={}, tx_digest={:?}, error={:?}",
+            reason.label(),
+            transaction_digest,
+            error
+        );
     }
 
     struct GasOutcome {
@@ -580,6 +650,7 @@ pub(crate) mod checked {
             return Outcome::BumpOnly {
                 gas_status,
                 error: iffw,
+                reason: BumpOnlyReason::InsufficientFundsForWithdraw,
             };
         }
 
@@ -636,10 +707,11 @@ pub(crate) mod checked {
             execution_params,
             trace_builder_opt,
         ) {
-            Err(error) => {
+            Err((error, reason)) => {
                 return Outcome::BumpOnly {
                     gas_status: gas_charger.into_gas_status(),
                     error,
+                    reason,
                 };
             }
             Ok((gas_cost_summary, execution_result, timings)) => {
@@ -666,9 +738,10 @@ pub(crate) mod checked {
                 execution_result,
                 timings,
             },
-            Err(error) => Outcome::BumpOnly {
+            Err((error, reason)) => Outcome::BumpOnly {
                 gas_status: gas_charger.into_gas_status(),
                 error,
+                reason,
             },
         }
     }
@@ -686,7 +759,7 @@ pub(crate) mod checked {
         metrics: Arc<ExecutionMetrics>,
         execution_params: ExecutionOrEarlyError,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<ExecutionOutcome<Mode>, Mode::Error> {
+    ) -> Result<ExecutionOutcome<Mode>, (Mode::Error, BumpOnlyReason)> {
         debug_assert!(
             gas_charger.no_charges(),
             "No gas charges must be applied yet"
@@ -728,7 +801,9 @@ pub(crate) mod checked {
         let result = result.and_then(|v| checks.map(|()| v));
 
         if result.is_err() {
-            gas_charger.reset_writes(temporary_store)?;
+            gas_charger
+                .reset_writes(temporary_store)
+                .map_err(|error| (error.into(), BumpOnlyReason::WriteReset))?;
         }
         let cost_summary = gas_charger.charge(temporary_store, &result);
         Ok((cost_summary, result, timings))

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -11,7 +11,9 @@ pub mod checked {
     use crate::temporary_store::TemporaryStore;
     use either::Either;
     use indexmap::IndexMap;
+    use move_core_types::language_storage::TypeTag;
     use mysten_common::assert_reachable;
+    use std::collections::BTreeMap;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::deny_list_v2::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS;
     use sui_types::digests::TransactionDigest;
@@ -48,9 +50,19 @@ pub mod checked {
     #[derive(Debug)]
     enum PaymentMetadata {
         Unmetered,
-        Gasless,
+        Gasless(GaslessMetadata),
         /// Contains the list of payments (coins and address balances) and additional metadata
         Smash(SmashMetadata),
+    }
+
+    /// Payment-source metadata for a gasless (metered-but-free) transaction.
+    /// Holds the per-`(owner, token type)` withdrawal reservations declared by the PTB's
+    /// `FundsWithdrawal` inputs, the only extra state `check_gasless_execution_requirements`
+    /// needs. Constant for the transaction's lifetime, so it lives here rather than being
+    /// threaded through the charging pipeline.
+    #[derive(Debug)]
+    struct GaslessMetadata {
+        withdrawal_reservations: BTreeMap<(SuiAddress, TypeTag), u64>,
     }
 
     /// State produced by smashing multiple gas payment sources into one.
@@ -84,7 +96,9 @@ pub mod checked {
     #[derive(Debug)]
     enum PaymentKind_ {
         Unmetered,
-        Gasless,
+        /// Carries the PTB's per-`(owner, token type)` withdrawal reservations, stored into
+        /// `GaslessMetadata` at construction.
+        Gasless(BTreeMap<(SuiAddress, TypeTag), u64>),
         /// A non-empty map of gas coins or address balance withdrawals, keyed by location.
         /// The first entry is the smash target; all others are smashed into it.
         Smash(IndexMap<PaymentLocation, PaymentMethod>),
@@ -130,7 +144,11 @@ pub mod checked {
             let gas_model_version = protocol_config.gas_model_version();
             let payment = match payment_kind.0 {
                 PaymentKind_::Unmetered => PaymentMetadata::Unmetered,
-                PaymentKind_::Gasless => PaymentMetadata::Gasless,
+                PaymentKind_::Gasless(withdrawal_reservations) => {
+                    PaymentMetadata::Gasless(GaslessMetadata {
+                        withdrawal_reservations,
+                    })
+                }
                 PaymentKind_::Smash(mut payment_methods) => {
                     let (_, smash_target) = payment_methods.shift_remove_index(0).unwrap();
                     let mut metadata = SmashMetadata {
@@ -165,7 +183,7 @@ pub mod checked {
         //       Explore way to remove it.
         pub(crate) fn used_coins(&self) -> impl Iterator<Item = &'_ ObjectRef> {
             match &self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => {
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => {
                     Either::Left(std::iter::empty())
                 }
                 PaymentMetadata::Smash(metadata) => Either::Right(metadata.used_coins()),
@@ -193,7 +211,7 @@ pub mod checked {
         /// is used.
         pub fn gas_payment_amount(&self) -> Option<GasPayment> {
             match &self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => None,
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => None,
                 PaymentMetadata::Smash(metadata) => Some(GasPayment {
                     location: metadata.smash_target.location(),
                     amount: metadata.total_smashed,
@@ -212,7 +230,7 @@ pub mod checked {
 
         pub(crate) fn gas_payment_location(&self) -> Option<PaymentLocation> {
             match &self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => None,
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => None,
                 PaymentMetadata::Smash(metadata) => Some(metadata.gas_charge_location),
             }
         }
@@ -233,6 +251,10 @@ pub mod checked {
 
         pub fn is_unmetered(&self) -> bool {
             self.gas_status.is_unmetered()
+        }
+
+        pub fn set_computation_to_budget(&mut self) {
+            self.gas_status.adjust_computation_on_out_of_gas();
         }
 
         pub fn move_gas_status(&self) -> &GasStatus {
@@ -260,7 +282,7 @@ pub mod checked {
         // are correct.
         fn smash_gas(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             match &mut self.payment {
-                PaymentMetadata::Unmetered | PaymentMetadata::Gasless => (),
+                PaymentMetadata::Unmetered | PaymentMetadata::Gasless(_) => (),
                 PaymentMetadata::Smash(smash_metadata) => {
                     smash_metadata.smash_gas(&self.tx_digest, temporary_store);
                 }
@@ -276,7 +298,7 @@ pub mod checked {
             object_id: ObjectID,
             new_size: usize,
             storage_rebate: u64,
-        ) -> u64 {
+        ) -> Option<u64> {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
         }
@@ -287,6 +309,21 @@ pub mod checked {
 
         pub fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
             self.gas_status.charge_publish_package(size)
+        }
+
+        /// Charge `storage_read` for each input object (system packages excepted). Charges go into the
+        /// Move VM meter, which `summary()` reads live — so the running summary reflects them on return.
+        pub fn charge_input_objects(
+            &mut self,
+            temporary_store: &TemporaryStore<'_>,
+        ) -> Result<(), ExecutionError> {
+            temporary_store
+                .objects()
+                .iter()
+                // don't charge for loading Sui Framework or Move stdlib
+                .filter(|(id, _)| !is_system_package(**id))
+                .map(|(_, obj)| obj.object_size_for_gas_metering())
+                .try_for_each(|size| self.gas_status.charge_storage_read(size))
         }
 
         pub fn charge_coin_transfers(
@@ -307,19 +344,186 @@ pub mod checked {
             self.gas_status.charge_storage_read(owner_cost)
         }
 
-        /// Resets any mutations, deletions, and events recorded in the store, as well as any storage costs and
-        /// rebates, then Re-runs gas smashing. Effects on store are now as if we were about to begin execution
+        /// Restore the store + gas state to the post-input shape: drop execution writes, clear storage
+        /// cost/rebate, re-smash gas (`drop_writes` cleared it), and re-touch mutable inputs so their
+        /// versions still bump on the err path. Used by the legacy storage-OOG fallback and the v15+
+        /// err-path handler.
         pub fn reset(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             temporary_store.drop_writes();
             self.gas_status.reset_storage_cost_and_rebate();
             self.smash_gas(temporary_store);
+            temporary_store.ensure_active_inputs_mutated();
+        }
+
+        /// Tail of `execute_ptb`: bucketize computation via `bucketize_computation`, which fixes the
+        /// effective gas price (lowered to the abort-tx cap on a Move abort) and signals OOG if priced
+        /// computation alone exceeds the budget. Runs on Ok or Err (to capture the abort flag); an
+        /// execution error keeps precedence over a rounding error. Skipped for unmetered.
+        pub fn round_computation<T, E: ExecutionErrorTrait>(
+            &mut self,
+            result: Result<T, E>,
+        ) -> Result<T, E> {
+            debug_assert!(self.gas_status.storage_rebate() == 0);
+            debug_assert!(self.gas_status.storage_gas_units() == 0);
+
+            if matches!(&self.payment, PaymentMetadata::Unmetered) {
+                return result;
+            }
+            let is_move_abort = matches!(
+                result.as_ref().err().map(|e| e.kind()),
+                Some(sui_types::execution_status::ExecutionErrorKind::MoveAbort(
+                    ..
+                ))
+            );
+            let round_res = self.gas_status.bucketize_computation(Some(is_move_abort));
+            match result {
+                Ok(v) => round_res.map(|_| v).map_err(Into::into),
+                Err(e) => Err(e),
+            }
+        }
+
+        /// Collect per-object storage cost/rebate and verify it fits the remaining budget. For gasless,
+        /// validate execution requirements first (before `ensure_active_inputs_mutated` adds objects to
+        /// written_objects). Does not retry/reset (the caller does) and does not apply payment (`charge` does).
+        pub fn charge_storage(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+        ) -> Result<(), ExecutionError> {
+            match &self.payment {
+                PaymentMetadata::Unmetered => {
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self)
+                }
+                PaymentMetadata::Gasless(meta) => {
+                    temporary_store
+                        .check_gasless_execution_requirements(Some(&meta.withdrawal_reservations))
+                        .map_err(|msg| {
+                            ExecutionError::new_with_source(
+                                sui_types::execution_status::ExecutionErrorKind::InsufficientGas,
+                                msg,
+                            )
+                        })?;
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self)
+                }
+                PaymentMetadata::Smash(_) => {
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self)?;
+                    self.gas_status.charge_storage_and_rebate()
+                }
+            }
+        }
+
+        /// Apply the final gas charge derived from the current `SuiGasStatus`, per payment kind
+        /// (`Unmetered` / `Gasless` / `Smash`).
+        ///
+        /// Reads `metadata.gas_charge_location` at apply time (no pre-rewind snapshot): the SUIPR-753
+        /// fix — `reset_writes` runs before `charge`, undoing any override (e.g. `coin::send_funds`)
+        /// on the err path before we read here.
+        pub fn charge<T, E: ExecutionErrorTrait>(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            execution_result: &Result<T, E>,
+        ) -> GasCostSummary {
+            match &self.payment {
+                PaymentMetadata::Unmetered => {
+                    // Park unmetered (system-tx) storage rebate into 0x5 so SUI is not dropped.
+                    let unmetered_storage_rebate = self.gas_status.unmetered_storage_rebate();
+                    temporary_store.conserve_unmetered_storage_rebate(unmetered_storage_rebate);
+                    GasCostSummary::default()
+                }
+                PaymentMetadata::Gasless(_) => {
+                    if execution_result.is_err() {
+                        return GasCostSummary::default();
+                    }
+                    let cost_summary = self.gas_status.summary();
+                    let storage_cost = cost_summary.storage_cost;
+                    assert!(
+                        storage_cost == 0,
+                        "Gasless transaction must not incur storage cost, got {storage_cost}"
+                    );
+                    let sender_rebate = cost_summary.storage_rebate;
+                    GasCostSummary {
+                        computation_cost: sender_rebate,
+                        storage_cost: 0,
+                        storage_rebate: sender_rebate,
+                        non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
+                    }
+                }
+                PaymentMetadata::Smash(metadata) => {
+                    let iffw_failure = execution_result.as_ref().err().is_some_and(|err| {
+                        matches!(
+                            err.kind(),
+                            sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
+                        )
+                    });
+                    // IFFW against an address balance: nothing was withdrawn, so charge nothing.
+                    if iffw_failure
+                        && matches!(
+                            metadata.gas_charge_location,
+                            PaymentLocation::AddressBalance(_)
+                        )
+                    {
+                        return GasCostSummary::default();
+                    }
+                    if let PaymentLocation::Coin(_) = metadata.gas_charge_location {
+                        #[skip_checked_arithmetic]
+                        trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+                    }
+                    let cost_summary = self.gas_status.summary();
+                    self.apply_payment(temporary_store, cost_summary, metadata.gas_charge_location)
+                }
+            }
+        }
+
+        /// Deduct the charge: from the gas coin (coin payment) or via an accumulator event (address
+        /// balance).
+        fn apply_payment(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            cost_summary: GasCostSummary,
+            gas_payment_location: PaymentLocation,
+        ) -> GasCostSummary {
+            let net_change = cost_summary.net_gas_usage();
+            match gas_payment_location {
+                PaymentLocation::AddressBalance(payer_address) => {
+                    if net_change != 0 {
+                        let balance_type = sui_types::balance::Balance::type_tag(
+                            sui_types::gas_coin::GAS::type_tag(),
+                        );
+                        let event = AccumulatorEvent::from_balance_change(
+                            payer_address,
+                            balance_type,
+                            net_change
+                                .checked_neg()
+                                .expect("net gas usage is never i64::MIN"),
+                        )
+                        .expect("Failed to create accumulator event for gas charging");
+                        temporary_store.add_accumulator_event(event);
+                    }
+                }
+                PaymentLocation::Coin(gas_object_id) => {
+                    let mut gas_object = temporary_store
+                        .read_object(&gas_object_id)
+                        .expect("gas coin is an input object and present after smashing")
+                        .clone();
+                    deduct_gas(&mut gas_object, net_change);
+                    #[skip_checked_arithmetic]
+                    trace!(net_change, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+                    temporary_store.mutate_new_or_input_object(gas_object);
+                }
+            }
+            cost_summary
         }
 
         // === legacy methods below — see `mod legacy` for the full bodies ===
     }
 
-    /// Frozen pre-v15 (`gas_model_version < 15`) gas charging, mirroring `origin/main` (incl. the
-    /// SUIPR-753 fix). Removed at the next execution-version cut.
+    /// Pre-refactor gas charging: a single monolithic `charge_gas` plus the storage-OOG
+    /// retry helpers. Kept here so transactions executed at `gas_model_version < 15`
+    /// (i.e. before the v15+ pipeline activates) replay bit-for-bit identically to
+    /// what `origin/main` produces today, including the SUIPR-753 surgical fix gated on
+    /// `refresh_gas_payment_location`. Will be removed when execution_version bumps past 4.
     mod legacy {
         use super::*;
 
@@ -393,7 +597,9 @@ pub mod checked {
 
                 // compute and collect storage charges
                 temporary_store.ensure_active_inputs_mutated();
-                temporary_store.collect_storage_and_rebate(self);
+                temporary_store
+                    .collect_storage_and_rebate(self)
+                    .expect("storage gas overflow");
 
                 if matches!(&self.payment, PaymentMetadata::Unmetered) {
                     return GasCostSummary::default();
@@ -434,7 +640,7 @@ pub mod checked {
                 let Some(gas_payment_location) = gas_payment_location else {
                     // Gasless: sender pays nothing.
                     assert!(
-                        matches!(self.payment, PaymentMetadata::Gasless),
+                        matches!(self.payment, PaymentMetadata::Gasless(_)),
                         "Only gasless transactions should reach this point without a payment location"
                     );
                     if execution_result.is_err() {
@@ -508,14 +714,18 @@ pub mod checked {
                     // Attempt to charge just for computation + input object storage costs - storage_rebate
                     self.reset(temporary_store);
                     temporary_store.ensure_active_inputs_mutated();
-                    temporary_store.collect_storage_and_rebate(self);
+                    temporary_store
+                        .collect_storage_and_rebate(self)
+                        .expect("storage gas overflow");
                     if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                         // we run out of gas attempting to charge for the input objects exclusively,
                         // deal with this edge case by not charging for storage: we charge (gas_budget - rebates).
                         self.reset(temporary_store);
                         self.gas_status.adjust_computation_on_out_of_gas();
                         temporary_store.ensure_active_inputs_mutated();
-                        temporary_store.collect_rebate(self);
+                        temporary_store
+                            .collect_rebate(self)
+                            .expect("storage gas overflow");
                         if execution_result.is_ok() {
                             *execution_result = Err(err.into());
                         }
@@ -523,6 +733,22 @@ pub mod checked {
                         *execution_result = Err(err.into());
                     }
                 }
+            }
+
+            /// Single reset for execution errors.
+            /// Invoked on any legitimate error (Move Abort, OOG, etc.).
+            /// Errors here become BumpOnly
+            pub(crate) fn reset_writes(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+            ) -> Result<(), ExecutionError> {
+                self.reset(temporary_store);
+                self.charge_storage(temporary_store).or_else(|_| {
+                    // Even input-only storage doesn't fit: full budget for computation, rebates only.
+                    self.reset(temporary_store);
+                    self.set_computation_to_budget();
+                    temporary_store.collect_rebate(self)
+                })
             }
         }
     }
@@ -670,8 +896,16 @@ pub mod checked {
             Self(PaymentKind_::Unmetered)
         }
 
+        /// Metered-but-free with no withdrawal reservations (the legacy path; never reads them).
         pub fn gasless() -> Self {
-            Self(PaymentKind_::Gasless)
+            Self(PaymentKind_::Gasless(BTreeMap::new()))
+        }
+
+        /// Metered-but-free carrying the withdrawal reservations.
+        pub fn gasless_with_reservations(
+            withdrawal_reservations: BTreeMap<(SuiAddress, TypeTag), u64>,
+        ) -> Self {
+            Self(PaymentKind_::Gasless(withdrawal_reservations))
         }
 
         pub fn smash(payment_methods: Vec<PaymentMethod>) -> Option<Self> {

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -393,9 +393,6 @@ pub mod checked {
             }
         }
 
-        /// Single reset for execution errors.
-        /// Invoked on any legitimate error (Move Abort, OOG, etc.).
-        /// Errors here become BumpOnly
         pub(crate) fn handle_error(
             &mut self,
             temporary_store: &mut TemporaryStore<'_>,
@@ -492,7 +489,7 @@ pub mod checked {
             cost_summary
         }
 
-        // === legacy methods below — see `mod legacy` for the full bodies ===
+        // === legacy methods below - see `mod legacy` for the full bodies ===
     }
 
     /// Pre-refactor gas charging: a single monolithic `charge_gas` plus the storage-OOG

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -48,6 +48,9 @@ pub mod checked {
     #[derive(Debug)]
     enum PaymentMetadata {
         Unmetered,
+        /// Metered-but-free; carries no state. The gasless withdrawal reservations the
+        /// storage-charging validation needs are cached on the `TemporaryStore` (see
+        /// `set_invariant_inputs`).
         Gasless,
         /// Contains the list of payments (coins and address balances) and additional metadata
         Smash(SmashMetadata),
@@ -152,12 +155,15 @@ pub mod checked {
             }
         }
 
-        pub fn new_unmetered(tx_digest: TransactionDigest) -> Self {
+        pub fn new_unmetered(
+            tx_digest: TransactionDigest,
+            protocol_config: &ProtocolConfig,
+        ) -> Self {
             Self {
                 tx_digest,
-                gas_model_version: 6, // pick any of the latest, it should not matter
+                gas_model_version: protocol_config.gas_model_version(),
                 payment: PaymentMetadata::Unmetered,
-                gas_status: SuiGasStatus::new_unmetered(),
+                gas_status: SuiGasStatus::new_unmetered(protocol_config),
             }
         }
 
@@ -235,6 +241,10 @@ pub mod checked {
             self.gas_status.is_unmetered()
         }
 
+        pub fn set_computation_to_budget(&mut self) {
+            self.gas_status.adjust_computation_on_out_of_gas();
+        }
+
         pub fn move_gas_status(&self) -> &GasStatus {
             self.gas_status.move_gas_status()
         }
@@ -276,7 +286,7 @@ pub mod checked {
             object_id: ObjectID,
             new_size: usize,
             storage_rebate: u64,
-        ) -> u64 {
+        ) -> Option<u64> {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
         }
@@ -287,6 +297,21 @@ pub mod checked {
 
         pub fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
             self.gas_status.charge_publish_package(size)
+        }
+
+        /// Charge `storage_read` for each input object (system packages excepted). Charges go into the
+        /// Move VM meter, which `summary()` reads live — so the running summary reflects them on return.
+        pub fn charge_input_objects(
+            &mut self,
+            temporary_store: &TemporaryStore<'_>,
+        ) -> Result<(), ExecutionError> {
+            temporary_store
+                .objects()
+                .iter()
+                // don't charge for loading Sui Framework or Move stdlib
+                .filter(|(id, _)| !is_system_package(**id))
+                .map(|(_, obj)| obj.object_size_for_gas_metering())
+                .try_for_each(|size| self.gas_status.charge_storage_read(size))
         }
 
         pub fn charge_coin_transfers(
@@ -307,19 +332,186 @@ pub mod checked {
             self.gas_status.charge_storage_read(owner_cost)
         }
 
-        /// Resets any mutations, deletions, and events recorded in the store, as well as any storage costs and
-        /// rebates, then Re-runs gas smashing. Effects on store are now as if we were about to begin execution
+        /// Restore the store + gas state to the post-input shape: drop execution writes, clear storage
+        /// cost/rebate, re-smash gas (`drop_writes` cleared it), and re-touch mutable inputs so their
+        /// versions still bump on the err path. Used by the legacy storage-OOG fallback and the v15+
+        /// err-path handler.
         pub fn reset(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             temporary_store.drop_writes();
             self.gas_status.reset_storage_cost_and_rebate();
             self.smash_gas(temporary_store);
+            temporary_store.ensure_active_inputs_mutated();
+        }
+
+        /// Tail of `execute_ptb`: bucketize computation via `bucketize_computation`, which fixes the
+        /// effective gas price (lowered to the abort-tx cap on a Move abort) and signals OOG if priced
+        /// computation alone exceeds the budget. Runs on Ok or Err (to capture the abort flag); an
+        /// execution error keeps precedence over a rounding error. Skipped for unmetered.
+        pub fn round_computation<T, E: ExecutionErrorTrait>(
+            &mut self,
+            result: Result<T, E>,
+        ) -> Result<T, E> {
+            debug_assert!(self.gas_status.storage_rebate() == 0);
+            debug_assert!(self.gas_status.storage_gas_units() == 0);
+
+            if matches!(&self.payment, PaymentMetadata::Unmetered) {
+                return result;
+            }
+            let is_move_abort = matches!(
+                result.as_ref().err().map(|e| e.kind()),
+                Some(sui_types::execution_status::ExecutionErrorKind::MoveAbort(
+                    ..
+                ))
+            );
+            let round_res = self.gas_status.bucketize_computation(Some(is_move_abort));
+            match result {
+                Ok(v) => round_res.map(|_| v).map_err(Into::into),
+                Err(e) => Err(e),
+            }
+        }
+
+        /// Collect per-object storage cost/rebate and verify it fits the remaining budget. For gasless,
+        /// validate execution requirements first (before `ensure_active_inputs_mutated` adds objects to
+        /// written_objects). Does not retry/reset (the caller does) and does not apply payment (`charge` does).
+        pub fn charge_storage(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+        ) -> Result<(), ExecutionError> {
+            match &self.payment {
+                PaymentMetadata::Unmetered => {
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self)
+                }
+                PaymentMetadata::Gasless => {
+                    temporary_store
+                        .check_gasless_execution_requirements()
+                        .map_err(|msg| {
+                            ExecutionError::new_with_source(
+                                sui_types::execution_status::ExecutionErrorKind::InsufficientGas,
+                                msg,
+                            )
+                        })?;
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self)
+                }
+                PaymentMetadata::Smash(_) => {
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self)?;
+                    self.gas_status.charge_storage_and_rebate()
+                }
+            }
+        }
+
+        /// Apply the final gas charge derived from the current `SuiGasStatus`, per payment kind
+        /// (`Unmetered` / `Gasless` / `Smash`).
+        ///
+        /// Reads `metadata.gas_charge_location` at apply time (no pre-rewind snapshot): the SUIPR-753
+        /// fix — `reset_writes` runs before `charge`, undoing any override (e.g. `coin::send_funds`)
+        /// on the err path before we read here.
+        pub fn charge<T, E: ExecutionErrorTrait>(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            execution_result: &Result<T, E>,
+        ) -> GasCostSummary {
+            match &self.payment {
+                PaymentMetadata::Unmetered => {
+                    // Park unmetered (system-tx) storage rebate into 0x5 so SUI is not dropped.
+                    let unmetered_storage_rebate = self.gas_status.unmetered_storage_rebate();
+                    temporary_store.conserve_unmetered_storage_rebate(unmetered_storage_rebate);
+                    GasCostSummary::default()
+                }
+                PaymentMetadata::Gasless => {
+                    if execution_result.is_err() {
+                        return GasCostSummary::default();
+                    }
+                    let cost_summary = self.gas_status.summary();
+                    let storage_cost = cost_summary.storage_cost;
+                    assert!(
+                        storage_cost == 0,
+                        "Gasless transaction must not incur storage cost, got {storage_cost}"
+                    );
+                    let sender_rebate = cost_summary.storage_rebate;
+                    GasCostSummary {
+                        computation_cost: sender_rebate,
+                        storage_cost: 0,
+                        storage_rebate: sender_rebate,
+                        non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
+                    }
+                }
+                PaymentMetadata::Smash(metadata) => {
+                    let iffw_failure = execution_result.as_ref().err().is_some_and(|err| {
+                        matches!(
+                            err.kind(),
+                            sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
+                        )
+                    });
+                    // IFFW against an address balance: nothing was withdrawn, so charge nothing.
+                    if iffw_failure
+                        && matches!(
+                            metadata.gas_charge_location,
+                            PaymentLocation::AddressBalance(_)
+                        )
+                    {
+                        return GasCostSummary::default();
+                    }
+                    if let PaymentLocation::Coin(_) = metadata.gas_charge_location {
+                        #[skip_checked_arithmetic]
+                        trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+                    }
+                    let cost_summary = self.gas_status.summary();
+                    self.apply_payment(temporary_store, cost_summary, metadata.gas_charge_location)
+                }
+            }
+        }
+
+        /// Deduct the charge: from the gas coin (coin payment) or via an accumulator event (address
+        /// balance).
+        fn apply_payment(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            cost_summary: GasCostSummary,
+            gas_payment_location: PaymentLocation,
+        ) -> GasCostSummary {
+            let net_change = cost_summary.net_gas_usage();
+            match gas_payment_location {
+                PaymentLocation::AddressBalance(payer_address) => {
+                    if net_change != 0 {
+                        let balance_type = sui_types::balance::Balance::type_tag(
+                            sui_types::gas_coin::GAS::type_tag(),
+                        );
+                        let event = AccumulatorEvent::from_balance_change(
+                            payer_address,
+                            balance_type,
+                            net_change
+                                .checked_neg()
+                                .expect("net gas usage is never i64::MIN"),
+                        )
+                        .expect("Failed to create accumulator event for gas charging");
+                        temporary_store.add_accumulator_event(event);
+                    }
+                }
+                PaymentLocation::Coin(gas_object_id) => {
+                    let mut gas_object = temporary_store
+                        .read_object(&gas_object_id)
+                        .expect("gas coin is an input object and present after smashing")
+                        .clone();
+                    deduct_gas(&mut gas_object, net_change);
+                    #[skip_checked_arithmetic]
+                    trace!(net_change, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+                    temporary_store.mutate_new_or_input_object(gas_object);
+                }
+            }
+            cost_summary
         }
 
         // === legacy methods below — see `mod legacy` for the full bodies ===
     }
 
-    /// Frozen pre-v15 (`gas_model_version < 15`) gas charging, mirroring `origin/main` (incl. the
-    /// SUIPR-753 fix). Removed at the next execution-version cut.
+    /// Pre-refactor gas charging: a single monolithic `charge_gas` plus the storage-OOG
+    /// retry helpers. Kept here so transactions executed at `gas_model_version < 15`
+    /// (i.e. before the v15+ pipeline activates) replay bit-for-bit identically to
+    /// what `origin/main` produces today, including the SUIPR-753 surgical fix gated on
+    /// `refresh_gas_payment_location`. Will be removed when execution_version bumps past 4.
     mod legacy {
         use super::*;
 
@@ -393,7 +585,9 @@ pub mod checked {
 
                 // compute and collect storage charges
                 temporary_store.ensure_active_inputs_mutated();
-                temporary_store.collect_storage_and_rebate(self);
+                temporary_store
+                    .collect_storage_and_rebate(self)
+                    .expect("storage gas overflow");
 
                 if matches!(&self.payment, PaymentMetadata::Unmetered) {
                     return GasCostSummary::default();
@@ -508,14 +702,18 @@ pub mod checked {
                     // Attempt to charge just for computation + input object storage costs - storage_rebate
                     self.reset(temporary_store);
                     temporary_store.ensure_active_inputs_mutated();
-                    temporary_store.collect_storage_and_rebate(self);
+                    temporary_store
+                        .collect_storage_and_rebate(self)
+                        .expect("storage gas overflow");
                     if let Err(err) = self.gas_status.charge_storage_and_rebate() {
                         // we run out of gas attempting to charge for the input objects exclusively,
                         // deal with this edge case by not charging for storage: we charge (gas_budget - rebates).
                         self.reset(temporary_store);
                         self.gas_status.adjust_computation_on_out_of_gas();
                         temporary_store.ensure_active_inputs_mutated();
-                        temporary_store.collect_rebate(self);
+                        temporary_store
+                            .collect_rebate(self)
+                            .expect("storage gas overflow");
                         if execution_result.is_ok() {
                             *execution_result = Err(err.into());
                         }
@@ -523,6 +721,22 @@ pub mod checked {
                         *execution_result = Err(err.into());
                     }
                 }
+            }
+
+            /// Single reset for execution errors.
+            /// Invoked on any legitimate error (Move Abort, OOG, etc.).
+            /// Errors here become BumpOnly
+            pub(crate) fn reset_writes(
+                &mut self,
+                temporary_store: &mut TemporaryStore<'_>,
+            ) -> Result<(), ExecutionError> {
+                self.reset(temporary_store);
+                self.charge_storage(temporary_store).or_else(|_| {
+                    // Even input-only storage doesn't fit: full budget for computation, rebates only.
+                    self.reset(temporary_store);
+                    self.set_computation_to_budget();
+                    temporary_store.collect_rebate(self)
+                })
             }
         }
     }
@@ -670,6 +884,7 @@ pub mod checked {
             Self(PaymentKind_::Unmetered)
         }
 
+        /// Metered-but-free.
         pub fn gasless() -> Self {
             Self(PaymentKind_::Gasless)
         }

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -48,9 +48,6 @@ pub mod checked {
     #[derive(Debug)]
     enum PaymentMetadata {
         Unmetered,
-        /// Metered-but-free; carries no state. The gasless withdrawal reservations the
-        /// storage-charging validation needs are cached on the `TemporaryStore` (see
-        /// `set_invariant_inputs`).
         Gasless,
         /// Contains the list of payments (coins and address balances) and additional metadata
         Smash(SmashMetadata),
@@ -299,8 +296,7 @@ pub mod checked {
             self.gas_status.charge_publish_package(size)
         }
 
-        /// Charge `storage_read` for each input object (system packages excepted). Charges go into the
-        /// Move VM meter, which `summary()` reads live — so the running summary reflects them on return.
+        /// Charge `storage_read` for each input object (system packages excepted).
         pub fn charge_input_objects(
             &mut self,
             temporary_store: &TemporaryStore<'_>,
@@ -332,10 +328,9 @@ pub mod checked {
             self.gas_status.charge_storage_read(owner_cost)
         }
 
-        /// Restore the store + gas state to the post-input shape: drop execution writes, clear storage
-        /// cost/rebate, re-smash gas (`drop_writes` cleared it), and re-touch mutable inputs so their
-        /// versions still bump on the err path. Used by the legacy storage-OOG fallback and the v15+
-        /// err-path handler.
+        /// Restore the store + gas state to the post-input shape: drop execution writes, clear
+        /// storage cost/rebate, re-smash gas, and re-touch mutable inputs so their versions still
+        /// bump on the err path.
         pub fn reset(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             temporary_store.drop_writes();
             self.gas_status.reset_storage_cost_and_rebate();
@@ -343,10 +338,6 @@ pub mod checked {
             temporary_store.ensure_active_inputs_mutated();
         }
 
-        /// Tail of `execute_ptb`: bucketize computation via `bucketize_computation`, which fixes the
-        /// effective gas price (lowered to the abort-tx cap on a Move abort) and signals OOG if priced
-        /// computation alone exceeds the budget. Runs on Ok or Err (to capture the abort flag); an
-        /// execution error keeps precedence over a rounding error. Skipped for unmetered.
         pub fn round_computation<T, E: ExecutionErrorTrait>(
             &mut self,
             result: Result<T, E>,
@@ -370,10 +361,10 @@ pub mod checked {
             }
         }
 
-        /// Collect per-object storage cost/rebate and verify it fits the remaining budget. For gasless,
-        /// validate execution requirements first (before `ensure_active_inputs_mutated` adds objects to
-        /// written_objects). Does not retry/reset (the caller does) and does not apply payment (`charge` does).
-        pub fn charge_storage(
+        /// Meter storage: collect per-object storage cost/rebate and verify it fits the remaining
+        /// budget. Payment is applied later, by `charge`. For gasless, the execution requirements
+        /// must be validated before `ensure_active_inputs_mutated` populates `written_objects`.
+        pub fn meter_storage(
             &mut self,
             temporary_store: &mut TemporaryStore<'_>,
         ) -> Result<(), ExecutionError> {
@@ -402,12 +393,24 @@ pub mod checked {
             }
         }
 
+        /// Single reset for execution errors.
+        /// Invoked on any legitimate error (Move Abort, OOG, etc.).
+        /// Errors here become BumpOnly
+        pub(crate) fn handle_error(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+        ) -> Result<(), ExecutionError> {
+            self.reset(temporary_store);
+            self.meter_storage(temporary_store).or_else(|_| {
+                // Even input-only storage doesn't fit: full budget for computation, rebates only.
+                self.reset(temporary_store);
+                self.set_computation_to_budget();
+                temporary_store.collect_rebate(self)
+            })
+        }
+
         /// Apply the final gas charge derived from the current `SuiGasStatus`, per payment kind
         /// (`Unmetered` / `Gasless` / `Smash`).
-        ///
-        /// Reads `metadata.gas_charge_location` at apply time (no pre-rewind snapshot): the SUIPR-753
-        /// fix — `reset_writes` runs before `charge`, undoing any override (e.g. `coin::send_funds`)
-        /// on the err path before we read here.
         pub fn charge<T, E: ExecutionErrorTrait>(
             &mut self,
             temporary_store: &mut TemporaryStore<'_>,
@@ -439,21 +442,6 @@ pub mod checked {
                     }
                 }
                 PaymentMetadata::Smash(metadata) => {
-                    let iffw_failure = execution_result.as_ref().err().is_some_and(|err| {
-                        matches!(
-                            err.kind(),
-                            sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
-                        )
-                    });
-                    // IFFW against an address balance: nothing was withdrawn, so charge nothing.
-                    if iffw_failure
-                        && matches!(
-                            metadata.gas_charge_location,
-                            PaymentLocation::AddressBalance(_)
-                        )
-                    {
-                        return GasCostSummary::default();
-                    }
                     if let PaymentLocation::Coin(_) = metadata.gas_charge_location {
                         #[skip_checked_arithmetic]
                         trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
@@ -464,8 +452,8 @@ pub mod checked {
             }
         }
 
-        /// Deduct the charge: from the gas coin (coin payment) or via an accumulator event (address
-        /// balance).
+        /// Apply the net gas charge or refund: to the gas coin (coin payment) or via an
+        /// accumulator event (address balance).
         fn apply_payment(
             &mut self,
             temporary_store: &mut TemporaryStore<'_>,
@@ -722,22 +710,6 @@ pub mod checked {
                     }
                 }
             }
-
-            /// Single reset for execution errors.
-            /// Invoked on any legitimate error (Move Abort, OOG, etc.).
-            /// Errors here become BumpOnly
-            pub(crate) fn reset_writes(
-                &mut self,
-                temporary_store: &mut TemporaryStore<'_>,
-            ) -> Result<(), ExecutionError> {
-                self.reset(temporary_store);
-                self.charge_storage(temporary_store).or_else(|_| {
-                    // Even input-only storage doesn't fit: full budget for computation, rebates only.
-                    self.reset(temporary_store);
-                    self.set_computation_to_budget();
-                    temporary_store.collect_rebate(self)
-                })
-            }
         }
     }
 
@@ -889,11 +861,9 @@ pub mod checked {
             Self(PaymentKind_::Gasless)
         }
 
+        /// `None` on an invalid payment set: empty, a duplicate gas coin, or an overflowing
+        /// address-balance reservation sum.
         pub fn smash(payment_methods: Vec<PaymentMethod>) -> Option<Self> {
-            debug_assert!(
-                !payment_methods.is_empty(),
-                "GasCharger must have at least one payment method"
-            );
             if payment_methods.is_empty() {
                 return None;
             }
@@ -914,16 +884,10 @@ pub mod checked {
                             unreachable!("Payment method does not match location")
                         };
                         assert_eq!(*addr, other, "Payment method does not match location");
-                        *amount += additional;
+                        *amount = amount.checked_add(additional)?;
                     }
-                    (indexmap::map::Entry::Occupied(_), _) => {
-                        debug_assert!(
-                            false,
-                            "Duplicate coin payment method found, \
-                             which should have been prevented by input checks"
-                        );
-                        return None;
-                    }
+                    // Duplicate gas coin; input checks should have rejected it.
+                    (indexmap::map::Entry::Occupied(_), _) => return None,
                 }
             }
             Some(Self(PaymentKind_::Smash(unique_methods)))

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -27,7 +27,7 @@ use sui_types::inner_temporary_store::InnerTemporaryStore;
 use sui_types::object::Data;
 use sui_types::storage::{BackingStore, DenyListResult, PackageObject};
 use sui_types::sui_system_state::{AdvanceEpochParams, get_sui_system_state_wrapper};
-use sui_types::transaction::{GasData, TransactionKind, is_gasless_transaction};
+use sui_types::transaction::{GasData, TransactionKind};
 use sui_types::{
     SUI_DENY_LIST_OBJECT_ID,
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
@@ -576,11 +576,10 @@ impl<'backing> TemporaryStore<'backing> {
         self.invariants.clear();
     }
 
-    /// Consume this (post-execution) store and return the "recorded no-op" store used by a BumpOnly bail:
-    /// keep the input-derived state it already computed, discard everything execution produced, then bump
-    /// the mutable inputs. Its effects then record ONLY those input version bumps and the input
-    /// dependencies — nothing the (now-discarded) execution touched.
-    pub(crate) fn into_recorded_noop(self) -> Self {
+    /// Consume this (post-execution) store and return the store used by a `BumpOnly` exit: keep
+    /// the input-derived state, discard everything execution produced, then bump the mutable
+    /// inputs. Its effects record only those version bumps and the input dependencies.
+    pub(crate) fn into_bump_only(self) -> Self {
         let Self {
             // Input-derived — reused verbatim.
             store,
@@ -602,7 +601,7 @@ impl<'backing> TemporaryStore<'backing> {
             loaded_per_epoch_config_objects: _,
             invariants: _,
         } = self;
-        let mut noop = Self {
+        let mut bump_only = Self {
             store,
             tx_digest,
             input_objects,
@@ -621,9 +620,9 @@ impl<'backing> TemporaryStore<'backing> {
             loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
             invariants: InvariantChecker::new(),
         };
-        // The only "writes" a no-op has: bump the versions of the mutable inputs it locked.
-        noop.ensure_active_inputs_mutated();
-        noop
+        // The only writes a BumpOnly exit records: bump the versions of the mutable inputs it locked.
+        bump_only.ensure_active_inputs_mutated();
+        bump_only
     }
 
     pub fn read_object(&self, id: &ObjectID) -> Option<&Object> {
@@ -708,12 +707,12 @@ impl<'backing> TemporaryStore<'backing> {
             .fold(0, |sum, obj| sum + obj.object_size_for_gas_metering())
     }
 
-    /// Validates gasless post-execution invariants, using the withdrawal reservations cached by
-    /// [`Self::set_invariant_inputs`].
+    /// Validates gasless post-execution invariants, using the withdrawal reservations derived
+    /// from the input reservations cached by [`Self::set_invariant_inputs`].
     pub(crate) fn check_gasless_execution_requirements(&self) -> Result<(), String> {
-        self.check_gasless_execution_requirements_with_reservations(
-            self.invariants.gasless_reservations(),
-        )
+        self.check_gasless_execution_requirements_with_reservations(Some(
+            &self.invariants.gasless_reservations(),
+        ))
     }
 
     /// Validates gasless post-execution invariants:
@@ -878,9 +877,8 @@ impl<'backing> TemporaryStore<'backing> {
         self.protocol_config
     }
 
-    /// Cache the transaction-derived inputs the system-invariant checks need (consumed by both the
-    /// conservation checks and the ownership-invariant check). Must be called once, before
-    /// execution, after any gas-smash filtering of `gas_data`.
+    /// Cache the transaction-derived inputs the system-invariant checks need. Must be called once,
+    /// before execution, after any gas-smash filtering of `gas_data`.
     /// See [`invariants::InvariantChecker::set_transaction_inputs`].
     pub(crate) fn set_invariant_inputs(
         &mut self,
@@ -888,15 +886,8 @@ impl<'backing> TemporaryStore<'backing> {
         gas_data: &GasData,
         transaction_signer: SuiAddress,
     ) {
-        // Same gasless predicate as the execution engine's `payment_kind`.
-        let is_gasless = self.protocol_config.enable_gasless()
-            && is_gasless_transaction(gas_data, transaction_kind);
-        self.invariants.set_transaction_inputs(
-            transaction_kind,
-            gas_data,
-            transaction_signer,
-            is_gasless,
-        );
+        self.invariants
+            .set_transaction_inputs(transaction_kind, gas_data, transaction_signer);
     }
 
     /// Run the (read-only) SUI-conservation and balance-accumulator invariant checks.

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -576,6 +576,59 @@ impl<'backing> TemporaryStore<'backing> {
         self.invariants.clear();
     }
 
+    /// Consume this (post-execution) store and return the "recorded no-op" store used by a BumpOnly bail:
+    /// keep the input-derived state it already computed, discard everything execution produced, then bump
+    /// the mutable inputs. Its effects then record ONLY those input version bumps and the input
+    /// dependencies — nothing the (now-discarded) execution touched.
+    ///
+    // REVIEW AND DELETE COMMENT AFTER: I tried to build this differently and everything leads to
+    //  confusing code. The comment should explain what we are trying to do...
+    pub(crate) fn into_recorded_noop(self) -> Self {
+        let Self {
+            // Input-derived — reused verbatim.
+            store,
+            tx_digest,
+            input_objects,
+            non_exclusive_input_original_versions,
+            stream_ended_consensus_objects,
+            lamport_timestamp,
+            mutable_input_refs,
+            receiving_objects,
+            cur_epoch,
+            protocol_config,
+            // Execution-derived — discarded.
+            execution_results: _,
+            loaded_runtime_objects: _,
+            wrapped_object_containers: _,
+            runtime_packages_loaded_from_db: _,
+            generated_runtime_ids: _,
+            loaded_per_epoch_config_objects: _,
+            invariants: _,
+        } = self;
+        let mut noop = Self {
+            store,
+            tx_digest,
+            input_objects,
+            non_exclusive_input_original_versions,
+            stream_ended_consensus_objects,
+            lamport_timestamp,
+            mutable_input_refs,
+            receiving_objects,
+            cur_epoch,
+            protocol_config,
+            execution_results: ExecutionResultsV2::default(),
+            loaded_runtime_objects: BTreeMap::new(),
+            wrapped_object_containers: BTreeMap::new(),
+            runtime_packages_loaded_from_db: RwLock::new(BTreeMap::new()),
+            generated_runtime_ids: BTreeSet::new(),
+            loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
+            invariants: InvariantChecker::new(),
+        };
+        // The only "writes" a no-op has: bump the versions of the mutable inputs it locked.
+        noop.ensure_active_inputs_mutated();
+        noop
+    }
+
     pub fn read_object(&self, id: &ObjectID) -> Option<&Object> {
         // there should be no read after delete
         debug_assert!(!self.execution_results.deleted_object_ids.contains(id));
@@ -854,7 +907,6 @@ impl<'backing> TemporaryStore<'backing> {
         sender: &SuiAddress,
         sponsor: &Option<SuiAddress>,
         gas_charger: &GasCharger,
-        mutable_inputs: &HashSet<ObjectID>,
         is_epoch_change: bool,
     ) -> SuiResult<()> {
         self.invariants.check_ownership_invariants(
@@ -862,7 +914,6 @@ impl<'backing> TemporaryStore<'backing> {
             sender,
             sponsor,
             gas_charger,
-            mutable_inputs,
             is_epoch_change,
         )
     }
@@ -875,7 +926,10 @@ impl TemporaryStore<'_> {
     /// All objects will be updated with their new (current) storage rebate/cost.
     /// `SuiGasStatus` `storage_rebate` and `storage_gas_units` track the transaction
     /// overall storage rebate and cost.
-    pub(crate) fn collect_storage_and_rebate(&mut self, gas_charger: &mut GasCharger) {
+    pub(crate) fn collect_storage_and_rebate(
+        &mut self,
+        gas_charger: &mut GasCharger,
+    ) -> Result<(), ExecutionError> {
         // Use two loops because we cannot mut iterate written while calling get_object_modified_at.
         let old_storage_rebates: Vec<_> = self
             .execution_results
@@ -896,18 +950,19 @@ impl TemporaryStore<'_> {
             // new object size
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
-            let new_storage_rebate = gas_charger.track_storage_mutation(
-                object.id(),
-                new_object_size,
-                old_storage_rebate,
-            );
+            let new_storage_rebate = gas_charger
+                .track_storage_mutation(object.id(), new_object_size, old_storage_rebate)
+                .ok_or_else(|| ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation))?;
             object.storage_rebate = new_storage_rebate;
         }
 
-        self.collect_rebate(gas_charger);
+        self.collect_rebate(gas_charger)
     }
 
-    pub(crate) fn collect_rebate(&self, gas_charger: &mut GasCharger) {
+    pub(crate) fn collect_rebate(
+        &self,
+        gas_charger: &mut GasCharger,
+    ) -> Result<(), ExecutionError> {
         for object_id in &self.execution_results.modified_objects {
             if self
                 .execution_results
@@ -922,8 +977,11 @@ impl TemporaryStore<'_> {
                 // Unwrap is safe because this loop iterates through all modified objects.
                 .unwrap()
                 .storage_rebate;
-            gas_charger.track_storage_mutation(*object_id, 0, storage_rebate);
+            gas_charger
+                .track_storage_mutation(*object_id, 0, storage_rebate)
+                .ok_or_else(|| ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation))?;
         }
+        Ok(())
     }
 
     pub fn check_execution_results_consistency<Mode: ExecutionMode>(

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -219,14 +219,14 @@ impl<'backing> TemporaryStore<'backing> {
     /// Bounding SUI to `TOTAL_SUPPLY_MIST` rejects any such amount here, *before* gas is charged, so
     /// the rejected PTB-emitted writes are dropped on gas reset and only the (bounded) gas events
     /// remain. Crucially, `TOTAL_SUPPLY_MIST` is ~8.4B SUI below `u64::MAX`, so the gas events emitted
-    /// after this check (which move only real SUI) cannot push any per-key total past `u64::MAX` —
+    /// after this check (which move only real SUI) cannot push any per-key total past `u64::MAX` -
     /// hence they need not be re-checked. Non-SUI balances have no uncapped gas path, so the
     /// object-runtime per-key `u64::MAX` cap is the binding guard there and we only backstop u64
     /// representability.
     ///
     /// The per-key limits are not sufficient on their own: withdrawn SUI can be spread across several
     /// object keys (each withdrawal `<= TOTAL_SUPPLY_MIST`) and then recombined *outside* the
-    /// accumulator — e.g. each withdrawal redeemed to a `Coin<SUI>` and merged into the PTB gas coin
+    /// accumulator - e.g. each withdrawal redeemed to a `Coin<SUI>` and merged into the PTB gas coin
     /// via `MergeCoins`, which is an object mutation, not an accumulator event. The recombined coin
     /// can then reach `u64::MAX` and overflow `deduct_gas` on a refund. So we also bound the
     /// *cross-key* total SUI withdrawn (gross Split) to the supply, capping the total SUI a single
@@ -581,7 +581,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// inputs. Its effects record only those version bumps and the input dependencies.
     pub(crate) fn into_bump_only(self) -> Self {
         let Self {
-            // Input-derived — reused verbatim.
+            // Input-derived - reused verbatim.
             store,
             tx_digest,
             input_objects,
@@ -592,7 +592,7 @@ impl<'backing> TemporaryStore<'backing> {
             receiving_objects,
             cur_epoch,
             protocol_config,
-            // Execution-derived — discarded.
+            // Execution-derived - discarded.
             execution_results: _,
             loaded_runtime_objects: _,
             wrapped_object_containers: _,

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -27,7 +27,7 @@ use sui_types::inner_temporary_store::InnerTemporaryStore;
 use sui_types::object::Data;
 use sui_types::storage::{BackingStore, DenyListResult, PackageObject};
 use sui_types::sui_system_state::{AdvanceEpochParams, get_sui_system_state_wrapper};
-use sui_types::transaction::{GasData, TransactionKind};
+use sui_types::transaction::{GasData, TransactionKind, is_gasless_transaction};
 use sui_types::{
     SUI_DENY_LIST_OBJECT_ID,
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
@@ -576,6 +576,56 @@ impl<'backing> TemporaryStore<'backing> {
         self.invariants.clear();
     }
 
+    /// Consume this (post-execution) store and return the "recorded no-op" store used by a BumpOnly bail:
+    /// keep the input-derived state it already computed, discard everything execution produced, then bump
+    /// the mutable inputs. Its effects then record ONLY those input version bumps and the input
+    /// dependencies — nothing the (now-discarded) execution touched.
+    pub(crate) fn into_recorded_noop(self) -> Self {
+        let Self {
+            // Input-derived — reused verbatim.
+            store,
+            tx_digest,
+            input_objects,
+            non_exclusive_input_original_versions,
+            stream_ended_consensus_objects,
+            lamport_timestamp,
+            mutable_input_refs,
+            receiving_objects,
+            cur_epoch,
+            protocol_config,
+            // Execution-derived — discarded.
+            execution_results: _,
+            loaded_runtime_objects: _,
+            wrapped_object_containers: _,
+            runtime_packages_loaded_from_db: _,
+            generated_runtime_ids: _,
+            loaded_per_epoch_config_objects: _,
+            invariants: _,
+        } = self;
+        let mut noop = Self {
+            store,
+            tx_digest,
+            input_objects,
+            non_exclusive_input_original_versions,
+            stream_ended_consensus_objects,
+            lamport_timestamp,
+            mutable_input_refs,
+            receiving_objects,
+            cur_epoch,
+            protocol_config,
+            execution_results: ExecutionResultsV2::default(),
+            loaded_runtime_objects: BTreeMap::new(),
+            wrapped_object_containers: BTreeMap::new(),
+            runtime_packages_loaded_from_db: RwLock::new(BTreeMap::new()),
+            generated_runtime_ids: BTreeSet::new(),
+            loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
+            invariants: InvariantChecker::new(),
+        };
+        // The only "writes" a no-op has: bump the versions of the mutable inputs it locked.
+        noop.ensure_active_inputs_mutated();
+        noop
+    }
+
     pub fn read_object(&self, id: &ObjectID) -> Option<&Object> {
         // there should be no read after delete
         debug_assert!(!self.execution_results.deleted_object_ids.contains(id));
@@ -658,12 +708,23 @@ impl<'backing> TemporaryStore<'backing> {
             .fold(0, |sum, obj| sum + obj.object_size_for_gas_metering())
     }
 
+    /// Validates gasless post-execution invariants, using the withdrawal reservations cached by
+    /// [`Self::set_invariant_inputs`].
+    pub(crate) fn check_gasless_execution_requirements(&self) -> Result<(), String> {
+        self.check_gasless_execution_requirements_with_reservations(
+            self.invariants.gasless_reservations(),
+        )
+    }
+
     /// Validates gasless post-execution invariants:
     /// - No new objects were created or existing objects mutated (written_objects is empty)
     /// - The set of deleted objects exactly equals the set of input Coin objects
     /// - Each recipient receives at least the minimum transfer amount per token type
     /// - Unused withdrawal reservation (reservation - actual split) is 0 or >= min_amount
-    pub fn check_gasless_execution_requirements(
+    ///
+    /// Parameterized entry for the legacy path, which computes its (flag-gated) reservations
+    /// out-of-band. Deleted with legacy at the next execution cut.
+    pub fn check_gasless_execution_requirements_with_reservations(
         &self,
         withdrawal_reservations: Option<&BTreeMap<(SuiAddress, TypeTag), u64>>,
     ) -> Result<(), String> {
@@ -827,8 +888,15 @@ impl<'backing> TemporaryStore<'backing> {
         gas_data: &GasData,
         transaction_signer: SuiAddress,
     ) {
-        self.invariants
-            .set_transaction_inputs(transaction_kind, gas_data, transaction_signer);
+        // Same gasless predicate as the execution engine's `payment_kind`.
+        let is_gasless = self.protocol_config.enable_gasless()
+            && is_gasless_transaction(gas_data, transaction_kind);
+        self.invariants.set_transaction_inputs(
+            transaction_kind,
+            gas_data,
+            transaction_signer,
+            is_gasless,
+        );
     }
 
     /// Run the (read-only) SUI-conservation and balance-accumulator invariant checks.
@@ -859,7 +927,6 @@ impl<'backing> TemporaryStore<'backing> {
         sender: &SuiAddress,
         sponsor: &Option<SuiAddress>,
         gas_charger: &GasCharger,
-        mutable_inputs: &HashSet<ObjectID>,
         is_epoch_change: bool,
     ) -> SuiResult<()> {
         self.invariants.check_ownership_invariants(
@@ -867,7 +934,6 @@ impl<'backing> TemporaryStore<'backing> {
             sender,
             sponsor,
             gas_charger,
-            mutable_inputs,
             is_epoch_change,
         )
     }
@@ -880,7 +946,10 @@ impl TemporaryStore<'_> {
     /// All objects will be updated with their new (current) storage rebate/cost.
     /// `SuiGasStatus` `storage_rebate` and `storage_gas_units` track the transaction
     /// overall storage rebate and cost.
-    pub(crate) fn collect_storage_and_rebate(&mut self, gas_charger: &mut GasCharger) {
+    pub(crate) fn collect_storage_and_rebate(
+        &mut self,
+        gas_charger: &mut GasCharger,
+    ) -> Result<(), ExecutionError> {
         // Use two loops because we cannot mut iterate written while calling get_object_modified_at.
         let old_storage_rebates: Vec<_> = self
             .execution_results
@@ -901,18 +970,19 @@ impl TemporaryStore<'_> {
             // new object size
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
-            let new_storage_rebate = gas_charger.track_storage_mutation(
-                object.id(),
-                new_object_size,
-                old_storage_rebate,
-            );
+            let new_storage_rebate = gas_charger
+                .track_storage_mutation(object.id(), new_object_size, old_storage_rebate)
+                .ok_or_else(|| ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation))?;
             object.storage_rebate = new_storage_rebate;
         }
 
-        self.collect_rebate(gas_charger);
+        self.collect_rebate(gas_charger)
     }
 
-    pub(crate) fn collect_rebate(&self, gas_charger: &mut GasCharger) {
+    pub(crate) fn collect_rebate(
+        &self,
+        gas_charger: &mut GasCharger,
+    ) -> Result<(), ExecutionError> {
         for object_id in &self.execution_results.modified_objects {
             if self
                 .execution_results
@@ -927,8 +997,11 @@ impl TemporaryStore<'_> {
                 // Unwrap is safe because this loop iterates through all modified objects.
                 .unwrap()
                 .storage_rebate;
-            gas_charger.track_storage_mutation(*object_id, 0, storage_rebate);
+            gas_charger
+                .track_storage_mutation(*object_id, 0, storage_rebate)
+                .ok_or_else(|| ExecutionError::from_kind(ExecutionErrorKind::InvariantViolation))?;
         }
+        Ok(())
     }
 
     pub fn check_execution_results_consistency<Mode: ExecutionMode>(

--- a/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
@@ -580,7 +580,6 @@ impl InvariantChecker {
         sender: &SuiAddress,
         sponsor: &Option<SuiAddress>,
         gas_charger: &GasCharger,
-        mutable_inputs: &HashSet<ObjectID>,
         is_epoch_change: bool,
     ) -> SuiResult<()> {
         // The funds-accumulator reservation budget is shared with the conservation checks; see
@@ -640,8 +639,15 @@ impl InvariantChecker {
             })
             .filter(|id| {
                 // remove any non-mutable inputs. This will remove deleted or readonly shared
-                // objects
-                mutable_inputs.contains(id)
+                // objects.
+                // REVIEW AND DELETE COMMENT AFTER: before we took a caller-passed `mutable_inputs`
+                // (= `input_objects.all_mutable_inputs()`); now we derive the identical set from the
+                // store. Verified exactly equivalent:
+                // all_mutable_inputs() ==
+                //      exclusive_mutable_inputs() (mutable_input_refs) ∪
+                //      non_exclusive_input_objects() (non_exclusive_input_original_versions).
+                store.mutable_input_refs.contains_key(id)
+                    || store.non_exclusive_input_original_versions.contains_key(id)
             })
             .copied()
             // Add any object IDs generated in the object runtime during execution to the

--- a/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
@@ -35,7 +35,7 @@ use sui_types::gas::GasCostSummary;
 use sui_types::is_system_package;
 use sui_types::layout_resolver::LayoutResolver;
 use sui_types::object::{Object, ObjectPermissions, Owner};
-use sui_types::transaction::{Command, GasData, TransactionKind};
+use sui_types::transaction::{Command, GasData, TransactionKind, is_gasless_transaction};
 
 use crate::execution_mode::ExecutionMode;
 use crate::gas_charger::{GasCharger, PaymentLocation};
@@ -50,15 +50,8 @@ use crate::type_layout_resolver::TypeLayoutResolver;
 struct InvariantInputs {
     /// Per-`(address, type)` funds-accumulator reservation budget authorized by this transaction.
     /// Sources: PTB `FundsWithdrawalArg`s (sender/sponsor as owner), gas paid entirely from an
-    /// address balance, and gas-data coin-reservation digests. Consumed by
-    /// `check_address_balance_changes` and `check_ownership_invariants`.
+    /// address balance, and gas-data coin-reservation digests.
     input_reservations: BTreeMap<(SuiAddress, TypeTag), u64>,
-    /// For gasless transactions only (`Some` even when empty): the per-`(owner, coin type)`
-    /// withdrawal reservations declared by the PTB's `FundsWithdrawal` inputs. Unlike
-    /// `input_reservations` this is keyed by the coin type `T` (not `Balance<T>`) and carries no
-    /// gas sources. Consumed by the reservation-dust rule of
-    /// `TemporaryStore::check_gasless_execution_requirements`.
-    gasless_reservations: Option<BTreeMap<(SuiAddress, TypeTag), u64>>,
     /// For the advance-epoch transaction, `(epoch_fees minted, epoch_rebates burned)`; `None`
     /// for every other transaction. Needed by `check_sui_conserved_expensive`, which must account
     /// for the SUI the epoch change mints and burns.
@@ -107,19 +100,17 @@ impl InvariantChecker {
         transaction_kind: &TransactionKind,
         gas_data: &GasData,
         transaction_signer: SuiAddress,
-        is_gasless: bool,
     ) {
+        // `enable_gasless` is not checked: a gasless-shaped tx cannot execute while the flag is
+        // off (rejected at validation with GasPriceUnderRGP).
+        let is_gasless = is_gasless_transaction(gas_data, transaction_kind);
         self.inputs = InvariantInputs {
             input_reservations: compute_input_reservations(
                 transaction_kind,
                 gas_data,
                 transaction_signer,
+                is_gasless,
             ),
-            gasless_reservations: is_gasless.then(|| {
-                let sponsor = (gas_data.owner != transaction_signer).then_some(gas_data.owner);
-                compute_gasless_reservations(transaction_kind, transaction_signer, sponsor)
-                    .unwrap_or_default()
-            }),
             advance_epoch_gas_summary: transaction_kind.get_advance_epoch_tx_gas_summary(),
             is_genesis: matches!(transaction_kind, TransactionKind::Genesis(_)),
             declared_packages: declared_packages(transaction_kind),
@@ -132,9 +123,18 @@ impl InvariantChecker {
         &self.inputs.input_reservations
     }
 
-    /// The gasless withdrawal reservations; `Some` iff the transaction is gasless.
-    pub(crate) fn gasless_reservations(&self) -> Option<&BTreeMap<(SuiAddress, TypeTag), u64>> {
-        self.inputs.gasless_reservations.as_ref()
+    /// The withdrawal reservations of a gasless transaction:
+    /// `input_reservations` re-keyed by the coin type `T` (unwrapped from `Balance<T>`).
+    pub(crate) fn gasless_reservations(&self) -> BTreeMap<(SuiAddress, TypeTag), u64> {
+        use sui_types::balance::Balance;
+        self.inputs
+            .input_reservations
+            .iter()
+            .filter_map(|((owner, ty), amount)| {
+                Balance::maybe_get_balance_type_param(ty)
+                    .map(|coin_type| ((*owner, coin_type), *amount))
+            })
+            .collect()
     }
 
     /// Drop the PTB-emitted ranges. Called from `TemporaryStore::drop_writes` since the
@@ -524,6 +524,7 @@ fn compute_input_reservations(
     transaction_kind: &TransactionKind,
     gas_data: &GasData,
     transaction_signer: SuiAddress,
+    is_gasless: bool,
 ) -> BTreeMap<(SuiAddress, TypeTag), u64> {
     use sui_types::balance::Balance;
     use sui_types::gas_coin::GAS;
@@ -538,63 +539,31 @@ fn compute_input_reservations(
             WithdrawFrom::Sponsor => gas_data.owner,
         };
         let Reservation::MaxAmountU64(reservation) = arg.reservation;
-        *reservations
+        let entry = reservations
             .entry((owner, arg.type_arg.to_type_tag()))
-            .or_insert(0) += reservation;
+            .or_insert(0);
+        *entry = entry.saturating_add(reservation);
     }
 
-    if is_gas_paid_from_address_balance(gas_data, transaction_kind) {
-        *reservations
+    // Gasless transactions charge no gas, so gas sources grant no reservation (their budget is
+    // validated to be 0 anyway; skipping keeps the map free of a phantom zero entry).
+    if !is_gasless && is_gas_paid_from_address_balance(gas_data, transaction_kind) {
+        let entry = reservations
             .entry((gas_data.owner, sui_balance_type.clone()))
-            .or_insert(0) += gas_data.budget;
+            .or_insert(0);
+        *entry = entry.saturating_add(gas_data.budget);
     }
 
     for entry in &gas_data.payment {
         if let Ok(parsed) = ParsedDigest::try_from(entry.2) {
-            *reservations
+            let entry = reservations
                 .entry((gas_data.owner, sui_balance_type.clone()))
-                .or_insert(0) += parsed.reservation_amount();
+                .or_insert(0);
+            *entry = entry.saturating_add(parsed.reservation_amount());
         }
     }
 
     reservations
-}
-
-/// Compute the per-`(owner, coin type)` withdrawal reservations of a gasless transaction from its
-/// PTB `FundsWithdrawal` inputs. Keyed by the coin type `T` to match the gasless allowed-token
-/// table, unlike `compute_input_reservations` above (keyed `Balance<T>`).
-fn compute_gasless_reservations(
-    transaction_kind: &TransactionKind,
-    sender: SuiAddress,
-    sponsor: Option<SuiAddress>,
-) -> Option<BTreeMap<(SuiAddress, TypeTag), u64>> {
-    use sui_types::transaction::{CallArg, Reservation, WithdrawFrom};
-
-    let TransactionKind::ProgrammableTransaction(pt) = transaction_kind else {
-        debug_fatal!("Gasless transaction must be a ProgrammableTransaction");
-        return None;
-    };
-    let mut reservations = BTreeMap::<(SuiAddress, TypeTag), u64>::new();
-    for input in &pt.inputs {
-        let CallArg::FundsWithdrawal(fw) = input else {
-            continue;
-        };
-        let Some(coin_type) = fw.type_arg.get_balance_type_param() else {
-            debug_fatal!("expected Balance type for withdrawal");
-            continue;
-        };
-        let owner = match fw.withdraw_from {
-            WithdrawFrom::Sender => sender,
-            WithdrawFrom::Sponsor => {
-                debug_fatal!("WithdrawFrom::Sponsor is not expected in gasless transactions");
-                sponsor.unwrap_or(sender)
-            }
-        };
-        let Reservation::MaxAmountU64(amount) = fw.reservation;
-        let entry = reservations.entry((owner, coin_type)).or_insert(0);
-        *entry = entry.saturating_add(amount);
-    }
-    Some(reservations)
 }
 
 impl InvariantChecker {

--- a/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
@@ -53,6 +53,12 @@ struct InvariantInputs {
     /// address balance, and gas-data coin-reservation digests. Consumed by
     /// `check_address_balance_changes` and `check_ownership_invariants`.
     input_reservations: BTreeMap<(SuiAddress, TypeTag), u64>,
+    /// For gasless transactions only (`Some` even when empty): the per-`(owner, coin type)`
+    /// withdrawal reservations declared by the PTB's `FundsWithdrawal` inputs. Unlike
+    /// `input_reservations` this is keyed by the coin type `T` (not `Balance<T>`) and carries no
+    /// gas sources. Consumed by the reservation-dust rule of
+    /// `TemporaryStore::check_gasless_execution_requirements`.
+    gasless_reservations: Option<BTreeMap<(SuiAddress, TypeTag), u64>>,
     /// For the advance-epoch transaction, `(epoch_fees minted, epoch_rebates burned)`; `None`
     /// for every other transaction. Needed by `check_sui_conserved_expensive`, which must account
     /// for the SUI the epoch change mints and burns.
@@ -101,6 +107,7 @@ impl InvariantChecker {
         transaction_kind: &TransactionKind,
         gas_data: &GasData,
         transaction_signer: SuiAddress,
+        is_gasless: bool,
     ) {
         self.inputs = InvariantInputs {
             input_reservations: compute_input_reservations(
@@ -108,6 +115,11 @@ impl InvariantChecker {
                 gas_data,
                 transaction_signer,
             ),
+            gasless_reservations: is_gasless.then(|| {
+                let sponsor = (gas_data.owner != transaction_signer).then_some(gas_data.owner);
+                compute_gasless_reservations(transaction_kind, transaction_signer, sponsor)
+                    .unwrap_or_default()
+            }),
             advance_epoch_gas_summary: transaction_kind.get_advance_epoch_tx_gas_summary(),
             is_genesis: matches!(transaction_kind, TransactionKind::Genesis(_)),
             declared_packages: declared_packages(transaction_kind),
@@ -118,6 +130,11 @@ impl InvariantChecker {
     /// `TemporaryStore::check_ownership_invariants`, which shares the same authorization model.
     pub(crate) fn input_reservations(&self) -> &BTreeMap<(SuiAddress, TypeTag), u64> {
         &self.inputs.input_reservations
+    }
+
+    /// The gasless withdrawal reservations; `Some` iff the transaction is gasless.
+    pub(crate) fn gasless_reservations(&self) -> Option<&BTreeMap<(SuiAddress, TypeTag), u64>> {
+        self.inputs.gasless_reservations.as_ref()
     }
 
     /// Drop the PTB-emitted ranges. Called from `TemporaryStore::drop_writes` since the
@@ -543,6 +560,43 @@ fn compute_input_reservations(
     reservations
 }
 
+/// Compute the per-`(owner, coin type)` withdrawal reservations of a gasless transaction from its
+/// PTB `FundsWithdrawal` inputs. Keyed by the coin type `T` to match the gasless allowed-token
+/// table, unlike `compute_input_reservations` above (keyed `Balance<T>`).
+fn compute_gasless_reservations(
+    transaction_kind: &TransactionKind,
+    sender: SuiAddress,
+    sponsor: Option<SuiAddress>,
+) -> Option<BTreeMap<(SuiAddress, TypeTag), u64>> {
+    use sui_types::transaction::{CallArg, Reservation, WithdrawFrom};
+
+    let TransactionKind::ProgrammableTransaction(pt) = transaction_kind else {
+        debug_fatal!("Gasless transaction must be a ProgrammableTransaction");
+        return None;
+    };
+    let mut reservations = BTreeMap::<(SuiAddress, TypeTag), u64>::new();
+    for input in &pt.inputs {
+        let CallArg::FundsWithdrawal(fw) = input else {
+            continue;
+        };
+        let Some(coin_type) = fw.type_arg.get_balance_type_param() else {
+            debug_fatal!("expected Balance type for withdrawal");
+            continue;
+        };
+        let owner = match fw.withdraw_from {
+            WithdrawFrom::Sender => sender,
+            WithdrawFrom::Sponsor => {
+                debug_fatal!("WithdrawFrom::Sponsor is not expected in gasless transactions");
+                sponsor.unwrap_or(sender)
+            }
+        };
+        let Reservation::MaxAmountU64(amount) = fw.reservation;
+        let entry = reservations.entry((owner, coin_type)).or_insert(0);
+        *entry = entry.saturating_add(amount);
+    }
+    Some(reservations)
+}
+
 impl InvariantChecker {
     /// Run the SUI-conservation and balance-accumulator invariant checks against the
     /// (already-finalized, gas-charged) `store`. Read-only: the caller (the execution engine's
@@ -631,7 +685,6 @@ impl InvariantChecker {
         sender: &SuiAddress,
         sponsor: &Option<SuiAddress>,
         gas_charger: &GasCharger,
-        mutable_inputs: &HashSet<ObjectID>,
         is_epoch_change: bool,
     ) -> SuiResult<()> {
         // The funds-accumulator reservation budget is shared with the conservation checks; see
@@ -691,8 +744,15 @@ impl InvariantChecker {
             })
             .filter(|id| {
                 // remove any non-mutable inputs. This will remove deleted or readonly shared
-                // objects
-                mutable_inputs.contains(id)
+                // objects.
+                // REVIEW AND DELETE COMMENT AFTER: before we took a caller-passed `mutable_inputs`
+                // (= `input_objects.all_mutable_inputs()`); now we derive the identical set from the
+                // store. Verified exactly equivalent:
+                // all_mutable_inputs() ==
+                //      exclusive_mutable_inputs() (mutable_input_refs) ∪
+                //      non_exclusive_input_objects() (non_exclusive_input_original_versions).
+                store.mutable_input_refs.contains_key(id)
+                    || store.non_exclusive_input_original_versions.contains_key(id)
             })
             .copied()
             // Add any object IDs generated in the object runtime during execution to the

--- a/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store/invariants.rs
@@ -103,13 +103,11 @@ impl InvariantChecker {
     ) {
         // `enable_gasless` is not checked: a gasless-shaped tx cannot execute while the flag is
         // off (rejected at validation with GasPriceUnderRGP).
-        let is_gasless = is_gasless_transaction(gas_data, transaction_kind);
         self.inputs = InvariantInputs {
             input_reservations: compute_input_reservations(
                 transaction_kind,
                 gas_data,
                 transaction_signer,
-                is_gasless,
             ),
             advance_epoch_gas_summary: transaction_kind.get_advance_epoch_tx_gas_summary(),
             is_genesis: matches!(transaction_kind, TransactionKind::Genesis(_)),
@@ -524,12 +522,12 @@ fn compute_input_reservations(
     transaction_kind: &TransactionKind,
     gas_data: &GasData,
     transaction_signer: SuiAddress,
-    is_gasless: bool,
 ) -> BTreeMap<(SuiAddress, TypeTag), u64> {
     use sui_types::balance::Balance;
     use sui_types::gas_coin::GAS;
     use sui_types::transaction::{Reservation, WithdrawFrom, is_gas_paid_from_address_balance};
 
+    let is_gasless = is_gasless_transaction(gas_data, transaction_kind);
     let mut reservations: BTreeMap<(SuiAddress, TypeTag), u64> = BTreeMap::new();
     let sui_balance_type = Balance::type_tag(GAS::type_tag());
 
@@ -714,12 +712,6 @@ impl InvariantChecker {
             .filter(|id| {
                 // remove any non-mutable inputs. This will remove deleted or readonly shared
                 // objects.
-                // REVIEW AND DELETE COMMENT AFTER: before we took a caller-passed `mutable_inputs`
-                // (= `input_objects.all_mutable_inputs()`); now we derive the identical set from the
-                // store. Verified exactly equivalent:
-                // all_mutable_inputs() ==
-                //      exclusive_mutable_inputs() (mutable_input_refs) ∪
-                //      non_exclusive_input_objects() (non_exclusive_input_original_versions).
                 store.mutable_input_refs.contains_key(id)
                     || store.non_exclusive_input_original_versions.contains_key(id)
             })

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -30,7 +30,7 @@ use move_vm_runtime_latest::runtime::MoveRuntime;
 use mysten_common::debug_fatal;
 use sui_adapter_latest::adapter::{new_move_runtime, run_metered_move_bytecode_verifier};
 use sui_adapter_latest::execution_engine::{
-    execute_genesis_state_update, execute_transaction_to_effects,
+    ExecutionOutput, execute_genesis_state_update, execute_transaction_to_effects,
 };
 use sui_adapter_latest::type_layout_resolver::TypeLayoutResolver;
 use sui_move_natives_latest::all_natives;
@@ -89,26 +89,31 @@ impl executor::Executor for Executor {
         Vec<ExecutionTiming>,
         Result<(), ExecutionFailure>,
     ) {
-        let (store_out, gas_status_out, effects, timings, result) =
-            execute_transaction_to_effects::<execution_mode::Normal>(
-                store,
-                input_objects,
-                system_object_versions,
-                gas,
-                gas_status,
-                transaction_kind,
-                rewritten_inputs,
-                transaction_signer,
-                transaction_digest,
-                &self.0,
-                epoch_id,
-                epoch_timestamp_ms,
-                protocol_config,
-                metrics,
-                enable_expensive_checks,
-                execution_params,
-                trace_builder_opt,
-            );
+        let ExecutionOutput {
+            inner_store: store_out,
+            gas_status: gas_status_out,
+            effects,
+            timings,
+            execution_result: result,
+        } = execute_transaction_to_effects::<execution_mode::Normal>(
+            store,
+            input_objects,
+            system_object_versions,
+            gas,
+            gas_status,
+            transaction_kind,
+            rewritten_inputs,
+            transaction_signer,
+            transaction_digest,
+            &self.0,
+            epoch_id,
+            epoch_timestamp_ms,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            execution_params,
+            trace_builder_opt,
+        );
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
@@ -140,26 +145,31 @@ impl executor::Executor for Executor {
         Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
-        let (store_out, gas_status_out, effects, timings, result) =
-            execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
-                store,
-                input_objects,
-                system_object_versions,
-                gas,
-                gas_status,
-                transaction_kind,
-                rewritten_inputs,
-                transaction_signer,
-                transaction_digest,
-                &self.0,
-                epoch_id,
-                epoch_timestamp_ms,
-                protocol_config,
-                metrics,
-                enable_expensive_checks,
-                execution_params,
-                trace_builder_opt,
-            );
+        let ExecutionOutput {
+            inner_store: store_out,
+            gas_status: gas_status_out,
+            effects,
+            timings,
+            execution_result: result,
+        } = execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
+            store,
+            input_objects,
+            system_object_versions,
+            gas,
+            gas_status,
+            transaction_kind,
+            rewritten_inputs,
+            transaction_signer,
+            transaction_digest,
+            &self.0,
+            epoch_id,
+            epoch_timestamp_ms,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            execution_params,
+            trace_builder_opt,
+        );
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
@@ -189,8 +199,16 @@ impl executor::Executor for Executor {
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        let (inner_temp_store, gas_status, effects, _timings, result) = if skip_all_checks {
-            execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
+        // The two arms return different `ExecutionOutput<Mode>` types, so each destructures
+        // into the common tuple.
+        let (inner_temp_store, gas_status, effects, result) = if skip_all_checks {
+            let ExecutionOutput {
+                inner_store,
+                gas_status,
+                effects,
+                timings: _,
+                execution_result,
+            } = execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
                 store,
                 input_objects,
                 // TODO: Support system object versions for dev-inspect.
@@ -209,9 +227,16 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
                 &mut None,
-            )
+            );
+            (inner_store, gas_status, effects, execution_result)
         } else {
-            execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
+            let ExecutionOutput {
+                inner_store,
+                gas_status,
+                effects,
+                timings: _,
+                execution_result,
+            } = execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
                 store,
                 input_objects,
                 // TODO: Support system object versions for dev-inspect.
@@ -230,7 +255,8 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
                 &mut None,
-            )
+            );
+            (inner_store, gas_status, effects, execution_result)
         };
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -162,7 +162,7 @@ mod checked {
         let input_objects = input_objects.into_inner();
         let mut temporary_store =
             TemporaryStore::new(store, input_objects, tx_context.digest(), protocol_config);
-        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());
+        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest(), protocol_config);
         programmable_transactions::execution::execute::<execution_mode::Genesis>(
             protocol_config,
             metrics,

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -206,6 +206,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -59,13 +59,16 @@ pub mod checked {
             }
         }
 
-        pub fn new_unmetered(tx_digest: TransactionDigest) -> Self {
+        pub fn new_unmetered(
+            tx_digest: TransactionDigest,
+            protocol_config: &ProtocolConfig,
+        ) -> Self {
             Self {
                 tx_digest,
                 gas_model_version: 6, // pick any of the latest, it should not matter
                 gas_coins: vec![],
                 smashed_gas_coin: None,
-                gas_status: SuiGasStatus::new_unmetered(),
+                gas_status: SuiGasStatus::new_unmetered(protocol_config),
             }
         }
 
@@ -206,6 +209,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -179,7 +179,7 @@ mod checked {
             tx_context.digest(),
             protocol_config,
         );
-        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());
+        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest(), protocol_config);
         programmable_transactions::execution::execute::<execution_mode::Genesis>(
             protocol_config,
             metrics,

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -207,6 +207,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -60,13 +60,16 @@ pub mod checked {
             }
         }
 
-        pub fn new_unmetered(tx_digest: TransactionDigest) -> Self {
+        pub fn new_unmetered(
+            tx_digest: TransactionDigest,
+            protocol_config: &ProtocolConfig,
+        ) -> Self {
             Self {
                 tx_digest,
                 gas_model_version: 6, // pick any of the latest, it should not matter
                 gas_coins: vec![],
                 smashed_gas_coin: None,
-                gas_status: SuiGasStatus::new_unmetered(),
+                gas_status: SuiGasStatus::new_unmetered(protocol_config),
             }
         }
 
@@ -207,6 +210,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -199,7 +199,7 @@ mod checked {
             tx_context.digest(),
             protocol_config,
         );
-        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest());
+        let mut gas_charger = GasCharger::new_unmetered(tx_context.digest(), protocol_config);
         programmable_transactions::execution::execute::<execution_mode::Genesis>(
             protocol_config,
             metrics,

--- a/sui-execution/v2/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v2/sui-adapter/src/gas_charger.rs
@@ -208,6 +208,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v2/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v2/sui-adapter/src/gas_charger.rs
@@ -60,13 +60,16 @@ pub mod checked {
             }
         }
 
-        pub fn new_unmetered(tx_digest: TransactionDigest) -> Self {
+        pub fn new_unmetered(
+            tx_digest: TransactionDigest,
+            protocol_config: &ProtocolConfig,
+        ) -> Self {
             Self {
                 tx_digest,
                 gas_model_version: 6, // pick any of the latest, it should not matter
                 gas_coins: vec![],
                 smashed_gas_coin: None,
-                gas_status: SuiGasStatus::new_unmetered(),
+                gas_status: SuiGasStatus::new_unmetered(protocol_config),
             }
         }
 
@@ -208,6 +211,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v3/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_engine.rs
@@ -252,7 +252,8 @@ mod checked {
             protocol_config,
             0,
         );
-        let mut gas_charger = GasCharger::new_unmetered(tx_context.borrow().digest());
+        let mut gas_charger =
+            GasCharger::new_unmetered(tx_context.borrow().digest(), protocol_config);
         programmable_transactions::execution::execute::<execution_mode::Genesis>(
             protocol_config,
             metrics,

--- a/sui-execution/v3/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v3/sui-adapter/src/gas_charger.rs
@@ -237,6 +237,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v3/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v3/sui-adapter/src/gas_charger.rs
@@ -83,13 +83,16 @@ pub mod checked {
             }
         }
 
-        pub fn new_unmetered(tx_digest: TransactionDigest) -> Self {
+        pub fn new_unmetered(
+            tx_digest: TransactionDigest,
+            protocol_config: &ProtocolConfig,
+        ) -> Self {
             Self {
                 tx_digest,
                 gas_model_version: 6, // pick any of the latest, it should not matter
                 payment_method: PaymentMethod::Unmetered,
                 smashed_gas_coin: None,
-                gas_status: SuiGasStatus::new_unmetered(),
+                gas_status: SuiGasStatus::new_unmetered(protocol_config),
             }
         }
 
@@ -237,6 +240,7 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
+                .expect("storage gas overflow")
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {


### PR DESCRIPTION
## Description
Introduce the alternative or forked `execute_transaction_to_effects` path. All the code is in but the protocol flag is not enabled yet (#27049)
One of the main reason for the refactor is to eliminate all the protocol gated checks that have polluted the code base over time, and have caused massive confusion.
The code is written on the old code and does not have divergences with the old behavior except in edge conditions. So semantics is very much the same. The few differences are protocol gated (by the feature itself) so small changes in edge condition are expected and welcome.
In time when we cut a new execution version we will be able to remove the old code entirely and apply even more "intrusive" changes/abstractions in the "new code".

Best way to review is probably go to `execute_transaction_to_effects` and walk the code. Side by side with the old code would be ideal.

## Test plan
Existing tests. Also looking in test coverage for transaction execution here (#27050)

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
