### PR TITLE
sui: retain fullnode address from network config

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1027,21 +1027,16 @@ async fn start(
         swarm_builder = swarm_builder.with_data_ingestion_dir(dir.clone());
     }
 
-    let mut fullnode_rpc_address = sui_config::node::default_json_rpc_address();
-    fullnode_rpc_address.set_port(fullnode_rpc_port);
-
-    if no_full_node {
+    let fullnode_rpc_address = if no_full_node {
         swarm_builder = swarm_builder.with_fullnode_count(0);
+        let mut fullnode_rpc_address = sui_config::node::default_json_rpc_address();
+        fullnode_rpc_address.set_port(fullnode_rpc_port);
+        fullnode_rpc_address
     } else {
         let rpc_config = sui_config::RpcConfig {
             enable_indexing: Some(true),
             ..Default::default()
         };
-
-        swarm_builder = swarm_builder
-            .with_fullnode_count(1)
-            .with_fullnode_rpc_addr(fullnode_rpc_address)
-            .with_fullnode_rpc_config(rpc_config.clone());
 
         let fullnode_config_path = config_dir.join(SUI_FULLNODE_CONFIG);
         if fullnode_config_path.exists() {
@@ -1052,7 +1047,7 @@ async fn start(
                         fullnode_config_path
                     ))
                 })?;
-            fullnode_config.json_rpc_address = fullnode_rpc_address;
+            fullnode_config.json_rpc_address.set_port(fullnode_rpc_port);
             fullnode_config.rpc = Some(rpc_config);
             let localhost = sui_config::local_ip_utils::localhost_for_testing();
             fullnode_config.metrics_address =
@@ -1070,9 +1065,21 @@ async fn start(
                     .checkpoint_executor_config
                     .data_ingestion_dir = Some(dir.clone());
             }
-            swarm_builder = swarm_builder.with_fullnode_config(fullnode_config);
+            let fullnode_rpc_address = fullnode_config.json_rpc_address;
+            swarm_builder = swarm_builder
+                .with_fullnode_count(1)
+                .with_fullnode_config(fullnode_config);
+            fullnode_rpc_address
+        } else {
+            let mut fullnode_rpc_address = sui_config::node::default_json_rpc_address();
+            fullnode_rpc_address.set_port(fullnode_rpc_port);
+            swarm_builder = swarm_builder
+                .with_fullnode_count(1)
+                .with_fullnode_rpc_addr(fullnode_rpc_address)
+                .with_fullnode_rpc_config(rpc_config);
+            fullnode_rpc_address
         }
-    }
+    };
 
     let mut swarm = swarm_builder.build();
     swarm.launch().await?;


### PR DESCRIPTION
## Description

Currently `sui` CLI always overrides the socket address configured for the fullnode to set it to `0.0.0.0`. It offers no way to set the socket address to bind to in the `sui start` invocation, and it ignores the socket address that's part of the network config.

The ideal solution would be to allow the socket address to be provided along with the port in the `sui start` invocation (similar to how it works for other RPCs exposed), but that would be an interface breaking change.

Instead, this change makes the `sui` CLI retain the socket address from the network config, if there is one, as a way to provide this information without breaking the current interface.

## Test plan

Manually tested.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui start` respects the fullnode RPC socket address that's part of its network config, if one is provided.
- [ ] Rust SDK:
- [ ] Indexing Framework:
