### PR TITLE
docker(sui-tools): build and ship the sui-fork binary

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -31,7 +31,8 @@ RUN cargo build --locked --profile ${PROFILE} \
     --bin sui-cluster-test \
     --bin sui-tool \
     --bin move-analyzer \
-    --bin sui-metric-checker
+    --bin sui-metric-checker \
+    --bin sui-fork
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
@@ -53,6 +54,7 @@ COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin/sui-clus
 COPY --from=builder /sui/target/release/sui-tool         /usr/local/bin/sui-tool
 COPY --from=builder /sui/target/release/move-analyzer    /usr/local/bin/move-analyzer
 COPY --from=builder /sui/target/release/sui-metric-checker  /usr/local/bin/sui-metric-checker
+COPY --from=builder /sui/target/release/sui-fork            /usr/local/bin/sui-fork
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## What
Add `--bin sui-fork` and its `COPY` to `docker/sui-tools/Dockerfile` so the image actually compiles and ships the `sui-fork` binary.

## Why
`sui-fork` was added to `binary-build-list.json` → `release_binaries` in #26570 (2026-05-11), but the build pipeline never caught up:
- the `sui-tools` image doesn't compile it (no `--bin sui-fork`), and
- mp3's `binary_upload_config` doesn't upload it.

So `s3://sui-releases/<sha>/sui-fork` is never produced, and `sui-operations`'s **Build and Publish Sui Binaries to GCP** fails on every run at "Download prebuilt binaries from S3" with `Missing prebuilt binaries … sui-fork`.

## Companion change
mp3 `binary_upload_config` is updated to upload `/usr/local/bin/sui-fork` (separate sui-operations PR). Both must land, then re-prebuild a commit that includes **this** Dockerfile change before re-running the publish workflow.

## Notes
- `sui-fork` is a real crate (`crates/sui-fork`, package `sui-fork` + `src/main.rs`) → valid `--bin` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)