### PR TITLE
Store epoch-start system object versions in a map

### DIFF
--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -3,40 +3,79 @@
 
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use sui_config::NodeConfig;
-use sui_types::accumulator_root::get_accumulator_root_obj_initial_shared_version;
-use sui_types::address_alias::get_address_alias_state_obj_initial_shared_version;
-use sui_types::display_registry::get_display_registry_obj_initial_shared_version;
 
 use std::fmt;
-use sui_types::authenticator_state::get_authenticator_state_obj_initial_shared_version;
-use sui_types::base_types::SequenceNumber;
-use sui_types::bridge::{get_bridge_obj_initial_shared_version, is_bridge_committee_initiated};
-use sui_types::coin_registry::get_coin_registry_obj_initial_shared_version;
-use sui_types::deny_list_v1::get_deny_list_obj_initial_shared_version;
+use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::bridge::is_bridge_committee_initiated;
 use sui_types::epoch_data::EpochData;
 use sui_types::error::SuiResult;
 use sui_types::messages_checkpoint::{CheckpointDigest, CheckpointTimestamp};
-use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
+use sui_types::object::Owner;
 use sui_types::storage::ObjectStore;
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
     EpochStartSystemState, EpochStartSystemStateTrait,
 };
+use sui_types::{
+    SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_ADDRESS_ALIAS_STATE_OBJECT_ID,
+    SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_BRIDGE_OBJECT_ID, SUI_COIN_REGISTRY_OBJECT_ID,
+    SUI_DENY_LIST_OBJECT_ID, SUI_DISPLAY_REGISTRY_OBJECT_ID, SUI_RANDOMNESS_STATE_OBJECT_ID,
+};
+
+/// Well-known shared system objects whose initial shared version is recorded in
+/// the epoch start configuration. To make a new system object's initial shared
+/// version available at epoch start, add its object id here -- no new
+/// `EpochStartConfiguration` version is required.
+const SYSTEM_SHARED_OBJECT_IDS: &[ObjectID] = &[
+    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+    SUI_RANDOMNESS_STATE_OBJECT_ID,
+    SUI_DENY_LIST_OBJECT_ID,
+    SUI_BRIDGE_OBJECT_ID,
+    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+    SUI_COIN_REGISTRY_OBJECT_ID,
+    SUI_DISPLAY_REGISTRY_OBJECT_ID,
+    SUI_ADDRESS_ALIAS_STATE_OBJECT_ID,
+];
+
+/// Reads the initial shared version of a system shared object from the store.
+/// Returns `None` if the object does not yet exist at the start of the epoch.
+fn get_system_object_initial_shared_version(
+    object_store: &dyn ObjectStore,
+    object_id: ObjectID,
+) -> Option<SequenceNumber> {
+    object_store
+        .get_object(&object_id)
+        .map(|obj| match obj.owner {
+            Owner::Shared {
+                initial_shared_version,
+            } => initial_shared_version,
+            _ => unreachable!("System object {object_id} must be shared"),
+        })
+}
+
+/// Helper for the frozen legacy configurations (V1..V10), whose individual
+/// `Option<SequenceNumber>` fields predate the generic version map. Looks up
+/// `object_id` against the (id, version) pairs the configuration stored.
+fn legacy_lookup(
+    object_id: ObjectID,
+    pairs: &[(ObjectID, Option<SequenceNumber>)],
+) -> Option<SequenceNumber> {
+    pairs
+        .iter()
+        .find(|(id, _)| *id == object_id)
+        .and_then(|(_, version)| *version)
+}
 
 #[enum_dispatch]
 pub trait EpochStartConfigTrait {
     fn epoch_digest(&self) -> CheckpointDigest;
     fn epoch_start_state(&self) -> &EpochStartSystemState;
     fn flags(&self) -> &[EpochFlag];
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
     fn bridge_committee_initiated(&self) -> bool;
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber>;
+    /// Returns the initial shared version of the given system object as of the
+    /// start of the epoch, or `None` if the object did not exist yet.
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber>;
 }
 
 // IMPORTANT: Assign explicit values to each variant to ensure that the values are stable.
@@ -159,6 +198,7 @@ pub enum EpochStartConfiguration {
     V8(EpochStartConfigurationV8),
     V9(EpochStartConfigurationV9),
     V10(EpochStartConfigurationV10),
+    V11(EpochStartConfigurationV11),
 }
 
 impl EpochStartConfiguration {
@@ -168,36 +208,20 @@ impl EpochStartConfiguration {
         object_store: &dyn ObjectStore,
         initial_epoch_flags: Vec<EpochFlag>,
     ) -> SuiResult<Self> {
-        let authenticator_obj_initial_shared_version =
-            get_authenticator_state_obj_initial_shared_version(object_store)?;
-        let randomness_obj_initial_shared_version =
-            get_randomness_state_obj_initial_shared_version(object_store)?;
-        let coin_deny_list_obj_initial_shared_version =
-            get_deny_list_obj_initial_shared_version(object_store);
-        let bridge_obj_initial_shared_version =
-            get_bridge_obj_initial_shared_version(object_store)?;
-        let accumulator_root_obj_initial_shared_version =
-            get_accumulator_root_obj_initial_shared_version(object_store)?;
-        let coin_registry_obj_initial_shared_version =
-            get_coin_registry_obj_initial_shared_version(object_store)?;
-        let display_registry_obj_initial_shared_version =
-            get_display_registry_obj_initial_shared_version(object_store)?;
-        let address_alias_state_obj_initial_shared_version =
-            get_address_alias_state_obj_initial_shared_version(object_store)?;
+        let mut system_object_versions = BTreeMap::new();
+        for &object_id in SYSTEM_SHARED_OBJECT_IDS {
+            if let Some(version) = get_system_object_initial_shared_version(object_store, object_id)
+            {
+                system_object_versions.insert(object_id, version);
+            }
+        }
         let bridge_committee_initiated = is_bridge_committee_initiated(object_store)?;
-        Ok(Self::V10(EpochStartConfigurationV10 {
+        Ok(Self::V11(EpochStartConfigurationV11 {
             system_state,
             epoch_digest,
             flags: initial_epoch_flags,
-            authenticator_obj_initial_shared_version,
-            randomness_obj_initial_shared_version,
-            coin_deny_list_obj_initial_shared_version,
-            bridge_obj_initial_shared_version,
+            system_object_versions,
             bridge_committee_initiated,
-            accumulator_root_obj_initial_shared_version,
-            coin_registry_obj_initial_shared_version,
-            display_registry_obj_initial_shared_version,
-            address_alias_state_obj_initial_shared_version,
         }))
     }
 
@@ -205,25 +229,12 @@ impl EpochStartConfiguration {
         // We only need to implement this function for the latest version.
         // When a new version is introduced, this function should be updated.
         match self {
-            Self::V10(config) => Self::V10(EpochStartConfigurationV10 {
+            Self::V11(config) => Self::V11(EpochStartConfigurationV11 {
                 system_state: config.system_state.new_at_next_epoch_for_testing(),
                 epoch_digest: config.epoch_digest,
                 flags: config.flags.clone(),
-                authenticator_obj_initial_shared_version: config
-                    .authenticator_obj_initial_shared_version,
-                randomness_obj_initial_shared_version: config.randomness_obj_initial_shared_version,
-                coin_deny_list_obj_initial_shared_version: config
-                    .coin_deny_list_obj_initial_shared_version,
-                bridge_obj_initial_shared_version: config.bridge_obj_initial_shared_version,
+                system_object_versions: config.system_object_versions.clone(),
                 bridge_committee_initiated: config.bridge_committee_initiated,
-                accumulator_root_obj_initial_shared_version: config
-                    .accumulator_root_obj_initial_shared_version,
-                coin_registry_obj_initial_shared_version: config
-                    .coin_registry_obj_initial_shared_version,
-                display_registry_obj_initial_shared_version: config
-                    .display_registry_obj_initial_shared_version,
-                address_alias_state_obj_initial_shared_version: config
-                    .address_alias_state_obj_initial_shared_version,
             }),
             _ => panic!(
                 "This function is only implemented for the latest version of EpochStartConfiguration"
@@ -241,6 +252,41 @@ impl EpochStartConfiguration {
 
     pub fn epoch_start_timestamp_ms(&self) -> CheckpointTimestamp {
         self.epoch_start_state().epoch_start_timestamp_ms()
+    }
+
+    // Convenience accessors for the well-known system objects. These delegate to
+    // the generic `system_object_initial_shared_version` lookup, so a new system
+    // object does not strictly require its own accessor.
+    pub fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_AUTHENTICATOR_STATE_OBJECT_ID)
+    }
+
+    pub fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_RANDOMNESS_STATE_OBJECT_ID)
+    }
+
+    pub fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_DENY_LIST_OBJECT_ID)
+    }
+
+    pub fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_BRIDGE_OBJECT_ID)
+    }
+
+    pub fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_ACCUMULATOR_ROOT_OBJECT_ID)
+    }
+
+    pub fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_COIN_REGISTRY_OBJECT_ID)
+    }
+
+    pub fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_DISPLAY_REGISTRY_OBJECT_ID)
+    }
+
+    pub fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+        self.system_object_initial_shared_version(SUI_ADDRESS_ALIAS_STATE_OBJECT_ID)
     }
 }
 
