### PR TITLE
ci(release): give the slow macos-latest-large sccache leg a 4h OIDC session

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -22,6 +22,15 @@ inputs:
       must grant `permissions: id-token: write`. Empty on fork PRs / untrusted
       contexts (graceful degradation to a local cache). See AWS_OIDC_ROLES.md.
     required: false
+  role-duration-seconds:
+    description: >
+      STS session duration (seconds) for the OIDC role assumption. Empty falls
+      back to configure-aws-credentials' default (3600 = 1h). Raise it for builds
+      that outlive a 1h session and would otherwise fail with an sccache S3
+      `ExpiredToken` mid-build (e.g. the slow macos-latest-large release leg). The
+      assumed role's MaxSessionDuration must be >= this value
+      (sui-sccache-rw-github is set to 14400).
+    required: false
   key-prefix:
     description: S3 key prefix for cache partitioning (e.g., ubuntu-ghcloud, windows-ghcloud)
     required: true
@@ -95,6 +104,9 @@ runs:
         role-to-assume: ${{ inputs.role-to-assume }}
         # Identify the run/attempt in CloudTrail's AssumeRoleWithWebIdentity events.
         role-session-name: sui-sccache-${{ github.run_id }}-${{ github.run_attempt }}
+        # Empty -> action default (3600 = 1h). Set higher for builds that run
+        # past 1h (the role's MaxSessionDuration must allow the requested value).
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
         # Fail closed if STS ever returns creds for an unexpected account.
         allowed-account-ids: '011083325127'
         aws-region: us-west-2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,11 @@ jobs:
         if: ${{ env.s3_existing_archive == '' }}
         with:
           role-to-assume: ${{ env.SCCACHE_ROLE }}
+          # macos-latest-large (Intel) is the slowest release runner; its build
+          # exceeds the default 1h OIDC session, expiring sccache's S3 token
+          # mid-build (ExpiredToken). Request a 4h session for that leg only.
+          # Requires sui-sccache-rw-github MaxSessionDuration >= 14400.
+          role-duration-seconds: ${{ matrix.os == 'macos-latest-large' && '14400' || '' }}
           key-prefix: ${{ matrix.os }}
 
       - name: Register cargo problem matcher


### PR DESCRIPTION
## Problem

The `release.yml` **`macos-latest-large` (Intel x86_64)** build leg fails deterministically with:

```
sccache: error: Server startup failed: cache storage failed to read:
  S3Error { code: "ExpiredToken", message: "The provided token has expired." }
→ error: could not compile sui-snapshot / sui-json-rpc / sui-telemetry
```

**Root cause:** `setup-sccache` assumes the OIDC role `sui-sccache-rw-github` with **no `role-duration-seconds`**, so `aws-actions/configure-aws-credentials` uses its default **1h** STS session. The `macos-latest-large` runner is the slowest in the matrix and its build runs **~74 min**; the session token expires mid-build, sccache's S3 backend read fails (`ExpiredToken`), and because `RUSTC_WRAPPER=sccache` the compile aborts.

This is a **credential-TTL race, not flakiness** — the faster legs (`macos-latest-xlarge` arm64, `ubuntu-ghcloud`, `ubuntu-arm64`, `windows-ghcloud`) all finish inside 1h and pass; only the Intel-mac leg loses the race, so every re-run fails identically (same root cause, different crates each attempt).

Observed on the **testnet-v1.74.1** release: run [28465730117](https://github.com/MystenLabs/sui/actions/runs/28465730117), job `84382946494` (4/5 legs green; the `macos-x86_64` archive is missing from the release).

Note: this failure mode was *introduced* by the static-key → OIDC migration — static IAM keys never expired (`ExpiredToken` is STS-temp-cred-only); the 1h OIDC session exposes it on the slow runner.

## Change

- Add an optional **`role-duration-seconds`** input to `.github/actions/setup-sccache/action.yml`, wired into the OIDC `configure-aws-credentials` step. Empty → action default (1h), so **all existing sccache callers are unchanged**.
- In `release.yml`, request a **4h** session **only for the `macos-latest-large` leg**: `role-duration-seconds: ${{ matrix.os == 'macos-latest-large' && '14400' || '' }}`. Smallest blast radius — only the runner that needs it holds a long-lived session; every other leg and every other workflow (`rust.yml`/`external.yml`/`bridge.yml`) stays at 1h.

## IAM dependency (already done)

`configure-aws-credentials` errors if it requests more than the role's `MaxSessionDuration`. **`sui-sccache-rw-github` MaxSessionDuration has been raised 3600 → 14400** (acct `011083325127`, via AWS CLI) **before** this PR — so merging is safe and the assume won't fail. Raising the max is purely permissive: callers that don't request a longer duration still get 1h.

## Test plan

- [x] Diff scoped to the two files; no new `actionlint` findings (pre-existing custom-runner-label + shellcheck notes only, in untouched code).
- [x] IAM `MaxSessionDuration` verified at 14400 prior to merge.
- [ ] After merge, re-run `release.yml` for `testnet-v1.74.1` to attach the missing `macos-x86_64` asset and confirm the Intel-mac leg assumes a 4h session and builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
