### PR TITLE
Deduplicate transaction submissions in authority service handler

### DIFF
--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -71,6 +71,7 @@ pub struct TestAuthorityBuilder<'a> {
     cache_config: Option<ExecutionCacheConfig>,
     chain_override: Option<Chain>,
     dev_inspect_disabled: bool,
+    recent_submission_dedup_window_ms: Option<u64>,
     /// Skip full RPC index initialization (use for tests that don't need RPC endpoints)
     skip_rpc_index_init: bool,
     /// Skip genesis owner/dynamic-field indexing (use for tests that don't query owned objects)
@@ -205,6 +206,15 @@ impl<'a> TestAuthorityBuilder<'a> {
 
     pub fn with_chain_override(mut self, chain: Chain) -> Self {
         self.chain_override = Some(chain);
+        self
+    }
+
+    pub fn with_recent_submission_dedup_window_ms(mut self, window_ms: u64) -> Self {
+        assert!(
+            self.recent_submission_dedup_window_ms
+                .replace(window_ms)
+                .is_none()
+        );
         self
     }
 
@@ -393,6 +403,9 @@ impl<'a> TestAuthorityBuilder<'a> {
         config.authority_overload_config = authority_overload_config;
         config.authority_store_pruning_config = pruning_config;
         config.dev_inspect_disabled = self.dev_inspect_disabled;
+        if let Some(window_ms) = self.recent_submission_dedup_window_ms {
+            config.recent_submission_dedup_window_ms = Some(window_ms);
+        }
 
         let chain_identifier = ChainIdentifier::from(*genesis.checkpoint().digest());
         let policy_config = config.policy_config.clone();

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -341,7 +341,7 @@ impl ValidatorServiceMetrics {
             .unwrap(),
             inflight_transactions: register_int_gauge_with_registry!(
                 "validator_service_inflight_transactions",
-                "Number of transaction digests from inflight submit requests",
+                "Number of transactions from inflight submit requests",
                 registry,
             )
             .unwrap(),
@@ -805,10 +805,16 @@ impl ValidatorService {
 
             // A request must not repeat a transaction.
             if !request_digests.insert(tx_digest) {
-                return Err(SuiErrorKind::UserInputError {
+                let error: SuiError = SuiErrorKind::UserInputError {
                     error: UserInputError::RepeatedTransactions { digest: tx_digest },
                 }
-                .into());
+                .into();
+                // Reject individual repeated transactions in batch.
+                if is_soft_bundle_request {
+                    return Err(error);
+                }
+                results[idx] = Some(SubmitTxResult::Rejected { error });
+                continue;
             }
 
             // Soft bundles require all transactions to use the same gas price.
@@ -978,7 +984,7 @@ impl ValidatorService {
                 results[idx] = Some(SubmitTxResult::Rejected {
                     error: SuiErrorKind::TransactionProcessing {
                         digest: tx_digest,
-                        status: "sequenced by consensus".to_string(),
+                        status: "consensus message processed".to_string(),
                     }
                     .into(),
                 });
@@ -1001,11 +1007,7 @@ impl ValidatorService {
                         .with_label_values(&[req_type])
                         .inc();
                     results[idx] = Some(SubmitTxResult::Rejected {
-                        error: SuiErrorKind::TransactionProcessing {
-                            digest: tx_digest,
-                            status: "submission in progress".to_string(),
-                        }
-                        .into(),
+                        error: SuiErrorKind::TransactionSubmitted { digest: tx_digest }.into(),
                     });
                     debug!(
                         ?tx_digest,
@@ -1022,11 +1024,7 @@ impl ValidatorService {
                         .recently_submitted_resubmission_interval
                         .observe(since.as_secs_f64());
                     results[idx] = Some(SubmitTxResult::Rejected {
-                        error: SuiErrorKind::TransactionProcessing {
-                            digest: tx_digest,
-                            status: "recently processed".to_string(),
-                        }
-                        .into(),
+                        error: SuiErrorKind::TransactionSubmitted { digest: tx_digest }.into(),
                     });
                     debug!(?tx_digest, "handle_submit_transaction: recently processed");
                     continue;
@@ -1311,6 +1309,7 @@ impl ValidatorService {
                         else {
                             return Err(err);
                         };
+                        // For TransactionProcessing error, ensure the per txn result has the correct digest.
                         for (idx, tx_digest) in txns_meta {
                             debug!(
                                 ?tx_digest,
@@ -1483,8 +1482,8 @@ struct InflightTransactionsGuard {
     recently_submitted: Cache<TransactionDigest, Instant>,
     window: Duration,
     metrics: Arc<ValidatorServiceMetrics>,
-    /// Digests this request successfully acquired (in acquisition order).
-    owned: Vec<TransactionDigest>,
+    /// Digests this request successfully acquired.
+    acquired: HashSet<TransactionDigest>,
 }
 
 enum AcquireOutcome {
@@ -1505,23 +1504,24 @@ impl InflightTransactionsGuard {
             recently_submitted: service.recently_submitted.clone(),
             window: service.recent_submission_window,
             metrics: service.metrics.clone(),
-            owned: Vec::new(),
+            acquired: HashSet::new(),
         }
     }
 
     fn try_acquire(&mut self, digest: TransactionDigest) -> AcquireOutcome {
         // A retry of this own request re-acquires the same digests.
-        if self.owned.contains(&digest) {
+        if self.acquired.contains(&digest) {
             return AcquireOutcome::AlreadyAcquiredByThisRequest;
+        }
+
+        // Suppress resubmissions of recently processed transactions.
+        if let Some(outcome) = self.recently_processed_outcome(digest) {
+            return outcome;
         }
 
         // Atomic check-and-acquire against concurrent in-flight transactions.
         {
             let mut set = self.inflight.lock();
-            // Suppress resubmissions of recently processed transactions.
-            if let Some(outcome) = self.recently_processed_outcome(digest) {
-                return outcome;
-            }
             // Only continue processing the transaction if it is not already inflight.
             if !set.insert(digest) {
                 return AcquireOutcome::AlreadyAcquiredByAnotherRequest;
@@ -1529,7 +1529,16 @@ impl InflightTransactionsGuard {
             self.metrics.inflight_transactions.set(set.len() as i64);
         }
 
-        self.owned.push(digest);
+        // Without this re-check, a duplicated transaction arriving between the first check and
+        // the digest acquisition could slip through.
+        if let Some(outcome) = self.recently_processed_outcome(digest) {
+            let mut set = self.inflight.lock();
+            set.remove(&digest);
+            self.metrics.inflight_transactions.set(set.len() as i64);
+            return outcome;
+        }
+
+        self.acquired.insert(digest);
         AcquireOutcome::Acquired
     }
 
@@ -1542,15 +1551,18 @@ impl InflightTransactionsGuard {
 
 impl Drop for InflightTransactionsGuard {
     fn drop(&mut self) {
-        if self.owned.is_empty() {
+        if self.acquired.is_empty() {
             return;
         }
-        // Demote inflight transactions to recently processed cache while holding the in-flight lock.
+        // Demote inflight transactions to recently submitted cache before taking the in-flight lock,
+        // to avoid cleaning up the cache with the lock.
         let now = Instant::now();
+        for digest in &self.acquired {
+            self.recently_submitted.insert(*digest, now);
+        }
         {
             let mut set = self.inflight.lock();
-            for digest in &self.owned {
-                self.recently_submitted.insert(*digest, now);
+            for digest in &self.acquired {
                 set.remove(digest);
             }
             self.metrics.inflight_transactions.set(set.len() as i64);
@@ -2125,7 +2137,7 @@ mod inflight_guard_tests {
             recently_submitted: cache,
             window: Duration::from_secs(10),
             metrics,
-            owned: Vec::new(),
+            acquired: HashSet::new(),
         }
     }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -11,6 +11,7 @@ use moka::sync::Cache;
 use mysten_common::ZipDebugEqIteratorExt;
 use mysten_common::{assert_reachable, debug_fatal};
 use mysten_metrics::spawn_monitored_task;
+use parking_lot::Mutex;
 use prometheus::{
     Gauge, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, Registry,
     register_gauge_with_registry, register_histogram_vec_with_registry,
@@ -204,6 +205,8 @@ pub struct ValidatorServiceMetrics {
     submission_suppressed_recently_submitted: IntCounterVec,
     recently_submitted_cache_size: IntGauge,
     recently_submitted_resubmission_interval: Histogram,
+    submission_suppressed_inflight: IntCounterVec,
+    inflight_transactions: IntGauge,
     connection_ip_not_found: IntCounter,
     forwarded_header_parse_error: IntCounter,
     forwarded_header_invalid: IntCounter,
@@ -328,6 +331,20 @@ impl ValidatorServiceMetrics {
                 registry,
             )
             .unwrap(),
+            submission_suppressed_inflight: register_int_counter_vec_with_registry!(
+                "validator_service_submission_suppressed_inflight",
+                "Number of submitted transactions suppressed because the same transaction was \
+                 already being handled by a concurrent in-flight submit request",
+                &["req_type"],
+                registry,
+            )
+            .unwrap(),
+            inflight_transactions: register_int_gauge_with_registry!(
+                "validator_service_inflight_transactions",
+                "Number of transaction digests from inflight submit requests",
+                registry,
+            )
+            .unwrap(),
             connection_ip_not_found: register_int_counter_with_registry!(
                 "validator_service_connection_ip_not_found",
                 "Number of times connection IP was not extractable from request",
@@ -418,6 +435,9 @@ pub struct ValidatorService {
     recently_submitted: Cache<TransactionDigest, Instant>,
     /// How long a transaction is suppressed after submission (from node config).
     recent_submission_window: Duration,
+    /// Digests currently being handled by an in-flight submit handler. Acquired atomically at
+    /// entry and removed (then demoted into `recently_submitted`) when the handler returns.
+    inflight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
 }
 
 /// Assumed peak distinct-submission rate, used to size the dedup cache (per window).
@@ -444,6 +464,7 @@ impl ValidatorService {
             admission_queue,
             recently_submitted: Self::new_recently_submitted_cache(recent_submission_window),
             recent_submission_window,
+            inflight_transactions: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -481,6 +502,7 @@ impl ValidatorService {
             admission_queue,
             recently_submitted: Self::new_recently_submitted_cache(recent_submission_window),
             recent_submission_window,
+            inflight_transactions: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -605,6 +627,7 @@ impl ValidatorService {
             admission_queue: _,
             recently_submitted: _,
             recent_submission_window: _,
+            inflight_transactions: _,
         } = self.clone();
 
         let submitter_client_addr = if let Some(client_id_source) = &client_id_source {
@@ -619,9 +642,16 @@ impl ValidatorService {
         let next_epoch = start_epoch + 1;
         let mut max_retries = 1;
 
+        let mut inflight_guard = InflightTransactionsGuard::new(self);
         loop {
             let res = self
-                .handle_submit_transaction_inner(&state, &metrics, &inner, submitter_client_addr)
+                .handle_submit_transaction_inner(
+                    &state,
+                    &metrics,
+                    &inner,
+                    submitter_client_addr,
+                    &mut inflight_guard,
+                )
                 .await;
             match res {
                 Ok((response, weight)) => return Ok((tonic::Response::new(response), weight)),
@@ -662,6 +692,7 @@ impl ValidatorService {
         metrics: &ValidatorServiceMetrics,
         request: &RawSubmitTxRequest,
         submitter_client_addr: Option<IpAddr>,
+        inflight_guard: &mut InflightTransactionsGuard,
     ) -> SuiResult<(RawSubmitTxResponse, Weight)> {
         let epoch_store = state.load_epoch_store_one_call_per_task();
         let submit_type = SubmitTxType::try_from(request.submit_type).map_err(|e| {
@@ -736,9 +767,8 @@ impl ValidatorService {
         let mut duplicate_at_admission = false;
         // First gas price seen in this soft bundle.
         let mut expected_soft_bundle_gas_price = None;
-        // Transaction digests seen in this soft bundle, used to reject bundles that repeat a
-        // transaction. No legitimate client constructs such a bundle.
-        let mut soft_bundle_digests = HashSet::new();
+        // Transaction digests seen in this request attempt, used to reject repeated transactions.
+        let mut request_digests = HashSet::new();
 
         let req_type = if is_ping_request {
             "ping"
@@ -773,17 +803,12 @@ impl ValidatorService {
             let tx_size = transaction.validity_check(&epoch_store.tx_validity_check_context())?;
             let tx_digest = *transaction.digest();
 
-            // Soft bundles must not repeat a transaction. Fail the whole request if they do.
-            if is_soft_bundle_request {
-                fp_ensure!(
-                    soft_bundle_digests.insert(tx_digest),
-                    SuiErrorKind::UserInputError {
-                        error: UserInputError::RepeatedTransactionInSoftBundle {
-                            digest: tx_digest
-                        }
-                    }
-                    .into()
-                );
+            // A request must not repeat a transaction.
+            if !request_digests.insert(tx_digest) {
+                return Err(SuiErrorKind::UserInputError {
+                    error: UserInputError::RepeatedTransactions { digest: tx_digest },
+                }
+                .into());
             }
 
             // Soft bundles require all transactions to use the same gas price.
@@ -964,32 +989,49 @@ impl ValidatorService {
                 continue;
             }
 
-            // Allow a given transaction into consensus at most once per `recent_submission_window`,
-            // dropping duplicate resubmissions early.
-            if let Some(recorded_at) = self.recently_submitted.get(&tx_digest)
-                && recorded_at.elapsed() < self.recent_submission_window
-            {
-                metrics
-                    .submission_suppressed_recently_submitted
-                    .with_label_values(&[req_type])
-                    .inc();
-                metrics
-                    .recently_submitted_resubmission_interval
-                    .observe(recorded_at.elapsed().as_secs_f64());
-                results[idx] = Some(SubmitTxResult::Rejected {
-                    error: SuiErrorKind::TransactionProcessing {
-                        digest: tx_digest,
-                        status: "recently submitted".to_string(),
-                    }
-                    .into(),
-                });
-                debug!(?tx_digest, "handle_submit_transaction: recently submitted");
-                continue;
+            // Atomically acquire the digest for the duration of this handler. Reject concurrent
+            // and recent duplicates and record the result per result index.
+            match inflight_guard.try_acquire(tx_digest) {
+                AcquireOutcome::Acquired | AcquireOutcome::AlreadyAcquiredByThisRequest => {
+                    // Continue to process the transaction and submit to consensus.
+                }
+                AcquireOutcome::AlreadyAcquiredByAnotherRequest => {
+                    metrics
+                        .submission_suppressed_inflight
+                        .with_label_values(&[req_type])
+                        .inc();
+                    results[idx] = Some(SubmitTxResult::Rejected {
+                        error: SuiErrorKind::TransactionProcessing {
+                            digest: tx_digest,
+                            status: "submission in progress".to_string(),
+                        }
+                        .into(),
+                    });
+                    debug!(
+                        ?tx_digest,
+                        "handle_submit_transaction: concurrent submission in progress"
+                    );
+                    continue;
+                }
+                AcquireOutcome::RecentlyProcessed { since } => {
+                    metrics
+                        .submission_suppressed_recently_submitted
+                        .with_label_values(&[req_type])
+                        .inc();
+                    metrics
+                        .recently_submitted_resubmission_interval
+                        .observe(since.as_secs_f64());
+                    results[idx] = Some(SubmitTxResult::Rejected {
+                        error: SuiErrorKind::TransactionProcessing {
+                            digest: tx_digest,
+                            status: "recently processed".to_string(),
+                        }
+                        .into(),
+                    });
+                    debug!(?tx_digest, "handle_submit_transaction: recently processed");
+                    continue;
+                }
             }
-            self.recently_submitted.insert(tx_digest, Instant::now());
-            metrics
-                .recently_submitted_cache_size
-                .set(self.recently_submitted.entry_count() as i64);
 
             debug!(
                 ?tx_digest,
@@ -1430,6 +1472,94 @@ impl ValidatorService {
 }
 
 type WrappedServiceResponse<T> = Result<(tonic::Response<T>, Weight), tonic::Status>;
+
+/// RAII guard tracking the transaction digests a single submit request is actively handling, so
+/// concurrent duplicates can be rejected. On drop, each acquired digest is removed from
+/// the in-flight set and demoted into `recently_submitted` cache, so resubmissions
+/// arriving shortly after the handler returns are still suppressed.
+struct InflightTransactionsGuard {
+    // Handle to inflight map and recently submitted cache.
+    inflight: Arc<Mutex<HashSet<TransactionDigest>>>,
+    recently_submitted: Cache<TransactionDigest, Instant>,
+    window: Duration,
+    metrics: Arc<ValidatorServiceMetrics>,
+    /// Digests this request successfully acquired (in acquisition order).
+    owned: Vec<TransactionDigest>,
+}
+
+enum AcquireOutcome {
+    /// Transaction digest newly acquired by this request.
+    Acquired,
+    /// Transaction digest already acquired by this request before this internal retry attempt.
+    AlreadyAcquiredByThisRequest,
+    /// Transaction digest being handled by another concurrent request — reject this index.
+    AlreadyAcquiredByAnotherRequest,
+    /// Transaction digest recently processed — reject this index.
+    RecentlyProcessed { since: Duration },
+}
+
+impl InflightTransactionsGuard {
+    fn new(service: &ValidatorService) -> Self {
+        Self {
+            inflight: service.inflight_transactions.clone(),
+            recently_submitted: service.recently_submitted.clone(),
+            window: service.recent_submission_window,
+            metrics: service.metrics.clone(),
+            owned: Vec::new(),
+        }
+    }
+
+    fn try_acquire(&mut self, digest: TransactionDigest) -> AcquireOutcome {
+        // A retry of this own request re-acquires the same digests.
+        if self.owned.contains(&digest) {
+            return AcquireOutcome::AlreadyAcquiredByThisRequest;
+        }
+
+        // Atomic check-and-acquire against concurrent in-flight transactions.
+        {
+            let mut set = self.inflight.lock();
+            // Suppress resubmissions of recently processed transactions.
+            if let Some(outcome) = self.recently_processed_outcome(digest) {
+                return outcome;
+            }
+            // Only continue processing the transaction if it is not already inflight.
+            if !set.insert(digest) {
+                return AcquireOutcome::AlreadyAcquiredByAnotherRequest;
+            }
+            self.metrics.inflight_transactions.set(set.len() as i64);
+        }
+
+        self.owned.push(digest);
+        AcquireOutcome::Acquired
+    }
+
+    fn recently_processed_outcome(&self, digest: TransactionDigest) -> Option<AcquireOutcome> {
+        let recorded_at = self.recently_submitted.get(&digest)?;
+        let since = recorded_at.elapsed();
+        (since < self.window).then_some(AcquireOutcome::RecentlyProcessed { since })
+    }
+}
+
+impl Drop for InflightTransactionsGuard {
+    fn drop(&mut self) {
+        if self.owned.is_empty() {
+            return;
+        }
+        // Demote inflight transactions to recently processed cache while holding the in-flight lock.
+        let now = Instant::now();
+        {
+            let mut set = self.inflight.lock();
+            for digest in &self.owned {
+                self.recently_submitted.insert(*digest, now);
+                set.remove(digest);
+            }
+            self.metrics.inflight_transactions.set(set.len() as i64);
+        }
+        self.metrics
+            .recently_submitted_cache_size
+            .set(self.recently_submitted.entry_count() as i64);
+    }
+}
 
 impl ValidatorService {
     async fn handle_submit_transaction_impl(
@@ -1977,5 +2107,83 @@ impl Validator for ValidatorService {
     ) -> Result<tonic::Response<sui_types::messages_grpc::RawValidatorHealthResponse>, tonic::Status>
     {
         handle_with_decoration!(self, validator_health_impl, request, "validator_health")
+    }
+}
+
+#[cfg(test)]
+mod inflight_guard_tests {
+    use super::*;
+    use prometheus::Registry;
+
+    fn make_guard(
+        inflight: Arc<Mutex<HashSet<TransactionDigest>>>,
+        cache: Cache<TransactionDigest, Instant>,
+        metrics: Arc<ValidatorServiceMetrics>,
+    ) -> InflightTransactionsGuard {
+        InflightTransactionsGuard {
+            inflight,
+            recently_submitted: cache,
+            window: Duration::from_secs(10),
+            metrics,
+            owned: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn concurrent_acquire_rejects_other_request_and_is_idempotent_for_owner() {
+        let inflight = Arc::new(Mutex::new(HashSet::new()));
+        let cache = ValidatorService::new_recently_submitted_cache(Duration::from_secs(10));
+        let metrics = Arc::new(ValidatorServiceMetrics::new(&Registry::new()));
+        let digest = TransactionDigest::random();
+
+        let mut g1 = make_guard(inflight.clone(), cache.clone(), metrics.clone());
+        let mut g2 = make_guard(inflight.clone(), cache.clone(), metrics.clone());
+
+        // First handler acquires it.
+        assert!(matches!(g1.try_acquire(digest), AcquireOutcome::Acquired));
+        assert_eq!(metrics.inflight_transactions.get(), 1);
+
+        // A concurrent handler sees another in-flight owner and is rejected.
+        assert!(matches!(
+            g2.try_acquire(digest),
+            AcquireOutcome::AlreadyAcquiredByAnotherRequest
+        ));
+
+        // The owning handler re-acquiring (epoch-end retry) is NOT a duplicate.
+        assert!(matches!(
+            g1.try_acquire(digest),
+            AcquireOutcome::AlreadyAcquiredByThisRequest
+        ));
+    }
+
+    #[test]
+    fn drop_demotes_into_recently_processed_outcome() {
+        let inflight = Arc::new(Mutex::new(HashSet::new()));
+        let cache = ValidatorService::new_recently_submitted_cache(Duration::from_secs(10));
+        let metrics = Arc::new(ValidatorServiceMetrics::new(&Registry::new()));
+        let digest = TransactionDigest::random();
+
+        {
+            let mut g = make_guard(inflight.clone(), cache.clone(), metrics.clone());
+            assert!(matches!(g.try_acquire(digest), AcquireOutcome::Acquired));
+            assert_eq!(inflight.lock().len(), 1);
+        } // guard dropped here -> remove from set + demote to TTL cache
+
+        assert_eq!(
+            inflight.lock().len(),
+            0,
+            "acquired digest must be removed from the in-flight set on drop"
+        );
+        assert_eq!(metrics.inflight_transactions.get(), 0);
+
+        // Make moka's read view deterministic before asserting the demoted entry.
+        cache.run_pending_tasks();
+
+        // A fresh request now sees the digest as recently processed (tail window).
+        let mut g_after = make_guard(inflight.clone(), cache.clone(), metrics.clone());
+        assert!(matches!(
+            g_after.try_acquire(digest),
+            AcquireOutcome::RecentlyProcessed { .. }
+        ));
     }
 }

--- a/crates/sui-core/src/unit_tests/consensus_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/consensus_test_utils.rs
@@ -135,6 +135,24 @@ pub struct TestConsensusHandlerSetup<C> {
     pub captured_transactions: CapturedTransactions,
 }
 
+/// Makes a consensus adapter with the standard test wiring (limits, metrics), backed by the
+/// given consensus client.
+pub fn make_consensus_adapter_with_client_for_test(
+    state: &Arc<AuthorityState>,
+    client: Arc<dyn ConsensusClient>,
+    max_pending_local_submissions: usize,
+) -> Arc<ConsensusAdapter> {
+    Arc::new(ConsensusAdapter::new(
+        client,
+        state.checkpoint_store.clone(),
+        state.name,
+        100_000,
+        max_pending_local_submissions,
+        ConsensusAdapterMetrics::new_test(),
+        Arc::new(tokio::sync::Notify::new()),
+    ))
+}
+
 pub fn make_consensus_adapter_for_test(
     state: Arc<AuthorityState>,
     process_via_checkpoint: HashSet<TransactionDigest>,
@@ -157,8 +175,6 @@ pub fn make_consensus_adapter_for_test_with_submit_limit(
     mock_block_status_receivers: Vec<BlockStatusReceiver>,
     max_pending_local_submissions: usize,
 ) -> Arc<ConsensusAdapter> {
-    let metrics = ConsensusAdapterMetrics::new_test();
-
     #[derive(Clone)]
     struct SubmitDirectly {
         state: Arc<AuthorityState>,
@@ -288,20 +304,13 @@ pub fn make_consensus_adapter_for_test_with_submit_limit(
         }
     }
     // Make a new consensus adapter instance.
-    Arc::new(ConsensusAdapter::new(
-        Arc::new(SubmitDirectly {
-            state: state.clone(),
-            process_via_checkpoint,
-            execute,
-            mock_block_status_receivers: Arc::new(Mutex::new(mock_block_status_receivers)),
-        }),
-        state.checkpoint_store.clone(),
-        state.name,
-        100_000,
-        max_pending_local_submissions,
-        metrics,
-        Arc::new(tokio::sync::Notify::new()),
-    ))
+    let client = Arc::new(SubmitDirectly {
+        state: state.clone(),
+        process_via_checkpoint,
+        execute,
+        mock_block_status_receivers: Arc::new(Mutex::new(mock_block_status_receivers)),
+    });
+    make_consensus_adapter_with_client_for_test(&state, client, max_pending_local_submissions)
 }
 
 /// Creates a ConsensusHandler for testing with a mock ExecutionSchedulerSender that captures transactions

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -33,8 +33,10 @@ use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::{AuthorityState, ExecutionEnv};
 use crate::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use crate::authority_server::AuthorityServer;
-use crate::consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, ConsensusClient};
-use crate::consensus_test_utils::make_consensus_adapter_for_test;
+use crate::consensus_adapter::{ConsensusAdapter, ConsensusClient};
+use crate::consensus_test_utils::{
+    make_consensus_adapter_for_test, make_consensus_adapter_with_client_for_test,
+};
 use crate::mock_consensus::with_block_status;
 
 use super::AuthorityServerHandle;
@@ -82,15 +84,7 @@ impl TestContext {
 
     async fn new_with_consensus_client(consensus_client: Arc<dyn ConsensusClient>) -> Self {
         Self::new_with_adapter(|authority| {
-            Arc::new(ConsensusAdapter::new(
-                consensus_client,
-                authority.checkpoint_store.clone(),
-                authority.name,
-                100_000,
-                100_000,
-                ConsensusAdapterMetrics::new_test(),
-                Arc::new(tokio::sync::Notify::new()),
-            ))
+            make_consensus_adapter_with_client_for_test(&authority, consensus_client, 100_000)
         })
         .await
     }
@@ -104,6 +98,10 @@ impl TestContext {
         let gas_object_ref = gas_object.compute_object_reference();
         let authority = TestAuthorityBuilder::new()
             .with_starting_objects(&[gas_object])
+            // Several tests assert that a resubmission is still suppressed as a recent duplicate;
+            // pin a dedup window far longer than any test's runtime so entries cannot expire
+            // mid-test under CI load (the default window is only 1s of wall-clock time).
+            .with_recent_submission_dedup_window_ms(600_000)
             .build()
             .await;
 
@@ -150,7 +148,7 @@ impl TestContext {
 struct BlockingConsensusClient {
     first_submit_seen: tokio::sync::watch::Sender<bool>,
     release_first_submit: tokio::sync::watch::Sender<bool>,
-    submit_count: Arc<AtomicUsize>,
+    submit_count: AtomicUsize,
 }
 
 impl BlockingConsensusClient {
@@ -160,7 +158,7 @@ impl BlockingConsensusClient {
         Arc::new(Self {
             first_submit_seen,
             release_first_submit,
-            submit_count: Arc::new(AtomicUsize::new(0)),
+            submit_count: AtomicUsize::new(0),
         })
     }
 
@@ -250,6 +248,7 @@ async fn test_duplicate_submission_suppressed_within_window() {
     .await;
 
     let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
 
     // First submission is accepted.
     let first = test_context
@@ -271,10 +270,7 @@ async fn test_duplicate_submission_suppressed_within_window() {
         .unwrap();
     match &second.results[0] {
         SubmitTxResult::Rejected { error } => match error.clone().into_inner() {
-            SuiErrorKind::TransactionProcessing { status, .. } => assert!(
-                status.contains("recently processed"),
-                "unexpected rejection status: {status}"
-            ),
+            SuiErrorKind::TransactionSubmitted { digest } => assert_eq!(digest, tx_digest),
             other => panic!("unexpected rejection error kind: {other:?}"),
         },
         other => panic!("expected duplicate submission to be rejected, got {other:?}"),
@@ -316,12 +312,8 @@ async fn test_concurrent_duplicate_submission_rejected_as_inflight() {
     assert_eq!(second.results.len(), 1);
     match &second.results[0] {
         SubmitTxResult::Rejected { error } => match error.as_inner() {
-            SuiErrorKind::TransactionProcessing { digest, status } => {
+            SuiErrorKind::TransactionSubmitted { digest } => {
                 assert_eq!(*digest, tx_digest);
-                assert!(
-                    status.contains("submission in progress"),
-                    "unexpected rejection status: {status}"
-                );
             }
             other => panic!("unexpected rejection error kind: {other:?}"),
         },
@@ -637,6 +629,8 @@ async fn test_submit_batched_transactions() {
     }
 }
 
+// A repeated transaction in a plain batch rejects only the repeated index with
+// `RepeatedTransactions`; the first occurrence is still submitted.
 #[tokio::test]
 async fn test_submit_batched_transactions_with_repeated_transaction() {
     let test_context = TestContext::new().await;
@@ -652,23 +646,35 @@ async fn test_submit_batched_transactions_with_repeated_transaction() {
         ..Default::default()
     };
 
-    let response = test_context
+    let raw_response = test_context
         .client
         .client()
         .unwrap()
         .submit_transaction(request)
-        .await;
-    assert!(response.is_err());
-    let error: SuiError = response.unwrap_err().into();
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(raw_response.results.len(), 2);
+    let result0: SubmitTxResult = raw_response.results[0].clone().try_into().unwrap();
+    let result1: SubmitTxResult = raw_response.results[1].clone().try_into().unwrap();
+
     assert!(
-        matches!(
-            error.into_inner(),
-            SuiErrorKind::UserInputError {
-                error: UserInputError::RepeatedTransactions { digest }
-            } if digest == tx_digest
-        ),
-        "expected RepeatedTransactions error"
+        matches!(result0, SubmitTxResult::Submitted { .. }),
+        "expected first occurrence to be submitted, got: {result0:?}"
     );
+    match result1 {
+        SubmitTxResult::Rejected { error } => assert!(
+            matches!(
+                error.as_inner(),
+                SuiErrorKind::UserInputError {
+                    error: UserInputError::RepeatedTransactions { digest }
+                } if *digest == tx_digest
+            ),
+            "expected RepeatedTransactions for repeated index, got: {error}"
+        ),
+        other => panic!("expected repeated index to be rejected, got: {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -1097,8 +1103,8 @@ async fn test_submit_oversized_transaction() {
 }
 
 // A batch containing a transaction that was already submitted (and is now in the recent-submission
-// window) rejects only that index with `TransactionProcessing { status: "recently processed" }`,
-// while a fresh transaction in the same batch is still submitted.
+// window) rejects only that index with `TransactionSubmitted`, while a fresh transaction in the
+// same batch is still submitted.
 #[tokio::test]
 async fn test_batch_with_recently_processed_duplicate_rejects_only_that_index() {
     // `execute = false` so the prior submission is suppressed via the recent-submission window
@@ -1166,12 +1172,8 @@ async fn test_batch_with_recently_processed_duplicate_rejects_only_that_index() 
     // tx1 rejected specifically as a recent duplicate.
     match result0 {
         SubmitTxResult::Rejected { error } => match error.as_inner() {
-            SuiErrorKind::TransactionProcessing { digest, status } => {
+            SuiErrorKind::TransactionSubmitted { digest } => {
                 assert_eq!(*digest, *tx1.digest());
-                assert!(
-                    status.contains("recently processed"),
-                    "unexpected rejection status: {status}"
-                );
             }
             other => panic!("unexpected rejection error kind: {other:?}"),
         },
@@ -1185,8 +1187,8 @@ async fn test_batch_with_recently_processed_duplicate_rejects_only_that_index() 
     }
 }
 
-// Same per-index dedup inside an atomic soft bundle: a previously-submitted member is rejected with
-// "recently processed" while the fresh member is still submitted. Confirms the dedup is
+// Same per-index dedup inside an atomic soft bundle: a previously-submitted member is rejected
+// with `TransactionSubmitted` while the fresh member is still submitted. Confirms the dedup is
 // req_type-agnostic (the per-tx loop sets `results[idx]` regardless of submit type).
 #[tokio::test]
 async fn test_soft_bundle_with_recently_processed_duplicate_rejects_only_that_index() {
@@ -1252,12 +1254,8 @@ async fn test_soft_bundle_with_recently_processed_duplicate_rejects_only_that_in
 
     match result0 {
         SubmitTxResult::Rejected { error } => match error.as_inner() {
-            SuiErrorKind::TransactionProcessing { digest, status } => {
+            SuiErrorKind::TransactionSubmitted { digest } => {
                 assert_eq!(*digest, *tx1.digest());
-                assert!(
-                    status.contains("recently processed"),
-                    "unexpected rejection status: {status}"
-                );
             }
             other => panic!("unexpected rejection error kind: {other:?}"),
         },

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
 
 use consensus_core::BlockStatus;
 use consensus_types::block::{BlockRef, PING_TRANSACTION_INDEX};
@@ -14,6 +18,7 @@ use sui_types::effects::TransactionEffectsAPI as _;
 use sui_types::error::{SuiError, SuiErrorKind, UserInputError};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::message_envelope::Message as _;
+use sui_types::messages_consensus::{ConsensusPosition, ConsensusTransaction};
 use sui_types::messages_grpc::{
     RawSubmitTxRequest, SubmitTxRequest, SubmitTxResponse, SubmitTxResult, SubmitTxType,
 };
@@ -23,10 +28,12 @@ use sui_types::transaction::{
 };
 use sui_types::utils::to_sender_signed_transaction;
 
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::{AuthorityState, ExecutionEnv};
 use crate::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use crate::authority_server::AuthorityServer;
+use crate::consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, ConsensusClient};
 use crate::consensus_test_utils::make_consensus_adapter_for_test;
 use crate::mock_consensus::with_block_status;
 
@@ -62,6 +69,35 @@ impl TestContext {
         execute: bool,
         block_status_receivers: Vec<crate::consensus_adapter::BlockStatusReceiver>,
     ) -> Self {
+        Self::new_with_adapter(|authority| {
+            make_consensus_adapter_for_test(
+                authority,
+                HashSet::new(),
+                execute,
+                block_status_receivers,
+            )
+        })
+        .await
+    }
+
+    async fn new_with_consensus_client(consensus_client: Arc<dyn ConsensusClient>) -> Self {
+        Self::new_with_adapter(|authority| {
+            Arc::new(ConsensusAdapter::new(
+                consensus_client,
+                authority.checkpoint_store.clone(),
+                authority.name,
+                100_000,
+                100_000,
+                ConsensusAdapterMetrics::new_test(),
+                Arc::new(tokio::sync::Notify::new()),
+            ))
+        })
+        .await
+    }
+
+    async fn new_with_adapter(
+        make_adapter: impl FnOnce(Arc<AuthorityState>) -> Arc<ConsensusAdapter>,
+    ) -> Self {
         telemetry_subscribers::init_for_testing();
         let (sender, keypair) = get_account_key_pair();
         let gas_object = Object::with_owner_for_testing(sender);
@@ -71,15 +107,9 @@ impl TestContext {
             .build()
             .await;
 
-        let adapter = make_consensus_adapter_for_test(
-            authority.clone(),
-            HashSet::new(),
-            execute,
-            block_status_receivers,
-        );
+        let adapter = make_adapter(authority.clone());
         let server =
             AuthorityServer::new_for_test_with_consensus_adapter(authority.clone(), adapter);
-        let _metrics = server.metrics.clone();
         let server_handle = server.spawn_for_test().await.unwrap();
         let client = NetworkAuthorityClient::connect(
             server_handle.address(),
@@ -114,6 +144,75 @@ impl TestContext {
             transaction: Some(transaction),
             ping_type: None,
         }
+    }
+}
+
+struct BlockingConsensusClient {
+    first_submit_seen: tokio::sync::watch::Sender<bool>,
+    release_first_submit: tokio::sync::watch::Sender<bool>,
+    submit_count: Arc<AtomicUsize>,
+}
+
+impl BlockingConsensusClient {
+    fn new() -> Arc<Self> {
+        let (first_submit_seen, _) = tokio::sync::watch::channel(false);
+        let (release_first_submit, _) = tokio::sync::watch::channel(false);
+        Arc::new(Self {
+            first_submit_seen,
+            release_first_submit,
+            submit_count: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    fn subscribe_first_submit(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.first_submit_seen.subscribe()
+    }
+
+    fn release_first_submit(&self) {
+        let _ = self.release_first_submit.send(true);
+    }
+
+    fn submit_count(&self) -> usize {
+        self.submit_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsensusClient for BlockingConsensusClient {
+    async fn submit(
+        &self,
+        transactions: &[ConsensusTransaction],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> sui_types::error::SuiResult<(
+        Vec<ConsensusPosition>,
+        crate::consensus_adapter::BlockStatusReceiver,
+    )> {
+        let submit_index = self.submit_count.fetch_add(1, Ordering::SeqCst);
+        if submit_index == 0 {
+            let _ = self.first_submit_seen.send(true);
+            let mut release_first_submit = self.release_first_submit.subscribe();
+            while !*release_first_submit.borrow() {
+                release_first_submit
+                    .changed()
+                    .await
+                    .map_err(|_| SuiError::from("blocking consensus release channel closed"))?;
+            }
+        }
+
+        let consensus_positions = transactions
+            .iter()
+            .enumerate()
+            .map(|(index, _)| ConsensusPosition {
+                epoch: epoch_store.epoch(),
+                block: BlockRef::MIN,
+                index: index as u16,
+            })
+            .collect();
+
+        Ok((
+            consensus_positions,
+            with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+        ))
     }
 }
 
@@ -173,13 +272,75 @@ async fn test_duplicate_submission_suppressed_within_window() {
     match &second.results[0] {
         SubmitTxResult::Rejected { error } => match error.clone().into_inner() {
             SuiErrorKind::TransactionProcessing { status, .. } => assert!(
-                status.contains("recently submitted"),
+                status.contains("recently processed"),
                 "unexpected rejection status: {status}"
             ),
             other => panic!("unexpected rejection error kind: {other:?}"),
         },
         other => panic!("expected duplicate submission to be rejected, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn test_concurrent_duplicate_submission_rejected_as_inflight() {
+    let consensus_client = BlockingConsensusClient::new();
+    let mut first_submit_seen = consensus_client.subscribe_first_submit();
+    let test_context = TestContext::new_with_consensus_client(consensus_client.clone()).await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+
+    let first_client = test_context.client.clone();
+    let first_request = test_context.build_submit_request(transaction.clone());
+    let first_submit =
+        tokio::spawn(async move { first_client.submit_transaction(first_request, None).await });
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !*first_submit_seen.borrow() {
+            first_submit_seen
+                .changed()
+                .await
+                .expect("blocking consensus client should remain alive");
+        }
+    })
+    .await
+    .expect("first submission should reach consensus client");
+    assert_eq!(consensus_client.submit_count(), 1);
+
+    let second = test_context
+        .client
+        .submit_transaction(test_context.build_submit_request(transaction), None)
+        .await
+        .unwrap();
+
+    assert_eq!(second.results.len(), 1);
+    match &second.results[0] {
+        SubmitTxResult::Rejected { error } => match error.as_inner() {
+            SuiErrorKind::TransactionProcessing { digest, status } => {
+                assert_eq!(*digest, tx_digest);
+                assert!(
+                    status.contains("submission in progress"),
+                    "unexpected rejection status: {status}"
+                );
+            }
+            other => panic!("unexpected rejection error kind: {other:?}"),
+        },
+        other => panic!("expected concurrent duplicate to be rejected, got {other:?}"),
+    }
+    assert_eq!(
+        consensus_client.submit_count(),
+        1,
+        "concurrent duplicate should be rejected before consensus submission"
+    );
+
+    consensus_client.release_first_submit();
+    let first = first_submit.await.unwrap().unwrap();
+    assert_eq!(first.results.len(), 1);
+    assert!(
+        matches!(first.results[0], SubmitTxResult::Submitted { .. }),
+        "first submission should complete after release, got {:?}",
+        first.results[0]
+    );
 }
 
 #[tokio::test]
@@ -477,6 +638,40 @@ async fn test_submit_batched_transactions() {
 }
 
 #[tokio::test]
+async fn test_submit_batched_transactions_with_repeated_transaction() {
+    let test_context = TestContext::new().await;
+
+    let tx = test_context.build_test_transaction();
+    let tx_digest = *tx.digest();
+
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx).unwrap().into(),
+            bcs::to_bytes(&tx).unwrap().into(),
+        ],
+        ..Default::default()
+    };
+
+    let response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await;
+    assert!(response.is_err());
+    let error: SuiError = response.unwrap_err().into();
+    assert!(
+        matches!(
+            error.into_inner(),
+            SuiErrorKind::UserInputError {
+                error: UserInputError::RepeatedTransactions { digest }
+            } if digest == tx_digest
+        ),
+        "expected RepeatedTransactions error"
+    );
+}
+
+#[tokio::test]
 async fn test_submit_batched_transactions_with_already_executed() {
     let test_context = TestContext::new().await;
 
@@ -704,10 +899,10 @@ async fn test_submit_soft_bundle_with_repeated_transaction() {
         matches!(
             error.into_inner(),
             SuiErrorKind::UserInputError {
-                error: UserInputError::RepeatedTransactionInSoftBundle { digest }
+                error: UserInputError::RepeatedTransactions { digest }
             } if digest == tx_digest
         ),
-        "expected RepeatedTransactionInSoftBundle error"
+        "expected RepeatedTransactions error"
     );
 }
 
@@ -899,4 +1094,178 @@ async fn test_submit_oversized_transaction() {
         error_str.contains("serialized transaction size exceeded maximum"),
         "Expected size limit error but got: {error_str}"
     );
+}
+
+// A batch containing a transaction that was already submitted (and is now in the recent-submission
+// window) rejects only that index with `TransactionProcessing { status: "recently processed" }`,
+// while a fresh transaction in the same batch is still submitted.
+#[tokio::test]
+async fn test_batch_with_recently_processed_duplicate_rejects_only_that_index() {
+    // `execute = false` so the prior submission is suppressed via the recent-submission window
+    // rather than short-circuited by the executed-effects path.
+    let test_context = TestContext::new_with_consensus(
+        false,
+        vec![
+            with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+            with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+        ],
+    )
+    .await;
+
+    // tx1: submit it once so it is demoted into the recent-submission cache when the handler returns.
+    let tx1 = test_context.build_test_transaction();
+    let first = test_context
+        .client
+        .submit_transaction(test_context.build_submit_request(tx1.clone()), None)
+        .await
+        .unwrap();
+    assert!(
+        matches!(first.results[0], SubmitTxResult::Submitted { .. }),
+        "first submission of tx1 should be accepted, got {:?}",
+        first.results[0]
+    );
+
+    // tx2: a distinct, fresh transaction from its own gas object.
+    let gas_object2 = Object::with_owner_for_testing(test_context.sender);
+    let gas_object_ref2 = gas_object2.compute_object_reference();
+    test_context.state.insert_genesis_object(gas_object2);
+    let tx_data2 = TestTransactionBuilder::new(
+        test_context.sender,
+        gas_object_ref2,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(None, test_context.sender)
+    .build();
+    let tx2 = to_sender_signed_transaction(tx_data2, &test_context.keypair);
+
+    // Batch [tx1, tx2]: tx1 is a recent duplicate, tx2 is fresh.
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx1).unwrap().into(),
+            bcs::to_bytes(&tx2).unwrap().into(),
+        ],
+        ..Default::default()
+    };
+
+    let raw_response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(raw_response.results.len(), 2);
+    let result0: SubmitTxResult = raw_response.results[0].clone().try_into().unwrap();
+    let result1: SubmitTxResult = raw_response.results[1].clone().try_into().unwrap();
+
+    // tx1 rejected specifically as a recent duplicate.
+    match result0 {
+        SubmitTxResult::Rejected { error } => match error.as_inner() {
+            SuiErrorKind::TransactionProcessing { digest, status } => {
+                assert_eq!(*digest, *tx1.digest());
+                assert!(
+                    status.contains("recently processed"),
+                    "unexpected rejection status: {status}"
+                );
+            }
+            other => panic!("unexpected rejection error kind: {other:?}"),
+        },
+        other => panic!("expected tx1 to be rejected as recent duplicate, got: {other:?}"),
+    }
+
+    // tx2 still submitted to consensus.
+    match result1 {
+        SubmitTxResult::Submitted { .. } => {}
+        other => panic!("expected tx2 to be submitted, got: {other:?}"),
+    }
+}
+
+// Same per-index dedup inside an atomic soft bundle: a previously-submitted member is rejected with
+// "recently processed" while the fresh member is still submitted. Confirms the dedup is
+// req_type-agnostic (the per-tx loop sets `results[idx]` regardless of submit type).
+#[tokio::test]
+async fn test_soft_bundle_with_recently_processed_duplicate_rejects_only_that_index() {
+    let test_context = TestContext::new_with_consensus(
+        false,
+        vec![
+            with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+            with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+        ],
+    )
+    .await;
+
+    // tx1: submit once so it is demoted into the recent-submission cache on handler return.
+    let tx1 = test_context.build_test_transaction();
+    let first = test_context
+        .client
+        .submit_transaction(test_context.build_submit_request(tx1.clone()), None)
+        .await
+        .unwrap();
+    assert!(
+        matches!(first.results[0], SubmitTxResult::Submitted { .. }),
+        "first submission of tx1 should be accepted, got {:?}",
+        first.results[0]
+    );
+
+    // tx2: distinct, fresh, same gas price (soft bundle requires a single shared gas price).
+    let gas_object2 = Object::with_owner_for_testing(test_context.sender);
+    let gas_object_ref2 = gas_object2.compute_object_reference();
+    test_context.state.insert_genesis_object(gas_object2);
+    let tx_data2 = TestTransactionBuilder::new(
+        test_context.sender,
+        gas_object_ref2,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(None, test_context.sender)
+    .build();
+    let tx2 = to_sender_signed_transaction(tx_data2, &test_context.keypair);
+
+    // Soft bundle [tx1, tx2]: tx1 is a recent duplicate, tx2 is fresh.
+    let request = RawSubmitTxRequest {
+        transactions: vec![
+            bcs::to_bytes(&tx1).unwrap().into(),
+            bcs::to_bytes(&tx2).unwrap().into(),
+        ],
+        submit_type: SubmitTxType::SoftBundle.into(),
+    };
+
+    let raw_response = test_context
+        .client
+        .client()
+        .unwrap()
+        .submit_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(raw_response.results.len(), 2);
+    let result0: SubmitTxResult = raw_response.results[0].clone().try_into().unwrap();
+    let result1: SubmitTxResult = raw_response.results[1].clone().try_into().unwrap();
+
+    match result0 {
+        SubmitTxResult::Rejected { error } => match error.as_inner() {
+            SuiErrorKind::TransactionProcessing { digest, status } => {
+                assert_eq!(*digest, *tx1.digest());
+                assert!(
+                    status.contains("recently processed"),
+                    "unexpected rejection status: {status}"
+                );
+            }
+            other => panic!("unexpected rejection error kind: {other:?}"),
+        },
+        other => panic!("expected tx1 to be rejected as recent duplicate, got: {other:?}"),
+    }
+
+    match result1 {
+        SubmitTxResult::Submitted { .. } => {}
+        other => panic!("expected tx2 to be submitted, got: {other:?}"),
+    }
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -824,11 +824,14 @@ pub enum SuiErrorKind {
     )]
     TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: u64 },
 
-    #[error("Transaction {digest} is being processed: {status}")]
+    #[error("Transaction {digest} is being processed post-consensus: {status}")]
     TransactionProcessing {
         digest: TransactionDigest,
         status: String,
     },
+
+    #[error("Transaction {digest} has been recently submitted to this validator.")]
+    TransactionSubmitted { digest: TransactionDigest },
 }
 
 #[repr(u64)]
@@ -1057,6 +1060,7 @@ impl SuiErrorKind {
             // submission is pointless. The client should retry by waiting for effects
             // rather than resubmitting.
             SuiErrorKind::TransactionProcessing { .. } => true,
+            SuiErrorKind::TransactionSubmitted { .. } => true,
 
             // Non retryable error
             SuiErrorKind::ExecutionError(..) => false,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -367,8 +367,8 @@ pub enum UserInputError {
     #[error("Transaction chain ID {provided} does not match network chain ID {expected}.")]
     InvalidChainId { provided: String, expected: String },
 
-    #[error("Transaction {digest} appears more than once in the Soft Bundle")]
-    RepeatedTransactionInSoftBundle { digest: TransactionDigest },
+    #[error("Transaction {digest} appears more than once in the request")]
+    RepeatedTransactions { digest: TransactionDigest },
 }
 
 #[derive(


### PR DESCRIPTION
## Summary

- add a ValidatorService in-flight digest guard so concurrent duplicate transaction submissions are rejected before consensus submission
- generalize repeated-transaction validation across batch and soft-bundle submit requests
- demote completed in-flight digests into the recent-submission cache under the same lock before removal
- add coverage for repeated request transactions, recent duplicate handling, guard lifecycle behavior, and handler-level concurrent duplicate submission

## Validation

- `cargo fmt --all -- --check`
- `SUI_SKIP_SIMTESTS=1 cargo test -p sui-core inflight_guard_tests --lib`
- `SUI_SKIP_SIMTESTS=1 cargo test -p sui-core test_submit_batched_transactions_with_repeated_transaction --lib`
- `SUI_SKIP_SIMTESTS=1 cargo test -p sui-core test_submit_soft_bundle_with_repeated_transaction --lib`
- `SUI_SKIP_SIMTESTS=1 cargo test -p sui-core test_concurrent_duplicate_submission_rejected_as_inflight --lib`
- `cargo xclippy` from `crates/sui-core`
- `git diff --check -- crates/sui-core/src/unit_tests/submit_transaction_tests.rs`