### PR TITLE
[autodebug] Treat transient withdraw-reservation reject votes as retriable in bench driver

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -1243,6 +1243,23 @@ type BundleResults = Vec<(
     anyhow::Result<Vec<(TransactionDigest, BundleItemResponse)>>,
 )>;
 
+/// Whether a reject vote should be retried rather than counted as a permanent failure.
+///
+/// `InvalidWithdrawReservation` on the (un-sequenced) signing/voting path is transient: a validator
+/// can vote before a freshly credited address balance has settled on its local view, so the
+/// withdraw reservation check sees a stale amount. The reservation check is best-effort and clients
+/// are expected to retry (the fullnode execute path treats it as retryable in `is_retryable_sdk_error`).
+fn rejection_is_retriable(error: &sui_types::error::SuiError) -> bool {
+    use sui_types::error::{SuiErrorKind, UserInputError};
+    error.individual_error_indicates_epoch_change()
+        || matches!(
+            error.as_inner(),
+            SuiErrorKind::UserInputError {
+                error: UserInputError::InvalidWithdrawReservation { .. }
+            }
+        )
+}
+
 fn process_bundle_results(
     num_txs: usize,
     mut payload: Box<dyn Payload>,
@@ -1300,8 +1317,7 @@ fn process_bundle_results(
                             }
                             WaitForEffectsResponse::Rejected { error } => {
                                 if let Some(error) = error {
-                                    let is_retriable =
-                                        error.individual_error_indicates_epoch_change();
+                                    let is_retriable = rejection_is_retriable(&error);
                                     let error_str = format!("{:?}", error);
                                     if is_retriable {
                                         BatchedTransactionStatus::RetriableFailure {


### PR DESCRIPTION
## Description

Fixes a flaky nightly Simulator Tests failure in `sui-benchmark::simtest test::test_addr_bal_deposit_workload` (CI run: https://github.com/MystenLabs/sui/actions/runs/28231211277, seed `91782468239`).

The deposit workload intermittently saw a handful of `InvalidWithdrawReservation` reject votes ("Available amount in account ... is less than requested: 0 < ...") clustered in the first few seconds, tripping the test's `permanent_failure == 0` assertion. These come from the address-balance withdraw-reservation check on the un-sequenced signing/voting path: a validator can vote on a withdrawal before a freshly seeded balance has settled into its local accumulator account view, so it reads a stale amount of 0. That check is best-effort and clients are expected to retry — the fullnode execute path already treats it as retryable via `is_retryable_sdk_error` — but the bench driver's batched path only treated epoch-change rejections as retriable and labeled this transient rejection permanent. Conflict-driven permanent failures (object-lock conflicts) are a different error kind and stay permanent.

## Test plan

On the failing seed, the workload reported 14 permanent failures before this change and 0 after (the 14 are now counted as retriable). A 200-seed seed-search of the test on the fixed code passed 200/200:

```
MSIM_TEST_SEED=91782468239 MSIM_TEST_NUM=1 cargo simtest -p sui-benchmark --test simtest -E 'test(=test::test_addr_bal_deposit_workload)'
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
