### PR TITLE
Add wait for previous running root in CheckpointExecutor

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -485,6 +485,11 @@ impl CheckpointExecutor {
         finish_stage!(pipeline_handle, UpdateRpcIndex);
 
         self.global_state_hasher
+            .wait_for_previous_running_root(&self.epoch_store, seq)
+            .await
+            .expect("Failed to wait for previous running root");
+
+        self.global_state_hasher
             .accumulate_running_root(&self.epoch_store, seq, ckpt_state.state_hasher)
             .expect("Failed to accumulate running root");
 


### PR DESCRIPTION
## Description 

Checkpoint executor panics with "Running root state hasher must exist for checkpoint N" when `checkpoint_execution_max_concurrency` > 1 (default: 4).

Root cause: `accumulate_running_root` is called between pipeline stages `UpdateRpcIndex` and `BumpHighestExecutedCheckpoint`. Pipeline synchronization enforces that `UpdateRpcIndex` for checkpoint `N` completes before `N+1` begins, but `accumulate_running_root` sits outside that boundary. With concurrency > 1, checkpoint `N+1` can reach `get_prior_root` before `N` has finished writing its running root, triggering a fatal panic:
```
2026-06-29T12:13:33.794051547Z thread 'sui-node-runtime' (8) panicked at crates/sui-core/src/global_state_hasher.rs:529:9:
2026-06-29T12:13:33.794055161Z Running root state hasher must exist for checkpoint 172170
2026-06-29T12:13:33.794058561Z 2026-06-29T12:13:33.793007Z ERROR execute_checkpoint{seq=172171}: sui_core::global_state_hasher: Running root state hasher must exist for checkpoint 172170 fatal=true
2026-06-29T12:13:33.794072960Z 2026-06-29T12:13:33.793045Z ERROR execute_checkpoint{seq=172171}: telemetry_subscribers: panicked at crates/sui-core/src/global_state_hasher.rs:529:9:
2026-06-29T12:13:33.794076379Z Running root state hasher must exist for checkpoint 172170 panic.file="crates/sui-core/src/global_state_hasher.rs" panic.line=529 panic.column=9
2026-06-29T12:13:33.794079470Z note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
```

Fix: Add `wait_for_previous_running_root` before `accumulate_running_root` in the checkpoint executor path, matching the correct pattern already used in `checkpoints/mod.rs`. The wait subscribes to a `tokio::watch` and blocks until the prior checkpoint's running root is persisted. Since `accumulate_running_root` itself is a trivial XOR of two 32-byte hashes, this adds negligible latency and does not reduce execution throughput - all heavy work (transaction execution, RocksDB commits, RPC indexing) remains fully parallel.

## Test plan 

Reproduced the panic by running a validator with checkpoint_execution_max_concurrency: 4. Applied the fix and confirmed the validator processes checkpoints beyond the previously-failing sequence number without panics. Existing cargo check and unit tests pass.

Also verified that the full-node path in `checkpoints/mod.rs` already has this wait, no change needed there.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Fixes a fatal panic in checkpoint executor when `checkpoint_execution_max_concurrency` > 1. Nodes running with the default config (concurrency=4) could hit this race. No config change required, the fix transparently serializes the running root accumulation without affecting transaction execution parallelism.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
