### PR TITLE
[trace-view] Improved UX for starting inlined instructions

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/adapter.ts
@@ -26,6 +26,7 @@ import {
     ExecutionResult,
     ExecutionResultKind,
     IMoveCallStack,
+    moveStackFrameDisplayLine,
 } from './runtime';
 import { EXT_SUMMARY_FRAME_ID, EXT_EVENT_FRAME_ID } from './trace_utils';
 import snakeCase from 'lodash.snakecase';
@@ -307,9 +308,7 @@ export class MoveDebugSession extends LoggingDebugSession {
                         const frameSource = frame.disassemblyModeTriggered
                             ? new Source(fileName, frame.bcodeFilePath!)
                             : new Source(fileName, frame.srcFilePath);
-                        const currentLine = frame.disassemblyModeTriggered
-                            ? frame.bcodeLine!
-                            : frame.srcLine;
+                        const currentLine = moveStackFrameDisplayLine(frame);
                         return new StackFrame(frame.id, frame.name, frameSource, currentLine);
                     }));
                     if (stack_height > 0) {

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/debug_info_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/debug_info_utils.ts
@@ -110,11 +110,15 @@ export interface IDebugInfoFunction {
      */
     localsInfo: ILocalInfo[],
     /**
-     * Location of function definition start.
+     * Location of the function name in the definition.
+     */
+    functionNameLoc: ILoc,
+    /**
+     * Location of function range start.
      */
     startLoc: ILoc,
     /**
-     * Location of function definition start.
+     * Location of function range end.
      */
     endLoc: ILoc
 }
@@ -300,6 +304,7 @@ function readDebugInfo(
         let nameEnd = funEntry.definition_location.end;
         const nameBytes = fileInfo.content.slice(nameStart, nameEnd);
         const funName = Buffer.from(nameBytes).toString('utf8');
+        const functionNameLoc = byteOffsetToLineColumn(fileInfo, funEntry.definition_location.start);
         const pcLocs: IFileLoc[] = [];
         let prevPC = 0;
         // we need to initialize `prevFileLoc` to make the compiler happy but it's never
@@ -359,10 +364,10 @@ function readDebugInfo(
             }
             localsNames.push({ name: localsName, internalName: local[0] });
         }
-        // compute start and end of function definition
+        // compute start and end of the full function range
         const startLoc = byteOffsetToLineColumn(fileInfo, funEntry.location.start);
         const endLoc = byteOffsetToLineColumn(fileInfo, funEntry.location.end);
-        functions.set(funName, { pcLocs, localsInfo: localsNames, startLoc, endLoc });
+        functions.set(funName, { pcLocs, localsInfo: localsNames, functionNameLoc, startLoc, endLoc });
     }
     return {
         filePath: fileInfo.path,

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -9,6 +9,7 @@ import {
     createFileInfo,
     IFileInfo,
     ILocalInfo,
+    ILoc,
     IDebugInfo,
     readAllDebugInfos,
     computeOptimizedLines,
@@ -131,7 +132,7 @@ interface IRuntimeVariable {
  * Describes a stack frame in the runtime representing a Move function
  * call and its current state during trace viewing session.
  */
-interface IMoveCallStackFrame {
+export interface IMoveCallStackFrame {
     /**
      *  Frame identifier.
      */
@@ -164,6 +165,14 @@ interface IMoveCallStackFrame {
      * Current line in the disassembled bytecode file corresponding to currently viewed instruction.
      */
     bcodeLine?: number; // 1-based
+    /**
+     * Function name location for display before the first source instruction is processed.
+     */
+    srcFunctionNameLoc?: ILoc;
+    /**
+     * Function name location for display before the first bytecode instruction is processed.
+     */
+    bcodeFunctionNameLoc?: ILoc;
     /**
      *  Local variable types by variable frame index.
      */
@@ -367,6 +376,19 @@ export type ExecutionResult =
     | { kind: ExecutionResultKind.TraceEnd }
     | { kind: ExecutionResultKind.Breakpoint }
     | { kind: ExecutionResultKind.Exception, msg: string };
+
+/**
+ * Returns the line to display for a Move stack frame.
+ */
+export function moveStackFrameDisplayLine(frame: IMoveCallStackFrame): number {
+    // Use actual frame line unless it's set to 0 which happens at frame
+    // creation time. Then try using function name location, which creates
+    // a much better user experience.
+    if (frame.disassemblyModeTriggered) {
+        return frame.bcodeLine || frame.bcodeFunctionNameLoc?.line || 0;
+    }
+    return frame.srcLine || frame.srcFunctionNameLoc?.line || 0;
+}
 
 /**
  * The runtime for viewing traces.
@@ -608,6 +630,8 @@ export class Runtime extends EventEmitter {
                     currentEvent.bcodeFileHash,
                     currentEvent.localsTypes,
                     currentEvent.localsNames,
+                    currentEvent.srcFunctionNameLoc,
+                    currentEvent.bcodeFunctionNameLoc,
                     currentEvent.optimizedSrcLines,
                     currentEvent.optimizedBcodeLines
                 );
@@ -865,6 +889,8 @@ export class Runtime extends EventEmitter {
                         currentEvent.bcodeFileHash,
                         currentEvent.localsTypes,
                         currentEvent.localsNames,
+                        currentEvent.srcFunctionNameLoc,
+                        currentEvent.bcodeFunctionNameLoc,
                         currentEvent.optimizedSrcLines,
                         currentEvent.optimizedBcodeLines
                     );
@@ -1446,6 +1472,8 @@ export class Runtime extends EventEmitter {
         bcodeFileHash: undefined | string,
         localsTypes: string[],
         localsInfo: ILocalInfo[],
+        srcFunctionNameLoc: undefined | ILoc,
+        bcodeFunctionNameLoc: undefined | ILoc,
         optimizedSrcLines: number[],
         optimizedBcodeLines: undefined | number[]
     ): IMoveCallStackFrame {
@@ -1473,9 +1501,12 @@ export class Runtime extends EventEmitter {
             bcodeFilePath,
             srcFileHash,
             bcodeFileHash,
-            // lines will be updated when next event (Instruction) is processed
+            // Keep execution lines unset until the first instruction is processed; otherwise
+            // same-line detection could skip the first instruction when it shares the function line.
             srcLine: 0,
             bcodeLine: 0,
+            srcFunctionNameLoc,
+            bcodeFunctionNameLoc,
             localsTypes,
             localsInfo,
             locals,
@@ -1589,14 +1620,13 @@ export class Runtime extends EventEmitter {
             const fileName = frame.disassemblyModeTriggered ?
                 path.basename(frame.bcodeFilePath!) :
                 path.basename(frame.srcFilePath);
-            const line = frame.disassemblyModeTriggered ? frame.bcodeLine : frame.srcLine;
             res += tabs + this.singleTab
                 + 'function: '
                 + frame.name
                 + ' ('
                 + fileName
                 + ':'
-                + line
+                + moveStackFrameDisplayLine(frame)
                 + ')\n';
             for (let i = 0; i < frame.locals.length; i++) {
                 res += tabs + this.singleTab + this.singleTab + 'scope ' + i + ' :\n';

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
@@ -335,6 +335,8 @@ export type TraceEvent =
         localsTypes: string[],
         localsNames: ILocalInfo[],
         paramValues: RuntimeValueType[]
+        srcFunctionNameLoc?: ILoc
+        bcodeFunctionNameLoc?: ILoc
         optimizedSrcLines: number[]
         optimizedBcodeLines?: number[]
         /**
@@ -1032,6 +1034,10 @@ function translateOpenFrame(
             localsTypes,
             localsNames: srcFunEntry.localsInfo,
             paramValues,
+            // Before the first instruction in this frame, display the function name
+            // rather than the function range start, which may be optimized away.
+            srcFunctionNameLoc: srcFunEntry.functionNameLoc,
+            bcodeFunctionNameLoc: bcodeFunEntry?.functionNameLoc,
             optimizedSrcLines,
             optimizedBcodeLines,
             forceDisassembly,

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_breakpoint/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_breakpoint/test.exp
@@ -1,7 +1,7 @@
 current frame stack:
   function: test (m.move:16)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:6)
     scope 0 :
   function: __inlined__ (m_dep.move:4)
     scope 0 :

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files/test.exp
@@ -1,14 +1,14 @@
 current frame stack:
   function: test (m.move:19)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:9)
     scope 0 :
   function: __inlined__ (m_dep_dep.move:4)
     scope 0 :
 current frame stack:
   function: test (m.move:19)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:9)
     scope 0 :
   function: __inlined__ (m_dep.move:6)
     scope 0 :

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files2/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files2/test.exp
@@ -1,14 +1,14 @@
 current frame stack:
   function: test (m.move:19)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:9)
     scope 0 :
   function: __inlined__ (m_dep.move:6)
     scope 0 :
 current frame stack:
   function: test (m.move:19)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:9)
     scope 0 :
   function: __inlined__ (m_dep_dep.move:4)
     scope 0 :

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_files/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_files/test.exp
@@ -1,7 +1,7 @@
 current frame stack:
   function: test (m.move:16)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:6)
     scope 0 :
       ret : 2
       type: u64

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files/test.exp
@@ -1,14 +1,14 @@
 current frame stack:
   function: test (m.move:20)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:10)
     scope 0 :
   function: __inlined__ (m_dep.move:4)
     scope 0 :
 current frame stack:
   function: test (m.move:20)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:10)
     scope 0 :
   function: __inlined__ (m_dep.move:10)
     scope 0 :

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files2/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files2/test.exp
@@ -1,14 +1,14 @@
 current frame stack:
   function: test (m.move:20)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:10)
     scope 0 :
   function: __inlined__ (m_dep.move:10)
     scope 0 :
 current frame stack:
   function: test (m.move:20)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:10)
     scope 0 :
   function: __inlined__ (m_dep.move:4)
     scope 0 :

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_inner_call/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_inner_call/test.exp
@@ -1,7 +1,7 @@
 current frame stack:
   function: test (m.move:17)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:7)
     scope 0 :
   function: __inlined__ (m_dep.move:6)
     scope 0 :
@@ -13,7 +13,7 @@ current frame stack:
 current frame stack:
   function: test (m.move:17)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:7)
     scope 0 :
       ret : 4
       type: u64

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files/test.exp
@@ -1,14 +1,14 @@
 current frame stack:
   function: test (m.move:26)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:16)
     scope 0 :
   function: __inlined__ (m_dep.move:4)
     scope 0 :
 current frame stack:
   function: test (m.move:26)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:16)
     scope 0 :
   function: __inlined__ (m.move:11)
     scope 0 :

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files2/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files2/test.exp
@@ -1,14 +1,14 @@
 current frame stack:
   function: test (m.move:27)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:17)
     scope 0 :
   function: __inlined__ (m.move:11)
     scope 0 :
 current frame stack:
   function: test (m.move:27)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:17)
     scope 0 :
   function: __inlined__ (m.move:11)
     scope 0 :

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_file/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_file/test.exp
@@ -1,7 +1,7 @@
 current frame stack:
   function: test (m.move:20)
     scope 0 :
-  function: foo (m.move:0)
+  function: foo (m.move:10)
     scope 0 :
       ret : 2
       type: u64

--- a/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "move-trace-debug",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "move-trace-debug",
-            "version": "0.0.19",
+            "version": "0.0.20",
             "license": "Apache-2.0",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",

--- a/external-crates/move/crates/move-analyzer/trace-debug/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package.json
@@ -5,7 +5,7 @@
     "publisher": "mysten",
     "icon": "images/move.png",
     "license": "Apache-2.0",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "preview": true,
     "repository": {
         "url": "https://github.com/MystenLabs/sui.git",


### PR DESCRIPTION
## Description 

When inlined instruction (for a macro) was the first one in a function, what the debugger was displaying wasn't ideal. It did put both the function's frame and the virtual (inlined) frame on the stack, but because the function's frame didn't really hit its first instruction with a concrete line number, it was displayed with line 0 (which meant that clicking this frame on the stack did not point to ANY line in the debugger window, other than top of the stack which is always there):
<img width="1711" height="1031" alt="image" src="https://github.com/user-attachments/assets/ee3fa214-5026-4f75-8b07-8cc73bdb9053" />

This PR finesses it by making sure that even if frame's line number is freshly initialized (i.e., it's 0) the debugger will actually display something meaningful, that is the line where the function's signature is defined (it's intentional - it is meant to indicate that something is off - that we are in fact no in the first real instruction of this frame; the user can switch to disassembly mode if they need to see more details):

<img width="1711" height="1031" alt="image" src="https://github.com/user-attachments/assets/39f2706a-1bc4-4fb9-acbd-bf092283d087" />


In the implementation we don't actually replace 0 with the line where the function signature is defined to avoid disturbing the stepping logic. If we did that, in the rare case when the first real instruction of the function is on the same line as the signature, we'd have debugger visually skip it due to how it handles multiple instructions that belong to the same source code line.

## Test plan 

Test output has been adjusted to reflect this change. Also tested manually.
