### PR TITLE
rpc-store: register RocksDB stats collector for embedded store

### DIFF
--- a/crates/sui-core/src/rpc_store_embed.rs
+++ b/crates/sui-core/src/rpc_store_embed.rs
@@ -42,6 +42,7 @@ use sui_consistent_store::Db;
 use sui_consistent_store::DbOptions;
 use sui_consistent_store::PipelineTaskKey;
 use sui_consistent_store::Watermark;
+use sui_consistent_store::metrics::ColumnFamilyStatsCollector;
 use sui_consistent_store::restore::RestoreDriverConfig;
 use sui_consistent_store::restore::metrics::RestoreMetrics;
 use sui_indexer_alt_framework::IndexerArgs;
@@ -268,6 +269,15 @@ impl EmbeddedRpcStore {
         let path = config.db_path().join(RPC_STORE_DIR);
         let (db, schema) = open_db(&path).await?;
         let schema = Arc::new(schema);
+
+        // Expose per-CF RocksDB stats (sizes, compaction backlog,
+        // write-stall state) for the store's database.
+        registry
+            .register(Box::new(ColumnFamilyStatsCollector::new(
+                Some(METRICS_PREFIX),
+                &db,
+            )))
+            .context("registering the embedded rpc-store RocksDB stats collector")?;
 
         // The highest checkpoint whose transaction outputs are durably
         // committed to the perpetual store. This is the live cohort's restore


### PR DESCRIPTION
The embedded `sui-rpc-store` path threaded the node's prometheus registry through to its ingestion, restore, and pipeline metrics, but never registered the `ColumnFamilyStatsCollector`. As a result the embedded store's own RocksDB instance (under `db_path()/rpc_store`) exposed no per-column-family gauges, so an operator could not see its compaction backlog, write-stall state, sizes, or cache usage -- the only signals into that database's health.

With this commit, `EmbeddedRpcStore::bootstrap` registers the collector once, right after opening the database and before the restore / seed work, mirroring the three standalone `sui-rpc-node` entry points. The collector holds only a weak handle, so it does not keep the database open. The gauges use the embedded `rpc_store_indexer` metrics prefix, grouping them with the ingestion and restore metrics already registered on the same path.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
