### PR TITLE
Automatic fork recovery gated on certified outcome and corrected binary version

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1446,11 +1446,13 @@ mod test {
         }
     }
 
-    // One validator forks (checkpoint fork) while the other three keep a quorum and certify past it.
-    // After the injection is cleared it restarts under RecoverOncePerVersion, clears its fork state,
-    // and rejoins.
+    // A checkpoint fork (vs the transaction fork below): one validator participates in consensus
+    // live with fork injection on all execution paths, so its builder constructs a divergent
+    // local checkpoint while the other three keep a quorum and certify the canonical one. After
+    // the injection is cleared it restarts under RecoverOncePerVersion as a corrected binary,
+    // clears its fork state, and rejoins.
     #[sim_test(config = "test_config()")]
-    async fn test_auto_fork_recovery_minority_validator() {
+    async fn test_auto_fork_recovery_checkpoint_fork() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
 
         let test_cluster = build_test_cluster(4, 10_000, 4).await;
@@ -1522,8 +1524,14 @@ mod test {
             "expected the forked validator to detect a checkpoint fork"
         );
 
-        // Corrected binary: stop injecting forks.
+        // Corrected binary: stop injecting forks and report a new binary version, since recovery
+        // refuses to clear a fork under the version that produced it.
         clear_fail_point("simulate_fork_during_execution");
+        register_fail_point_arg("override_binary_version", || {
+            Some(std::sync::Arc::new(std::sync::Mutex::new(
+                "corrected-binary".to_string(),
+            )))
+        });
 
         // Restart the forked validator under RecoverOncePerVersion (no overrides).
         for validator in test_cluster.swarm.validator_nodes() {
@@ -1549,6 +1557,7 @@ mod test {
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
         clear_fork_kill_failpoints();
+        clear_fail_point("override_binary_version");
 
         let target_name = *forked_validators
             .lock()
@@ -1557,7 +1566,7 @@ mod test {
             .next()
             .expect("a validator forked");
 
-        // The forked validator auto-recovered: fork markers cleared, recovery attempt recorded.
+        // The forked validator auto-recovered: fork markers cleared.
         test_cluster
             .swarm
             .validator_nodes()
@@ -1575,10 +1584,6 @@ mod test {
                 assert!(
                     cp.get_transaction_fork_detected().unwrap().is_none(),
                     "transaction fork marker should be cleared after auto-recovery"
-                );
-                assert!(
-                    cp.get_auto_recovery_attempt().unwrap().is_some(),
-                    "an auto-recovery attempt should be recorded for this binary version"
                 );
             });
 
@@ -1708,7 +1713,7 @@ mod test {
         test_cluster.wait_for_next_epoch_all_nodes().await;
     }
 
-    // A transaction fork (vs the checkpoint fork in the minority test): a fallen-behind validator
+    // A transaction fork (vs the checkpoint fork above): a fallen-behind validator
     // re-executes a certified checkpoint's transactions via the checkpoint executor (where
     // expected_effects_digest is set) and diverges, tripping the per-transaction fork check. The
     // executor_path_only injection flag forks only on that path, guaranteeing a transaction fork; it
@@ -1822,7 +1827,14 @@ mod test {
             "expected a transaction fork (no checkpoint fork should have been recorded)"
         );
 
-        // Recover under RecoverOncePerVersion: clears the tx fork marker and re-executes canonically.
+        // Recover under RecoverOncePerVersion with a new binary version (recovery refuses to
+        // clear a fork under the version that produced it): clears the tx fork marker and
+        // re-executes canonically.
+        register_fail_point_arg("override_binary_version", || {
+            Some(std::sync::Arc::new(std::sync::Mutex::new(
+                "corrected-binary".to_string(),
+            )))
+        });
         {
             let target_node = test_cluster
                 .swarm
@@ -1843,8 +1855,9 @@ mod test {
         }
 
         clear_fork_kill_failpoints();
+        clear_fail_point("override_binary_version");
 
-        // The recovered validator cleared its transaction fork marker and recorded a recovery attempt.
+        // The recovered validator cleared its transaction fork marker.
         test_cluster
             .swarm
             .validator_nodes()
@@ -1858,10 +1871,6 @@ mod test {
                 assert!(
                     cp.get_transaction_fork_detected().unwrap().is_none(),
                     "transaction fork marker should be cleared after recovery"
-                );
-                assert!(
-                    cp.get_auto_recovery_attempt().unwrap().is_some(),
-                    "a recovery attempt should be recorded for this binary version"
                 );
             });
 

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -11,7 +11,7 @@ mod test {
     use std::num::NonZeroUsize;
     use std::path::PathBuf;
     use std::str::FromStr;
-    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
     use sui_benchmark::BenchmarkProxyMetrics;
@@ -1018,6 +1018,73 @@ mod test {
         }
     }
 
+    fn fork_test_node_to_authority_map(
+        test_cluster: &TestCluster,
+    ) -> std::collections::HashMap<sui_simulator::task::NodeId, AuthorityName> {
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .filter_map(|validator| {
+                validator.get_node_handle().map(|handle| {
+                    let node_id = handle.with(|node| node.get_sim_node_id());
+                    (node_id, validator.name())
+                })
+            })
+            .collect()
+    }
+
+    // Intercept fork fatal!s for forked validators, shutting the node down (so it can restart into
+    // recovery) instead of aborting the sim.
+    fn register_fork_kill_failpoints(
+        forked_validators: Arc<Mutex<HashSet<AuthorityName>>>,
+        checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>>,
+        node_to_authority_map: std::collections::HashMap<
+            sui_simulator::task::NodeId,
+            AuthorityName,
+        >,
+    ) {
+        register_fail_point_arg("kill_checkpoint_fork_node", {
+            let forked_validators = forked_validators.clone();
+            let checkpoint_overrides = checkpoint_overrides.clone();
+            let node_to_authority_map = node_to_authority_map.clone();
+            move || {
+                let current = node_to_authority_map.get(&sui_simulator::current_simnode_id())?;
+                if forked_validators.lock().unwrap().contains(current) {
+                    Some(checkpoint_overrides.clone())
+                } else {
+                    None
+                }
+            }
+        });
+        register_fail_point_if("kill_transaction_fork_node", {
+            let forked_validators = forked_validators.clone();
+            let node_to_authority_map = node_to_authority_map.clone();
+            move || {
+                node_to_authority_map
+                    .get(&sui_simulator::current_simnode_id())
+                    .is_some_and(|current| forked_validators.lock().unwrap().contains(current))
+            }
+        });
+        // Split-brain bookkeeping: record the canonical (non-forked) digest into checkpoint_overrides.
+        register_fail_point_arg("kill_split_brain_node", {
+            let checkpoint_overrides = checkpoint_overrides.clone();
+            let forked_validators = forked_validators.clone();
+            move || Some((checkpoint_overrides.clone(), forked_validators.clone()))
+        });
+        // check_for_split_brain's debug_fatal! logs-and-continues in release; make the sim match that
+        // (instead of panicking) so validators ride through split brain.
+        register_debug_fatal_handler!(
+            "Split brain detected in checkpoint signature aggregation",
+            || {}
+        );
+    }
+
+    fn clear_fork_kill_failpoints() {
+        clear_fail_point("kill_checkpoint_fork_node");
+        clear_fail_point("kill_transaction_fork_node");
+        clear_fail_point("kill_split_brain_node");
+    }
+
     async fn build_test_cluster(
         default_num_validators: usize,
         default_epoch_duration_ms: u64,
@@ -1379,200 +1446,427 @@ mod test {
         }
     }
 
+    // One validator forks (checkpoint fork) while the other three keep a quorum and certify past it.
+    // After the injection is cleared it restarts under RecoverOncePerVersion, clears its fork state,
+    // and rejoins.
     #[sim_test(config = "test_config()")]
-    async fn test_fork_recovery_transaction_effects_simulation() {
+    async fn test_auto_fork_recovery_minority_validator() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
 
         let test_cluster = build_test_cluster(4, 10_000, 4).await;
 
-        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
-            Arc::new(Mutex::new(BTreeMap::new()));
         let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
             Arc::new(Mutex::new(BTreeMap::new()));
-
+        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
         let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
             Arc::new(Mutex::new(HashSet::new()));
 
-        let transaction_counter: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+        let node_to_authority_map = fork_test_node_to_authority_map(&test_cluster);
 
-        let node_to_authority_map: std::collections::HashMap<
-            sui_simulator::task::NodeId,
-            AuthorityName,
-        > = test_cluster
-            .swarm
-            .validator_nodes()
-            .filter_map(|validator| {
-                validator.get_node_handle().map(|handle| {
-                    let node_id = handle.with(|node| node.get_sim_node_id());
-                    (node_id, validator.name())
-                })
-            })
-            .collect();
+        // Fork exactly one validator so the other three keep a quorum.
+        let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
 
-        info!("Fork recovery test: Running transactions to trigger fork scenario");
-
-        let test_cluster_for_handler = test_cluster.clone();
-
-        let mut config = SimulatedLoadConfig::default();
-        // composite workload is very strict about error checking and fails during
-        // this test.
-        config.composite_weight = 0;
+        let mut load_config = SimulatedLoadConfig::default();
+        load_config.composite_weight = 0;
 
         test_simulated_load_with_test_config(
             test_cluster.clone(),
-            30,
-            config,
-            None, // target_qps
-            None, // num_workers
+            6,
+            load_config,
+            None,
+            None,
             Some({
                 let forked_validators = forked_validators.clone();
                 let checkpoint_overrides = checkpoint_overrides.clone();
                 let effects_overrides = effects_overrides.clone();
                 let node_to_authority_map = node_to_authority_map.clone();
-                let _test_cluster_for_handler = test_cluster_for_handler.clone();
                 move |_cluster: Arc<TestCluster>| async move {
-                    // Simulate fork during execution to generate divergent effects
+                    // Only the target validator forks, so the fork stays a minority.
                     register_fail_point_arg("simulate_fork_during_execution", {
                         let forked_validators = forked_validators.clone();
                         let effects_overrides = effects_overrides.clone();
-                        let _transaction_counter = transaction_counter.clone();
-                        move || {
-                            Some((
-                                forked_validators.clone(),
-                                /* full_halt: */ true,
-                                effects_overrides.clone(),
-                                0.1f32,
-                            ))
-                        }
-                    });
-
-                    // Intercept validator panic when overwriting a previously-computed digest & shutdown instead
-                    register_fail_point_arg("kill_checkpoint_fork_node", {
-                        let forked_validators: Arc<
-                            Mutex<HashSet<sui_types::crypto::AuthorityPublicKeyBytes>>,
-                        > = forked_validators.clone();
-                        let checkpoint_overrides = checkpoint_overrides.clone();
                         let node_to_authority_map = node_to_authority_map.clone();
                         move || {
-                            let current_node_id = sui_simulator::current_simnode_id();
-                            let authority_name =
-                                node_to_authority_map.get(&current_node_id).unwrap();
-
-                            if forked_validators.lock().unwrap().contains(authority_name) {
-                                Some(checkpoint_overrides.clone())
+                            let current =
+                                node_to_authority_map.get(&sui_simulator::current_simnode_id())?;
+                            if *current == target {
+                                Some((
+                                    forked_validators.clone(),
+                                    /* full_halt: */ false,
+                                    effects_overrides.clone(),
+                                    1.0f32,
+                                    /* executor_path_only: */ false,
+                                ))
                             } else {
                                 None
                             }
                         }
                     });
-                    // Intercept validator panic when txn effects fork detected & shutdown instead
-                    register_fail_point_if("kill_transaction_fork_node", {
-                        let forked_validators = forked_validators.clone();
-                        let node_to_authority_map = node_to_authority_map.clone();
-                        move || {
-                            forked_validators.lock().unwrap().contains(
-                                node_to_authority_map
-                                    .get(&sui_simulator::current_simnode_id())
-                                    .unwrap(),
-                            )
-                        }
-                    });
 
-                    // Intercept validator panic when split brain detected & shutdown instead
-                    register_fail_point_arg("kill_split_brain_node", {
-                        let checkpoint_overrides = checkpoint_overrides.clone();
-                        let forked_validators = forked_validators.clone();
-                        move || Some((checkpoint_overrides.clone(), forked_validators.clone()))
-                    });
-
-                    register_debug_fatal_handler!(
-                        "Split brain detected in checkpoint signature aggregation",
-                        move || {
-                            //noop
-                        }
+                    register_fork_kill_failpoints(
+                        forked_validators.clone(),
+                        checkpoint_overrides.clone(),
+                        node_to_authority_map.clone(),
                     );
                 }
             }),
-            false, // disable surfer for fork recovery test
+            false,
         )
         .await;
-        info!("Fork recovery test: First load gen done");
 
-        assert!(forked_validators.lock().unwrap().len() > 1);
-
-        clear_fail_point("simulate_fork_during_execution");
-
-        // The fail points have already computed the correct checkpoint overrides
-        let checkpoint_overrides_computed = checkpoint_overrides.lock().unwrap().clone();
-
-        if checkpoint_overrides_computed.is_empty() {
-            panic!(
-                "Fork should have been triggered during the test and checkpoint overrides should be computed"
-            );
-        }
-
-        let captured_effects = effects_overrides.lock().unwrap().clone();
-
-        let fork_recovery_config = ForkRecoveryConfig {
-            transaction_overrides: captured_effects,
-            checkpoint_overrides: checkpoint_overrides_computed,
-            fork_crash_behavior: ForkCrashBehavior::ReturnError,
-        };
-
-        info!(
-            "Fork recovery config created: transaction_overrides count: {}, checkpoint_overrides count: {}",
-            fork_recovery_config.transaction_overrides.len(),
-            fork_recovery_config.checkpoint_overrides.len()
+        // Exactly one validator forked and detected a checkpoint fork.
+        assert_eq!(forked_validators.lock().unwrap().len(), 1);
+        assert!(
+            !checkpoint_overrides.lock().unwrap().is_empty(),
+            "expected the forked validator to detect a checkpoint fork"
         );
 
-        // Log some details about the overrides for debugging
-        for (digest, override_val) in &fork_recovery_config.transaction_overrides {
-            info!("Transaction override: {} -> {}", digest, override_val);
-        }
+        // Corrected binary: stop injecting forks.
+        clear_fail_point("simulate_fork_during_execution");
 
-        for (checkpoint_seq, override_val) in &fork_recovery_config.checkpoint_overrides {
-            info!(
-                "Checkpoint override: {} -> {}",
-                checkpoint_seq, override_val
-            );
-        }
-
+        // Restart the forked validator under RecoverOncePerVersion (no overrides).
         for validator in test_cluster.swarm.validator_nodes() {
-            let validator_name = validator.name();
-            if forked_validators.lock().unwrap().contains(&validator_name) {
-                // Force restart each validator individually to ensure config is applied
+            if forked_validators
+                .lock()
+                .unwrap()
+                .contains(&validator.name())
+            {
                 validator.stop();
                 tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                info!("node stopped {}", validator_name.concise());
-
                 {
-                    let mut config = validator.config();
-                    config.fork_recovery = Some(fork_recovery_config.clone());
-                    info!(
-                        "Override applied for validator {}: fork_recovery={:?}",
-                        validator_name.concise(),
-                        config.fork_recovery
-                    );
+                    let mut cfg = validator.config();
+                    cfg.fork_recovery = Some(ForkRecoveryConfig {
+                        transaction_overrides: Default::default(),
+                        checkpoint_overrides: Default::default(),
+                        fork_crash_behavior: ForkCrashBehavior::RecoverOncePerVersion,
+                    });
                 }
-
                 validator.start().await.unwrap();
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             }
         }
-        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-        clear_fail_point("kill_checkpoint_fork_node");
-        clear_fail_point("kill_transaction_fork_node");
-        clear_fail_point("kill_split_brain_node");
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
-        // Send one txn to ensure liveness
-        let sender = test_cluster.get_address_0();
-        let rgp = test_cluster.get_reference_gas_price().await;
+        clear_fork_kill_failpoints();
+
+        let target_name = *forked_validators
+            .lock()
+            .unwrap()
+            .iter()
+            .next()
+            .expect("a validator forked");
+
+        // The forked validator auto-recovered: fork markers cleared, recovery attempt recorded.
         test_cluster
-            .fund_address_and_return_gas(rgp, None, sender)
-            .await;
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == target_name)
+            .unwrap()
+            .get_node_handle()
+            .expect("forked validator should be running after auto-recovery")
+            .with(|node| {
+                let state = node.state();
+                let cp = state.get_checkpoint_store();
+                assert!(
+                    cp.get_checkpoint_fork_detected().unwrap().is_none(),
+                    "checkpoint fork marker should be cleared after auto-recovery"
+                );
+                assert!(
+                    cp.get_transaction_fork_detected().unwrap().is_none(),
+                    "transaction fork marker should be cleared after auto-recovery"
+                );
+                assert!(
+                    cp.get_auto_recovery_attempt().unwrap().is_some(),
+                    "an auto-recovery attempt should be recorded for this binary version"
+                );
+            });
 
-        test_cluster.wait_for_epoch(None).await;
+        // Liveness: every node, including the recovered validator, advances an epoch, proving it
+        // rejoined (a fullnode-only wait could be satisfied by the other three).
+        test_cluster.wait_for_next_epoch_all_nodes().await;
+    }
+
+    // A quorum-breaking fork: no checkpoint digest reaches quorum, so nothing certifies (split
+    // brain). check_for_split_brain only logs in release (debug_fatal!), so recovery is manual:
+    // restart with checkpoint_overrides naming the canonical digest. Reconvergence works because the
+    // forked effects were never durably committed (the writeback dirty set is flushed only by the
+    // checkpoint executor, on certified checkpoints), so the restart discards them and re-execution
+    // is canonical; checkpoint_overrides clears the only durable forked state, locally_computed.
+    #[sim_test(config = "test_config()")]
+    async fn test_split_brain_recovery_via_checkpoint_overrides() {
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+
+        let test_cluster = build_test_cluster(4, 10_000, 4).await;
+
+        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
+            Arc::new(Mutex::new(HashSet::new()));
+
+        let node_to_authority_map = fork_test_node_to_authority_map(&test_cluster);
+
+        let mut load_config = SimulatedLoadConfig::default();
+        load_config.composite_weight = 0;
+
+        // Split brain kills liveness, so the load never returns; run it in the background just to
+        // drive traffic until the fork fires, then abort it.
+        let load_task = tokio::spawn({
+            let test_cluster = test_cluster.clone();
+            let forked_validators = forked_validators.clone();
+            let checkpoint_overrides = checkpoint_overrides.clone();
+            let effects_overrides = effects_overrides.clone();
+            let node_to_authority_map = node_to_authority_map.clone();
+            async move {
+                test_simulated_load_with_test_config(
+                    test_cluster,
+                    60,
+                    load_config,
+                    None,
+                    None,
+                    Some({
+                        let forked_validators = forked_validators.clone();
+                        let checkpoint_overrides = checkpoint_overrides.clone();
+                        let effects_overrides = effects_overrides.clone();
+                        let node_to_authority_map = node_to_authority_map.clone();
+                        move |_cluster: Arc<TestCluster>| async move {
+                            register_fail_point_arg("simulate_fork_during_execution", {
+                                let forked_validators = forked_validators.clone();
+                                let effects_overrides = effects_overrides.clone();
+                                move || {
+                                    Some((
+                                        forked_validators.clone(),
+                                        /* full_halt: */ true,
+                                        effects_overrides.clone(),
+                                        0.1f32,
+                                        /* executor_path_only: */ false,
+                                    ))
+                                }
+                            });
+                            register_fork_kill_failpoints(
+                                forked_validators.clone(),
+                                checkpoint_overrides.clone(),
+                                node_to_authority_map.clone(),
+                            );
+                        }
+                    }),
+                    false,
+                )
+                .await;
+            }
+        });
+
+        // Wait until split brain is detected (kill_split_brain recorded the canonical digest).
+        let mut detected = false;
+        for _ in 0..120 {
+            if forked_validators.lock().unwrap().len() > 1
+                && !checkpoint_overrides.lock().unwrap().is_empty()
+            {
+                detected = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+        load_task.abort();
+        assert!(
+            detected,
+            "expected a quorum-breaking fork with split brain detected"
+        );
+
+        // Corrected binary: stop injecting forks and clear the kill failpoints so they can't
+        // interrupt reconvergence.
+        clear_fail_point("simulate_fork_during_execution");
+        clear_fork_kill_failpoints();
+
+        // Operator recovery: stop all (discards the in-memory forked effects), then restart with
+        // checkpoint_overrides naming the canonical digest. Forked validators clear locally_computed
+        // and re-execute canonically, so quorum re-forms.
+        let overrides = checkpoint_overrides.lock().unwrap().clone();
+        for validator in test_cluster.swarm.validator_nodes() {
+            validator.stop();
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        for validator in test_cluster.swarm.validator_nodes() {
+            {
+                let mut cfg = validator.config();
+                cfg.fork_recovery = Some(ForkRecoveryConfig {
+                    transaction_overrides: Default::default(),
+                    checkpoint_overrides: overrides.clone(),
+                    fork_crash_behavior: ForkCrashBehavior::AwaitForkRecovery,
+                });
+            }
+            validator
+                .start()
+                .await
+                .expect("validator should restart under operator checkpoint_overrides recovery");
+        }
+
+        // Liveness: every node, including both recovered validators, advances an epoch — i.e. quorum
+        // re-formed and the forked validators rejoined.
+        test_cluster.wait_for_next_epoch_all_nodes().await;
+    }
+
+    // A transaction fork (vs the checkpoint fork in the minority test): a fallen-behind validator
+    // re-executes a certified checkpoint's transactions via the checkpoint executor (where
+    // expected_effects_digest is set) and diverges, tripping the per-transaction fork check. The
+    // executor_path_only injection flag forks only on that path, guaranteeing a transaction fork; it
+    // then recovers under RecoverOncePerVersion.
+    #[sim_test(config = "test_config()")]
+    async fn test_auto_fork_recovery_transaction_fork() {
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+
+        let test_cluster = build_test_cluster(4, 10_000, 4).await;
+
+        let effects_overrides: Arc<Mutex<BTreeMap<String, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+        let forked_validators: Arc<Mutex<HashSet<AuthorityName>>> =
+            Arc::new(Mutex::new(HashSet::new()));
+
+        let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
+
+        let mut load_config = SimulatedLoadConfig::default();
+        load_config.composite_weight = 0;
+
+        // Background load so certified checkpoints carrying user transactions accumulate while the
+        // target is down and during its catch-up.
+        let load_task = tokio::spawn({
+            let test_cluster = test_cluster.clone();
+            async move {
+                test_simulated_load_with_test_config(
+                    test_cluster,
+                    60,
+                    load_config,
+                    None,
+                    None,
+                    None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
+                    false,
+                )
+                .await;
+            }
+        });
+
+        // Let certified checkpoints accumulate, then stop the target so it falls behind the tip.
+        tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == target)
+            .unwrap()
+            .stop();
+        tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+
+        // Restart the target (it gets a new sim node id) and rebuild the map before arming the
+        // injection. start() returns before the executor catches up, so the injection lands first.
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == target)
+            .unwrap()
+            .start()
+            .await
+            .unwrap();
+        let node_to_authority_map = fork_test_node_to_authority_map(&test_cluster);
+
+        // Fork the target only on the executor path, so its catch-up re-execution trips the tx check.
+        register_fail_point_arg("simulate_fork_during_execution", {
+            let forked_validators = forked_validators.clone();
+            let effects_overrides = effects_overrides.clone();
+            let node_to_authority_map = node_to_authority_map.clone();
+            move || {
+                let current = node_to_authority_map.get(&sui_simulator::current_simnode_id())?;
+                if *current == target {
+                    Some((
+                        forked_validators.clone(),
+                        /* full_halt: */ false,
+                        effects_overrides.clone(),
+                        1.0f32,
+                        /* executor_path_only: */ true,
+                    ))
+                } else {
+                    None
+                }
+            }
+        });
+        register_fork_kill_failpoints(
+            forked_validators.clone(),
+            checkpoint_overrides.clone(),
+            node_to_authority_map.clone(),
+        );
+
+        // Wait until the target forks (after which kill_transaction_fork_node shuts it down).
+        let mut forked = false;
+        for _ in 0..60 {
+            if forked_validators.lock().unwrap().contains(&target) {
+                forked = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+        assert!(
+            forked,
+            "target should transaction-fork while catching up on the executor path"
+        );
+
+        // Corrected binary: stop injecting forks.
+        clear_fail_point("simulate_fork_during_execution");
+        load_task.abort();
+
+        // Confirm it was a transaction fork: checkpoint_overrides (set only by the checkpoint/split-
+        // brain failpoints) is empty even though the target forked.
+        assert!(
+            checkpoint_overrides.lock().unwrap().is_empty(),
+            "expected a transaction fork (no checkpoint fork should have been recorded)"
+        );
+
+        // Recover under RecoverOncePerVersion: clears the tx fork marker and re-executes canonically.
+        {
+            let target_node = test_cluster
+                .swarm
+                .validator_nodes()
+                .find(|validator| validator.name() == target)
+                .unwrap();
+            target_node.stop();
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            {
+                let mut cfg = target_node.config();
+                cfg.fork_recovery = Some(ForkRecoveryConfig {
+                    transaction_overrides: Default::default(),
+                    checkpoint_overrides: Default::default(),
+                    fork_crash_behavior: ForkCrashBehavior::RecoverOncePerVersion,
+                });
+            }
+            target_node.start().await.unwrap();
+        }
+
+        clear_fork_kill_failpoints();
+
+        // The recovered validator cleared its transaction fork marker and recorded a recovery attempt.
+        test_cluster
+            .swarm
+            .validator_nodes()
+            .find(|validator| validator.name() == target)
+            .unwrap()
+            .get_node_handle()
+            .expect("target should be running after recovery")
+            .with(|node| {
+                let state = node.state();
+                let cp = state.get_checkpoint_store();
+                assert!(
+                    cp.get_transaction_fork_detected().unwrap().is_none(),
+                    "transaction fork marker should be cleared after recovery"
+                );
+                assert!(
+                    cp.get_auto_recovery_attempt().unwrap().is_some(),
+                    "a recovery attempt should be recorded for this binary version"
+                );
+            });
+
+        // Liveness: every node, including the recovered validator, advances an epoch.
+        test_cluster.wait_for_next_epoch_all_nodes().await;
     }
 
     /// Scans every executed checkpoint on the test cluster's fullnode, finds

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -334,10 +334,18 @@ fn default_congestion_log_max_files() -> u32 {
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ForkCrashBehavior {
-    #[serde(rename = "await-fork-recovery")]
+    /// On a detected fork, clear the local fork state and re-execute against the canonical
+    /// certified checkpoint, at most once per binary version; halt if the same binary re-forks.
+    #[serde(rename = "recover-once-per-version")]
     #[default]
+    RecoverOncePerVersion,
+
+    /// Halt at startup awaiting operator intervention (e.g. supplying
+    /// canonical checkpoint digests).
+    #[serde(rename = "await-fork-recovery")]
     AwaitForkRecovery,
-    /// Return an error instead of blocking forever. This is primarily for testing.
+
+    /// Return an error instead of halting. This is primarily for testing.
     #[serde(rename = "return-error")]
     ReturnError,
 }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -335,7 +335,13 @@ fn default_congestion_log_max_files() -> u32 {
 #[serde(rename_all = "kebab-case")]
 pub enum ForkCrashBehavior {
     /// On a detected fork, clear the local fork state and re-execute against the canonical
-    /// certified checkpoint, at most once per binary version; halt if the same binary re-forks.
+    /// certified checkpoint. Recovery only proceeds when (1) the fork was recorded by a
+    /// different binary version than the one now running — the binary that forked would
+    /// deterministically fork again, so the node halts until a corrected binary is deployed —
+    /// and (2) a certified checkpoint covering the forked checkpoint or transaction is verified
+    /// in the local store — proof that the network already sealed the canonical outcome, so
+    /// re-deriving cannot equivocate on an undecided result. Forks failing either condition
+    /// halt the node awaiting a new binary or operator intervention.
     #[serde(rename = "recover-once-per-version")]
     #[default]
     RecoverOncePerVersion,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -808,6 +808,36 @@ impl AuthorityMetrics {
 ///
 pub type StableSyncAuthoritySigner = Pin<Arc<dyn Signer<AuthoritySignature> + Send + Sync>>;
 
+/// The expected effects digest of a transaction, when the effects are known before execution,
+/// tagged with where the expectation came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpectedEffectsDigest {
+    /// Read from the contents of the certified checkpoint at `checkpoint_seq`.
+    Certified {
+        digest: TransactionEffectsDigest,
+        checkpoint_seq: CheckpointSequenceNumber,
+    },
+    /// Known but not network-certified: this validator's own previously signed effects, or an
+    /// operator override.
+    Uncertified(TransactionEffectsDigest),
+}
+
+impl ExpectedEffectsDigest {
+    pub fn digest(&self) -> TransactionEffectsDigest {
+        match self {
+            Self::Certified { digest, .. } => *digest,
+            Self::Uncertified(digest) => *digest,
+        }
+    }
+
+    pub fn checkpoint_seq(&self) -> Option<CheckpointSequenceNumber> {
+        match self {
+            Self::Certified { checkpoint_seq, .. } => Some(*checkpoint_seq),
+            Self::Uncertified(_) => None,
+        }
+    }
+}
+
 /// Execution env contains the "environment" for the transaction to be executed in, that is,
 /// all the information necessary for execution that is not specified by the transaction itself.
 #[derive(Debug, Clone)]
@@ -816,7 +846,7 @@ pub struct ExecutionEnv {
     pub assigned_versions: AssignedVersions,
     /// The expected digest of the effects of the transaction, if executing from checkpoint or
     /// other sources where the effects are known in advance.
-    pub expected_effects_digest: Option<TransactionEffectsDigest>,
+    pub expected_effects_digest: Option<ExpectedEffectsDigest>,
     /// Status of the address funds withdraw scheduling of the transaction,
     /// including both address and object funds withdraws.
     pub funds_withdraw_status: FundsWithdrawStatus,
@@ -841,11 +871,8 @@ impl ExecutionEnv {
         Default::default()
     }
 
-    pub fn with_expected_effects_digest(
-        mut self,
-        expected_effects_digest: TransactionEffectsDigest,
-    ) -> Self {
-        self.expected_effects_digest = Some(expected_effects_digest);
+    pub fn with_expected_effects(mut self, expected: ExpectedEffectsDigest) -> Self {
+        self.expected_effects_digest = Some(expected);
         self
     }
 
@@ -1500,7 +1527,8 @@ impl AuthorityState {
                 override_digest = ?override_digest,
                 "Applying fork recovery override for transaction effects digest"
             );
-            execution_env.expected_effects_digest = Some(override_digest);
+            execution_env.expected_effects_digest =
+                Some(ExpectedEffectsDigest::Uncertified(override_digest));
         }
 
         // prevent concurrent executions of the same tx.
@@ -1511,7 +1539,7 @@ impl AuthorityState {
             if let Some(expected_effects_digest) = execution_env.expected_effects_digest {
                 assert_eq!(
                     effects.digest(),
-                    expected_effects_digest,
+                    expected_effects_digest.digest(),
                     "Unexpected effects digest for transaction {:?}",
                     tx_digest
                 );
@@ -1759,7 +1787,7 @@ impl AuthorityState {
                 // restarting with a new binary. In this situation, if we have published an effects signature,
                 // we must be sure not to equivocate.
                 match epoch_store.get_signed_effects_digest(&tx_digest) {
-                    Ok(digest) => digest,
+                    Ok(digest) => digest.map(ExpectedEffectsDigest::Uncertified),
                     Err(e) => return ExecutionOutput::Fatal(e),
                 }
             }
@@ -2013,7 +2041,7 @@ impl AuthorityState {
         _execution_guard: &ExecutionLockReadGuard<'_>,
         certificate: &VerifiedExecutableTransaction,
         input_objects: InputObjects,
-        expected_effects_digest: Option<TransactionEffectsDigest>,
+        expected_effects_digest: Option<ExpectedEffectsDigest>,
         execution_env: ExecutionEnv,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> ExecutionOutput<(
@@ -2203,9 +2231,10 @@ impl AuthorityState {
             }
         });
 
-        if let Some(expected_effects_digest) = expected_effects_digest
-            && effects.digest() != expected_effects_digest
+        if let Some(expected) = expected_effects_digest
+            && effects.digest() != expected.digest()
         {
+            let expected_effects_digest = expected.digest();
             // We dont want to mask the original error, so we log it and continue.
             match self.debug_dump_transaction_state(
                 &tx_digest,
@@ -2231,7 +2260,7 @@ impl AuthorityState {
                 .get_effects(&expected_effects_digest);
             error!(
                 ?tx_digest,
-                ?expected_effects_digest,
+                ?expected,
                 actual_effects = ?effects,
                 expected_effects = ?expected_effects,
                 "fork detected!"
@@ -2240,6 +2269,7 @@ impl AuthorityState {
                 tx_digest,
                 expected_effects_digest,
                 effects.digest(),
+                expected.checkpoint_seq(),
             ) {
                 error!("Failed to record transaction fork: {e}");
             }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2166,6 +2166,43 @@ impl AuthorityState {
             return ExecutionOutput::RetryLater;
         }
 
+        // (test-only) Inject a fork before the effects-digest check below. Placed here so that a
+        // forked validator executing a *certified* checkpoint (expected_effects_digest is set, i.e.
+        // the checkpoint-executor path) trips the transaction-fork check. On the builder path
+        // (expected_effects_digest is None) the check is skipped, so this still produces a checkpoint
+        // fork as before.
+        fail_point_arg!("simulate_fork_during_execution", |(
+            forked_validators,
+            full_halt,
+            effects_overrides,
+            fork_probability,
+            executor_path_only,
+        ): (
+            std::sync::Arc<
+                std::sync::Mutex<std::collections::HashSet<sui_types::base_types::AuthorityName>>,
+            >,
+            bool,
+            std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<String, String>>>,
+            f32,
+            bool,
+        )| {
+            #[cfg(msim)]
+            // When `executor_path_only` is set, fork only while executing a certified checkpoint
+            // (expected_effects_digest is set) so the divergence trips the transaction-fork check
+            // below; otherwise fork on any path (the builder path yields a checkpoint fork).
+            if !executor_path_only || expected_effects_digest.is_some() {
+                self.simulate_fork_during_execution(
+                    certificate,
+                    epoch_store,
+                    &mut effects,
+                    forked_validators,
+                    full_halt,
+                    effects_overrides,
+                    fork_probability,
+                );
+            }
+        });
+
         if let Some(expected_effects_digest) = expected_effects_digest
             && effects.digest() != expected_effects_digest
         {
@@ -2226,31 +2263,6 @@ impl AuthorityState {
                 effects.digest()
             );
         }
-
-        fail_point_arg!("simulate_fork_during_execution", |(
-            forked_validators,
-            full_halt,
-            effects_overrides,
-            fork_probability,
-        ): (
-            std::sync::Arc<
-                std::sync::Mutex<std::collections::HashSet<sui_types::base_types::AuthorityName>>,
-            >,
-            bool,
-            std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<String, String>>>,
-            f32,
-        )| {
-            #[cfg(msim)]
-            self.simulate_fork_during_execution(
-                certificate,
-                epoch_store,
-                &mut effects,
-                forked_validators,
-                full_halt,
-                effects_overrides,
-                fork_probability,
-            );
-        });
 
         let unchanged_loaded_runtime_objects =
             crate::transaction_outputs::unchanged_loaded_runtime_objects(

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -49,7 +49,7 @@ use tracing::{debug, info, instrument};
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::backpressure::BackpressureManager;
-use crate::authority::{AuthorityState, ExecutionEnv};
+use crate::authority::{AuthorityState, ExecutionEnv, ExpectedEffectsDigest};
 use crate::execution_scheduler::ExecutionScheduler;
 use crate::execution_scheduler::execution_scheduler_impl::BarrierDependencyBuilder;
 use crate::global_state_hasher::GlobalStateHasher;
@@ -641,7 +641,8 @@ impl CheckpointExecutor {
         finish_stage!(pipeline_handle, WaitForTransactions);
 
         if ckpt_state.data.checkpoint.is_last_checkpoint_of_epoch() {
-            self.execute_change_epoch_tx(&tx_data).await;
+            self.execute_change_epoch_tx(&tx_data, ckpt_state.data.checkpoint.sequence_number)
+                .await;
         }
 
         self.finalize_executed_checkpoint_transactions(ckpt_state, &tx_data, pipeline_handle)
@@ -947,7 +948,10 @@ impl CheckpointExecutor {
 
                         let mut env = ExecutionEnv::new()
                             .with_assigned_versions(assigned_versions)
-                            .with_expected_effects_digest(*expected_fx_digest)
+                            .with_expected_effects(ExpectedEffectsDigest::Certified {
+                                digest: *expected_fx_digest,
+                                checkpoint_seq: ckpt_state.data.checkpoint.sequence_number,
+                            })
                             .with_barrier_dependencies(barrier_deps);
 
                         // Check if the expected effects indicate insufficient balance
@@ -974,7 +978,11 @@ impl CheckpointExecutor {
 
     // Execute the change epoch txn
     #[instrument(level = "error", skip_all)]
-    async fn execute_change_epoch_tx(&self, tx_data: &CheckpointTransactionData) {
+    async fn execute_change_epoch_tx(
+        &self,
+        tx_data: &CheckpointTransactionData,
+        checkpoint_seq: CheckpointSequenceNumber,
+    ) {
         let change_epoch_tx = tx_data.transactions.last().unwrap();
         let change_epoch_fx = tx_data.effects.last().unwrap();
         assert_eq!(
@@ -1024,7 +1032,10 @@ impl CheckpointExecutor {
                 change_epoch_tx.clone(),
                 ExecutionEnv::new()
                     .with_assigned_versions(assigned_versions)
-                    .with_expected_effects_digest(change_epoch_fx.digest()),
+                    .with_expected_effects(ExpectedEffectsDigest::Certified {
+                        digest: change_epoch_fx.digest(),
+                        checkpoint_seq,
+                    }),
             )],
             &self.epoch_store,
         );

--- a/crates/sui-core/src/checkpoints/metrics.rs
+++ b/crates/sui-core/src/checkpoints/metrics.rs
@@ -30,6 +30,9 @@ pub struct CheckpointMetrics {
     pub split_brain_checkpoint_forks: IntCounter,
     pub checkpoint_fork_crash_mode: IntGaugeVec,
     pub transaction_fork_crash_mode: IntGaugeVec,
+    pub checkpoint_fork_auto_recovered: IntGauge,
+    pub transaction_fork_auto_recovered: IntGauge,
+    pub fork_auto_recovery_exhausted: IntGauge,
     pub last_created_checkpoint_age: Histogram,
     // TODO: delete once users are migrated to non-Mysten histogram.
     pub last_created_checkpoint_age_ms: MystenHistogram,
@@ -168,6 +171,25 @@ impl CheckpointMetrics {
                 "transaction_fork_crash_mode",
                 "Indicates node is in crash mode due to transaction fork",
                 &["tx_digest_prefix", "expected_effects_prefix", "actual_effects_prefix", "detected_at"],
+                registry
+            )
+            .unwrap(),
+            checkpoint_fork_auto_recovered: register_int_gauge_with_registry!(
+                "checkpoint_fork_auto_recovered",
+                "Set to 1 when the node automatically recovered from a checkpoint fork on startup",
+                registry
+            )
+            .unwrap(),
+            transaction_fork_auto_recovered: register_int_gauge_with_registry!(
+                "transaction_fork_auto_recovered",
+                "Set to 1 when the node automatically recovered from a transaction fork on startup",
+                registry
+            )
+            .unwrap(),
+            fork_auto_recovery_exhausted: register_int_gauge_with_registry!(
+                "fork_auto_recovery_exhausted",
+                "Set to 1 when automatic fork recovery was already attempted with this binary \
+                 version and the node equivocated again, so it is halting awaiting a new binary",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/checkpoints/metrics.rs
+++ b/crates/sui-core/src/checkpoints/metrics.rs
@@ -32,7 +32,8 @@ pub struct CheckpointMetrics {
     pub transaction_fork_crash_mode: IntGaugeVec,
     pub checkpoint_fork_auto_recovered: IntGauge,
     pub transaction_fork_auto_recovered: IntGauge,
-    pub fork_auto_recovery_exhausted: IntGauge,
+    pub fork_auto_recovery_awaiting_new_binary: IntGauge,
+    pub fork_auto_recovery_blocked_uncertified: IntGauge,
     pub last_created_checkpoint_age: Histogram,
     // TODO: delete once users are migrated to non-Mysten histogram.
     pub last_created_checkpoint_age_ms: MystenHistogram,
@@ -186,10 +187,20 @@ impl CheckpointMetrics {
                 registry
             )
             .unwrap(),
-            fork_auto_recovery_exhausted: register_int_gauge_with_registry!(
-                "fork_auto_recovery_exhausted",
-                "Set to 1 when automatic fork recovery was already attempted with this binary \
-                 version and the node equivocated again, so it is halting awaiting a new binary",
+            fork_auto_recovery_awaiting_new_binary: register_int_gauge_with_registry!(
+                "fork_auto_recovery_awaiting_new_binary",
+                "Set to 1 when a fork marker was recorded by the currently running binary \
+                 version, which would deterministically fork again; the node is halting until a \
+                 corrected binary is deployed",
+                registry
+            )
+            .unwrap(),
+            fork_auto_recovery_blocked_uncertified: register_int_gauge_with_registry!(
+                "fork_auto_recovery_blocked_uncertified",
+                "Set to 1 when a fork marker was left in place because the fork was not detected \
+                 against a certified checkpoint or the covering certificate could not be \
+                 verified locally, so automatic recovery would risk equivocating on an undecided \
+                 outcome; the node is halting awaiting operator intervention",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -92,6 +92,7 @@ use typed_store::{
 };
 
 const TRANSACTION_FORK_DETECTED_KEY: u8 = 0;
+const AUTO_RECOVERY_ATTEMPT_KEY: u8 = 0;
 
 pub type CheckpointHeight = u64;
 
@@ -184,6 +185,11 @@ pub struct CheckpointStoreTables {
     >,
     #[default_options_override_fn = "full_checkpoint_content_table_default_config"]
     full_checkpoint_content_v2: DBMap<CheckpointSequenceNumber, VersionedFullCheckpointContents>,
+
+    /// Records the node build version that last performed an automatic fork recovery. Used to
+    /// bound automatic recovery to one attempt per binary version: if the same binary equivocates
+    /// again after recovering, the node hangs awaiting a corrected binary instead of crash-looping.
+    pub(crate) auto_recovery_attempt: DBMap<u8, String>,
 }
 
 #[cfg(not(tidehunter))]
@@ -303,6 +309,17 @@ impl CheckpointStoreTables {
                     |sequence_number: CheckpointSequenceNumber| sequence_number,
                     true,
                 )),
+            ),
+            (
+                "auto_recovery_attempt",
+                ThConfig::new_with_config(
+                    1,
+                    1,
+                    KeyType::uniform(1),
+                    KeySpaceConfig::new()
+                        .with_value_cache_size(10)
+                        .disable_unload(),
+                ),
             ),
         ];
         Self::open_tables_read_write(
@@ -1263,6 +1280,18 @@ impl CheckpointStore {
         self.tables
             .transaction_fork_detected
             .remove(&TRANSACTION_FORK_DETECTED_KEY)
+    }
+
+    pub fn record_auto_recovery_attempt(&self, build_version: &str) -> Result<(), TypedStoreError> {
+        self.tables
+            .auto_recovery_attempt
+            .insert(&AUTO_RECOVERY_ATTEMPT_KEY, &build_version.to_string())
+    }
+
+    pub fn get_auto_recovery_attempt(&self) -> Result<Option<String>, TypedStoreError> {
+        self.tables
+            .auto_recovery_attempt
+            .get(&AUTO_RECOVERY_ATTEMPT_KEY)
     }
 }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -55,6 +55,7 @@ use std::io::Write;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::Weak;
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime};
@@ -92,9 +93,41 @@ use typed_store::{
 };
 
 const TRANSACTION_FORK_DETECTED_KEY: u8 = 0;
-const AUTO_RECOVERY_ATTEMPT_KEY: u8 = 0;
+const CHECKPOINT_FORK_DETECTED_KEY: u8 = 0;
 
 pub type CheckpointHeight = u64;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransactionForkInfo {
+    pub tx_digest: TransactionDigest,
+    pub expected_effects_digest: TransactionEffectsDigest,
+    pub actual_effects_digest: TransactionEffectsDigest,
+    /// Sequence of the certified checkpoint whose contents supplied `expected_effects_digest`,
+    /// when the fork was detected while executing a synced checkpoint. None when the
+    /// expectation came from a non-certified source (e.g. this validator's own previously
+    /// signed effects), in which case automatic recovery is never allowed: nothing proves the
+    /// network certified the outcome.
+    pub certified_checkpoint_seq: Option<CheckpointSequenceNumber>,
+    /// The binary version that produced the fork (the node sets the store's version at startup,
+    /// before any fork can be recorded). Automatic recovery refuses to clear a marker carrying
+    /// the currently running version: re-deriving with the binary that forked would
+    /// deterministically fork again, so the node hangs until a corrected binary is deployed.
+    pub binary_version: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CheckpointForkInfo {
+    pub checkpoint_seq: CheckpointSequenceNumber,
+    /// Digest of the locally computed checkpoint that diverged.
+    pub checkpoint_digest: CheckpointDigest,
+    /// Digest of the certified checkpoint the local one diverged from, when the fork was
+    /// detected against a certified checkpoint. None when the builder re-derived a previously
+    /// computed sequence with a different result (e.g. after a binary upgrade): nothing proves
+    /// the network certified this sequence, so automatic recovery is never allowed.
+    pub certified_checkpoint_digest: Option<CheckpointDigest>,
+    /// See [`TransactionForkInfo::binary_version`].
+    pub binary_version: String,
+}
 
 pub struct EpochStats {
     pub checkpoint_count: u64,
@@ -174,22 +207,16 @@ pub struct CheckpointStoreTables {
     /// fully executed checkpoints
     pub(crate) watermarks: DBMap<CheckpointWatermark, (CheckpointSequenceNumber, CheckpointDigest)>,
 
-    /// Stores transaction fork detection information
-    pub(crate) transaction_fork_detected: DBMap<
-        u8,
-        (
-            TransactionDigest,
-            TransactionEffectsDigest,
-            TransactionEffectsDigest,
-        ),
-    >,
+    /// Stores transaction fork detection information, including the certified checkpoint (if
+    /// any) that supplied the expected effects digest and the binary version that forked.
+    /// Automatic fork recovery is gated on both: it may only proceed once the network has
+    /// certified the forked outcome, and only under a different binary version.
+    pub(crate) transaction_fork_detected_v2: DBMap<u8, TransactionForkInfo>,
     #[default_options_override_fn = "full_checkpoint_content_table_default_config"]
     full_checkpoint_content_v2: DBMap<CheckpointSequenceNumber, VersionedFullCheckpointContents>,
 
-    /// Records the node build version that last performed an automatic fork recovery. Used to
-    /// bound automatic recovery to one attempt per binary version: if the same binary equivocates
-    /// again after recovering, the node hangs awaiting a corrected binary instead of crash-looping.
-    pub(crate) auto_recovery_attempt: DBMap<u8, String>,
+    /// Stores checkpoint fork detection information, including the binary version that forked.
+    pub(crate) checkpoint_fork_detected: DBMap<u8, CheckpointForkInfo>,
 }
 
 #[cfg(not(tidehunter))]
@@ -293,7 +320,18 @@ impl CheckpointStoreTables {
                 ThConfig::new_with_config(4, 1, KeyType::uniform(1), watermarks_config.clone()),
             ),
             (
-                "transaction_fork_detected",
+                "transaction_fork_detected_v2",
+                ThConfig::new_with_config(
+                    1,
+                    1,
+                    KeyType::uniform(1),
+                    watermarks_config
+                        .clone()
+                        .with_relocation_filter(|_, _| Decision::Remove),
+                ),
+            ),
+            (
+                "checkpoint_fork_detected",
                 ThConfig::new_with_config(
                     1,
                     1,
@@ -309,17 +347,6 @@ impl CheckpointStoreTables {
                     |sequence_number: CheckpointSequenceNumber| sequence_number,
                     true,
                 )),
-            ),
-            (
-                "auto_recovery_attempt",
-                ThConfig::new_with_config(
-                    1,
-                    1,
-                    KeyType::uniform(1),
-                    KeySpaceConfig::new()
-                        .with_value_cache_size(10)
-                        .disable_unload(),
-                ),
             ),
         ];
         Self::open_tables_read_write(
@@ -352,6 +379,9 @@ pub struct CheckpointStore {
     pub(crate) tables: CheckpointStoreTables,
     synced_checkpoint_notify_read: NotifyRead<CheckpointSequenceNumber, VerifiedCheckpoint>,
     executed_checkpoint_notify_read: NotifyRead<CheckpointSequenceNumber, VerifiedCheckpoint>,
+    /// The running binary's version, set once at node startup. Embedded in fork markers so
+    /// recovery can refuse to clear a fork with the same binary version that produced it.
+    binary_version: OnceLock<String>,
 }
 
 impl CheckpointStore {
@@ -361,6 +391,7 @@ impl CheckpointStore {
             tables,
             synced_checkpoint_notify_read: NotifyRead::new(),
             executed_checkpoint_notify_read: NotifyRead::new(),
+            binary_version: OnceLock::new(),
         })
     }
 
@@ -379,7 +410,12 @@ impl CheckpointStore {
             tables,
             synced_checkpoint_notify_read: NotifyRead::new(),
             executed_checkpoint_notify_read: NotifyRead::new(),
+            binary_version: OnceLock::new(),
         })
+    }
+
+    pub fn set_binary_version(&self, version: &str) {
+        let _ = self.binary_version.set(version.to_string());
     }
 
     #[cfg(not(tidehunter))]
@@ -743,6 +779,7 @@ impl CheckpointStore {
             if let Err(e) = self.record_checkpoint_fork_detected(
                 *local_checkpoint.sequence_number(),
                 local_checkpoint.digest(),
+                Some(*verified_checkpoint.digest()),
             ) {
                 error!("Failed to record checkpoint fork in database: {:?}", e);
             }
@@ -1217,30 +1254,39 @@ impl CheckpointStore {
         &self,
         checkpoint_seq: CheckpointSequenceNumber,
         checkpoint_digest: CheckpointDigest,
+        certified_checkpoint_digest: Option<CheckpointDigest>,
     ) -> Result<(), TypedStoreError> {
+        let binary_version = self.binary_version.get().cloned().unwrap_or_default();
         info!(
             checkpoint_seq = checkpoint_seq,
             checkpoint_digest = ?checkpoint_digest,
+            certified_checkpoint_digest = ?certified_checkpoint_digest,
+            binary_version,
             "Recording checkpoint fork detection in database"
         );
-        self.tables.watermarks.insert(
-            &CheckpointWatermark::CheckpointForkDetected,
-            &(checkpoint_seq, checkpoint_digest),
+        self.tables.checkpoint_fork_detected.insert(
+            &CHECKPOINT_FORK_DETECTED_KEY,
+            &CheckpointForkInfo {
+                checkpoint_seq,
+                checkpoint_digest,
+                certified_checkpoint_digest,
+                binary_version,
+            },
         )
     }
 
     pub fn get_checkpoint_fork_detected(
         &self,
-    ) -> Result<Option<(CheckpointSequenceNumber, CheckpointDigest)>, TypedStoreError> {
+    ) -> Result<Option<CheckpointForkInfo>, TypedStoreError> {
         self.tables
-            .watermarks
-            .get(&CheckpointWatermark::CheckpointForkDetected)
+            .checkpoint_fork_detected
+            .get(&CHECKPOINT_FORK_DETECTED_KEY)
     }
 
     pub fn clear_checkpoint_fork_detected(&self) -> Result<(), TypedStoreError> {
         self.tables
-            .watermarks
-            .remove(&CheckpointWatermark::CheckpointForkDetected)
+            .checkpoint_fork_detected
+            .remove(&CHECKPOINT_FORK_DETECTED_KEY)
     }
 
     pub fn record_transaction_fork_detected(
@@ -1248,50 +1294,41 @@ impl CheckpointStore {
         tx_digest: TransactionDigest,
         expected_effects_digest: TransactionEffectsDigest,
         actual_effects_digest: TransactionEffectsDigest,
+        certified_checkpoint_seq: Option<CheckpointSequenceNumber>,
     ) -> Result<(), TypedStoreError> {
+        let binary_version = self.binary_version.get().cloned().unwrap_or_default();
         info!(
             tx_digest = ?tx_digest,
             expected_effects_digest = ?expected_effects_digest,
             actual_effects_digest = ?actual_effects_digest,
+            certified_checkpoint_seq = ?certified_checkpoint_seq,
+            binary_version,
             "Recording transaction fork detection in database"
         );
-        self.tables.transaction_fork_detected.insert(
+        self.tables.transaction_fork_detected_v2.insert(
             &TRANSACTION_FORK_DETECTED_KEY,
-            &(tx_digest, expected_effects_digest, actual_effects_digest),
+            &TransactionForkInfo {
+                tx_digest,
+                expected_effects_digest,
+                actual_effects_digest,
+                certified_checkpoint_seq,
+                binary_version,
+            },
         )
     }
 
     pub fn get_transaction_fork_detected(
         &self,
-    ) -> Result<
-        Option<(
-            TransactionDigest,
-            TransactionEffectsDigest,
-            TransactionEffectsDigest,
-        )>,
-        TypedStoreError,
-    > {
+    ) -> Result<Option<TransactionForkInfo>, TypedStoreError> {
         self.tables
-            .transaction_fork_detected
+            .transaction_fork_detected_v2
             .get(&TRANSACTION_FORK_DETECTED_KEY)
     }
 
     pub fn clear_transaction_fork_detected(&self) -> Result<(), TypedStoreError> {
         self.tables
-            .transaction_fork_detected
+            .transaction_fork_detected_v2
             .remove(&TRANSACTION_FORK_DETECTED_KEY)
-    }
-
-    pub fn record_auto_recovery_attempt(&self, build_version: &str) -> Result<(), TypedStoreError> {
-        self.tables
-            .auto_recovery_attempt
-            .insert(&AUTO_RECOVERY_ATTEMPT_KEY, &build_version.to_string())
-    }
-
-    pub fn get_auto_recovery_attempt(&self) -> Result<Option<String>, TypedStoreError> {
-        self.tables
-            .auto_recovery_attempt
-            .get(&AUTO_RECOVERY_ATTEMPT_KEY)
     }
 }
 
@@ -1301,6 +1338,8 @@ pub enum CheckpointWatermark {
     HighestSynced,
     HighestExecuted,
     HighestPruned,
+    /// Retired: checkpoint fork markers now live in the `checkpoint_fork_detected` table. Kept
+    /// because existing databases may hold this key.
     CheckpointForkDetected,
 }
 
@@ -1777,6 +1816,17 @@ impl CheckpointBuilder {
             .get(&summary.sequence_number)?
             && previously_computed_summary.digest() != summary.digest()
         {
+            // The builder re-derived this sequence with a different result than a previous run
+            // (e.g. after a binary upgrade), which may already have signed and sent its result
+            // to consensus. No certified checkpoint proves which result is canonical, so the
+            // marker carries no certified digest and is never cleared automatically.
+            if let Err(e) = self.store.record_checkpoint_fork_detected(
+                summary.sequence_number,
+                previously_computed_summary.digest(),
+                None,
+            ) {
+                error!("Failed to record checkpoint fork in database: {:?}", e);
+            }
             fatal!(
                 "Checkpoint {} was previously built with a different result: previously_computed_summary {:?} vs current_summary {:?}",
                 summary.sequence_number,
@@ -3277,21 +3327,25 @@ mod tests {
     #[tokio::test]
     async fn test_fork_detection_storage() {
         let store = CheckpointStore::new_for_tests();
+        store.set_binary_version("v1");
         // checkpoint fork
         let seq_num = 42;
         let digest = CheckpointDigest::random();
+        let certified_digest = CheckpointDigest::random();
 
         assert!(store.get_checkpoint_fork_detected().unwrap().is_none());
 
         store
-            .record_checkpoint_fork_detected(seq_num, digest)
+            .record_checkpoint_fork_detected(seq_num, digest, Some(certified_digest))
             .unwrap();
 
         let retrieved = store.get_checkpoint_fork_detected().unwrap();
         assert!(retrieved.is_some());
-        let (retrieved_seq, retrieved_digest) = retrieved.unwrap();
-        assert_eq!(retrieved_seq, seq_num);
-        assert_eq!(retrieved_digest, digest);
+        let info = retrieved.unwrap();
+        assert_eq!(info.checkpoint_seq, seq_num);
+        assert_eq!(info.checkpoint_digest, digest);
+        assert_eq!(info.certified_checkpoint_digest, Some(certified_digest));
+        assert_eq!(info.binary_version, "v1");
 
         store.clear_checkpoint_fork_detected().unwrap();
         assert!(store.get_checkpoint_fork_detected().unwrap().is_none());
@@ -3304,15 +3358,17 @@ mod tests {
         assert!(store.get_transaction_fork_detected().unwrap().is_none());
 
         store
-            .record_transaction_fork_detected(tx_digest, expected_effects, actual_effects)
+            .record_transaction_fork_detected(tx_digest, expected_effects, actual_effects, Some(7))
             .unwrap();
 
         let retrieved = store.get_transaction_fork_detected().unwrap();
         assert!(retrieved.is_some());
-        let (retrieved_tx, retrieved_expected, retrieved_actual) = retrieved.unwrap();
-        assert_eq!(retrieved_tx, tx_digest);
-        assert_eq!(retrieved_expected, expected_effects);
-        assert_eq!(retrieved_actual, actual_effects);
+        let info = retrieved.unwrap();
+        assert_eq!(info.tx_digest, tx_digest);
+        assert_eq!(info.expected_effects_digest, expected_effects);
+        assert_eq!(info.actual_effects_digest, actual_effects);
+        assert_eq!(info.certified_checkpoint_seq, Some(7));
+        assert_eq!(info.binary_version, "v1");
 
         store.clear_transaction_fork_detected().unwrap();
         assert!(store.get_transaction_fork_detected().unwrap().is_none());

--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -88,6 +88,7 @@ async fn test_checkpoint_split_brain() {
                 String,
             >::new())),
             1.0f32, // fork_probability
+            false,  // executor_path_only
         ))
     });
 

--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -215,14 +215,18 @@ async fn test_checkpoint_fork_detection_storage() {
         );
 
         checkpoint_store
-            .record_checkpoint_fork_detected(fork_seq, fork_digest)
+            .record_checkpoint_fork_detected(
+                fork_seq,
+                fork_digest,
+                Some(CheckpointDigest::random()),
+            )
             .expect("Failed to record checkpoint fork");
 
         let retrieved = checkpoint_store.get_checkpoint_fork_detected().unwrap();
         assert!(retrieved.is_some());
-        let (retrieved_seq, retrieved_digest) = retrieved.unwrap();
-        assert_eq!(retrieved_seq, fork_seq);
-        assert_eq!(retrieved_digest, fork_digest);
+        let fork_info = retrieved.unwrap();
+        assert_eq!(fork_info.checkpoint_seq, fork_seq);
+        assert_eq!(fork_info.checkpoint_digest, fork_digest);
 
         checkpoint_store.clear_checkpoint_fork_detected().unwrap();
         let retrieved_after_clear = checkpoint_store.get_checkpoint_fork_detected().unwrap();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -520,6 +520,7 @@ impl SuiNode {
                 &checkpoint_store,
                 &checkpoint_metrics,
                 config.fork_recovery.as_ref(),
+                server_version.version,
             )
             .await?;
         }
@@ -2185,11 +2186,24 @@ impl SuiNode {
         checkpoint_store: &CheckpointStore,
         checkpoint_metrics: &CheckpointMetrics,
         fork_recovery: Option<&ForkRecoveryConfig>,
+        build_version: &str,
     ) -> Result<()> {
-        // Try to recover from forks if recovery config is provided
+        // Manual recovery from operator-supplied overrides; runs regardless of fork_crash_behavior
+        // and only acts on the checkpoints / transactions explicitly listed in the config.
         if let Some(recovery) = fork_recovery {
             Self::try_recover_checkpoint_fork(checkpoint_store, recovery)?;
             Self::try_recover_transaction_fork(checkpoint_store, recovery)?;
+        }
+
+        let behavior = fork_recovery
+            .map(|fr| fr.fork_crash_behavior)
+            .unwrap_or_default();
+
+        match behavior {
+            ForkCrashBehavior::RecoverOncePerVersion => {
+                Self::try_recover_forks(checkpoint_store, checkpoint_metrics, build_version)?;
+            }
+            ForkCrashBehavior::AwaitForkRecovery | ForkCrashBehavior::ReturnError => {}
         }
 
         if let Some((checkpoint_seq, checkpoint_digest)) = checkpoint_store
@@ -2227,12 +2241,17 @@ impl SuiNode {
         Ok(())
     }
 
+    /// Manual recovery: for each `seq -> digest` override, if the locally computed checkpoint at
+    /// `seq` differs, clear locally computed checkpoints from `seq` (and the checkpoint fork marker)
+    /// so the node rebuilds toward the operator-specified digest.
     fn try_recover_checkpoint_fork(
         checkpoint_store: &CheckpointStore,
         recovery: &ForkRecoveryConfig,
     ) -> Result<()> {
-        // If configured overrides include a checkpoint whose locally computed digest mismatches,
-        // clear locally computed checkpoints from that sequence (inclusive).
+        if recovery.checkpoint_overrides.is_empty() {
+            return Ok(());
+        }
+
         for (seq, expected_digest_str) in &recovery.checkpoint_overrides {
             let Ok(expected_digest) = CheckpointDigest::from_str(expected_digest_str) else {
                 anyhow::bail!(
@@ -2276,6 +2295,8 @@ impl SuiNode {
         Ok(())
     }
 
+    /// Manual recovery: if the forked transaction is listed in transaction_overrides, clear its fork
+    /// marker so the node proceeds on restart.
     fn try_recover_transaction_fork(
         checkpoint_store: &CheckpointStore,
         recovery: &ForkRecoveryConfig,
@@ -2297,6 +2318,66 @@ impl SuiNode {
                 .clear_transaction_fork_detected()
                 .expect("Failed to clear transaction fork detected marker");
         }
+        Ok(())
+    }
+
+    /// Auto-recovery: clear any fork markers (the affected seq/tx is read from the markers) so the
+    /// node re-derives canonically, at most once per binary version. If this binary already recovered
+    /// and re-forked, the markers are left in place so it halts rather than crash-looping; deploying a
+    /// new binary version resets the guard.
+    fn try_recover_forks(
+        checkpoint_store: &CheckpointStore,
+        checkpoint_metrics: &CheckpointMetrics,
+        build_version: &str,
+    ) -> Result<()> {
+        let checkpoint_fork = checkpoint_store.get_checkpoint_fork_detected()?;
+        let transaction_fork = checkpoint_store.get_transaction_fork_detected()?;
+        if checkpoint_fork.is_none() && transaction_fork.is_none() {
+            return Ok(());
+        }
+
+        if checkpoint_store.get_auto_recovery_attempt()?.as_deref() == Some(build_version) {
+            error!(
+                build_version,
+                "Fork recovery already attempted with this binary version, but the node \
+                 equivocated again. Halting; deploy a corrected binary to recover."
+            );
+            checkpoint_metrics.fork_auto_recovery_exhausted.set(1);
+            return Ok(());
+        }
+
+        // Record the attempt before clearing so a crash mid-recovery still counts as this binary
+        // version's one attempt.
+        checkpoint_store.record_auto_recovery_attempt(build_version)?;
+
+        if let Some((checkpoint_seq, checkpoint_digest)) = checkpoint_fork {
+            info!(
+                checkpoint_seq,
+                ?checkpoint_digest,
+                build_version,
+                "Fork recovery: clearing checkpoint fork and locally computed checkpoints from the \
+                 forked sequence so the builder rebuilds toward the certified checkpoint"
+            );
+            checkpoint_store
+                .clear_locally_computed_checkpoints_from(checkpoint_seq)
+                .context("Failed to clear locally computed checkpoints during fork recovery")?;
+            checkpoint_store.clear_checkpoint_fork_detected()?;
+            checkpoint_metrics.checkpoint_fork_auto_recovered.set(1);
+        }
+
+        if let Some((tx_digest, expected_effects, actual_effects)) = transaction_fork {
+            info!(
+                ?tx_digest,
+                ?expected_effects,
+                ?actual_effects,
+                build_version,
+                "Fork recovery: clearing transaction fork; re-execution will converge toward the \
+                 canonical certified effects"
+            );
+            checkpoint_store.clear_transaction_fork_detected()?;
+            checkpoint_metrics.transaction_fork_auto_recovered.set(1);
+        }
+
         Ok(())
     }
 
@@ -2327,7 +2408,7 @@ impl SuiNode {
             .unwrap_or_default();
 
         match behavior {
-            ForkCrashBehavior::AwaitForkRecovery => {
+            ForkCrashBehavior::AwaitForkRecovery | ForkCrashBehavior::RecoverOncePerVersion => {
                 error!(
                     checkpoint_seq = checkpoint_seq,
                     checkpoint_digest = ?checkpoint_digest,
@@ -2373,7 +2454,7 @@ impl SuiNode {
             .unwrap_or_default();
 
         match behavior {
-            ForkCrashBehavior::AwaitForkRecovery => {
+            ForkCrashBehavior::AwaitForkRecovery | ForkCrashBehavior::RecoverOncePerVersion => {
                 error!(
                     tx_digest = ?tx_digest,
                     expected_effects_digest = ?expected_effects_digest,
@@ -2867,103 +2948,319 @@ mod tests {
         assert!(sibling.exists());
     }
 
+    // Halt / ReturnError never clear markers; ReturnError surfaces the fork as a startup error.
     #[tokio::test]
-    async fn test_fork_error_and_recovery_both_paths() {
+    async fn test_return_error_does_not_recover() {
         let checkpoint_store = CheckpointStore::new_for_tests();
         let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
-
-        // ---------- Checkpoint fork path ----------
-        let seq_num = 42;
-        let digest = CheckpointDigest::random();
-        checkpoint_store
-            .record_checkpoint_fork_detected(seq_num, digest)
-            .unwrap();
-
-        let fork_recovery = ForkRecoveryConfig {
+        let cfg = ForkRecoveryConfig {
             transaction_overrides: Default::default(),
             checkpoint_overrides: Default::default(),
             fork_crash_behavior: ForkCrashBehavior::ReturnError,
         };
 
+        // Checkpoint fork.
+        checkpoint_store
+            .record_checkpoint_fork_detected(42, CheckpointDigest::random())
+            .unwrap();
         let r = SuiNode::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            Some(&fork_recovery),
+            Some(&cfg),
+            "v1",
         )
         .await;
-        assert!(r.is_err());
         assert!(
             r.unwrap_err()
                 .to_string()
                 .contains("Checkpoint fork detected")
         );
+        assert!(
+            checkpoint_store
+                .get_checkpoint_fork_detected()
+                .unwrap()
+                .is_some()
+        );
+        checkpoint_store.clear_checkpoint_fork_detected().unwrap();
 
-        let mut checkpoint_overrides = BTreeMap::new();
-        checkpoint_overrides.insert(seq_num, digest.to_string());
-        let fork_recovery_with_override = ForkRecoveryConfig {
-            transaction_overrides: Default::default(),
-            checkpoint_overrides,
-            fork_crash_behavior: ForkCrashBehavior::ReturnError,
-        };
+        // Transaction fork.
+        checkpoint_store
+            .record_transaction_fork_detected(
+                TransactionDigest::random(),
+                TransactionEffectsDigest::random(),
+                TransactionEffectsDigest::random(),
+            )
+            .unwrap();
         let r = SuiNode::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            Some(&fork_recovery_with_override),
+            Some(&cfg),
+            "v1",
         )
         .await;
-        assert!(r.is_ok());
+        assert!(
+            r.unwrap_err()
+                .to_string()
+                .contains("Transaction fork detected")
+        );
+    }
+
+    // RecoverOncePerVersion clears the fork marker once per binary version (deriving the sequence
+    // from the marker), but leaves it set if the same binary version re-forks; a new binary version
+    // gets a fresh attempt.
+    #[tokio::test]
+    async fn test_recover_once_per_version() {
+        let checkpoint_store = CheckpointStore::new_for_tests();
+        let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
+        let seq = 7;
+        let digest = CheckpointDigest::random();
+        checkpoint_store
+            .record_checkpoint_fork_detected(seq, digest)
+            .unwrap();
+
+        // First attempt with "v1": recovers and flags the recovery in metrics.
+        SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v1").unwrap();
         assert!(
             checkpoint_store
                 .get_checkpoint_fork_detected()
                 .unwrap()
                 .is_none()
         );
+        assert_eq!(
+            checkpoint_store.get_auto_recovery_attempt().unwrap(),
+            Some("v1".to_string())
+        );
+        assert_eq!(checkpoint_metrics.checkpoint_fork_auto_recovered.get(), 1);
+        assert_eq!(checkpoint_metrics.fork_auto_recovery_exhausted.get(), 0);
 
-        // ---------- Transaction fork path ----------
-        let tx_digest = TransactionDigest::random();
-        let expected_effects = TransactionEffectsDigest::random();
-        let actual_effects = TransactionEffectsDigest::random();
+        // Same binary version re-forks: one-shot consumed, marker stays, exhaustion is flagged.
         checkpoint_store
-            .record_transaction_fork_detected(tx_digest, expected_effects, actual_effects)
+            .record_checkpoint_fork_detected(seq, digest)
+            .unwrap();
+        SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v1").unwrap();
+        assert!(
+            checkpoint_store
+                .get_checkpoint_fork_detected()
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(checkpoint_metrics.fork_auto_recovery_exhausted.get(), 1);
+
+        // Corrected binary (new version): fresh attempt.
+        SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v2").unwrap();
+        assert!(
+            checkpoint_store
+                .get_checkpoint_fork_detected()
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            checkpoint_store.get_auto_recovery_attempt().unwrap(),
+            Some("v2".to_string())
+        );
+    }
+
+    // The default behavior (RecoverOncePerVersion) recovers with no fork-recovery config present.
+    #[tokio::test]
+    async fn test_default_recovers() {
+        let checkpoint_store = CheckpointStore::new_for_tests();
+        let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
+
+        let tx_digest = TransactionDigest::random();
+        checkpoint_store
+            .record_transaction_fork_detected(
+                tx_digest,
+                TransactionEffectsDigest::random(),
+                TransactionEffectsDigest::random(),
+            )
             .unwrap();
 
-        let fork_recovery = ForkRecoveryConfig {
-            transaction_overrides: Default::default(),
-            checkpoint_overrides: Default::default(),
-            fork_crash_behavior: ForkCrashBehavior::ReturnError,
-        };
-        let r = SuiNode::check_and_recover_forks(
-            &checkpoint_store,
-            &checkpoint_metrics,
-            Some(&fork_recovery),
-        )
-        .await;
-        assert!(r.is_err());
-        assert!(
-            r.unwrap_err()
-                .to_string()
-                .contains("Transaction fork detected")
-        );
-
-        let mut transaction_overrides = BTreeMap::new();
-        transaction_overrides.insert(tx_digest.to_string(), actual_effects.to_string());
-        let fork_recovery_with_override = ForkRecoveryConfig {
-            transaction_overrides,
-            checkpoint_overrides: Default::default(),
-            fork_crash_behavior: ForkCrashBehavior::ReturnError,
-        };
-        let r = SuiNode::check_and_recover_forks(
-            &checkpoint_store,
-            &checkpoint_metrics,
-            Some(&fork_recovery_with_override),
-        )
-        .await;
+        let r =
+            SuiNode::check_and_recover_forks(&checkpoint_store, &checkpoint_metrics, None, "v1")
+                .await;
         assert!(r.is_ok());
         assert!(
             checkpoint_store
                 .get_transaction_fork_detected()
                 .unwrap()
                 .is_none()
+        );
+        assert_eq!(
+            checkpoint_store.get_auto_recovery_attempt().unwrap(),
+            Some("v1".to_string())
+        );
+    }
+
+    // checkpoint_overrides clears only the checkpoint fork marker (when the forked seq is listed); it
+    // is decoupled from the transaction fork marker, which is cleared by transaction_overrides.
+    #[tokio::test]
+    async fn test_checkpoint_overrides_clear_checkpoint_marker_only() {
+        let checkpoint_store = CheckpointStore::new_for_tests();
+        let seq = 9;
+
+        checkpoint_store
+            .record_checkpoint_fork_detected(seq, CheckpointDigest::random())
+            .unwrap();
+        checkpoint_store
+            .record_transaction_fork_detected(
+                TransactionDigest::random(),
+                TransactionEffectsDigest::random(),
+                TransactionEffectsDigest::random(),
+            )
+            .unwrap();
+
+        // No overrides: both markers are left intact.
+        SuiNode::try_recover_checkpoint_fork(&checkpoint_store, &ForkRecoveryConfig::default())
+            .unwrap();
+        assert!(
+            checkpoint_store
+                .get_checkpoint_fork_detected()
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            checkpoint_store
+                .get_transaction_fork_detected()
+                .unwrap()
+                .is_some()
+        );
+
+        // Override for the forked seq: clears the checkpoint marker but leaves the transaction marker.
+        let mut checkpoint_overrides = BTreeMap::new();
+        checkpoint_overrides.insert(seq, CheckpointDigest::random().to_string());
+        let cfg = ForkRecoveryConfig {
+            transaction_overrides: Default::default(),
+            checkpoint_overrides,
+            fork_crash_behavior: ForkCrashBehavior::AwaitForkRecovery,
+        };
+        SuiNode::try_recover_checkpoint_fork(&checkpoint_store, &cfg).unwrap();
+        assert!(
+            checkpoint_store
+                .get_checkpoint_fork_detected()
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            checkpoint_store
+                .get_transaction_fork_detected()
+                .unwrap()
+                .is_some(),
+            "checkpoint_overrides must not touch the transaction fork marker"
+        );
+    }
+
+    // transaction_overrides clears the transaction fork marker when the forked tx is listed.
+    #[tokio::test]
+    async fn test_transaction_overrides_clear_transaction_marker() {
+        let checkpoint_store = CheckpointStore::new_for_tests();
+        let tx_digest = TransactionDigest::random();
+        checkpoint_store
+            .record_transaction_fork_detected(
+                tx_digest,
+                TransactionEffectsDigest::random(),
+                TransactionEffectsDigest::random(),
+            )
+            .unwrap();
+
+        // Unrelated override: marker stays.
+        let mut transaction_overrides = BTreeMap::new();
+        transaction_overrides.insert(TransactionDigest::random().to_string(), String::new());
+        let cfg = ForkRecoveryConfig {
+            transaction_overrides,
+            checkpoint_overrides: Default::default(),
+            fork_crash_behavior: ForkCrashBehavior::AwaitForkRecovery,
+        };
+        SuiNode::try_recover_transaction_fork(&checkpoint_store, &cfg).unwrap();
+        assert!(
+            checkpoint_store
+                .get_transaction_fork_detected()
+                .unwrap()
+                .is_some()
+        );
+
+        // Override for the forked tx: marker cleared.
+        let mut transaction_overrides = BTreeMap::new();
+        transaction_overrides.insert(tx_digest.to_string(), String::new());
+        let cfg = ForkRecoveryConfig {
+            transaction_overrides,
+            checkpoint_overrides: Default::default(),
+            fork_crash_behavior: ForkCrashBehavior::AwaitForkRecovery,
+        };
+        SuiNode::try_recover_transaction_fork(&checkpoint_store, &cfg).unwrap();
+        assert!(
+            checkpoint_store
+                .get_transaction_fork_detected()
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    // Under RecoverOncePerVersion, a checkpoint override clears the fork via the manual path without
+    // consuming the per-version one-shot (which would otherwise burn the node's one auto attempt).
+    #[tokio::test]
+    async fn test_override_does_not_consume_one_shot() {
+        let checkpoint_store = CheckpointStore::new_for_tests();
+        let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
+        let seq = 5;
+        checkpoint_store
+            .record_checkpoint_fork_detected(seq, CheckpointDigest::random())
+            .unwrap();
+
+        let mut checkpoint_overrides = BTreeMap::new();
+        checkpoint_overrides.insert(seq, CheckpointDigest::random().to_string());
+        let cfg = ForkRecoveryConfig {
+            transaction_overrides: Default::default(),
+            checkpoint_overrides,
+            fork_crash_behavior: ForkCrashBehavior::RecoverOncePerVersion,
+        };
+
+        SuiNode::check_and_recover_forks(&checkpoint_store, &checkpoint_metrics, Some(&cfg), "v1")
+            .await
+            .unwrap();
+
+        // The manual override cleared the marker...
+        assert!(
+            checkpoint_store
+                .get_checkpoint_fork_detected()
+                .unwrap()
+                .is_none()
+        );
+        // ...and the auto path left the one-shot untouched (no marker remained to act on).
+        assert!(
+            checkpoint_store
+                .get_auto_recovery_attempt()
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    // After the one-shot is exhausted on one binary version (marker still set, attempt recorded), a
+    // node started on a new binary version recovers via the full check_and_recover_forks dispatch.
+    #[tokio::test]
+    async fn test_new_version_recovers_after_exhaustion() {
+        let checkpoint_store = CheckpointStore::new_for_tests();
+        let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
+        let seq = 5;
+
+        // Exhausted "v1": the fork marker is still present and "v1" already used its attempt.
+        checkpoint_store
+            .record_checkpoint_fork_detected(seq, CheckpointDigest::random())
+            .unwrap();
+        checkpoint_store.record_auto_recovery_attempt("v1").unwrap();
+
+        // A new binary version recovers (default behavior, no explicit config).
+        SuiNode::check_and_recover_forks(&checkpoint_store, &checkpoint_metrics, None, "v2")
+            .await
+            .unwrap();
+        assert!(
+            checkpoint_store
+                .get_checkpoint_fork_detected()
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            checkpoint_store.get_auto_recovery_attempt().unwrap(),
+            Some("v2".to_string())
         );
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -132,7 +132,7 @@ use sui_json_rpc::read_api::ReadApi;
 use sui_json_rpc::transaction_builder_api::TransactionBuilderApi;
 use sui_json_rpc::transaction_execution_api::TransactionExecutionApi;
 use sui_macros::fail_point;
-use sui_macros::{fail_point_async, replay_log};
+use sui_macros::{fail_point_arg, fail_point_async, replay_log};
 use sui_network::api::ValidatorServer;
 use sui_network::discovery;
 use sui_network::endpoint_manager::EndpointManager;
@@ -515,12 +515,26 @@ impl SuiNode {
         );
         let checkpoint_metrics = CheckpointMetrics::new(&registry_service.default_registry());
 
+        #[allow(unused_mut)]
+        let mut build_version = server_version.version.to_string();
+        fail_point_arg!("override_binary_version", |version: std::sync::Arc<
+            std::sync::Mutex<String>,
+        >| {
+            #[cfg(msim)]
+            {
+                build_version = version.lock().unwrap().clone();
+            }
+        });
+        // Embedded in any fork marker this run records, so recovery can refuse to clear a fork
+        // under the same binary version that produced it.
+        checkpoint_store.set_binary_version(&build_version);
+
         if node_role.runs_consensus() {
             Self::check_and_recover_forks(
                 &checkpoint_store,
                 &checkpoint_metrics,
                 config.fork_recovery.as_ref(),
-                server_version.version,
+                &build_version,
             )
             .await?;
         }
@@ -2206,7 +2220,7 @@ impl SuiNode {
             ForkCrashBehavior::AwaitForkRecovery | ForkCrashBehavior::ReturnError => {}
         }
 
-        if let Some((checkpoint_seq, checkpoint_digest)) = checkpoint_store
+        if let Some(fork_info) = checkpoint_store
             .get_checkpoint_fork_detected()
             .map_err(|e| {
                 error!("Failed to check for checkpoint fork: {:?}", e);
@@ -2214,14 +2228,14 @@ impl SuiNode {
             })?
         {
             Self::handle_checkpoint_fork(
-                checkpoint_seq,
-                checkpoint_digest,
+                fork_info.checkpoint_seq,
+                fork_info.checkpoint_digest,
                 checkpoint_metrics,
                 fork_recovery,
             )
             .await?;
         }
-        if let Some((tx_digest, expected_effects, actual_effects)) = checkpoint_store
+        if let Some(fork_info) = checkpoint_store
             .get_transaction_fork_detected()
             .map_err(|e| {
                 error!("Failed to check for transaction fork: {:?}", e);
@@ -2229,9 +2243,9 @@ impl SuiNode {
             })?
         {
             Self::handle_transaction_fork(
-                tx_digest,
-                expected_effects,
-                actual_effects,
+                fork_info.tx_digest,
+                fork_info.expected_effects_digest,
+                fork_info.actual_effects_digest,
                 checkpoint_metrics,
                 fork_recovery,
             )
@@ -2280,13 +2294,14 @@ impl SuiNode {
             }
         }
 
-        if let Some((checkpoint_seq, checkpoint_digest)) =
-            checkpoint_store.get_checkpoint_fork_detected()?
-            && recovery.checkpoint_overrides.contains_key(&checkpoint_seq)
+        if let Some(fork_info) = checkpoint_store.get_checkpoint_fork_detected()?
+            && recovery
+                .checkpoint_overrides
+                .contains_key(&fork_info.checkpoint_seq)
         {
             info!(
                 "Fork recovery enabled: clearing checkpoint fork at seq {} with digest {:?}",
-                checkpoint_seq, checkpoint_digest
+                fork_info.checkpoint_seq, fork_info.checkpoint_digest
             );
             checkpoint_store
                 .clear_checkpoint_fork_detected()
@@ -2305,14 +2320,14 @@ impl SuiNode {
             return Ok(());
         }
 
-        if let Some((tx_digest, _, _)) = checkpoint_store.get_transaction_fork_detected()?
+        if let Some(fork_info) = checkpoint_store.get_transaction_fork_detected()?
             && recovery
                 .transaction_overrides
-                .contains_key(&tx_digest.to_string())
+                .contains_key(&fork_info.tx_digest.to_string())
         {
             info!(
                 "Fork recovery enabled: clearing transaction fork for tx {:?}",
-                tx_digest
+                fork_info.tx_digest
             );
             checkpoint_store
                 .clear_transaction_fork_detected()
@@ -2321,61 +2336,107 @@ impl SuiNode {
         Ok(())
     }
 
-    /// Auto-recovery: clear any fork markers (the affected seq/tx is read from the markers) so the
-    /// node re-derives canonically, at most once per binary version. If this binary already recovered
-    /// and re-forked, the markers are left in place so it halts rather than crash-looping; deploying a
-    /// new binary version resets the guard.
+    /// Auto-recovery: clear fork markers (the affected seq/tx is read from the markers) so the
+    /// node re-derives canonically. A marker is cleared only if both gates pass:
+    ///
+    /// - Version gate: the marker was recorded by a different binary version than the one now
+    ///   running. The binary that forked would deterministically fork again, so clearing under
+    ///   it would only add a second equivocation; the node hangs until a corrected binary is
+    ///   deployed.
+    /// - Certification gate: the marker records the certified checkpoint the node diverged
+    ///   from. Markers carry it only when detection compared against a certificate already
+    ///   durably persisted locally, so its presence proves the network certified the canonical
+    ///   outcome. Recovery is deliberate equivocation — the node may have already signed the
+    ///   forked result and will sign a different one after re-deriving — which is safe only
+    ///   under that proof: a quorum certificate is irrevocable (a conflicting certificate would
+    ///   require f+1 double-signers), so re-signing can no longer influence what finalizes.
+    ///   Self-divergence markers (the node disagreeing with its own prior result rather than a
+    ///   certificate) carry no certified reference and never pass; the node halts awaiting
+    ///   operator intervention.
     fn try_recover_forks(
         checkpoint_store: &CheckpointStore,
         checkpoint_metrics: &CheckpointMetrics,
         build_version: &str,
     ) -> Result<()> {
-        let checkpoint_fork = checkpoint_store.get_checkpoint_fork_detected()?;
-        let transaction_fork = checkpoint_store.get_transaction_fork_detected()?;
-        if checkpoint_fork.is_none() && transaction_fork.is_none() {
-            return Ok(());
+        if let Some(fork_info) = checkpoint_store.get_checkpoint_fork_detected()? {
+            if fork_info.binary_version == build_version {
+                error!(
+                    checkpoint_seq = fork_info.checkpoint_seq,
+                    build_version,
+                    "Fork recovery blocked: this binary version produced the checkpoint fork and \
+                     would fork again. Halting; deploy a corrected binary to recover."
+                );
+                checkpoint_metrics
+                    .fork_auto_recovery_awaiting_new_binary
+                    .set(1);
+            } else if fork_info.certified_checkpoint_digest.is_none() {
+                // The builder re-derived a previously computed checkpoint differently: the fork
+                // is against the node's own prior result, not a certified checkpoint, so there
+                // is no canonical outcome to converge toward.
+                error!(
+                    checkpoint_seq = fork_info.checkpoint_seq,
+                    checkpoint_digest = ?fork_info.checkpoint_digest,
+                    "Fork recovery blocked: the builder re-derived its own previous checkpoint \
+                     differently, so there is no certified checkpoint proving the canonical \
+                     outcome to converge toward. Halting awaiting operator intervention."
+                );
+                checkpoint_metrics
+                    .fork_auto_recovery_blocked_uncertified
+                    .set(1);
+            } else {
+                info!(
+                    checkpoint_seq = fork_info.checkpoint_seq,
+                    checkpoint_digest = ?fork_info.checkpoint_digest,
+                    forked_binary_version = ?fork_info.binary_version,
+                    build_version,
+                    "Fork recovery: clearing checkpoint fork and locally computed checkpoints \
+                     from the forked sequence so the builder rebuilds toward the certified \
+                     checkpoint"
+                );
+                checkpoint_store
+                    .clear_locally_computed_checkpoints_from(fork_info.checkpoint_seq)
+                    .context("Failed to clear locally computed checkpoints during fork recovery")?;
+                checkpoint_store.clear_checkpoint_fork_detected()?;
+                checkpoint_metrics.checkpoint_fork_auto_recovered.set(1);
+            }
         }
 
-        if checkpoint_store.get_auto_recovery_attempt()?.as_deref() == Some(build_version) {
-            error!(
-                build_version,
-                "Fork recovery already attempted with this binary version, but the node \
-                 equivocated again. Halting; deploy a corrected binary to recover."
-            );
-            checkpoint_metrics.fork_auto_recovery_exhausted.set(1);
-            return Ok(());
-        }
-
-        // Record the attempt before clearing so a crash mid-recovery still counts as this binary
-        // version's one attempt.
-        checkpoint_store.record_auto_recovery_attempt(build_version)?;
-
-        if let Some((checkpoint_seq, checkpoint_digest)) = checkpoint_fork {
-            info!(
-                checkpoint_seq,
-                ?checkpoint_digest,
-                build_version,
-                "Fork recovery: clearing checkpoint fork and locally computed checkpoints from the \
-                 forked sequence so the builder rebuilds toward the certified checkpoint"
-            );
-            checkpoint_store
-                .clear_locally_computed_checkpoints_from(checkpoint_seq)
-                .context("Failed to clear locally computed checkpoints during fork recovery")?;
-            checkpoint_store.clear_checkpoint_fork_detected()?;
-            checkpoint_metrics.checkpoint_fork_auto_recovered.set(1);
-        }
-
-        if let Some((tx_digest, expected_effects, actual_effects)) = transaction_fork {
-            info!(
-                ?tx_digest,
-                ?expected_effects,
-                ?actual_effects,
-                build_version,
-                "Fork recovery: clearing transaction fork; re-execution will converge toward the \
-                 canonical certified effects"
-            );
-            checkpoint_store.clear_transaction_fork_detected()?;
-            checkpoint_metrics.transaction_fork_auto_recovered.set(1);
+        if let Some(fork_info) = checkpoint_store.get_transaction_fork_detected()? {
+            if fork_info.binary_version == build_version {
+                error!(
+                    tx_digest = ?fork_info.tx_digest,
+                    build_version,
+                    "Fork recovery blocked: this binary version produced the transaction fork and \
+                     would fork again. Halting; deploy a corrected binary to recover."
+                );
+                checkpoint_metrics
+                    .fork_auto_recovery_awaiting_new_binary
+                    .set(1);
+            } else if fork_info.certified_checkpoint_seq.is_none() {
+                error!(
+                    tx_digest = ?fork_info.tx_digest,
+                    "Fork recovery blocked: the expected effects of the forked transaction did \
+                     not come from a certified checkpoint (they came from this validator's own \
+                     previously signed effects), so the network has not provably certified the \
+                     canonical outcome. Halting awaiting operator intervention."
+                );
+                checkpoint_metrics
+                    .fork_auto_recovery_blocked_uncertified
+                    .set(1);
+            } else {
+                info!(
+                    tx_digest = ?fork_info.tx_digest,
+                    expected_effects = ?fork_info.expected_effects_digest,
+                    actual_effects = ?fork_info.actual_effects_digest,
+                    certified_checkpoint_seq = ?fork_info.certified_checkpoint_seq,
+                    forked_binary_version = ?fork_info.binary_version,
+                    build_version,
+                    "Fork recovery: clearing transaction fork; re-execution will converge toward \
+                     the canonical certified effects"
+                );
+                checkpoint_store.clear_transaction_fork_detected()?;
+                checkpoint_metrics.transaction_fork_auto_recovered.set(1);
+            }
         }
 
         Ok(())
@@ -2961,7 +3022,11 @@ mod tests {
 
         // Checkpoint fork.
         checkpoint_store
-            .record_checkpoint_fork_detected(42, CheckpointDigest::random())
+            .record_checkpoint_fork_detected(
+                42,
+                CheckpointDigest::random(),
+                Some(CheckpointDigest::random()),
+            )
             .unwrap();
         let r = SuiNode::check_and_recover_forks(
             &checkpoint_store,
@@ -2989,6 +3054,7 @@ mod tests {
                 TransactionDigest::random(),
                 TransactionEffectsDigest::random(),
                 TransactionEffectsDigest::random(),
+                Some(1),
             )
             .unwrap();
         let r = SuiNode::check_and_recover_forks(
@@ -3005,38 +3071,25 @@ mod tests {
         );
     }
 
-    // RecoverOncePerVersion clears the fork marker once per binary version (deriving the sequence
-    // from the marker), but leaves it set if the same binary version re-forks; a new binary version
-    // gets a fresh attempt.
+    // A fork marker carrying the currently running binary version is never cleared — the binary
+    // that forked would deterministically fork again — so the node hangs until a corrected
+    // binary (different version) runs recovery.
     #[tokio::test]
-    async fn test_recover_once_per_version() {
+    async fn test_same_binary_version_does_not_recover() {
         let checkpoint_store = CheckpointStore::new_for_tests();
         let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
         let seq = 7;
-        let digest = CheckpointDigest::random();
+        // The fork is recorded by binary "v1", against a certified checkpoint.
+        checkpoint_store.set_binary_version("v1");
         checkpoint_store
-            .record_checkpoint_fork_detected(seq, digest)
+            .record_checkpoint_fork_detected(
+                seq,
+                CheckpointDigest::random(),
+                Some(CheckpointDigest::random()),
+            )
             .unwrap();
 
-        // First attempt with "v1": recovers and flags the recovery in metrics.
-        SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v1").unwrap();
-        assert!(
-            checkpoint_store
-                .get_checkpoint_fork_detected()
-                .unwrap()
-                .is_none()
-        );
-        assert_eq!(
-            checkpoint_store.get_auto_recovery_attempt().unwrap(),
-            Some("v1".to_string())
-        );
-        assert_eq!(checkpoint_metrics.checkpoint_fork_auto_recovered.get(), 1);
-        assert_eq!(checkpoint_metrics.fork_auto_recovery_exhausted.get(), 0);
-
-        // Same binary version re-forks: one-shot consumed, marker stays, exhaustion is flagged.
-        checkpoint_store
-            .record_checkpoint_fork_detected(seq, digest)
-            .unwrap();
+        // Restarting the same binary: recovery refused despite certification.
         SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v1").unwrap();
         assert!(
             checkpoint_store
@@ -3044,9 +3097,15 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
-        assert_eq!(checkpoint_metrics.fork_auto_recovery_exhausted.get(), 1);
+        assert_eq!(
+            checkpoint_metrics
+                .fork_auto_recovery_awaiting_new_binary
+                .get(),
+            1
+        );
+        assert_eq!(checkpoint_metrics.checkpoint_fork_auto_recovered.get(), 0);
 
-        // Corrected binary (new version): fresh attempt.
+        // Corrected binary (new version): recovers.
         SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v2").unwrap();
         assert!(
             checkpoint_store
@@ -3054,10 +3113,7 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
-        assert_eq!(
-            checkpoint_store.get_auto_recovery_attempt().unwrap(),
-            Some("v2".to_string())
-        );
+        assert_eq!(checkpoint_metrics.checkpoint_fork_auto_recovered.get(), 1);
     }
 
     // The default behavior (RecoverOncePerVersion) recovers with no fork-recovery config present.
@@ -3067,16 +3123,20 @@ mod tests {
         let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
 
         let tx_digest = TransactionDigest::random();
+        // The fork was recorded by binary "v1"; its expected effects came from certified
+        // checkpoint 3, so recovery under "v2" is permitted.
+        checkpoint_store.set_binary_version("v1");
         checkpoint_store
             .record_transaction_fork_detected(
                 tx_digest,
                 TransactionEffectsDigest::random(),
                 TransactionEffectsDigest::random(),
+                Some(3),
             )
             .unwrap();
 
         let r =
-            SuiNode::check_and_recover_forks(&checkpoint_store, &checkpoint_metrics, None, "v1")
+            SuiNode::check_and_recover_forks(&checkpoint_store, &checkpoint_metrics, None, "v2")
                 .await;
         assert!(r.is_ok());
         assert!(
@@ -3085,10 +3145,7 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
-        assert_eq!(
-            checkpoint_store.get_auto_recovery_attempt().unwrap(),
-            Some("v1".to_string())
-        );
+        assert_eq!(checkpoint_metrics.transaction_fork_auto_recovered.get(), 1);
     }
 
     // checkpoint_overrides clears only the checkpoint fork marker (when the forked seq is listed); it
@@ -3099,13 +3156,18 @@ mod tests {
         let seq = 9;
 
         checkpoint_store
-            .record_checkpoint_fork_detected(seq, CheckpointDigest::random())
+            .record_checkpoint_fork_detected(
+                seq,
+                CheckpointDigest::random(),
+                Some(CheckpointDigest::random()),
+            )
             .unwrap();
         checkpoint_store
             .record_transaction_fork_detected(
                 TransactionDigest::random(),
                 TransactionEffectsDigest::random(),
                 TransactionEffectsDigest::random(),
+                None,
             )
             .unwrap();
 
@@ -3159,6 +3221,7 @@ mod tests {
                 tx_digest,
                 TransactionEffectsDigest::random(),
                 TransactionEffectsDigest::random(),
+                None,
             )
             .unwrap();
 
@@ -3195,15 +3258,21 @@ mod tests {
         );
     }
 
-    // Under RecoverOncePerVersion, a checkpoint override clears the fork via the manual path without
-    // consuming the per-version one-shot (which would otherwise burn the node's one auto attempt).
+    // Under RecoverOncePerVersion, a checkpoint override clears the fork via the manual path
+    // even when the auto path would refuse (here: the fork was recorded by the currently running
+    // binary version and the sequence is not certified).
     #[tokio::test]
-    async fn test_override_does_not_consume_one_shot() {
+    async fn test_override_clears_fork_auto_recovery_refuses() {
         let checkpoint_store = CheckpointStore::new_for_tests();
         let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
         let seq = 5;
+        checkpoint_store.set_binary_version("v1");
         checkpoint_store
-            .record_checkpoint_fork_detected(seq, CheckpointDigest::random())
+            .record_checkpoint_fork_detected(
+                seq,
+                CheckpointDigest::random(),
+                Some(CheckpointDigest::random()),
+            )
             .unwrap();
 
         let mut checkpoint_overrides = BTreeMap::new();
@@ -3218,49 +3287,76 @@ mod tests {
             .await
             .unwrap();
 
-        // The manual override cleared the marker...
         assert!(
             checkpoint_store
                 .get_checkpoint_fork_detected()
-                .unwrap()
-                .is_none()
-        );
-        // ...and the auto path left the one-shot untouched (no marker remained to act on).
-        assert!(
-            checkpoint_store
-                .get_auto_recovery_attempt()
                 .unwrap()
                 .is_none()
         );
     }
 
-    // After the one-shot is exhausted on one binary version (marker still set, attempt recorded), a
-    // node started on a new binary version recovers via the full check_and_recover_forks dispatch.
+    // A self-divergence checkpoint fork (the builder re-derived its own previous checkpoint
+    // differently; no certified digest in the marker) is never auto-recovered, even under a new
+    // binary version, because neither result is proven canonical. It requires operator
+    // overrides.
     #[tokio::test]
-    async fn test_new_version_recovers_after_exhaustion() {
+    async fn test_self_divergence_checkpoint_fork_blocks_recovery() {
         let checkpoint_store = CheckpointStore::new_for_tests();
         let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
-        let seq = 5;
-
-        // Exhausted "v1": the fork marker is still present and "v1" already used its attempt.
+        let seq = 17;
+        checkpoint_store.set_binary_version("v1");
         checkpoint_store
-            .record_checkpoint_fork_detected(seq, CheckpointDigest::random())
+            .record_checkpoint_fork_detected(seq, CheckpointDigest::random(), None)
             .unwrap();
-        checkpoint_store.record_auto_recovery_attempt("v1").unwrap();
 
-        // A new binary version recovers (default behavior, no explicit config).
-        SuiNode::check_and_recover_forks(&checkpoint_store, &checkpoint_metrics, None, "v2")
-            .await
-            .unwrap();
+        SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v2").unwrap();
+
         assert!(
             checkpoint_store
                 .get_checkpoint_fork_detected()
                 .unwrap()
-                .is_none()
+                .is_some()
         );
         assert_eq!(
-            checkpoint_store.get_auto_recovery_attempt().unwrap(),
-            Some("v2".to_string())
+            checkpoint_metrics
+                .fork_auto_recovery_blocked_uncertified
+                .get(),
+            1
+        );
+        assert_eq!(checkpoint_metrics.checkpoint_fork_auto_recovered.get(), 0);
+    }
+
+    // A transaction fork whose expected effects did not come from a certified checkpoint (i.e.
+    // they came from this validator's own previously signed effects) is never auto-recovered,
+    // even on a new binary version.
+    #[tokio::test]
+    async fn test_uncertified_transaction_fork_blocks_recovery() {
+        let checkpoint_store = CheckpointStore::new_for_tests();
+        let checkpoint_metrics = CheckpointMetrics::new(&Registry::new());
+        checkpoint_store.set_binary_version("v1");
+        checkpoint_store
+            .record_transaction_fork_detected(
+                TransactionDigest::random(),
+                TransactionEffectsDigest::random(),
+                TransactionEffectsDigest::random(),
+                None,
+            )
+            .unwrap();
+
+        SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v2").unwrap();
+        SuiNode::try_recover_forks(&checkpoint_store, &checkpoint_metrics, "v3").unwrap();
+
+        assert!(
+            checkpoint_store
+                .get_transaction_fork_detected()
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            checkpoint_metrics
+                .fork_auto_recovery_blocked_uncertified
+                .get(),
+            1
         );
     }
 }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -485,6 +485,49 @@ impl TestCluster {
             .expect("timed out waiting for reconfiguration to complete");
     }
 
+    /// Waits until every node advances to a strictly higher epoch than the one it is at when this is
+    /// called. Unlike `wait_for_epoch_all_nodes`, which matches a target epoch exactly, this only
+    /// requires forward progress, so it is safe when the cluster catches up through several epochs at
+    /// once (e.g. recovering from a stall) and would blow past any fixed target.
+    pub async fn wait_for_next_epoch_all_nodes(&self) {
+        let handles: Vec<_> = self
+            .swarm
+            .all_nodes()
+            .map(|node| node.get_node_handle().unwrap())
+            .collect();
+        let tasks: Vec<_> = handles
+            .iter()
+            .map(|handle| {
+                handle.with_async(|node| async {
+                    let start_epoch = node.state().epoch_store_for_testing().epoch();
+                    let mut retries = 0;
+                    loop {
+                        let epoch = node.state().epoch_store_for_testing().epoch();
+                        if epoch > start_epoch {
+                            if let Some(agg) = node.clone_authority_aggregator() {
+                                // Fullnode: also wait for its auth aggregator to reconfigure.
+                                if agg.committee.epoch() > start_epoch {
+                                    break;
+                                }
+                            } else {
+                                break;
+                            }
+                        }
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        retries += 1;
+                        if retries % 5 == 0 {
+                            tracing::warn!(validator=?node.state().name.concise(), "Waiting {:?}s for an epoch beyond {:?}; currently at {:?}", retries, start_epoch, epoch);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        timeout(Duration::from_secs(40), join_all(tasks))
+            .await
+            .expect("timed out waiting for all nodes to advance an epoch");
+    }
+
     pub fn subscribe_to_epoch_change(&self) -> broadcast::Receiver<SuiSystemState> {
         // fullnode_handle is not part of swarm and cannot be dropped / killed
         self.fullnode_handle


### PR DESCRIPTION
## Description

When a validator detects a fork it records a marker and dies; recovery (clearing the marker and re-deriving) is deliberate equivocation, since the node may have already signed the forked result. This is safe only when the network has already certified the canonical outcome — a quorum certificate is irrevocable, so re-signing cannot change what finalizes — and pointless under the binary that forked, which would deterministically fork again.

Automatic recovery at startup therefore clears a fork marker only when both hold:

- the marker records the certified checkpoint the node diverged from (checkpoint forks store the certified digest; transaction forks store the sequence of the certified checkpoint that supplied the expected effects). Detection persists the certificate before the marker, so this provenance proves the network sealed the outcome. Self-divergence — the builder re-deriving its own previous checkpoint differently, or execution diverging from the node's own previously signed effects — carries no certified reference and is never auto-recovered; it requires explicit `ForkRecoveryConfig` overrides.
- the marker was recorded by a different binary version than the one now running, so the node hangs after a fork until a corrected binary is deployed. This also bounds recurrence without a separate attempt counter: if the new binary forks too, its own marker blocks it in turn.

Markers move to new column families (`checkpoint_fork_detected`, `transaction_fork_detected_v2`) carrying the provenance and forking version; the old watermark key and tuple table are retired. `ExecutionEnv`'s expected effects digest becomes an enum (`Certified { digest, checkpoint_seq }` / `Uncertified`) so provenance is explicit at every call site.

## Test plan

- sui-node unit tests cover the recovery gates: same-version forks hang until a new binary, self-divergence and own-signed-effects forks never auto-recover, certified forks recover, and operator overrides clear markers the auto path refuses.
- Simtests `test_auto_fork_recovery_checkpoint_fork` and `test_auto_fork_recovery_transaction_fork` exercise both fork classes end-to-end (detection, crash, restart under a corrected binary via an `override_binary_version` failpoint, recovery, rejoin); `test_split_brain_recovery_via_checkpoint_overrides` covers the manual path when nothing certifies.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Validators automatically recover from checkpoint and transaction forks on restart when the network has certified the canonical outcome and a new binary version is deployed; forks caused by the running binary version, or without a certified outcome, halt the node awaiting a corrected binary or operator-supplied fork recovery overrides.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
