### PR TITLE
Batch per-transaction work in the consensus commit-handler filter stage

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1970,12 +1970,33 @@ impl AuthorityPerEpochStore {
             .get_owned_object_locks(&tables, obj_refs)
     }
 
+    /// Batched read of existing owned-object locks, returned as a map containing only
+    /// the refs that are currently locked. The consensus commit handler prefetches the
+    /// cross-commit lock state (constant for the duration of a commit) once with this,
+    /// rather than reading per transaction inside
+    /// `try_acquire_owned_object_locks_post_consensus`.
+    pub fn get_owned_object_locks_map(
+        &self,
+        obj_refs: &[ObjectRef],
+    ) -> SuiResult<HashMap<ObjectRef, LockDetails>> {
+        let locks = self.get_owned_object_locks(obj_refs)?;
+        Ok(obj_refs
+            .iter()
+            .cloned()
+            .zip_eq(locks)
+            .filter_map(|(obj_ref, lock)| lock.map(|lock| (obj_ref, lock)))
+            .collect())
+    }
+
     /// Attempts to acquire owned object locks for a transaction post-consensus.
     ///
     /// Checks whether the object versions are already locked by searching:
-    /// 1. The current commit
-    /// 2. Quarantine and cache (earlier consensus commits in this epoch)
-    /// 3. DB (cache miss)
+    /// 1. The current commit (`current_commit_locks`, accumulated as earlier
+    ///    transactions in this commit acquire locks).
+    /// 2. `existing_locks`: locks from earlier commits in this epoch (and the DB after
+    ///    crash recovery). These are constant for the duration of a commit, so the
+    ///    caller prefetches them once via `get_owned_object_locks_map` rather than
+    ///    reading per transaction.
     ///
     /// Returns the new locks to add on success, or error if a conflict exists.
     pub fn try_acquire_owned_object_locks_post_consensus(
@@ -1983,13 +2004,10 @@ impl AuthorityPerEpochStore {
         owned_object_refs: &[ObjectRef],
         tx_digest: TransactionDigest,
         current_commit_locks: &HashMap<ObjectRef, TransactionDigest>,
+        existing_locks: &HashMap<ObjectRef, LockDetails>,
     ) -> SuiResult<Vec<(ObjectRef, LockDetails)>> {
-        if owned_object_refs.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Check for intra-commit conflicts (transactions processed earlier in the same commit).
         for obj_ref in owned_object_refs {
+            // Conflict with a transaction earlier in the same commit.
             if let Some(locked_tx_digest) = current_commit_locks.get(obj_ref)
                 && *locked_tx_digest != tx_digest
             {
@@ -1999,16 +2017,8 @@ impl AuthorityPerEpochStore {
                 }
                 .into());
             }
-        }
-
-        // Check quarantine and epoch store for existing locks.
-        let existing_locks = self
-            .get_owned_object_locks(owned_object_refs)
-            .unwrap_or_default();
-
-        // Check for conflicts with existing locks (from earlier commits or crash recovery)
-        for (lock, obj_ref) in existing_locks.iter().zip_debug_eq(owned_object_refs) {
-            if let Some(locked_tx_digest) = lock
+            // Conflict with a lock from an earlier commit (or crash recovery).
+            if let Some(locked_tx_digest) = existing_locks.get(obj_ref)
                 && *locked_tx_digest != tx_digest
             {
                 return Err(SuiErrorKind::ObjectLockConflict {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3488,6 +3488,7 @@ impl AuthorityPerEpochStore {
         self.signature_verifier.clear_signature_cache();
     }
 
+    #[cfg(test)]
     pub(crate) fn set_consensus_tx_status(
         &self,
         position: ConsensusPosition,
@@ -3495,6 +3496,14 @@ impl AuthorityPerEpochStore {
     ) {
         self.consensus_tx_status_cache
             .set_transaction_status(position, status);
+    }
+
+    pub(crate) fn set_consensus_tx_statuses(
+        &self,
+        updates: Vec<(ConsensusPosition, ConsensusTxStatus)>,
+    ) {
+        self.consensus_tx_status_cache
+            .set_transaction_statuses(updates);
     }
 
     pub(crate) fn set_rejection_vote_reason(&self, position: ConsensusPosition, reason: &SuiError) {

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -75,28 +75,54 @@ impl ConsensusTxStatusCache {
         }
     }
 
+    /// Single-update convenience wrapper around [`Self::set_transaction_statuses`].
+    /// Production code uses the batched form; this is retained for tests.
+    #[cfg(test)]
     pub(crate) fn set_transaction_status(&self, pos: ConsensusPosition, status: ConsensusTxStatus) {
-        if let Some(last_committed_leader_round) = *self.last_committed_leader_round_rx.borrow()
-            && pos.block.round + CONSENSUS_STATUS_RETENTION_ROUNDS <= last_committed_leader_round
-        {
-            // Ignore stale status updates.
-            return;
-        }
+        self.set_transaction_statuses(vec![(pos, status)]);
+    }
 
-        let mut inner = self.inner.write();
-        let old_status = inner.transaction_status.insert(pos, status);
-        if let Some(old_status) = old_status
-            && old_status != status
+    /// Batched form of `set_transaction_status`: applies all updates under a
+    /// single write lock and issues the notifications after the lock is released.
+    /// The consensus commit handler uses this to replace a per-transaction lock
+    /// acquisition (and a notify held across the write lock) with one acquisition
+    /// per commit. Semantics are otherwise identical: stale updates are dropped, a
+    /// conflicting status for an already-recorded position panics, and every applied
+    /// update is notified.
+    pub(crate) fn set_transaction_statuses(
+        &self,
+        updates: Vec<(ConsensusPosition, ConsensusTxStatus)>,
+    ) {
+        // The committed leader round is constant for the duration of a commit, so
+        // read it once for the whole batch rather than per update.
+        let last_committed_leader_round = *self.last_committed_leader_round_rx.borrow();
+        let mut to_notify = Vec::with_capacity(updates.len());
         {
-            panic!(
-                "Conflicting status updates for transaction {:?}: {:?} -> {:?}",
-                pos, old_status, status
-            );
+            let mut inner = self.inner.write();
+            for (pos, status) in updates {
+                if let Some(last_committed_leader_round) = last_committed_leader_round
+                    && pos.block.round + CONSENSUS_STATUS_RETENTION_ROUNDS
+                        <= last_committed_leader_round
+                {
+                    // Ignore stale status updates.
+                    continue;
+                }
+                let old_status = inner.transaction_status.insert(pos, status);
+                if let Some(old_status) = old_status
+                    && old_status != status
+                {
+                    panic!(
+                        "Conflicting status updates for transaction {:?}: {:?} -> {:?}",
+                        pos, old_status, status
+                    );
+                }
+                debug!("Transaction status is set for {}: {:?}", pos, status);
+                to_notify.push((pos, status));
+            }
         }
-
-        // All code paths leading to here should have set the status.
-        debug!("Transaction status is set for {}: {:?}", pos, status);
-        self.status_notify_read.notify(&pos, &status);
+        for (pos, status) in to_notify {
+            self.status_notify_read.notify(&pos, &status);
+        }
     }
 
     /// Given a known previous status provided by `old_status`, this function will return a new

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -2451,6 +2451,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let _scope = monitored_scope("ConsensusCommitHandler::filter_consensus_txns");
         let mut transactions = Vec::new();
         let mut owned_object_locks = HashMap::new();
+        // Consensus transaction status updates are collected here and flushed in a
+        // single batched write (one lock acquisition, notifications outside the lock)
+        // at the end of the commit, rather than one write+notify per transaction.
+        let mut status_updates: Vec<(ConsensusPosition, ConsensusTxStatus)> = Vec::new();
         let epoch = self.epoch_store.epoch();
         let mut num_finalized_user_transactions = vec![0; self.committee.size()];
         let mut num_rejected_user_transactions = vec![0; self.committee.size()];
@@ -2461,10 +2465,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             self.last_consensus_stats.stats.inc_num_messages(author);
 
             // Set the "ping" transaction status for this block. This is necessary as there might be some ping requests waiting for the ping transaction to be certified.
-            self.epoch_store.set_consensus_tx_status(
+            status_updates.push((
                 ConsensusPosition::ping(epoch, block),
                 ConsensusTxStatus::Finalized,
-            );
+            ));
 
             for (tx_index, parsed) in parsed_transactions.into_iter().enumerate() {
                 let position = ConsensusPosition {
@@ -2534,8 +2538,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
                 if parsed.rejected {
                     if parsed.transaction.is_user_transaction() {
-                        self.epoch_store
-                            .set_consensus_tx_status(position, ConsensusTxStatus::Rejected);
+                        status_updates.push((position, ConsensusTxStatus::Rejected));
                         num_rejected_user_transactions[author] += 1;
                     }
                     // Skip processing rejected transactions.
@@ -2664,14 +2667,12 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         Ok(new_locks) => {
                             owned_object_locks.extend(new_locks.into_iter());
                             // Lock acquisition succeeded - now set Finalized status
-                            self.epoch_store
-                                .set_consensus_tx_status(position, ConsensusTxStatus::Finalized);
+                            status_updates.push((position, ConsensusTxStatus::Finalized));
                             num_finalized_user_transactions[author] += 1;
                         }
                         Err(e) => {
                             debug!("Dropping transaction {}: {}", tx.digest(), e);
-                            self.epoch_store
-                                .set_consensus_tx_status(position, ConsensusTxStatus::Dropped);
+                            status_updates.push((position, ConsensusTxStatus::Dropped));
                             self.epoch_store.set_rejection_vote_reason(position, &e);
                             continue;
                         }
@@ -2682,6 +2683,11 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 transactions.push((transaction, author as u32));
             }
         }
+
+        // Flush all collected status updates in one batched write. None of the logic
+        // above reads transaction status back, so deferring visibility to here (still
+        // before dedup/processing) is equivalent to setting each status inline.
+        self.epoch_store.set_consensus_tx_statuses(status_updates);
 
         for (i, authority) in self.committee.authorities() {
             let hostname = &authority.hostname;

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -52,8 +52,8 @@ use sui_types::{
     },
     sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
     transaction::{
-        InputObjectKind, SenderSignedData, TransactionDataAPI, TransactionKey, VerifiedTransaction,
-        WithAliases,
+        InputObjectKind, PlainTransactionWithClaims, SenderSignedData, TransactionDataAPI,
+        TransactionKey, VerifiedTransaction, WithAliases,
     },
 };
 use tokio::task::JoinSet;
@@ -2458,6 +2458,33 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let epoch = self.epoch_store.epoch();
         let mut num_finalized_user_transactions = vec![0; self.committee.size()];
         let mut num_rejected_user_transactions = vec![0; self.committee.size()];
+
+        // Prefetch the cross-commit owned-object lock state for the whole commit in one
+        // batched read. These locks are constant for the duration of a commit (new locks
+        // are only written at commit end), so this replaces the per-transaction
+        // quarantine+DB lookup that try_acquire_owned_object_locks_post_consensus used to
+        // do. Over-reading refs of transactions that are later filtered out is harmless.
+        let existing_locks = {
+            let mut prefetch_refs: Vec<ObjectRef> = Vec::new();
+            for (_block, parsed_transactions) in &block_transactions {
+                for parsed in parsed_transactions {
+                    if let ConsensusTransactionKind::UserTransactionV2(tx_with_claims) =
+                        &parsed.transaction.kind
+                        && let Some(refs) = owned_object_refs_to_lock(tx_with_claims)
+                    {
+                        prefetch_refs.extend(refs);
+                    }
+                }
+            }
+            prefetch_refs.sort();
+            prefetch_refs.dedup();
+            // On a read error fall back to an empty map (treat refs as unlocked) — the
+            // same lenient behavior the per-transaction read had.
+            self.epoch_store
+                .get_owned_object_locks_map(&prefetch_refs)
+                .unwrap_or_default()
+        };
+
         for (block, parsed_transactions) in block_transactions {
             let author = block.author.value();
             let author_hostname = self.committee.authority(block.author).hostname.as_str();
@@ -2634,28 +2661,11 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 if let ConsensusTransactionKind::UserTransactionV2(tx_with_claims) =
                     &parsed.transaction.kind
                 {
-                    let immutable_object_ids: HashSet<ObjectID> =
-                        tx_with_claims.get_immutable_objects().into_iter().collect();
                     let tx = tx_with_claims.tx();
-
-                    let Ok(input_objects) = tx.transaction_data().input_objects() else {
+                    let Some(owned_object_refs) = owned_object_refs_to_lock(tx_with_claims) else {
                         debug_fatal!("Invalid input objects for transaction {}", tx.digest());
                         continue;
                     };
-
-                    // Filter ImmOrOwnedMoveObject inputs, excluding those claimed to be immutable.
-                    // Immutable objects don't need lock acquisition as they can be used concurrently.
-                    let owned_object_refs: Vec<_> = input_objects
-                        .iter()
-                        .filter_map(|obj| match obj {
-                            InputObjectKind::ImmOrOwnedMoveObject(obj_ref)
-                                if !immutable_object_ids.contains(&obj_ref.0) =>
-                            {
-                                Some(*obj_ref)
-                            }
-                            _ => None,
-                        })
-                        .collect();
 
                     match self
                         .epoch_store
@@ -2663,6 +2673,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                             &owned_object_refs,
                             *tx.digest(),
                             &owned_object_locks,
+                            &existing_locks,
                         ) {
                         Ok(new_locks) => {
                             owned_object_locks.extend(new_locks.into_iter());
@@ -3135,6 +3146,36 @@ fn authenticator_state_update_transaction(
             .expect("authenticator state obj must exist"),
     );
     VerifiedExecutableTransaction::new_system(transaction, epoch)
+}
+
+/// The owned (non-immutable `ImmOrOwnedMoveObject`) object refs that a
+/// `UserTransactionV2` must lock post-consensus. Immutable objects are excluded as
+/// they can be used concurrently. Returns `None` if the transaction's input objects
+/// are invalid. Used both to prefetch existing locks for the whole commit and, per
+/// transaction, to perform conflict detection — keeping the two in sync.
+fn owned_object_refs_to_lock(
+    tx_with_claims: &PlainTransactionWithClaims,
+) -> Option<Vec<ObjectRef>> {
+    let immutable_object_ids: HashSet<ObjectID> =
+        tx_with_claims.get_immutable_objects().into_iter().collect();
+    let input_objects = tx_with_claims
+        .tx()
+        .transaction_data()
+        .input_objects()
+        .ok()?;
+    Some(
+        input_objects
+            .iter()
+            .filter_map(|obj| match obj {
+                InputObjectKind::ImmOrOwnedMoveObject(obj_ref)
+                    if !immutable_object_ids.contains(&obj_ref.0) =>
+                {
+                    Some(*obj_ref)
+                }
+                _ => None,
+            })
+            .collect(),
+    )
 }
 
 pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {


### PR DESCRIPTION
## Description

Follow-up to #27052. The consensus commit handler is the bottleneck at high TPS; `filter_consensus_txns` did two things once per transaction that are cheaper batched per commit:

- **Consensus-tx-status writes** — each `set_consensus_tx_status` took the status-cache write lock and notified waiters under it. Now collected and flushed once per commit (single lock acquisition, notifications outside the lock). Filter never reads status back, so end-of-filter visibility is equivalent.
- **Owned-object lock reads** — `try_acquire_owned_object_locks_post_consensus` read existing locks (quarantine + DB) per transaction. The cross-commit locks are constant for a commit's duration (new locks are written only at commit end), so they're prefetched once and passed into the per-tx conflict check. A loop-invariant hoist; intra-commit conflict logic is unchanged.

## Test plan

Both changes are behavior-preserving (equivalence argued in the commit messages). Covered by existing tests in `consensus_handler` and `consensus_tx_status_cache`.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: