### PR TITLE
Reduce and pipeline consensus commit-handler hot-path work

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -261,6 +261,7 @@ pub mod consensus_tx_status_cache;
 pub(crate) mod epoch_marker_key;
 pub mod epoch_start_configuration;
 pub mod execution_time_estimator;
+pub mod finalized_transactions_cache;
 pub mod shared_object_congestion_tracker;
 pub mod shared_object_version_manager;
 pub mod submitted_transaction_cache;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -18,7 +18,6 @@ use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId, OIDCProvider};
 use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;
 use futures::future::{Either, join_all};
 use itertools::Itertools;
-use moka::sync::SegmentedCache as MokaCache;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use mysten_common::ZipDebugEqIteratorExt;
 use mysten_common::assert_reachable;
@@ -90,6 +89,7 @@ use super::authority_store_tables::ENV_VAR_LOCKS_BLOCK_CACHE_SIZE;
 use super::consensus_tx_status_cache::{ConsensusTxStatus, ConsensusTxStatusCache};
 use super::epoch_start_configuration::EpochStartConfigTrait;
 use super::execution_time_estimator::{ConsensusObservations, ExecutionTimeEstimator};
+use super::finalized_transactions_cache::FinalizedTransactionsCache;
 use super::shared_object_congestion_tracker::{
     CongestionPerObjectDebt, SharedObjectCongestionTracker,
 };