@@ -366,6 +412,21 @@ pub struct EpochStartConfigurationV10 {
     address_alias_state_obj_initial_shared_version: Option<SequenceNumber>,
 }
 
+/// Current configuration shape. The per-object initial shared versions are kept
+/// in a map keyed by object id, so introducing a new system shared object only
+/// requires extending `SYSTEM_SHARED_OBJECT_IDS` -- no new configuration version.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct EpochStartConfigurationV11 {
+    system_state: EpochStartSystemState,
+    epoch_digest: CheckpointDigest,
+    flags: Vec<EpochFlag>,
+    /// Initial shared versions of the system shared objects that existed at the
+    /// start of the epoch, keyed by object id. Objects absent from the map did
+    /// not exist yet.
+    system_object_versions: BTreeMap<ObjectID, SequenceNumber>,
+    bridge_committee_initiated: bool,
+}
+
 impl EpochStartConfigurationV1 {
     pub fn new(system_state: EpochStartSystemState, epoch_digest: CheckpointDigest) -> Self {
         Self {
@@ -388,39 +449,11 @@ impl EpochStartConfigTrait for EpochStartConfigurationV1 {
         &[]
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
     fn bridge_committee_initiated(&self) -> bool {
         false
     }
 
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+    fn system_object_initial_shared_version(&self, _object_id: ObjectID) -> Option<SequenceNumber> {
         None
     }
 }
@@ -438,39 +471,11 @@ impl EpochStartConfigTrait for EpochStartConfigurationV2 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
     fn bridge_committee_initiated(&self) -> bool {
         false
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
+    fn system_object_initial_shared_version(&self, _object_id: ObjectID) -> Option<SequenceNumber> {
         None
     }
 }
@@ -488,39 +493,18 @@ impl EpochStartConfigTrait for EpochStartConfigurationV3 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
     fn bridge_committee_initiated(&self) -> bool {
         false
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[(
+                SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                self.authenticator_obj_initial_shared_version,
+            )],
+        )
     }
 }
 
@@ -537,40 +521,24 @@ impl EpochStartConfigTrait for EpochStartConfigurationV4 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.randomness_obj_initial_shared_version
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
     fn bridge_committee_initiated(&self) -> bool {
         false
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[
+                (
+                    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                    self.authenticator_obj_initial_shared_version,
+                ),
+                (
+                    SUI_RANDOMNESS_STATE_OBJECT_ID,
+                    self.randomness_obj_initial_shared_version,
+                ),
+            ],
+        )
     }
 }
 
@@ -587,39 +555,28 @@ impl EpochStartConfigTrait for EpochStartConfigurationV5 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.randomness_obj_initial_shared_version
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_deny_list_obj_initial_shared_version
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
     fn bridge_committee_initiated(&self) -> bool {
         false
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[
+                (
+                    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                    self.authenticator_obj_initial_shared_version,
+                ),
+                (
+                    SUI_RANDOMNESS_STATE_OBJECT_ID,
+                    self.randomness_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DENY_LIST_OBJECT_ID,
+                    self.coin_deny_list_obj_initial_shared_version,
+                ),
+            ],
+        )
     }
 }
 
@@ -636,40 +593,29 @@ impl EpochStartConfigTrait for EpochStartConfigurationV6 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.randomness_obj_initial_shared_version
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_deny_list_obj_initial_shared_version
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.bridge_obj_initial_shared_version
-    }
-
     fn bridge_committee_initiated(&self) -> bool {
         self.bridge_committee_initiated
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[
+                (
+                    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                    self.authenticator_obj_initial_shared_version,
+                ),
+                (
+                    SUI_RANDOMNESS_STATE_OBJECT_ID,
+                    self.randomness_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DENY_LIST_OBJECT_ID,
+                    self.coin_deny_list_obj_initial_shared_version,
+                ),
+                (SUI_BRIDGE_OBJECT_ID, self.bridge_obj_initial_shared_version),
+            ],
+        )
     }
 }
 
@@ -686,40 +632,33 @@ impl EpochStartConfigTrait for EpochStartConfigurationV7 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.randomness_obj_initial_shared_version
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_deny_list_obj_initial_shared_version
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.bridge_obj_initial_shared_version
-    }
-
     fn bridge_committee_initiated(&self) -> bool {
         self.bridge_committee_initiated
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.accumulator_root_obj_initial_shared_version
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[
+                (
+                    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                    self.authenticator_obj_initial_shared_version,
+                ),
+                (
+                    SUI_RANDOMNESS_STATE_OBJECT_ID,
+                    self.randomness_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DENY_LIST_OBJECT_ID,
+                    self.coin_deny_list_obj_initial_shared_version,
+                ),
+                (SUI_BRIDGE_OBJECT_ID, self.bridge_obj_initial_shared_version),
+                (
+                    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+                    self.accumulator_root_obj_initial_shared_version,
+                ),
+            ],
+        )
     }
 }
 
@@ -736,40 +675,37 @@ impl EpochStartConfigTrait for EpochStartConfigurationV8 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.randomness_obj_initial_shared_version
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_deny_list_obj_initial_shared_version
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.bridge_obj_initial_shared_version
-    }
-
     fn bridge_committee_initiated(&self) -> bool {
         self.bridge_committee_initiated
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.accumulator_root_obj_initial_shared_version
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_registry_obj_initial_shared_version
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[
+                (
+                    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                    self.authenticator_obj_initial_shared_version,
+                ),
+                (
+                    SUI_RANDOMNESS_STATE_OBJECT_ID,
+                    self.randomness_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DENY_LIST_OBJECT_ID,
+                    self.coin_deny_list_obj_initial_shared_version,
+                ),
+                (SUI_BRIDGE_OBJECT_ID, self.bridge_obj_initial_shared_version),
+                (
+                    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+                    self.accumulator_root_obj_initial_shared_version,
+                ),
+                (
+                    SUI_COIN_REGISTRY_OBJECT_ID,
+                    self.coin_registry_obj_initial_shared_version,
+                ),
+            ],
+        )
     }
 }
 
@@ -786,40 +722,41 @@ impl EpochStartConfigTrait for EpochStartConfigurationV9 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
-    }
-
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.randomness_obj_initial_shared_version
-    }
-
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_deny_list_obj_initial_shared_version
-    }
-
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.bridge_obj_initial_shared_version
-    }
-
     fn bridge_committee_initiated(&self) -> bool {
         self.bridge_committee_initiated
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.accumulator_root_obj_initial_shared_version
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_registry_obj_initial_shared_version
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.display_registry_obj_initial_shared_version
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        None
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[
+                (
+                    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                    self.authenticator_obj_initial_shared_version,
+                ),
+                (
+                    SUI_RANDOMNESS_STATE_OBJECT_ID,
+                    self.randomness_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DENY_LIST_OBJECT_ID,
+                    self.coin_deny_list_obj_initial_shared_version,
+                ),
+                (SUI_BRIDGE_OBJECT_ID, self.bridge_obj_initial_shared_version),
+                (
+                    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+                    self.accumulator_root_obj_initial_shared_version,
+                ),
+                (
+                    SUI_COIN_REGISTRY_OBJECT_ID,
+                    self.coin_registry_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DISPLAY_REGISTRY_OBJECT_ID,
+                    self.display_registry_obj_initial_shared_version,
+                ),
+            ],
+        )
     }
 }
 
@@ -836,39 +773,66 @@ impl EpochStartConfigTrait for EpochStartConfigurationV10 {
         &self.flags
     }
 
-    fn authenticator_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.authenticator_obj_initial_shared_version
+    fn bridge_committee_initiated(&self) -> bool {
+        self.bridge_committee_initiated
     }
 
