### PR TITLE
Reject soft bundles that repeat a transaction

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -17,6 +17,7 @@ use prometheus::{
     register_int_counter_with_registry,
 };
 use std::{
+    collections::HashSet,
     io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
@@ -670,6 +671,9 @@ impl ValidatorService {
         let mut spam_weight = Weight::zero();
         // First gas price seen in this soft bundle.
         let mut expected_soft_bundle_gas_price = None;
+        // Transaction digests seen in this soft bundle, used to reject bundles that repeat a
+        // transaction. No legitimate client constructs such a bundle.
+        let mut soft_bundle_digests = HashSet::new();
 
         let req_type = if is_ping_request {
             "ping"
@@ -703,6 +707,19 @@ impl ValidatorService {
             // Ok to fail the request when any transaction is invalid.
             let tx_size = transaction.validity_check(&epoch_store.tx_validity_check_context())?;
             let tx_digest = *transaction.digest();
+
+            // Soft bundles must not repeat a transaction. Fail the whole request if they do.
+            if is_soft_bundle_request {
+                fp_ensure!(
+                    soft_bundle_digests.insert(tx_digest),
+                    SuiErrorKind::UserInputError {
+                        error: UserInputError::RepeatedTransactionInSoftBundle {
+                            digest: tx_digest
+                        }
+                    }
+                    .into()
+                );
+            }
 
             // Soft bundles require all transactions to use the same gas price.
             if is_soft_bundle_request {

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -449,7 +449,22 @@ async fn test_submit_soft_bundle_transactions() {
     let test_context = TestContext::new().await;
 
     let tx1 = test_context.build_test_transaction();
-    let tx2 = test_context.build_test_transaction();
+
+    // tx2 must be distinct from tx1: a soft bundle may not repeat a transaction.
+    let gas_object2 = Object::with_owner_for_testing(test_context.sender);
+    let gas_object_ref2 = gas_object2.compute_object_reference();
+    test_context.state.insert_genesis_object(gas_object2);
+    let tx_data2 = TestTransactionBuilder::new(
+        test_context.sender,
+        gas_object_ref2,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(None, test_context.sender)
+    .build();
+    let tx2 = to_sender_signed_transaction(tx_data2, &test_context.keypair);
 
     // Build request with batched transactions.
     let request = RawSubmitTxRequest {
@@ -482,6 +497,41 @@ async fn test_submit_soft_bundle_transactions() {
             _ => panic!("Expected Submitted status for all transactions"),
         }
     }
+}
+
+// A soft bundle that repeats the same transaction is rejected outright.
+#[tokio::test]
+async fn test_submit_soft_bundle_with_repeated_transaction() {
+    let test_context = TestContext::new().await;
+
+    let tx = test_context.build_test_transaction();
+    let tx_digest = *tx.digest();
+
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx).unwrap().into(),
+            bcs::to_bytes(&tx).unwrap().into(),
+        ],
+        submit_type: SubmitTxType::SoftBundle.into(),
+    };
+
+    let response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await;
+    assert!(response.is_err());
+    let error: SuiError = response.unwrap_err().into();
+    assert!(
+        matches!(
+            error.into_inner(),
+            SuiErrorKind::UserInputError {
+                error: UserInputError::RepeatedTransactionInSoftBundle { digest }
+            } if digest == tx_digest
+        ),
+        "expected RepeatedTransactionInSoftBundle error"
+    );
 }
 
 #[tokio::test]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -366,6 +366,9 @@ pub enum UserInputError {
 
     #[error("Transaction chain ID {provided} does not match network chain ID {expected}.")]
     InvalidChainId { provided: String, expected: String },
+
+    #[error("Transaction {digest} appears more than once in the Soft Bundle")]
+    RepeatedTransactionInSoftBundle { digest: TransactionDigest },
 }
 
 #[derive(


### PR DESCRIPTION
## Description

A soft bundle should never contain the same transaction more than once; no legitimate client constructs one. Reject such bundles at submission with a new `RepeatedTransactionInSoftBundle` user input error instead of forwarding duplicates.

## Test plan

`test_submit_soft_bundle_with_repeated_transaction` covers the rejection. `test_submit_soft_bundle_transactions` was building two identical transactions (same gas object → same digest) and now uses a distinct second transaction.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: