### PR TITLE
[consensus] fix block publish/subscribe issues

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -337,11 +337,10 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
     ) -> ConsensusResult<BlockStream> {
         fail_point_async!("consensus-rpc-response");
 
-        // Subscribe to the live broadcast BEFORE snapshotting past proposed blocks below.
-        // resubscribe() positions the receiver at the current tail, so a block proposed
-        // concurrently with the snapshot lands in both segments (a harmless duplicate that the
-        // receiving peer dedups) rather than in neither (a gap that would otherwise have to be
-        // recovered via ancestor fetch).
+        // Subscribe before snapshotting past blocks below. This can duplicate
+        // a block in both the subscription stream and snapshot, which is fine.
+        // Otherwise, it is possible to miss a block if it is broadcasted after snapshotting
+        // but before subscribing.
         let broadcast_rx = self.rx_block_broadcast.resubscribe();
 
         // Find past proposed blocks as the initial blocks to send to the peer.
@@ -355,8 +354,10 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
         let past_proposed_blocks = {
             let dag_state = self.dag_state.read();
 
-            let mut proposed_blocks =
-                dag_state.get_cached_blocks(self.context.own_index, last_received + 1);
+            // Saturate so an out-of-range round from the peer cannot wrap to 0 and
+            // replay the entire block cache.
+            let mut proposed_blocks = dag_state
+                .get_cached_blocks(self.context.own_index, last_received.saturating_add(1));
             if proposed_blocks.is_empty() {
                 let last_proposed_block = dag_state
                     .get_last_proposed_block()
@@ -377,9 +378,7 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
             )
         };
 
-        // Validator streams carry only this validator's own proposals, and the tonic layer
-        // throttles them to min_round_delay / 2. Keep this at 1 so broadcast backpressure
-        // remains visible instead of draining extra blocks into per-subscriber buffers.
+        // Ok to not batch own proposed blocks, which is < 20/s.
         const MAX_BLOCKS_PER_POLL: usize = 1;
         let broadcasted_blocks = BroadcastedBlockStream::new(
             PeerId::Validator(peer),
@@ -510,10 +509,14 @@ impl SubscriptionCounter {
     fn increment(&self, peer: &PeerId) {
         let mut counter = self.counter.lock();
         counter.count += 1;
-        *counter
-            .subscriptions_by_peer
-            .entry(peer.clone())
-            .or_insert(0) += 1;
+        let peer_count = {
+            let count = counter
+                .subscriptions_by_peer
+                .entry(peer.clone())
+                .or_default();
+            *count += 1;
+            *count
+        };
 
         match peer {
             PeerId::Validator(authority) => {
@@ -526,25 +529,29 @@ impl SubscriptionCounter {
                     .set(1);
             }
             PeerId::Observer(_) => {
-                self.context
-                    .metrics
-                    .node_metrics
-                    .subscribed_by
-                    .with_label_values(&["observer"])
-                    .inc();
+                // Only count the first subscription from each peer.
+                if peer_count == 1 {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .subscribed_by
+                        .with_label_values(&["observer"])
+                        .inc();
+                }
             }
         }
     }
 
     fn decrement(&self, peer: &PeerId) {
         let mut counter = self.counter.lock();
-        counter.count -= 1;
-        *counter
+        counter.count = counter.count.saturating_sub(1);
+        let peer_count = counter
             .subscriptions_by_peer
             .entry(peer.clone())
-            .or_insert(0) -= 1;
+            .or_default();
+        *peer_count = peer_count.saturating_sub(1);
 
-        if counter.subscriptions_by_peer[peer] == 0 {
+        if *peer_count == 0 {
             match peer {
                 PeerId::Validator(authority) => {
                     let peer_hostname = &self.context.committee.authority(*authority).hostname;
@@ -598,8 +605,6 @@ impl<T: 'static + Clone + Send> BroadcastStream<T> {
         subscription_counter: Arc<SubscriptionCounter>,
     ) -> Self {
         assert!(max_items_per_poll > 0, "max_items_per_poll must be > 0");
-        // Increment before storing `peer`/`subscription_counter`, so the matching decrement in
-        // Drop only ever runs for a subscription that was actually counted.
         subscription_counter.increment(&peer);
         Self {
             peer: Some(peer),

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -337,6 +337,13 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
     ) -> ConsensusResult<BlockStream> {
         fail_point_async!("consensus-rpc-response");
 
+        // Subscribe to the live broadcast BEFORE snapshotting past proposed blocks below.
+        // resubscribe() positions the receiver at the current tail, so a block proposed
+        // concurrently with the snapshot lands in both segments (a harmless duplicate that the
+        // receiving peer dedups) rather than in neither (a gap that would otherwise have to be
+        // recovered via ancestor fetch).
+        let broadcast_rx = self.rx_block_broadcast.resubscribe();
+
         // Find past proposed blocks as the initial blocks to send to the peer.
         //
         // If there are cached blocks in the range which the peer requested, send all of them.
@@ -370,10 +377,13 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
             )
         };
 
+        // Validator streams carry only this validator's own proposals, and the tonic layer
+        // throttles them to min_round_delay / 2. Keep this at 1 so broadcast backpressure
+        // remains visible instead of draining extra blocks into per-subscriber buffers.
         const MAX_BLOCKS_PER_POLL: usize = 1;
         let broadcasted_blocks = BroadcastedBlockStream::new(
             PeerId::Validator(peer),
-            self.rx_block_broadcast.resubscribe(),
+            broadcast_rx,
             MAX_BLOCKS_PER_POLL,
             self.subscription_counter.clone(),
         );
@@ -497,7 +507,7 @@ impl SubscriptionCounter {
         }
     }
 
-    fn increment(&self, peer: &PeerId) -> Result<(), ConsensusError> {
+    fn increment(&self, peer: &PeerId) {
         let mut counter = self.counter.lock();
         counter.count += 1;
         *counter
@@ -524,11 +534,9 @@ impl SubscriptionCounter {
                     .inc();
             }
         }
-
-        Ok(())
     }
 
-    fn decrement(&self, peer: &PeerId) -> Result<(), ConsensusError> {
+    fn decrement(&self, peer: &PeerId) {
         let mut counter = self.counter.lock();
         counter.count -= 1;
         *counter
@@ -557,8 +565,6 @@ impl SubscriptionCounter {
                 }
             }
         }
-
-        Ok(())
     }
 }
 
@@ -592,12 +598,9 @@ impl<T: 'static + Clone + Send> BroadcastStream<T> {
         subscription_counter: Arc<SubscriptionCounter>,
     ) -> Self {
         assert!(max_items_per_poll > 0, "max_items_per_poll must be > 0");
-        if let Err(err) = subscription_counter.increment(&peer) {
-            match err {
-                ConsensusError::Shutdown => {}
-                _ => panic!("Unexpected error: {err}"),
-            }
-        }
+        // Increment before storing `peer`/`subscription_counter`, so the matching decrement in
+        // Drop only ever runs for a subscription that was actually counted.
+        subscription_counter.increment(&peer);
         Self {
             peer: Some(peer),
             inner: ReusableBoxFuture::new(make_recv_future(rx)),
@@ -666,13 +669,8 @@ impl<T: 'static + Clone + Send> Stream for BroadcastStream<T> {
 
 impl<T> Drop for BroadcastStream<T> {
     fn drop(&mut self) {
-        if let (Some(counter), Some(peer)) = (&self.subscription_counter, &self.peer)
-            && let Err(err) = counter.decrement(peer)
-        {
-            match err {
-                ConsensusError::Shutdown => {}
-                _ => panic!("Unexpected error: {err}"),
-            }
+        if let (Some(counter), Some(peer)) = (&self.subscription_counter, &self.peer) {
+            counter.decrement(peer);
         }
     }
 }
@@ -849,7 +847,7 @@ mod tests {
         async fn stream_blocks(
             &self,
             _peer: crate::network::PeerId,
-            _highest_round_per_authority: Vec<u64>,
+            _highest_round_per_authority: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<crate::network::ObserverBlockStream> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -976,7 +976,7 @@ mod tests {
         async fn stream_blocks(
             &self,
             _peer: crate::network::PeerId,
-            _highest_round_per_authority: Vec<u64>,
+            _highest_round_per_authority: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<crate::network::ObserverBlockStream> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -275,7 +275,7 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
     async fn handle_stream_blocks(
         &self,
         peer: NodeId,
-        highest_round_per_authority: Vec<u64>,
+        highest_round_per_authority: Vec<Round>,
     ) -> ConsensusResult<ObserverBlockStream>;
 
     /// Handles the request to fetch blocks by references from an observer peer.
@@ -307,7 +307,7 @@ pub(crate) trait ObserverNetworkClient: Send + Sync + Sized + 'static {
     async fn stream_blocks(
         &self,
         peer: PeerId,
-        highest_round_per_authority: Vec<u64>,
+        highest_round_per_authority: Vec<Round>,
         timeout: Duration,
     ) -> ConsensusResult<ObserverBlockStream>;
 

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -34,8 +34,8 @@ use super::{ObserverNetworkService, tonic_gen::observer_service_server::Observer
 // Observer block streaming messages
 #[derive(Clone, prost::Message)]
 pub(crate) struct BlockStreamRequest {
-    #[prost(uint64, repeated, tag = "1")]
-    pub(crate) highest_round_per_authority: Vec<u64>,
+    #[prost(uint32, repeated, tag = "1")]
+    pub(crate) highest_round_per_authority: Vec<Round>,
 }
 
 /// Auxiliary data carried alongside blocks in the observer stream.
@@ -256,7 +256,7 @@ impl ObserverNetworkClient for TonicObserverClient {
     async fn stream_blocks(
         &self,
         peer: PeerId,
-        highest_round_per_authority: Vec<u64>,
+        highest_round_per_authority: Vec<Round>,
         timeout: Duration,
     ) -> ConsensusResult<ObserverBlockStream> {
         let mut client = self.get_client(peer.clone(), timeout).await?;
@@ -563,7 +563,7 @@ mod tests {
         let observer_peer_id = keys[0].0.public().clone();
 
         let block_stream = service
-            .handle_stream_blocks(observer_peer_id.clone(), vec![0u64, 0, 0, 0])
+            .handle_stream_blocks(observer_peer_id.clone(), vec![0u32, 0, 0, 0])
             .await
             .unwrap();
 
@@ -595,7 +595,7 @@ mod tests {
 
         let observer_peer_id = keys[0].0.public().clone();
 
-        let highest_round_per_authority = vec![50u64, 50, 50, 50];
+        let highest_round_per_authority = vec![50u32, 50, 50, 50];
 
         let block_stream = service
             .handle_stream_blocks(observer_peer_id, highest_round_per_authority)
@@ -664,7 +664,7 @@ mod tests {
         let peer_id = PeerId::Validator(context.committee.to_authority_index(0).unwrap());
 
         let result = observer_client_0
-            .stream_blocks(peer_id, vec![10u64, 10, 10, 10], Duration::from_secs(5))
+            .stream_blocks(peer_id, vec![10u32, 10, 10, 10], Duration::from_secs(5))
             .await;
 
         // This should work with proper TonicManager setup

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -121,7 +121,7 @@ impl ObserverNetworkService for Mutex<TestService> {
     async fn handle_stream_blocks(
         &self,
         peer: NodeId,
-        highest_round_per_authority: Vec<u64>,
+        highest_round_per_authority: Vec<Round>,
     ) -> ConsensusResult<ObserverBlockStream> {
         use futures::stream;
 

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -221,7 +221,7 @@ impl ObserverNetworkService for ObserverService {
     async fn handle_stream_blocks(
         &self,
         peer: NodeId,
-        highest_round_per_authority: Vec<u64>,
+        highest_round_per_authority: Vec<Round>,
     ) -> ConsensusResult<ObserverBlockStream> {
         if highest_round_per_authority.len() != self.context.committee.size() {
             return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
@@ -230,6 +230,11 @@ impl ObserverNetworkService for ObserverService {
             ));
         }
 
+        // Subscribe to the live broadcast BEFORE snapshotting past blocks below, so a block
+        // accepted concurrently with the snapshot lands in both segments (a harmless duplicate
+        // that the receiver dedups) rather than in neither (a gap).
+        let broadcast_rx = self.rx_accepted_block_broadcast.resubscribe();
+
         // Collect all accepted blocks from DagState that the observer hasn't yet seen,
         // sorted by round for consistent ordering.
         let past_blocks = {
@@ -237,7 +242,7 @@ impl ObserverNetworkService for ObserverService {
             let mut past_blocks = Vec::new();
 
             for (authority, _) in self.context.committee.authorities() {
-                let from_round = highest_round_per_authority[authority.value()] as u32 + 1;
+                let from_round = highest_round_per_authority[authority.value()] + 1;
                 past_blocks.extend(dag_state.get_cached_blocks(authority, from_round));
             }
 
@@ -258,7 +263,7 @@ impl ObserverNetworkService for ObserverService {
         const MAX_BLOCKS_PER_POLL: usize = 20;
         let live_block_stream = BroadcastStream::<VerifiedBlock>::new(
             PeerId::Observer(Box::new(peer)),
-            self.rx_accepted_block_broadcast.resubscribe(),
+            broadcast_rx,
             MAX_BLOCKS_PER_POLL,
             self.subscription_counter.clone(),
         )
@@ -378,7 +383,7 @@ mod tests {
         );
 
         // Observer starts with no blocks seen
-        let highest_round_per_authority = vec![0u64; context.committee.size()];
+        let highest_round_per_authority = vec![0u32; context.committee.size()];
         let peer = keys[0].0.public().clone();
 
         let mut stream = observer_service
@@ -452,7 +457,7 @@ mod tests {
         let peer = keys[0].0.public().clone();
 
         // Test with wrong size of highest_round_per_authority
-        let invalid_highest_rounds = vec![0u64; 10]; // Wrong size, should be 4
+        let invalid_highest_rounds = vec![0u32; 10]; // Wrong size, should be 4
         let result = observer_service
             .handle_stream_blocks(peer, invalid_highest_rounds)
             .await;

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -230,9 +230,10 @@ impl ObserverNetworkService for ObserverService {
             ));
         }
 
-        // Subscribe to the live broadcast BEFORE snapshotting past blocks below, so a block
-        // accepted concurrently with the snapshot lands in both segments (a harmless duplicate
-        // that the receiver dedups) rather than in neither (a gap).
+        // Subscribe before snapshotting past blocks below. This can duplicate
+        // a block in both the subscription stream and snapshot, which is fine.
+        // Otherwise, it is possible to miss a block if it is broadcasted after snapshotting
+        // but before subscribing.
         let broadcast_rx = self.rx_accepted_block_broadcast.resubscribe();
 
         // Collect all accepted blocks from DagState that the observer hasn't yet seen,
@@ -242,7 +243,9 @@ impl ObserverNetworkService for ObserverService {
             let mut past_blocks = Vec::new();
 
             for (authority, _) in self.context.committee.authorities() {
-                let from_round = highest_round_per_authority[authority.value()] + 1;
+                // Saturate so an out-of-range round from the peer cannot wrap to 0 and
+                // replay the entire block cache.
+                let from_round = highest_round_per_authority[authority.value()].saturating_add(1);
                 past_blocks.extend(dag_state.get_cached_blocks(authority, from_round));
             }
 
@@ -383,7 +386,7 @@ mod tests {
         );
 
         // Observer starts with no blocks seen
-        let highest_round_per_authority = vec![0u32; context.committee.size()];
+        let highest_round_per_authority = vec![0 as Round; context.committee.size()];
         let peer = keys[0].0.public().clone();
 
         let mut stream = observer_service
@@ -457,7 +460,7 @@ mod tests {
         let peer = keys[0].0.public().clone();
 
         // Test with wrong size of highest_round_per_authority
-        let invalid_highest_rounds = vec![0u32; 10]; // Wrong size, should be 4
+        let invalid_highest_rounds = vec![0 as Round; 10]; // Wrong size, should be 4
         let result = observer_service
             .handle_stream_blocks(peer, invalid_highest_rounds)
             .await;

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -131,10 +131,9 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             // already-seen blocks.
             let highest_round_per_authority = {
                 let ds = dag_state.read();
-                let mut rounds = vec![0u64; context.committee.size()];
+                let mut rounds = vec![0u32; context.committee.size()];
                 for (authority, _) in context.committee.authorities() {
-                    rounds[authority.value()] =
-                        ds.get_last_block_for_authority(authority).round() as u64;
+                    rounds[authority.value()] = ds.get_last_block_for_authority(authority).round();
                 }
                 rounds
             };
@@ -308,7 +307,7 @@ mod tests {
         async fn stream_blocks(
             &self,
             peer: PeerId,
-            _highest_round_per_authority: Vec<u64>,
+            _highest_round_per_authority: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<ObserverBlockStream> {
             // Return different block content based on peer to distinguish them in tests
@@ -374,7 +373,7 @@ mod tests {
         async fn handle_stream_blocks(
             &self,
             _peer: NodeId,
-            _highest_round_per_authority: Vec<u64>,
+            _highest_round_per_authority: Vec<Round>,
         ) -> ConsensusResult<ObserverBlockStream> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -9,6 +9,7 @@ use std::{
     time::Duration,
 };
 
+use consensus_types::block::Round;
 use futures::StreamExt;
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use parking_lot::Mutex;
@@ -128,12 +129,17 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
 
             // Recompute highest rounds from DagState before each connection attempt
             // so reconnections resume from where we left off rather than re-fetching
-            // already-seen blocks.
+            // already-seen blocks. Clamp to the GC round, since blocks below it would
+            // be skipped anyway.
             let highest_round_per_authority = {
                 let ds = dag_state.read();
-                let mut rounds = vec![0u32; context.committee.size()];
+                let gc_round = ds.gc_round();
+                let mut rounds = vec![0 as Round; context.committee.size()];
                 for (authority, _) in context.committee.authorities() {
-                    rounds[authority.value()] = ds.get_last_block_for_authority(authority).round();
+                    rounds[authority.value()] = ds
+                        .get_last_block_for_authority(authority)
+                        .round()
+                        .max(gc_round);
                 }
                 rounds
             };

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -137,14 +137,14 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
 
             // Recompute the resume round from DagState before each connection attempt, so a
             // reconnection resumes from the latest accepted round rather than re-streaming and
-            // re-verifying blocks that have been accepted since this subscription started. Clamp
-            // to the GC round, since blocks below it would be skipped anyway.
+            // re-verifying blocks that have been accepted since this subscription started.
             let last_received: Round = {
                 let dag_state = dag_state.read();
+                let gc_round = dag_state.gc_round();
                 dag_state
                     .get_last_block_for_authority(peer)
                     .round()
-                    .max(dag_state.gc_round())
+                    .max(gc_round)
             };
 
             // Use longer timeout when retry delay is long, to adapt to slow network.
@@ -251,11 +251,20 @@ mod test {
         storage::mem_store::MemStore,
     };
 
-    struct SubscriberTestClient {}
+    struct SubscriberTestClient {
+        // Records the `last_received` round passed to each subscribe_blocks() call.
+        subscribe_calls: Mutex<Vec<Round>>,
+    }
 
     impl SubscriberTestClient {
         fn new() -> Self {
-            Self {}
+            Self {
+                subscribe_calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn subscribe_calls(&self) -> Vec<Round> {
+            self.subscribe_calls.lock().clone()
         }
     }
 
@@ -273,9 +282,10 @@ mod test {
         async fn subscribe_blocks(
             &self,
             _peer: AuthorityIndex,
-            _last_received: Round,
+            last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockStream> {
+            self.subscribe_calls.lock().push(last_received);
             let block_stream = stream::unfold((), |_| async {
                 sleep(Duration::from_millis(1)).await;
                 let block = ExtendedSerializedBlock {
@@ -376,90 +386,15 @@ mod test {
     async fn subscriber_recomputes_resume_round_on_reconnect() {
         use crate::block::TestBlock;
 
-        // Records the `last_received` round passed to each subscribe_blocks() call, then returns a
-        // single-block stream that ends immediately to force frequent reconnections.
-        struct RecordingClient {
-            calls: Arc<Mutex<Vec<Round>>>,
-        }
-
-        #[async_trait]
-        impl ValidatorNetworkClient for RecordingClient {
-            async fn send_block(
-                &self,
-                _peer: AuthorityIndex,
-                _block: &VerifiedBlock,
-                _timeout: Duration,
-            ) -> ConsensusResult<()> {
-                unimplemented!("Unimplemented")
-            }
-
-            async fn subscribe_blocks(
-                &self,
-                _peer: AuthorityIndex,
-                last_received: Round,
-                _timeout: Duration,
-            ) -> ConsensusResult<BlockStream> {
-                self.calls.lock().push(last_received);
-                let block_stream = stream::once(async {
-                    sleep(Duration::from_millis(1)).await;
-                    ExtendedSerializedBlock {
-                        block: Bytes::from(vec![1u8; 8]),
-                        excluded_ancestors: vec![],
-                    }
-                });
-                Ok(Box::pin(block_stream))
-            }
-
-            async fn fetch_blocks(
-                &self,
-                _peer: AuthorityIndex,
-                _block_refs: Vec<BlockRef>,
-                _fetch_after_rounds: Vec<Round>,
-                _fetch_missing_ancestors: bool,
-                _timeout: Duration,
-            ) -> ConsensusResult<Vec<Bytes>> {
-                unimplemented!("Unimplemented")
-            }
-
-            async fn fetch_commits(
-                &self,
-                _peer: AuthorityIndex,
-                _commit_range: CommitRange,
-                _timeout: Duration,
-            ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
-                unimplemented!("Unimplemented")
-            }
-
-            async fn fetch_latest_blocks(
-                &self,
-                _peer: AuthorityIndex,
-                _authorities: Vec<AuthorityIndex>,
-                _timeout: Duration,
-            ) -> ConsensusResult<Vec<Bytes>> {
-                unimplemented!("Unimplemented")
-            }
-
-            async fn get_latest_rounds(
-                &self,
-                _peer: AuthorityIndex,
-                _timeout: Duration,
-            ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
-                unimplemented!("Unimplemented")
-            }
-        }
-
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let calls = Arc::new(Mutex::new(Vec::new()));
-        let network_client = Arc::new(RecordingClient {
-            calls: calls.clone(),
-        });
+        let network_client = Arc::new(SubscriberTestClient::new());
         let authority_service = Arc::new(Mutex::new(TestService::new()));
         let subscriber = Subscriber::new(
             context.clone(),
-            network_client,
+            network_client.clone(),
             authority_service,
             dag_state.clone(),
         );
@@ -468,11 +403,9 @@ mod test {
         subscriber.subscribe(peer);
 
         // Before any block from the peer is accepted, every reconnect resumes from genesis (0).
-        for _ in 0..3 {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
         {
-            let recorded = calls.lock();
+            let recorded = network_client.subscribe_calls();
             assert!(
                 !recorded.is_empty() && recorded.iter().all(|&r| r == 0),
                 "before a block is accepted, every reconnect should resume from round 0: {recorded:?}"
@@ -490,7 +423,7 @@ mod test {
         let mut observed_resume = false;
         for _ in 0..10 {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            if calls.lock().last() == Some(&RESUME_ROUND) {
+            if network_client.subscribe_calls().last() == Some(&RESUME_ROUND) {
                 observed_resume = true;
                 break;
             }
@@ -499,7 +432,7 @@ mod test {
             observed_resume,
             "after accepting a block at round {RESUME_ROUND}, the subscriber should resume from it; \
              recorded resume rounds: {:?}",
-            calls.lock()
+            network_client.subscribe_calls()
         );
     }
 }

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -59,23 +59,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let authority_service = self.authority_service.clone();
-        let (mut last_received, gc_round) = {
-            let dag_state = self.dag_state.read();
-            (
-                dag_state.get_last_block_for_authority(peer).round(),
-                dag_state.gc_round(),
-            )
-        };
-
-        // If the latest block we have accepted by an authority is older than the current gc round,
-        // then do not attempt to fetch any blocks from that point as they will simply be skipped. Instead
-        // do attempt to fetch from the gc round.
-        if last_received < gc_round {
-            info!(
-                "Last received block for peer {peer} is older than GC round, {last_received} < {gc_round}, fetching from GC round"
-            );
-            last_received = gc_round;
-        }
+        let dag_state = self.dag_state.clone();
 
         let mut subscriptions = self.subscriptions.lock();
         self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
@@ -83,8 +67,8 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             context,
             network_client,
             authority_service,
+            dag_state,
             peer,
-            last_received,
         )));
     }
 
@@ -114,8 +98,8 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         context: Arc<Context>,
         network_client: Arc<C>,
         authority_service: Arc<S>,
+        dag_state: Arc<RwLock<DagState>>,
         peer: AuthorityIndex,
-        last_received: Round,
     ) {
         const IMMEDIATE_RETRIES: i64 = 3;
         const MIN_TIMEOUT: Duration = Duration::from_millis(500);
@@ -150,6 +134,18 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
                 tokio::task::yield_now().await;
             }
             retries += 1;
+
+            // Recompute the resume round from DagState before each connection attempt, so a
+            // reconnection resumes from the latest accepted round rather than re-streaming and
+            // re-verifying blocks that have been accepted since this subscription started. Clamp
+            // to the GC round, since blocks below it would be skipped anyway.
+            let last_received: Round = {
+                let dag_state = dag_state.read();
+                dag_state
+                    .get_last_block_for_authority(peer)
+                    .round()
+                    .max(dag_state.gc_round())
+            };
 
             // Use longer timeout when retry delay is long, to adapt to slow network.
             let request_timeout = MIN_TIMEOUT.max(delay);
@@ -219,8 +215,11 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
                                 }
                             }
                         }
-                        // Reset retries when a block is received.
+                        // Reset the retry counter and backoff when a block is received, so a peer
+                        // that recovers after flapping reconnects promptly instead of inheriting
+                        // the previously escalated delay.
                         retries = 0;
+                        backoff.reset();
                     }
                     None => {
                         debug!(
@@ -368,5 +367,139 @@ mod test {
                 }
             );
         }
+    }
+
+    // Regression test: `last_received` must be recomputed from DagState before each connection
+    // attempt. Previously it was captured once at subscribe() time and reused for every reconnect,
+    // causing already-accepted blocks to be re-streamed and re-verified.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_recomputes_resume_round_on_reconnect() {
+        use crate::block::TestBlock;
+
+        // Records the `last_received` round passed to each subscribe_blocks() call, then returns a
+        // single-block stream that ends immediately to force frequent reconnections.
+        struct RecordingClient {
+            calls: Arc<Mutex<Vec<Round>>>,
+        }
+
+        #[async_trait]
+        impl ValidatorNetworkClient for RecordingClient {
+            async fn send_block(
+                &self,
+                _peer: AuthorityIndex,
+                _block: &VerifiedBlock,
+                _timeout: Duration,
+            ) -> ConsensusResult<()> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn subscribe_blocks(
+                &self,
+                _peer: AuthorityIndex,
+                last_received: Round,
+                _timeout: Duration,
+            ) -> ConsensusResult<BlockStream> {
+                self.calls.lock().push(last_received);
+                let block_stream = stream::once(async {
+                    sleep(Duration::from_millis(1)).await;
+                    ExtendedSerializedBlock {
+                        block: Bytes::from(vec![1u8; 8]),
+                        excluded_ancestors: vec![],
+                    }
+                });
+                Ok(Box::pin(block_stream))
+            }
+
+            async fn fetch_blocks(
+                &self,
+                _peer: AuthorityIndex,
+                _block_refs: Vec<BlockRef>,
+                _fetch_after_rounds: Vec<Round>,
+                _fetch_missing_ancestors: bool,
+                _timeout: Duration,
+            ) -> ConsensusResult<Vec<Bytes>> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn fetch_commits(
+                &self,
+                _peer: AuthorityIndex,
+                _commit_range: CommitRange,
+                _timeout: Duration,
+            ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn fetch_latest_blocks(
+                &self,
+                _peer: AuthorityIndex,
+                _authorities: Vec<AuthorityIndex>,
+                _timeout: Duration,
+            ) -> ConsensusResult<Vec<Bytes>> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn get_latest_rounds(
+                &self,
+                _peer: AuthorityIndex,
+                _timeout: Duration,
+            ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+                unimplemented!("Unimplemented")
+            }
+        }
+
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let network_client = Arc::new(RecordingClient {
+            calls: calls.clone(),
+        });
+        let authority_service = Arc::new(Mutex::new(TestService::new()));
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client,
+            authority_service,
+            dag_state.clone(),
+        );
+
+        let peer = context.committee.to_authority_index(2).unwrap();
+        subscriber.subscribe(peer);
+
+        // Before any block from the peer is accepted, every reconnect resumes from genesis (0).
+        for _ in 0..3 {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        {
+            let recorded = calls.lock();
+            assert!(
+                !recorded.is_empty() && recorded.iter().all(|&r| r == 0),
+                "before a block is accepted, every reconnect should resume from round 0: {recorded:?}"
+            );
+        }
+
+        // Advance the locally accepted round for the peer.
+        const RESUME_ROUND: Round = 10;
+        dag_state.write().accept_block(VerifiedBlock::new_for_test(
+            TestBlock::new(RESUME_ROUND, peer.value() as u32).build(),
+        ));
+
+        // After the block is accepted, reconnects must resume from the advanced round. With the
+        // bug, `last_received` would stay at 0 forever.
+        let mut observed_resume = false;
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            if calls.lock().last() == Some(&RESUME_ROUND) {
+                observed_resume = true;
+                break;
+            }
+        }
+        assert!(
+            observed_resume,
+            "after accepting a block at round {RESUME_ROUND}, the subscriber should resume from it; \
+             recorded resume rounds: {:?}",
+            calls.lock()
+        );
     }
 }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1579,7 +1579,7 @@ mod tests {
         async fn stream_blocks(
             &self,
             _peer: crate::network::PeerId,
-            _highest_round_per_authority: Vec<u64>,
+            _highest_round_per_authority: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<crate::network::ObserverBlockStream> {
             unimplemented!("stream_blocks not implemented in mock")


### PR DESCRIPTION
## Description

Review of the consensus block publish/subscribe path with coding agent surfaced several issues which are fixed:

- **Snapshot/live race (both stream servers).** Each subscription snapshots cached blocks and only *then* subscribes to the live broadcast, so a block produced in the gap is sent in neither segment. Fixed by subscribing before snapshotting, which turns a possible gap into a harmless duplicate the receiver dedups.
- **Stale resume round.** The validator subscriber captured `last_received` once at subscribe time and reused it on every reconnect, re-streaming and re-verifying already-accepted blocks. It is now recomputed from `DagState` before each connection attempt, matching the observer path.
- **Observer round narrowing.** `highest_round_per_authority` was `uint64` on the wire and narrowed with `as u32 + 1`, so an out-of-range value could wrap to 0 and replay the entire block cache. The field is now `uint32` / `Vec<Round>` end-to-end.

Plus two minor cleanups: reset the subscriber's reconnect backoff when a block is received (so a recovered peer doesn't inherit an escalated delay), and make `SubscriptionCounter` increment/decrement infallible so the inc/dec pairing can't drift.

## Test plan

New `subscriber_recomputes_resume_round_on_reconnect` covers the resume-round fix: it advances the accepted round mid-subscription and asserts that reconnects resume from the advanced round. The rest is covered by existing `subscriber` / `authority_service` / `observer_*` tests.
