### PR TITLE
Prioritize system messages over user transactions in consensus adapter

### DIFF
--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -181,6 +181,14 @@ pub trait SubmitToConsensus: Sync + Send + 'static {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult;
 
+    /// Submits a system transaction to consensus once, without waiting for it to
+    /// be sequenced and without retrying if it is garbage collected, bounded by
+    /// `timeout`. Suits periodic, self-superseding messages (e.g. execution time
+    /// observations) where a missed submission is replaced by the next one.
+    ///
+    /// For system transactions only. User transactions are rejected:
+    /// this fire-and-forget, no-retry, backpressure-free path would
+    /// silently mishandle them.
     fn submit_best_effort(
         &self,
         transaction: &ConsensusTransaction,
@@ -469,6 +477,7 @@ impl ConsensusAdapter {
         // - If is_soft_bundle, then all transactions are of CertifiedTransaction or UserTransaction kind.
         // - If not is_soft_bundle, then transactions must contain exactly 1 tx, and transactions[0] can be of any kind.
         let is_soft_bundle = transactions.len() > 1;
+        let is_system_message = !transactions[0].is_user_transaction();
 
         let mut transaction_keys = Vec::new();
         let mut tx_consensus_positions = tx_consensus_positions;
@@ -554,12 +563,20 @@ impl ConsensusAdapter {
             debug!("Submitting {:?} to consensus", transaction_keys);
             guard.submitted = true;
 
-            let _permit: SemaphorePermit = self
-                .submit_semaphore
-                .acquire()
-                .count_in_flight(self.metrics.sequencing_in_flight_semaphore_wait.clone())
-                .await
-                .expect("Consensus adapter does not close semaphore");
+            // System messages (checkpoint signatures, EndOfPublish, capability
+            // notifications, randomness DKG, etc.) are not buffered behind user
+            // tx; they are excluded from the semaphore.
+            let _permit: Option<SemaphorePermit> = if is_system_message {
+                None
+            } else {
+                Some(
+                    self.submit_semaphore
+                        .acquire()
+                        .count_in_flight(self.metrics.sequencing_in_flight_semaphore_wait.clone())
+                        .await
+                        .expect("Consensus adapter does not close semaphore"),
+                )
+            };
             let _in_flight_submission_guard =
                 GaugeGuard::acquire(&self.metrics.sequencing_in_flight_submissions);
 
@@ -1074,13 +1091,15 @@ impl SubmitToConsensus for Arc<ConsensusAdapter> {
         // timeout is required, or the spawned task can run forever
         timeout: Duration,
     ) -> SuiResult {
-        let permit = match self.submit_semaphore.clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(_) => {
-                return Err(SuiErrorKind::TooManyTransactionsPendingConsensus.into());
+        if transaction.is_user_transaction() {
+            debug_fatal!("submit_best_effort called with a user transaction");
+            return Err(SuiErrorKind::GenericAuthorityError {
+                error: "submit_best_effort does not accept user transactions".to_string(),
             }
-        };
+            .into());
+        }
 
+        // There is no submit semaphone on this path as it services system msgs only.
         let _in_flight_submission_guard =
             GaugeGuard::acquire(&self.metrics.sequencing_in_flight_submissions);
 
@@ -1093,8 +1112,6 @@ impl SubmitToConsensus for Arc<ConsensusAdapter> {
             let this = self.clone();
 
             async move {
-                let _permit = permit; // Hold permit for lifetime of task
-
                 let result = tokio::time::timeout(
                     timeout,
                     this.submit_inner(&[transaction], &epoch_store, &[key], tx_type),

--- a/crates/sui-core/src/unit_tests/consensus_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/consensus_test_utils.rs
@@ -141,6 +141,22 @@ pub fn make_consensus_adapter_for_test(
     execute: bool,
     mock_block_status_receivers: Vec<BlockStatusReceiver>,
 ) -> Arc<ConsensusAdapter> {
+    make_consensus_adapter_for_test_with_submit_limit(
+        state,
+        process_via_checkpoint,
+        execute,
+        mock_block_status_receivers,
+        100_000,
+    )
+}
+
+pub fn make_consensus_adapter_for_test_with_submit_limit(
+    state: Arc<AuthorityState>,
+    process_via_checkpoint: HashSet<TransactionDigest>,
+    execute: bool,
+    mock_block_status_receivers: Vec<BlockStatusReceiver>,
+    max_pending_local_submissions: usize,
+) -> Arc<ConsensusAdapter> {
     let metrics = ConsensusAdapterMetrics::new_test();
 
     #[derive(Clone)]
@@ -282,7 +298,7 @@ pub fn make_consensus_adapter_for_test(
         state.checkpoint_store.clone(),
         state.name,
         100_000,
-        100_000,
+        max_pending_local_submissions,
         metrics,
         Arc::new(tokio::sync::Notify::new()),
     ))

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 use super::*;
 use crate::authority::{AuthorityState, authority_tests::init_state_with_objects};
 
-use crate::consensus_test_utils::make_consensus_adapter_for_test;
+use crate::consensus_test_utils::{
+    make_consensus_adapter_for_test, make_consensus_adapter_for_test_with_submit_limit,
+};
 use crate::mock_consensus::with_block_status;
 use consensus_core::BlockStatus;
 use consensus_types::block::{BlockRef, PING_TRANSACTION_INDEX};
@@ -263,6 +265,64 @@ async fn submit_multiple_transactions_to_consensus_adapter() {
         )
         .unwrap();
     waiter.await.unwrap();
+}
+
+#[sim_test]
+async fn system_message_bypasses_exhausted_submit_semaphore() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let user_tx = test_user_transactions(&state, shared_object)
+        .await
+        .pop()
+        .unwrap();
+    let epoch_store = state.epoch_store_for_testing();
+
+    // Zero submit permits: any transaction that must acquire the submit semaphore
+    // blocks indefinitely. The one mock block status is reserved for the system
+    // message, which is the only submission expected to reach consensus.
+    let adapter = make_consensus_adapter_for_test_with_submit_limit(
+        state.clone(),
+        HashSet::new(),
+        false,
+        vec![with_block_status(BlockStatus::Sequenced(BlockRef::MIN))],
+        0,
+    );
+
+    // A user transaction cannot acquire a permit, so it blocks.
+    let user_consensus_tx =
+        ConsensusTransaction::new_user_transaction_v2_message(&state.name, user_tx.into());
+    let mut user_waiter = adapter
+        .submit(
+            user_consensus_tx,
+            Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+            &epoch_store,
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_secs(2), &mut user_waiter)
+            .await
+            .is_err(),
+        "user transaction must block on the exhausted submit semaphore"
+    );
+    // The submission is parked on the semaphore forever; abort it so it does not
+    // outlive the test.
+    user_waiter.abort();
+
+    // The system message bypasses the semaphore and completes.
+    let end_of_publish = ConsensusTransaction::new_end_of_publish(state.name);
+    let system_waiter = adapter
+        .submit(end_of_publish, None, &epoch_store, None, None)
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(10), system_waiter)
+        .await
+        .expect("system message must not block on an exhausted submit semaphore")
+        .unwrap();
 }
 
 #[sim_test]


### PR DESCRIPTION
## Description

Under high load, user transactions saturate the consensus adapter's submit semaphore, so system messages (checkpoint signatures, `EndOfPublish`, capability notifications, randomness DKG) block behind them.

System messages now bypass the submit semaphore (both the blocking `submit_and_wait_inner` path and the best-effort path used for execution-time observations); user transactions still contend for a permit. `submit_best_effort` now rejects user transactions, which are never expected on that path.

Part of CORE-192.

## Test plan

New unit test `system_message_bypasses_exhausted_submit_semaphore`: with a 0-permit semaphore, a user transaction blocks while an `EndOfPublish` completes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
