### PR TITLE
[move-ide] Sort abilities for on-hover display

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.43",
+      "version": "1.0.44",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/symbols/ide_strings.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/ide_strings.rs
@@ -17,6 +17,7 @@ use move_compiler::{
         },
     },
     naming::ast::{Type, TypeInner, TypeName_},
+    parser::ast::Ability_,
     shared::{Identifier, Name},
     typing::ast::{Exp, ExpListItem, SequenceItem, SequenceItem_, UnannotatedExp_},
 };
@@ -399,13 +400,22 @@ pub fn abilities_to_ide_string(abilities: &AbilitySet) -> String {
     } else {
         format!(
             " has {}",
-            abilities
-                .iter()
-                .map(|a| format!("{a}"))
-                .collect::<Vec<_>>()
-                .join(", ")
+            ordered_ability_strings_for_ide(abilities).join(", ")
         )
     }
+}
+
+/// Returns ability names in the canonical order used for IDE hover display.
+fn ordered_ability_strings_for_ide(abilities: &AbilitySet) -> Vec<&'static str> {
+    [
+        (Ability_::Key, Ability_::KEY),
+        (Ability_::Copy, Ability_::COPY),
+        (Ability_::Drop, Ability_::DROP),
+        (Ability_::Store, Ability_::STORE),
+    ]
+    .into_iter()
+    .filter_map(|(ability, name)| abilities.has_ability_(ability).then_some(name))
+    .collect()
 }
 
 pub fn variant_to_ide_string(variants: &[VariantInfo]) -> String {

--- a/external-crates/move/crates/move-analyzer/tests/abilities.ide
+++ b/external-crates/move/crates/move-analyzer/tests/abilities.ide
@@ -1,0 +1,22 @@
+// Checks that hover renders abilities in canonical formatter order.
+{
+  "UseDef": {
+    "project": "tests/abilities",
+    "file_tests": {
+      "abilities.move": [
+        {
+          "use_line": 3,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 5,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 7,
+          "use_ndx": 0
+        }
+      ]
+    }
+  }
+}

--- a/external-crates/move/crates/move-analyzer/tests/abilities.snap
+++ b/external-crates/move/crates/move-analyzer/tests/abilities.snap
@@ -1,0 +1,27 @@
+---
+source: crates/move-analyzer/tests/ide_testsuite.rs
+---
+== abilities.move ========================================================
+-- test 0 -------------------
+use line: 3, use_ndx: 0
+Use: 'AllAbilities', start: 18, end: 30
+Def: 'AllAbilities', line: 2, def char: 18
+TypeDef: 'AllAbilities', line: 2, char: 18
+On Hover:
+public struct Abilities::abilities::AllAbilities has key, copy, drop, store {}
+
+-- test 1 -------------------
+use line: 5, use_ndx: 0
+Use: 'CopyKey', start: 18, end: 25
+Def: 'CopyKey', line: 4, def char: 18
+TypeDef: 'CopyKey', line: 4, char: 18
+On Hover:
+public struct Abilities::abilities::CopyKey has key, copy {}
+
+-- test 2 -------------------
+use line: 7, use_ndx: 0
+Use: 'CopyDropStore', start: 18, end: 31
+Def: 'CopyDropStore', line: 6, def char: 18
+TypeDef: 'CopyDropStore', line: 6, char: 18
+On Hover:
+public struct Abilities::abilities::CopyDropStore has copy, drop, store {}

--- a/external-crates/move/crates/move-analyzer/tests/abilities/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/abilities/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Abilities"
+edition = "2024.beta"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+Abilities = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/abilities/sources/abilities.move
+++ b/external-crates/move/crates/move-analyzer/tests/abilities/sources/abilities.move
@@ -1,0 +1,20 @@
+module Abilities::abilities {
+
+    public struct AllAbilities has store, drop, copy, key {}
+
+    public struct CopyKey has copy, key {}
+
+    public struct CopyDropStore has store, drop, copy {}
+
+    fun all_abilities(value: AllAbilities): AllAbilities {
+        value
+    }
+
+    fun copy_key(value: CopyKey): CopyKey {
+        value
+    }
+
+    fun copy_drop_store(value: CopyDropStore): CopyDropStore {
+        value
+    }
+}


### PR DESCRIPTION
## Description 

This PR sorts abilities presented to the user when hovering over type definitions to match the order enforced by the formatter (i.e., `key` ability always first, otherwise other abilities sorted alphabetically).

## Test plan 

New test has been added. All tests must pass
