### PR TITLE
[typed-store] Adopt tidehunter keyspace reorder/remove + name-based handle API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8484,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=45c3606a8017186cf96f15adc8b66938854045f9#45c3606a8017186cf96f15adc8b66938854045f9"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=e22a81b6adace0d20022f679eaf6480a81035192#e22a81b6adace0d20022f679eaf6480a81035192"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18197,7 +18197,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=45c3606a8017186cf96f15adc8b66938854045f9#45c3606a8017186cf96f15adc8b66938854045f9"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=e22a81b6adace0d20022f679eaf6480a81035192#e22a81b6adace0d20022f679eaf6480a81035192"
 dependencies = [
  "anyhow",
  "clap",
@@ -18212,7 +18212,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=45c3606a8017186cf96f15adc8b66938854045f9#45c3606a8017186cf96f15adc8b66938854045f9"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=e22a81b6adace0d20022f679eaf6480a81035192#e22a81b6adace0d20022f679eaf6480a81035192"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7895,7 +7895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8484,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=131e31eccdbddf5a859b8466aafda10868c2850a#131e31eccdbddf5a859b8466aafda10868c2850a"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=45c3606a8017186cf96f15adc8b66938854045f9#45c3606a8017186cf96f15adc8b66938854045f9"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18197,7 +18197,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=131e31eccdbddf5a859b8466aafda10868c2850a#131e31eccdbddf5a859b8466aafda10868c2850a"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=45c3606a8017186cf96f15adc8b66938854045f9#45c3606a8017186cf96f15adc8b66938854045f9"
 dependencies = [
  "anyhow",
  "clap",
@@ -18212,7 +18212,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=131e31eccdbddf5a859b8466aafda10868c2850a#131e31eccdbddf5a859b8466aafda10868c2850a"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=45c3606a8017186cf96f15adc8b66938854045f9#45c3606a8017186cf96f15adc8b66938854045f9"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -55,7 +55,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "45c3606a8017186cf96f15adc8b66938854045f9", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "e22a81b6adace0d20022f679eaf6480a81035192", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -55,7 +55,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "131e31eccdbddf5a859b8466aafda10868c2850a", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "45c3606a8017186cf96f15adc8b66938854045f9", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -367,24 +367,21 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     cf_configs: std::collections::BTreeMap<String, typed_store::tidehunter_util::ThConfig>,
                 ) -> Self {
                     let mut builder = typed_store::tidehunter_util::KeyShapeBuilder::new();
-                    let (
-                        #(
-                            #field_names,
-                        )*
-                    ) = (
-                        #(
-                            typed_store::tidehunter_util::add_key_space(
-                                &mut builder,
-                                stringify!(#cf_names),
-                                cf_configs.get(stringify!(#cf_names))
-                                    .unwrap_or_else(|| panic!("Missing tidehunter configuration for table {} from database {}", stringify!(#cf_names), stringify!(#name))),
-                            ),
-                        )*
-                    );
+                    // Declare each column family by name; the canonical handle
+                    // is resolved from `keyspaces` (returned by `open`) below,
+                    // not from declaration order.
+                    #(
+                        typed_store::tidehunter_util::add_key_space(
+                            &mut builder,
+                            stringify!(#cf_names),
+                            cf_configs.get(stringify!(#cf_names))
+                                .unwrap_or_else(|| panic!("Missing tidehunter configuration for table {} from database {}", stringify!(#cf_names), stringify!(#name))),
+                        );
+                    )*
                     let key_shape = builder.build();
                     let (inner_db, registry_id) = typed_store::tidehunter_util::open(path.as_path(), key_shape, &metric_conf);
                     let db = std::sync::Arc::new(typed_store::rocks::Database::new(
-                        typed_store::rocks::Storage::TideHunter(inner_db),
+                        typed_store::rocks::Storage::TideHunter(inner_db.clone()),
                         metric_conf,
                         Some(registry_id)));
                     let (
@@ -393,7 +390,8 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                         ),*
                     ) = (#(
                         DBMap::#inner_types::reopen_th(
-                            db.clone(), stringify!(#cf_names), #field_names,
+                            db.clone(), stringify!(#cf_names),
+                            inner_db.ks(stringify!(#cf_names)),
                             cf_configs[stringify!(#cf_names)].prefix.clone()
                         )
                     ),*);

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "131e31eccdbddf5a859b8466aafda10868c2850a", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "45c3606a8017186cf96f15adc8b66938854045f9", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "45c3606a8017186cf96f15adc8b66938854045f9", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "e22a81b6adace0d20022f679eaf6480a81035192", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -882,12 +882,13 @@ fn open_th_map(name: &str) -> DBMap<u64, String> {
     let mut builder = KeyShapeBuilder::new();
     // u64 keys serialize to 8 fixed bytes via `be_fix_int_ser`.
     let config = ThConfig::new(8, 16, KeyType::uniform(1));
-    let ks = add_key_space(&mut builder, name, &config);
+    add_key_space(&mut builder, name, &config);
     let key_shape = builder.build();
     let metric_conf = MetricConf::new("test_snapshot_iter");
     let (inner_db, registry_id) = open(temp_dir().as_path(), key_shape, &metric_conf);
+    let ks = inner_db.ks(name);
     let db = Arc::new(Database::new(
-        Storage::TideHunter(inner_db),
+        Storage::TideHunter(inner_db.clone()),
         metric_conf,
         Some(registry_id),
     ));

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -13,7 +13,7 @@ use tidehunter::compressed_batch::BatchCodec;
 use tidehunter::config::Config;
 use tidehunter::db::Db;
 use tidehunter::iterators::db_iterator::DbIterator;
-use tidehunter::key_shape::{KeyShape, KeySpace};
+use tidehunter::key_shape::KeyShape;
 use tidehunter::metrics::Metrics;
 pub use tidehunter::{
     Decision, WalPosition,
@@ -38,6 +38,9 @@ pub fn open(path: &Path, key_shape: KeyShape, metric_conf: &MetricConf) -> (Arc<
     let registry_id = registry_service.add(registry.clone());
     let metrics = Metrics::new_in(&registry);
     ensure_database_type(path, StorageType::TideHunter).expect("failed to open tidehunter db");
+    // `Db::open` reconciles the declared shape against the persisted registry
+    // (matching by name; supports reorder/add/remove). Callers resolve each
+    // column family's handle by name via `Db::ks`.
     let db = Db::open(path, key_shape, Arc::new(thdb_config(metric_conf)), metrics)
         .expect("failed to open tidehunter db");
     db.start_periodic_snapshot();
@@ -49,14 +52,17 @@ fn new_db_registry(name: String) -> Registry {
     Registry::new_custom(None, Some(labels)).expect("failed to create registry")
 }
 
-pub fn add_key_space(builder: &mut KeyShapeBuilder, name: &str, config: &ThConfig) -> KeySpace {
+pub fn add_key_space(builder: &mut KeyShapeBuilder, name: &str, config: &ThConfig) {
+    // `add_key_space_config_indexing` returns `&mut KeyShapeBuilder`; the
+    // canonical handle is no longer assigned here. It is resolved by name from
+    // the `KeySpaces` returned by `open` (see the DBMapUtils derive macro).
     builder.add_key_space_config_indexing(
         name,
         config.key_indexing.clone(),
         config.mutexes,
         config.key_type,
         config.config.clone(),
-    )
+    );
 }
 
 fn parse_env_usize(name: &str, minimum: usize) -> Option<usize> {


### PR DESCRIPTION
## Description

Bumps the `tidehunter` and `tideconsole` git revs to the `keyspace-reorder` branch and updates the typed-store integration to its new API.

The tidehunter change decouples a keyspace's on-disk id (the byte in every WAL frame / the control-region snapshot slot) from its declaration order in the `KeyShape`:

- **Reorder** keyspaces across reopens is now safe (a persisted append-only registry reconciled by name), instead of a silent misroute. Opening a pre-registry DB with a changed shape panics rather than corrupting; unchanged shapes just work and create the registry.
- **Remove** is non-destructive, like RocksDB (which never drops a column family implicitly): a keyspace absent from the declared shape is retained, and re-declaring its name reconnects to its data intact. So an accidentally omitted keyspace is not data loss.
- **Handles by name**: `Db::open` now returns `Arc<Db>` (no tuple), and a keyspace is resolved via `db.ks("name")`.

typed-store integration:
- `tidehunter_util::open` returns `(Arc<Db>, RegistryID)`.
- The `DBMapUtils` tidehunter branch resolves each column family's handle via `inner_db.ks(cf_name)` instead of a positional handle from the builder.

**Draft** because the rev is pinned to the `keyspace-reorder` branch commit (`MystenLabs/tidehunter@45c3606`); it should be re-pointed to the merge commit once the tidehunter PR lands.

## Test plan

- CI (with the tidehunter build enabled) exercises the `#[cfg(tidehunter)]` paths.
- Verified locally against a path-patched tidehunter: `USE_TIDEHUNTER=1 cargo test -p typed-store --features tidehunter` — the `rocks::tests` tidehunter test and the macro-derived `tidehunter_tests::test_tidehunter_map` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)