### PR TITLE
Add chain identifier to ProtocolConfig

### DIFF
--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -145,8 +145,8 @@ fn apply_v3_threshold_overrides(committee: Committee) -> Committee {
     )
 }
 
-fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> ConsensusProtocolConfig {
-    let chain_type = match chain {
+fn to_consensus_protocol_config(config: &ProtocolConfig) -> ConsensusProtocolConfig {
+    let chain_type = match config.chain() {
         Chain::Mainnet => ChainType::Mainnet,
         Chain::Testnet => ChainType::Testnet,
         Chain::Unknown => ChainType::Unknown,
@@ -250,8 +250,7 @@ impl ConsensusManager {
     ) {
         let epoch = epoch_store.epoch();
         let protocol_config = epoch_store.protocol_config();
-        let consensus_protocol_config =
-            to_consensus_protocol_config(protocol_config, epoch_store.get_chain());
+        let consensus_protocol_config = to_consensus_protocol_config(protocol_config);
         let system_state = epoch_store.epoch_start_state();
         let committee = if consensus_protocol_config.enable_v3() {
             apply_v3_threshold_overrides(system_state.get_consensus_committee())

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1285,6 +1285,13 @@ impl ConsensusNetwork {
 pub struct ProtocolConfig {
     pub version: ProtocolVersion,
 
+    /// The chain this config was instantiated for. Unlike the other fields, this is not a
+    /// versioned protocol constant: it identifies the network rather than describing protocol
+    /// behavior, so it is intentionally excluded from serialization (and from the config
+    /// snapshots) and is populated directly from the chain passed to `get_for_version`.
+    #[serde(skip)]
+    chain: Chain,
+
     feature_flags: FeatureFlags,
 
     // ==== Transaction input limits ====
@@ -2047,6 +2054,11 @@ pub struct AliasedAddress {
 
 // feature flags
 impl ProtocolConfig {
+    /// The chain this config was instantiated for (see the `chain` field).
+    pub fn chain(&self) -> Chain {
+        self.chain
+    }
+
     // Add checks for feature flag support here, e.g.:
     // pub fn check_new_protocol_feature_supported(&self) -> Result<(), Error> {
     //     if self.feature_flags.new_protocol_feature_supported {
@@ -2911,6 +2923,7 @@ impl ProtocolConfig {
 
         let mut ret = Self::get_for_version_impl(version, chain);
         ret.version = version;
+        ret.chain = chain;
 
         ret = Self::apply_config_override(version, ret);
 
@@ -2933,6 +2946,7 @@ impl ProtocolConfig {
         if version.0 >= ProtocolVersion::MIN.0 && version.0 <= ProtocolVersion::MAX_ALLOWED.0 {
             let mut ret = Self::get_for_version_impl(version, chain);
             ret.version = version;
+            ret.chain = chain;
             ret = Self::apply_config_override(version, ret);
             Some(ret)
         } else {
@@ -3002,6 +3016,7 @@ impl ProtocolConfig {
         let mut cfg = Self {
             // will be overwritten before being returned
             version,
+            chain,
 
             // All flags are disabled in V1
             feature_flags: Default::default(),


### PR DESCRIPTION
## Description

Execution code needs to branch on the chain (e.g. to gate a fix to mainnet only), but `ProtocolConfig` did not retain the `Chain` it was constructed with, forcing callers to thread a chain identifier separately. Store it on the config and expose `chain()`.

The chain is not a versioned protocol constant — it names the network rather than describing protocol behavior — so it is `#[serde(skip)]` and excluded from the config snapshots.

## Test plan

Covered by existing `sui-protocol-config` tests; snapshots unchanged since the field is not serialized.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: