### PR TITLE
sui-indexer-alt-framework: surface underlying source in ingestion fetch-retry log

### DIFF
--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -332,7 +332,12 @@ impl IngestionMetrics {
         reason: &str,
         error: Error,
     ) -> backoff::Error<Error> {
-        warn!(checkpoint, reason, "Retrying due to error: {error}");
+        warn!(
+            checkpoint,
+            reason,
+            "Retrying due to error: {}",
+            error_with_sources(&error)
+        );
 
         self.total_ingested_transient_retries
             .with_label_values(&[reason])
@@ -803,6 +808,33 @@ impl CheckpointLagMetricReporter {
     }
 }
 
+/// Render an error together with its [`std::error::Error::source`] chain. Several wrappers
+/// (object_store, reqwest, anyhow) already inline their source's message in their own `Display`,
+/// so we skip any source whose message is already contained in its parent's message to avoid
+/// repetition, and append only genuinely-new sources. This surfaces the underlying `io::Error`
+/// ("Connection refused" / "operation timed out") that is otherwise hidden behind reqwest's terse
+/// "error sending request" leaf.
+fn error_with_sources(mut err: &dyn std::error::Error) -> String {
+    let mut out = String::new();
+    let mut next = err.to_string();
+
+    let mut prefix = "";
+    while let Some(src) = err.source() {
+        err = src;
+        let msg = err.to_string();
+        if !next.contains(&msg) {
+            out.push_str(prefix);
+            out.push_str(&next);
+            prefix = ": ";
+            next = msg;
+        }
+    }
+
+    out.push_str(prefix);
+    out.push_str(&next);
+    out
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use std::sync::Arc;
@@ -819,5 +851,53 @@ pub(crate) mod tests {
     /// Construct IngestionMetrics for test purposes.
     pub fn test_ingestion_metrics() -> Arc<IngestionMetrics> {
         IngestionMetrics::new(None, &Registry::new())
+    }
+
+    #[test]
+    fn test_error_with_sources_dedupes_inlined_and_appends_new() {
+        /// Leaf error with no source — mimics the underlying `io::Error`.
+        #[derive(thiserror::Error, Debug)]
+        #[error("operation timed out")]
+        struct Leaf;
+
+        /// Wrapper whose `Display` does NOT inline its source — mimics reqwest's
+        /// terse "error sending request" that hides the real source.
+        #[derive(thiserror::Error, Debug)]
+        #[error("error sending request")]
+        struct Terse(#[source] Leaf);
+
+        /// Wrapper whose `Display` DOES inline its source — mimics object_store.
+        #[derive(thiserror::Error, Debug)]
+        #[error("Error performing GET: {0}")]
+        struct Inlining(#[source] Terse);
+
+        // The already-inlined "error sending request" fragment is not repeated, but the
+        // genuinely-new "operation timed out" source (hidden behind the terse leaf) is appended.
+        let err = Inlining(Terse(Leaf));
+        assert_eq!(
+            error_with_sources(&err),
+            "Error performing GET: error sending request: operation timed out"
+        );
+    }
+
+    #[test]
+    fn test_error_with_sources_dedupes_inlined_mid_message() {
+        /// Leaf error with no source.
+        #[derive(thiserror::Error, Debug)]
+        #[error("operation timed out")]
+        struct Leaf;
+
+        /// Wrapper that inlines its source in the *middle* of its `Display`, not as a suffix.
+        #[derive(thiserror::Error, Debug)]
+        #[error("failed [{0}] while fetching")]
+        struct MidInlining(#[source] Leaf);
+
+        // The inlined source is contained in its parent's message, so it is not appended again
+        // even though the parent's message does not end with it.
+        let err = MidInlining(Leaf);
+        assert_eq!(
+            error_with_sources(&err),
+            "failed [operation timed out] while fetching"
+        );
     }
 }


### PR DESCRIPTION
## Description

The ingestion fetch-retry warning logs reqwest's terse `error sending request`, which hides why a fetch failed (request timeout vs connection refused vs reset). Today the cause is only inferable from the line's duration. Walk the error's `source()` chain at the log site so the underlying cause (`operation timed out`, `Connection refused`, …) is printed inline.

A small de-duping helper is used rather than `anyhow`/`eyre` `{:#}` because those join the chain without de-duping, and the object_store/reqwest wrappers already inline their child's message.

## Test plan

New unit test covers the helper: an already-inlined fragment is not repeated, and a genuinely-new leaf cause is appended.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