@@ -434,7 +434,7 @@ pub struct AuthorityPerEpochStore {
     pub(crate) submitted_transaction_cache: SubmittedTransactionCache,
 
     /// A cache which tracks recently finalized transactions.
-    pub(crate) finalized_transactions_cache: MokaCache<TransactionDigest, ()>,
+    pub(crate) finalized_transactions_cache: FinalizedTransactionsCache,
 
     /// The node's role for this epoch, derived from committee membership and
     /// the configured sync mode. Computed once at construction.
@@ -1165,10 +1165,8 @@ impl AuthorityPerEpochStore {
         let submitted_transaction_cache =
             SubmittedTransactionCache::new(None, submitted_transaction_cache_metrics);
 
-        let finalized_transactions_cache = MokaCache::builder(8)
-            .max_capacity(randomize_cache_capacity_in_tests(100_000))
-            .eviction_policy(moka::policy::EvictionPolicy::lru())
-            .build();
+        let finalized_transactions_cache =
+            FinalizedTransactionsCache::new(randomize_cache_capacity_in_tests(100_000));
 
         let s = Arc::new(Self {
             name,
@@ -3514,14 +3512,14 @@ impl AuthorityPerEpochStore {
 
     /// Caches recent finalized transactions, to avoid revoting them.
     pub(crate) fn cache_recently_finalized_transaction(&self, tx_digest: TransactionDigest) {
-        self.finalized_transactions_cache.insert(tx_digest, ());
+        self.finalized_transactions_cache.insert(tx_digest);
     }
 
     /// If true, transaction is recently finalized and should not be voted on.
     /// If false, the transaction may never be finalized, or has been finalized
     /// but the info has been evicted from the cache.
     pub(crate) fn is_recently_finalized(&self, tx_digest: &TransactionDigest) -> bool {
-        self.finalized_transactions_cache.contains_key(tx_digest)
+        self.finalized_transactions_cache.contains(tx_digest)
     }
 
     /// Only used by admin API

--- a/crates/sui-core/src/authority/finalized_transactions_cache.rs
+++ b/crates/sui-core/src/authority/finalized_transactions_cache.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use parking_lot::RwLock;
+use sui_types::digests::TransactionDigest;
+
+/// An advisory set of recently finalized transaction digests, used by the
+/// transaction voting path to short-circuit re-voting on already-finalized
+/// transactions (`AuthorityPerEpochStore::is_recently_finalized`).
+///
+/// Workload: a single writer (the consensus commit handler, ~one insert per
+/// finalized transaction) and many concurrent readers (the voting path, one
+/// `contains` per submitted transaction across the whole RPC/network worker
+/// pool). This is the inverse of what a concurrent cache like `moka` optimizes
+/// for cheaply: `moka`'s per-insert maintenance dominated the single-threaded
+/// handler at high TPS, while its lock-free reads were not the constraint.
+///
+/// Membership is all the read path needs, so entries never need recency
+/// promotion on read — that lets readers take a shared lock and run
+/// concurrently. Eviction is generational (FIFO): inserts fill `current`; once
+/// it reaches the per-generation capacity, `current` ages into `previous` (the
+/// prior `previous` is dropped) and a fresh `current` begins. `contains` checks
+/// both generations, so the most recent `generation_capacity` digests are always
+/// retained, and at most `2 * generation_capacity` are held at once. FIFO is also
+/// a better fit than LRU here: a transaction is finalized once, so being
+/// repeatedly voted on should not extend how long it is "recently finalized".
+///
+/// The cache is advisory — `is_recently_finalized` falls back to the executed-tx
+/// check — so the eventual-consistency and bounded-window behavior here is safe.
+pub struct FinalizedTransactionsCache {
+    inner: RwLock<Generations>,
+    /// Age `current` into `previous` once it reaches this many entries.
+    generation_capacity: usize,
+}
+
+struct Generations {
+    current: HashSet<TransactionDigest>,
+    previous: HashSet<TransactionDigest>,
+}
+
+impl FinalizedTransactionsCache {
+    /// `capacity` is the target total number of digests retained; it is split
+    /// across two generations so the live set stays within `capacity`.
+    pub fn new(capacity: usize) -> Self {
+        let generation_capacity = (capacity / 2).max(1);
+        Self {
+            inner: RwLock::new(Generations {
+                current: HashSet::with_capacity(generation_capacity),
+                previous: HashSet::new(),
+            }),
+            generation_capacity,
+        }
+    }
+
+    pub fn insert(&self, tx_digest: TransactionDigest) {
+        // Hold the write lock only for the O(1) in-memory mutation. On rotation we
+        // move the aged-out generation *out* (rather than letting `inner.previous =
+        // full` drop it in place) so its deallocation happens after the block — i.e.
+        // after the write guard is released — keeping it off the readers' critical
+        // path.
+        let _aged_out = {
+            let mut inner = self.inner.write();
+            let aged_out = if inner.current.len() >= self.generation_capacity {
+                let full = std::mem::replace(
+                    &mut inner.current,
+                    HashSet::with_capacity(self.generation_capacity),
+                );
+                Some(std::mem::replace(&mut inner.previous, full))
+            } else {
+                None
+            };
+            inner.current.insert(tx_digest);
+            aged_out
+        };
+    }
+
+    pub fn contains(&self, tx_digest: &TransactionDigest) -> bool {
+        let inner = self.inner.read();
+        inner.current.contains(tx_digest) || inner.previous.contains(tx_digest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_contains() {
+        let cache = FinalizedTransactionsCache::new(100);
+        let a = TransactionDigest::random();
+        let b = TransactionDigest::random();
+        assert!(!cache.contains(&a));
+        cache.insert(a);
+        assert!(cache.contains(&a));
+        assert!(!cache.contains(&b));
+    }
+
+    #[test]
+    fn retains_across_one_rotation_then_evicts() {
+        // generation_capacity = 1: each generation holds one entry, so an entry
+        // survives exactly one rotation before being dropped.
+        let cache = FinalizedTransactionsCache::new(2);
+        let first = TransactionDigest::random();
+        cache.insert(first); // current = {first}
+
+        let second = TransactionDigest::random();
+        cache.insert(second); // rotate: previous = {first}, current = {second}
+        assert!(cache.contains(&first), "survives one rotation");
+        assert!(cache.contains(&second));
+
+        let third = TransactionDigest::random();
+        cache.insert(third); // rotate: previous = {second}, current = {third}
+        assert!(!cache.contains(&first), "evicted after second rotation");
+        assert!(cache.contains(&second));
+        assert!(cache.contains(&third));
+    }
+
+    #[test]
+    fn rotation_boundary_with_larger_generation() {
+        // capacity = 100 => generation_capacity = 50; exercises the >= boundary
+        // for G > 1 (the single-rotation test above only covers G = 1).
+        let cache = FinalizedTransactionsCache::new(100);
+        let batch_a: Vec<_> = (0..50).map(|_| TransactionDigest::random()).collect();
+        let batch_b: Vec<_> = (0..50).map(|_| TransactionDigest::random()).collect();
+
+        // Fill `current` exactly to capacity; no rotation yet, all of A present.
+        for d in &batch_a {
+            cache.insert(*d);
+        }
+        assert!(batch_a.iter().all(|d| cache.contains(d)));
+
+        // The first B insert rotates A into `previous`, where it survives the full
+        // generation; afterwards both batches are retained (2 * generation_capacity).
+        for d in &batch_b {
+            cache.insert(*d);
+        }
+        assert!(
+            batch_a.iter().all(|d| cache.contains(d)),
+            "A survives one rotation"
+        );
+        assert!(batch_b.iter().all(|d| cache.contains(d)));
+
+        // One more insert rotates again and evicts A; B and the new entry remain.
+        let extra = TransactionDigest::random();
+        cache.insert(extra);
+        assert!(
+            batch_a.iter().all(|d| !cache.contains(d)),
+            "A evicted on next rotation"
+        );
+        assert!(batch_b.iter().all(|d| cache.contains(d)));
+        assert!(cache.contains(&extra));
+    }
+}

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -3052,15 +3052,9 @@ impl MysticetiConsensusHandler {
         );
         tasks.spawn(monitored_future!(async move {
             while let Some(consensus_commit) = commit_receiver.recv().await {
-                // Prior commits are only replayed for `observe_commit` metadata and don't use
-                // the parsed transactions, so skip parsing them.
                 let transactions: ParsedConsensusTransactions = {
                     let _scope = monitored_scope("ConsensusCommitHandler::deserialize_worker");
-                    if consensus_commit.commit_ref.index > last_processed_commit_at_startup {
-                        consensus_commit.transactions()
-                    } else {
-                        Vec::new()
-                    }
+                    consensus_commit.transactions()
                 };
                 // The send is intentionally outside the scope above: on the bounded channel it
                 // blocks when the handler is the bottleneck, and that idle-wait would otherwise

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -3052,15 +3052,19 @@ impl MysticetiConsensusHandler {
         );
         tasks.spawn(monitored_future!(async move {
             while let Some(consensus_commit) = commit_receiver.recv().await {
-                let _scope = monitored_scope("ConsensusCommitHandler::deserialize_worker");
                 // Prior commits are only replayed for `observe_commit` metadata and don't use
                 // the parsed transactions, so skip parsing them.
-                let transactions: ParsedConsensusTransactions =
+                let transactions: ParsedConsensusTransactions = {
+                    let _scope = monitored_scope("ConsensusCommitHandler::deserialize_worker");
                     if consensus_commit.commit_ref.index > last_processed_commit_at_startup {
                         consensus_commit.transactions()
                     } else {
                         Vec::new()
-                    };
+                    }
+                };
+                // The send is intentionally outside the scope above: on the bounded channel it
+                // blocks when the handler is the bottleneck, and that idle-wait would otherwise
+                // inflate the deserialize_worker scope (making it read as CPU work, not waiting).
                 if parsed_sender
                     .send((consensus_commit, transactions))
                     .await

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -11,6 +11,7 @@ use std::{
 
 use consensus_config::Committee as ConsensusCommittee;
 use consensus_core::{CommitConsumerMonitor, CommitIndex, CommitRef};
+use consensus_types::block::BlockRef;
 use consensus_types::block::TransactionIndex;
 use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use lru::LruCache;
@@ -81,7 +82,7 @@ use crate::{
     },
     consensus_adapter::ConsensusAdapter,
     consensus_throughput_calculator::ConsensusThroughputCalculator,
-    consensus_types::consensus_output_api::ConsensusCommitAPI,
+    consensus_types::consensus_output_api::{ConsensusCommitAPI, ParsedTransaction},
     epoch::{
         randomness::{DkgStatus, RandomnessManager},
         reconfiguration::ReconfigState,
@@ -1077,13 +1078,16 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         &mut self,
         consensus_commit: impl ConsensusCommitAPI,
     ) {
-        self.handle_consensus_commit(consensus_commit).await;
+        let transactions = consensus_commit.transactions();
+        self.handle_consensus_commit(consensus_commit, transactions)
+            .await;
     }
 
     #[instrument(level = "debug", skip_all, fields(epoch = self.epoch_store.epoch(), round = consensus_commit.leader_round()))]
     pub(crate) async fn handle_consensus_commit(
         &mut self,
         consensus_commit: impl ConsensusCommitAPI,
+        transactions: ParsedConsensusTransactions,
     ) {
         {
             let protocol_config = self.epoch_store.protocol_config();
@@ -1164,7 +1168,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         } = self.filter_consensus_txns(
             state.initial_reconfig_state.clone(),
             &commit_info,
-            &consensus_commit,
+            transactions,
         );
         // Buffer owned object locks for batch write.
         if !owned_object_locks.is_empty() {
@@ -2442,7 +2446,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         &mut self,
         initial_reconfig_state: ReconfigState,
         commit_info: &ConsensusCommitInfo,
-        consensus_commit: &impl ConsensusCommitAPI,
+        block_transactions: ParsedConsensusTransactions,
     ) -> FilteredConsensusOutput {
         let _scope = monitored_scope("ConsensusCommitHandler::filter_consensus_txns");
         let mut transactions = Vec::new();
@@ -2450,7 +2454,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let epoch = self.epoch_store.epoch();
         let mut num_finalized_user_transactions = vec![0; self.committee.size()];
         let mut num_rejected_user_transactions = vec![0; self.committee.size()];
-        for (block, parsed_transactions) in consensus_commit.transactions() {
+        for (block, parsed_transactions) in block_transactions {
             let author = block.author.value();
             // TODO: consider only messages within 1~3 rounds of the leader?
             self.last_consensus_stats.stats.inc_num_messages(author);
@@ -3009,6 +3013,16 @@ impl ExecutionSchedulerSender {
     }
 }
 
+/// Capacity of the channel from the deserialize worker to the commit handler. Small/bounded: lets
+/// the worker prepare ~1 commit ahead (pipelining) while applying backpressure when the handler is
+/// behind, instead of buffering parsed commits unboundedly.
+const CONSENSUS_HANDLER_DESERIALIZE_CHANNEL_CAPACITY: usize = 2;
+
+/// Transactions BCS-deserialized out of a consensus commit, grouped by block. Produced by the
+/// deserialize worker and consumed by the commit handler, so parsing stays off the handler's
+/// critical path.
+type ParsedConsensusTransactions = Vec<(BlockRef, Vec<ParsedTransaction>)>;
+
 /// Manages the lifetime of tasks handling the commits and transactions output by consensus.
 pub(crate) struct MysticetiConsensusHandler {
     tasks: JoinSet<()>,
@@ -3026,15 +3040,47 @@ impl MysticetiConsensusHandler {
             "Starting consensus replay"
         );
         let mut tasks = JoinSet::new();
+
+        // Stage 1 — deserialize worker: BCS-parses each commit's transactions off the handler's
+        // critical path, so parsing overlaps the handler processing the previous commit. The
+        // channel is bounded (small) so the worker prepares ~1 commit ahead but applies
+        // backpressure (rather than buffering parsed commits unboundedly) when the handler is the
+        // bottleneck. Single-threaded; ordering is preserved (one worker, FIFO channel, one handler).
+        let (parsed_sender, mut parsed_receiver) = monitored_mpsc::channel(
+            "consensus_deserialized_commits",
+            CONSENSUS_HANDLER_DESERIALIZE_CHANNEL_CAPACITY,
+        );
+        tasks.spawn(monitored_future!(async move {
+            while let Some(consensus_commit) = commit_receiver.recv().await {
+                let _scope = monitored_scope("ConsensusCommitHandler::deserialize_worker");
+                // Prior commits are only replayed for `observe_commit` metadata and don't use
+                // the parsed transactions, so skip parsing them.
+                let transactions: ParsedConsensusTransactions =
+                    if consensus_commit.commit_ref.index > last_processed_commit_at_startup {
+                        consensus_commit.transactions()
+                    } else {
+                        Vec::new()
+                    };
+                if parsed_sender
+                    .send((consensus_commit, transactions))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }));
+
+        // Stage 2 — commit handler: processes pre-parsed commits in order.
         tasks.spawn(monitored_future!(async move {
             // TODO: pause when execution is overloaded, so consensus can detect the backpressure.
-            while let Some(consensus_commit) = commit_receiver.recv().await {
+            while let Some((consensus_commit, transactions)) = parsed_receiver.recv().await {
                 let commit_index = consensus_commit.commit_ref.index;
                 if commit_index <= last_processed_commit_at_startup {
                     consensus_handler.handle_prior_consensus_commit(consensus_commit);
                 } else {
                     consensus_handler
-                        .handle_consensus_commit(consensus_commit)
+                        .handle_consensus_commit(consensus_commit, transactions)
                         .await;
                 }
                 commit_consumer_monitor.set_highest_handled_commit(commit_index);
@@ -3520,7 +3566,8 @@ mod tests {
 
         // AND process the consensus commit once
         {
-            let waiter = consensus_handler.handle_consensus_commit(committed_sub_dag.clone());
+            let waiter =
+                consensus_handler.handle_consensus_commit_for_test(committed_sub_dag.clone());
             pin_mut!(waiter);
 
             // waiter should not complete within 5 seconds
@@ -3713,7 +3760,7 @@ mod tests {
             state.consensus_gasless_counter.clone(),
         );
 
-        handler.handle_consensus_commit(commit).await;
+        handler.handle_consensus_commit_for_test(commit).await;
 
         use crate::consensus_handler::SequencedConsensusTransactionKey as SK;
         use sui_types::messages_consensus::ConsensusTransactionKey as CK;
@@ -3839,7 +3886,7 @@ mod tests {
             state.consensus_gasless_counter.clone(),
         );
 
-        handler.handle_consensus_commit(commit).await;
+        handler.handle_consensus_commit_for_test(commit).await;
 
         use crate::consensus_handler::SequencedConsensusTransactionKey as SK;
         use sui_types::messages_consensus::ConsensusTransactionKey as CK;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5791,7 +5791,9 @@ where
         TestConsensusCommit::new(consensus_txns, round, epoch_start_ms + (1000 * round), 0);
 
     // Process through the consensus handler
-    consensus_handler.handle_consensus_commit(commit).await;
+    consensus_handler
+        .handle_consensus_commit_for_test(commit)
+        .await;
 
     // Give a bit of time for the async capture to complete
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -305,7 +305,9 @@ async fn test_congestion_control_execution_cancellation() {
     )];
     let commit = TestConsensusCommit::new(consensus_transactions, 1, 0, 0);
 
-    consensus_handler.handle_consensus_commit(commit).await;
+    consensus_handler
+        .handle_consensus_commit_for_test(commit)
+        .await;
 
     // Wait for captured transactions to be available
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;


### PR DESCRIPTION
## Description

The consensus commit handler is effectively single-threaded and is the bottleneck at high TPS. This reduces and pipelines its per-commit work:

- **Pipeline BCS deserialization** onto a dedicated single-threaded deserialize worker, so parsing a commit overlaps the handler processing the previous one. A small bounded channel preserves ordering (one worker, FIFO, one handler) and applies backpressure instead of buffering. Runs on the default runtime.
- **Replace the finalized-tx moka cache with a generational `RwLock<HashSet>`.** The cache has a single writer (the handler, ~15k inserts/s) and many concurrent readers (the voting path); moka's per-insert maintenance was ~15% of the handler's CPU under load, while its lock-free reads weren't the constraint. Membership is all the read path needs, so reads take a shared lock and inserts are a cheap hashset insert plus an occasional O(1) generation rotation — cheap enough to stay inline. The cache is advisory (`is_recently_finalized` falls back to the executed-tx check), so the bounded two-generation retention window is safe.

(The fine-grained `monitored_scope`s that were in this PR have landed on `main` separately and dropped out on rebase.)

## Test plan

New unit tests cover the cache's insert/contains and generation-rotation eviction. The deser pipeline preserves commit ordering by construction (single worker, FIFO bounded channel, single handler) and is covered by existing `consensus_handler` tests.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: