### PR TITLE
feat(transaction-driver): wait for effects on durably-processing transactions

### DIFF
--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -104,12 +104,22 @@ impl EffectsCertifier {
                 None => (None, None),
             },
             SubmitTxResult::Rejected { error } => {
-                return Err(TransactionDriverError::ClientInternal {
-                    error: format!(
-                        "Unexpected submission error in get_certified_finalized_effects(): {}",
-                        error
-                    ),
-                });
+                if matches!(
+                    error.as_inner(),
+                    SuiErrorKind::TransactionProcessing { digest, .. } if Some(*digest) == tx_digest
+                ) {
+                    // Already being processed by consensus: no consensus position to track, so
+                    // wait for the finalized outcome by digest — same path as an `Executed`
+                    // response with no inline effects.
+                    (None, None)
+                } else {
+                    return Err(TransactionDriverError::ClientInternal {
+                        error: format!(
+                            "Unexpected submission error in get_certified_finalized_effects(): {}",
+                            error
+                        ),
+                    });
+                }
             }
         };
 

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -333,7 +333,16 @@ where
                 options,
             )
             .await?;
-        if let SubmitTxResult::Rejected { error } = &submit_txn_result {
+        // A `TransactionProcessing` rejection for this transaction is expected: the submitter
+        // returns it as a result (not a retriable error) and the certifier waits for the finalized
+        // outcome by digest. Any other `Rejected` should have come back as a submission error.
+        if let SubmitTxResult::Rejected { error } = &submit_txn_result
+            && !matches!(
+                error.as_inner(),
+                sui_types::error::SuiErrorKind::TransactionProcessing { digest, .. }
+                    if Some(*digest) == tx_digest
+            )
+        {
             return Err(TransactionDriverError::ClientInternal {
                 error: format!(
                     "SubmitTxResult::Rejected should have been returned as an error in submit_transaction(): {}",

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -272,16 +272,36 @@ impl TransactionSubmitter {
         }
         let result = resp.results.into_iter().next().unwrap();
 
-        // Since only one transaction is submitted, it is ok to return error when the submission is rejected.
+        // A rejection normally means submission failed; retry elsewhere. Two exceptions, both keyed
+        // to this transaction's digest:
+        // - `TransactionProcessing`: the transaction is already being processed by consensus, so
+        //   surface the rejection as a result and let the driver wait for the finalized outcome by
+        //   digest instead of resubmitting.
+        // - `TransactionSubmitted`: a dedup hit on the driver's own recent submission; stays
+        //   retriable, but is not a validator fault so it does not count against the validator's
+        //   score.
+        // Rejections naming a different digest are malformed and stay retriable.
         if let SubmitTxResult::Rejected { error } = &result {
-            if is_validator_error(error.categorize()) {
-                client_monitor.record_interaction_result(OperationFeedback {
-                    authority_name: validator,
-                    display_name,
-                    operation: OperationType::Submit,
-                    ping_type: request.ping_type,
-                    result: Err(()),
-                });
+            match error.as_inner() {
+                sui_types::error::SuiErrorKind::TransactionProcessing { digest, .. }
+                    if Some(*digest) == request.tx_digest() =>
+                {
+                    // No fresh submission was accepted, so record neither success nor failure.
+                    return Ok(result);
+                }
+                sui_types::error::SuiErrorKind::TransactionSubmitted { digest }
+                    if Some(*digest) == request.tx_digest() => {}
+                _ => {
+                    if is_validator_error(error.categorize()) {
+                        client_monitor.record_interaction_result(OperationFeedback {
+                            authority_name: validator,
+                            display_name,
+                            operation: OperationType::Submit,
+                            ping_type: request.ping_type,
+                            result: Err(()),
+                        });
+                    }
+                }
             }
             return Err(TransactionRequestError::RejectedAtValidator(error.clone()));
         }

--- a/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
@@ -301,6 +301,72 @@ async fn test_successful_certified_effects() {
 }
 
 #[tokio::test]
+async fn test_transaction_processing_waits_for_effects() {
+    telemetry_subscribers::init_for_testing();
+    let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
+    let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
+    let certifier = EffectsCertifier::new(metrics);
+
+    let tx_digest = create_test_transaction_digest(1);
+    let effects_digest = create_test_effects_digest(1);
+    let executed_data = create_test_executed_data();
+
+    let executed_response_full = WaitForEffectsResponse::Executed {
+        effects_digest,
+        details: Some(Box::new(executed_data.clone())),
+    };
+    let executed_response_ack = WaitForEffectsResponse::Executed {
+        effects_digest,
+        details: None,
+    };
+    for (_, safe_client) in authority_aggregator.authority_clients.iter() {
+        let client = safe_client.authority_client();
+        client.set_ack_response(tx_digest, executed_response_ack.clone());
+        client.set_full_response(tx_digest, executed_response_full.clone());
+    }
+
+    let options = SubmitTransactionOptions::default();
+    let name = authority_aggregator
+        .authority_clients
+        .keys()
+        .next()
+        .unwrap();
+
+    // Submission came back as "already processing" (no consensus position). The certifier should
+    // wait for the finalized effects by digest, not treat it as an internal error.
+    let submit_tx_result = SubmitTxResult::Rejected {
+        error: SuiErrorKind::TransactionProcessing {
+            digest: tx_digest,
+            status: "consensus message processed".to_string(),
+        }
+        .into(),
+    };
+    let result = certifier
+        .get_certified_finalized_effects(
+            &authority_aggregator,
+            &client_monitor,
+            Some(tx_digest),
+            TxType::SingleWriter,
+            *name,
+            submit_tx_result,
+            &options,
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "expected certified effects, got: {result:?}"
+    );
+    match result.unwrap().effects.finality_info {
+        EffectsFinalityInfo::QuorumExecuted(_) => {}
+        other => panic!("Expected QuorumExecuted finality info, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_transaction_rejected_non_retriable() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());

--- a/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
@@ -508,3 +508,218 @@ async fn test_submit_transaction_invalid_input() {
         e => panic!("Expected InvalidTransaction error, got: {:?}", e),
     }
 }
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_transaction_processing_returned_as_result() {
+    telemetry_subscribers::init_for_testing();
+
+    let reference_gas_price = 1000;
+    let (authority_aggregator, mock_authorities) =
+        create_test_authority_aggregator_with_rgp(reference_gas_price);
+    let authority_aggregator = Arc::new(authority_aggregator);
+
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
+    let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
+    let submitter = TransactionSubmitter::new(metrics);
+
+    let request = create_test_submit_request(reference_gas_price);
+    let tx_digest = *request.transaction.as_ref().unwrap().digest();
+
+    // Every validator reports the transaction is already being processed by consensus.
+    for mock_authority in &mock_authorities {
+        mock_authority.set_submit_response(
+            tx_digest,
+            Ok(SubmitTxResult::Rejected {
+                error: SuiErrorKind::TransactionProcessing {
+                    digest: tx_digest,
+                    status: "consensus message processed".to_string(),
+                }
+                .into(),
+            }),
+        );
+    }
+
+    let options = SubmitTransactionOptions::default();
+    // A `TransactionProcessing` rejection must be surfaced as a result (so the driver can wait for
+    // effects by digest), NOT turned into a retriable submission error that resubmits the tx.
+    let (_, result) = submitter
+        .submit_transaction(
+            &authority_aggregator,
+            &client_monitor,
+            TxType::SingleWriter,
+            1,
+            request,
+            &options,
+        )
+        .await
+        .expect("TransactionProcessing should be returned as a result, not a submission error");
+
+    assert!(matches!(
+        result,
+        SubmitTxResult::Rejected { error }
+            if matches!(error.as_inner(), SuiErrorKind::TransactionProcessing { .. })
+    ));
+
+    // Accepted from the first validator without resubmitting to the others.
+    let total_submissions: usize = mock_authorities
+        .iter()
+        .map(|auth| auth.get_submission_count())
+        .sum();
+    assert_eq!(total_submissions, 1);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_transaction_submitted_is_retriable() {
+    telemetry_subscribers::init_for_testing();
+
+    let reference_gas_price = 1000;
+    let (authority_aggregator, mock_authorities) =
+        create_test_authority_aggregator_with_rgp(reference_gas_price);
+    let authority_aggregator = Arc::new(authority_aggregator);
+
+    // Hold the monitor metrics to assert on recorded submit feedback below.
+    let monitor_metrics =
+        Arc::new(crate::validator_client_monitor::ValidatorClientMetrics::new_for_tests());
+    let client_monitor = ValidatorClientMonitor::new(
+        sui_config::validator_client_monitor_config::ValidatorClientMonitorConfig::default(),
+        monitor_metrics.clone(),
+        Arc::new(arc_swap::ArcSwap::new(authority_aggregator.clone())),
+    );
+    let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
+    let submitter = TransactionSubmitter::new(metrics);
+
+    let request = create_test_submit_request(reference_gas_price);
+    let tx_digest = *request.transaction.as_ref().unwrap().digest();
+
+    // Every validator responds with the `TransactionSubmitted` dedup rejection. Unlike a
+    // `TransactionProcessing` rejection, this does NOT mean the transaction reached consensus,
+    // so the submitter must keep resubmitting to other validators rather than short-circuiting into
+    // a wait-for-effects.
+    for mock_authority in &mock_authorities {
+        mock_authority.set_submit_response(
+            tx_digest,
+            Ok(SubmitTxResult::Rejected {
+                error: SuiErrorKind::TransactionSubmitted { digest: tx_digest }.into(),
+            }),
+        );
+    }
+
+    let options = SubmitTransactionOptions::default();
+    let result = submitter
+        .submit_transaction(
+            &authority_aggregator,
+            &client_monitor,
+            TxType::SingleWriter,
+            1,
+            request,
+            &options,
+        )
+        .await;
+
+    // Comes back as a retriable submission error (the driver's outer loop retries), NOT surfaced as
+    // a result to wait on.
+    assert!(
+        matches!(result, Err(TransactionDriverError::Aborted { .. })),
+        "TransactionSubmitted rejections must stay retriable, got: {result:?}"
+    );
+
+    // The submitter resubmitted to every validator instead of stopping after the first.
+    let total_submissions: usize = mock_authorities
+        .iter()
+        .map(|auth| auth.get_submission_count())
+        .sum();
+    assert_eq!(total_submissions, mock_authorities.len());
+
+    // The dedup hit is caused by the driver's own resubmission, not a validator fault, so no
+    // submit failure is recorded against any validator's score.
+    for name in authority_aggregator.authority_clients.keys() {
+        let display_name = authority_aggregator.get_display_name(name);
+        assert_eq!(
+            monitor_metrics
+                .operation_failure
+                .with_label_values(&[display_name.as_str(), "submit", "false"])
+                .get(),
+            0
+        );
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_processing_wrong_digest_is_retriable() {
+    telemetry_subscribers::init_for_testing();
+
+    let reference_gas_price = 1000;
+    let (authority_aggregator, mock_authorities) =
+        create_test_authority_aggregator_with_rgp(reference_gas_price);
+    let authority_aggregator = Arc::new(authority_aggregator);
+
+    // Hold the monitor metrics to assert on recorded submit feedback below.
+    let monitor_metrics =
+        Arc::new(crate::validator_client_monitor::ValidatorClientMetrics::new_for_tests());
+    let client_monitor = ValidatorClientMonitor::new(
+        sui_config::validator_client_monitor_config::ValidatorClientMonitorConfig::default(),
+        monitor_metrics.clone(),
+        Arc::new(arc_swap::ArcSwap::new(authority_aggregator.clone())),
+    );
+    let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
+    let submitter = TransactionSubmitter::new(metrics);
+
+    let request = create_test_submit_request(reference_gas_price);
+    let tx_digest = *request.transaction.as_ref().unwrap().digest();
+    let other_digest = TransactionDigest::random();
+    assert_ne!(tx_digest, other_digest);
+
+    // A `TransactionProcessing` rejection that refers to a DIFFERENT transaction. The submitter
+    // must not stop resubmitting our transaction based on a claim about another one; it stays
+    // retriable.
+    for mock_authority in &mock_authorities {
+        mock_authority.set_submit_response(
+            tx_digest,
+            Ok(SubmitTxResult::Rejected {
+                error: SuiErrorKind::TransactionProcessing {
+                    digest: other_digest,
+                    status: "consensus message processed".to_string(),
+                }
+                .into(),
+            }),
+        );
+    }
+
+    let options = SubmitTransactionOptions::default();
+    let result = submitter
+        .submit_transaction(
+            &authority_aggregator,
+            &client_monitor,
+            TxType::SingleWriter,
+            1,
+            request,
+            &options,
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(TransactionDriverError::Aborted { .. })),
+        "a durable rejection for a different digest must stay retriable, got: {result:?}"
+    );
+
+    let total_submissions: usize = mock_authorities
+        .iter()
+        .map(|auth| auth.get_submission_count())
+        .sum();
+    assert_eq!(total_submissions, mock_authorities.len());
+
+    // A processing claim about a different transaction is a malformed response, and does count
+    // against the validator's score.
+    for name in authority_aggregator.authority_clients.keys() {
+        let display_name = authority_aggregator.get_display_name(name);
+        assert_eq!(
+            monitor_metrics
+                .operation_failure
+                .with_label_values(&[display_name.as_str(), "submit", "false"])
+                .get(),
+            1
+        );
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to #27083. When a validator rejects a submission with `TransactionProcessing`, the transaction driver treated it as a retriable error and resubmitted — which the validator just suppresses again, causing retry churn. When the transaction is durably in flight (sequenced by consensus, or executed via a checkpoint) its outcome is already final, so the driver now waits for that outcome by digest instead of resubmitting. The non-durable "recently submitted" dedup status (#27069) is not evidence the transaction reached consensus, so it stays retriable.

The wait path is only taken when the rejection's digest matches the request, and a processing rejection for the driver's own transaction no longer counts against the validator's client-monitor score (the dedup hit is caused by the driver's own resubmission, not a validator fault).

## Test plan

New unit tests cover: a durable rejection is surfaced as a result after a single submission (no churn) and routes the certifier into the wait-for-effects path; "recently submitted" and wrong-digest rejections stay retriable and resubmit to all validators; validator score feedback is recorded for malformed (wrong-digest) responses but not for own-transaction dedup hits; and the durable/non-durable classification helper in `sui-types`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 