### PR TITLE
[Stress] allow create duplicate and amplified traffic

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -55,7 +55,7 @@ use tokio::{time, time::Instant};
 use tracing::{debug, error, info, warn};
 
 use super::Interval;
-use super::{BenchmarkStats, StressStats};
+use super::{BenchmarkStats, StressStats, SubmissionAmplification};
 
 /// Randomly partitions a list of transactions into groups for soft bundle submission.
 /// Each group will be submitted as a separate soft bundle.
@@ -257,6 +257,7 @@ pub struct BenchWorker {
     pub execution_proxy: Arc<dyn ValidatorProxy + Send + Sync>,
     pub group: u32,
     pub duration: Interval,
+    pub submission_amplification: SubmissionAmplification,
 }
 
 impl Debug for BenchWorker {
@@ -349,6 +350,7 @@ impl BenchDriver {
                     execution_proxy: execution_proxy.clone(),
                     group: workload_info.workload_params.group,
                     duration: workload_info.workload_params.duration,
+                    submission_amplification: workload_info.submission_amplification,
                 });
                 payloads = remaining;
                 qps -= target_qps;
@@ -1117,18 +1119,16 @@ async fn run_bench_worker(
                         // TODO: clone committee for each request is not ideal.
                         let committee = worker.execution_proxy.clone_committee();
 
-                        // Occasionally submit to multiple validators to test unpaid amplification deferral.
-                        // With 5% probability, submit to 3 to N validators to trigger deferral logic.
-                        let use_amplification = rand::thread_rng().gen_bool(0.05);
-                        let committee_size = committee.num_members();
+                        let submission_amplification = worker.submission_amplification;
                         let proxy = worker.execution_proxy.clone_new();
                         let res = async move {
-                            let res = if use_amplification {
-                                // Cap at 5 validators to limit amplification traffic and reduce latency impact
-                                let max_validators = committee_size.min(5);
-                                let min_validators = 3.min(max_validators);
-                                let num_validators = rand::thread_rng().gen_range(min_validators..=max_validators);
-                                proxy.execute_transaction_block_with_amplification(tx.clone(), num_validators).await
+                            let res = if submission_amplification.is_enabled() {
+                                proxy
+                                    .execute_transaction_block_with_submission_amplification(
+                                        tx.clone(),
+                                        submission_amplification,
+                                    )
+                                    .await
                             } else {
                                 proxy.execute_transaction_block(tx.clone()).await
                             };

--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -95,6 +95,14 @@ impl SubmissionAmplification {
             duplicate_copies_per_validator > 0,
             "duplicate copies per validator must be greater than zero"
         );
+        ensure!(
+            amplification_probability == 0.0 || amplification_validators_per_tx > 1,
+            "amplification validators per tx must be greater than one when amplification probability is non-zero"
+        );
+        ensure!(
+            duplicate_probability == 0.0 || duplicate_copies_per_validator > 1,
+            "duplicate copies per validator must be greater than one when duplicate probability is non-zero"
+        );
 
         Ok(Self {
             amplification_probability,
@@ -128,6 +136,12 @@ impl SubmissionAmplification {
         }
     }
 
+    /// Approximate expected submissions per logical transaction, for informational logging.
+    /// It slightly undercounts attempted submissions: when amplification triggers, the extra
+    /// direct submissions are sent in addition to the regular TransactionDriver submission,
+    /// which is not counted here. Conversely, delivered copies may be fewer than attempted,
+    /// since extras are aborted once the regular submission completes and the validator set
+    /// is clamped to the committee size.
     pub fn expected_submission_multiplier(&self) -> f64 {
         (1.0 + self.amplification_probability * (self.amplification_validators_per_tx - 1) as f64)
             * (1.0 + self.duplicate_probability * (self.duplicate_copies_per_validator - 1) as f64)

--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -5,10 +5,127 @@ use duration_str::parse;
 use std::fmt::Formatter;
 use std::{str::FromStr, time::Duration};
 
+use anyhow::ensure;
+use clap::ValueEnum;
+use rand::Rng;
+
 pub mod bench_driver;
 pub mod driver;
 use comfy_table::{Cell, Color, ContentArrangement, Row, Table};
 use hdrhistogram::{Histogram, serialization::Serializer};
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, Eq, PartialEq, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum ValidatorSelection {
+    Random,
+    HighestPerformance,
+}
+
+impl std::fmt::Display for ValidatorSelection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidatorSelection::Random => f.write_str("random"),
+            ValidatorSelection::HighestPerformance => f.write_str("highest-performance"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct SubmissionAmplification {
+    pub amplification_probability: f64,
+    pub amplification_validators_per_tx: usize,
+    pub duplicate_probability: f64,
+    pub duplicate_copies_per_validator: usize,
+    pub validator_selection: ValidatorSelection,
+}
+
+impl Default for SubmissionAmplification {
+    fn default() -> Self {
+        Self {
+            amplification_probability: 0.0,
+            amplification_validators_per_tx: 1,
+            duplicate_probability: 0.0,
+            duplicate_copies_per_validator: 1,
+            validator_selection: ValidatorSelection::Random,
+        }
+    }
+}
+
+impl SubmissionAmplification {
+    pub fn new(
+        amplification_probability: f64,
+        amplification_validators_per_tx: usize,
+        duplicate_probability: f64,
+        duplicate_copies_per_validator: usize,
+        validator_selection: ValidatorSelection,
+    ) -> anyhow::Result<Self> {
+        ensure!(
+            (0.0..=1.0).contains(&amplification_probability),
+            "amplification probability must be between 0.0 and 1.0"
+        );
+        ensure!(
+            (0.0..=1.0).contains(&duplicate_probability),
+            "duplicate probability must be between 0.0 and 1.0"
+        );
+        ensure!(
+            amplification_validators_per_tx > 0,
+            "amplification validators per tx must be greater than zero"
+        );
+        ensure!(
+            duplicate_copies_per_validator > 0,
+            "duplicate copies per validator must be greater than zero"
+        );
+
+        Ok(Self {
+            amplification_probability,
+            amplification_validators_per_tx,
+            duplicate_probability,
+            duplicate_copies_per_validator,
+            validator_selection,
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        (self.amplification_probability > 0.0 && self.amplification_validators_per_tx > 1)
+            || (self.duplicate_probability > 0.0 && self.duplicate_copies_per_validator > 1)
+    }
+
+    pub fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SubmissionAmplificationSample {
+        let validators_per_tx = if rng.gen_bool(self.amplification_probability) {
+            self.amplification_validators_per_tx
+        } else {
+            1
+        };
+        let copies_per_validator = if rng.gen_bool(self.duplicate_probability) {
+            self.duplicate_copies_per_validator
+        } else {
+            1
+        };
+        SubmissionAmplificationSample {
+            validators_per_tx,
+            copies_per_validator,
+            validator_selection: self.validator_selection,
+        }
+    }
+
+    pub fn expected_submission_multiplier(&self) -> f64 {
+        (1.0 + self.amplification_probability * (self.amplification_validators_per_tx - 1) as f64)
+            * (1.0 + self.duplicate_probability * (self.duplicate_copies_per_validator - 1) as f64)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct SubmissionAmplificationSample {
+    pub validators_per_tx: usize,
+    pub copies_per_validator: usize,
+    pub validator_selection: ValidatorSelection,
+}
+
+impl SubmissionAmplificationSample {
+    pub fn total_submissions(&self) -> usize {
+        self.validators_per_tx * self.copies_per_validator
+    }
+}
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 pub enum Interval {

--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -52,6 +52,26 @@ impl Default for SubmissionAmplification {
 }
 
 impl SubmissionAmplification {
+    // Default values shared between the stress CLI options and simtests, so both
+    // exercise the same duplicate/amplified submission behavior out of the box.
+    pub const DEFAULT_AMPLIFICATION_PROBABILITY: f64 = 0.05;
+    pub const DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX: usize = 3;
+    pub const DEFAULT_DUPLICATE_PROBABILITY: f64 = 0.02;
+    pub const DEFAULT_DUPLICATE_COPIES_PER_VALIDATOR: usize = 2;
+    pub const DEFAULT_VALIDATOR_SELECTION: ValidatorSelection = ValidatorSelection::Random;
+
+    /// Returns an enabled configuration with the default amplification/duplication values,
+    /// unlike `Default::default()` which returns a disabled (no-op) configuration.
+    pub fn default_enabled() -> Self {
+        Self {
+            amplification_probability: Self::DEFAULT_AMPLIFICATION_PROBABILITY,
+            amplification_validators_per_tx: Self::DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX,
+            duplicate_probability: Self::DEFAULT_DUPLICATE_PROBABILITY,
+            duplicate_copies_per_validator: Self::DEFAULT_DUPLICATE_COPIES_PER_VALIDATOR,
+            validator_selection: Self::DEFAULT_VALIDATOR_SELECTION,
+        }
+    }
+
     pub fn new(
         amplification_probability: f64,
         amplification_validators_per_tx: usize,

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use anyhow::bail;
 use async_trait::async_trait;
 use fullnode_reconfig_observer::FullNodeReconfigObserver;
 use futures::TryStreamExt;
@@ -58,8 +59,11 @@ use sui_types::{
     execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus},
 };
 use sui_types::{gas_coin::GAS, sui_system_state::sui_system_state_summary::SuiSystemStateSummary};
-use tokio::time::sleep;
+use tokio::task::JoinSet;
+use tokio::time::{sleep, timeout};
 use tracing::{debug, info, instrument, warn};
+
+use crate::drivers::{SubmissionAmplification, SubmissionAmplificationSample, ValidatorSelection};
 
 pub mod bank;
 
@@ -353,14 +357,18 @@ pub trait ValidatorProxy {
 
     async fn execute_transaction_block(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects>;
 
-    /// Submit a transaction to multiple validators to cause consensus amplification.
-    /// Used to test the unpaid amplification deferral logic.
-    /// Default implementation just calls execute_transaction_block.
-    async fn execute_transaction_block_with_amplification(
+    /// Submit a transaction with optional duplicate/amplified validator traffic.
+    /// Only the local validator proxy supports this direct validator submission path.
+    async fn execute_transaction_block_with_submission_amplification(
         &self,
         tx: Transaction,
-        _num_validators: usize,
+        submission_amplification: SubmissionAmplification,
     ) -> anyhow::Result<ExecutionEffects> {
+        if submission_amplification.is_enabled() {
+            bail!(
+                "duplicate/amplified validator submissions are only supported by LocalValidatorAggregatorProxy"
+            );
+        }
         self.execute_transaction_block(tx).await
     }
 
@@ -489,45 +497,100 @@ impl LocalValidatorAggregatorProxy {
         ))
     }
 
-    /// Submit a transaction to multiple validators to cause consensus amplification.
-    /// This is used to test the unpaid amplification deferral logic.
-    ///
-    /// `num_validators` specifies how many additional validators to submit to beyond
-    /// the normal submission path. For example, if `num_validators == 2`, the transaction
-    /// will be submitted to 2 validators directly, plus once via the normal driver path.
-    pub async fn submit_transaction_with_amplification(
+    async fn submit_transaction_with_submission_amplification(
         &self,
         tx: Transaction,
-        num_validators: usize,
+        submission_amplification: SubmissionAmplification,
     ) -> anyhow::Result<ExecutionEffects> {
         use sui_core::authority_client::AuthorityAPI;
-        use sui_types::messages_grpc::SubmitTxRequest;
 
-        // Submit to multiple validators in parallel
-        let validators: Vec<_> = self
-            .clients
-            .values()
-            .take(num_validators)
-            .cloned()
-            .collect();
-        let request = SubmitTxRequest::new_transaction(tx.clone());
+        const EXTRA_SUBMIT_TIMEOUT: Duration = Duration::from_secs(2);
+        const PREFERRED_VALIDATOR_LATENCY_DELTA: f64 = 0.02;
 
-        // Fire off all submissions as spawned tasks - don't wait for responses.
-        // We just need to ensure the submissions are sent to trigger amplification.
-        // Add explicit 2s timeout to prevent unbounded task pile-up under load.
-        for client in validators {
-            let req = request.clone();
-            tokio::spawn(async move {
-                let _ = tokio::time::timeout(
-                    Duration::from_secs(2),
-                    client.submit_transaction(req, None),
-                )
-                .await;
-            });
+        let sample = {
+            let mut rng = rand::thread_rng();
+            submission_amplification.sample(&mut rng)
+        };
+        if sample.total_submissions() == 1 {
+            return self.submit_transaction_block(tx).await;
         }
 
-        // Use the normal path to get the final result
-        self.submit_transaction_block(tx).await
+        let tx_digest = *tx.digest();
+        let validators = self.select_validators_for_submission_amplification(
+            sample,
+            PREFERRED_VALIDATOR_LATENCY_DELTA,
+        )?;
+        let request = SubmitTxRequest::new_transaction(tx.clone());
+        let mut additional_requests = JoinSet::new();
+
+        for (validator_name, client) in validators.iter() {
+            for _ in 0..sample.copies_per_validator {
+                let req = request.clone();
+                let client = client.clone();
+                additional_requests.spawn(async move {
+                    let _ =
+                        timeout(EXTRA_SUBMIT_TIMEOUT, client.submit_transaction(req, None)).await;
+                });
+            }
+            debug!(
+                ?tx_digest,
+                ?validator_name,
+                copies_per_validator = sample.copies_per_validator,
+                "spawned direct validator submissions for amplification"
+            );
+        }
+
+        debug!(
+            ?tx_digest,
+            ?sample,
+            "submitting transaction with extra direct validator amplification"
+        );
+
+        let result = self.submit_transaction_block(tx).await;
+        additional_requests.abort_all();
+        result
+    }
+
+    fn select_validators_for_submission_amplification(
+        &self,
+        sample: SubmissionAmplificationSample,
+        preferred_validator_latency_delta: f64,
+    ) -> anyhow::Result<Vec<(AuthorityName, NetworkAuthorityClient)>> {
+        let num_validators = sample
+            .validators_per_tx
+            .min(self.committee.num_members())
+            .min(self.clients.len());
+
+        let validator_names = match sample.validator_selection {
+            ValidatorSelection::Random => {
+                let mut rng = rand::thread_rng();
+                self.clients
+                    .keys()
+                    .copied()
+                    .choose_multiple(&mut rng, num_validators)
+            }
+            ValidatorSelection::HighestPerformance => self
+                .td
+                .select_preferred_validators(preferred_validator_latency_delta)
+                .into_iter()
+                .filter(|name| self.clients.contains_key(name))
+                .take(num_validators)
+                .collect(),
+        };
+
+        let validators = validator_names
+            .into_iter()
+            .filter_map(|name| {
+                self.clients
+                    .get(&name)
+                    .cloned()
+                    .map(|client| (name, client))
+            })
+            .collect::<Vec<_>>();
+        if validators.is_empty() {
+            bail!("No validators available for submission amplification");
+        }
+        Ok(validators)
     }
 }
 
@@ -565,12 +628,12 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
         self.submit_transaction_block(tx).await
     }
 
-    async fn execute_transaction_block_with_amplification(
+    async fn execute_transaction_block_with_submission_amplification(
         &self,
         tx: Transaction,
-        num_validators: usize,
+        submission_amplification: SubmissionAmplification,
     ) -> anyhow::Result<ExecutionEffects> {
-        self.submit_transaction_with_amplification(tx, num_validators)
+        self.submit_transaction_with_submission_amplification(tx, submission_amplification)
             .await
     }
 

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -5,7 +5,7 @@ use clap::*;
 
 use strum_macros::EnumString;
 
-use crate::drivers::{Interval, ValidatorSelection};
+use crate::drivers::{Interval, SubmissionAmplification, ValidatorSelection};
 use std::str::FromStr;
 
 #[derive(Parser)]
@@ -258,19 +258,19 @@ pub enum RunSpec {
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [5])]
         in_flight_ratio: Vec<u64>,
         // Probability that a logical transaction is submitted to multiple validators.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.05])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_PROBABILITY])]
         amplification_probability: Vec<f64>,
         // Number of validators to submit to when amplification_probability triggers.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [3])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX])]
         amplification_validators_per_tx: Vec<usize>,
         // Probability that each selected validator receives multiple copies.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.02])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_PROBABILITY])]
         duplicate_probability: Vec<f64>,
         // Number of copies sent to each selected validator when duplicate_probability triggers.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [2])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_COPIES_PER_VALIDATOR])]
         duplicate_copies_per_validator: Vec<usize>,
         // Validator selection strategy for duplicate/amplified submissions.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [ValidatorSelection::Random])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_VALIDATOR_SELECTION])]
         validator_selection: Vec<ValidatorSelection>,
 
         // Setting the duration of each benchmark. Benchmarks will run in sequence.

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -5,7 +5,7 @@ use clap::*;
 
 use strum_macros::EnumString;
 
-use crate::drivers::Interval;
+use crate::drivers::{Interval, ValidatorSelection};
 use std::str::FromStr;
 
 #[derive(Parser)]
@@ -107,7 +107,7 @@ pub struct Opts {
     pub min_tps: Option<f64>,
 }
 
-#[derive(Debug, Clone, Parser, Eq, PartialEq, EnumString)]
+#[derive(Debug, Clone, Parser, PartialEq, EnumString)]
 #[non_exhaustive]
 #[clap(rename_all = "kebab-case")]
 pub enum RunSpec {
@@ -257,6 +257,21 @@ pub enum RunSpec {
         // Max in-flight ratio
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [5])]
         in_flight_ratio: Vec<u64>,
+        // Probability that a logical transaction is submitted to multiple validators.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
+        amplification_probability: Vec<f64>,
+        // Number of validators to submit to when amplification_probability triggers.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [1])]
+        amplification_validators_per_tx: Vec<usize>,
+        // Probability that each selected validator receives multiple copies.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
+        duplicate_probability: Vec<f64>,
+        // Number of copies sent to each selected validator when duplicate_probability triggers.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [1])]
+        duplicate_copies_per_validator: Vec<usize>,
+        // Validator selection strategy for duplicate/amplified submissions.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [ValidatorSelection::Random])]
+        validator_selection: Vec<ValidatorSelection>,
 
         // Setting the duration of each benchmark. Benchmarks will run in sequence.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [Interval::from_str("unbounded").unwrap()])]

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -258,16 +258,16 @@ pub enum RunSpec {
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [5])]
         in_flight_ratio: Vec<u64>,
         // Probability that a logical transaction is submitted to multiple validators.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.05])]
         amplification_probability: Vec<f64>,
         // Number of validators to submit to when amplification_probability triggers.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [1])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [3])]
         amplification_validators_per_tx: Vec<usize>,
         // Probability that each selected validator receives multiple copies.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.02])]
         duplicate_probability: Vec<f64>,
         // Number of copies sent to each selected validator when duplicate_probability triggers.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [1])]
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [2])]
         duplicate_copies_per_validator: Vec<usize>,
         // Validator selection strategy for duplicate/amplified submissions.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [ValidatorSelection::Random])]

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -21,7 +21,7 @@ pub mod workload_configuration;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::drivers::Interval;
+use crate::drivers::{Interval, SubmissionAmplification};
 use crate::workloads::payload::Payload;
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::AccountKeyPair;
@@ -48,6 +48,7 @@ pub struct WorkloadBuilderInfo {
 pub struct WorkloadInfo {
     pub workload_params: WorkloadParams,
     pub workload: Box<dyn Workload<dyn Payload>>,
+    pub submission_amplification: SubmissionAmplification,
 }
 
 pub type Gas = (ObjectRef, SuiAddress, Arc<AccountKeyPair>);

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::bank::BenchmarkBank;
-use crate::drivers::Interval;
+use crate::drivers::{Interval, SubmissionAmplification};
 use crate::options::{Opts, RunSpec};
 use crate::system_state_observer::SystemStateObserver;
 use crate::workloads::addr_bal_deposit::{AddrBalDepositConfig, AddrBalDepositWorkloadBuilder};
@@ -13,7 +13,7 @@ use crate::workloads::shared_counter::SharedCounterWorkloadBuilder;
 use crate::workloads::slow::SlowWorkloadBuilder;
 use crate::workloads::transfer_object::TransferObjectWorkloadBuilder;
 use crate::workloads::{ExpectedFailureType, GroupID, WorkloadBuilderInfo, WorkloadInfo};
-use anyhow::Result;
+use anyhow::{Result, bail};
 use futures::future::join_all;
 use mysten_common::ZipDebugEqIteratorExt;
 use std::collections::BTreeMap;
@@ -75,6 +75,7 @@ impl WorkloadConfiguration {
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Result<BTreeMap<GroupID, Vec<WorkloadInfo>>> {
         let mut workload_builders = vec![];
+        let mut submission_amplification_by_group = BTreeMap::new();
 
         // Create the workload builders for each Run spec
         match opts.run_spec.clone() {
@@ -103,6 +104,11 @@ impl WorkloadConfiguration {
                 target_qps,
                 num_workers,
                 in_flight_ratio,
+                amplification_probability,
+                amplification_validators_per_tx,
+                duplicate_probability,
+                duplicate_copies_per_validator,
+                validator_selection,
                 duration,
                 deposit_target_address,
                 deposit_seed_sui,
@@ -116,6 +122,29 @@ impl WorkloadConfiguration {
                 // benchmark group will run in the same time for the same duration.
                 for workload_group in 0..num_of_benchmark_groups {
                     let i = workload_group as usize;
+                    let submission_amplification = SubmissionAmplification::new(
+                        amplification_probability[i],
+                        amplification_validators_per_tx[i],
+                        duplicate_probability[i],
+                        duplicate_copies_per_validator[i],
+                        validator_selection[i],
+                    )?;
+                    if opts.use_fullnode_for_execution && submission_amplification.is_enabled() {
+                        bail!(
+                            "duplicate/amplified validator submissions are only supported with local validator execution; set --use-fullnode-for-execution false"
+                        );
+                    }
+                    if submission_amplification.is_enabled() {
+                        info!(
+                            "Benchmark group {} submission amplification: {:?}, expected validator submission multiplier {:.2}",
+                            workload_group,
+                            submission_amplification,
+                            submission_amplification.expected_submission_multiplier()
+                        );
+                    }
+                    submission_amplification_by_group
+                        .insert(workload_group, submission_amplification);
+
                     let config = WorkloadConfig {
                         group: workload_group,
                         num_workers: num_workers[i],
@@ -179,6 +208,7 @@ impl WorkloadConfiguration {
                     bank,
                     system_state_observer,
                     opts.gas_request_chunk_size,
+                    submission_amplification_by_group,
                 )
                 .await
             }
@@ -190,6 +220,7 @@ impl WorkloadConfiguration {
         mut bank: BenchmarkBank,
         system_state_observer: Arc<SystemStateObserver>,
         gas_request_chunk_size: u64,
+        submission_amplification_by_group: BTreeMap<GroupID, SubmissionAmplification>,
     ) -> Result<BTreeMap<GroupID, Vec<WorkloadInfo>>> {
         // Generate the workloads and init them
         let reference_gas_price = system_state_observer.state.borrow().reference_gas_price;
@@ -221,6 +252,10 @@ impl WorkloadConfiguration {
             BTreeMap::<GroupID, Vec<WorkloadInfo>>::new(),
             |mut acc, (workload, workload_params)| {
                 let w = WorkloadInfo {
+                    submission_amplification: submission_amplification_by_group
+                        .get(&workload_params.group)
+                        .copied()
+                        .unwrap_or_default(),
                     workload,
                     workload_params,
                 };

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1286,6 +1286,7 @@ mod test {
             bank,
             system_state_observer.clone(),
             gas_request_chunk_size,
+            BTreeMap::new(),
         )
         .await
         .unwrap();
@@ -1933,6 +1934,7 @@ mod test {
             bank,
             system_state_observer.clone(),
             100,
+            BTreeMap::new(),
         )
         .await
         .unwrap();

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -27,7 +27,7 @@ mod test {
     };
     use sui_benchmark::{
         FullNodeProxy, LocalValidatorAggregatorProxy, ValidatorProxy,
-        drivers::{Interval, bench_driver::BenchDriver, driver::Driver},
+        drivers::{Interval, SubmissionAmplification, bench_driver::BenchDriver, driver::Driver},
         util::get_ed25519_keypair_from_keystore,
     };
     use sui_config::ExecutionCacheConfig;
@@ -1281,12 +1281,20 @@ mod test {
         )
         .await;
 
+        // Duplicate/amplified validator submissions are only supported by the
+        // LocalValidatorAggregatorProxy, which is used when remote_env is false.
+        let submission_amplification_by_group = if config.remote_env {
+            BTreeMap::new()
+        } else {
+            BTreeMap::from([(0, SubmissionAmplification::default_enabled())])
+        };
+
         let workloads = WorkloadConfiguration::build(
             workloads_builders,
             bank,
             system_state_observer.clone(),
             gas_request_chunk_size,
-            BTreeMap::new(),
+            submission_amplification_by_group,
         )
         .await
         .unwrap();

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -27,6 +27,7 @@ use parking_lot::Mutex;
 use rand::Rng;
 use sui_config::NodeConfig;
 use sui_types::{
+    base_types::AuthorityName,
     committee::EpochId,
     error::{ErrorCategory, UserInputError},
     messages_grpc::{SubmitTxRequest, SubmitTxResult, TxType},
@@ -139,6 +140,12 @@ where
     /// Returns the authority aggregator wrapper which upgrades on epoch changes.
     pub fn authority_aggregator(&self) -> &Arc<ArcSwap<AuthorityAggregator<A>>> {
         &self.authority_aggregator
+    }
+
+    pub fn select_preferred_validators(&self, delta: f64) -> Vec<AuthorityName> {
+        let authority_aggregator = self.authority_aggregator.load();
+        self.client_monitor
+            .select_shuffled_preferred_validators(&authority_aggregator.committee, delta)
     }
 
     /// Drives transaction to finalization.


### PR DESCRIPTION
## Description 

Stress nodes, given a desired configuration, can now send:
* same duplicate transaction(s) to the same node
* amplified transaction copies across multiple nodes
* the combination of above two


## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
