### PR TITLE
nickv/list checkpoints bugfix

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -47,6 +47,7 @@ use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
+use sui_kv_rpc::KvRpcConfig;
 use sui_kv_rpc::KvRpcServer;
 use sui_kvstore::ALL_PIPELINE_NAMES;
 use sui_kvstore::ALPHA_PIPELINE_NAMES;
@@ -160,6 +161,9 @@ pub struct OffchainClusterConfig {
     pub jsonrpc_node_args: JsonRpcNodeArgs,
     pub graphql_config: GraphQlConfig,
     pub bootstrap_genesis: Option<BootstrapGenesis>,
+    /// Configuration for the archival kv-rpc (LedgerService) server. Lets tests
+    /// tune ledger-history budgets and per-stage chunk sizes.
+    pub kv_rpc_config: KvRpcConfig,
 }
 
 impl FullCluster {
@@ -343,6 +347,7 @@ impl OffchainCluster {
             jsonrpc_node_args,
             graphql_config,
             bootstrap_genesis,
+            kv_rpc_config,
         }: OffchainClusterConfig,
         registry: &prometheus::Registry,
     ) -> anyhow::Result<Self> {
@@ -419,7 +424,7 @@ impl OffchainCluster {
         };
 
         let (bigtable_client, bigtable_emulator, archival_service) =
-            start_archival(client_args.clone(), kv_rpc_address, registry).await?;
+            start_archival(client_args.clone(), kv_rpc_address, kv_rpc_config, registry).await?;
 
         let kv_args = KvArgs {
             ledger_grpc_url: Some(
@@ -750,6 +755,7 @@ impl Default for OffchainClusterConfig {
             jsonrpc_node_args: Default::default(),
             graphql_config: Default::default(),
             bootstrap_genesis: None,
+            kv_rpc_config: KvRpcConfig::default(),
         }
     }
 }
@@ -819,6 +825,7 @@ pub async fn write_checkpoint(path: &Path, checkpoint: Checkpoint) -> anyhow::Re
 async fn start_archival(
     client_args: ClientArgs,
     kv_rpc_address: SocketAddr,
+    kv_rpc_config: KvRpcConfig,
     registry: &prometheus::Registry,
 ) -> anyhow::Result<(BigTableClient, BigTableEmulator, Service)> {
     let emulator = tokio::task::spawn_blocking(BigTableEmulator::start)
@@ -862,10 +869,16 @@ async fn start_archival(
         .await
         .context("Failed to start BigTable indexer")?;
 
-    let kv_rpc_server =
-        KvRpcServer::new_local(emulator.host().to_string(), INSTANCE_ID.to_string(), None)
-            .await
-            .context("Failed to create KvRpcServer")?;
+    let kv_rpc_server = KvRpcServer::new_local_with_config(
+        emulator.host().to_string(),
+        INSTANCE_ID.to_string(),
+        None,
+        kv_rpc_config.ledger_history(),
+        kv_rpc_config.request_bigtable_concurrency(),
+        kv_rpc_config.stages(),
+    )
+    .await
+    .context("Failed to create KvRpcServer")?;
     let kv_rpc_service = kv_rpc_server
         .start_service(
             kv_rpc_address,

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -161,8 +161,6 @@ pub struct OffchainClusterConfig {
     pub jsonrpc_node_args: JsonRpcNodeArgs,
     pub graphql_config: GraphQlConfig,
     pub bootstrap_genesis: Option<BootstrapGenesis>,
-    /// Configuration for the archival kv-rpc (LedgerService) server. Lets tests
-    /// tune ledger-history budgets and per-stage chunk sizes.
     pub kv_rpc_config: KvRpcConfig,
 }
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -4126,11 +4126,13 @@ async fn test_list_checkpoints_dense_bucket_matches_transactions() {
     // multi-chunk-within-one-bucket scan. Every matching tx in a feasible
     // dataset shares bitmap bucket 0 (BUCKET_SIZE = 65_536), so the chunk
     // boundary — not a bucket boundary — is what drives the loop.
-    let mut stages = StagesConfig::default();
-    stages.tx_seq_digest = Some(StageConfig {
-        chunk_size: Some(2),
-        concurrency: None,
-    });
+    let stages = StagesConfig {
+        tx_seq_digest: Some(StageConfig {
+            chunk_size: Some(2),
+            concurrency: None,
+        }),
+        ..Default::default()
+    };
     let kv_rpc_config = KvRpcConfig {
         stages: Some(stages),
         ..Default::default()

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -4018,9 +4018,9 @@ async fn test_list_transactions_resume_from_standalone_watermark() {
 // tests in `sui-kv-rpc`.
 
 /// Execute `n` self-transfers from `sender` (each matched by a sender filter on
-/// `sender`) and seal them into a single checkpoint. Returns the sealed
+/// `sender`), then create a single checkpoint containing them. Returns that
 /// checkpoint's sequence number and the updated gas ref.
-async fn seal_matching_checkpoint(
+async fn checkpoint_matching_txns(
     cluster: &mut FullCluster,
     sender: SuiAddress,
     kp: &AccountKeyPair,
@@ -4158,19 +4158,19 @@ async fn test_list_checkpoints_dense_bucket_matches_transactions() {
     // trailing so the scan crosses empty checkpoint regions and reaches the tip
     // on a non-matching checkpoint.
     let (cp_lo, gas) =
-        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 3).await;
+        checkpoint_matching_txns(&mut cluster, match_sender, &match_kp, match_gas, 3).await;
     match_gas = gas;
     noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
     let (cp_m1, gas) =
-        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 1).await;
+        checkpoint_matching_txns(&mut cluster, match_sender, &match_kp, match_gas, 1).await;
     match_gas = gas;
     noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
     let (cp_m2, gas) =
-        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 1).await;
+        checkpoint_matching_txns(&mut cluster, match_sender, &match_kp, match_gas, 1).await;
     match_gas = gas;
     noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
     let (cp_hi, gas) =
-        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 3).await;
+        checkpoint_matching_txns(&mut cluster, match_sender, &match_kp, match_gas, 3).await;
     match_gas = gas;
     noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
     let _ = (match_gas, noise_gas);

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -1,10 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use move_core_types::ident_str;
+use simulacrum::Simulacrum;
 use sui_indexer_alt_e2e_tests::FullCluster;
+use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
+use sui_kv_rpc::KvRpcConfig;
+use sui_kv_rpc::StageConfig;
+use sui_kv_rpc::StagesConfig;
 use sui_rpc::field::FieldMask;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
@@ -4010,3 +4016,200 @@ async fn test_list_transactions_resume_from_standalone_watermark() {
 // configurable — both are out of scope. The ScanLimit cursor contract is
 // unit-tested in `sui-inverted-index` (budget validation) and handler-level
 // tests in `sui-kv-rpc`.
+
+/// Execute `n` self-transfers from `sender` (each matched by a sender filter on
+/// `sender`) and seal them into a single checkpoint. Returns the sealed
+/// checkpoint's sequence number and the updated gas ref.
+async fn seal_matching_checkpoint(
+    cluster: &mut FullCluster,
+    sender: SuiAddress,
+    kp: &AccountKeyPair,
+    mut gas: ObjectRef,
+    n: usize,
+) -> (u64, ObjectRef) {
+    for _ in 0..n {
+        let (_, new_gas) = transfer_self(cluster, sender, kp, gas).await;
+        gas = new_gas;
+    }
+    let checkpoint = cluster.create_checkpoint().await;
+    (checkpoint.sequence_number, gas)
+}
+
+fn is_resumable(reason: QueryEndReason) -> bool {
+    matches!(
+        reason,
+        QueryEndReason::ItemLimit | QueryEndReason::ScanLimit
+    )
+}
+
+/// Drain a filtered `ListTransactions` fully, following cursors, and return the
+/// distinct set of checkpoint sequence numbers its transactions fall in.
+async fn drain_transaction_checkpoints(
+    client: &mut KvLedgerServiceClient<Channel>,
+    filter: TransactionFilter,
+    ascending: bool,
+    limit: u32,
+) -> BTreeSet<u64> {
+    let mut cps = BTreeSet::new();
+    let mut cursor: Option<prost::bytes::Bytes> = None;
+    for _ in 0..100 {
+        let mut req = ListTransactionsRequest::default();
+        req.read_mask = Some(FieldMask::from_paths(["checkpoint"]));
+        req.filter = Some(filter.clone());
+        req.options = Some(if ascending {
+            query_options_maybe_after(limit, cursor.clone())
+        } else {
+            query_options_descending_maybe_before(limit, cursor.clone())
+        });
+        let result = list_transactions_result(client, req).await;
+        for item in &result.transactions {
+            let cp = item
+                .transaction
+                .as_ref()
+                .and_then(|tx| tx.checkpoint)
+                .expect("transaction checkpoint populated");
+            cps.insert(cp);
+        }
+        let reason = result.end_reason.expect("list_transactions end reason");
+        match (is_resumable(reason), result.end_cursor.clone()) {
+            (true, Some(c)) => cursor = Some(c),
+            _ => return cps,
+        }
+    }
+    panic!("drain_transaction_checkpoints did not terminate");
+}
+
+/// Drain a filtered `ListCheckpoints` fully, following cursors, and return the
+/// set of checkpoint sequence numbers plus the final terminal reason.
+async fn drain_checkpoint_set(
+    client: &mut KvLedgerServiceClient<Channel>,
+    filter: TransactionFilter,
+    ascending: bool,
+    limit: u32,
+) -> (BTreeSet<u64>, QueryEndReason) {
+    let mut cps = BTreeSet::new();
+    let mut cursor: Option<prost::bytes::Bytes> = None;
+    for _ in 0..100 {
+        let mut req = ListCheckpointsRequest::default();
+        req.read_mask = Some(FieldMask::from_paths(["sequence_number"]));
+        req.filter = Some(filter.clone());
+        req.options = Some(if ascending {
+            query_options_maybe_after(limit, cursor.clone())
+        } else {
+            query_options_descending_maybe_before(limit, cursor.clone())
+        });
+        let result = list_checkpoints_result(client, req).await;
+        for item in &result.checkpoints {
+            cps.insert(checkpoint_sequence(item));
+        }
+        let reason = result.end_reason.expect("list_checkpoints end reason");
+        match (is_resumable(reason), result.end_cursor.clone()) {
+            (true, Some(c)) => cursor = Some(c),
+            _ => return (cps, reason),
+        }
+    }
+    panic!("drain_checkpoint_set did not terminate");
+}
+
+/// Regression: filtered `ListCheckpoints` must return exactly the checkpoints
+/// that filtered `ListTransactions` reports — even when a single bitmap bucket
+/// holds more matching transactions than one scan chunk.
+///
+/// The tx_seq -> distinct-checkpoint layer used to `break` its scan loop
+/// whenever a chunk filled (rather than only on a true upstream EOF), so a
+/// dense bucket truncated the result after one chunk and the stream ended with
+/// the pre-computed terminal reason (CHECKPOINT_BOUND / LEDGER_TIP) before the
+/// scan reached the bound. The set under-returned and was order-dependent.
+#[tokio::test]
+async fn test_list_checkpoints_dense_bucket_matches_transactions() {
+    // A small `tx_seq_digest` chunk size lets a modest dataset reproduce the
+    // multi-chunk-within-one-bucket scan. Every matching tx in a feasible
+    // dataset shares bitmap bucket 0 (BUCKET_SIZE = 65_536), so the chunk
+    // boundary — not a bucket boundary — is what drives the loop.
+    let mut stages = StagesConfig::default();
+    stages.tx_seq_digest = Some(StageConfig {
+        chunk_size: Some(2),
+        concurrency: None,
+    });
+    let kv_rpc_config = KvRpcConfig {
+        stages: Some(stages),
+        ..Default::default()
+    };
+
+    let mut cluster = FullCluster::new_with_configs(
+        Simulacrum::new(),
+        OffchainClusterConfig {
+            kv_rpc_config,
+            ..Default::default()
+        },
+        &prometheus::Registry::new(),
+    )
+    .await
+    .unwrap();
+
+    let (match_sender, match_kp, mut match_gas) =
+        cluster.funded_account(60 * DEFAULT_GAS_BUDGET).unwrap();
+    let (noise_sender, noise_kp, mut noise_gas) =
+        cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
+
+    // Sparse matches spanning the range: two checkpoints densely packed with
+    // matching txs (> chunk_size) at the low and high ends, two single-match
+    // checkpoints in the middle, with noise checkpoints interspersed and
+    // trailing so the scan crosses empty checkpoint regions and reaches the tip
+    // on a non-matching checkpoint.
+    let (cp_lo, gas) =
+        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 3).await;
+    match_gas = gas;
+    noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
+    let (cp_m1, gas) =
+        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 1).await;
+    match_gas = gas;
+    noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
+    let (cp_m2, gas) =
+        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 1).await;
+    match_gas = gas;
+    noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
+    let (cp_hi, gas) =
+        seal_matching_checkpoint(&mut cluster, match_sender, &match_kp, match_gas, 3).await;
+    match_gas = gas;
+    noise_gas = transfer_in_own_checkpoint(&mut cluster, noise_sender, &noise_kp, noise_gas).await;
+    let _ = (match_gas, noise_gas);
+
+    let expected: BTreeSet<u64> = [cp_lo, cp_m1, cp_m2, cp_hi].into_iter().collect();
+    assert_eq!(expected.len(), 4, "distinct matching checkpoints");
+
+    let mut client = KvLedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
+        .await
+        .unwrap();
+    let filter = tx_sender(match_sender);
+
+    // Small page size so the drains also follow cursors across multiple pages.
+    const LIMIT: u32 = 3;
+
+    for ascending in [true, false] {
+        let tx_cps =
+            drain_transaction_checkpoints(&mut client, filter.clone(), ascending, LIMIT).await;
+        assert_eq!(
+            tx_cps, expected,
+            "ListTransactions distinct checkpoints (ascending={ascending})"
+        );
+
+        let (cp_set, reason) =
+            drain_checkpoint_set(&mut client, filter.clone(), ascending, LIMIT).await;
+        assert_eq!(
+            cp_set, tx_cps,
+            "ListCheckpoints set must equal ListTransactions distinct checkpoints \
+             (ascending={ascending})"
+        );
+        // The fully drained stream genuinely reaches the range end, so the
+        // terminal reason must be a reached-end reason (never a premature one
+        // while matches remain).
+        assert!(
+            matches!(
+                reason,
+                QueryEndReason::LedgerTip | QueryEndReason::CheckpointBound
+            ),
+            "ListCheckpoints terminal reason (ascending={ascending}): {reason:?}"
+        );
+    }
+}

--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -294,6 +294,23 @@ impl BigTableClient {
             .map_err(RpcError::from)
     }
 
+    /// Streaming variant of `resolve_tx_checkpoints`. The permit is held for the
+    /// stream's lifetime (see `gate_stream`); rows arrive in BigTable order.
+    pub(crate) async fn resolve_tx_checkpoints_stream(
+        &self,
+        tx_sequence_numbers: Vec<u64>,
+    ) -> Result<BoxStream<'static, Result<(u64, CheckpointSequenceNumber), anyhow::Error>>, RpcError>
+    {
+        let permit = self.acquire(stage::CHECKPOINTS).await?;
+        let inner = self
+            .inner
+            .clone()
+            .resolve_tx_checkpoints_stream(tx_sequence_numbers)
+            .await
+            .map_err(RpcError::from)?;
+        Ok(gate_stream(permit, inner.boxed()))
+    }
+
     /// Eval a `BitmapQuery`. Bitmap scans stay outside the downstream request
     /// semaphore; their concurrency is bounded by `max_bitmap_filter_literals`
     /// during filter validation.

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -209,6 +209,29 @@ impl KvRpcServer {
         instance_id: String,
         server_version: Option<ServerVersion>,
     ) -> anyhow::Result<Self> {
+        Self::new_local_with_config(
+            host,
+            instance_id,
+            server_version,
+            LedgerHistoryConfig::default(),
+            KvRpcConfig::default().request_bigtable_concurrency(),
+            StagesConfig::default(),
+        )
+        .await
+    }
+
+    /// Construct a KvRpcServer backed by a local BigTable emulator with explicit
+    /// ledger-history and per-stage configuration. Tests use this to exercise
+    /// scan-budget / chunk-size behaviour (e.g. a small `tx_seq_digest` chunk
+    /// size) against a modest synthetic dataset.
+    pub async fn new_local_with_config(
+        host: String,
+        instance_id: String,
+        server_version: Option<ServerVersion>,
+        ledger_history: LedgerHistoryConfig,
+        request_bigtable_concurrency: usize,
+        stages: StagesConfig,
+    ) -> anyhow::Result<Self> {
         let client = BigTableClient::new_local(host, instance_id).await?;
         // Emulator/test path: metrics are inert (no scrape endpoint), but the
         // request-scoped BigTable wrapper still expects a handle.
@@ -219,9 +242,9 @@ impl KvRpcServer {
             server_version,
             default_service_info_watermark_pipelines(false),
             metrics,
-            LedgerHistoryConfig::default(),
-            KvRpcConfig::default().request_bigtable_concurrency(),
-            StagesConfig::default(),
+            ledger_history,
+            request_bigtable_concurrency,
+            stages,
         )
     }
 

--- a/crates/sui-kv-rpc/src/pipeline.rs
+++ b/crates/sui-kv-rpc/src/pipeline.rs
@@ -396,6 +396,39 @@ where
     .boxed()
 }
 
+/// Collapse runs of equal `Watermarked::Item` values into one, forwarding
+/// `Watermarked::Watermark` frames and errors unchanged. Items must already be
+/// in scan order. Used by `ListCheckpoints` to turn the per-transaction
+/// checkpoint ids of a filtered scan (a checkpoint's txs are contiguous in scan
+/// order) into a single id per checkpoint. Unlike a per-chunk mapper this
+/// carries its dedup state across the whole stream, so duplicates split across
+/// chunk boundaries still collapse.
+pub(crate) fn dedup_consecutive<T, E>(
+    stream: BoxStream<'static, Result<Watermarked<T>, E>>,
+) -> BoxStream<'static, Result<Watermarked<T>, E>>
+where
+    T: PartialEq + Clone + Send + 'static,
+    E: Send + 'static,
+{
+    async_stream::try_stream! {
+        futures::pin_mut!(stream);
+        let mut last: Option<T> = None;
+        while let Some(item) = stream.next().await {
+            match item? {
+                Watermarked::Item(t) => {
+                    if last.as_ref() == Some(&t) {
+                        continue;
+                    }
+                    last = Some(t.clone());
+                    yield Watermarked::Item(t);
+                }
+                Watermarked::Watermark(p) => yield Watermarked::Watermark(p),
+            }
+        }
+    }
+    .boxed()
+}
+
 /// Buffers values arriving keyed-but-out-of-input-order and emits them in
 /// input order as their slots become contiguous. Used by chunk fetch stages
 /// to translate BigTable's arrival-order multi_get responses into the

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -30,6 +30,7 @@ use crate::operation::QueryContext;
 use crate::pipeline::InputOrderEmitter;
 use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
+use crate::pipeline::dedup_consecutive;
 use crate::pipeline::pipelined_chunks;
 use crate::pipeline::resolve_watermarks;
 use crate::pipeline::take_items;
@@ -76,6 +77,7 @@ pub(crate) async fn list_checkpoints(
     let checkpoints_stage = ctx.stage(PipelineStage::Checkpoints);
     let transactions_stage = ctx.stage(PipelineStage::Transactions);
     let objects_stage = ctx.stage(PipelineStage::Objects);
+    let tx_seq_digest_stage = ctx.stage(PipelineStage::TxSeqDigest);
 
     let checkpoint_range = CheckpointRange::from_request(
         request.start_checkpoint,
@@ -152,18 +154,29 @@ pub(crate) async fn list_checkpoints(
     > = if let Some(filter) = &request.filter {
         let scan_budget = ctx.scan_budget(BitmapIndexSpec::tx());
         let tx_range = client.checkpoint_to_tx_range(cp_range.clone()).await?;
-        let seq_stream = filtered_checkpoint_seq_stream(
-            &ctx,
-            filter,
+        let query = ctx.transaction_filter_query(filter)?;
+        let tx_seq_stream = client.eval_bitmap_query_stream(
+            query,
             tx_range,
-            limit_items,
-            options.clone(),
+            BitmapIndexSpec::tx(),
+            direction,
             scan_budget,
-        )
-        .await?;
-        let seq_stream = take_items(seq_stream, limit_items);
+            ctx.bitmap_scan_observer(),
+        );
+        let ascending = direction.is_ascending();
+        let cp_seq_stream = pipelined_chunks(
+            tx_seq_stream,
+            tx_seq_digest_stage.chunk_size,
+            tx_seq_digest_stage.concurrency,
+            {
+                let client = client.clone();
+                move |tx_seqs| resolve_checkpoint_seqs(client.clone(), tx_seqs, ascending)
+            },
+        );
+        let cp_seq_stream = take_items(dedup_consecutive(cp_seq_stream), limit_items);
+        // Stage A3: fetch checkpoint rows for the deduped cp_seqs.
         pipelined_chunks(
-            seq_stream,
+            cp_seq_stream,
             checkpoints_stage.chunk_size,
             checkpoints_stage.concurrency,
             {
@@ -421,6 +434,31 @@ async fn fetch_checkpoint_data(
     .boxed())
 }
 
+/// Resolve a batch of `tx_sequence_number`s to their checkpoint sequence
+/// numbers, restoring scan order (multi-get responses are unordered) and
+/// dropping the tx_seq. Consecutive duplicates — the multiple transactions of
+/// one checkpoint — are collapsed downstream by `dedup_consecutive`.
+async fn resolve_checkpoint_seqs(
+    client: BigTableClient,
+    tx_seqs: Vec<u64>,
+    ascending: bool,
+) -> Result<BoxStream<'static, Result<u64, anyhow::Error>>, anyhow::Error> {
+    if tx_seqs.is_empty() {
+        return Ok(stream::empty().boxed());
+    }
+    let mut tx_checkpoints = client.resolve_tx_checkpoints(&tx_seqs).await?;
+    if ascending {
+        tx_checkpoints.sort_by_key(|(tx_seq, _)| *tx_seq);
+    } else {
+        tx_checkpoints.sort_by_key(|(tx_seq, _)| std::cmp::Reverse(*tx_seq));
+    }
+    let cp_seqs: Vec<u64> = tx_checkpoints
+        .into_iter()
+        .map(|(_, cp_seq)| cp_seq)
+        .collect();
+    Ok(stream::iter(cp_seqs.into_iter().map(Ok)).boxed())
+}
+
 fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {
     let mut item = CheckpointItem::default();
     item.checkpoint = Some(message);
@@ -438,114 +476,6 @@ fn end_response(reason: QueryEndReason) -> ListCheckpointsResponse {
     let mut response = ListCheckpointsResponse::default();
     response.response = Some(list_checkpoints_response::Response::End(end));
     response
-}
-
-/// Filtered cp_seq discovery for `ListCheckpoints`. The tx-bitmap scan and
-/// the `tx_seq -> cp_seq` mapping live in the same chunked loop so cp dedup
-/// stays local. Tx-space watermarks emitted by the bitmap are
-/// translated into cp-space watermarks in-band: each marker arrival
-/// flushes the current chunk (so the marker stays ordered AFTER any cps it
-/// dominates) and then emits `Watermarked::Watermark(cp_seq)` of its own.
-///
-/// Returns the cp_seq stream. `BitmapScanLimitExceeded` propagates as `anyhow::Error`
-/// through the stream; the parent handler downcasts to detect it.
-async fn filtered_checkpoint_seq_stream(
-    ctx: &QueryContext,
-    filter: &sui_rpc::proto::sui::rpc::v2alpha::TransactionFilter,
-    tx_range: std::ops::Range<u64>,
-    limit: usize,
-    options: QueryOptions,
-    budget: u64,
-) -> Result<BoxStream<'static, Result<Watermarked<u64>, anyhow::Error>>, RpcError> {
-    if limit == 0 || tx_range.is_empty() {
-        return Ok(stream::empty().boxed());
-    }
-
-    let client = ctx.client();
-    let query = ctx.transaction_filter_query(filter)?;
-    let chunk_max = ctx.stage(PipelineStage::TxSeqDigest).chunk_size;
-
-    let tx_seq_stream = client.eval_bitmap_query_stream(
-        query,
-        tx_range,
-        BitmapIndexSpec::tx(),
-        options.scan_direction(),
-        budget,
-        ctx.bitmap_scan_observer(),
-    );
-    let fetch_client: BigTableClient = client.clone();
-    let direction = options.scan_direction();
-
-    let stream = async_stream::try_stream! {
-        futures::pin_mut!(tx_seq_stream);
-        let mut tx_seq_chunk: Vec<u64> = Vec::with_capacity(chunk_max);
-        let mut last_cp_seq: Option<u64> = None;
-        let mut emitted = 0usize;
-
-        loop {
-            // Read until we have a full chunk of tx_seq Items, OR a Frontier
-            // marker arrives (forcing flush), OR the upstream ends.
-            let mut pending_watermark: Option<u64> = None;
-            let mut upstream_done = false;
-            while tx_seq_chunk.len() < chunk_max && pending_watermark.is_none() {
-                match tx_seq_stream.try_next().await? {
-                    Some(Watermarked::Item(tx_seq)) => tx_seq_chunk.push(tx_seq),
-                    Some(Watermarked::Watermark(p)) => pending_watermark = Some(p),
-                    None => {
-                        upstream_done = true;
-                        break;
-                    }
-                }
-            }
-
-            // Resolve items' cps via one multi_get; dedupe by cp_seq.
-            // The WM (if any) stays in tx-space — it passes through to
-            // the tail `coalesce_watermarks`, which may drop it as
-            // item-superseded. Surviving WMs do their own one-row
-            // lookup in the handler at emit time. This decouples the
-            // small WM lookup from the bulky item multi_get, mirroring
-            // the structure in list_transactions / list_events.
-            if !tx_seq_chunk.is_empty() {
-                let mut tx_checkpoints = fetch_client.resolve_tx_checkpoints(&tx_seq_chunk).await?;
-                if direction.is_ascending() {
-                    tx_checkpoints.sort_by_key(|(tx_seq, _)| *tx_seq);
-                } else {
-                    tx_checkpoints.sort_by_key(|(tx_seq, _)| std::cmp::Reverse(*tx_seq));
-                }
-                tx_seq_chunk.clear();
-                for (_, cp_seq) in tx_checkpoints {
-                    if last_cp_seq == Some(cp_seq) {
-                        continue;
-                    }
-                    last_cp_seq = Some(cp_seq);
-                    emitted += 1;
-                    yield Watermarked::Item(cp_seq);
-                    if emitted >= limit {
-                        return;
-                    }
-                }
-            }
-
-            // Pass the WM through untranslated (tx-space position).
-            // Downstream `coalesce_watermarks` drops it if items
-            // follow; otherwise the handler resolves it to cp and
-            // applies the clamp at emit time.
-            if let Some(tx_frontier) = pending_watermark {
-                yield Watermarked::Watermark(tx_frontier);
-            }
-
-            // Only a genuine upstream EOF ends the scan. A full chunk that hit
-            // neither a watermark nor EOF means the current bitmap bucket holds
-            // more matching txs than one chunk; keep draining so the scan does
-            // not truncate mid-bucket and report a premature terminal reason.
-            if upstream_done {
-                break;
-            }
-        }
-    }
-    .boxed();
-
-    Ok(stream)
 }
 
 /// Determine the checkpoint_sequence_number scan window from the logical

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -163,14 +163,18 @@ pub(crate) async fn list_checkpoints(
             scan_budget,
             ctx.bitmap_scan_observer(),
         );
-        let ascending = direction.is_ascending();
+        // Stage A2: resolve tx_seq -> cp_seq, streaming each cp as soon as the
+        // scan-order prefix is contiguous, then collapse each checkpoint's
+        // (contiguous) transactions to a single cp_seq. Dedup is its own stage
+        // rather than a per-chunk mapper because it carries state across chunk
+        // boundaries.
         let cp_seq_stream = pipelined_chunks(
             tx_seq_stream,
             tx_seq_digest_stage.chunk_size,
             tx_seq_digest_stage.concurrency,
             {
                 let client = client.clone();
-                move |tx_seqs| resolve_checkpoint_seqs(client.clone(), tx_seqs, ascending)
+                move |tx_seqs| resolve_checkpoint_seqs(client.clone(), tx_seqs)
             },
         );
         let cp_seq_stream = take_items(dedup_consecutive(cp_seq_stream), limit_items);
@@ -434,29 +438,38 @@ async fn fetch_checkpoint_data(
     .boxed())
 }
 
-/// Resolve a batch of `tx_sequence_number`s to their checkpoint sequence
-/// numbers, restoring scan order (multi-get responses are unordered) and
-/// dropping the tx_seq. Consecutive duplicates — the multiple transactions of
-/// one checkpoint — are collapsed downstream by `dedup_consecutive`.
+/// Resolve a chunk of `tx_sequence_number`s (already in scan order) to their
+/// checkpoint sequence numbers, streaming each cp_seq as soon as the scan-order
+/// prefix is contiguously available rather than buffering the whole batch.
+/// BigTable multi-get rows arrive unordered, so `InputOrderEmitter` (keyed by
+/// the input scan order) releases the contiguous front as rows fill in — the
+/// same ordering trick as `fetch_checkpoint_data`. Consecutive duplicates (one
+/// checkpoint's multiple transactions) are collapsed downstream by
+/// `dedup_consecutive`.
 async fn resolve_checkpoint_seqs(
     client: BigTableClient,
     tx_seqs: Vec<u64>,
-    ascending: bool,
 ) -> Result<BoxStream<'static, Result<u64, anyhow::Error>>, anyhow::Error> {
     if tx_seqs.is_empty() {
         return Ok(stream::empty().boxed());
     }
-    let mut tx_checkpoints = client.resolve_tx_checkpoints(&tx_seqs).await?;
-    if ascending {
-        tx_checkpoints.sort_by_key(|(tx_seq, _)| *tx_seq);
-    } else {
-        tx_checkpoints.sort_by_key(|(tx_seq, _)| std::cmp::Reverse(*tx_seq));
+    let rows = client
+        .resolve_tx_checkpoints_stream(tx_seqs.clone())
+        .await?;
+    Ok(async_stream::try_stream! {
+        let mut emitter: InputOrderEmitter<u64, u64> = InputOrderEmitter::new(tx_seqs);
+        futures::pin_mut!(rows);
+        while let Some(row) = rows.next().await {
+            let (tx_seq, cp_seq) = row?;
+            for cp in emitter.push(tx_seq, cp_seq, "list_checkpoints: tx -> checkpoint resolution")? {
+                yield cp;
+            }
+        }
+        for cp in emitter.finish("list_checkpoints: missing tx -> checkpoint row")? {
+            yield cp;
+        }
     }
-    let cp_seqs: Vec<u64> = tx_checkpoints
-        .into_iter()
-        .map(|(_, cp_seq)| cp_seq)
-        .collect();
-    Ok(stream::iter(cp_seqs.into_iter().map(Ok)).boxed())
+    .boxed())
 }
 
 fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsResponse {

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -486,11 +486,15 @@ async fn filtered_checkpoint_seq_stream(
             // Read until we have a full chunk of tx_seq Items, OR a Frontier
             // marker arrives (forcing flush), OR the upstream ends.
             let mut pending_watermark: Option<u64> = None;
+            let mut upstream_done = false;
             while tx_seq_chunk.len() < chunk_max && pending_watermark.is_none() {
                 match tx_seq_stream.try_next().await? {
                     Some(Watermarked::Item(tx_seq)) => tx_seq_chunk.push(tx_seq),
                     Some(Watermarked::Watermark(p)) => pending_watermark = Some(p),
-                    None => break,
+                    None => {
+                        upstream_done = true;
+                        break;
+                    }
                 }
             }
 
@@ -528,11 +532,15 @@ async fn filtered_checkpoint_seq_stream(
             // applies the clamp at emit time.
             if let Some(tx_frontier) = pending_watermark {
                 yield Watermarked::Watermark(tx_frontier);
-                continue;
             }
 
-            // Upstream ended.
-            break;
+            // Only a genuine upstream EOF ends the scan. A full chunk that hit
+            // neither a watermark nor EOF means the current bitmap bucket holds
+            // more matching txs than one chunk; keep draining so the scan does
+            // not truncate mid-bucket and report a premature terminal reason.
+            if upstream_done {
+                break;
+            }
         }
     }
     .boxed();

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -1194,7 +1194,24 @@ impl BigTableClient {
         if tx_sequence_numbers.is_empty() {
             return Ok(Vec::new());
         }
+        let rows = self
+            .resolve_tx_checkpoints_stream(tx_sequence_numbers.to_vec())
+            .await?;
+        futures::pin_mut!(rows);
+        let mut result = Vec::with_capacity(tx_sequence_numbers.len());
+        while let Some(row) = rows.next().await {
+            result.push(row?);
+        }
+        Ok(result)
+    }
 
+    /// Streaming variant of `resolve_tx_checkpoints`. Yields
+    /// `(tx_sequence_number, checkpoint_number)` per row as it arrives (arrival
+    /// order, not key order — callers needing a stable order must reorder).
+    pub async fn resolve_tx_checkpoints_stream(
+        &mut self,
+        tx_sequence_numbers: Vec<u64>,
+    ) -> Result<impl futures::Stream<Item = Result<(u64, CheckpointSequenceNumber)>> + use<>> {
         let keys: Vec<Vec<u8>> = tx_sequence_numbers
             .iter()
             .map(|s| tx_seq_digest::encode_key(*s))
@@ -1202,16 +1219,19 @@ impl BigTableClient {
         let filter = Some(Self::column_filter(&[
             tx_seq_digest::col::CHECKPOINT_NUMBER,
         ]));
-        let rows = self.multi_get(tx_seq_digest::NAME, keys, filter).await?;
+        let rows = self
+            .multi_get_stream(tx_seq_digest::NAME, keys, filter)
+            .await?;
 
-        let mut result = Vec::with_capacity(rows.len());
-        for (row_key, cells) in &rows {
-            let tx_seq = tx_seq_digest::decode_key(row_key.as_ref())?;
-            let checkpoint_number = tx_seq_digest::decode_checkpoint_number(cells)?;
-            result.push((tx_seq, checkpoint_number));
-        }
-
-        Ok(result)
+        Ok(async_stream::try_stream! {
+            futures::pin_mut!(rows);
+            while let Some(row) = rows.next().await {
+                let (key, cells) = row?;
+                let tx_seq = tx_seq_digest::decode_key(key.as_ref())?;
+                let checkpoint_number = tx_seq_digest::decode_checkpoint_number(&cells)?;
+                yield (tx_seq, checkpoint_number);
+            }
+        })
     }
 
     /// Streaming variant of `get_transactions_filtered`. Yields


### PR DESCRIPTION
## Description

The ListCheckpoints API had its own function to batch up "chunks" of txn ids to resolve to checkpoints because it needed de-duping logic that the common `pipelined_chunks` helper didn't do. This function had a bug that caused it to terminate when a chunk was full, even if the bitmap still had more bits that hadn't been streamed out yet.

This refactors the code to use `pipelined_chunks` for chunking (which never had that bug) along with a new dedupe stream combinator.

I also did a little bit of (probably marginally important) stream debottlenecking while I was in there (see the changes in the sui-kvstore bigtable client).

## Test plan

Reproduced the bug with an integration test and fixed it TDD style.
