### PR TITLE
Passing of accumulator_version should not be conditional on network

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -69,7 +69,6 @@ use std::{
 use sui_config::NodeConfig;
 use sui_config::node::{AuthorityOverloadConfig, StateDebugDumpConfig};
 use sui_execution::Executor;
-use sui_protocol_config::Chain;
 use sui_protocol_config::PerObjectCongestionControlMode;
 use sui_types::accumulator_root::AccumulatorObjId;
 use sui_types::dynamic_field::visitor as DFV;
@@ -1975,14 +1974,7 @@ impl AuthorityState {
             self.config.certificate_deny_config.certificate_deny_set(),
             &execution_env.funds_withdraw_status,
         );
-        // Mainnet-only: feed the accumulator (settlement) version so the address-balance gas-smash
-        // short-circuit activates at its rollout version and replays bit-for-bit. Other chains pass
-        // `None`, where the short-circuit applies unconditionally.
-        let accumulator_version = if self.chain_identifier.chain() == Chain::Mainnet {
-            execution_env.assigned_versions.accumulator_version
-        } else {
-            None
-        };
+        let accumulator_version = execution_env.assigned_versions.accumulator_version;
         let execution_params = match early_execution_error {
             None => ExecutionOrEarlyError::ok(accumulator_version),
             Some(errors) => ExecutionOrEarlyError::failed(errors, accumulator_version),

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -145,8 +145,8 @@ fn apply_v3_threshold_overrides(committee: Committee) -> Committee {
     )
 }
 
-fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> ConsensusProtocolConfig {
-    let chain_type = match chain {
+fn to_consensus_protocol_config(config: &ProtocolConfig) -> ConsensusProtocolConfig {
+    let chain_type = match config.chain() {
         Chain::Mainnet => ChainType::Mainnet,
         Chain::Testnet => ChainType::Testnet,
         Chain::Unknown => ChainType::Unknown,
@@ -250,8 +250,7 @@ impl ConsensusManager {
     ) {
         let epoch = epoch_store.epoch();
         let protocol_config = epoch_store.protocol_config();
-        let consensus_protocol_config =
-            to_consensus_protocol_config(protocol_config, epoch_store.get_chain());
+        let consensus_protocol_config = to_consensus_protocol_config(protocol_config);
         let system_state = epoch_store.epoch_start_state();
         let committee = if consensus_protocol_config.enable_v3() {
             apply_v3_threshold_overrides(system_state.get_consensus_committee())

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1285,6 +1285,13 @@ impl ConsensusNetwork {
 pub struct ProtocolConfig {
     pub version: ProtocolVersion,
 
+    /// The chain this config was instantiated for. Unlike the other fields, this is not a
+    /// versioned protocol constant: it identifies the network rather than describing protocol
+    /// behavior, so it is intentionally excluded from serialization (and from the config
+    /// snapshots) and is populated directly from the chain passed to `get_for_version`.
+    #[serde(skip)]
+    chain: Chain,
+
     feature_flags: FeatureFlags,
 
     // ==== Transaction input limits ====
@@ -2047,6 +2054,11 @@ pub struct AliasedAddress {
 
 // feature flags
 impl ProtocolConfig {
+    /// The chain this config was instantiated for (see the `chain` field).
+    pub fn chain(&self) -> Chain {
+        self.chain
+    }
+
     // Add checks for feature flag support here, e.g.:
     // pub fn check_new_protocol_feature_supported(&self) -> Result<(), Error> {
     //     if self.feature_flags.new_protocol_feature_supported {
@@ -2911,6 +2923,7 @@ impl ProtocolConfig {
 
         let mut ret = Self::get_for_version_impl(version, chain);
         ret.version = version;
+        ret.chain = chain;
 
         ret = Self::apply_config_override(version, ret);
 
@@ -2933,6 +2946,7 @@ impl ProtocolConfig {
         if version.0 >= ProtocolVersion::MIN.0 && version.0 <= ProtocolVersion::MAX_ALLOWED.0 {
             let mut ret = Self::get_for_version_impl(version, chain);
             ret.version = version;
+            ret.chain = chain;
             ret = Self::apply_config_override(version, ret);
             Some(ret)
         } else {
@@ -3002,6 +3016,7 @@ impl ProtocolConfig {
         let mut cfg = Self {
             // will be overwritten before being returned
             version,
+            chain,
 
             // All flags are disabled in V1
             feature_flags: Default::default(),

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -43,7 +43,8 @@ mod checked {
     use move_core_types::language_storage::TypeTag;
     use sui_move_natives::all_natives;
     use sui_protocol_config::{
-        LimitThresholdCrossed, PerObjectCongestionControlMode, ProtocolConfig, check_limit_by_meter,
+        Chain, LimitThresholdCrossed, PerObjectCongestionControlMode, ProtocolConfig,
+        check_limit_by_meter,
     };
     use sui_types::authenticator_state::{
         AUTHENTICATOR_STATE_CREATE_FUNCTION_NAME, AUTHENTICATOR_STATE_EXPIRE_JWKS_FUNCTION_NAME,
@@ -143,9 +144,10 @@ mod checked {
         // the 1.72 mainnet release (where it was deployed as an ungated hotfix).
         in_test_configuration()
             || protocol_config.early_exit_on_iffw()
-            || execution_params
-                .accumulator_version()
-                .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION)
+            || (protocol_config.chain() == Chain::Mainnet
+                && execution_params
+                    .accumulator_version()
+                    .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_FIX_MIN_ACCUMULATOR_VERSION))
     }
 
     /// Whether to short-circuit an IFFW transaction. When an accumulator version is assigned
@@ -173,9 +175,10 @@ mod checked {
 
         // otherwise gate by accumulator version (if present) or protocol flag
         protocol_config.early_exit_on_iffw()
-            || execution_params
-                .accumulator_version()
-                .is_some_and(|v| v >= ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION)
+            || (protocol_config.chain() == Chain::Mainnet
+                && execution_params.accumulator_version().is_some_and(|v| {
+                    v >= ADDRESS_BALANCE_SMASH_SHORT_CIRCUIT_MIN_ACCUMULATOR_VERSION
+                }))
     }
 
     fn payment_kind(


### PR DESCRIPTION
## Description 

It is a footgun that the value of accumulator_version passed to execution layer depends on the network.
We should always pass it, and in places where we check it we check the network.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
