### PR TITLE
ci(release): drop vestigial static sccache AWS keys (OIDC-only)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,8 +173,6 @@ jobs:
         if: ${{ env.s3_existing_archive == '' }}
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ${{ matrix.os }}
 
       - name: Register cargo problem matcher


### PR DESCRIPTION
## What

Remove the now-vestigial `aws-access-key-id` / `aws-secret-access-key` inputs from the `setup-sccache` call in `release.yml`. The call already passes `role-to-assume: ${{ env.SCCACHE_ROLE }}`, so `setup-sccache` takes the OIDC path (`sui-sccache-rw-github`) and the static-creds step is skipped (`if: role-to-assume == ''`). These two inputs were dead.

## Why

This is the last consumer of the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets. After this lands, those secrets are **unreferenced by every workflow** (rust/external/bridge dropped them in #26962; `release.yml` is OIDC for both sccache and S3). That unblocks the destructive Phase-7 teardown — deleting the repo secrets and disabling the IAM access key.

The separate `AWS_KMS_TEST_*` secrets (E2E KMS test) are unrelated and untouched.

## Safety

- **No behavior change**: OIDC already takes precedence; the removed inputs were never consumed when `role-to-assume` is set.
- The OIDC release-build path is proven on the v1.74.0 devnet release (run `27968467371`: `Assuming role with OIDC` → `sui-sccache-rw-github`, build success).
- All active release branches are now OIDC (`main`, v1.74.0, and v1.73.0 via #27044); v1.72.0 is EOL.

## Diff

2 lines removed. `git grep secrets.AWS_ACCESS_KEY_ID -- .github/workflows/` returns nothing (excluding the unrelated `AWS_KMS_TEST_*` track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
