### PR TITLE
[move-ide] Fixes to auto-import and quick-fix

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/code_action.rs
+++ b/external-crates/move/crates/move-analyzer/src/code_action.rs
@@ -257,6 +257,7 @@ pub fn access_chain_autofix_actions_for_error(
                                 two_element_access_chain_autofixes(
                                     code_actions,
                                     symbols,
+                                    cursor,
                                     file_url.clone(),
                                     unbound_name,
                                     name_path.entries[0].name,
@@ -369,6 +370,7 @@ fn single_element_access_chain_autofixes<I, K>(
 fn two_element_access_chain_autofixes<I, K>(
     code_actions: &mut Vec<CodeAction>,
     symbols: &Symbols,
+    cursor: &CursorContext,
     file_url: Url,
     unbound_first_name: Name,
     second_name: Name,
@@ -388,6 +390,8 @@ fn two_element_access_chain_autofixes<I, K>(
             if mod_ident.value.module.value() == unbound_first_name.value
                 && member_name == second_name.value
             {
+                // Fully qualifying the package prefix preserves the existing module-qualified use
+                // site, e.g. `foo::Bar` becomes `Pkg::foo::Bar`.
                 let qualified_prefix =
                     format!("{}::", addr_to_ide_string(&mod_ident.value.address));
                 let text_edit = TextEdit {
@@ -400,6 +404,29 @@ fn two_element_access_chain_autofixes<I, K>(
                 let title = format!(
                     "Qualify as `{}{}::{}`",
                     qualified_prefix, unbound_first_name, second_name
+                );
+                code_actions.push(access_chain_code_action(
+                    title,
+                    text_edit,
+                    diag.clone(),
+                    file_url.clone(),
+                ));
+                // Importing the module is enough to resolve the first element of the chain while
+                // keeping the source expression as `module::member`.
+                let Some(import_insertion_info) = import_insertion_info(symbols, cursor) else {
+                    continue;
+                };
+                let import_text = format!(
+                    "use {}::{}",
+                    addr_to_ide_string(&mod_ident.value.address),
+                    mod_ident.value.module,
+                );
+                let text_edit = auto_import_text_edit(import_text.clone(), import_insertion_info);
+                let title = format!(
+                    "Import `{}` for `{}::{}`",
+                    import_text.trim_start_matches("use "),
+                    unbound_first_name,
+                    second_name
                 );
                 code_actions.push(access_chain_code_action(
                     title,

--- a/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
@@ -207,6 +207,7 @@ pub fn name_chain_completions(
         imports_for_name_chain_entry(
             symbols,
             cursor,
+            &info,
             leading_name.loc,
             chain_kind,
             &path_entries,
@@ -703,6 +704,8 @@ fn all_single_name_member_completions(
 
 /// Returns list of completion items that represent module members
 /// auto-imports.
+/// For `B`, when completing `Bar`, the algorithm should end up with
+/// auto-completed `Bar` and auto-inserted `use pkg::foo::Bar;`.
 fn member_auto_imports(
     symbols: &Symbols,
     cursor: &CursorContext,
@@ -726,6 +729,32 @@ fn member_auto_imports(
             addr_to_ide_string(&mod_ident.address),
             mod_ident.module,
             member_name,
+        );
+        add_auto_import_to_completion_item(item, auto_import_text, auto_import_pos);
+    });
+    member_completions
+}
+
+/// Returns auto-import completions for a member accessed through an unresolved module prefix.
+/// For `foo::B`, when completing `Bar`, the algorithm should end up with
+/// auto-completed `foo::Bar` and auto-inserted `use pkg::foo;`.
+fn member_completions_with_module_import(
+    symbols: &Symbols,
+    cursor: &CursorContext,
+    mod_defs: &ModuleDefs,
+    chain_kind: ChainCompletionKind,
+    auto_import_pos: AutoImportInsertionInfo,
+) -> Vec<CompletionItem> {
+    let mod_ident = sp(mod_defs.name_loc, mod_defs.ident);
+    let mut member_completions = module_member_completions(
+        symbols, cursor, &mod_ident, chain_kind, /* inside_use */ false,
+    );
+    let mod_ident = mod_defs.ident;
+    member_completions.iter_mut().for_each(|item| {
+        let auto_import_text = format!(
+            "use {}::{}",
+            addr_to_ide_string(&mod_ident.address),
+            mod_ident.module,
         );
         add_auto_import_to_completion_item(item, auto_import_text, auto_import_pos);
     });
@@ -910,6 +939,7 @@ fn next_name_chain_component_kind(
 fn imports_for_name_chain_entry(
     symbols: &Symbols,
     cursor: &CursorContext,
+    info: &AliasAutocompleteInfo,
     prev_loc: Loc,
     chain_kind: ChainCompletionKind,
     path_entries: &[Name],
@@ -941,27 +971,19 @@ fn imports_for_name_chain_entry(
         let P::LeadingNameAccess_::Name(name) = leading_name.value else {
             return;
         };
+        // If the prefix already resolves to a module, regular member completion covers this chain.
+        if info.modules.contains_key(&name.value) {
+            return;
+        }
         for mod_defs in symbols.file_mods.values().flatten() {
             if mod_defs.ident.module.value() == name.value {
-                mod_defs
-                    .functions
-                    .keys()
-                    .chain(
-                        mod_defs
-                            .structs
-                            .keys()
-                            .chain(mod_defs.enums.keys().chain(mod_defs.constants.keys())),
-                    )
-                    .for_each(|member_name| {
-                        completions.extend(member_auto_imports(
-                            symbols,
-                            cursor,
-                            mod_defs,
-                            member_name,
-                            chain_kind,
-                            auto_import_pos,
-                        ))
-                    });
+                completions.extend(member_completions_with_module_import(
+                    symbols,
+                    cursor,
+                    mod_defs,
+                    chain_kind,
+                    auto_import_pos,
+                ));
             }
         }
     }

--- a/external-crates/move/crates/move-analyzer/tests/autofix/sources/colon_colon.move
+++ b/external-crates/move/crates/move-analyzer/tests/autofix/sources/colon_colon.move
@@ -14,8 +14,8 @@ module Autofix::colon_colon {
         let s: another_dep;
     }
 
-    // only qualifcation should be offered here as importing `Autofix::another_dep::AnotherDepEnum`
-    // does not actually solve the problem
+    // importing the module should be offered here, as importing the member itself
+    // would not resolve the unbound module prefix
     public fun two_names(s: another_dep::AnotherDepStruct) {
     }
 

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.snap
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.snap
@@ -13,3 +13,4 @@ CODE ACTION: Qualify as `Autofix::another_dep`
 CODE ACTION: Import as `Autofix::another_dep`
 -- test 3 -------------------
 CODE ACTION: Qualify as `Autofix::another_dep::AnotherDepStruct`
+CODE ACTION: Import `Autofix::another_dep` for `another_dep::AnotherDepStruct`

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_import.ide
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_import.ide
@@ -9,6 +9,10 @@
           "use_col": 9
         },
         {
+          "use_line": 11,
+          "use_col": 13
+        },
+        {
           "use_line": 15,
           "use_col": 21
         },

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_import.snap
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_import.snap
@@ -74,18 +74,33 @@ Enum 'PubEnum'
     use Import::dep::PubEnum;'
 
 -- test 1 -------------------
-use line: 15, use_col: 21
-Struct 'AnotherDepStruct'
-    TARGET     : '(use Import::another_dep::AnotherDepStruct)'
-    ADDITIONAL EDIT: '
-    use Import::another_dep::AnotherDepStruct;'
+use line: 11, use_col: 13
+Method 'bar()'
+    INSERT TEXT: 'bar()'
+    TARGET     : '(Import::dep::bar)'
+    TYPE       : 'fun ()'
+Method 'pkg_fun()'
+    INSERT TEXT: 'pkg_fun()'
+    TARGET     : '(Import::dep::pkg_fun)'
+    TYPE       : 'fun ()'
+Method 'pub_fun()'
+    INSERT TEXT: 'pub_fun()'
+    TARGET     : '(Import::dep::pub_fun)'
+    TYPE       : 'fun ()'
 
 -- test 2 -------------------
+use line: 15, use_col: 21
+Struct 'AnotherDepStruct'
+    TARGET     : '(use Import::another_dep)'
+    ADDITIONAL EDIT: '
+    use Import::another_dep;'
+
+-- test 3 -------------------
 use line: 19, use_col: 22
 Struct 'AnotherDepStruct'
-    TARGET     : '(use Import::another_dep::AnotherDepStruct)'
+    TARGET     : '(use Import::another_dep)'
     ADDITIONAL EDIT: '
-    use Import::another_dep::AnotherDepStruct;'
+    use Import::another_dep;'
 
 == dep.move ========================================================
 -- test 0 -------------------
@@ -153,7 +168,7 @@ Module 'another_dep'
 Module 'colon_colon'
 Module 'dep'
 Struct 'SomeStruct'
-    TARGET     : '(use Import::Import::SomeStruct)'
-    ADDITIONAL EDIT: 'use Import::Import::SomeStruct;
+    TARGET     : '(use Import::Import)'
+    ADDITIONAL EDIT: 'use Import::Import;
 
     '

--- a/external-crates/move/crates/move-analyzer/tests/import/sources/colon_colon.move
+++ b/external-crates/move/crates/move-analyzer/tests/import/sources/colon_colon.move
@@ -1,6 +1,7 @@
 module Import::colon_colon {
 
     use Import::dep;
+    use Import::another_dep;
 
     // test insertion with imports present
     public fun foo() {
@@ -12,7 +13,7 @@ module Import::colon_colon {
     }
 
     fun bak() {
-        another_dep::
+        another_dep::AnotherDepStruct
     }
 
     fun bam() {

--- a/external-crates/move/crates/move-analyzer/tests/import/sources/colon_colon.move
+++ b/external-crates/move/crates/move-analyzer/tests/import/sources/colon_colon.move
@@ -1,7 +1,6 @@
 module Import::colon_colon {
 
     use Import::dep;
-    use Import::another_dep;
 
     // test insertion with imports present
     public fun foo() {
@@ -13,7 +12,7 @@ module Import::colon_colon {
     }
 
     fun bak() {
-        another_dep::AnotherDepStruct
+        another_dep::
     }
 
     fun bam() {


### PR DESCRIPTION
## Description 

This PR provides two fixes to the auto-imports algorithm:
- avoid suggesting member auto-imports when the typed prefix already resolves to an in-scope module, since normal module::member completion is sufficient and actually inserting auto-import would result in an immediately "unused" `use` declaration
- for unresolved module-qualified chains like `foo::Bar`, allow auto-importing the module with `use pkg::foo` instead of incorrectly importing the member with `use pkg::foo::Bar`

It also fixes quick-fix algorithm to correctly handle module-prefixed (but without module import) accesses similarly to how it's done for auto-imports (e.g., for `foo::Bar` where module is not yet imported, include `use pkg::foo` in the auto-fix)

## Test plan 

New test has been added and test output has been regenerated
