### PR TITLE
Suppress resubmission of consensus-processed transactions

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -882,7 +882,11 @@ impl ValidatorService {
                     .with_label_values(&[req_type])
                     .inc();
                 results[idx] = Some(SubmitTxResult::Rejected {
-                    error: UserInputError::TransactionAlreadyExecuted { digest: tx_digest }.into(),
+                    error: SuiErrorKind::TransactionProcessing {
+                        digest: tx_digest,
+                        status: "sequenced by consensus".to_string(),
+                    }
+                    .into(),
                 });
                 debug!(
                     ?tx_digest,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -29,7 +29,9 @@ use sui_network::{
 };
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::message_envelope::Message;
-use sui_types::messages_consensus::{ConsensusPosition, ConsensusTransaction};
+use sui_types::messages_consensus::{
+    ConsensusPosition, ConsensusTransaction, ConsensusTransactionKey,
+};
 use sui_types::messages_grpc::{
     ObjectInfoRequest, ObjectInfoResponse, RawSubmitTxResponse, SystemStateRequest,
     TransactionInfoRequest, TransactionInfoResponse,
@@ -67,6 +69,7 @@ use crate::gasless_rate_limiter::GaslessRateLimiter;
 use crate::{
     authority::{AuthorityState, consensus_tx_status_cache::ConsensusTxStatus},
     consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, ConsensusOverloadChecker},
+    consensus_handler::SequencedConsensusTransactionKey,
     traffic_controller::{TrafficController, parse_ip, policies::TrafficTally},
 };
 use crate::{
@@ -197,6 +200,7 @@ pub struct ValidatorServiceMetrics {
 
     num_rejected_tx_during_overload: IntCounterVec,
     submission_rejected_transactions: IntCounterVec,
+    submission_suppressed_already_processed: IntCounterVec,
     connection_ip_not_found: IntCounter,
     forwarded_header_parse_error: IntCounter,
     forwarded_header_invalid: IntCounter,
@@ -289,6 +293,14 @@ impl ValidatorServiceMetrics {
                 "validator_service_submission_rejected_transactions",
                 "Number of transactions rejected during submission",
                 &["reason"],
+                registry,
+            )
+            .unwrap(),
+            submission_suppressed_already_processed: register_int_counter_vec_with_registry!(
+                "validator_service_submission_suppressed_already_processed",
+                "Number of submitted transactions suppressed because consensus had already \
+                 processed them this epoch (re-submission of already-processed transactions)",
+                &["req_type"],
                 registry,
             )
             .unwrap(),
@@ -852,6 +864,29 @@ impl ValidatorService {
                 debug!(
                     ?tx_digest,
                     "handle_submit_transaction: transaction already executed in previous epoch"
+                );
+                continue;
+            }
+
+            // Suppress resubmission of transactions consensus already processed this epoch:
+            // executed transactions whose effects details could not be reconstructed above (e.g.
+            // objects pruned), and sequenced-but-deferred transactions. Rejected is imperfect for
+            // the deferred case, but acceptable since well-behaved clients get Executed before
+            // pruning; this mainly sheds continuous resubmissions from faulty clients.
+            let consensus_key = SequencedConsensusTransactionKey::External(
+                ConsensusTransactionKey::Certificate(tx_digest),
+            );
+            if epoch_store.is_consensus_message_processed(&consensus_key)? {
+                metrics
+                    .submission_suppressed_already_processed
+                    .with_label_values(&[req_type])
+                    .inc();
+                results[idx] = Some(SubmitTxResult::Rejected {
+                    error: UserInputError::TransactionAlreadyExecuted { digest: tx_digest }.into(),
+                });
+                debug!(
+                    ?tx_digest,
+                    "handle_submit_transaction: consensus message already processed"
                 );
                 continue;
             }

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -276,9 +276,7 @@ async fn test_submit_transaction_consensus_message_processed() {
             assert!(
                 matches!(
                     error.as_inner(),
-                    SuiErrorKind::UserInputError {
-                        error: UserInputError::TransactionAlreadyExecuted { digest }
-                    } if *digest == tx_digest
+                    SuiErrorKind::TransactionProcessing { digest, .. } if *digest == tx_digest
                 ),
                 "unexpected rejection error: {error}"
             );

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -249,6 +249,44 @@ async fn test_submit_transaction_already_executed() {
     };
 }
 
+// Test that a transaction already processed by consensus this epoch but not yet executed
+// (e.g. deferred) is suppressed rather than resubmitted to consensus.
+#[tokio::test]
+async fn test_submit_transaction_consensus_message_processed() {
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let request = test_context.build_submit_request(transaction);
+
+    // Mark the transaction as processed by consensus without executing it, simulating a
+    // sequenced-but-deferred transaction. Its gas object is still unspent, so without the
+    // is_consensus_message_processed check it would be resubmitted to consensus.
+    let epoch_store = test_context.state.epoch_store_for_testing();
+    epoch_store.test_insert_user_signature(tx_digest, vec![]);
+
+    let response = test_context
+        .client
+        .submit_transaction(request, None)
+        .await
+        .unwrap();
+    assert_eq!(response.results.len(), 1);
+    match &response.results[0] {
+        SubmitTxResult::Rejected { error } => {
+            assert!(
+                matches!(
+                    error.as_inner(),
+                    SuiErrorKind::UserInputError {
+                        error: UserInputError::TransactionAlreadyExecuted { digest }
+                    } if *digest == tx_digest
+                ),
+                "unexpected rejection error: {error}"
+            );
+        }
+        other => panic!("Expected Rejected response, got {other:?}"),
+    };
+}
+
 #[tokio::test]
 async fn test_submit_transaction_wrong_epoch() {
     let test_context = TestContext::new().await;
@@ -550,6 +588,69 @@ async fn test_submit_soft_bundle_transactions_with_already_executed() {
             // Expected: second transaction was submitted to consensus
         }
         _ => panic!("Expected Submitted status for second transaction"),
+    }
+}
+
+// Test that a transaction already processed by consensus (but not executed) is removed from a
+// soft bundle before submission, while the remaining transactions in the bundle are still
+// submitted to consensus.
+#[tokio::test]
+async fn test_submit_soft_bundle_transactions_with_consensus_message_processed() {
+    let test_context = TestContext::new().await;
+
+    // 1st transaction: mark as already processed by consensus without executing it.
+    let tx1 = test_context.build_test_transaction();
+    let tx1_digest = *tx1.digest();
+    let epoch_store = test_context.state.epoch_store_for_testing();
+    epoch_store.test_insert_user_signature(tx1_digest, vec![]);
+
+    // 2nd transaction: a fresh, unprocessed transaction with its own gas object.
+    let gas_object2 = Object::with_owner_for_testing(test_context.sender);
+    let gas_object_ref2 = gas_object2.compute_object_reference();
+    test_context.state.insert_genesis_object(gas_object2);
+
+    let tx_data2 = TestTransactionBuilder::new(
+        test_context.sender,
+        gas_object_ref2,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(None, test_context.sender)
+    .build();
+    let tx2 = to_sender_signed_transaction(tx_data2, &test_context.keypair);
+
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx1).unwrap().into(),
+            bcs::to_bytes(&tx2).unwrap().into(),
+        ],
+        submit_type: SubmitTxType::SoftBundle.into(),
+    };
+
+    let raw_response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(raw_response.results.len(), 2);
+
+    // The already-processed transaction is rejected and excluded from the bundle submitted to
+    // consensus; the remaining transaction is still submitted.
+    match &raw_response.results[0].inner {
+        Some(sui_types::messages_grpc::RawValidatorSubmitStatus::Rejected(_)) => {}
+        other => {
+            panic!("Expected Rejected status for already-processed transaction, got {other:?}")
+        }
+    }
+    match &raw_response.results[1].inner {
+        Some(sui_types::messages_grpc::RawValidatorSubmitStatus::Submitted(_)) => {}
+        other => panic!("Expected Submitted status for remaining transaction, got {other:?}"),
     }
 }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -820,6 +820,12 @@ pub enum SuiErrorKind {
         "Transaction was outbid by higher-gas-price transactions in the admission queue (current minimum gas price required: {min_gas_price})"
     )]
     TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: u64 },
+
+    #[error("Transaction {digest} is being processed: {status}")]
+    TransactionProcessing {
+        digest: TransactionDigest,
+        status: String,
+    },
 }
 
 #[repr(u64)]


### PR DESCRIPTION
## Description

Validators were resubmitting transactions that had already executed long ago. `handle_submit_transaction` only short-circuited an already-executed transaction when it could *also* rebuild the full `ExecutedData` response, but `complete_executed_data` fails once the transaction's input/output object versions have been pruned — so the dedup checks silently fell through and the transaction was sent to consensus again.

Gate on `is_consensus_message_processed` (current epoch), which is true for any transaction consensus has already processed regardless of whether its effects data is still retrievable, also covering transactions that are sequenced but still deferred. `Rejected { TransactionAlreadyExecuted }` is not a perfect fit for the deferred case, but is acceptable here since well-behaved clients receive `Executed` before pruning and this path primarily guards against faulty clients resubmitting indefinitely.

## Test plan

- `test_submit_transaction_consensus_message_processed`: a single processed-but-not-executed (deferred) transaction is suppressed.
- `test_submit_soft_bundle_transactions_with_consensus_message_processed`: a processed transaction is removed from a soft bundle before submission while the rest of the bundle is still submitted.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: