### PR TITLE
[4/7] Record read system objects in effects, and reproduce them on replay

### DIFF
--- a/crates/sui-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/sui-cluster-test/src/test_case/shared_object_test.rs
@@ -48,7 +48,7 @@ impl TestCaseImpl for SharedCounterTest {
 
         response
             .effects
-            .input_consensus_objects()
+            .accessed_consensus_objects()
             .iter()
             .find(|o| o.id_and_version().0 == counter_id)
             .expect("Expect obj {counter_id} in shared_objects");

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1920,7 +1920,7 @@ impl AuthorityState {
         self.metrics.total_effects.inc();
         self.metrics.total_certs.inc();
 
-        let consensus_object_count = effects.input_consensus_objects().len();
+        let consensus_object_count = effects.accessed_consensus_objects().len();
         if consensus_object_count > 0 {
             self.metrics.shared_obj_tx.inc();
         }
@@ -6826,7 +6826,7 @@ impl NodeStateDump {
 
         // Record all the shared objects
         let mut shared_objects = Vec::new();
-        for kind in effects.input_consensus_objects() {
+        for kind in effects.accessed_consensus_objects() {
             match kind {
                 InputConsensusObject::Mutate(obj_ref) | InputConsensusObject::ReadOnly(obj_ref) => {
                     if let Some(w) = object_store.get_object_by_key(&obj_ref.0, obj_ref.1) {

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -26,7 +26,10 @@ use sui_types::storage::{
 };
 use sui_types::transaction::SharedObjectMutability;
 use sui_types::transaction::{SharedInputObject, TransactionDataAPI, TransactionKey};
-use sui_types::{SUI_RANDOMNESS_STATE_OBJECT_ID, base_types::SequenceNumber, error::SuiResult};
+use sui_types::{
+    IMPLICITLY_READ_SYSTEM_OBJECTS, SUI_RANDOMNESS_STATE_OBJECT_ID, base_types::SequenceNumber,
+    error::SuiResult,
+};
 use tracing::trace;
 
 pub struct SharedObjVerManager {}
@@ -362,27 +365,57 @@ impl SharedObjVerManager {
                 .into_iter()
                 .map(|input| input.into_id_and_version())
                 .collect();
-            let cert_assigned_versions: Vec<_> = effects
-                .input_consensus_objects()
+            let accessed_versions: BTreeMap<ObjectID, SequenceNumber> = effects
+                .accessed_consensus_objects()
                 .into_iter()
-                .map(|iso| {
-                    let (id, version) = iso.id_and_version();
-                    let initial_version = initial_version_map
-                        .get(&id)
-                        .expect("transaction must have all inputs from effects");
-                    ((id, *initial_version), version)
+                .map(|iso| iso.id_and_version())
+                .collect();
+            debug_assert!(
+                accessed_versions
+                    .keys()
+                    .all(|id| initial_version_map.contains_key(id)
+                        || IMPLICITLY_READ_SYSTEM_OBJECTS.contains(id)),
+                "accessed consensus object is neither a declared input nor a known implicitly read system object: \
+                 accessed={accessed_versions:?} declared={initial_version_map:?}"
+            );
+            let cert_assigned_versions: Vec<_> = accessed_versions
+                .iter()
+                .filter_map(|(id, version)| {
+                    initial_version_map
+                        .get(id)
+                        .map(|initial_version| ((*id, *initial_version), *version))
                 })
                 .collect();
+            // Record the version each known implicitly-read system object was read at (from
+            // effects) so the checkpoint-execution read resolves to the same version the original
+            // execution used. This holds even when the transaction also declares the object as an
+            // explicit input. A cancelled transaction records special sentinel versions (e.g.
+            // CONGESTED) for its declared inputs; those may land in this map, which is harmless —
+            // a cancelled transaction never enters Move execution, so its entries are never read.
+            let mut system_object_versions: BTreeMap<ObjectID, SequenceNumber> =
+                IMPLICITLY_READ_SYSTEM_OBJECTS
+                    .iter()
+                    .filter_map(|id| accessed_versions.get(id).map(|version| (*id, *version)))
+                    .collect();
+            // The accumulator root version is needed even when the transaction doesn't read it in
+            // execution (e.g. coin-reservation rewriting), so always write the version
+            // reconstructed from the settlement transaction. A version harvested from effects must
+            // agree with it, unless it is a cancelled sentinel, which this overwrite corrects.
+            if let Some(v) = *accumulator_version {
+                let prev = system_object_versions.insert(SUI_ACCUMULATOR_ROOT_OBJECT_ID, v);
+                debug_assert!(
+                    prev.is_none_or(|p| p == v || p.is_cancelled()),
+                    "accumulator root version from effects {prev:?} disagrees with the \
+                     reconstructed accumulator version {v:?}"
+                );
+            }
             let tx_key = cert.key();
             trace!(
                 ?tx_key,
                 ?cert_assigned_versions,
+                ?system_object_versions,
                 "assigned consensus object versions from effects"
             );
-            let system_object_versions: BTreeMap<ObjectID, SequenceNumber> = (*accumulator_version)
-                .map(|v| (SUI_ACCUMULATOR_ROOT_OBJECT_ID, v))
-                .into_iter()
-                .collect();
             assigned_versions.push((
                 tx_key,
                 AssignedVersions::new(cert_assigned_versions, system_object_versions),

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -148,7 +148,7 @@ impl RWLockDependencyBuilder {
         let mut read_version: HashMap<ObjectKey, Vec<TransactionDigest>> = Default::default();
         let mut overwrite_versions: HashMap<TransactionDigest, Vec<ObjectKey>> = Default::default();
         for effect in effects {
-            for kind in effect.input_consensus_objects() {
+            for kind in effect.accessed_consensus_objects() {
                 match kind {
                     InputConsensusObject::ReadOnly(obj_ref) => {
                         let obj_key = obj_ref.into();

--- a/crates/sui-core/src/congestion_tracker.rs
+++ b/crates/sui-core/src/congestion_tracker.rs
@@ -94,7 +94,7 @@ impl CongestionTracker {
                 cleared_events.push((
                     gas_price,
                     effect
-                        .input_consensus_objects()
+                        .accessed_consensus_objects()
                         .into_iter()
                         .filter_map(|object| match object {
                             InputConsensusObject::Mutate((id, _, _)) => Some(id),

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -363,7 +363,7 @@ async fn test_congestion_control_execution_cancellation() {
 
     // Tests consensus object versions in effects are set correctly.
     assert_eq!(
-        effects.input_consensus_objects(),
+        effects.accessed_consensus_objects(),
         vec![
             InputConsensusObject::Cancelled(shared_object_1.0, SequenceNumber::CONGESTED),
             InputConsensusObject::Cancelled(shared_object_2.0, SequenceNumber::CANCELLED_READ)

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -569,7 +569,7 @@ async fn test_delete_shared_object() {
 
     // assert the shared object was deleted
     let deleted_obj_id = effects.deleted()[0].0;
-    let shared_obj_id = effects.input_consensus_objects()[0].id_and_version().0;
+    let shared_obj_id = effects.accessed_consensus_objects()[0].id_and_version().0;
     assert_eq!(deleted_obj_id, shared_obj_id);
 
     // assert the version of the deleted shared object was incremented
@@ -688,7 +688,7 @@ async fn test_delete_shared_object_immut_mut_mut_interleave() {
 
     // assert the shared object was deleted
     let deleted_obj_id = effects.deleted()[0].0;
-    let shared_obj_id = effects.input_consensus_objects()[0].id_and_version().0;
+    let shared_obj_id = effects.accessed_consensus_objects()[0].id_and_version().0;
     assert_eq!(deleted_obj_id, shared_obj_id);
 
     // assert the version of the deleted shared object was incremented
@@ -786,7 +786,7 @@ async fn test_delete_shared_object_immut_mut_immut_interleave() {
 
     // assert the shared object was deleted
     let deleted_obj_id = effects.deleted()[0].0;
-    let shared_obj_id = effects.input_consensus_objects()[0].id_and_version().0;
+    let shared_obj_id = effects.accessed_consensus_objects()[0].id_and_version().0;
     assert_eq!(deleted_obj_id, shared_obj_id);
 
     // assert the version of the deleted shared object was incremented

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -335,8 +335,8 @@ async fn test_deposits() {
             .get_transaction_cache_reader()
             .get_executed_effects(&settlement_digest)
             .expect("settlement digest should exist");
-        let input_consensus_objects = settlement_effects.input_consensus_objects();
-        input_consensus_objects.iter().find(|input_consensus_object| {
+        let accessed_consensus_objects = settlement_effects.accessed_consensus_objects();
+        accessed_consensus_objects.iter().find(|input_consensus_object| {
             matches!(input_consensus_object, InputConsensusObject::ReadOnly(obj_ref) if obj_ref.0 == SUI_ACCUMULATOR_ROOT_OBJECT_ID)
         }).expect("settlement should have accumulator root object as read-only input consensus object");
     });

--- a/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
@@ -202,7 +202,7 @@ impl StressTestRunner {
         }
 
         println!("CONSENSUS:");
-        for kind in effects.input_consensus_objects() {
+        for kind in effects.accessed_consensus_objects() {
             let (obj_id, version) = kind.id_and_version();
             let object = state
                 .get_object_store()

--- a/crates/sui-e2e-tests/tests/party_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/party_objects_tests.rs
@@ -45,7 +45,7 @@ async fn party_object_deletion() {
         .effects;
 
     assert_eq!(effects.deleted().len(), 1);
-    assert_eq!(effects.input_consensus_objects().len(), 1);
+    assert_eq!(effects.accessed_consensus_objects().len(), 1);
 
     // assert the shared object was deleted
     let deleted_obj_id = effects.deleted()[0].0;
@@ -217,7 +217,7 @@ async fn party_object_transfer() {
         .await
         .effects;
 
-    assert_eq!(effects.input_consensus_objects().len(), 1);
+    assert_eq!(effects.accessed_consensus_objects().len(), 1);
     let mutated_party = effects
         .mutated()
         .into_iter()

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -70,7 +70,7 @@ async fn shared_object_deletion() {
         .effects;
 
     assert_eq!(effects.deleted().len(), 1);
-    assert_eq!(effects.input_consensus_objects().len(), 1);
+    assert_eq!(effects.accessed_consensus_objects().len(), 1);
 
     // assert the shared object was deleted
     let deleted_obj_id = effects.deleted()[0].0;

--- a/crates/sui-execution-backtest/src/execute.rs
+++ b/crates/sui-execution-backtest/src/execute.rs
@@ -216,7 +216,7 @@ pub(crate) fn execute_one_transaction(
     // no live version and are excluded above, so only mutated/read-only entries remain.
     let system_object_versions = executed
         .effects
-        .input_consensus_objects()
+        .accessed_consensus_objects()
         .into_iter()
         .filter_map(|ico| match ico {
             InputConsensusObject::Mutate((id, v, _))
@@ -543,7 +543,7 @@ fn log_divergence(
         .collect();
     let missing_consensus: Vec<String> = executed
         .effects
-        .input_consensus_objects()
+        .accessed_consensus_objects()
         .into_iter()
         .filter_map(|ico| match ico {
             InputConsensusObject::Mutate((id, v, _))

--- a/crates/sui-execution-backtest/src/store.rs
+++ b/crates/sui-execution-backtest/src/store.rs
@@ -436,7 +436,7 @@ pub fn resolve_input_objects(
     effects: &TransactionEffects,
     store: &ScanStore,
 ) -> anyhow::Result<InputObjects> {
-    let consensus_inputs = effects.input_consensus_objects();
+    let consensus_inputs = effects.accessed_consensus_objects();
     // Per-tx version for the inputs we resolve against — only plain mutate/read-only consensus
     // inputs are materialized at a specific version in the checkpoint. Other kinds (cancelled,
     // ended consensus streams) carry no live version and fall through to the latest-version lookup,

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1058,7 +1058,7 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
                 gas_used: effect.gas_cost_summary().clone(),
                 shared_objects: to_sui_object_ref(
                     effect
-                        .input_consensus_objects()
+                        .accessed_consensus_objects()
                         .into_iter()
                         .map(|kind| {
                             #[allow(deprecated)]

--- a/crates/sui-replay-2/src/replay_txn.rs
+++ b/crates/sui-replay-2/src/replay_txn.rs
@@ -667,7 +667,7 @@ fn get_input_ids(txn_data: &TransactionData) -> Result<BTreeSet<ObjectKey>, Erro
 // Get the input shared objects and unchanged consensus objects from the transaction effects
 fn get_effects_ids(effects: &TransactionEffects) -> Result<BTreeSet<ObjectKey>, Error> {
     let mut object_keys = effects
-        .input_consensus_objects()
+        .accessed_consensus_objects()
         .iter()
         .map(|input_consensus_object| match input_consensus_object {
             InputConsensusObject::MutateConsensusStreamEnded(object_id, version)

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -175,7 +175,7 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         unimplemented!("Only supposed by v2 and above");
     }
 
-    fn input_consensus_objects(&self) -> Vec<InputConsensusObject> {
+    fn accessed_consensus_objects(&self) -> Vec<InputConsensusObject> {
         let modified: HashSet<_> = self.modified_at_versions.iter().map(|(r, _)| r).collect();
         self.shared_objects
             .iter()
@@ -330,7 +330,7 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
     }
 
     fn unchanged_consensus_objects(&self) -> Vec<(ObjectID, UnchangedConsensusKind)> {
-        self.input_consensus_objects()
+        self.accessed_consensus_objects()
             .iter()
             .filter_map(|o| match o {
                 // In effects v1, the only unchanged consensus objects are read-only shared objects.

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -120,7 +120,7 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
             .collect()
     }
 
-    fn input_consensus_objects(&self) -> Vec<InputConsensusObject> {
+    fn accessed_consensus_objects(&self) -> Vec<InputConsensusObject> {
         self.changed_objects
             .iter()
             .filter_map(|(id, change)| match &change.input_state {
@@ -582,16 +582,16 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
 }
 
 impl TransactionEffectsV2 {
-    /// Derive the unchanged consensus objects of a transaction from its shared inputs and the
-    /// per-epoch config objects it read, given the set of objects it changed. Callers compute
-    /// this before constructing the effects and pass the result to [`Self::new`], so additional
-    /// unchanged consensus objects can be appended before construction if needed.
+    /// Derive the unchanged consensus objects of a transaction from its shared inputs, the
+    /// per-epoch config objects it read, and the system objects it read during execution, given
+    /// the set of objects it changed.
     pub fn compute_unchanged_consensus_objects(
         shared_objects: Vec<SharedInput>,
         loaded_per_epoch_config_objects: BTreeSet<ObjectID>,
         changed_objects: &BTreeMap<ObjectID, EffectsObjectChange>,
+        loaded_system_objects: BTreeMap<ObjectID, VersionDigest>,
     ) -> Vec<(ObjectID, UnchangedConsensusKind)> {
-        shared_objects
+        let mut unchanged_consensus_objects: Vec<_> = shared_objects
             .into_iter()
             .filter_map(|shared_input| match shared_input {
                 SharedInput::Existing((id, version, digest)) => {
@@ -630,7 +630,53 @@ impl TransactionEffectsV2 {
                     .into_iter()
                     .map(|id| (id, UnchangedConsensusKind::PerEpochConfig)),
             )
-            .collect()
+            .collect();
+
+        // Record system objects read during execution (e.g. the accumulator root) as read-only
+        // consensus objects, so nodes executing from these effects (checkpoint execution, crash
+        // recovery) can reproduce the read. Skip any that already appear
+        // as a changed object or as an unchanged consensus object — those versions are already
+        // recorded. Alongside each already-recorded id, keep the version (and digest) its entry
+        // carries — the input version for a changed object, the recorded version for a read-only
+        // one — so we can check it matches what the in-execution read observed.
+        let already_recorded: BTreeMap<ObjectID, Option<VersionDigest>> = changed_objects
+            .iter()
+            .map(|(id, change)| {
+                let recorded = match &change.input_state {
+                    ObjectIn::Exist((version_digest, _)) => Some(*version_digest),
+                    _ => None,
+                };
+                (*id, recorded)
+            })
+            .chain(unchanged_consensus_objects.iter().map(|(id, kind)| {
+                let recorded = match kind {
+                    UnchangedConsensusKind::ReadOnlyRoot(version_digest) => Some(*version_digest),
+                    _ => None,
+                };
+                (*id, recorded)
+            }))
+            .collect();
+        for (id, version_digest) in loaded_system_objects {
+            match already_recorded.get(&id) {
+                None => {
+                    unchanged_consensus_objects
+                        .push((id, UnchangedConsensusKind::ReadOnlyRoot(version_digest)));
+                }
+                Some(recorded) => {
+                    // The existing entry must record the same version the in-execution read
+                    // observed — both come from the version this transaction was sequenced
+                    // against. `None` means the entry's kind carries no version to compare
+                    // (e.g. a created object or a per-epoch-config read), which no implicitly
+                    // readable system object should ever coincide with.
+                    debug_assert_eq!(
+                        *recorded,
+                        Some(version_digest),
+                        "system object {id} read at a version different from its recorded entry"
+                    );
+                }
+            }
+        }
+        unchanged_consensus_objects
     }
 
     pub fn new(

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -668,11 +668,12 @@ impl TransactionEffectsV2 {
                     // against. `None` means the entry's kind carries no version to compare
                     // (e.g. a created object or a per-epoch-config read), which no implicitly
                     // readable system object should ever coincide with.
-                    debug_assert_eq!(
-                        *recorded,
-                        Some(version_digest),
-                        "system object {id} read at a version different from its recorded entry"
-                    );
+                    if *recorded != Some(version_digest) {
+                        mysten_common::debug_fatal!(
+                            "system object {id} read at version {version_digest:?} but its \
+                             effects entry records {recorded:?}"
+                        );
+                    }
                 }
             }
         }

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -323,12 +323,18 @@ pub trait TransactionEffectsAPI {
     /// It includes objects that are mutated, wrapped and deleted.
     /// This API is only available on effects v2 and above.
     fn old_object_metadata(&self) -> Vec<(ObjectRef, Owner)>;
-    /// Returns the list of sequenced consensus objects used in the input.
-    /// This is needed in effects because in transaction we only have object ID
-    /// for consensus objects. Their version and digest can only be figured out after sequencing.
-    /// Also provides the use kind to indicate whether the object was mutated or read-only.
-    /// It does not include per epoch config objects since they do not require sequencing.
-    fn input_consensus_objects(&self) -> Vec<InputConsensusObject>;
+    /// Returns the consensus objects the transaction read or wrote, with the version and digest
+    /// resolved during execution (the transaction itself only carries the object ID for consensus
+    /// objects; version and digest are known only after sequencing). Each entry's kind indicates
+    /// whether the object was mutated or read-only.
+    ///
+    /// This includes system objects (e.g. the accumulator root) read during execution but not
+    /// declared as sequenced inputs — they are recorded as read-only so nodes executing from
+    /// effects can reproduce the read, and are indistinguishable here from genuinely-sequenced
+    /// read-only inputs. Callers
+    /// that need only the transaction's declared inputs must filter using the transaction's own
+    /// input set. It does not include per epoch config objects, since they do not require sequencing.
+    fn accessed_consensus_objects(&self) -> Vec<InputConsensusObject>;
     fn created(&self) -> Vec<(ObjectRef, Owner)>;
     fn mutated(&self) -> Vec<(ObjectRef, Owner)>;
     fn unwrapped(&self) -> Vec<(ObjectRef, Owner)>;
@@ -361,7 +367,7 @@ pub trait TransactionEffectsAPI {
     fn gas_cost_summary(&self) -> &GasCostSummary;
 
     fn stream_ended_mutably_accessed_consensus_objects(&self) -> Vec<ObjectID> {
-        self.input_consensus_objects()
+        self.accessed_consensus_objects()
             .into_iter()
             .filter_map(|kind| match kind {
                 InputConsensusObject::MutateConsensusStreamEnded(id, _) => Some(id),

--- a/crates/sui-types/src/effects/test_effects_builder.rs
+++ b/crates/sui-types/src/effects/test_effects_builder.rs
@@ -314,6 +314,7 @@ impl TestEffectsBuilder {
             shared_objects,
             BTreeSet::new(),
             &changed_objects,
+            BTreeMap::new(),
         );
         TransactionEffects::new_from_execution_v2(
             status,

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -149,6 +149,20 @@ built_in_ids! {
 pub const SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 pub const SUI_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 
+/// System objects that a transaction may read *implicitly* during execution, i.e. without declaring
+/// them as shared inputs. Their read version is recorded in effects (as a read-only consensus
+/// object) and reproduced when executing from effects (checkpoint execution during state sync, and
+/// crash recovery) so the read resolves to the same version on every node. Execution paths that are
+/// not sequenced by consensus (dev-inspect / dry-run) pin these objects at their latest committed
+/// versions instead.
+///
+/// Membership here only says the object *may* be read implicitly, so its read version must be
+/// reproducible. A transaction can still declare such an object as an explicit shared input (e.g.
+/// a settlement transaction mutating the accumulator root, or a user transaction that passes it
+/// in); declared inputs are version-assigned through the normal shared-input path, independent of
+/// this set. Extend this as more implicitly-read system objects arise.
+pub const IMPLICITLY_READ_SYSTEM_OBJECTS: &[ObjectID] = &[SUI_ACCUMULATOR_ROOT_OBJECT_ID];
+
 pub fn sui_framework_address_concat_string(suffix: &str) -> String {
     format!("{}{suffix}", SUI_FRAMEWORK_ADDRESS.to_hex_literal())
 }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -525,10 +525,12 @@ impl<'backing> TemporaryStore<'backing> {
         let lamport_version = self.lamport_timestamp;
         // TODO: Cleanup this clone. Potentially add unchanged_shraed_objects directly to InnerTempStore.
         let loaded_per_epoch_config_objects = self.loaded_per_epoch_config_objects.read().clone();
+        let loaded_system_objects = self.loaded_system_objects.borrow().clone();
         let unchanged_consensus_objects = TransactionEffectsV2::compute_unchanged_consensus_objects(
             shared_object_refs,
             loaded_per_epoch_config_objects,
             &object_changes,
+            loaded_system_objects,
         );
         let inner = self.into_inner(accumulator_running_max_withdraws);
 

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -358,6 +358,7 @@ impl<'backing> TemporaryStore<'backing> {
             shared_object_refs,
             BTreeSet::new(),
             &object_changes,
+            BTreeMap::new(),
         );
         let inner = self.into_inner();
 

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -376,6 +376,7 @@ impl<'backing> TemporaryStore<'backing> {
             shared_object_refs,
             BTreeSet::new(),
             &object_changes,
+            BTreeMap::new(),
         );
         let inner = self.into_inner();
 

--- a/sui-execution/v3/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v3/sui-adapter/src/temporary_store.rs
@@ -344,6 +344,7 @@ impl<'backing> TemporaryStore<'backing> {
             shared_object_refs,
             loaded_per_epoch_config_objects,
             &object_changes,
+            BTreeMap::new(),
         );
         let inner = self.into_inner(accumulator_running_max_withdraws);
 


### PR DESCRIPTION
## Description

Stack of 7 (builds on [3/7], merged). Emits the system objects read during execution into the transaction effects as `ReadOnlyRoot` unchanged-consensus objects, and reconstructs their versions when executing from effects via `assign_versions_from_effects`. This makes checkpoint execution deterministic for transactions that gate on system-object versions, without re-deriving them from live consensus assignment.

## Test plan

Exercised by replay/checkpoint paths and, end to end, by the object-balance withdraw stress test once the stack is complete.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes are not required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: