### PR TITLE
[simtest] Fix seed-search build when naming specific test targets

### DIFF
--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -266,7 +266,11 @@ def discover_binaries(args, repo_root):
     discovered = []
 
     if not args.no_build and (args.package or test_names_in_build):
-        cmd = ["cargo", "simtest", "build", "--tests"]
+        cmd = ["cargo", "simtest", "build"]
+        # `--tests` builds all test targets; it conflicts with naming specific
+        # targets via `--test`, so only pass it when no `--test` is present.
+        if not test_names_in_build:
+            cmd.append("--tests")
         for pkg in args.package or []:
             cmd.extend(["--package", pkg])
         for name in test_names_in_build:


### PR DESCRIPTION
## Description

When specific test targets were passed via `--test`, `seed-search.py` also passed `cargo simtest build --tests`, causing it to build *all* test targets instead of just the named one. Only pass `--tests` when no specific test target is requested.

## Test plan

Ran `seed-search.py` with a `--test <name>` filter and confirmed only that target is built.

## Release notes

Check each box that your change affects. If you are unsure about any of these, please ask -- our community considers these criteria important.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: