### PR TITLE
[2/6] Rename ChildObjectResolver to RuntimeObjectResolver

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -35,7 +35,7 @@ use sui_types::effects::TransactionEffectsAPI;
 use sui_types::messages_consensus::ConsensusDeterminedVersionAssignments;
 use sui_types::object::{Object, Owner};
 use sui_types::storage::ObjectKey;
-use sui_types::storage::{ChildObjectResolver, ObjectStore, ReadStore, RpcStateReader};
+use sui_types::storage::{ObjectStore, ReadStore, RpcStateReader, RuntimeObjectResolver};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::transaction::EndOfEpochTransactionKind;
 use sui_types::{
@@ -725,7 +725,7 @@ impl<T, V: store::SimulatorStore> ObjectStore for Simulacrum<T, V> {
     }
 }
 
-impl<T, V: store::SimulatorStore> ChildObjectResolver for Simulacrum<T, V> {
+impl<T, V: store::SimulatorStore> RuntimeObjectResolver for Simulacrum<T, V> {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -22,7 +22,7 @@ use sui_types::{
         VerifiedCheckpoint,
     },
     object::{Object, Owner},
-    storage::{BackingPackageStore, ChildObjectResolver, ObjectStore, ParentSync},
+    storage::{BackingPackageStore, ObjectStore, ParentSync, RuntimeObjectResolver},
     transaction::VerifiedTransaction,
 };
 
@@ -228,7 +228,7 @@ impl BackingPackageStore for InMemoryStore {
     }
 }
 
-impl ChildObjectResolver for InMemoryStore {
+impl RuntimeObjectResolver for InMemoryStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -20,7 +20,7 @@ use sui_types::{
         VerifiedCheckpoint,
     },
     object::Object,
-    storage::{BackingStore, ChildObjectResolver, ParentSync},
+    storage::{BackingStore, ParentSync, RuntimeObjectResolver},
     transaction::{InputObjectKind, VerifiedTransaction},
 };
 pub mod in_mem_store;
@@ -29,7 +29,7 @@ pub trait SimulatorStore:
     sui_types::storage::BackingPackageStore
     + sui_types::storage::ObjectStore
     + ParentSync
-    + ChildObjectResolver
+    + RuntimeObjectResolver
 {
     fn init_with_genesis(&mut self, genesis: &genesis::Genesis) {
         self.insert_checkpoint(genesis.checkpoint());

--- a/crates/sui-core/src/accumulators/balances.rs
+++ b/crates/sui-core/src/accumulators/balances.rs
@@ -3,19 +3,19 @@
 
 use sui_types::{
     TypeTag, accumulator_root::AccumulatorValue, balance::Balance, base_types::SuiAddress,
-    error::SuiResult, storage::ChildObjectResolver,
+    error::SuiResult, storage::RuntimeObjectResolver,
 };
 
 /// Get the balance for a given owner address (which can be a wallet or an object)
 /// and currency type (e.g. 0x2::sui::SUI)
 pub fn get_balance(
     owner: SuiAddress,
-    child_object_resolver: &dyn ChildObjectResolver,
+    runtime_object_resolver: &dyn RuntimeObjectResolver,
     currency_type: TypeTag,
 ) -> SuiResult<u64> {
     let balance_type = Balance::type_tag(currency_type);
     let address_balance =
-        AccumulatorValue::load(child_object_resolver, None, owner, &balance_type)?
+        AccumulatorValue::load(runtime_object_resolver, None, owner, &balance_type)?
             .and_then(|b| b.as_u128())
             .unwrap_or(0);
 
@@ -40,13 +40,13 @@ pub fn get_balance(
 /// (which can be a wallet or an object)
 pub fn get_all_balances_for_owner(
     owner: SuiAddress,
-    child_object_resolver: &dyn ChildObjectResolver,
+    runtime_object_resolver: &dyn RuntimeObjectResolver,
     index_store: &crate::jsonrpc_index::IndexStore,
 ) -> SuiResult<Vec<(TypeTag, u64)>> {
     let currency_types = index_store.get_address_balance_coin_types_iter(owner);
     let mut balances = Vec::new();
     for currency_type in currency_types {
-        let balance = get_balance(owner, child_object_resolver, currency_type.clone())?;
+        let balance = get_balance(owner, runtime_object_resolver, currency_type.clone())?;
         balances.push((currency_type, balance));
     }
     Ok(balances)

--- a/crates/sui-core/src/accumulators/coin_reservations.rs
+++ b/crates/sui-core/src/accumulators/coin_reservations.rs
@@ -11,7 +11,7 @@ use sui_types::{
         CoinReservationResolver, CoinReservationResolverTrait, ParsedObjectRefWithdrawal,
     },
     error::{UserInputError, UserInputResult},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
     transaction::FundsWithdrawalArg,
 };
 
@@ -23,9 +23,9 @@ pub struct CachingCoinReservationResolver {
 }
 
 impl CachingCoinReservationResolver {
-    pub fn new(child_object_resolver: Arc<dyn ChildObjectResolver + Send + Sync>) -> Self {
+    pub fn new(runtime_object_resolver: Arc<dyn RuntimeObjectResolver + Send + Sync>) -> Self {
         Self {
-            inner: CoinReservationResolver::new(child_object_resolver),
+            inner: CoinReservationResolver::new(runtime_object_resolver),
             cache: MokaCache::builder().max_capacity(1000).build(),
         }
     }

--- a/crates/sui-core/src/accumulators/design_docs/data_model.md
+++ b/crates/sui-core/src/accumulators/design_docs/data_model.md
@@ -118,7 +118,7 @@ Three things to internalize:
 The per-account accumulator object itself is also versioned. Reads can be **version-bounded**:
 
 ```rust
-AccumulatorValue::load(child_object_resolver, version_bound, owner, type_) -> Option<Self>
+AccumulatorValue::load(runtime_object_resolver, version_bound, owner, type_) -> Option<Self>
 ```
 
 This is how `AccountFundsRead::get_account_amount_at_version` works. Version-bounded reads use

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -84,9 +84,9 @@ use sui_types::layout_resolver::into_struct_layout;
 use sui_types::messages_consensus::AuthorityCapabilitiesV2;
 use sui_types::node_role::NodeRole;
 use sui_types::object::bounded_visitor::BoundedVisitor;
-use sui_types::storage::ChildObjectResolver;
 use sui_types::storage::InputKey;
 use sui_types::storage::OverlayBackingPackageStore;
+use sui_types::storage::RuntimeObjectResolver;
 use sui_types::storage::TrackingBackingStore;
 use sui_types::traffic_control::{
     PolicyConfig, RemoteFirewallConfig, TrafficControlReconfigParams,
@@ -3698,7 +3698,9 @@ impl AuthorityState {
         });
 
         let coin_reservation_resolver = Arc::new(CachingCoinReservationResolver::new(
-            execution_cache_trait_pointers.child_object_resolver.clone(),
+            execution_cache_trait_pointers
+                .runtime_object_resolver
+                .clone(),
         ));
 
         let object_funds_checker_metrics =
@@ -3813,8 +3815,8 @@ impl AuthorityState {
         &self.execution_cache_trait_pointers.backing_store
     }
 
-    pub fn get_child_object_resolver(&self) -> &Arc<dyn ChildObjectResolver + Send + Sync> {
-        &self.execution_cache_trait_pointers.child_object_resolver
+    pub fn get_runtime_object_resolver(&self) -> &Arc<dyn RuntimeObjectResolver + Send + Sync> {
+        &self.execution_cache_trait_pointers.runtime_object_resolver
     }
 
     pub(crate) fn get_account_funds_read(&self) -> &Arc<dyn AccountFundsRead> {
@@ -4658,7 +4660,7 @@ impl AuthorityState {
     ) -> SuiResult<Option<(ObjectRef, u64, TransactionDigest)>> {
         let accumulator_id = AccumulatorValue::get_field_id(owner, &balance_type)?;
         let accumulator_obj = AccumulatorValue::load_object_by_id(
-            self.get_child_object_resolver().as_ref(),
+            self.get_runtime_object_resolver().as_ref(),
             None,
             *accumulator_id.inner(),
         )?;
@@ -4674,7 +4676,7 @@ impl AuthorityState {
 
         let balance = crate::accumulators::balances::get_balance(
             owner,
-            self.get_child_object_resolver().as_ref(),
+            self.get_runtime_object_resolver().as_ref(),
             currency_type,
         )?;
 

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -31,8 +31,8 @@ use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::storage::{
-    BackingPackageStore, BackingStore, ChildObjectResolver, FullObjectKey, MarkerValue, ObjectKey,
-    ObjectOrTombstone, ObjectStore, PackageObject, ParentSync,
+    BackingPackageStore, BackingStore, FullObjectKey, MarkerValue, ObjectKey, ObjectOrTombstone,
+    ObjectStore, PackageObject, ParentSync, RuntimeObjectResolver,
 };
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::transaction::VerifiedTransaction;
@@ -62,7 +62,7 @@ pub struct ExecutionCacheTraitPointers {
     pub transaction_cache_reader: Arc<dyn TransactionCacheRead>,
     pub cache_writer: Arc<dyn ExecutionCacheWrite>,
     pub backing_store: Arc<dyn BackingStore + Send + Sync>,
-    pub child_object_resolver: Arc<dyn ChildObjectResolver + Send + Sync>,
+    pub runtime_object_resolver: Arc<dyn RuntimeObjectResolver + Send + Sync>,
     pub backing_package_store: Arc<dyn BackingPackageStore + Send + Sync>,
     pub object_store: Arc<dyn ObjectStore + Send + Sync>,
     pub reconfig_api: Arc<dyn ExecutionCacheReconfigAPI>,
@@ -97,7 +97,7 @@ impl ExecutionCacheTraitPointers {
             transaction_cache_reader: cache.clone(),
             cache_writer: cache.clone(),
             backing_store: cache.clone(),
-            child_object_resolver: cache.clone(),
+            runtime_object_resolver: cache.clone(),
             backing_package_store: cache.clone(),
             object_store: cache.clone(),
             reconfig_api: cache.clone(),
@@ -722,7 +722,7 @@ macro_rules! implement_storage_traits {
             }
         }
 
-        impl ChildObjectResolver for $implementor {
+        impl RuntimeObjectResolver for $implementor {
             fn read_child_object(
                 &self,
                 parent: &ObjectID,

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -22,7 +22,7 @@ use sui_types::{
     base_types::{FullObjectRef, SuiAddress, random_object_ref},
     crypto::{AccountKeyPair, deterministic_random_account_key, get_key_pair_from_rng},
     object::{MoveObject, OBJECT_START_VERSION, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 use sui_types::{
     effects::{TestEffectsBuilder, TransactionEffectsAPI},

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -29,7 +29,6 @@ use sui_types::object::Object;
 use sui_types::object::Owner;
 use sui_types::storage::BalanceInfo;
 use sui_types::storage::BalanceIterator;
-use sui_types::storage::ChildObjectResolver;
 use sui_types::storage::CoinInfo;
 use sui_types::storage::DynamicFieldKey;
 use sui_types::storage::LedgerBitmapBucketIterator;
@@ -39,6 +38,7 @@ use sui_types::storage::ObjectStore;
 use sui_types::storage::OwnedObjectInfo;
 use sui_types::storage::RpcIndexes;
 use sui_types::storage::RpcStateReader;
+use sui_types::storage::RuntimeObjectResolver;
 use sui_types::storage::WriteStore;
 use sui_types::storage::error::Error as StorageError;
 use sui_types::storage::error::Result;
@@ -531,7 +531,7 @@ impl ReadStore for RestReadStore {
     }
 }
 
-impl ChildObjectResolver for RestReadStore {
+impl RuntimeObjectResolver for RestReadStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,
@@ -778,7 +778,7 @@ impl ReadStore for RpcStoreReadStore {
     }
 }
 
-impl ChildObjectResolver for RpcStoreReadStore {
+impl RuntimeObjectResolver for RpcStoreReadStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -321,13 +321,13 @@ async fn test_deposits() {
     test_env.cluster.fullnode_handle.sui_node.with(|node| {
 
         let state = node.state();
-        let child_object_resolver = state.get_child_object_resolver().as_ref();
+        let runtime_object_resolver = state.get_runtime_object_resolver().as_ref();
 
         // Ensure that the accumulator root object is considered a read-only InputConsensusObject
         // by the settlement transaction.
         let sui_coin_type = Balance::type_tag(GAS::type_tag());
         let accumulator_object =
-            AccumulatorValue::load_object(child_object_resolver, None, recipient, &sui_coin_type)
+            AccumulatorValue::load_object(runtime_object_resolver, None, recipient, &sui_coin_type)
                 .expect("read cannot fail")
                 .expect("accumulator should exist");
         let settlement_digest = accumulator_object.previous_transaction;
@@ -3001,9 +3001,10 @@ async fn test_get_all_balances() {
     test_env.cluster.fullnode_handle.sui_node.with(|node| {
         let state = node.state();
         let indexes = state.indexes.clone().unwrap();
-        let child_object_resolver = state.get_child_object_resolver().as_ref();
+        let runtime_object_resolver = state.get_runtime_object_resolver().as_ref();
 
-        let balances = get_all_balances_for_owner(sender, child_object_resolver, &indexes).unwrap();
+        let balances =
+            get_all_balances_for_owner(sender, runtime_object_resolver, &indexes).unwrap();
 
         assert_eq!(balances.len(), 2);
         assert!(

--- a/crates/sui-fork/src/store.rs
+++ b/crates/sui-fork/src/store.rs
@@ -45,7 +45,6 @@ use sui_types::storage::BackingPackageStore;
 use sui_types::storage::BackingStore;
 use sui_types::storage::BalanceInfo;
 use sui_types::storage::BalanceIterator;
-use sui_types::storage::ChildObjectResolver;
 use sui_types::storage::CoinInfo;
 use sui_types::storage::DynamicFieldIteratorItem;
 use sui_types::storage::DynamicFieldKey;
@@ -60,6 +59,7 @@ use sui_types::storage::ParentSync;
 use sui_types::storage::ReadStore;
 use sui_types::storage::RpcIndexes;
 use sui_types::storage::RpcStateReader;
+use sui_types::storage::RuntimeObjectResolver;
 use sui_types::storage::error::Error as StorageError;
 use sui_types::storage::error::Result as StorageResult;
 use sui_types::storage::load_package_object_from_object_store;
@@ -872,7 +872,7 @@ impl ParentSync for DataStore {
     }
 }
 
-impl ChildObjectResolver for DataStore {
+impl RuntimeObjectResolver for DataStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -571,7 +571,7 @@ fn test_read_child_object_uses_highest_local_version_within_bound() {
     store.local().write_object(&child_v5).unwrap();
     store.local().write_object(&child_v7).unwrap();
 
-    let child = sui_types::storage::ChildObjectResolver::read_child_object(
+    let child = sui_types::storage::RuntimeObjectResolver::read_child_object(
         &store,
         &parent,
         &child_id,
@@ -610,7 +610,7 @@ async fn test_read_child_object_falls_back_to_remote_root_version() {
 
     let store =
         DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), checkpoint);
-    let read = sui_types::storage::ChildObjectResolver::read_child_object(
+    let read = sui_types::storage::RuntimeObjectResolver::read_child_object(
         &store,
         &parent,
         &child_id,
@@ -636,7 +636,7 @@ fn test_read_child_object_rejects_wrong_owner_after_bounded_lookup() {
 
     store.local().write_object(&child).unwrap();
 
-    let err = sui_types::storage::ChildObjectResolver::read_child_object(
+    let err = sui_types::storage::RuntimeObjectResolver::read_child_object(
         &store,
         &parent,
         &child_id,

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -653,11 +653,11 @@ impl StateRead for AuthorityState {
         coin_type: TypeTag,
     ) -> StateReadResult<TotalBalance> {
         let indexes = self.indexes.clone();
-        let child_object_resolver = self.get_child_object_resolver().clone();
+        let runtime_object_resolver = self.get_runtime_object_resolver().clone();
         Ok(
             tokio::task::spawn_blocking(move || -> SuiResult<TotalBalance> {
                 let address_balance =
-                    get_balance(owner, child_object_resolver.as_ref(), coin_type.clone())?;
+                    get_balance(owner, runtime_object_resolver.as_ref(), coin_type.clone())?;
                 let coin_balance = indexes
                     .as_ref()
                     .ok_or(SuiErrorKind::IndexStoreNotAvailable)?
@@ -682,14 +682,14 @@ impl StateRead for AuthorityState {
         owner: SuiAddress,
     ) -> StateReadResult<Arc<HashMap<TypeTag, TotalBalance>>> {
         let indexes = self.indexes.clone();
-        let child_object_resolver = self.get_child_object_resolver().clone();
+        let runtime_object_resolver = self.get_runtime_object_resolver().clone();
         Ok(tokio::task::spawn_blocking(
             move || -> SuiResult<Arc<HashMap<TypeTag, TotalBalance>>> {
                 let indexes = indexes
                     .as_ref()
                     .ok_or(SuiErrorKind::IndexStoreNotAvailable)?;
                 let address_balances =
-                    get_all_balances_for_owner(owner, child_object_resolver.as_ref(), indexes)?;
+                    get_all_balances_for_owner(owner, runtime_object_resolver.as_ref(), indexes)?;
                 let coin_balances = (*indexes.get_all_coin_object_balances(owner)?).clone();
                 let mut all_balances = coin_balances;
                 for (coin_type, balance) in address_balances {

--- a/crates/sui-replay-2/README.md
+++ b/crates/sui-replay-2/README.md
@@ -63,7 +63,7 @@ The 3 main interfaces are:
 <p>
 
 `execution.rs` is the wrapper around `execute_transaction_to_effects` and the implementation of the storage traits
-is there (`BackingPackageStore`, `ObjectStore`, `ChildObjectResolver`)
+is there (`BackingPackageStore`, `ObjectStore`, `RuntimeObjectResolver`)
 </p>
 <p>
 

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -9,7 +9,7 @@
 //! as in transaction data and effects, and from the `ObjectStore` for dynamic loads
 //! (e.g. dynamic fields).
 //! This module also contains the traits used by execution to talk to
-//! the store (BackingPackageStore, ObjectStore, ChildObjectResolver)
+//! the store (BackingPackageStore, ObjectStore, RuntimeObjectResolver)
 
 use crate::replay_txn::ReplayTransaction;
 use anyhow::{Context, Error, anyhow};
@@ -33,7 +33,7 @@ use sui_types::{
     inner_temporary_store::InnerTemporaryStore,
     metrics::ExecutionMetrics,
     object::Object,
-    storage::{BackingPackageStore, ChildObjectResolver, PackageObject, ParentSync},
+    storage::{BackingPackageStore, PackageObject, ParentSync, RuntimeObjectResolver},
     supported_protocol_versions::ProtocolConfig,
     transaction::{CheckedInputObjects, TransactionData, TransactionDataAPI},
 };
@@ -346,7 +346,7 @@ impl sui_types::storage::ObjectStore for ReplayStore<'_> {
     }
 }
 
-impl ChildObjectResolver for ReplayStore<'_> {
+impl RuntimeObjectResolver for ReplayStore<'_> {
     // Load an `Object` at a root version. That is the version that is
     // less than or equal to the given `child_version_upper_bound`.
     fn read_child_object(

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -59,7 +59,7 @@ use sui_types::{
     metrics::ExecutionMetrics,
     object::{Object, Owner},
     storage::get_module_by_id,
-    storage::{BackingPackageStore, ChildObjectResolver, ObjectStore, ParentSync},
+    storage::{BackingPackageStore, ObjectStore, ParentSync, RuntimeObjectResolver},
     transaction::{
         CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
         SenderSignedData, Transaction, TransactionDataAPI, TransactionKind, VerifiedTransaction,
@@ -1938,7 +1938,7 @@ impl BackingPackageStore for LocalExec {
     }
 }
 
-impl ChildObjectResolver for LocalExec {
+impl RuntimeObjectResolver for LocalExec {
     /// This uses `get_object`, which does not download from the network
     /// Hence all objects must be in store already
     fn read_child_object(
@@ -1983,7 +1983,7 @@ impl ChildObjectResolver for LocalExec {
             .lock()
             .expect("Unable to lock events list")
             .push(
-                ExecutionStoreEvent::ChildObjectResolverStoreReadChildObject {
+                ExecutionStoreEvent::RuntimeObjectResolverStoreReadChildObject {
                     parent: *parent,
                     child: *child,
                     result: res.clone(),

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -282,7 +282,7 @@ pub enum ExecutionStoreEvent {
         package_id: ObjectID,
         result: SuiResult<Option<Object>>,
     },
-    ChildObjectResolverStoreReadChildObject {
+    RuntimeObjectResolverStoreReadChildObject {
         parent: ObjectID,
         child: ObjectID,
         result: SuiResult<Option<Object>>,

--- a/crates/sui-rpc-store/src/reader/child_resolver.rs
+++ b/crates/sui-rpc-store/src/reader/child_resolver.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! [`ChildObjectResolver`] adapter.
+//! [`RuntimeObjectResolver`] adapter.
 //!
-//! `ChildObjectResolver` is one of the supertrait bounds on
+//! `RuntimeObjectResolver` is one of the supertrait bounds on
 //! [`sui_types::storage::RpcStateReader`]. Its methods feed the
 //! Move runtime's dynamic-field / receive-object paths. **This
 //! adapter is read-only and does not serve Move execution**: it
@@ -21,11 +21,11 @@ use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::error::SuiResult;
 use sui_types::object::Object;
-use sui_types::storage::ChildObjectResolver;
+use sui_types::storage::RuntimeObjectResolver;
 
 use crate::reader::RpcStoreReader;
 
-impl<R: Reader + Send + Sync> ChildObjectResolver for RpcStoreReader<R> {
+impl<R: Reader + Send + Sync> RuntimeObjectResolver for RpcStoreReader<R> {
     fn read_child_object(
         &self,
         _parent: &ObjectID,

--- a/crates/sui-rpc-store/src/reader/mod.rs
+++ b/crates/sui-rpc-store/src/reader/mod.rs
@@ -3,7 +3,7 @@
 
 //! Adapter that exposes [`RpcStoreSchema`] through the trait stack
 //! `sui-rpc-api` consumes — [`ObjectStore`], [`ReadStore`],
-//! [`ChildObjectResolver`], [`RpcStateReader`], and [`RpcIndexes`].
+//! [`RuntimeObjectResolver`], [`RpcStateReader`], and [`RpcIndexes`].
 //!
 //! The adapter type, [`RpcStoreReader`], is generic over a
 //! [`Reader`] so a single struct serves both tip reads (`R = Db`)
@@ -15,7 +15,7 @@
 //!
 //! [`ObjectStore`]: sui_types::storage::ObjectStore
 //! [`ReadStore`]: sui_types::storage::ReadStore
-//! [`ChildObjectResolver`]: sui_types::storage::ChildObjectResolver
+//! [`RuntimeObjectResolver`]: sui_types::storage::RuntimeObjectResolver
 //! [`RpcStateReader`]: sui_types::storage::RpcStateReader
 //! [`RpcIndexes`]: sui_types::storage::RpcIndexes
 //! [`Reader`]: sui_consistent_store::reader::Reader

--- a/crates/sui-rpc-store/src/reader/state_reader.rs
+++ b/crates/sui-rpc-store/src/reader/state_reader.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! [`RpcStateReader`] rollup — composes [`ObjectStore`],
-//! [`ReadStore`], [`ChildObjectResolver`], and [`RpcIndexes`] (all
+//! [`ReadStore`], [`RuntimeObjectResolver`], and [`RpcIndexes`] (all
 //! impl'd in sibling modules) into the top-level trait
 //! `sui-rpc-api` consumes.
 //!

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -14,7 +14,7 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::inner_temporary_store::InnerTemporaryStore;
 use sui_types::object::{Object, Owner};
 use sui_types::storage::{
-    BackingPackageStore, ChildObjectResolver, ObjectStore, PackageObject, ParentSync,
+    BackingPackageStore, ObjectStore, PackageObject, ParentSync, RuntimeObjectResolver,
     get_module_by_id,
 };
 use sui_types::transaction::{InputObjectKind, InputObjects, ObjectReadResult, TransactionKey};
@@ -116,7 +116,7 @@ impl BackingPackageStore for InMemoryObjectStore {
     }
 }
 
-impl ChildObjectResolver for InMemoryObjectStore {
+impl RuntimeObjectResolver for InMemoryObjectStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -28,7 +28,7 @@ use sui_types::{
     },
     object::{Object, Owner},
     storage::{
-        BackingPackageStore, ChildObjectResolver, ObjectStore, PackageObject, ParentSync,
+        BackingPackageStore, ObjectStore, PackageObject, ParentSync, RuntimeObjectResolver,
         load_package_object_from_object_store,
     },
     transaction::VerifiedTransaction,
@@ -401,7 +401,7 @@ impl BackingPackageStore for PersistedStore {
     }
 }
 
-impl ChildObjectResolver for PersistedStore {
+impl RuntimeObjectResolver for PersistedStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,
@@ -673,7 +673,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
     }
 }
 
-impl ChildObjectResolver for PersistedStoreInnerReadOnlyWrapper {
+impl RuntimeObjectResolver for PersistedStoreInnerReadOnlyWrapper {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/sui-types/src/accumulator_root.rs
+++ b/crates/sui-types/src/accumulator_root.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     error::{SuiError, SuiErrorKind, SuiResult},
     object::{MoveObject, Object, Owner},
-    storage::{ChildObjectResolver, ObjectStore},
+    storage::{ObjectStore, RuntimeObjectResolver},
 };
 use move_core_types::{
     ident_str,
@@ -136,7 +136,7 @@ impl AccumulatorValue {
     }
 
     pub fn exists(
-        child_object_resolver: &dyn ChildObjectResolver,
+        runtime_object_resolver: &dyn RuntimeObjectResolver,
         version_bound: Option<SequenceNumber>,
         owner: SuiAddress,
         type_: &TypeTag,
@@ -155,11 +155,11 @@ impl AccumulatorValue {
             AccumulatorKey::get_type_tag(std::slice::from_ref(type_)),
         )
         .into_id_with_bound(version_bound.unwrap_or(SequenceNumber::MAX))?
-        .exists(child_object_resolver)
+        .exists(runtime_object_resolver)
     }
 
     pub fn load_by_id<T>(
-        child_object_resolver: &dyn ChildObjectResolver,
+        runtime_object_resolver: &dyn RuntimeObjectResolver,
         version_bound: Option<SequenceNumber>,
         id: AccumulatorObjId,
     ) -> SuiResult<Option<T>>
@@ -171,13 +171,13 @@ impl AccumulatorValue {
             id.0,
             version_bound.unwrap_or(SequenceNumber::MAX),
         )
-        .load_object(child_object_resolver)?
+        .load_object(runtime_object_resolver)?
         .map(|o| o.load_value::<T>())
         .transpose()
     }
 
     pub fn load(
-        child_object_resolver: &dyn ChildObjectResolver,
+        runtime_object_resolver: &dyn RuntimeObjectResolver,
         version_bound: Option<SequenceNumber>,
         owner: SuiAddress,
         type_: &TypeTag,
@@ -194,7 +194,7 @@ impl AccumulatorValue {
 
         let Some(value) = DynamicFieldKey(SUI_ACCUMULATOR_ROOT_OBJECT_ID, key, key_type_tag)
             .into_id_with_bound(version_bound.unwrap_or(SequenceNumber::MAX))?
-            .load_object(child_object_resolver)?
+            .load_object(runtime_object_resolver)?
             .map(|o| o.load_value::<U128>())
             .transpose()?
         else {
@@ -205,7 +205,7 @@ impl AccumulatorValue {
     }
 
     pub fn load_object(
-        child_object_resolver: &dyn ChildObjectResolver,
+        runtime_object_resolver: &dyn RuntimeObjectResolver,
         version_bound: Option<SequenceNumber>,
         owner: SuiAddress,
         type_: &TypeTag,
@@ -216,13 +216,13 @@ impl AccumulatorValue {
         Ok(
             DynamicFieldKey(SUI_ACCUMULATOR_ROOT_OBJECT_ID, key, key_type_tag)
                 .into_id_with_bound(version_bound.unwrap_or(SequenceNumber::MAX))?
-                .load_object(child_object_resolver)?
+                .load_object(runtime_object_resolver)?
                 .map(|o| o.into_object()),
         )
     }
 
     pub fn load_object_by_id(
-        child_object_resolver: &dyn ChildObjectResolver,
+        runtime_object_resolver: &dyn RuntimeObjectResolver,
         version_bound: Option<SequenceNumber>,
         id: ObjectID,
     ) -> SuiResult<Option<Object>> {
@@ -231,7 +231,7 @@ impl AccumulatorValue {
             id,
             version_bound.unwrap_or(SequenceNumber::MAX),
         )
-        .load_object(child_object_resolver)?
+        .load_object(runtime_object_resolver)?
         .map(|o| o.into_object()))
     }
 

--- a/crates/sui-types/src/coin_reservation.rs
+++ b/crates/sui-types/src/coin_reservation.rs
@@ -45,7 +45,7 @@ use crate::{
     committee::EpochId,
     digests::{ChainIdentifier, ObjectDigest},
     error::{UserInputError, UserInputResult},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
     transaction::FundsWithdrawalArg,
 };
 
@@ -208,13 +208,13 @@ pub fn encode_object_ref(
 /// Resolves coin reservations by looking up the accumulator object to determine
 /// the owner and type of the balance being withdrawn.
 pub struct CoinReservationResolver {
-    child_object_resolver: Arc<dyn ChildObjectResolver + Send + Sync>,
+    runtime_object_resolver: Arc<dyn RuntimeObjectResolver + Send + Sync>,
 }
 
 impl CoinReservationResolver {
-    pub fn new(child_object_resolver: Arc<dyn ChildObjectResolver + Send + Sync>) -> Self {
+    pub fn new(runtime_object_resolver: Arc<dyn RuntimeObjectResolver + Send + Sync>) -> Self {
         Self {
-            child_object_resolver,
+            runtime_object_resolver,
         }
     }
 
@@ -229,7 +229,7 @@ impl CoinReservationResolver {
         accumulator_version: Option<SequenceNumber>,
     ) -> UserInputResult<Option<(SuiAddress, TypeTag)>> {
         let Some(object) = AccumulatorValue::load_object_by_id(
-            self.child_object_resolver.as_ref(),
+            self.runtime_object_resolver.as_ref(),
             accumulator_version,
             object_id,
         )

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -6,7 +6,7 @@ use crate::crypto::DefaultHash;
 use crate::error::{SuiError, SuiErrorKind, SuiResult};
 use crate::id::UID;
 use crate::object::{MoveObject, Object};
-use crate::storage::{ChildObjectResolver, ObjectStore};
+use crate::storage::{ObjectStore, RuntimeObjectResolver};
 use crate::sui_serde::Readable;
 use crate::sui_serde::SuiTypeTag;
 use crate::{MoveTypeTagTrait, ObjectID, SUI_FRAMEWORK_ADDRESS, SequenceNumber};
@@ -570,16 +570,20 @@ where
     /// If the field does not exist, return None.
     pub fn load_object(
         self,
-        child_object_resolver: &dyn ChildObjectResolver,
+        runtime_object_resolver: &dyn RuntimeObjectResolver,
     ) -> Result<Option<DynamicFieldObject<K>>, SuiError> {
-        child_object_resolver
+        runtime_object_resolver
             .read_child_object(&self.0, &self.1, self.2)
             .map(|r| r.map(DynamicFieldObject::<K>::new))
     }
 
     /// Check if the field object exists in the store.
-    pub fn exists(self, child_object_resolver: &dyn ChildObjectResolver) -> Result<bool, SuiError> {
-        self.load_object(child_object_resolver).map(|r| r.is_some())
+    pub fn exists(
+        self,
+        runtime_object_resolver: &dyn RuntimeObjectResolver,
+    ) -> Result<bool, SuiError> {
+        self.load_object(runtime_object_resolver)
+            .map(|r| r.is_some())
     }
 }
 

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -14,7 +14,7 @@ use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::{SuiError, SuiResult},
     object::{Object, Owner},
-    storage::{BackingPackageStore, ChildObjectResolver, ObjectStore, ParentSync},
+    storage::{BackingPackageStore, ObjectStore, ParentSync, RuntimeObjectResolver},
 };
 use better_any::{Tid, TidAble};
 use move_binary_format::CompiledModule;
@@ -37,7 +37,7 @@ impl BackingPackageStore for InMemoryStorage {
     }
 }
 
-impl ChildObjectResolver for InMemoryStorage {
+impl RuntimeObjectResolver for InMemoryStorage {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -181,12 +181,12 @@ pub enum ObjectChange {
     Delete(DeleteKindWithOldVersion),
 }
 
-pub trait StorageView: Storage + ParentSync + ChildObjectResolver {}
-impl<T: Storage + ParentSync + ChildObjectResolver> StorageView for T {}
+pub trait StorageView: Storage + ParentSync + RuntimeObjectResolver {}
+impl<T: Storage + ParentSync + RuntimeObjectResolver> StorageView for T {}
 
 /// An abstraction of the (possibly distributed) store for objects. This
 /// API only allows for the retrieval of objects, not any state changes
-pub trait ChildObjectResolver {
+pub trait RuntimeObjectResolver {
     /// `child` must have an `ObjectOwner` ownership equal to `owner`.
     fn read_child_object(
         &self,
@@ -477,14 +477,14 @@ impl<S: ParentSync> ParentSync for &mut S {
     }
 }
 
-impl<S: ChildObjectResolver> ChildObjectResolver for std::sync::Arc<S> {
+impl<S: RuntimeObjectResolver> RuntimeObjectResolver for std::sync::Arc<S> {
     fn read_child_object(
         &self,
         parent: &ObjectID,
         child: &ObjectID,
         child_version_upper_bound: SequenceNumber,
     ) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::read_child_object(
+        RuntimeObjectResolver::read_child_object(
             self.as_ref(),
             parent,
             child,
@@ -498,7 +498,7 @@ impl<S: ChildObjectResolver> ChildObjectResolver for std::sync::Arc<S> {
         receive_object_at_version: SequenceNumber,
         epoch_id: EpochId,
     ) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::get_object_received_at_version(
+        RuntimeObjectResolver::get_object_received_at_version(
             self.as_ref(),
             owner,
             receiving_object_id,
@@ -508,14 +508,14 @@ impl<S: ChildObjectResolver> ChildObjectResolver for std::sync::Arc<S> {
     }
 }
 
-impl<S: ChildObjectResolver> ChildObjectResolver for &S {
+impl<S: RuntimeObjectResolver> RuntimeObjectResolver for &S {
     fn read_child_object(
         &self,
         parent: &ObjectID,
         child: &ObjectID,
         child_version_upper_bound: SequenceNumber,
     ) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::read_child_object(*self, parent, child, child_version_upper_bound)
+        RuntimeObjectResolver::read_child_object(*self, parent, child, child_version_upper_bound)
     }
     fn get_object_received_at_version(
         &self,
@@ -524,7 +524,7 @@ impl<S: ChildObjectResolver> ChildObjectResolver for &S {
         receive_object_at_version: SequenceNumber,
         epoch_id: EpochId,
     ) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::get_object_received_at_version(
+        RuntimeObjectResolver::get_object_received_at_version(
             *self,
             owner,
             receiving_object_id,
@@ -534,14 +534,14 @@ impl<S: ChildObjectResolver> ChildObjectResolver for &S {
     }
 }
 
-impl<S: ChildObjectResolver> ChildObjectResolver for &mut S {
+impl<S: RuntimeObjectResolver> RuntimeObjectResolver for &mut S {
     fn read_child_object(
         &self,
         parent: &ObjectID,
         child: &ObjectID,
         child_version_upper_bound: SequenceNumber,
     ) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::read_child_object(*self, parent, child, child_version_upper_bound)
+        RuntimeObjectResolver::read_child_object(*self, parent, child, child_version_upper_bound)
     }
     fn get_object_received_at_version(
         &self,
@@ -550,7 +550,7 @@ impl<S: ChildObjectResolver> ChildObjectResolver for &mut S {
         receive_object_at_version: SequenceNumber,
         epoch_id: EpochId,
     ) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::get_object_received_at_version(
+        RuntimeObjectResolver::get_object_received_at_version(
             *self,
             owner,
             receiving_object_id,
@@ -718,7 +718,7 @@ impl Display for DeleteKind {
 }
 
 pub trait BackingStore:
-    BackingPackageStore + ChildObjectResolver + ObjectStore + ParentSync
+    BackingPackageStore + RuntimeObjectResolver + ObjectStore + ParentSync
 {
     fn as_object_store(&self) -> &dyn ObjectStore;
 }
@@ -726,7 +726,7 @@ pub trait BackingStore:
 impl<T> BackingStore for T
 where
     T: BackingPackageStore,
-    T: ChildObjectResolver,
+    T: RuntimeObjectResolver,
     T: ObjectStore,
     T: ParentSync,
 {
@@ -887,7 +887,7 @@ impl BackingPackageStore for TrackingBackingStore<'_> {
     }
 }
 
-impl ChildObjectResolver for TrackingBackingStore<'_> {
+impl RuntimeObjectResolver for TrackingBackingStore<'_> {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -624,7 +624,7 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
 /// It extends both ObjectStore and ReadStore by adding functionality that may require more
 /// detailed underlying databases or indexes to support.
 pub trait RpcStateReader:
-    ObjectStore + ReadStore + super::ChildObjectResolver + Send + Sync
+    ObjectStore + ReadStore + super::RuntimeObjectResolver + Send + Sync
 {
     /// Lowest available checkpoint for which object data can be requested.
     ///

--- a/crates/test-cluster/src/addr_balance_test_env.rs
+++ b/crates/test-cluster/src/addr_balance_test_env.rs
@@ -24,7 +24,7 @@ use sui_types::{
     gas_coin::GAS,
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
     transaction::{
         CallArg, FundsWithdrawalArg, GasData, ObjectArg, TransactionData, TransactionDataV1,
         TransactionExpiration, TransactionKind,
@@ -412,8 +412,8 @@ impl TestEnv {
     pub fn verify_accumulator_exists(&self, owner: SuiAddress, expected_balance: u64) {
         self.cluster.fullnode_handle.sui_node.with(|node| {
             let state = node.state();
-            let child_object_resolver = state.get_child_object_resolver().as_ref();
-            verify_accumulator_exists(child_object_resolver, owner, expected_balance);
+            let runtime_object_resolver = state.get_runtime_object_resolver().as_ref();
+            verify_accumulator_exists(runtime_object_resolver, owner, expected_balance);
         });
     }
 
@@ -451,8 +451,8 @@ impl TestEnv {
             let coin_type = coin_type.clone();
             move |node| {
                 let state = node.state();
-                let child_object_resolver = state.get_child_object_resolver().as_ref();
-                get_balance(child_object_resolver, owner, coin_type)
+                let runtime_object_resolver = state.get_runtime_object_resolver().as_ref();
+                get_balance(runtime_object_resolver, owner, coin_type)
             }
         });
 
@@ -495,10 +495,10 @@ impl TestEnv {
     pub fn verify_accumulator_removed(&self, owner: SuiAddress) {
         self.cluster.fullnode_handle.sui_node.with(|node| {
             let state = node.state();
-            let child_object_resolver = state.get_child_object_resolver().as_ref();
+            let runtime_object_resolver = state.get_runtime_object_resolver().as_ref();
             let sui_coin_type = Balance::type_tag(GAS::type_tag());
             assert!(
-                !AccumulatorValue::exists(child_object_resolver, None, owner, &sui_coin_type)
+                !AccumulatorValue::exists(runtime_object_resolver, None, owner, &sui_coin_type)
                     .unwrap(),
                 "Accumulator value should have been removed"
             );
@@ -794,31 +794,35 @@ pub fn get_accumulator_object_id(sender: SuiAddress, coin_type: TypeTag) -> Obje
 }
 
 pub fn get_balance(
-    child_object_resolver: &dyn ChildObjectResolver,
+    runtime_object_resolver: &dyn RuntimeObjectResolver,
     owner: SuiAddress,
     coin_type: TypeTag,
 ) -> u64 {
-    sui_core::accumulators::balances::get_balance(owner, child_object_resolver, coin_type).unwrap()
+    sui_core::accumulators::balances::get_balance(owner, runtime_object_resolver, coin_type)
+        .unwrap()
 }
 
-pub fn get_sui_balance(child_object_resolver: &dyn ChildObjectResolver, owner: SuiAddress) -> u64 {
-    get_balance(child_object_resolver, owner, GAS::type_tag())
+pub fn get_sui_balance(
+    runtime_object_resolver: &dyn RuntimeObjectResolver,
+    owner: SuiAddress,
+) -> u64 {
+    get_balance(runtime_object_resolver, owner, GAS::type_tag())
 }
 
 pub fn verify_accumulator_exists(
-    child_object_resolver: &dyn ChildObjectResolver,
+    runtime_object_resolver: &dyn RuntimeObjectResolver,
     owner: SuiAddress,
     expected_balance: u64,
 ) {
     let sui_coin_type = Balance::type_tag(GAS::type_tag());
 
     assert!(
-        AccumulatorValue::exists(child_object_resolver, None, owner, &sui_coin_type).unwrap(),
+        AccumulatorValue::exists(runtime_object_resolver, None, owner, &sui_coin_type).unwrap(),
         "Accumulator value should have been created"
     );
 
     let accumulator_object =
-        AccumulatorValue::load_object(child_object_resolver, None, owner, &sui_coin_type)
+        AccumulatorValue::load_object(runtime_object_resolver, None, owner, &sui_coin_type)
             .expect("read cannot fail")
             .expect("accumulator should exist");
 
@@ -832,7 +836,7 @@ pub fn verify_accumulator_exists(
     );
 
     let accumulator_value =
-        AccumulatorValue::load(child_object_resolver, None, owner, &sui_coin_type)
+        AccumulatorValue::load(runtime_object_resolver, None, owner, &sui_coin_type)
             .expect("read cannot fail")
             .expect("accumulator should exist");
 

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -36,7 +36,7 @@ mod checked {
         error::{ExecutionError, SuiError},
         execution_status::ExecutionErrorKind,
         metrics::ExecutionMetrics,
-        storage::ChildObjectResolver,
+        storage::RuntimeObjectResolver,
     };
     use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
 
@@ -79,7 +79,7 @@ mod checked {
     }
 
     pub fn new_native_extensions<'r>(
-        child_resolver: &'r dyn ChildObjectResolver,
+        child_resolver: &'r dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
         is_metered: bool,
         protocol_config: &'r ProtocolConfig,

--- a/sui-execution/latest/sui-adapter/src/execution_value.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_value.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::storage::{BackingPackageStore, ChildObjectResolver, Storage};
+use sui_types::storage::{BackingPackageStore, RuntimeObjectResolver, Storage};
 
 pub trait SuiResolver: BackingPackageStore {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
@@ -17,16 +17,16 @@ where
 }
 
 /// Interface with the store necessary to execute a programmable transaction
-pub trait ExecutionState: Storage + ChildObjectResolver + SuiResolver {
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver;
+pub trait ExecutionState: Storage + RuntimeObjectResolver + SuiResolver {
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
 }
 
 impl<T> ExecutionState for T
 where
-    T: Storage + ChildObjectResolver,
+    T: Storage + RuntimeObjectResolver,
     T: SuiResolver,
 {
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver {
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
         self
     }
 }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -41,7 +41,7 @@ use sui_types::{
     gas::GasCostSummary,
     object::Object,
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, Storage},
+    storage::{BackingPackageStore, RuntimeObjectResolver, Storage},
     transaction::InputObjects,
 };
 use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, TypeTag, is_system_package};
@@ -113,7 +113,7 @@ pub struct TemporaryStore<'backing> {
     /// digest) at which they were read. Recorded by `check_system_object_available` and
     /// emitted into the transaction effects as read-only consensus objects so the read can be
     /// reproduced on replay. Interior-mutable because reads happen behind `&self`
-    /// (`ChildObjectResolver`).
+    /// (`RuntimeObjectResolver`).
     loaded_system_objects: RefCell<BTreeMap<ObjectID, (SequenceNumber, ObjectDigest)>>,
 
     /// Recorded when execution determines the transaction must be retried later rather than
@@ -122,7 +122,7 @@ pub struct TemporaryStore<'backing> {
     /// still runs to completion and produces effects; this signal is carried out on
     /// `InnerTemporaryStore` so the authority can discard those effects and re-enqueue. A
     /// `OnceCell` rather than a lock: execution is single-threaded, and the condition is detected
-    /// behind `&self` (`ChildObjectResolver`), so the field must be interior-mutable; it is
+    /// behind `&self` (`RuntimeObjectResolver`), so the field must be interior-mutable; it is
     /// recorded at most once (the first detection, after which execution unwinds), which
     /// `OnceCell` enforces.
     retry_request: OnceCell<ExecutionRetryError>,
@@ -1058,7 +1058,7 @@ impl TemporaryStore<'_> {
     }
 }
 
-impl ChildObjectResolver for TemporaryStore<'_> {
+impl RuntimeObjectResolver for TemporaryStore<'_> {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -42,7 +42,7 @@ use sui_types::{
     id::UID,
     metrics::ExecutionMetrics,
     object::{MoveObject, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 use tracing::error;
 
@@ -155,7 +155,7 @@ impl TestInventories {
 
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
-        object_resolver: &'a dyn ChildObjectResolver,
+        object_resolver: &'a dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, InputObject>,
         is_metered: bool,
         protocol_config: &'a ProtocolConfig,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -17,7 +17,7 @@ use sui_types::{
     execution::DynamicallyLoadedObjectMetadata,
     metrics::ExecutionMetrics,
     object::{Data, MoveObject, Object, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 
 pub(super) struct ChildObject {
@@ -67,7 +67,7 @@ pub(crate) type ChildObjectEffects = BTreeMap<ObjectID, ChildObjectEffect>;
 
 struct Inner<'a> {
     // used for loading child objects
-    resolver: &'a dyn ChildObjectResolver,
+    resolver: &'a dyn RuntimeObjectResolver,
     // The version of the root object in ownership at the beginning of the transaction.
     // If it was a child object, it resolves to the root parent's sequence number.
     // Otherwise, it is just the sequence number at the beginning of the transaction.
@@ -89,7 +89,7 @@ struct Inner<'a> {
 }
 
 // maintains the runtime GlobalValues for child objects and manages the fetching of objects
-// from storage, through the `ChildObjectResolver`
+// from storage, through the `RuntimeObjectResolver`
 pub(super) struct ChildObjectStore<'a> {
     // contains object resolver and object cache
     // kept as a separate struct to deal with lifetime issues where the `store` is accessed
@@ -210,7 +210,7 @@ impl Inner<'_> {
                 previous_transaction: object.previous_transaction,
             };
 
-            // `ChildObjectResolver::receive_object_at_version` should return the object at the
+            // `RuntimeObjectResolver::receive_object_at_version` should return the object at the
             // version or nothing at all. If it returns an object with a different version, we
             // should raise an invariant violation since it should be checked by
             // `receive_object_at_version`.
@@ -410,7 +410,7 @@ fn deserialize_move_object(
 
 impl<'a> ChildObjectStore<'a> {
     pub(super) fn new(
-        resolver: &'a dyn ChildObjectResolver,
+        resolver: &'a dyn RuntimeObjectResolver,
         root_version: BTreeMap<ObjectID, SequenceNumber>,
         wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
         is_metered: bool,

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -47,7 +47,7 @@ use sui_types::{
     id::UID,
     in_memory_storage::InMemoryStorage,
     object::{MoveObject, Object, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 
 const E_COULD_NOT_GENERATE_EFFECTS: u64 = 0;
@@ -66,7 +66,7 @@ type Set<K> = IndexSet<K>;
 pub struct InMemoryTestStore(pub RefCell<InMemoryStorage>);
 impl<'a> NativeExtensionMarker<'a> for &'a InMemoryTestStore {}
 
-impl ChildObjectResolver for InMemoryTestStore {
+impl RuntimeObjectResolver for InMemoryTestStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/sui-execution/v0/sui-adapter/src/adapter.rs
+++ b/sui-execution/v0/sui-adapter/src/adapter.rs
@@ -32,7 +32,7 @@ mod checked {
         error::{ExecutionError, SuiError},
         execution_status::ExecutionErrorKind,
         metrics::ExecutionMetrics,
-        storage::ChildObjectResolver,
+        storage::RuntimeObjectResolver,
     };
     use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
 
@@ -71,7 +71,7 @@ mod checked {
     }
 
     pub fn new_native_extensions<'r>(
-        child_resolver: &'r dyn ChildObjectResolver,
+        child_resolver: &'r dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/v0/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_value.rs
@@ -11,7 +11,7 @@ use sui_types::{
     error::ExecutionError,
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, StorageView},
+    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
 
@@ -31,7 +31,7 @@ where
 /// Interface with the store necessary to execute a programmable transaction
 pub trait ExecutionState: StorageView + SuiResolver {
     fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver;
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
 }
 
 impl<T> ExecutionState for T
@@ -43,7 +43,7 @@ where
         self
     }
 
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver {
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
         self
     }
 }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -50,8 +50,8 @@ mod checked {
         move_package::MovePackage,
         object::{Data, MoveObject, Object, ObjectInner, Owner},
         storage::{
-            BackingPackageStore, ChildObjectResolver, DeleteKind, DeleteKindWithOldVersion,
-            ObjectChange, WriteKind,
+            BackingPackageStore, DeleteKind, DeleteKindWithOldVersion, ObjectChange,
+            RuntimeObjectResolver, WriteKind,
         },
         transaction::{Argument, CallArg, ObjectArg},
     };
@@ -938,7 +938,7 @@ mod checked {
     pub(crate) fn new_session<'state, 'vm>(
         vm: &'vm MoveVM,
         linkage: LinkageView<'state>,
-        child_resolver: &'state dyn ChildObjectResolver,
+        child_resolver: &'state dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -24,7 +24,7 @@ use sui_types::{
     object::Owner,
     object::{Data, Object},
     storage::{
-        BackingPackageStore, ChildObjectResolver, ObjectChange, ParentSync, Storage, WriteKind,
+        BackingPackageStore, ObjectChange, ParentSync, RuntimeObjectResolver, Storage, WriteKind,
     },
     transaction::InputObjects,
     TypeTag,
@@ -960,7 +960,7 @@ impl TemporaryStore<'_> {
     }
 }
 
-impl ChildObjectResolver for TemporaryStore<'_> {
+impl RuntimeObjectResolver for TemporaryStore<'_> {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
@@ -26,7 +26,7 @@ use sui_types::{
     id::UID,
     metrics::ExecutionMetrics,
     object::{MoveObject, Owner},
-    storage::{ChildObjectResolver, DeleteKind, WriteKind},
+    storage::{DeleteKind, RuntimeObjectResolver, WriteKind},
     SUI_CLOCK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
@@ -161,7 +161,7 @@ impl TestInventories {
 
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
-        object_resolver: &'a dyn ChildObjectResolver,
+        object_resolver: &'a dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, InputObject>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
@@ -19,7 +19,7 @@ use sui_types::{
     error::VMMemoryLimitExceededSubStatusCode,
     metrics::ExecutionMetrics,
     object::{Data, MoveObject, Object, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 
 use super::get_all_uids;
@@ -41,7 +41,7 @@ pub(crate) struct ChildObjectEffect {
 
 struct Inner<'a> {
     // used for loading child objects
-    resolver: &'a dyn ChildObjectResolver,
+    resolver: &'a dyn RuntimeObjectResolver,
     // The version of the root object in ownership at the beginning of the transaction.
     // If it was a child object, it resolves to the root parent's sequence number.
     // Otherwise, it is just the sequence number at the beginning of the transaction.
@@ -58,7 +58,7 @@ struct Inner<'a> {
 }
 
 // maintains the runtime GlobalValues for child objects and manages the fetching of objects
-// from storage, through the `ChildObjectResolver`
+// from storage, through the `RuntimeObjectResolver`
 pub(super) struct ObjectStore<'a> {
     // contains object resolver and object cache
     // kept as a separate struct to deal with lifetime issues where the `store` is accessed
@@ -241,7 +241,7 @@ impl Inner<'_> {
 
 impl<'a> ObjectStore<'a> {
     pub(super) fn new(
-        resolver: &'a dyn ChildObjectResolver,
+        resolver: &'a dyn RuntimeObjectResolver,
         root_version: BTreeMap<ObjectID, SequenceNumber>,
         is_metered: bool,
         constants: LocalProtocolConfig,

--- a/sui-execution/v1/sui-adapter/src/adapter.rs
+++ b/sui-execution/v1/sui-adapter/src/adapter.rs
@@ -32,7 +32,7 @@ mod checked {
         error::{ExecutionError, SuiError},
         execution_status::ExecutionErrorKind,
         metrics::ExecutionMetrics,
-        storage::ChildObjectResolver,
+        storage::RuntimeObjectResolver,
     };
     use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
 
@@ -71,7 +71,7 @@ mod checked {
     }
 
     pub fn new_native_extensions<'r>(
-        child_resolver: &'r dyn ChildObjectResolver,
+        child_resolver: &'r dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/v1/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_value.rs
@@ -11,7 +11,7 @@ use sui_types::{
     error::ExecutionError,
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, StorageView},
+    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
 
@@ -31,7 +31,7 @@ where
 /// Interface with the store necessary to execute a programmable transaction
 pub trait ExecutionState: StorageView + SuiResolver {
     fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver;
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
 }
 
 impl<T> ExecutionState for T
@@ -43,7 +43,7 @@ where
         self
     }
 
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver {
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
         self
     }
 }

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -24,7 +24,7 @@ use sui_types::{
     gas::GasCostSummary,
     object::Object,
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
+    storage::{BackingPackageStore, ParentSync, RuntimeObjectResolver, Storage},
     transaction::InputObjects,
     TypeTag,
 };
@@ -1062,7 +1062,7 @@ impl TemporaryStore<'_> {
     }
 }
 
-impl ChildObjectResolver for TemporaryStore<'_> {
+impl RuntimeObjectResolver for TemporaryStore<'_> {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
@@ -31,7 +31,7 @@ use sui_types::{
     id::UID,
     metrics::ExecutionMetrics,
     object::{MoveObject, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
     SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_CLOCK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
@@ -176,7 +176,7 @@ impl TestInventories {
 
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
-        object_resolver: &'a dyn ChildObjectResolver,
+        object_resolver: &'a dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, InputObject>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/v1/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/v1/sui-move-natives/src/object_runtime/object_store.rs
@@ -21,7 +21,7 @@ use sui_types::{
     execution::DynamicallyLoadedObjectMetadata,
     metrics::ExecutionMetrics,
     object::{Data, MoveObject, Object, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 
 pub(super) struct ChildObject {
@@ -40,7 +40,7 @@ pub(crate) struct ChildObjectEffect {
 
 struct Inner<'a> {
     // used for loading child objects
-    resolver: &'a dyn ChildObjectResolver,
+    resolver: &'a dyn RuntimeObjectResolver,
     // The version of the root object in ownership at the beginning of the transaction.
     // If it was a child object, it resolves to the root parent's sequence number.
     // Otherwise, it is just the sequence number at the beginning of the transaction.
@@ -59,7 +59,7 @@ struct Inner<'a> {
 }
 
 // maintains the runtime GlobalValues for child objects and manages the fetching of objects
-// from storage, through the `ChildObjectResolver`
+// from storage, through the `RuntimeObjectResolver`
 pub(super) struct ChildObjectStore<'a> {
     // contains object resolver and object cache
     // kept as a separate struct to deal with lifetime issues where the `store` is accessed
@@ -114,7 +114,7 @@ impl Inner<'_> {
                 previous_transaction: object.previous_transaction,
             };
 
-            // `ChildObjectResolver::receive_object_at_version` should return the object at the
+            // `RuntimeObjectResolver::receive_object_at_version` should return the object at the
             // version or nothing at all. If it returns an object with a different version, we
             // should raise an invariant violation since it should be checked by
             // `receive_object_at_version`.
@@ -338,7 +338,7 @@ fn deserialize_move_object(
 
 impl<'a> ChildObjectStore<'a> {
     pub(super) fn new(
-        resolver: &'a dyn ChildObjectResolver,
+        resolver: &'a dyn RuntimeObjectResolver,
         root_version: BTreeMap<ObjectID, SequenceNumber>,
         is_metered: bool,
         local_config: LocalProtocolConfig,

--- a/sui-execution/v2/sui-adapter/src/adapter.rs
+++ b/sui-execution/v2/sui-adapter/src/adapter.rs
@@ -31,7 +31,7 @@ mod checked {
         error::{ExecutionError, SuiError},
         execution_status::ExecutionErrorKind,
         metrics::ExecutionMetrics,
-        storage::ChildObjectResolver,
+        storage::RuntimeObjectResolver,
     };
     use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
 
@@ -69,7 +69,7 @@ mod checked {
     }
 
     pub fn new_native_extensions<'r>(
-        child_resolver: &'r dyn ChildObjectResolver,
+        child_resolver: &'r dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
         is_metered: bool,
         protocol_config: &'r ProtocolConfig,

--- a/sui-execution/v2/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_value.rs
@@ -11,7 +11,7 @@ use sui_types::{
     error::ExecutionError,
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, StorageView},
+    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
 
@@ -31,7 +31,7 @@ where
 /// Interface with the store necessary to execute a programmable transaction
 pub trait ExecutionState: StorageView + SuiResolver {
     fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver;
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
 }
 
 impl<T> ExecutionState for T
@@ -43,7 +43,7 @@ where
         self
     }
 
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver {
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
         self
     }
 }

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -24,7 +24,7 @@ use sui_types::{
     gas::GasCostSummary,
     object::Object,
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
+    storage::{BackingPackageStore, ParentSync, RuntimeObjectResolver, Storage},
     transaction::InputObjects,
     TypeTag,
 };
@@ -1114,7 +1114,7 @@ impl TemporaryStore<'_> {
     }
 }
 
-impl ChildObjectResolver for TemporaryStore<'_> {
+impl RuntimeObjectResolver for TemporaryStore<'_> {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/sui-execution/v2/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v2/sui-move-natives/src/object_runtime/mod.rs
@@ -37,7 +37,7 @@ use sui_types::{
     id::UID,
     metrics::ExecutionMetrics,
     object::{MoveObject, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
     SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_CLOCK_OBJECT_ID, SUI_DENY_LIST_OBJECT_ID,
     SUI_RANDOMNESS_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
@@ -128,7 +128,7 @@ impl TestInventories {
 
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
-        object_resolver: &'a dyn ChildObjectResolver,
+        object_resolver: &'a dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, InputObject>,
         is_metered: bool,
         protocol_config: &'a ProtocolConfig,

--- a/sui-execution/v2/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/v2/sui-move-natives/src/object_runtime/object_store.rs
@@ -21,7 +21,7 @@ use sui_types::{
     execution::DynamicallyLoadedObjectMetadata,
     metrics::ExecutionMetrics,
     object::{Data, MoveObject, Object, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 
 pub(super) struct ChildObject {
@@ -40,7 +40,7 @@ pub(crate) struct ChildObjectEffect {
 
 struct Inner<'a> {
     // used for loading child objects
-    resolver: &'a dyn ChildObjectResolver,
+    resolver: &'a dyn RuntimeObjectResolver,
     // The version of the root object in ownership at the beginning of the transaction.
     // If it was a child object, it resolves to the root parent's sequence number.
     // Otherwise, it is just the sequence number at the beginning of the transaction.
@@ -62,7 +62,7 @@ struct Inner<'a> {
 }
 
 // maintains the runtime GlobalValues for child objects and manages the fetching of objects
-// from storage, through the `ChildObjectResolver`
+// from storage, through the `RuntimeObjectResolver`
 pub(super) struct ChildObjectStore<'a> {
     // contains object resolver and object cache
     // kept as a separate struct to deal with lifetime issues where the `store` is accessed
@@ -117,7 +117,7 @@ impl Inner<'_> {
                 previous_transaction: object.previous_transaction,
             };
 
-            // `ChildObjectResolver::receive_object_at_version` should return the object at the
+            // `RuntimeObjectResolver::receive_object_at_version` should return the object at the
             // version or nothing at all. If it returns an object with a different version, we
             // should raise an invariant violation since it should be checked by
             // `receive_object_at_version`.
@@ -345,7 +345,7 @@ fn deserialize_move_object(
 
 impl<'a> ChildObjectStore<'a> {
     pub(super) fn new(
-        resolver: &'a dyn ChildObjectResolver,
+        resolver: &'a dyn RuntimeObjectResolver,
         root_version: BTreeMap<ObjectID, SequenceNumber>,
         wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
         is_metered: bool,

--- a/sui-execution/v3/sui-adapter/src/adapter.rs
+++ b/sui-execution/v3/sui-adapter/src/adapter.rs
@@ -35,7 +35,7 @@ mod checked {
         error::{ExecutionError, SuiError},
         execution_status::ExecutionErrorKind,
         metrics::ExecutionMetrics,
-        storage::ChildObjectResolver,
+        storage::RuntimeObjectResolver,
     };
     use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
 
@@ -74,7 +74,7 @@ mod checked {
     }
 
     pub fn new_native_extensions<'r>(
-        child_resolver: &'r dyn ChildObjectResolver,
+        child_resolver: &'r dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
         is_metered: bool,
         protocol_config: &'r ProtocolConfig,

--- a/sui-execution/v3/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_value.rs
@@ -14,7 +14,7 @@ use sui_types::{
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     funds_accumulator::Withdrawal,
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, StorageView},
+    storage::{BackingPackageStore, RuntimeObjectResolver, StorageView},
     transfer::Receiving,
 };
 
@@ -34,7 +34,7 @@ where
 /// Interface with the store necessary to execute a programmable transaction
 pub trait ExecutionState: StorageView + SuiResolver {
     fn as_sui_resolver(&self) -> &dyn SuiResolver;
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver;
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver;
 }
 
 impl<T> ExecutionState for T
@@ -46,7 +46,7 @@ where
         self
     }
 
-    fn as_child_resolver(&self) -> &dyn ChildObjectResolver {
+    fn as_child_resolver(&self) -> &dyn RuntimeObjectResolver {
         self
     }
 }

--- a/sui-execution/v3/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v3/sui-adapter/src/temporary_store.rs
@@ -32,7 +32,7 @@ use sui_types::{
     gas::GasCostSummary,
     object::Object,
     object::Owner,
-    storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
+    storage::{BackingPackageStore, ParentSync, RuntimeObjectResolver, Storage},
     transaction::InputObjects,
 };
 use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, TypeTag, is_system_package};
@@ -1111,7 +1111,7 @@ impl TemporaryStore<'_> {
     }
 }
 
-impl ChildObjectResolver for TemporaryStore<'_> {
+impl RuntimeObjectResolver for TemporaryStore<'_> {
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/sui-execution/v3/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v3/sui-move-natives/src/object_runtime/mod.rs
@@ -45,7 +45,7 @@ use sui_types::{
     id::UID,
     metrics::ExecutionMetrics,
     object::{MoveObject, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 use tracing::error;
 
@@ -156,7 +156,7 @@ impl TestInventories {
 
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
-        object_resolver: &'a dyn ChildObjectResolver,
+        object_resolver: &'a dyn RuntimeObjectResolver,
         input_objects: BTreeMap<ObjectID, InputObject>,
         is_metered: bool,
         protocol_config: &'a ProtocolConfig,

--- a/sui-execution/v3/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/v3/sui-move-natives/src/object_runtime/object_store.rs
@@ -20,7 +20,7 @@ use sui_types::{
     execution::DynamicallyLoadedObjectMetadata,
     metrics::ExecutionMetrics,
     object::{Data, MoveObject, Object, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 
 pub(super) struct ChildObject {
@@ -84,7 +84,7 @@ pub(crate) enum ChildObjectEffects {
 
 struct Inner<'a> {
     // used for loading child objects
-    resolver: &'a dyn ChildObjectResolver,
+    resolver: &'a dyn RuntimeObjectResolver,
     // The version of the root object in ownership at the beginning of the transaction.
     // If it was a child object, it resolves to the root parent's sequence number.
     // Otherwise, it is just the sequence number at the beginning of the transaction.
@@ -106,7 +106,7 @@ struct Inner<'a> {
 }
 
 // maintains the runtime GlobalValues for child objects and manages the fetching of objects
-// from storage, through the `ChildObjectResolver`
+// from storage, through the `RuntimeObjectResolver`
 pub(super) struct ChildObjectStore<'a> {
     // contains object resolver and object cache
     // kept as a separate struct to deal with lifetime issues where the `store` is accessed
@@ -229,7 +229,7 @@ impl Inner<'_> {
                 previous_transaction: object.previous_transaction,
             };
 
-            // `ChildObjectResolver::receive_object_at_version` should return the object at the
+            // `RuntimeObjectResolver::receive_object_at_version` should return the object at the
             // version or nothing at all. If it returns an object with a different version, we
             // should raise an invariant violation since it should be checked by
             // `receive_object_at_version`.
@@ -433,7 +433,7 @@ fn deserialize_move_object(
 
 impl<'a> ChildObjectStore<'a> {
     pub(super) fn new(
-        resolver: &'a dyn ChildObjectResolver,
+        resolver: &'a dyn RuntimeObjectResolver,
         root_version: BTreeMap<ObjectID, SequenceNumber>,
         wrapped_object_containers: BTreeMap<ObjectID, ObjectID>,
         is_metered: bool,

--- a/sui-execution/v3/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v3/sui-move-natives/src/test_scenario.rs
@@ -38,7 +38,7 @@ use sui_types::{
     id::UID,
     in_memory_storage::InMemoryStorage,
     object::{MoveObject, Object, Owner},
-    storage::ChildObjectResolver,
+    storage::RuntimeObjectResolver,
 };
 
 const E_COULD_NOT_GENERATE_EFFECTS: u64 = 0;
@@ -57,7 +57,7 @@ type Set<K> = IndexSet<K>;
 pub struct InMemoryTestStore(pub RefCell<InMemoryStorage>);
 impl<'a> NativeExtensionMarker<'a> for &'a InMemoryTestStore {}
 
-impl ChildObjectResolver for InMemoryTestStore {
+impl RuntimeObjectResolver for InMemoryTestStore {
     fn read_child_object(
         &self,
         parent: &ObjectID,


### PR DESCRIPTION
## Description

Stack of 6 (builds on [1/6]). Pure refactor: renames the `ChildObjectResolver` trait and its variables to `RuntimeObjectResolver`, reflecting its broader execution-time role. [5/6] adds the object-funds sufficiency check to this trait.

## Test plan

Mechanical rename with no behavior change; covered by existing tests.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes are not required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:

