### PR TITLE
[1.74] Suppress resubmission of consensus-processed transactions (#27054) & reject repeated soft-bundle txns (#27056)

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -17,6 +17,7 @@ use prometheus::{
     register_int_counter_with_registry,
 };
 use std::{
+    collections::HashSet,
     io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
@@ -682,6 +683,9 @@ impl ValidatorService {
         let mut spam_weight = Weight::zero();
         // First gas price seen in this soft bundle.
         let mut expected_soft_bundle_gas_price = None;
+        // Transaction digests seen in this soft bundle, used to reject bundles that repeat a
+        // transaction. No legitimate client constructs such a bundle.
+        let mut soft_bundle_digests = HashSet::new();
 
         let req_type = if is_ping_request {
             "ping"
@@ -715,6 +719,19 @@ impl ValidatorService {
             // Ok to fail the request when any transaction is invalid.
             let tx_size = transaction.validity_check(&epoch_store.tx_validity_check_context())?;
             let tx_digest = *transaction.digest();
+
+            // Soft bundles must not repeat a transaction. Fail the whole request if they do.
+            if is_soft_bundle_request {
+                fp_ensure!(
+                    soft_bundle_digests.insert(tx_digest),
+                    SuiErrorKind::UserInputError {
+                        error: UserInputError::RepeatedTransactionInSoftBundle {
+                            digest: tx_digest
+                        }
+                    }
+                    .into()
+                );
+            }
 
             // Soft bundles require all transactions to use the same gas price.
             if is_soft_bundle_request {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -29,7 +29,9 @@ use sui_network::{
 };
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::message_envelope::Message;
-use sui_types::messages_consensus::{ConsensusPosition, ConsensusTransaction};
+use sui_types::messages_consensus::{
+    ConsensusPosition, ConsensusTransaction, ConsensusTransactionKey,
+};
 use sui_types::messages_grpc::{
     ObjectInfoRequest, ObjectInfoResponse, RawSubmitTxResponse, SystemStateRequest,
     TransactionInfoRequest, TransactionInfoResponse,
@@ -67,6 +69,7 @@ use crate::gasless_rate_limiter::GaslessRateLimiter;
 use crate::{
     authority::{AuthorityState, consensus_tx_status_cache::ConsensusTxStatus},
     consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, ConsensusOverloadChecker},
+    consensus_handler::SequencedConsensusTransactionKey,
     traffic_controller::{TrafficController, parse_ip, policies::TrafficTally},
 };
 use crate::{
@@ -197,6 +200,7 @@ pub struct ValidatorServiceMetrics {
 
     num_rejected_tx_during_overload: IntCounterVec,
     submission_rejected_transactions: IntCounterVec,
+    submission_suppressed_already_processed: IntCounterVec,
     connection_ip_not_found: IntCounter,
     forwarded_header_parse_error: IntCounter,
     forwarded_header_invalid: IntCounter,
@@ -289,6 +293,14 @@ impl ValidatorServiceMetrics {
                 "validator_service_submission_rejected_transactions",
                 "Number of transactions rejected during submission",
                 &["reason"],
+                registry,
+            )
+            .unwrap(),
+            submission_suppressed_already_processed: register_int_counter_vec_with_registry!(
+                "validator_service_submission_suppressed_already_processed",
+                "Number of submitted transactions suppressed because consensus had already \
+                 processed them this epoch (re-submission of already-processed transactions)",
+                &["req_type"],
                 registry,
             )
             .unwrap(),
@@ -852,6 +864,33 @@ impl ValidatorService {
                 debug!(
                     ?tx_digest,
                     "handle_submit_transaction: transaction already executed in previous epoch"
+                );
+                continue;
+            }
+
+            // Suppress resubmission of transactions consensus already processed this epoch:
+            // executed transactions whose effects details could not be reconstructed above (e.g.
+            // objects pruned), and sequenced-but-deferred transactions. Rejected is imperfect for
+            // the deferred case, but acceptable since well-behaved clients get Executed before
+            // pruning; this mainly sheds continuous resubmissions from faulty clients.
+            let consensus_key = SequencedConsensusTransactionKey::External(
+                ConsensusTransactionKey::Certificate(tx_digest),
+            );
+            if epoch_store.is_consensus_message_processed(&consensus_key)? {
+                metrics
+                    .submission_suppressed_already_processed
+                    .with_label_values(&[req_type])
+                    .inc();
+                results[idx] = Some(SubmitTxResult::Rejected {
+                    error: SuiErrorKind::TransactionProcessing {
+                        digest: tx_digest,
+                        status: "sequenced by consensus".to_string(),
+                    }
+                    .into(),
+                });
+                debug!(
+                    ?tx_digest,
+                    "handle_submit_transaction: consensus message already processed"
                 );
                 continue;
             }

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -485,7 +485,22 @@ async fn test_submit_soft_bundle_transactions() {
     let test_context = TestContext::new().await;
 
     let tx1 = test_context.build_test_transaction();
-    let tx2 = test_context.build_test_transaction();
+
+    // tx2 must be distinct from tx1: a soft bundle may not repeat a transaction.
+    let gas_object2 = Object::with_owner_for_testing(test_context.sender);
+    let gas_object_ref2 = gas_object2.compute_object_reference();
+    test_context.state.insert_genesis_object(gas_object2);
+    let tx_data2 = TestTransactionBuilder::new(
+        test_context.sender,
+        gas_object_ref2,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(None, test_context.sender)
+    .build();
+    let tx2 = to_sender_signed_transaction(tx_data2, &test_context.keypair);
 
     // Build request with batched transactions.
     let request = RawSubmitTxRequest {
@@ -518,6 +533,41 @@ async fn test_submit_soft_bundle_transactions() {
             _ => panic!("Expected Submitted status for all transactions"),
         }
     }
+}
+
+// A soft bundle that repeats the same transaction is rejected outright.
+#[tokio::test]
+async fn test_submit_soft_bundle_with_repeated_transaction() {
+    let test_context = TestContext::new().await;
+
+    let tx = test_context.build_test_transaction();
+    let tx_digest = *tx.digest();
+
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx).unwrap().into(),
+            bcs::to_bytes(&tx).unwrap().into(),
+        ],
+        submit_type: SubmitTxType::SoftBundle.into(),
+    };
+
+    let response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await;
+    assert!(response.is_err());
+    let error: SuiError = response.unwrap_err().into();
+    assert!(
+        matches!(
+            error.into_inner(),
+            SuiErrorKind::UserInputError {
+                error: UserInputError::RepeatedTransactionInSoftBundle { digest }
+            } if digest == tx_digest
+        ),
+        "expected RepeatedTransactionInSoftBundle error"
+    );
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -249,6 +249,42 @@ async fn test_submit_transaction_already_executed() {
     };
 }
 
+// Test that a transaction already processed by consensus this epoch but not yet executed
+// (e.g. deferred) is suppressed rather than resubmitted to consensus.
+#[tokio::test]
+async fn test_submit_transaction_consensus_message_processed() {
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let request = test_context.build_submit_request(transaction);
+
+    // Mark the transaction as processed by consensus without executing it, simulating a
+    // sequenced-but-deferred transaction. Its gas object is still unspent, so without the
+    // is_consensus_message_processed check it would be resubmitted to consensus.
+    let epoch_store = test_context.state.epoch_store_for_testing();
+    epoch_store.test_insert_user_signature(tx_digest, vec![]);
+
+    let response = test_context
+        .client
+        .submit_transaction(request, None)
+        .await
+        .unwrap();
+    assert_eq!(response.results.len(), 1);
+    match &response.results[0] {
+        SubmitTxResult::Rejected { error } => {
+            assert!(
+                matches!(
+                    error.as_inner(),
+                    SuiErrorKind::TransactionProcessing { digest, .. } if *digest == tx_digest
+                ),
+                "unexpected rejection error: {error}"
+            );
+        }
+        other => panic!("Expected Rejected response, got {other:?}"),
+    };
+}
+
 #[tokio::test]
 async fn test_submit_transaction_wrong_epoch() {
     let test_context = TestContext::new().await;
@@ -550,6 +586,69 @@ async fn test_submit_soft_bundle_transactions_with_already_executed() {
             // Expected: second transaction was submitted to consensus
         }
         _ => panic!("Expected Submitted status for second transaction"),
+    }
+}
+
+// Test that a transaction already processed by consensus (but not executed) is removed from a
+// soft bundle before submission, while the remaining transactions in the bundle are still
+// submitted to consensus.
+#[tokio::test]
+async fn test_submit_soft_bundle_transactions_with_consensus_message_processed() {
+    let test_context = TestContext::new().await;
+
+    // 1st transaction: mark as already processed by consensus without executing it.
+    let tx1 = test_context.build_test_transaction();
+    let tx1_digest = *tx1.digest();
+    let epoch_store = test_context.state.epoch_store_for_testing();
+    epoch_store.test_insert_user_signature(tx1_digest, vec![]);
+
+    // 2nd transaction: a fresh, unprocessed transaction with its own gas object.
+    let gas_object2 = Object::with_owner_for_testing(test_context.sender);
+    let gas_object_ref2 = gas_object2.compute_object_reference();
+    test_context.state.insert_genesis_object(gas_object2);
+
+    let tx_data2 = TestTransactionBuilder::new(
+        test_context.sender,
+        gas_object_ref2,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(None, test_context.sender)
+    .build();
+    let tx2 = to_sender_signed_transaction(tx_data2, &test_context.keypair);
+
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx1).unwrap().into(),
+            bcs::to_bytes(&tx2).unwrap().into(),
+        ],
+        submit_type: SubmitTxType::SoftBundle.into(),
+    };
+
+    let raw_response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(raw_response.results.len(), 2);
+
+    // The already-processed transaction is rejected and excluded from the bundle submitted to
+    // consensus; the remaining transaction is still submitted.
+    match &raw_response.results[0].inner {
+        Some(sui_types::messages_grpc::RawValidatorSubmitStatus::Rejected(_)) => {}
+        other => {
+            panic!("Expected Rejected status for already-processed transaction, got {other:?}")
+        }
+    }
+    match &raw_response.results[1].inner {
+        Some(sui_types::messages_grpc::RawValidatorSubmitStatus::Submitted(_)) => {}
+        other => panic!("Expected Submitted status for remaining transaction, got {other:?}"),
     }
 }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -366,6 +366,9 @@ pub enum UserInputError {
 
     #[error("Transaction chain ID {provided} does not match network chain ID {expected}.")]
     InvalidChainId { provided: String, expected: String },
+
+    #[error("Transaction {digest} appears more than once in the Soft Bundle")]
+    RepeatedTransactionInSoftBundle { digest: TransactionDigest },
 }
 
 #[derive(

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -820,6 +820,12 @@ pub enum SuiErrorKind {
         "Transaction was outbid by higher-gas-price transactions in the admission queue (current minimum gas price required: {min_gas_price})"
     )]
     TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: u64 },
+
+    #[error("Transaction {digest} is being processed: {status}")]
+    TransactionProcessing {
+        digest: TransactionDigest,
+        status: String,
+    },
 }
 
 #[repr(u64)]


### PR DESCRIPTION
## Summary
Cherry-pick of two related fixes to the 1.74 release branch:
- #27054 — Suppress resubmission of consensus-processed transactions
- #27056 — Reject soft bundles that repeat a transaction

Original commits:
- c28e6fa3083... (#27054)
- d07864d340... (#27056)

## Test plan
Cherry-picked cleanly with no conflicts; relies on existing tests from the original PRs.