### PR TITLE
[state sync] support GCS (incl. requester-pays) in archive fallback

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -968,6 +968,7 @@ impl NodeConfig {
             .map(|config| ArchiveReaderConfig {
                 ingestion_url: config.ingestion_url.clone(),
                 remote_store_options: config.remote_store_options.clone(),
+                remote_store_headers: config.remote_store_headers.clone(),
                 download_concurrency: NonZeroUsize::new(config.concurrency)
                     .unwrap_or(NonZeroUsize::new(5).unwrap()),
                 remote_store_config: ObjectStoreConfig::default(),
@@ -1329,6 +1330,7 @@ pub struct ArchiveReaderConfig {
     pub download_concurrency: NonZeroUsize,
     pub ingestion_url: Option<String>,
     pub remote_store_options: Vec<(String, String)>,
+    pub remote_store_headers: Vec<(String, String)>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
@@ -1345,6 +1347,11 @@ pub struct StateArchiveConfig {
         deserialize_with = "deserialize_remote_store_options"
     )]
     pub remote_store_options: Vec<(String, String)>,
+    /// Default headers (name, value) attached to every archive store request,
+    /// e.g. `x-goog-user-project` to bill a GCS requester-pays bucket. Unlike
+    /// `remote_store_options`, these are HTTP headers, not object-store config keys.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub remote_store_headers: Vec<(String, String)>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -1616,8 +1616,11 @@ async fn sync_checkpoint_contents_from_archive_iteration<S>(
             warn!("{} can't be used as an archival fallback", ingestion_url);
             return;
         }
-        let obj_store =
-            build_object_store(ingestion_url, archive_config.remote_store_options.clone());
+        let obj_store = build_object_store(
+            ingestion_url,
+            archive_config.remote_store_options.clone(),
+            archive_config.remote_store_headers.clone(),
+        );
         let mut checkpoint_stream = futures::stream::iter(start..=end)
             .map(|seq| {
                 let obj_store = obj_store.clone();

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -315,6 +315,7 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
         download_concurrency: NonZeroUsize::new(1).unwrap(),
         ingestion_url: Some(format!("file://{}", temp_dir.display())),
         remote_store_options: vec![],
+        remote_store_headers: vec![],
     };
     // Build and connect two nodes where Node 1 will be given access to an archive store
     // Node 2 will prune older checkpoints, so Node 1 is forced to backfill from the archive

--- a/crates/sui-storage/src/object_store/util.rs
+++ b/crates/sui-storage/src/object_store/util.rs
@@ -14,6 +14,7 @@ use indicatif::ProgressBar;
 use itertools::Itertools;
 use mysten_common::ZipDebugEqIteratorExt;
 use object_store::aws::{AmazonS3Builder, AmazonS3ConfigKey};
+use object_store::gcp::{GoogleCloudStorageBuilder, GoogleConfigKey};
 use object_store::http::HttpBuilder;
 use object_store::local::LocalFileSystem;
 use object_store::path::Path;
@@ -21,6 +22,7 @@ use object_store::{
     ClientOptions, DynObjectStore, Error, ObjectStore, ObjectStoreExt, RetryConfig,
 };
 use prost::Message;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::BTreeMap;
@@ -442,11 +444,22 @@ pub async fn write_snapshot_manifest<S: ObjectStoreListExt + ObjectStorePutExt>(
 pub fn build_object_store(
     ingestion_url: &str,
     remote_store_options: Vec<(String, String)>,
+    remote_store_headers: Vec<(String, String)>,
 ) -> Arc<dyn ObjectStore> {
     let timeout_secs = 5;
-    let client_options = ClientOptions::new()
+    let mut client_options = ClientOptions::new()
         .with_timeout(Duration::from_secs(timeout_secs))
         .with_allow_http(true);
+    if !remote_store_headers.is_empty() {
+        let mut headers = HeaderMap::new();
+        for (name, value) in &remote_store_headers {
+            headers.insert(
+                HeaderName::from_bytes(name.as_bytes()).expect("invalid remote store header name"),
+                HeaderValue::from_str(value).expect("invalid remote store header value"),
+            );
+        }
+        client_options = client_options.with_default_headers(headers);
+    }
     let retry_config = RetryConfig {
         max_retries: 10,
         retry_timeout: Duration::from_secs(timeout_secs + 1),
@@ -463,6 +476,18 @@ pub fn build_object_store(
             )
             .expect("failed to create local file system store"),
         )
+    } else if url.scheme() == "gs" {
+        let mut builder = GoogleCloudStorageBuilder::new()
+            .with_client_options(client_options)
+            .with_retry(retry_config)
+            .with_url(ingestion_url);
+        for (key, value) in &remote_store_options {
+            builder = builder.with_config(
+                GoogleConfigKey::from_str(key).expect("invalid GCS config key"),
+                value.clone(),
+            );
+        }
+        Arc::new(builder.build().expect("failed to build GCS store"))
     } else if url.host_str().unwrap_or_default().starts_with("s3") {
         let mut builder = AmazonS3Builder::new()
             .with_client_options(client_options)
@@ -529,7 +554,7 @@ pub async fn end_of_epoch_data(
     url: &str,
     remote_store_options: Vec<(String, String)>,
 ) -> anyhow::Result<Vec<CheckpointSequenceNumber>> {
-    let store = build_object_store(url, remote_store_options);
+    let store = build_object_store(url, remote_store_options, vec![]);
     let response = store.get(&Path::from("epochs.json")).await?;
     let bytes = response.bytes().await?;
     Ok(serde_json::from_slice(&bytes)?)

--- a/crates/sui-tool/src/formal_snapshot_util.rs
+++ b/crates/sui-tool/src/formal_snapshot_util.rs
@@ -20,7 +20,7 @@ pub(crate) async fn read_summaries_for_list_no_verify<S>(
 where
     S: WriteStore + Clone,
 {
-    let client = build_object_store(&ingestion_url, vec![]);
+    let client = build_object_store(&ingestion_url, vec![], vec![]);
     futures::stream::iter(checkpoints)
         .map(|sq| fetch_checkpoint(&client, sq))
         .buffer_unordered(concurrency)

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -1115,7 +1115,7 @@ async fn backfill_epoch_transaction_digests(
         ),
     );
 
-    let client = build_object_store(&ingestion_url, vec![]);
+    let client = build_object_store(&ingestion_url, vec![], vec![]);
     let checkpoint_counter = Arc::new(AtomicU64::new(0));
     let tx_counter = Arc::new(AtomicU64::new(0));
     let cloned_checkpoint_counter = checkpoint_counter.clone();


### PR DESCRIPTION
## Description

`build_object_store` (in `sui-storage`), used by the state-sync archive fallback, dispatched only on `file` / `s3` / `http` URLs and had **no GCS branch**. A `gs://` ingestion-url therefore fell through to the plain `HttpBuilder` and failed with a request `"builder error"`, and there was no way to use a GCS bucket — let alone a requester-pays one — as the archive fallback.

The `gs://` branch had existed in `sui-data-ingestion-core::create_remote_store_client` but was lost when #26006 reimplemented store construction inside `sui-storage` to drop the `sui-data-ingestion-core` dependency.

This keeps the archive fallback on the single URL-based store builder (no `ObjectStoreConfig` in the state-sync path) and adds:

- A `gs://` branch in `build_object_store` using `GoogleCloudStorageBuilder`. `remote_store_options` map to `GoogleConfigKey`s (e.g. `google_service_account`), exactly as the `s3` branch maps them to `AmazonS3ConfigKey`s.
- A first-class **`remote_store_headers`** input on `StateArchiveConfig` / `ArchiveReaderConfig`, applied as default headers on every request for *all* backends. `object_store`'s `GoogleConfigKey` has no requester-pays variant, and a billing project is an HTTP header (`x-goog-user-project`), not an object-store config key — so it's modeled as a header rather than special-cased by key name inside `remote_store_options`. This mirrors `sui-indexer-alt-framework`'s `--remote-store-header`, which configures the identical requester-pays buckets in production today.

`file` / `s3` / `http` behavior is unchanged.

### Example config

```yaml
state-archive-read-config:
  - ingestion-url: "gs://my-checkpoints-bucket"
    remote-store-options: # object-store config keys
      - ["google_service_account", "/opt/sui/config/gcs-sa.json"]
    remote-store-headers: # HTTP headers
      - ["x-goog-user-project", "my-billing-project"] # requester-pays billing
    concurrency: 5
```

## Release notes

- [x] Nodes (Validators and Full nodes): the state-sync archive fallback now supports `gs://` (Google Cloud Storage) ingestion URLs. A new `remote-store-headers` option under `state-archive-read-config` attaches default HTTP headers to archive requests, which enables requester-pays GCS buckets via `x-goog-user-project`. Previously only `file` / `s3` / `http` archive stores were supported.