### PR TITLE
Cancel pre-submission when a transaction is already processed by consensus

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -31,9 +31,7 @@ use sui_network::{
 };
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::message_envelope::Message;
-use sui_types::messages_consensus::{
-    ConsensusPosition, ConsensusTransaction, ConsensusTransactionKey,
-};
+use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKey};
 use sui_types::messages_grpc::{
     ObjectInfoRequest, ObjectInfoResponse, RawSubmitTxResponse, SystemStateRequest,
     TransactionInfoRequest, TransactionInfoResponse,
@@ -1165,7 +1163,30 @@ impl ValidatorService {
                 .collect()
         };
 
-        let consensus_positions: Vec<ConsensusPosition> = match submit_mode {
+        // Map each submission group back to the (result index, digest) of the transactions it
+        // contains, so a per-group outcome — consensus positions, or an "already processing"
+        // error — can be recorded against each individual transaction. Soft bundles submit as a
+        // single group; individual transactions submit one group each.
+        let group_tx_meta = if is_soft_bundle_request {
+            vec![
+                transaction_indexes
+                    .into_iter()
+                    .zip_debug_eq(tx_digests)
+                    .collect::<Vec<_>>(),
+            ]
+        } else {
+            transaction_indexes
+                .into_iter()
+                .zip_debug_eq(tx_digests)
+                .map(|pair| vec![pair])
+                .collect::<Vec<_>>()
+        };
+
+        // Collect one result per submission group WITHOUT short-circuiting. An
+        // already-processing transaction is reported per-tx as a retriable below;
+        // any other error fails the whole request, after all groups have settled.
+        // Soft bundles submit as a single group; individual transactions submit one group each.
+        let group_results = match submit_mode {
             AdmissionQueueSubmitMode::Bypass | AdmissionQueueSubmitMode::Disabled => {
                 if matches!(submit_mode, AdmissionQueueSubmitMode::Bypass) {
                     self.metrics.admission_queue_direct_bypasses.inc();
@@ -1182,11 +1203,7 @@ impl ValidatorService {
                         submitter_client_addr,
                     )
                 });
-                future::try_join_all(futures)
-                    .await?
-                    .into_iter()
-                    .flatten()
-                    .collect()
+                future::join_all(futures).await
             }
             AdmissionQueueSubmitMode::Queue => {
                 let aq = self
@@ -1207,35 +1224,65 @@ impl ValidatorService {
                     }
                     receivers.push(rx);
                 }
-                let results = future::try_join_all(receivers.into_iter().map(|rx| async move {
-                    rx.await.map_err(|_| {
-                        SuiError::from(SuiErrorKind::TooManyTransactionsPendingConsensus)
-                    })?
+                future::join_all(receivers.into_iter().map(|rx| async move {
+                    match rx.await {
+                        Ok(result) => result.map_err(SuiError::from),
+                        Err(_) => Err(SuiError::from(
+                            SuiErrorKind::TooManyTransactionsPendingConsensus,
+                        )),
+                    }
                 }))
-                .await?;
-                results.into_iter().flatten().collect()
+                .await
             }
         };
 
         if is_ping_request {
-            // For ping requests, return the special consensus position.
+            // For ping requests there is a single group returning the special consensus position.
+            let consensus_positions = group_results
+                .into_iter()
+                .next()
+                .expect("Ping request must have exactly one submission group")?;
             assert_eq!(consensus_positions.len(), 1);
             results.push(Some(SubmitTxResult::Submitted {
                 consensus_position: consensus_positions[0],
             }));
         } else {
-            // Otherwise, return the consensus position for each transaction.
-            for ((idx, tx_digest), consensus_position) in transaction_indexes
-                .into_iter()
-                .zip_debug_eq(tx_digests)
-                .zip_debug_eq(consensus_positions)
-            {
-                debug!(
-                    ?tx_digest,
-                    "handle_submit_transaction: submitted consensus transaction at {}",
-                    consensus_position,
-                );
-                results[idx] = Some(SubmitTxResult::Submitted { consensus_position });
+            for (group_result, txns_meta) in group_results.into_iter().zip_debug_eq(group_tx_meta) {
+                match group_result {
+                    Ok(consensus_positions) => {
+                        for ((idx, tx_digest), consensus_position) in
+                            txns_meta.into_iter().zip_debug_eq(consensus_positions)
+                        {
+                            debug!(
+                                ?tx_digest,
+                                "handle_submit_transaction: submitted consensus transaction at {}",
+                                consensus_position,
+                            );
+                            results[idx] = Some(SubmitTxResult::Submitted { consensus_position });
+                        }
+                    }
+                    // The transaction(s) in this group are already being processed by consensus.
+                    // Report per-tx as a retriable rejection rather than failing the whole request.
+                    Err(err)
+                        if matches!(err.as_inner(), SuiErrorKind::TransactionProcessing { .. }) =>
+                    {
+                        for (idx, tx_digest) in txns_meta {
+                            debug!(
+                                ?tx_digest,
+                                "handle_submit_transaction: transaction already processing: {err}"
+                            );
+                            // Same suppression the upfront `is_consensus_message_processed` check
+                            // records, just detected during submission instead of before it. The
+                            // two paths are mutually exclusive, so this does not double-count.
+                            metrics
+                                .submission_suppressed_already_processed
+                                .with_label_values(&[req_type])
+                                .inc();
+                            results[idx] = Some(SubmitTxResult::Rejected { error: err.clone() });
+                        }
+                    }
+                    Err(err) => return Err(err),
+                }
             }
         }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1171,13 +1171,13 @@ impl ValidatorService {
             vec![
                 transaction_indexes
                     .into_iter()
-                    .zip_debug_eq(tx_digests)
+                    .zip_eq(tx_digests)
                     .collect::<Vec<_>>(),
             ]
         } else {
             transaction_indexes
                 .into_iter()
-                .zip_debug_eq(tx_digests)
+                .zip_eq(tx_digests)
                 .map(|pair| vec![pair])
                 .collect::<Vec<_>>()
         };
@@ -1263,9 +1263,12 @@ impl ValidatorService {
                     }
                     // The transaction(s) in this group are already being processed by consensus.
                     // Report per-tx as a retriable rejection rather than failing the whole request.
-                    Err(err)
-                        if matches!(err.as_inner(), SuiErrorKind::TransactionProcessing { .. }) =>
-                    {
+                    Err(err) => {
+                        let SuiErrorKind::TransactionProcessing { status, .. } =
+                            err.as_inner().clone()
+                        else {
+                            return Err(err);
+                        };
                         for (idx, tx_digest) in txns_meta {
                             debug!(
                                 ?tx_digest,
@@ -1278,10 +1281,15 @@ impl ValidatorService {
                                 .submission_suppressed_already_processed
                                 .with_label_values(&[req_type])
                                 .inc();
-                            results[idx] = Some(SubmitTxResult::Rejected { error: err.clone() });
+                            results[idx] = Some(SubmitTxResult::Rejected {
+                                error: SuiErrorKind::TransactionProcessing {
+                                    digest: tx_digest,
+                                    status: status.clone(),
+                                }
+                                .into(),
+                            });
                         }
                     }
-                    Err(err) => return Err(err),
                 }
             }
         }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -512,10 +512,7 @@ impl ConsensusAdapter {
         };
 
         // Skip submission if the tx is already processed via consensus output or
-        // checkpoint state sync. Unlike before, this check now also runs when a caller
-        // is waiting for a consensus position (mfp): rather than redundantly submitting
-        // an already-processed transaction, we cancel the pre-submission request and
-        // tell the caller the transaction is already processing.
+        // checkpoint state sync.
         let already_processed =
             self.check_processed_via_consensus_or_checkpoint(&transaction_keys, epoch_store);
         if let Some(method) = already_processed {
@@ -643,17 +640,9 @@ impl ConsensusAdapter {
             let processed_waiter = self
                 .processed_notify(transaction_keys.clone(), epoch_store)
                 .boxed();
-            // Whether processing was observed via `processed_notify` winning the race,
-            // rather than our own submission completing. The channel send is deferred until
-            // after the match: `submit_fut` holds a mutable borrow of `tx_consensus_positions`
-            // for as long as the `select` result (`Either`) is alive, i.e. until the match
-            // expression ends, so touching the channel inside an arm is a borrow conflict.
             let processed_via_notify;
             guard.processed_method = match select(processed_waiter, submit_fut.boxed()).await {
                 Either::Left((observed, _submit_fut)) => {
-                    // The transaction came out of consensus output (or a checkpoint) before
-                    // our submission completed. `_submit_fut` is dropped at the end of this
-                    // arm, cancelling the retry loop cleanly.
                     processed_via_notify = true;
                     observed
                 }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -287,13 +287,11 @@ impl ConsensusAdapter {
             )?;
         }
 
-        rx_consensus_positions
-            .await
-            .map_err(|e| {
-                SuiError::from(SuiErrorKind::FailedToSubmitToConsensus(format!(
-                    "Failed to get consensus position: {e}"
-                )))
-            })?
+        rx_consensus_positions.await.map_err(|e| {
+            SuiError::from(SuiErrorKind::FailedToSubmitToConsensus(format!(
+                "Failed to get consensus position: {e}"
+            )))
+        })?
     }
 
     pub fn recover_end_of_publish(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
@@ -645,23 +643,36 @@ impl ConsensusAdapter {
             let processed_waiter = self
                 .processed_notify(transaction_keys.clone(), epoch_store)
                 .boxed();
+            // Whether processing was observed via `processed_notify` winning the race,
+            // rather than our own submission completing. The channel send is deferred until
+            // after the match: `submit_fut` holds a mutable borrow of `tx_consensus_positions`
+            // for as long as the `select` result (`Either`) is alive, i.e. until the match
+            // expression ends, so touching the channel inside an arm is a borrow conflict.
+            let processed_via_notify;
             guard.processed_method = match select(processed_waiter, submit_fut.boxed()).await {
-                Either::Left((observed, submit_fut)) => {
-                    // The transaction came out of consensus output (or a checkpoint)
-                    // before our submission completed. Drop the submit future to release
-                    // its borrow of `tx_consensus_positions`, then, if we have not already
-                    // sent a position to a waiting caller, report that it is processing.
-                    drop(submit_fut);
-                    if let Some(tx_consensus_positions) = tx_consensus_positions.take() {
-                        let _ = tx_consensus_positions.send(Err(make_processing_error(observed)));
-                    }
+                Either::Left((observed, _submit_fut)) => {
+                    // The transaction came out of consensus output (or a checkpoint) before
+                    // our submission completed. `_submit_fut` is dropped at the end of this
+                    // arm, cancelling the retry loop cleanly.
+                    processed_via_notify = true;
                     observed
                 }
                 Either::Right(((), processed_waiter)) => {
                     debug!("Submitted {transaction_keys:?} to consensus");
+                    processed_via_notify = false;
                     processed_waiter.await
                 }
             };
+            // If processing was observed before a position was sent to a waiting caller,
+            // report that the transaction is already processing so the caller returns a
+            // retriable error. If a position was already sent, the channel is taken and this
+            // is a no-op.
+            if processed_via_notify
+                && let Some(tx_consensus_positions) = tx_consensus_positions.take()
+            {
+                let _ =
+                    tx_consensus_positions.send(Err(make_processing_error(guard.processed_method)));
+            }
         }
         debug!("{transaction_keys:?} processed by consensus");
 

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -273,9 +273,9 @@ impl ConsensusAdapter {
                 return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
             }
 
-            // Submit to consensus and wait for position, we do not check if tx
-            // has been processed by consensus already as this method is called
-            // to get back a consensus position.
+            // Submit to consensus and wait for the position. If the transaction has
+            // already been processed via consensus output or a checkpoint, the adapter
+            // skips submission and reports `TransactionProcessing` instead of a position.
             let _metrics_guard = self.metrics.consensus_latency.start_timer();
 
             self.submit_batch(
@@ -287,12 +287,13 @@ impl ConsensusAdapter {
             )?;
         }
 
-        rx_consensus_positions.await.map_err(|e| {
-            SuiErrorKind::FailedToSubmitToConsensus(format!(
-                "Failed to get consensus position: {e}"
-            ))
-            .into()
-        })
+        rx_consensus_positions
+            .await
+            .map_err(|e| {
+                SuiError::from(SuiErrorKind::FailedToSubmitToConsensus(format!(
+                    "Failed to get consensus position: {e}"
+                )))
+            })?
     }
 
     pub fn recover_end_of_publish(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
@@ -317,7 +318,7 @@ impl ConsensusAdapter {
         transaction: ConsensusTransaction,
         lock: Option<&RwLockReadGuard<ReconfigState>>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-        tx_consensus_position: Option<oneshot::Sender<Vec<ConsensusPosition>>>,
+        tx_consensus_position: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) -> SuiResult<JoinHandle<()>> {
         self.submit_batch(
@@ -336,7 +337,7 @@ impl ConsensusAdapter {
         transactions: &[ConsensusTransaction],
         _lock: Option<&RwLockReadGuard<ReconfigState>>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-        tx_consensus_position: Option<oneshot::Sender<Vec<ConsensusPosition>>>,
+        tx_consensus_position: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) -> SuiResult<JoinHandle<()>> {
         if transactions.len() > 1 {
@@ -374,7 +375,7 @@ impl ConsensusAdapter {
         self: &Arc<Self>,
         transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
-        tx_consensus_position: Option<oneshot::Sender<Vec<ConsensusPosition>>>,
+        tx_consensus_position: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) -> JoinHandle<()> {
         // Reconfiguration lock is dropped when pending_consensus_transactions is persisted, before it is handled by consensus
@@ -397,7 +398,7 @@ impl ConsensusAdapter {
         self: Arc<Self>,
         transactions: Vec<ConsensusTransaction>,
         epoch_store: Arc<AuthorityPerEpochStore>,
-        tx_consensus_position: Option<oneshot::Sender<Vec<ConsensusPosition>>>,
+        tx_consensus_position: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) {
         // When epoch_terminated signal is received all pending submit_and_wait_inner are dropped.
@@ -430,7 +431,7 @@ impl ConsensusAdapter {
         self: Arc<Self>,
         transactions: Vec<ConsensusTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-        mut tx_consensus_positions: Option<oneshot::Sender<Vec<ConsensusPosition>>>,
+        mut tx_consensus_positions: Option<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
         submitter_client_addr: Option<IpAddr>,
     ) {
         if transactions.is_empty() {
@@ -444,7 +445,7 @@ impl ConsensusAdapter {
                 .await;
 
             if let Some(tx_consensus_positions) = tx_consensus_positions.take() {
-                let _ = tx_consensus_positions.send(consensus_positions);
+                let _ = tx_consensus_positions.send(Ok(consensus_positions));
             } else {
                 debug_fatal!("Ping check must have a consensus position channel");
             }
@@ -464,11 +465,6 @@ impl ConsensusAdapter {
                 );
             }
         }
-
-        // If tx_consensus_positions channel is provided, the caller is looking for a
-        // consensus position for mfp. Therefore we will skip shortcutting submission
-        // if txes have already been processed.
-        let skip_processed_checks = tx_consensus_positions.is_some();
 
         // Current code path ensures:
         // - If transactions.len() > 1, it is a soft bundle. System transactions should have been submitted individually.
@@ -498,17 +494,37 @@ impl ConsensusAdapter {
 
         let mut guard = InflightDropGuard::acquire(&self, tx_type, transactions.len() as u64);
 
-        // Skip submission if the tx is already processed via consensus output
-        // or checkpoint state sync. `skip_processed_checks` is set by callers
-        // that need a consensus position (mfp/ping), so we must submit even
-        // if already processed.
-        let already_processed = if skip_processed_checks {
-            None
-        } else {
-            self.check_processed_via_consensus_or_checkpoint(&transaction_keys, epoch_store)
+        // Builds the error reported to a position-waiting caller (mfp) when the
+        // transaction is already being processed and we therefore skip (re)submission.
+        // The caller surfaces this as a retriable error so the client waits for
+        // effects / retries instead of receiving a meaningless consensus position.
+        let make_processing_error = |method: ProcessedMethod| -> SuiError {
+            let digest = transactions
+                .iter()
+                .find_map(|t| t.kind.as_user_transaction().map(|tx| *tx.digest()))
+                .unwrap_or_default();
+            SuiErrorKind::TransactionProcessing {
+                digest,
+                status: match method {
+                    ProcessedMethod::Consensus => "sequenced by consensus".to_string(),
+                    ProcessedMethod::Checkpoint => "executed via checkpoint".to_string(),
+                },
+            }
+            .into()
         };
-        if let Some(method) = &already_processed {
-            guard.processed_method = *method;
+
+        // Skip submission if the tx is already processed via consensus output or
+        // checkpoint state sync. Unlike before, this check now also runs when a caller
+        // is waiting for a consensus position (mfp): rather than redundantly submitting
+        // an already-processed transaction, we cancel the pre-submission request and
+        // tell the caller the transaction is already processing.
+        let already_processed =
+            self.check_processed_via_consensus_or_checkpoint(&transaction_keys, epoch_store);
+        if let Some(method) = already_processed {
+            guard.processed_method = method;
+            if let Some(tx_consensus_positions) = tx_consensus_positions.take() {
+                let _ = tx_consensus_positions.send(Err(make_processing_error(method)));
+            }
         }
 
         // Log warnings for administrative transactions that fail to get sequenced
@@ -576,7 +592,7 @@ impl ConsensusAdapter {
                         // consensus adapter due to an error or GC. They can handle retries
                         // as needed if the consensus position does not return the desired
                         // results (e.g. not sequenced due to garbage collection).
-                        let _ = tx_consensus_positions.send(consensus_positions);
+                        let _ = tx_consensus_positions.send(Ok(consensus_positions));
                     }
 
                     match status_waiter.await {
@@ -621,25 +637,29 @@ impl ConsensusAdapter {
                 }
             };
 
-            guard.processed_method = if skip_processed_checks {
-                // When getting consensus positions, we only care about submit_fut completing.
-                submit_fut.await;
-                ProcessedMethod::Consensus
-            } else {
-                // Race `processed_notify` against the submit loop. If the tx is
-                // processed via another path (consensus output from another
-                // validator's submission, or checkpoint state sync) while we're
-                // inside the submit loop, the submission future is dropped and
-                // the retry loop is cancelled cleanly.
-                let processed_waiter = self
-                    .processed_notify(transaction_keys.clone(), epoch_store)
-                    .boxed();
-                match select(processed_waiter, submit_fut.boxed()).await {
-                    Either::Left((observed, _submit_fut)) => observed,
-                    Either::Right(((), processed_waiter)) => {
-                        debug!("Submitted {transaction_keys:?} to consensus");
-                        processed_waiter.await
+            // Race `processed_notify` against the submit loop. If the tx is
+            // processed via another path (consensus output from another
+            // validator's submission, or checkpoint state sync) while we're
+            // inside the submit loop, the submission future is dropped and
+            // the retry loop is cancelled cleanly.
+            let processed_waiter = self
+                .processed_notify(transaction_keys.clone(), epoch_store)
+                .boxed();
+            guard.processed_method = match select(processed_waiter, submit_fut.boxed()).await {
+                Either::Left((observed, submit_fut)) => {
+                    // The transaction came out of consensus output (or a checkpoint)
+                    // before our submission completed. Drop the submit future to release
+                    // its borrow of `tx_consensus_positions`, then, if we have not already
+                    // sent a position to a waiting caller, report that it is processing.
+                    drop(submit_fut);
+                    if let Some(tx_consensus_positions) = tx_consensus_positions.take() {
+                        let _ = tx_consensus_positions.send(Err(make_processing_error(observed)));
                     }
+                    observed
+                }
+                Either::Right(((), processed_waiter)) => {
+                    debug!("Submitted {transaction_keys:?} to consensus");
+                    processed_waiter.await
                 }
             };
         }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -19,6 +19,7 @@ use sui_macros::sim_test;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
 use sui_types::crypto::{AccountKeyPair, deterministic_random_account_key};
+use sui_types::error::SuiErrorKind;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSignatureMessage, CheckpointSummary,
@@ -390,4 +391,58 @@ async fn submit_empty_array_of_transactions_to_consensus_adapter() {
             index: PING_TRANSACTION_INDEX,
         }]
     );
+}
+
+// When a transaction that is requesting a consensus position (e.g. mfp) has already been
+// processed via consensus output, the adapter must NOT resubmit it. Instead it reports that
+// the transaction is already processing, so the caller can return a retriable error to the
+// client rather than a (now meaningless) consensus position.
+#[tokio::test]
+async fn submit_already_processed_transaction_returns_processing_error() {
+    telemetry_subscribers::init_for_testing();
+
+    // Initialize an authority with gas and a shared object, then build a user transaction.
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let transaction = test_user_transactions(&state, shared_object)
+        .await
+        .into_iter()
+        .next()
+        .unwrap();
+    let epoch_store = state.epoch_store_for_testing();
+    let tx_digest = *transaction.tx().digest();
+
+    // Simulate the transaction already appearing in consensus output before this submission.
+    epoch_store.test_insert_user_signature(tx_digest, vec![]);
+
+    // A mock block status receiver is provided so that, if the adapter were to (incorrectly)
+    // submit, it could complete and return positions, surfacing the regression as a failure.
+    let adapter = make_consensus_adapter_for_test(
+        state.clone(),
+        HashSet::new(),
+        false,
+        vec![with_block_status(BlockStatus::Sequenced(BlockRef::MIN))],
+    );
+
+    let consensus_tx =
+        ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+
+    let result = adapter
+        .submit_and_get_positions(vec![consensus_tx], &epoch_store, None)
+        .await;
+
+    match result {
+        Err(err) => assert!(
+            matches!(
+                err.as_inner(),
+                SuiErrorKind::TransactionProcessing { digest, .. } if *digest == tx_digest
+            ),
+            "expected TransactionProcessing error, got: {err}"
+        ),
+        Ok(positions) => {
+            panic!("expected TransactionProcessing error, got positions: {positions:?}")
+        }
+    }
 }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -382,7 +382,7 @@ async fn submit_empty_array_of_transactions_to_consensus_adapter() {
         .unwrap();
     waiter.await.unwrap();
 
-    let consensus_position = rx_consensus_position.await.unwrap();
+    let consensus_position = rx_consensus_position.await.unwrap().unwrap();
     assert_eq!(
         consensus_position,
         vec![ConsensusPosition {

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -548,6 +548,79 @@ async fn test_submit_batched_transactions_with_already_executed() {
     }
 }
 
+// A batch containing a transaction that is already being processed by consensus must NOT fail the
+// whole request. The already-processing transaction is reported per-tx as
+// `Rejected { TransactionProcessing }` (a retriable rejection), while the rest of the batch still
+// returns its consensus position.
+#[tokio::test]
+async fn test_submit_batched_transactions_with_already_processing() {
+    let test_context = TestContext::new().await;
+    let epoch_store = test_context.state.epoch_store_for_testing();
+
+    // tx1: mark as already sequenced by consensus so the validator must not resubmit it.
+    let tx1 = test_context.build_test_transaction();
+    epoch_store.test_insert_user_signature(*tx1.digest(), vec![]);
+
+    // tx2: a distinct, fresh transaction that should be submitted normally.
+    let gas_object2 = Object::with_owner_for_testing(test_context.sender);
+    let gas_object_ref2 = gas_object2.compute_object_reference();
+    test_context.state.insert_genesis_object(gas_object2);
+    let tx_data2 = TestTransactionBuilder::new(
+        test_context.sender,
+        gas_object_ref2,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(None, test_context.sender)
+    .build();
+    let tx2 = to_sender_signed_transaction(tx_data2, &test_context.keypair);
+
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx1).unwrap().into(),
+            bcs::to_bytes(&tx2).unwrap().into(),
+        ],
+        ..Default::default()
+    };
+
+    // The whole RPC must still succeed (no top-level error).
+    let raw_response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(raw_response.results.len(), 2);
+
+    let result0: SubmitTxResult = raw_response.results[0].clone().try_into().unwrap();
+    let result1: SubmitTxResult = raw_response.results[1].clone().try_into().unwrap();
+
+    // tx1 is rejected specifically because it is already being processed by consensus.
+    match result0 {
+        SubmitTxResult::Rejected { error } => assert!(
+            matches!(
+                error.as_inner(),
+                SuiErrorKind::TransactionProcessing { digest, .. } if *digest == *tx1.digest()
+            ),
+            "expected TransactionProcessing for tx1, got: {error}"
+        ),
+        other => {
+            panic!("Expected Rejected status for already-processing transaction, got: {other:?}")
+        }
+    }
+
+    // tx2 is still submitted to consensus.
+    match result1 {
+        SubmitTxResult::Submitted { .. } => {}
+        other => panic!("Expected Submitted status for fresh transaction, got: {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn test_submit_soft_bundle_transactions() {
     let test_context = TestContext::new().await;

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -1053,6 +1053,11 @@ impl SuiErrorKind {
             SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion { .. } => true,
             SuiErrorKind::ValidatorOverloadedRetryAfter { .. } => true,
 
+            // The transaction is already being processed by consensus, so a fresh
+            // submission is pointless. The client should retry by waiting for effects
+            // rather than resubmitting.
+            SuiErrorKind::TransactionProcessing { .. } => true,
+
             // Non retryable error
             SuiErrorKind::ExecutionError(..) => false,
             SuiErrorKind::ByzantineAuthoritySuspicion { .. } => false,


### PR DESCRIPTION
## Description

When a transaction is submitted for a consensus position (mfp) that consensus has already
processed, the adapter used to skip the already-processed check, resubmit, and return a position
for a redundant duplicate — one that doesn't track the placement that actually determines the
transaction's outcome. This removes `skip_processed_checks` so the check runs on the position path
too, and reports the transaction per-transaction as a retriable `TransactionProcessing` instead of
that meaningless position. Reporting it per-transaction (rather than a top-level error) keeps a
multi-transaction request from failing wholesale.

Follow-up (separate PR): on `TransactionProcessing`, have the transaction driver drop to
`wait_for_effects` by digest instead of resubmitting.

## Test plan

New `test_submit_batched_transactions_with_already_processing`: a batch containing an
already-processing transaction returns `[Rejected { TransactionProcessing }, Submitted]` with the
RPC still succeeding. The single-tx and ping paths are covered by the existing consensus-adapter
and submit-transaction tests.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