-    fn randomness_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.randomness_obj_initial_shared_version
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        legacy_lookup(
+            object_id,
+            &[
+                (
+                    SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+                    self.authenticator_obj_initial_shared_version,
+                ),
+                (
+                    SUI_RANDOMNESS_STATE_OBJECT_ID,
+                    self.randomness_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DENY_LIST_OBJECT_ID,
+                    self.coin_deny_list_obj_initial_shared_version,
+                ),
+                (SUI_BRIDGE_OBJECT_ID, self.bridge_obj_initial_shared_version),
+                (
+                    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+                    self.accumulator_root_obj_initial_shared_version,
+                ),
+                (
+                    SUI_COIN_REGISTRY_OBJECT_ID,
+                    self.coin_registry_obj_initial_shared_version,
+                ),
+                (
+                    SUI_DISPLAY_REGISTRY_OBJECT_ID,
+                    self.display_registry_obj_initial_shared_version,
+                ),
+                (
+                    SUI_ADDRESS_ALIAS_STATE_OBJECT_ID,
+                    self.address_alias_state_obj_initial_shared_version,
+                ),
+            ],
+        )
+    }
+}
+
+impl EpochStartConfigTrait for EpochStartConfigurationV11 {
+    fn epoch_digest(&self) -> CheckpointDigest {
+        self.epoch_digest
     }
 
-    fn coin_deny_list_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_deny_list_obj_initial_shared_version
+    fn epoch_start_state(&self) -> &EpochStartSystemState {
+        &self.system_state
     }
 
-    fn bridge_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.bridge_obj_initial_shared_version
+    fn flags(&self) -> &[EpochFlag] {
+        &self.flags
     }
 
     fn bridge_committee_initiated(&self) -> bool {
         self.bridge_committee_initiated
     }
 
-    fn accumulator_root_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.accumulator_root_obj_initial_shared_version
-    }
-
-    fn coin_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.coin_registry_obj_initial_shared_version
-    }
-
-    fn display_registry_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.display_registry_obj_initial_shared_version
-    }
-
-    fn address_alias_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        self.address_alias_state_obj_initial_shared_version
+    fn system_object_initial_shared_version(&self, object_id: ObjectID) -> Option<SequenceNumber> {
+        self.system_object_versions.get(&object_id).copied()
     }
 }

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -28,8 +28,6 @@ use sui_types::transaction::{SharedInputObject, TransactionDataAPI, TransactionK
 use sui_types::{SUI_RANDOMNESS_STATE_OBJECT_ID, base_types::SequenceNumber, error::SuiResult};
 use tracing::trace;
 
-use super::epoch_start_configuration::EpochStartConfigTrait;
-
 pub struct SharedObjVerManager {}
 
 /// Version assignments for a single transaction
@@ -541,7 +539,6 @@ mod tests {
     use super::*;
 
     use crate::authority::AuthorityState;
-    use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
     use crate::authority::shared_object_version_manager::{
         ConsensusSharedObjVerAssignment, SharedObjVerManager,
     };

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -8,7 +8,6 @@ mod metrics;
 
 use crate::accumulators::{self, AccumulatorSettlementTxBuilder};
 use crate::authority::AuthorityState;
-use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority_client::{AuthorityAPI, make_network_authority_clients_with_network_config};
 use crate::checkpoints::causal_order::CausalOrder;
 use crate::checkpoints::checkpoint_output::CertifiedCheckpointOutput;

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -70,7 +70,6 @@ use crate::{
         backpressure::{BackpressureManager, BackpressureSubscriber},
         congestion_log::CongestionCommitLogger,
         consensus_tx_status_cache::ConsensusTxStatus,
-        epoch_start_configuration::EpochStartConfigTrait,
         execution_time_estimator::ExecutionTimeEstimator,
         shared_object_congestion_tracker::SharedObjectCongestionTracker,
         shared_object_version_manager::{AssignedTxAndVersions, AssignedVersions, Schedulable},

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -5,7 +5,6 @@ use crate::{
     accumulators::funds_read::AccountFundsRead,
     authority::{
         AuthorityMetrics, ExecutionEnv, authority_per_epoch_store::AuthorityPerEpochStore,
-        epoch_start_configuration::EpochStartConfigTrait,
         shared_object_version_manager::Schedulable,
     },
     execution_cache::{ObjectCacheRead, TransactionCacheRead},

--- a/crates/sui-core/src/execution_scheduler/settlement_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/settlement_scheduler.rs
@@ -7,7 +7,6 @@ use crate::{
     authority::{
         ExecutionEnv,
         authority_per_epoch_store::AuthorityPerEpochStore,
-        epoch_start_configuration::EpochStartConfigTrait,
         shared_object_version_manager::{AssignedVersions, Schedulable},
     },
     checkpoints::causal_order::CausalOrder,

--- a/crates/sui-core/src/randomness_round_receiver.rs
+++ b/crates/sui-core/src/randomness_round_receiver.rs
@@ -26,7 +26,6 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, instrument, warn};
 
 use crate::authority::AuthorityState;
-use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 
 /// A randomness signature for a specific epoch and round, broadcast to observer peers.
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## Description

Each new shared system object (authenticator state, randomness, deny list, bridge, accumulator root, coin registry, display registry, address alias, ...) has required a brand-new `EpochStartConfiguration` version: a new struct copying every prior field plus one `Option<SequenceNumber>`, a new trait getter, and a getter impl on every historical version.

This replaces the per-object fields with a single `BTreeMap<ObjectID, SequenceNumber>` in a new `V11`. Adding a system object now only requires appending its `ObjectID` to `SYSTEM_SHARED_OBJECT_IDS` — no new config version, enum variant, or trait method.

V1–V10 are left byte-identical and frozen for deserialization; their trait impls answer the new generic query from the fields they already stored. The existing named accessors are kept as thin convenience methods so all call sites are unchanged.

## Test plan

Internal refactor with no behavior change — covered by existing reconfiguration and shared-object-version-assignment tests in `sui-core` and `sui-e2e-tests`, which build and read `EpochStartConfiguration` across epoch boundaries.

## Release notes

Check each box that your change affects. If you are unsure about any of these, please ask us by commenting before merging.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
