### PR TITLE
[autodebug] Fix flaky party_object_read test: drop duplicate tx submission

### DIFF
--- a/crates/sui-e2e-tests/tests/party_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/party_objects_tests.rs
@@ -501,13 +501,8 @@ async fn party_object_read() {
         .build();
     let signed_transfer = test_cluster.sign_transaction(&transfer_transaction).await;
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
-    test_cluster
-        .submit_and_execute(signed_transfer.clone(), Some(client_ip))
-        .await
-        .unwrap();
-
     let (transfer_effects, _) = test_cluster
-        .submit_and_execute(signed_transfer.clone(), None)
+        .submit_and_execute(signed_transfer.clone(), Some(client_ip))
         .await
         .unwrap();
     all_digests.push(*signed_transfer.digest());


### PR DESCRIPTION
## Description

Fixes a flaky nightly Simulator Tests failure in `party_objects_tests::party_object_read` (CI run: https://github.com/MystenLabs/sui/actions/runs/28404231154).

The test submitted the transfer transaction twice via `submit_and_execute`. This was a mechanical artifact of the Quorum Driver → Transaction Driver migration (#24742), which replaced the two distinct `create_certificate` + `submit_transaction_to_validators` calls with two identical `submit_and_execute` calls. `submit_and_execute` now both sequences a transaction through consensus and returns its effects in one call, so the second call races: once the first submission is sequenced, the validator rejects the duplicate with `"is being processed: sequenced by consensus"`, surfacing as a flaky `.unwrap()` panic. The fix captures effects from the single submission and drops the redundant resubmit.

## Test plan

Seed search on `party_object_read`: the bug reproduced 3/200 on the unfixed code; with the fix, 400/400 seeds pass (two batches of 200 covering the previously-failing seeds and the CI seed range).

```
cargo simtest -p sui-e2e-tests --test party_objects_tests -E 'test(=party_object_read)'
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
