### PR TITLE
Stress-test large object-balance withdrawals

### DIFF
--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -10,9 +10,9 @@ pub use operations::{
     ALIAS_ADD, ALIAS_REMOVE, ALIAS_TX, ALL_OPERATIONS, AccumulatorBalanceRead,
     AddressBalanceDeposit, AddressBalanceOverdraw, AddressBalanceWithdraw, AuthenticatedEventEmit,
     CoinReservationWithdraw, INVALID_ALIAS_TX, ImmutableObjectRead, ObjectBalanceDeposit,
-    ObjectBalanceOverdraw, ObjectBalanceWithdraw, OperationDescriptor, RandomnessRead,
-    SharedCounterIncrement, SharedCounterRead, TestCoinAddressDeposit, TestCoinAddressWithdraw,
-    TestCoinMint, TestCoinObjectWithdraw,
+    ObjectBalanceLargeWithdraw, ObjectBalanceOverdraw, ObjectBalanceWithdraw, OperationDescriptor,
+    RandomnessRead, SharedCounterIncrement, SharedCounterRead, TestCoinAddressDeposit,
+    TestCoinAddressWithdraw, TestCoinMint, TestCoinObjectWithdraw,
 };
 use rand::seq::SliceRandom;
 
@@ -316,6 +316,7 @@ impl CompositeWorkloadConfig {
         probabilities.insert(AddressBalanceOverdraw::NAME, 0.1);
         probabilities.insert(AccumulatorBalanceRead::NAME, 0.3);
         probabilities.insert(ObjectBalanceOverdraw::NAME, 0.1);
+        probabilities.insert(ObjectBalanceLargeWithdraw::NAME, 0.1);
         probabilities.insert(AuthenticatedEventEmit::NAME, 0.1);
         probabilities.insert(ImmutableObjectRead::NAME, 0.2);
         probabilities.insert(CoinReservationWithdraw::NAME, 0.1);
@@ -400,6 +401,7 @@ pub struct OperationPool {
     pub accumulator_root_initial_shared_version: SequenceNumber,
     pub hotness: f32,
     pub balance_pool: Option<(ObjectID, SequenceNumber)>,
+    pub empty_balance_pool: Option<(ObjectID, SequenceNumber)>,
     pub test_coin_cap: Option<(ObjectID, SequenceNumber)>,
     pub test_coin_type: Option<TypeTag>,
     pub chain_identifier: sui_types::digests::ChainIdentifier,
@@ -526,6 +528,7 @@ impl CompositePayload {
         let mut randomness = None;
         let mut accumulator_root = None;
         let mut balance_pool = None;
+        let mut empty_balance_pool = None;
         let mut test_coin_cap = None;
         let mut chain_identifier = None;
         let mut epoch = None;
@@ -541,6 +544,9 @@ impl CompositePayload {
                 ResourceRequest::AddressBalance => {}
                 ResourceRequest::ObjectBalance => {
                     balance_pool = pool.balance_pool;
+                }
+                ResourceRequest::EmptyBalancePool => {
+                    empty_balance_pool = pool.empty_balance_pool;
                 }
                 ResourceRequest::TestCoinCap => {
                     test_coin_cap = pool.test_coin_cap;
@@ -564,6 +570,7 @@ impl CompositePayload {
             package_id: pool.package_id,
             address_balance_amount: config.address_balance_amount,
             balance_pool,
+            empty_balance_pool,
             test_coin_cap,
             test_coin_type: pool.test_coin_type.clone(),
             immutable_object: pool.immutable_object,
@@ -591,6 +598,7 @@ impl CompositePayload {
                             r,
                             ResourceRequest::AddressBalance
                                 | ResourceRequest::ObjectBalance
+                                | ResourceRequest::EmptyBalancePool
                                 | ResourceRequest::AccumulatorRoot
                                 | ResourceRequest::CoinReservation
                         )
@@ -1118,6 +1126,16 @@ impl Payload for CompositePayload {
                     } else if effects.is_insufficient_funds() {
                         metrics.record_insufficient_funds(tx_info.op_set.clone());
                     } else if effects.is_ok() {
+                        // A withdrawal from the always-empty pool must never succeed:
+                        // there are no funds to withdraw, so it must fail with IFFW.
+                        if tx_info.op_set.contains(ObjectBalanceLargeWithdraw::NAME) {
+                            debug_fatal!(
+                                "Large object-balance withdrawal from an empty pool succeeded \
+                                 (tx {}): this indicates a balance-accounting bug. op_set: {}",
+                                result.digest,
+                                tx_info.op_set.describe()
+                            );
+                        }
                         metrics.record_success(tx_info.op_set.clone());
                     } else {
                         metrics.record_abort(tx_info.op_set.clone());
@@ -1354,6 +1372,7 @@ impl WorkloadBuilder<dyn Payload> for CompositeWorkloadBuilder {
             randomness_initial_shared_version: None,
             accumulator_root_initial_shared_version: None,
             balance_pool: None,
+            empty_balance_pool: None,
             test_coin_cap: None,
             immutable_object: None,
             init_gas,
@@ -1374,6 +1393,7 @@ pub struct CompositeWorkload {
     randomness_initial_shared_version: Option<SequenceNumber>,
     accumulator_root_initial_shared_version: Option<SequenceNumber>,
     balance_pool: Option<(ObjectID, SequenceNumber)>,
+    empty_balance_pool: Option<(ObjectID, SequenceNumber)>,
     test_coin_cap: Option<(ObjectID, SequenceNumber)>,
     immutable_object: Option<ObjectRef>,
     init_gas: Vec<Gas>,
@@ -1587,6 +1607,33 @@ impl Workload<dyn Payload> for CompositeWorkload {
             };
             self.balance_pool = Some((obj_ref.0, initial_shared_version));
             info!("Created balance pool {:?}", self.balance_pool);
+        }
+
+        if init_requirements.contains(&InitRequirement::CreateEmptyBalancePool) {
+            // This pool is deliberately never seeded, so its `Balance<T>` stays zero for
+            // every type. Withdrawals from it must always trigger IFFW.
+            info!("Creating empty balance pool for large-withdrawal operations");
+            let (multi_gas, sender, keypair) = &mut self.payload_gas[0];
+            let gas = &mut multi_gas[0];
+            let tx = TestTransactionBuilder::new(*sender, *gas, gas_price)
+                .move_call(self.package_id.unwrap(), "balance_pool", "create", vec![])
+                .ensure_unique()
+                .build_and_sign(keypair.as_ref());
+
+            let execution_result = execution_proxy.execute_transaction_block(tx).await;
+            let effects = execution_result.expect("Empty balance pool creation should succeed");
+
+            update_gas!(gas, effects);
+
+            let (obj_ref, owner) = effects.created()[0].clone();
+            let initial_shared_version = match owner {
+                Owner::Shared {
+                    initial_shared_version,
+                } => initial_shared_version,
+                _ => panic!("Empty balance pool should be shared"),
+            };
+            self.empty_balance_pool = Some((obj_ref.0, initial_shared_version));
+            info!("Created empty balance pool {:?}", self.empty_balance_pool);
         }
 
         if init_requirements.contains(&InitRequirement::SeedBalancePool) {
@@ -1924,6 +1971,7 @@ impl Workload<dyn Payload> for CompositeWorkload {
                 .unwrap(),
             hotness: self.config.shared_counter_hotness,
             balance_pool: self.balance_pool,
+            empty_balance_pool: self.empty_balance_pool,
             test_coin_cap: self.test_coin_cap,
             test_coin_type,
             chain_identifier: self.chain_identifier.unwrap(),

--- a/crates/sui-benchmark/src/workloads/composite/operations.rs
+++ b/crates/sui-benchmark/src/workloads/composite/operations.rs
@@ -10,7 +10,7 @@ use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::coin_reservation::ParsedObjectRefWithdrawal;
 use sui_types::committee::EpochId;
 use sui_types::digests::ChainIdentifier;
-use sui_types::gas_coin::GAS;
+use sui_types::gas_coin::{GAS, TOTAL_SUPPLY_MIST};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{
     Argument, CallArg, Command, FundsWithdrawalArg, ObjectArg, SharedObjectMutability,
@@ -31,6 +31,9 @@ pub enum InitRequirement {
     SeedTestCoinAddressBalance,
     EnableAddressAlias,
     CreateImmutableObject,
+    /// Create a balance pool that is never seeded, so its `Balance<T>` is always
+    /// zero for every type `T`. Used to guarantee withdrawals trigger IFFW.
+    CreateEmptyBalancePool,
 }
 
 pub const ALIAS_TX: &str = "alias_tx";
@@ -58,6 +61,7 @@ pub const ALL_OPERATIONS: &[OperationDescriptor] = &[
     AddressBalanceOverdraw::DESCRIPTOR,
     AccumulatorBalanceRead::DESCRIPTOR,
     ObjectBalanceOverdraw::DESCRIPTOR,
+    ObjectBalanceLargeWithdraw::DESCRIPTOR,
     AuthenticatedEventEmit::DESCRIPTOR,
     ImmutableObjectRead::DESCRIPTOR,
     CoinReservationWithdraw::DESCRIPTOR,
@@ -73,6 +77,7 @@ pub enum ResourceRequest {
     AccumulatorRoot,
     ImmutableObject,
     CoinReservation,
+    EmptyBalancePool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -87,6 +92,7 @@ pub struct OperationResources {
     pub package_id: ObjectID,
     pub address_balance_amount: u64,
     pub balance_pool: Option<(ObjectID, SequenceNumber)>,
+    pub empty_balance_pool: Option<(ObjectID, SequenceNumber)>,
     pub test_coin_cap: Option<(ObjectID, SequenceNumber)>,
     pub test_coin_type: Option<TypeTag>,
     pub immutable_object: Option<ObjectRef>,
@@ -999,6 +1005,123 @@ impl Operation for ObjectBalanceOverdraw {
             Identifier::new("coin").unwrap(),
             Identifier::new("from_balance").unwrap(),
             vec![GAS::type_tag()],
+            vec![balance],
+        );
+
+        let recipient = SuiAddress::random_for_testing_only();
+        builder.transfer_arg(recipient, coin);
+    }
+}
+
+/// Picks a withdrawal amount from a set of boundary values that are most likely to
+/// expose overflow or balance-accounting bugs in funds-accumulator withdrawals. Each case is
+/// equally likely, including a uniform full-range draw so any `u64` can occur in
+/// principle. `0` is intentionally excluded: a zero reservation is rejected as
+/// invalid rather than executed, so it would not exercise the withdrawal path.
+fn large_withdraw_amount() -> u64 {
+    let mut rng = get_rng();
+    // 2^63: the u64 sign-bit boundary (one past i64::MAX).
+    const SIGN_BIT: u64 = i64::MAX as u64 + 1;
+    let cases: [u64; 15] = [
+        rng.gen_range(1..=u64::MAX), // uniform over the full (nonzero) u64 range
+        1,
+        2,
+        u64::MAX,
+        u64::MAX - 1,
+        i64::MAX as u64,
+        i64::MAX as u64 - 1,
+        SIGN_BIT,
+        SIGN_BIT + 1,
+        u32::MAX as u64, // 2^32 - 1, the 32-bit boundary
+        u32::MAX as u64 + 1,
+        TOTAL_SUPPLY_MIST,
+        TOTAL_SUPPLY_MIST - 1,
+        TOTAL_SUPPLY_MIST + 1,
+        TOTAL_SUPPLY_MIST + TOTAL_SUPPLY_MIST / 2, // beyond any conceivable real supply (~1.5x)
+    ];
+    cases[rng.gen_range(0..cases.len())]
+}
+
+/// Withdraws a potentially enormous amount (up to `u64::MAX`) from an object balance
+/// that is guaranteed to be empty. Exercises both SUI and a custom coin type.
+///
+/// Because the target object's `Balance<T>` is always zero, every such withdrawal
+/// must fail (IFFW). A success would mean funds were withdrawn that never existed, so a
+/// successful transaction containing this operation is treated as a critical bug in
+/// `handle_batch_results`.
+pub struct ObjectBalanceLargeWithdraw;
+
+impl ObjectBalanceLargeWithdraw {
+    pub const NAME: &'static str = "object_balance_large_withdraw";
+    pub const DESCRIPTOR: OperationDescriptor = OperationDescriptor {
+        name: Self::NAME,
+        factory: || Box::new(ObjectBalanceLargeWithdraw),
+    };
+}
+
+impl Operation for ObjectBalanceLargeWithdraw {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn resource_requests(&self) -> Vec<ResourceRequest> {
+        vec![ResourceRequest::EmptyBalancePool]
+    }
+
+    fn init_requirements(&self) -> Vec<InitRequirement> {
+        vec![InitRequirement::CreateEmptyBalancePool]
+    }
+
+    fn apply(
+        &self,
+        builder: &mut ProgrammableTransactionBuilder,
+        resources: &OperationResources,
+        _account_state: &AccountState,
+    ) {
+        let (pool_id, initial_shared_version) = resources
+            .empty_balance_pool
+            .expect("Empty balance pool not resolved");
+
+        // Withdraw SUI or, when a custom coin is configured, the custom coin with equal
+        // probability. The empty pool holds neither, so both withdrawals trigger IFFW.
+        let coin_type = match &resources.test_coin_type {
+            Some(test_coin_type) if get_rng().gen_bool(0.5) => test_coin_type.clone(),
+            _ => GAS::type_tag(),
+        };
+
+        let withdraw_amount = large_withdraw_amount();
+
+        let pool_arg = builder
+            .obj(ObjectArg::SharedObject {
+                id: pool_id,
+                initial_shared_version,
+                mutability: SharedObjectMutability::Mutable,
+            })
+            .unwrap();
+
+        let amount_arg = builder.pure(withdraw_amount).unwrap();
+
+        let withdrawal = builder.programmable_move_call(
+            resources.package_id,
+            Identifier::new("balance_pool").unwrap(),
+            Identifier::new("withdraw").unwrap(),
+            vec![coin_type.clone()],
+            vec![pool_arg, amount_arg],
+        );
+
+        let balance = builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance").unwrap(),
+            Identifier::new("redeem_funds").unwrap(),
+            vec![coin_type.clone()],
+            vec![withdrawal],
+        );
+
+        let coin = builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("from_balance").unwrap(),
+            vec![coin_type],
             vec![balance],
         );
 

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2451,6 +2451,26 @@ mod test {
             .build()
             .await
             .into();
-        test_simulated_load(test_cluster, 30).await;
+
+        // The large object-balance withdrawal operation exposes a bug present in the older
+        // execution layers this test targets, so disable it here. It is exercised against
+        // the latest execution version elsewhere.
+        let config = SimulatedLoadConfig {
+            composite_config: Some(CompositeWorkloadConfig::balanced().with_probability(
+                sui_benchmark::workloads::composite::ObjectBalanceLargeWithdraw::NAME,
+                0.0,
+            )),
+            ..Default::default()
+        };
+        test_simulated_load_with_test_config(
+            test_cluster,
+            30,
+            config,
+            None,
+            None,
+            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
+            true, // enable_surfer
+        )
+        .await;
     }
 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1646,6 +1646,7 @@ mod test {
         .with_probability(AddressBalanceOverdraw::NAME, 0.3)
         .with_probability(AccumulatorBalanceRead::NAME, 0.3)
         .with_probability(AuthenticatedEventEmit::NAME, 0.1)
+        .with_probability(ObjectBalanceLargeWithdraw::NAME, 0.2)
         .with_probability(CoinReservationWithdraw::NAME, 0.3);
 
         let test_cluster_for_scan = test_cluster.clone();
@@ -1685,6 +1686,29 @@ mod test {
             assert!(
                 accum_read_stats.success_count > 0,
                 "expected at least one accumulator balance read"
+            );
+
+            // Large withdrawals target an always-empty pool, so they must be exercised
+            // but must never succeed (a success would mean withdrawing funds that never existed).
+            let mut large_withdraw_txs = 0;
+            let mut large_withdraw_successes = 0;
+            for (op_set, stats) in metrics.iter_stats() {
+                if op_set.contains(ObjectBalanceLargeWithdraw::NAME) {
+                    large_withdraw_txs += stats.signed_and_sent_count;
+                    large_withdraw_successes += stats.success_count;
+                }
+            }
+            info!(
+                "large object-balance withdraw metrics: sent={}, successes={}",
+                large_withdraw_txs, large_withdraw_successes
+            );
+            assert!(
+                large_withdraw_txs > 0,
+                "expected at least one large object-balance withdrawal to be attempted"
+            );
+            assert_eq!(
+                large_withdraw_successes, 0,
+                "large object-balance withdrawal from an empty pool must never succeed"
             );
 
             // Verify accumulators are actually being deleted by scanning all checkpoints

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2077,6 +2077,7 @@ mod test {
         .with_probability(AddressBalanceOverdraw::NAME, 0.3)
         .with_probability(AccumulatorBalanceRead::NAME, 0.3)
         .with_probability(AuthenticatedEventEmit::NAME, 0.1)
+        .with_probability(ObjectBalanceLargeWithdraw::NAME, 0.2)
         .with_probability(CoinReservationWithdraw::NAME, 0.3);
 
         let test_cluster_for_scan = test_cluster.clone();
@@ -2116,6 +2117,29 @@ mod test {
             assert!(
                 accum_read_stats.success_count > 0,
                 "expected at least one accumulator balance read"
+            );
+
+            // Large withdrawals target an always-empty pool, so they must be exercised
+            // but must never succeed (a success would mean withdrawing funds that never existed).
+            let mut large_withdraw_txs = 0;
+            let mut large_withdraw_successes = 0;
+            for (op_set, stats) in metrics.iter_stats() {
+                if op_set.contains(ObjectBalanceLargeWithdraw::NAME) {
+                    large_withdraw_txs += stats.signed_and_sent_count;
+                    large_withdraw_successes += stats.success_count;
+                }
+            }
+            info!(
+                "large object-balance withdraw metrics: sent={}, successes={}",
+                large_withdraw_txs, large_withdraw_successes
+            );
+            assert!(
+                large_withdraw_txs > 0,
+                "expected at least one large object-balance withdrawal to be attempted"
+            );
+            assert_eq!(
+                large_withdraw_successes, 0,
+                "large object-balance withdrawal from an empty pool must never succeed"
             );
 
             // Verify accumulators are actually being deleted by scanning all checkpoints

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2774,6 +2774,26 @@ mod test {
             .build()
             .await
             .into();
-        test_simulated_load(test_cluster, 30).await;
+
+        // The large object-balance withdrawal operation exposes a bug present in the older
+        // execution layers this test targets, so disable it here. It is exercised against
+        // the latest execution version elsewhere.
+        let config = SimulatedLoadConfig {
+            composite_config: Some(CompositeWorkloadConfig::balanced().with_probability(
+                sui_benchmark::workloads::composite::ObjectBalanceLargeWithdraw::NAME,
+                0.0,
+            )),
+            ..Default::default()
+        };
+        test_simulated_load_with_test_config(
+            test_cluster,
+            30,
+            config,
+            None,
+            None,
+            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
+            true, // enable_surfer
+        )
+        .await;
     }
 }


### PR DESCRIPTION
## Description

The composite stress workload had no coverage for large or boundary-value object-balance withdrawals, which are the inputs most likely to expose overflow or minting bugs in the funds accumulator.

Adds an `object_balance_large_withdraw` operation that withdraws boundary values (1, `u32::MAX`±1, `i64::MAX`/sign-bit, `u64::MAX`±1, `TOTAL_SUPPLY_MIST`±1, and a uniform full-range draw) from a balance pool that is deliberately never seeded. Since the pool's `Balance<T>` is always zero, every such withdrawal must fail with insufficient funds — a success would mean funds were minted from nothing, which trips a `debug_fatal!`.

## Test plan

Extends the `test_composite_workload` simtest to exercise the operation and assert it is both attempted and never succeeds.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
