### PR TITLE
indexer-alt: group pipelines into ingestion cohorts by distance from tip

### DIFF
--- a/crates/sui-analytics-indexer/src/config.rs
+++ b/crates/sui-analytics-indexer/src/config.rs
@@ -133,6 +133,7 @@ pub struct IngestionLayer {
     pub streaming_backoff_max_batch_size: Option<usize>,
     pub streaming_connection_timeout_ms: Option<u64>,
     pub streaming_statement_timeout_ms: Option<u64>,
+    pub min_cohort_boundary: Option<u64>,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber_channel_size`.
@@ -165,6 +166,7 @@ impl IngestionLayer {
             streaming_statement_timeout_ms: self
                 .streaming_statement_timeout_ms
                 .unwrap_or(base.streaming_statement_timeout_ms),
+            min_cohort_boundary: self.min_cohort_boundary.unwrap_or(base.min_cohort_boundary),
         }
     }
 }

--- a/crates/sui-checkpoint-blob-indexer/src/config.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/config.rs
@@ -118,6 +118,7 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
+    pub min_cohort_boundary: u64,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -139,6 +140,7 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            min_cohort_boundary: config.min_cohort_boundary,
             checkpoint_buffer_size: None,
         }
     }
@@ -161,6 +163,7 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            min_cohort_boundary: config.min_cohort_boundary,
         }
     }
 }

--- a/crates/sui-core/src/rpc_store_embed.rs
+++ b/crates/sui-core/src/rpc_store_embed.rs
@@ -44,7 +44,7 @@ use sui_consistent_store::metrics::ColumnFamilyStatsCollector;
 use sui_consistent_store::restore::RestoreDriverConfig;
 use sui_consistent_store::restore::metrics::RestoreMetrics;
 use sui_indexer_alt_framework::IndexerArgs;
-use sui_indexer_alt_framework::ingestion::BoxedStreamingClient;
+use sui_indexer_alt_framework::ingestion::ArcStreamingClient;
 use sui_indexer_alt_framework::ingestion::IngestionConfig;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClient;
 use sui_indexer_alt_framework::metrics::IngestionMetrics;
@@ -529,12 +529,12 @@ async fn build_indexer(
     // reads the current tip from the same local store the ingestion
     // client uses (so the framework's `peek()` resolves immediately even
     // on an idle chain), and the ingestion client backfills any gap.
-    let streaming_client: Option<BoxedStreamingClient> = checkpoint_sender.map(|sender| {
-        Box::new(BroadcastStreamingClient::new(
+    let streaming_client: Option<ArcStreamingClient> = checkpoint_sender.map(|sender| {
+        Arc::new(BroadcastStreamingClient::new(
             sender,
             chain_id,
             ingestion_source,
-        )) as BoxedStreamingClient
+        )) as ArcStreamingClient
     });
 
     let mut indexer = Indexer::from_store(

--- a/crates/sui-core/src/rpc_store_streaming_client.rs
+++ b/crates/sui-core/src/rpc_store_streaming_client.rs
@@ -94,7 +94,7 @@ impl<R: ReadStore> BroadcastStreamingClient<R> {
 impl<R: ReadStore + Send + Sync + 'static> CheckpointStreamingClient
     for BroadcastStreamingClient<R>
 {
-    async fn connect(&mut self) -> Result<CheckpointStream, Error> {
+    async fn connect(&self) -> Result<CheckpointStream, Error> {
         // Subscribe before reading the tip so no checkpoint published between
         // the two is missed (the broadcast only carries checkpoints published
         // after `subscribe`).
@@ -131,7 +131,7 @@ impl<R: ReadStore + Send + Sync + 'static> CheckpointStreamingClient
         })
     }
 
-    async fn latest_checkpoint_number(&mut self) -> Result<u64, Error> {
+    async fn latest_checkpoint_number(&self) -> Result<u64, Error> {
         // Read the local store directly; the default trait impl peeks the
         // stream, which blocks on an idle chain (see `connect`).
         self.store
@@ -151,7 +151,7 @@ mod tests {
     async fn seeds_tip_then_streams_published_checkpoints_in_order() {
         let (sender, _keep) = broadcast::channel(16);
         // The local store is at checkpoint 5; the broadcast then publishes 6, 7.
-        let mut client =
+        let client =
             BroadcastStreamingClient::new(sender.clone(), test_chain_id(), store_with([5]));
 
         let mut connected = client.connect().await.unwrap();
@@ -172,8 +172,7 @@ mod tests {
     #[tokio::test]
     async fn latest_checkpoint_number_reads_the_local_tip() {
         let (sender, _keep) = broadcast::channel(16);
-        let mut client =
-            BroadcastStreamingClient::new(sender, test_chain_id(), store_with([0, 4, 9]));
+        let client = BroadcastStreamingClient::new(sender, test_chain_id(), store_with([0, 4, 9]));
         assert_eq!(client.latest_checkpoint_number().await.unwrap(), 9);
     }
 
@@ -183,7 +182,7 @@ mod tests {
         // oldest, so the first live read observes `Lagged`.
         let (sender, _keep) = broadcast::channel(2);
         // Tip 9 is distinct from the published 0..4 so we can tell them apart.
-        let mut client =
+        let client =
             BroadcastStreamingClient::new(sender.clone(), test_chain_id(), store_with([9]));
         let mut connected = client.connect().await.unwrap();
 
@@ -206,7 +205,7 @@ mod tests {
     #[tokio::test]
     async fn stream_ends_when_all_senders_dropped() {
         let (sender, _initial_rx) = broadcast::channel(16);
-        let mut client =
+        let client =
             BroadcastStreamingClient::new(sender.clone(), test_chain_id(), store_with([5]));
         let mut connected = client.connect().await.unwrap();
 

--- a/crates/sui-core/src/rpc_store_test_utils.rs
+++ b/crates/sui-core/src/rpc_store_test_utils.rs
@@ -48,6 +48,7 @@ pub(crate) fn checkpoint(sequence_number: u64) -> Arc<Checkpoint> {
 /// checkpoints. Only the methods the ingestion / streaming clients
 /// exercise are implemented; the rest panic so a future change that
 /// starts relying on them is caught loudly.
+#[derive(Clone)]
 pub(crate) struct MockReadStore {
     pub(crate) checkpoints: BTreeMap<CheckpointSequenceNumber, Checkpoint>,
     /// When set, `get_checkpoint_contents_by_digest` returns `None` for

--- a/crates/sui-indexer-alt-consistent-store/src/config.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/config.rs
@@ -46,6 +46,7 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
+    pub min_cohort_boundary: u64,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -154,6 +155,7 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            min_cohort_boundary: config.min_cohort_boundary,
             checkpoint_buffer_size: None,
         }
     }
@@ -176,6 +178,7 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            min_cohort_boundary: config.min_cohort_boundary,
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -378,7 +378,13 @@ mod tests {
         assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 10);
         // 10 checkpoints, 2 user transactions + 1 settlement transaction per checkpoint
         assert_eq!(ingestion_metrics.total_ingested_transactions.get(), 30);
-        assert_eq!(ingestion_metrics.latest_ingested_checkpoint.get(), 9);
+        assert_eq!(
+            ingestion_metrics
+                .latest_ingested_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            9
+        );
 
         macro_rules! assert_pipeline_metric {
             ($name:ident, $value:expr) => {

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -375,9 +375,21 @@ mod tests {
         }
 
         // Check that ingestion metrics were updated.
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 10);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            10
+        );
         // 10 checkpoints, 2 user transactions + 1 settlement transaction per checkpoint
-        assert_eq!(ingestion_metrics.total_ingested_transactions.get(), 30);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_transactions
+                .with_label_values(&["0"])
+                .get(),
+            30
+        );
         assert_eq!(
             ingestion_metrics
                 .latest_ingested_checkpoint

--- a/crates/sui-indexer-alt-framework/src/cohort.rs
+++ b/crates/sui-indexer-alt-framework/src/cohort.rs
@@ -1,0 +1,187 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Grouping of pipelines into ingestion cohorts based on how far behind the network tip each
+//! pipeline's resume checkpoint is. Pipelines in the same cohort share one ingestion service, so
+//! a far-behind pipeline only applies backpressure to similarly-lagging peers, not to pipelines
+//! that are already at the tip.
+
+use crate::PendingPipeline;
+
+/// Default for [`IngestionConfig::min_cohort_boundary`]: a cohort's boundary (its maximum member
+/// distance from the tip) is at least this many checkpoints, so that pipelines that are roughly
+/// caught up are not fragmented into many tiny cohorts, each with its own ingestion service.
+///
+/// [`IngestionConfig::min_cohort_boundary`]: crate::ingestion::IngestionConfig::min_cohort_boundary
+pub(crate) const DEFAULT_MIN_COHORT_BOUNDARY: u64 = 25_000;
+
+/// Group pipelines into cohorts by their distance from the network tip.
+///
+/// Each pipeline's distance is how far behind `latest_checkpoint` it will resume from. `pipelines`
+/// may be in any order; they are sorted (nearest-tip first) internally. The closest unassigned
+/// pipeline (distance `d`) seeds a cohort that absorbs every pipeline whose distance is at most
+/// `max(2 * d, min_cohort_boundary)`; the next unassigned pipeline seeds the next cohort, and so
+/// on.
+///
+/// Returns the cohorts ordered nearest-tip first, each holding its members in ascending distance
+/// order (pipelines at equal distances keep registration order).
+pub(crate) fn cohorts(
+    mut pipelines: Vec<PendingPipeline>,
+    latest_checkpoint: u64,
+    min_cohort_boundary: u64,
+) -> Vec<Vec<PendingPipeline>> {
+    // Stable sort: pipelines at equal distances keep registration order.
+    pipelines.sort_by_key(|p| latest_checkpoint.saturating_sub(p.next_checkpoint));
+
+    // The closest unassigned pipeline seeds a cohort that absorbs every peer within
+    // `max(2 * its distance, min_cohort_boundary)`; the first pipeline beyond that boundary seeds
+    // the next cohort, and so on.
+    let mut cohorts: Vec<Vec<PendingPipeline>> = vec![];
+    let mut boundary = None;
+    for pipeline in pipelines {
+        let dist = latest_checkpoint.saturating_sub(pipeline.next_checkpoint);
+        if boundary.is_none_or(|b| dist > b) {
+            cohorts.push(vec![]);
+            boundary = Some(dist.saturating_mul(2).max(min_cohort_boundary));
+        }
+        cohorts.last_mut().unwrap().push(pipeline);
+    }
+    cohorts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pipeline resuming exactly `distance` checkpoints behind the tip. Tests fix the tip at
+    /// `u64::MAX` so scenarios can be written directly in distances and the overflow case is
+    /// reachable.
+    fn at(distance: u64) -> PendingPipeline {
+        PendingPipeline {
+            name: "test",
+            next_checkpoint: u64::MAX - distance,
+            build: Box::new(|_| unreachable!("cohort grouping never builds pipelines")),
+        }
+    }
+
+    /// Group `pipelines` (tip at `u64::MAX`) and read each cohort back out as member distances.
+    fn grouped(pipelines: Vec<PendingPipeline>, min_cohort_boundary: u64) -> Vec<Vec<u64>> {
+        cohorts(pipelines, u64::MAX, min_cohort_boundary)
+            .iter()
+            .map(|cohort| {
+                cohort
+                    .iter()
+                    .map(|p| u64::MAX - p.next_checkpoint)
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_empty() {
+        assert_eq!(
+            grouped(vec![], DEFAULT_MIN_COHORT_BOUNDARY),
+            Vec::<Vec<u64>>::new()
+        );
+    }
+
+    #[test]
+    fn test_singleton() {
+        assert_eq!(
+            grouped(vec![at(0)], DEFAULT_MIN_COHORT_BOUNDARY),
+            vec![vec![0]]
+        );
+    }
+
+    #[test]
+    fn test_all_equal_distances() {
+        assert_eq!(
+            grouped(vec![at(42), at(42), at(42)], DEFAULT_MIN_COHORT_BOUNDARY),
+            vec![vec![42, 42, 42]]
+        );
+    }
+
+    /// Input may be given in any order; cohorts and their members come back nearest-tip first.
+    #[test]
+    fn test_sorts_unsorted_input() {
+        assert_eq!(
+            grouped(
+                vec![at(200_000), at(10), at(70_000), at(30_000)],
+                DEFAULT_MIN_COHORT_BOUNDARY
+            ),
+            vec![vec![10], vec![30_000], vec![70_000], vec![200_000]],
+        );
+    }
+
+    /// The minimum boundary is inclusive: a seed at the tip absorbs pipelines exactly
+    /// `min_cohort_boundary` away, but not one checkpoint further.
+    #[test]
+    fn test_min_boundary_inclusive() {
+        assert_eq!(
+            grouped(
+                vec![
+                    at(0),
+                    at(DEFAULT_MIN_COHORT_BOUNDARY),
+                    at(DEFAULT_MIN_COHORT_BOUNDARY + 1)
+                ],
+                DEFAULT_MIN_COHORT_BOUNDARY,
+            ),
+            vec![
+                vec![0, DEFAULT_MIN_COHORT_BOUNDARY],
+                vec![DEFAULT_MIN_COHORT_BOUNDARY + 1]
+            ],
+        );
+    }
+
+    /// Once the seed is further out than half the minimum boundary, twice its distance takes
+    /// over as the cohort boundary.
+    #[test]
+    fn test_double_seed_distance_boundary() {
+        assert_eq!(
+            grouped(
+                vec![at(20_000), at(40_000), at(40_001)],
+                DEFAULT_MIN_COHORT_BOUNDARY
+            ),
+            vec![vec![20_000, 40_000], vec![40_001]]
+        );
+    }
+
+    /// Each cohort's boundary is derived from its own seed, not the previous cohort's.
+    #[test]
+    fn test_chained_reseeding() {
+        assert_eq!(
+            grouped(
+                vec![at(10), at(30_000), at(70_000), at(200_000)],
+                DEFAULT_MIN_COHORT_BOUNDARY
+            ),
+            vec![vec![10], vec![30_000], vec![70_000], vec![200_000]],
+        );
+    }
+
+    /// Doubling an enormous seed distance saturates instead of overflowing.
+    #[test]
+    fn test_distance_overflow_saturates() {
+        assert_eq!(
+            grouped(
+                vec![at(25_000), at(u64::MAX - 1), at(u64::MAX)],
+                DEFAULT_MIN_COHORT_BOUNDARY
+            ),
+            vec![vec![25_000], vec![u64::MAX - 1, u64::MAX]],
+        );
+    }
+
+    /// A custom (non-default) boundary is honored: with a boundary of 100 a seed at the tip
+    /// absorbs a peer 100 away but not one at 101 — whereas the default boundary would have put
+    /// all three in one cohort.
+    #[test]
+    fn test_custom_boundary() {
+        assert_eq!(
+            grouped(vec![at(0), at(100), at(101)], 100),
+            vec![vec![0, 100], vec![101]]
+        );
+        assert_eq!(
+            grouped(vec![at(0), at(100), at(101)], DEFAULT_MIN_COHORT_BOUNDARY),
+            vec![vec![0, 100, 101]]
+        );
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -27,7 +27,7 @@ use crate::ingestion::error::Error;
 use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::ingestion::ingestion_client::IngestionClient;
 use crate::ingestion::streaming_client::CheckpointStream;
-use crate::metrics::IngestionMetrics;
+use crate::metrics::CohortMetrics;
 
 /// If the network's latest checkpoint (per the streaming client) is more than this many
 /// checkpoints ahead of where ingestion currently is, skip streaming and let the ingestion
@@ -54,14 +54,14 @@ pub(super) fn broadcaster<R>(
     config: IngestionConfig,
     client: IngestionClient,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
-    metrics: Arc<IngestionMetrics>,
-    cohort: usize,
 ) -> Service
 where
     R: std::ops::RangeBounds<u64> + Send + 'static,
 {
     Service::new().spawn_aborting(async move {
         info!("Starting broadcaster");
+
+        let cohort_metrics = client.cohort_metrics().clone();
 
         // Extract start and end from the range bounds
         let start_cp = match checkpoints.start_bound() {
@@ -104,8 +104,7 @@ where
                 &mut streaming_backoff_batch_size,
                 &config,
                 &subscribers,
-                &metrics,
-                cohort,
+                &cohort_metrics,
             )
             .await;
 
@@ -118,8 +117,7 @@ where
                 config.ingest_concurrency.clone(),
                 client.clone(),
                 subscribers.clone(),
-                metrics.clone(),
-                cohort,
+                cohort_metrics.clone(),
             );
 
             let (streaming_result, ingestion_result) =
@@ -165,17 +163,11 @@ fn ingest_and_broadcast_range(
     ingest_concurrency: ConcurrencyConfig,
     client: IngestionClient,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
-    metrics: Arc<IngestionMetrics>,
-    cohort: usize,
+    cohort_metrics: Arc<CohortMetrics>,
 ) -> TaskGuard<Result<(), Break<Error>>> {
     TaskGuard::new(tokio::spawn(async move {
-        let cohort = cohort.to_string();
-        let concurrency_limit = metrics
-            .ingestion_concurrency_limit
-            .with_label_values(&[cohort.as_str()]);
-        let concurrency_inflight = metrics
-            .ingestion_concurrency_inflight
-            .with_label_values(&[cohort.as_str()]);
+        let concurrency_limit = cohort_metrics.ingestion_concurrency_limit.clone();
+        let concurrency_inflight = cohort_metrics.ingestion_concurrency_inflight.clone();
         futures::stream::iter(start..end)
             .try_for_each_broadcast_spawned(
                 ingest_concurrency.into(),
@@ -208,8 +200,7 @@ async fn setup_streaming_task(
     streaming_backoff_batch_size: &mut u64,
     config: &IngestionConfig,
     subscribers: &[mpsc::Sender<Arc<CheckpointEnvelope>>],
-    metrics: &Arc<IngestionMetrics>,
-    cohort: usize,
+    cohort_metrics: &Arc<CohortMetrics>,
 ) -> (TaskGuard<u64>, u64) {
     // No streaming client configured so we ingest all the way to end_cp.
     let Some(streaming_client) = streaming_client else {
@@ -218,6 +209,8 @@ async fn setup_streaming_task(
 
     let backoff_batch_size = *streaming_backoff_batch_size;
 
+    let connection_failures = cohort_metrics.total_streaming_connection_failures.clone();
+
     // Convenient closure to handle streaming fallback logic due to connection or peek failure.
     let mut fallback = |reason: &str| {
         let ingestion_end = (checkpoint_hi + backoff_batch_size).min(end_cp);
@@ -225,7 +218,7 @@ async fn setup_streaming_task(
             checkpoint_hi,
             ingestion_end, "{reason}, falling back to ingestion"
         );
-        metrics.total_streaming_connection_failures.inc();
+        connection_failures.inc();
         *streaming_backoff_batch_size =
             (backoff_batch_size * 2).min(config.streaming_backoff_max_batch_size as u64);
         (noop_streaming_task(ingestion_end), ingestion_end)
@@ -283,8 +276,7 @@ async fn setup_streaming_task(
         end_cp,
         envelope_stream,
         subscribers.to_vec(),
-        metrics.clone(),
-        cohort,
+        cohort_metrics.clone(),
     )));
 
     (stream_guard, ingestion_end)
@@ -300,16 +292,16 @@ async fn stream_and_broadcast_range(
     hi: u64,
     mut stream: impl Stream<Item = Result<CheckpointEnvelope, Error>> + Unpin,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
-    metrics: Arc<IngestionMetrics>,
-    cohort: usize,
+    cohort_metrics: Arc<CohortMetrics>,
 ) -> u64 {
-    let cohort = cohort.to_string();
-    let latest_streamed = metrics
-        .latest_streamed_checkpoint
-        .with_label_values(&[cohort.as_str()]);
-    let latest_skipped = metrics
-        .latest_skipped_streamed_checkpoint
-        .with_label_values(&[cohort.as_str()]);
+    let latest_streamed = cohort_metrics.latest_streamed_checkpoint.clone();
+    let latest_skipped = cohort_metrics.latest_skipped_streamed_checkpoint.clone();
+    let skipped_streamed = cohort_metrics.total_skipped_streamed_checkpoints.clone();
+    let out_of_order_streamed = cohort_metrics
+        .total_out_of_order_streamed_checkpoints
+        .clone();
+    let streamed = cohort_metrics.total_streamed_checkpoints.clone();
+    let stream_disconnections = cohort_metrics.total_stream_disconnections.clone();
     while lo < hi {
         let Some(item) = stream.next().await else {
             warn!(lo, "Streaming ended unexpectedly");
@@ -331,14 +323,14 @@ async fn stream_and_broadcast_range(
                 checkpoint = sequence_number,
                 lo, "Skipping already processed checkpoint"
             );
-            metrics.total_skipped_streamed_checkpoints.inc();
+            skipped_streamed.inc();
             latest_skipped.set(sequence_number as i64);
             continue;
         }
 
         if sequence_number > lo {
             warn!(checkpoint = sequence_number, lo, "Out-of-order checkpoint");
-            metrics.total_out_of_order_streamed_checkpoints.inc();
+            out_of_order_streamed.inc();
             // Return to main loop to fill up the gap.
             break;
         }
@@ -353,14 +345,14 @@ async fn stream_and_broadcast_range(
         }
 
         debug!(checkpoint = lo, "Streamed checkpoint");
-        metrics.total_streamed_checkpoints.inc();
+        streamed.inc();
         latest_streamed.set(lo as i64);
         lo += 1;
     }
 
     // We exit the loop either due to cancellation, error or completion of the range,
     // in all cases we disconnect the stream and return the current watermark.
-    metrics.total_stream_disconnections.inc();
+    stream_disconnections.inc();
     lo
 }
 
@@ -395,6 +387,7 @@ mod tests {
     use crate::ingestion::IngestionConfig;
     use crate::ingestion::ingestion_client::tests::MockIngestionClient;
     use crate::ingestion::streaming_client::test_utils::MockStreamingClient;
+    use crate::metrics::IngestionMetrics;
     use crate::metrics::tests::test_ingestion_metrics;
 
     use super::*;
@@ -411,7 +404,9 @@ mod tests {
     ) -> IngestionClient {
         let mock = MockIngestionClient::default();
         mock.insert_checkpoints(checkpoints);
-        IngestionClient::from_trait(Arc::new(mock), metrics)
+        // Bind to cohort 0, matching production where the broadcaster always runs under a cohort's
+        // client rather than the unlabeled base client.
+        IngestionClient::from_trait(Arc::new(mock), metrics).for_cohort(0)
     }
 
     /// Create a test config
@@ -502,8 +497,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
-            metrics,
-            0,
         );
 
         assert_eq!(
@@ -525,8 +518,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics,
-            0,
         );
 
         assert_eq!(
@@ -549,8 +540,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics,
-            0,
         );
 
         assert_eq!(
@@ -576,8 +565,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscribers,
-            metrics,
-            0,
         );
 
         // Both subscribers should receive checkpoints
@@ -615,16 +602,26 @@ mod tests {
             test_config(),
             mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should receive all checkpoints from the stream in order
         assert_eq!(recv_vec(&mut subscriber_rx, 5).await, Vec::from_iter(0..5));
 
         // We should get all checkpoints from streaming.
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 5);
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
         assert_eq!(
             metrics
                 .latest_streamed_checkpoint
@@ -651,8 +648,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..60, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         assert_eq!(
@@ -663,8 +658,20 @@ mod tests {
         // Verify both ingestion and streaming were used. The exact split depends on the
         // peek'd network_latest (49) and STREAMING_CATCHUP_THRESHOLD: streaming begins at
         // the peek'd checkpoint, ingestion fills in below it.
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 49); // [0..49)
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 11); // [49..60)
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            49
+        ); // [0..49)
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            11
+        ); // [49..60)
         assert_eq!(
             metrics
                 .latest_streamed_checkpoint
@@ -693,8 +700,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..30, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should use only ingestion since streaming is beyond end_cp
@@ -704,8 +709,20 @@ mod tests {
         );
 
         // Verify no streaming was used (all from ingestion)
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 0);
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 30);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            30
+        );
 
         svc.join().await.unwrap();
     }
@@ -725,8 +742,6 @@ mod tests {
             test_config(),
             mock_client_with_range(30..100, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         assert_eq!(
@@ -735,8 +750,20 @@ mod tests {
         );
 
         // Verify only streaming was used (all from streaming)
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 70);
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            70
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
         assert_eq!(
             metrics
                 .latest_streamed_checkpoint
@@ -744,7 +771,13 @@ mod tests {
                 .get(),
             99
         );
-        assert_eq!(metrics.total_skipped_streamed_checkpoints.get(), 30);
+        assert_eq!(
+            metrics
+                .total_skipped_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            30
+        );
         assert_eq!(
             metrics
                 .latest_skipped_streamed_checkpoint
@@ -776,8 +809,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should receive all checkpoints exactly once (no duplicates) from streaming.
@@ -786,8 +817,20 @@ mod tests {
             Vec::from_iter(0..20)
         );
 
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 20);
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            20
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
         assert_eq!(
             metrics
                 .latest_streamed_checkpoint
@@ -795,7 +838,13 @@ mod tests {
                 .get(),
             19
         );
-        assert_eq!(metrics.total_skipped_streamed_checkpoints.get(), 2);
+        assert_eq!(
+            metrics
+                .total_skipped_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            2
+        );
         assert_eq!(
             metrics
                 .latest_skipped_streamed_checkpoint
@@ -824,8 +873,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..10, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should receive first three checkpoints from streaming in order
@@ -838,8 +885,20 @@ mod tests {
             BTreeSet::from_iter(3..10)
         );
 
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 6);
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 4);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            6
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            4
+        );
         assert_eq!(
             metrics
                 .latest_streamed_checkpoint
@@ -847,7 +906,13 @@ mod tests {
                 .get(),
             9
         );
-        assert_eq!(metrics.total_out_of_order_streamed_checkpoints.get(), 1);
+        assert_eq!(
+            metrics
+                .total_out_of_order_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
 
         svc.join().await.unwrap();
     }
@@ -870,8 +935,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should receive first 5 checkpoints from streaming in order
@@ -884,9 +947,21 @@ mod tests {
         );
 
         // Verify streaming was used initially
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 10);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            10
+        );
         // Then ingestion was used to recover the missing checkpoints.
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
         // The last checkpoint should come from streaming after recovery.
         assert_eq!(
             metrics
@@ -917,8 +992,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should eventually receive all checkpoints despite errors from streaming.
@@ -927,7 +1000,13 @@ mod tests {
             Vec::from_iter(0..20)
         );
 
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 20);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            20
+        );
         assert_eq!(
             metrics
                 .latest_streamed_checkpoint
@@ -935,8 +1014,20 @@ mod tests {
                 .get(),
             19
         );
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
-        assert_eq!(metrics.total_stream_disconnections.get(), 3); // 2 errors + 1 completion
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .total_stream_disconnections
+                .with_label_values(&["0"])
+                .get(),
+            3
+        ); // 2 errors + 1 completion
 
         svc.join().await.unwrap();
     }
@@ -958,8 +1049,6 @@ mod tests {
             },
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should fallback to ingestion for initial batch size checkpoints
@@ -974,8 +1063,20 @@ mod tests {
             Vec::from_iter(5..20)
         );
 
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 15);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            15
+        );
 
         svc.join().await.unwrap();
     }
@@ -999,8 +1100,6 @@ mod tests {
             },
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should fallback to ingestion for first 10 checkpoints
@@ -1016,8 +1115,20 @@ mod tests {
         );
 
         // Verify both were used
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 15);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            15
+        );
 
         svc.join().await.unwrap();
     }
@@ -1037,8 +1148,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should fallback to ingestion for all checkpoints
@@ -1048,11 +1157,29 @@ mod tests {
         );
 
         // Verify failure counter incremented 6 times with batche sizes 2 -> 4 -> 8 -> 16 -> 16 -> 4 (completing the last 4).
-        assert_eq!(metrics.total_streaming_connection_failures.get(), 6);
+        assert_eq!(
+            metrics
+                .total_streaming_connection_failures
+                .with_label_values(&["0"])
+                .get(),
+            6
+        );
 
         // Verify only ingestion was used (streaming never succeeded)
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 50);
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 0);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            50
+        );
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
 
         svc.join().await.unwrap();
     }
@@ -1074,8 +1201,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should fallback to ingestion for first 2 + 4 + 8 + 16 = 30 checkpoints
@@ -1103,11 +1228,29 @@ mod tests {
         );
 
         // Verify failure counter incremented 5 times
-        assert_eq!(metrics.total_streaming_connection_failures.get(), 5);
+        assert_eq!(
+            metrics
+                .total_streaming_connection_failures
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
 
         // Ingestion was used for 2 + 4 + 8 + 16 + 2 = 32 checkpoints
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 32);
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 18);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            32
+        );
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            18
+        );
 
         svc.join().await.unwrap();
     }
@@ -1133,8 +1276,6 @@ mod tests {
             config,
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should fallback to ingestion for initial batch size checkpoints
@@ -1149,9 +1290,27 @@ mod tests {
             Vec::from_iter(5..20)
         );
 
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 15);
-        assert_eq!(metrics.total_streaming_connection_failures.get(), 1);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            15
+        );
+        assert_eq!(
+            metrics
+                .total_streaming_connection_failures
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
 
         svc.join().await.unwrap();
     }
@@ -1177,8 +1336,6 @@ mod tests {
             config,
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should fallback to ingestion for first batch
@@ -1194,8 +1351,20 @@ mod tests {
         );
 
         // Verify both were used
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 15);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            15
+        );
 
         svc.join().await.unwrap();
     }
@@ -1216,8 +1385,6 @@ mod tests {
             test_config(),
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
-            metrics.clone(),
-            0,
         );
 
         // Should receive first 5 checkpoints from streaming in order
@@ -1230,9 +1397,21 @@ mod tests {
         );
 
         // Verify streaming was used initially and later recovered
-        assert_eq!(metrics.total_streamed_checkpoints.get(), 10);
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            10
+        );
         // Then ingestion was used to recover the missing checkpoints
-        assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            5
+        );
         // The last checkpoint should come from streaming after recovery
         assert_eq!(
             metrics

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -391,6 +391,7 @@ mod tests {
 
     use tokio::time::timeout;
 
+    use crate::cohort::DEFAULT_MIN_COHORT_BOUNDARY;
     use crate::ingestion::IngestionConfig;
     use crate::ingestion::ingestion_client::tests::MockIngestionClient;
     use crate::ingestion::streaming_client::test_utils::MockStreamingClient;
@@ -422,6 +423,7 @@ mod tests {
             streaming_backoff_max_batch_size: 16,
             streaming_connection_timeout_ms: 100,
             streaming_statement_timeout_ms: 100,
+            min_cohort_boundary: DEFAULT_MIN_COHORT_BOUNDARY,
         }
     }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -21,7 +21,7 @@ use tracing::info;
 use tracing::warn;
 
 use crate::config::ConcurrencyConfig;
-use crate::ingestion::BoxedStreamingClient;
+use crate::ingestion::ArcStreamingClient;
 use crate::ingestion::IngestionConfig;
 use crate::ingestion::error::Error;
 use crate::ingestion::ingestion_client::CheckpointEnvelope;
@@ -50,7 +50,7 @@ const STREAMING_CATCHUP_THRESHOLD: u64 = 1_000;
 /// ingest concurrency. The task will shut down if the `checkpoints` range completes.
 pub(super) fn broadcaster<R>(
     checkpoints: R,
-    mut streaming_client: Option<BoxedStreamingClient>,
+    streaming_client: Option<ArcStreamingClient>,
     config: IngestionConfig,
     client: IngestionClient,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
@@ -97,7 +97,7 @@ where
             // The ingestion task fill up the gap from checkpoint_hi to ingestion_end (exclusive) while the streaming
             // task covers from ingestion_end to end_cp.
             let (stream_guard, ingestion_end) = setup_streaming_task(
-                &mut streaming_client,
+                &streaming_client,
                 checkpoint_hi,
                 end_cp,
                 &mut streaming_backoff_batch_size,
@@ -196,7 +196,7 @@ fn ingest_and_broadcast_range(
 /// the current checkpoint_hi, and returns a streaming task handle and the `ingestion_end`
 /// telling the main task that ingestion should be used up to this point.
 async fn setup_streaming_task(
-    streaming_client: &mut Option<BoxedStreamingClient>,
+    streaming_client: &Option<ArcStreamingClient>,
     checkpoint_hi: u64,
     end_cp: u64,
     streaming_backoff_batch_size: &mut u64,
@@ -591,7 +591,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..5, // Bounded range
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
@@ -620,7 +620,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..60,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..60, metrics.clone()),
             subscriber_dest,
@@ -655,7 +655,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..30,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..30, metrics.clone()),
             subscriber_dest,
@@ -686,7 +686,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             30..100,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(30..100, metrics.clone()),
             subscriber_dest,
@@ -724,7 +724,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
@@ -759,7 +759,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..10,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..10, metrics.clone()),
             subscriber_dest,
@@ -798,7 +798,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..15,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
@@ -838,7 +838,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
@@ -869,7 +869,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            Some(Box::new(streaming_service) as BoxedStreamingClient),
+            Some(Arc::new(streaming_service)),
             IngestionConfig {
                 streaming_backoff_initial_batch_size: non_zero(5),
                 ..test_config()
@@ -909,7 +909,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             IngestionConfig {
                 streaming_backoff_initial_batch_size: non_zero(5),
                 ..test_config()
@@ -949,7 +949,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..50,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
@@ -985,7 +985,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..50,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
@@ -1043,7 +1043,7 @@ mod tests {
         };
         let mut svc = broadcaster(
             0..20,
-            Some(Box::new(streaming_service) as BoxedStreamingClient),
+            Some(Arc::new(streaming_service)),
             config,
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
@@ -1086,7 +1086,7 @@ mod tests {
         };
         let mut svc = broadcaster(
             0..20,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             config,
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
@@ -1124,7 +1124,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..15,
-            Some(Box::new(streaming_client) as BoxedStreamingClient),
+            Some(Arc::new(streaming_client)),
             test_config(),
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -55,6 +55,7 @@ pub(super) fn broadcaster<R>(
     client: IngestionClient,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
     metrics: Arc<IngestionMetrics>,
+    cohort: usize,
 ) -> Service
 where
     R: std::ops::RangeBounds<u64> + Send + 'static,
@@ -104,6 +105,7 @@ where
                 &config,
                 &subscribers,
                 &metrics,
+                cohort,
             )
             .await;
 
@@ -117,6 +119,7 @@ where
                 client.clone(),
                 subscribers.clone(),
                 metrics.clone(),
+                cohort,
             );
 
             let (streaming_result, ingestion_result) =
@@ -163,9 +166,16 @@ fn ingest_and_broadcast_range(
     client: IngestionClient,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
     metrics: Arc<IngestionMetrics>,
+    cohort: usize,
 ) -> TaskGuard<Result<(), Break<Error>>> {
     TaskGuard::new(tokio::spawn(async move {
-        let report_metrics = metrics.clone();
+        let cohort = cohort.to_string();
+        let concurrency_limit = metrics
+            .ingestion_concurrency_limit
+            .with_label_values(&[cohort.as_str()]);
+        let concurrency_inflight = metrics
+            .ingestion_concurrency_inflight
+            .with_label_values(&[cohort.as_str()]);
         futures::stream::iter(start..end)
             .try_for_each_broadcast_spawned(
                 ingest_concurrency.into(),
@@ -180,12 +190,8 @@ fn ingest_and_broadcast_range(
                 },
                 subscribers,
                 move |stats| {
-                    report_metrics
-                        .ingestion_concurrency_limit
-                        .set(stats.limit as i64);
-                    report_metrics
-                        .ingestion_concurrency_inflight
-                        .set(stats.inflight as i64);
+                    concurrency_limit.set(stats.limit as i64);
+                    concurrency_inflight.set(stats.inflight as i64);
                 },
             )
             .await
@@ -203,6 +209,7 @@ async fn setup_streaming_task(
     config: &IngestionConfig,
     subscribers: &[mpsc::Sender<Arc<CheckpointEnvelope>>],
     metrics: &Arc<IngestionMetrics>,
+    cohort: usize,
 ) -> (TaskGuard<u64>, u64) {
     // No streaming client configured so we ingest all the way to end_cp.
     let Some(streaming_client) = streaming_client else {
@@ -277,6 +284,7 @@ async fn setup_streaming_task(
         envelope_stream,
         subscribers.to_vec(),
         metrics.clone(),
+        cohort,
     )));
 
     (stream_guard, ingestion_end)
@@ -293,7 +301,15 @@ async fn stream_and_broadcast_range(
     mut stream: impl Stream<Item = Result<CheckpointEnvelope, Error>> + Unpin,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
     metrics: Arc<IngestionMetrics>,
+    cohort: usize,
 ) -> u64 {
+    let cohort = cohort.to_string();
+    let latest_streamed = metrics
+        .latest_streamed_checkpoint
+        .with_label_values(&[cohort.as_str()]);
+    let latest_skipped = metrics
+        .latest_skipped_streamed_checkpoint
+        .with_label_values(&[cohort.as_str()]);
     while lo < hi {
         let Some(item) = stream.next().await else {
             warn!(lo, "Streaming ended unexpectedly");
@@ -316,9 +332,7 @@ async fn stream_and_broadcast_range(
                 lo, "Skipping already processed checkpoint"
             );
             metrics.total_skipped_streamed_checkpoints.inc();
-            metrics
-                .latest_skipped_streamed_checkpoint
-                .set(sequence_number as i64);
+            latest_skipped.set(sequence_number as i64);
             continue;
         }
 
@@ -340,7 +354,7 @@ async fn stream_and_broadcast_range(
 
         debug!(checkpoint = lo, "Streamed checkpoint");
         metrics.total_streamed_checkpoints.inc();
-        metrics.latest_streamed_checkpoint.set(lo as i64);
+        latest_streamed.set(lo as i64);
         lo += 1;
     }
 
@@ -487,6 +501,7 @@ mod tests {
             mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
             metrics,
+            0,
         );
 
         assert_eq!(
@@ -509,6 +524,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics,
+            0,
         );
 
         assert_eq!(
@@ -532,6 +548,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics,
+            0,
         );
 
         assert_eq!(
@@ -558,6 +575,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscribers,
             metrics,
+            0,
         );
 
         // Both subscribers should receive checkpoints
@@ -596,6 +614,7 @@ mod tests {
             mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should receive all checkpoints from the stream in order
@@ -604,7 +623,13 @@ mod tests {
         // We should get all checkpoints from streaming.
         assert_eq!(metrics.total_streamed_checkpoints.get(), 5);
         assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 4);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            4
+        );
 
         svc.join().await.unwrap();
     }
@@ -625,6 +650,7 @@ mod tests {
             mock_client_with_range(0..60, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         assert_eq!(
@@ -637,7 +663,13 @@ mod tests {
         // the peek'd checkpoint, ingestion fills in below it.
         assert_eq!(metrics.total_ingested_checkpoints.get(), 49); // [0..49)
         assert_eq!(metrics.total_streamed_checkpoints.get(), 11); // [49..60)
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 59);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            59
+        );
 
         svc.join().await.unwrap();
     }
@@ -660,6 +692,7 @@ mod tests {
             mock_client_with_range(0..30, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should use only ingestion since streaming is beyond end_cp
@@ -691,6 +724,7 @@ mod tests {
             mock_client_with_range(30..100, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         assert_eq!(
@@ -701,9 +735,21 @@ mod tests {
         // Verify only streaming was used (all from streaming)
         assert_eq!(metrics.total_streamed_checkpoints.get(), 70);
         assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 99);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            99
+        );
         assert_eq!(metrics.total_skipped_streamed_checkpoints.get(), 30);
-        assert_eq!(metrics.latest_skipped_streamed_checkpoint.get(), 29);
+        assert_eq!(
+            metrics
+                .latest_skipped_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            29
+        );
 
         svc.join().await.unwrap();
     }
@@ -729,6 +775,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should receive all checkpoints exactly once (no duplicates) from streaming.
@@ -739,9 +786,21 @@ mod tests {
 
         assert_eq!(metrics.total_streamed_checkpoints.get(), 20);
         assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 19);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            19
+        );
         assert_eq!(metrics.total_skipped_streamed_checkpoints.get(), 2);
-        assert_eq!(metrics.latest_skipped_streamed_checkpoint.get(), 4);
+        assert_eq!(
+            metrics
+                .latest_skipped_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            4
+        );
 
         svc.join().await.unwrap();
     }
@@ -764,6 +823,7 @@ mod tests {
             mock_client_with_range(0..10, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should receive first three checkpoints from streaming in order
@@ -778,7 +838,13 @@ mod tests {
 
         assert_eq!(metrics.total_streamed_checkpoints.get(), 6);
         assert_eq!(metrics.total_ingested_checkpoints.get(), 4);
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 9);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            9
+        );
         assert_eq!(metrics.total_out_of_order_streamed_checkpoints.get(), 1);
 
         svc.join().await.unwrap();
@@ -803,6 +869,7 @@ mod tests {
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should receive first 5 checkpoints from streaming in order
@@ -819,7 +886,13 @@ mod tests {
         // Then ingestion was used to recover the missing checkpoints.
         assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
         // The last checkpoint should come from streaming after recovery.
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 14);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            14
+        );
 
         svc.join().await.unwrap();
     }
@@ -843,6 +916,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should eventually receive all checkpoints despite errors from streaming.
@@ -852,7 +926,13 @@ mod tests {
         );
 
         assert_eq!(metrics.total_streamed_checkpoints.get(), 20);
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 19);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            19
+        );
         assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
         assert_eq!(metrics.total_stream_disconnections.get(), 3); // 2 errors + 1 completion
 
@@ -877,6 +957,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should fallback to ingestion for initial batch size checkpoints
@@ -917,6 +998,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should fallback to ingestion for first 10 checkpoints
@@ -954,6 +1036,7 @@ mod tests {
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should fallback to ingestion for all checkpoints
@@ -990,6 +1073,7 @@ mod tests {
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should fallback to ingestion for first 2 + 4 + 8 + 16 = 30 checkpoints
@@ -1048,6 +1132,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should fallback to ingestion for initial batch size checkpoints
@@ -1091,6 +1176,7 @@ mod tests {
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should fallback to ingestion for first batch
@@ -1129,6 +1215,7 @@ mod tests {
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
+            0,
         );
 
         // Should receive first 5 checkpoints from streaming in order
@@ -1145,7 +1232,13 @@ mod tests {
         // Then ingestion was used to recover the missing checkpoints
         assert_eq!(metrics.total_ingested_checkpoints.get(), 5);
         // The last checkpoint should come from streaming after recovery
-        assert_eq!(metrics.latest_streamed_checkpoint.get(), 14);
+        assert_eq!(
+            metrics
+                .latest_streamed_checkpoint
+                .with_label_values(&["0"])
+                .get(),
+            14
+        );
 
         svc.join().await.unwrap();
     }

--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -38,7 +38,7 @@ use crate::ingestion::Result as IngestionResult;
 use crate::ingestion::byte_count::ByteCountMakeCallbackHandler;
 use crate::ingestion::decode;
 use crate::ingestion::store_client::StoreIngestionClient;
-use crate::metrics::CheckpointLagMetricReporter;
+use crate::metrics::CohortMetrics;
 use crate::metrics::IngestionMetrics;
 use crate::types::full_checkpoint_content::Checkpoint;
 
@@ -51,6 +51,11 @@ const MAX_TRANSIENT_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 /// continue executing without being canceled. This helps identify network issues or
 /// slow remote stores without interrupting the ingestion process.
 const SLOW_OPERATION_WARNING_THRESHOLD: Duration = Duration::from_secs(60);
+
+/// The `cohort` metric label for the base client, before it has been rebound to a specific cohort via
+/// [`IngestionClient::for_cohort`]. It keeps checkpoint fetches made before the indexer starts (e.g.
+/// the factory's tip probe) out of any real cohort's series.
+const DEFAULT_COHORT_LABEL: &str = "";
 
 #[async_trait]
 pub trait IngestionClientTrait: Send + Sync {
@@ -181,9 +186,12 @@ pub type CheckpointResult = Result<Checkpoint, CheckpointError>;
 #[derive(Clone)]
 pub struct IngestionClient {
     client: Arc<dyn IngestionClientTrait>,
-    /// Wrap the metrics in an `Arc` to keep copies of the client cheap.
+    /// The metrics registry this client's cohort view is bound against, and the handle its peers
+    /// reuse (see [`Self::metrics`]). Also owns the global `total_ingested_bytes` counter wired into
+    /// the checkpoint source.
     metrics: Arc<IngestionMetrics>,
-    checkpoint_lag_reporter: Arc<CheckpointLagMetricReporter>,
+    /// This client's cohort-labeled metric handles, rebound per cohort by [`Self::for_cohort`].
+    cohort_metrics: Arc<CohortMetrics>,
     chain_id: OnceCell<ChainIdentifier>,
 }
 
@@ -296,6 +304,11 @@ impl IngestionClient {
         &self.metrics
     }
 
+    /// This client's cohort-labeled metric view, bound to the cohort it was created for.
+    pub(crate) fn cohort_metrics(&self) -> &Arc<CohortMetrics> {
+        &self.cohort_metrics
+    }
+
     /// Wrap an arbitrary [`IngestionClientTrait`] implementation in an [`IngestionClient`]. Use
     /// this when the source of checkpoints is not one of the built-in remote object stores or gRPC
     /// endpoints — for example, when embedding the indexer in a fullnode that already has
@@ -304,31 +317,21 @@ impl IngestionClient {
         client: Arc<dyn IngestionClientTrait>,
         metrics: Arc<IngestionMetrics>,
     ) -> Self {
-        let checkpoint_lag_reporter = CheckpointLagMetricReporter::with_label(
-            &metrics.ingested_checkpoint_timestamp_lag,
-            &metrics.latest_ingested_checkpoint_timestamp_lag_ms,
-            &metrics.latest_ingested_checkpoint,
-            "0",
-        );
+        let cohort_metrics = CohortMetrics::new(&metrics, DEFAULT_COHORT_LABEL);
         IngestionClient {
             client,
             metrics,
-            checkpoint_lag_reporter,
+            cohort_metrics,
             chain_id: OnceCell::new(),
         }
     }
 
-    /// A clone of this client that reports checkpoint-lag gauges under `cohort`, so services minted
-    /// for different cohorts don't overwrite each other. The checkpoint source and chain-id cache
-    /// are shared; only the metric reporter is rebound.
+    /// A clone of this client that reports its cohort-labeled metrics under `cohort`, so services
+    /// minted for different cohorts don't overwrite each other. The checkpoint source and chain-id
+    /// cache are shared; only the cohort metric view is rebound.
     pub(crate) fn for_cohort(&self, cohort: usize) -> Self {
         let mut client = self.clone();
-        client.checkpoint_lag_reporter = CheckpointLagMetricReporter::with_label(
-            &self.metrics.ingested_checkpoint_timestamp_lag,
-            &self.metrics.latest_ingested_checkpoint_timestamp_lag_ms,
-            &self.metrics.latest_ingested_checkpoint,
-            &cohort.to_string(),
-        );
+        client.cohort_metrics = CohortMetrics::new(&self.metrics, &cohort.to_string());
         client
     }
 
@@ -348,7 +351,7 @@ impl IngestionClient {
             self.checkpoint(checkpoint).await.map_err(|e| match e {
                 IE::NotFound(checkpoint) => {
                     debug!(checkpoint, "Checkpoint not found, retrying...");
-                    self.metrics.total_ingested_not_found_retries.inc();
+                    self.cohort_metrics.total_ingested_not_found_retries.inc();
                     BE::transient(e)
                 }
                 e => BE::permanent(e),
@@ -386,12 +389,12 @@ impl IngestionClient {
                             // upstream checkpoint data source. If the upstream checkpoint data
                             // source is corrected, then the indexer will automatically recover
                             // the next time the read is attempted.
-                            CheckpointError::Fetch(e) => self.metrics.inc_retry(
+                            CheckpointError::Fetch(e) => self.cohort_metrics.inc_retry(
                                 cp_sequence_number,
                                 "fetch",
                                 IE::FetchError(cp_sequence_number, e),
                             ),
-                            CheckpointError::Decode(e) => self.metrics.inc_retry(
+                            CheckpointError::Decode(e) => self.cohort_metrics.inc_retry(
                                 cp_sequence_number,
                                 e.reason(),
                                 IE::DecodeError(cp_sequence_number, e.into()),
@@ -399,7 +402,7 @@ impl IngestionClient {
                         })
                 }
             },
-            &self.metrics.ingested_checkpoint_latency,
+            &self.cohort_metrics.ingested_checkpoint_latency,
         );
 
         let client = self.client.clone();
@@ -415,22 +418,23 @@ impl IngestionClient {
                             .map_err(|e| BE::transient(IE::ChainIdError(cp_sequence_number, e)))
                     }
                 },
-                &self.metrics.ingested_chain_id_latency,
+                &self.cohort_metrics.ingested_chain_id_latency,
             )
         });
 
         let (checkpoint, chain_id) = tokio::try_join!(checkpoint_data_fut, chain_id_fut)?;
 
-        self.checkpoint_lag_reporter
+        self.cohort_metrics
+            .checkpoint_lag
             .report_lag(cp_sequence_number, checkpoint.summary.timestamp_ms);
 
-        self.metrics.total_ingested_checkpoints.inc();
+        self.cohort_metrics.total_ingested_checkpoints.inc();
 
-        self.metrics
+        self.cohort_metrics
             .total_ingested_transactions
             .inc_by(checkpoint.transactions.len() as u64);
 
-        self.metrics.total_ingested_events.inc_by(
+        self.cohort_metrics.total_ingested_events.inc_by(
             checkpoint
                 .transactions
                 .iter()
@@ -438,7 +442,7 @@ impl IngestionClient {
                 .sum(),
         );
 
-        self.metrics
+        self.cohort_metrics
             .total_ingested_objects
             .inc_by(checkpoint.object_set.len() as u64);
 
@@ -628,7 +632,9 @@ pub(crate) mod tests {
         let registry = Registry::new_custom(Some("test".to_string()), None).unwrap();
         let metrics = IngestionMetrics::new(None, &registry);
         let mock_client = Arc::new(MockIngestionClient::default());
-        let client = IngestionClient::from_trait(mock_client.clone(), metrics);
+        // Bind to cohort 0, matching production where the broadcaster always runs under a cohort's
+        // client rather than the unlabeled base client.
+        let client = IngestionClient::from_trait(mock_client.clone(), metrics).for_cohort(0);
         (client, mock_client)
     }
 
@@ -764,11 +770,39 @@ pub(crate) mod tests {
         let result = client.checkpoint(1).await.unwrap();
         assert_eq!(result.checkpoint.summary.sequence_number(), &1);
         assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
-        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
-        assert_eq!(client.metrics.total_ingested_transactions.get(), 1);
-        assert_eq!(client.metrics.total_ingested_events.get(), 1);
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_transactions
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_events
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
         // 1 created object + 2 gas object versions (input + output)
-        assert_eq!(client.metrics.total_ingested_objects.get(), 3);
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_objects
+                .with_label_values(&["0"])
+                .get(),
+            3
+        );
     }
 
     #[tokio::test]
@@ -778,10 +812,38 @@ pub(crate) mod tests {
         // Try to fetch non-existent checkpoint
         let result = client.checkpoint(1).await;
         assert!(matches!(result, Err(IE::NotFound(1))));
-        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 0);
-        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
-        assert_eq!(client.metrics.total_ingested_events.get(), 0);
-        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_transactions
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_events
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_objects
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -800,13 +862,41 @@ pub(crate) mod tests {
         let retries = client
             .metrics
             .total_ingested_transient_retries
-            .with_label_values(&["fetch"])
+            .with_label_values(&["fetch", "0"])
             .get();
         assert_eq!(retries, 2);
-        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
-        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
-        assert_eq!(client.metrics.total_ingested_events.get(), 0);
-        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_transactions
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_events
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_objects
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -825,13 +915,41 @@ pub(crate) mod tests {
         let retries = client
             .metrics
             .total_ingested_transient_retries
-            .with_label_values(&["deserialization"])
+            .with_label_values(&["deserialization", "0"])
             .get();
         assert_eq!(retries, 2);
-        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
-        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
-        assert_eq!(client.metrics.total_ingested_events.get(), 0);
-        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_transactions
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_events
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_objects
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -847,12 +965,44 @@ pub(crate) mod tests {
         assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
 
         // Verify that exactly 1 retry was recorded
-        let retries = client.metrics.total_ingested_not_found_retries.get();
+        let retries = client
+            .metrics
+            .total_ingested_not_found_retries
+            .with_label_values(&["0"])
+            .get();
         assert_eq!(retries, 1);
-        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
-        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
-        assert_eq!(client.metrics.total_ingested_events.get(), 0);
-        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_transactions
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_events
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_objects
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -864,9 +1014,37 @@ pub(crate) mod tests {
         let result = client.wait_for(1, Duration::from_millis(50)).await.unwrap();
         assert_eq!(result.checkpoint.summary.sequence_number(), &1);
         assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
-        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
-        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
-        assert_eq!(client.metrics.total_ingested_events.get(), 0);
-        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_transactions
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_events
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            client
+                .metrics
+                .total_ingested_objects
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -304,10 +304,11 @@ impl IngestionClient {
         client: Arc<dyn IngestionClientTrait>,
         metrics: Arc<IngestionMetrics>,
     ) -> Self {
-        let checkpoint_lag_reporter = CheckpointLagMetricReporter::new(
-            metrics.ingested_checkpoint_timestamp_lag.clone(),
-            metrics.latest_ingested_checkpoint_timestamp_lag_ms.clone(),
-            metrics.latest_ingested_checkpoint.clone(),
+        let checkpoint_lag_reporter = CheckpointLagMetricReporter::with_label(
+            &metrics.ingested_checkpoint_timestamp_lag,
+            &metrics.latest_ingested_checkpoint_timestamp_lag_ms,
+            &metrics.latest_ingested_checkpoint,
+            "0",
         );
         IngestionClient {
             client,
@@ -315,6 +316,20 @@ impl IngestionClient {
             checkpoint_lag_reporter,
             chain_id: OnceCell::new(),
         }
+    }
+
+    /// A clone of this client that reports checkpoint-lag gauges under `cohort`, so services minted
+    /// for different cohorts don't overwrite each other. The checkpoint source and chain-id cache
+    /// are shared; only the metric reporter is rebound.
+    pub(crate) fn for_cohort(&self, cohort: usize) -> Self {
+        let mut client = self.clone();
+        client.checkpoint_lag_reporter = CheckpointLagMetricReporter::with_label(
+            &self.metrics.ingested_checkpoint_timestamp_lag,
+            &self.metrics.latest_ingested_checkpoint_timestamp_lag_ms,
+            &self.metrics.latest_ingested_checkpoint,
+            &cohort.to_string(),
+        );
+        client
     }
 
     /// Fetch checkpoint data by sequence number.

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -87,6 +87,27 @@ pub struct IngestionService {
     streaming_client: Option<ArcStreamingClient>,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
     metrics: Arc<IngestionMetrics>,
+    /// The cohort this service belongs to, used to label its ingestion gauges so services running
+    /// for different cohorts don't overwrite each other's metrics.
+    cohort: usize,
+}
+
+/// Creates the [IngestionService]s that an indexer runs. The factory holds the clients services
+/// are made from; services are only constructed when requested through [Self::create], and every
+/// service is created the same way: it shares the factory's ingestion client (and so reports to
+/// the same metrics -- counters aggregate across services, while latest-checkpoint style gauges
+/// are labeled by cohort so concurrently-running services don't overwrite each other), and it
+/// gets its own clone of the streaming client, if there is one.
+pub(crate) struct IngestionFactory {
+    /// The ingestion configuration shared by every service this factory creates.
+    config: IngestionConfig,
+
+    /// The client shared by [Self::latest_checkpoint_number] and the services this factory
+    /// creates.
+    ingestion_client: IngestionClient,
+
+    /// Cloned into every service created, and used by [Self::latest_checkpoint_number].
+    streaming_client: Option<ArcStreamingClient>,
 }
 
 impl IngestionConfig {
@@ -121,20 +142,11 @@ impl IngestionService {
         registry: &Registry,
     ) -> Result<Self> {
         let metrics = IngestionMetrics::new(metrics_prefix, registry);
-        let ingestion_client = IngestionClient::new(args.ingestion, metrics.clone())?;
-        let streaming_client: Option<ArcStreamingClient> =
-            args.streaming.streaming_url.map(|uri| {
-                Arc::new(GrpcStreamingClient::new(
-                    uri,
-                    config.streaming_connection_timeout(),
-                    config.streaming_statement_timeout(),
-                )) as ArcStreamingClient
-            });
-        Ok(Self::from_clients(
+        let (ingestion_client, streaming_client) = clients_from_args(args, &config, metrics)?;
+        Ok(Self::with_clients(
             ingestion_client,
             streaming_client,
             config,
-            metrics,
         ))
     }
 
@@ -145,83 +157,20 @@ impl IngestionService {
     /// implementations — for example, when embedding the indexer in a fullnode that already has
     /// checkpoint data on hand — use this constructor instead of [`Self::new`].
     ///
-    /// `metrics` is the shared [`IngestionMetrics`] handle. The caller is expected to have built
-    /// it once and passed the same handle to [`IngestionClient::from_trait`] (or another
-    /// `IngestionClient` constructor) so the service and the client report against a single set of
-    /// registered metric vectors — building two sets against the same prometheus registry would
-    /// double-register the metric names.
-    ///
     /// [`IngestionClientTrait`]: crate::ingestion::ingestion_client::IngestionClientTrait
     pub fn with_clients(
         ingestion_client: IngestionClient,
         streaming_client: Option<ArcStreamingClient>,
         config: IngestionConfig,
-        metrics: Arc<IngestionMetrics>,
-    ) -> Self {
-        Self::from_clients(ingestion_client, streaming_client, config, metrics)
-    }
-
-    /// Common assembly point for both [`Self::new`] and [`Self::with_clients`]: stamps the fields
-    /// onto the struct once a metrics handle has been resolved (either built fresh from a
-    /// registry, or in the [`Self::new`] case, threaded through from the ingestion-client
-    /// construction).
-    fn from_clients(
-        ingestion_client: IngestionClient,
-        streaming_client: Option<ArcStreamingClient>,
-        config: IngestionConfig,
-        metrics: Arc<IngestionMetrics>,
     ) -> Self {
         Self {
             config,
+            metrics: ingestion_client.metrics().clone(),
             ingestion_client,
             streaming_client,
             subscribers: Vec::new(),
-            metrics,
+            cohort: 0,
         }
-    }
-
-    /// The ingestion client this service uses to fetch checkpoints.
-    pub(crate) fn ingestion_client(&self) -> &IngestionClient {
-        &self.ingestion_client
-    }
-
-    /// Return the latest checkpoint number known to the ingestion service, preferably via the
-    /// streaming client, and failing that via the ingestion client.
-    pub async fn latest_checkpoint_number(&mut self) -> anyhow::Result<u64> {
-        if let Some(streaming_client) = self.streaming_client.as_deref() {
-            match streaming_client.latest_checkpoint_number().await {
-                Ok(checkpoint_number) => return Ok(checkpoint_number),
-                Err(e) => {
-                    warn!(
-                        operation = "latest_checkpoint_number",
-                        "Failed to get latest checkpoint number from streaming client: {e}"
-                    );
-                }
-            }
-        }
-
-        let ingestion_client = self.ingestion_client.clone();
-        let future = move || {
-            let ingestion_client = ingestion_client.clone();
-            async move {
-                ingestion_client
-                    .latest_checkpoint_number()
-                    .await
-                    .map_err(|e| backoff::Error::transient(Error::LatestCheckpointError(e)))
-            }
-        };
-
-        Ok(retry_transient_with_slow_monitor(
-            "latest_checkpoint_number",
-            future,
-            &self.metrics.ingested_latest_checkpoint_latency,
-        )
-        .await?)
-    }
-
-    /// Access to the ingestion metrics.
-    pub(crate) fn metrics(&self) -> &Arc<IngestionMetrics> {
-        &self.metrics
     }
 
     /// The ingestion configuration this service was built with.
@@ -263,6 +212,7 @@ impl IngestionService {
             streaming_client,
             subscribers,
             metrics,
+            cohort,
         } = self;
 
         if subscribers.is_empty() {
@@ -276,7 +226,73 @@ impl IngestionService {
             ingestion_client,
             subscribers,
             metrics,
+            cohort,
         ))
+    }
+}
+
+impl IngestionFactory {
+    /// Create a factory whose services fetch checkpoints as specified by `args`, reporting
+    /// metrics registered under `metrics_prefix` in `registry`.
+    pub(crate) fn new(
+        args: ClientArgs,
+        config: IngestionConfig,
+        metrics_prefix: Option<&str>,
+        registry: &Registry,
+    ) -> Result<Self> {
+        let metrics = IngestionMetrics::new(metrics_prefix, registry);
+        let (ingestion_client, streaming_client) = clients_from_args(args, &config, metrics)?;
+        Ok(Self::with_clients(
+            ingestion_client,
+            streaming_client,
+            config,
+        ))
+    }
+
+    /// Create a factory from pre-built clients, bypassing [ClientArgs]-driven construction.
+    /// Callers that supply their own [`IngestionClientTrait`] / [`CheckpointStreamingClient`]
+    /// implementations -- for example, when embedding the indexer in a fullnode that already has
+    /// checkpoint data on hand -- use this constructor instead of [`Self::new`].
+    ///
+    /// [`IngestionClientTrait`]: crate::ingestion::ingestion_client::IngestionClientTrait
+    pub(crate) fn with_clients(
+        ingestion_client: IngestionClient,
+        streaming_client: Option<ArcStreamingClient>,
+        config: IngestionConfig,
+    ) -> Self {
+        Self {
+            config,
+            ingestion_client,
+            streaming_client,
+        }
+    }
+
+    /// Return the latest checkpoint number known to the underlying checkpoint source, preferably
+    /// via the streaming client, and failing that via the ingestion client.
+    pub(crate) async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+        latest_checkpoint_number(self.streaming_client.as_deref(), &self.ingestion_client).await
+    }
+
+    /// The ingestion client this factory's services fetch checkpoints with.
+    pub(crate) fn ingestion_client(&self) -> &IngestionClient {
+        &self.ingestion_client
+    }
+
+    /// The metrics that this factory's services report to.
+    pub(crate) fn metrics(&self) -> &Arc<IngestionMetrics> {
+        self.ingestion_client.metrics()
+    }
+
+    /// Create an ingestion service for `cohort` from the factory's clients. The cohort labels the
+    /// service's ingestion gauges so concurrently-running services don't overwrite each other.
+    pub(crate) fn create(&self, cohort: usize) -> IngestionService {
+        let mut service = IngestionService::with_clients(
+            self.ingestion_client.for_cohort(cohort),
+            self.streaming_client.clone(),
+            self.config.clone(),
+        );
+        service.cohort = cohort;
+        service
     }
 }
 
@@ -297,6 +313,65 @@ impl Default for IngestionConfig {
             streaming_statement_timeout_ms: 5000,    // 5 seconds
         }
     }
+}
+
+/// Build the ingestion client (and optional streaming client) described by `args`.
+fn clients_from_args(
+    args: ClientArgs,
+    config: &IngestionConfig,
+    metrics: Arc<IngestionMetrics>,
+) -> Result<(IngestionClient, Option<ArcStreamingClient>)> {
+    let ingestion_client = IngestionClient::new(args.ingestion, metrics)?;
+    let streaming_client = args.streaming.streaming_url.map(|uri| {
+        Arc::new(GrpcStreamingClient::new(
+            uri,
+            config.streaming_connection_timeout(),
+            config.streaming_statement_timeout(),
+        )) as ArcStreamingClient
+    });
+    Ok((ingestion_client, streaming_client))
+}
+
+/// Return the latest checkpoint number known to the underlying checkpoint source, preferably
+/// via the streaming client, and failing that via the ingestion client.
+async fn latest_checkpoint_number<S>(
+    streaming_client: Option<&S>,
+    ingestion_client: &IngestionClient,
+) -> anyhow::Result<u64>
+where
+    S: CheckpointStreamingClient + Send + Sync + ?Sized,
+{
+    if let Some(streaming_client) = streaming_client {
+        match streaming_client.latest_checkpoint_number().await {
+            Ok(checkpoint_number) => return Ok(checkpoint_number),
+            Err(e) => {
+                warn!(
+                    operation = "latest_checkpoint_number",
+                    "Failed to get latest checkpoint number from streaming client: {e}"
+                );
+            }
+        }
+    }
+
+    let client = ingestion_client.clone();
+    let future = move || {
+        let client = client.clone();
+        async move {
+            client
+                .latest_checkpoint_number()
+                .await
+                .map_err(|e| backoff::Error::transient(Error::LatestCheckpointError(e)))
+        }
+    };
+
+    Ok(retry_transient_with_slow_monitor(
+        "latest_checkpoint_number",
+        future,
+        &ingestion_client
+            .metrics()
+            .ingested_latest_checkpoint_latency,
+    )
+    .await?)
 }
 
 #[cfg(test)]
@@ -368,33 +443,6 @@ mod tests {
 
             seqs
         }))
-    }
-
-    /// Probe the streaming client (if any) for the latest checkpoint number, falling back to the
-    /// ingestion client on no-streaming-client or streaming-side failure. Mirrors the inline logic in
-    /// [`IngestionService::latest_checkpoint_number`] in a form unit tests can drive directly with
-    /// concrete mock clients (without having to build an `IngestionService`).
-    #[cfg(test)]
-    async fn latest_checkpoint_number<S>(
-        streaming_client: Option<&S>,
-        ingestion_client: &IngestionClient,
-    ) -> anyhow::Result<u64>
-    where
-        S: CheckpointStreamingClient + Send + Sync + ?Sized,
-    {
-        if let Some(streaming_client) = streaming_client {
-            match streaming_client.latest_checkpoint_number().await {
-                Ok(checkpoint_number) => return Ok(checkpoint_number),
-                Err(e) => {
-                    warn!(
-                        operation = "latest_checkpoint_number",
-                        "Failed to get latest checkpoint number from streaming client: {e}"
-                    );
-                }
-            }
-        }
-
-        ingestion_client.latest_checkpoint_number().await
     }
 
     /// If the ingestion service has no subscribers, it will fail fast (before fetching any
@@ -555,8 +603,7 @@ mod tests {
     #[tokio::test]
     async fn latest_checkpoint_number_no_streaming_client() {
         let client = mock_ingestion_client(FALLBACK);
-        let streaming: Option<MockStreamingClient> = None;
-        let result = latest_checkpoint_number(streaming.as_ref(), &client).await;
+        let result = latest_checkpoint_number(None::<&MockStreamingClient>, &client).await;
         assert_eq!(result.unwrap(), FALLBACK);
     }
 
@@ -573,8 +620,7 @@ mod tests {
         let client = mock_ingestion_client(FALLBACK);
         let mut mock = MockStreamingClient::new(std::iter::empty::<u64>(), None);
         mock.insert_error();
-        let streaming = Some(mock);
-        let result = latest_checkpoint_number(streaming.as_ref(), &client).await;
+        let result = latest_checkpoint_number(Some(&mock), &client).await;
         assert_eq!(result.unwrap(), FALLBACK);
     }
 
@@ -605,51 +651,66 @@ mod tests {
         assert!(error.to_string().contains("nonzero"));
     }
 
-    /// `with_clients` resolves `latest_checkpoint_number` through the supplied streaming client
-    /// when it is healthy, without going through `ClientArgs`-driven setup.
-    #[tokio::test]
-    async fn with_clients_uses_supplied_streaming_client() {
-        const STREAM_LATEST: u64 = 42;
-
+    /// Every service an args-driven factory creates shares the factory's metrics; no additional
+    /// metrics are registered.
+    #[test]
+    fn factory_from_args_shares_metrics() {
         let registry = Registry::new();
-        let metrics = IngestionMetrics::new(None, &registry);
-        let mut service = IngestionService::with_clients(
-            IngestionClient::from_trait(
-                Arc::new(MockIngestionClient {
-                    latest_checkpoint: FALLBACK,
-                    ..Default::default()
-                }),
-                metrics.clone(),
-            ),
-            Some(Arc::new(MockStreamingClient::new([STREAM_LATEST], None))),
-            IngestionConfig::default(),
-            metrics,
-        );
+        let dir = tempfile::tempdir().unwrap();
+        let args = ClientArgs {
+            ingestion: IngestionClientArgs {
+                local_ingestion_path: Some(dir.path().to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
 
-        let latest = service.latest_checkpoint_number().await.unwrap();
-        assert_eq!(latest, STREAM_LATEST);
+        let factory =
+            IngestionFactory::new(args, IngestionConfig::default(), None, &registry).unwrap();
+
+        let first = factory.create(0);
+        let second = factory.create(1);
+        assert!(Arc::ptr_eq(&first.metrics, factory.metrics()));
+        assert!(Arc::ptr_eq(&second.metrics, factory.metrics()));
+        assert!(
+            registry
+                .gather()
+                .iter()
+                .all(|family| !family.name().contains("cohort"))
+        );
     }
 
-    /// With no streaming client supplied, `with_clients` falls back to the ingestion client for
-    /// the latest-checkpoint probe.
+    /// Services created by a client-driven factory all share the client's metrics handle, and
+    /// each gets its own clone of the streaming client. When the streaming client cannot serve
+    /// the latest checkpoint (the mock's shared queue is exhausted by the first probe), the
+    /// factory's probe falls back to the ingestion client.
     #[tokio::test]
-    async fn with_clients_falls_back_to_ingestion_when_no_streaming() {
+    async fn factory_from_clients_shares_metrics() {
         let registry = Registry::new();
         let metrics = IngestionMetrics::new(None, &registry);
-        let mut service = IngestionService::with_clients(
-            IngestionClient::from_trait(
-                Arc::new(MockIngestionClient {
-                    latest_checkpoint: FALLBACK,
-                    ..Default::default()
-                }),
-                metrics.clone(),
-            ),
-            None,
-            IngestionConfig::default(),
-            metrics,
+        let client = IngestionClient::from_trait(
+            Arc::new(MockIngestionClient {
+                latest_checkpoint: FALLBACK,
+                ..Default::default()
+            }),
+            metrics.clone(),
         );
 
-        let latest = service.latest_checkpoint_number().await.unwrap();
-        assert_eq!(latest, FALLBACK);
+        let factory = IngestionFactory::with_clients(
+            client,
+            Some(Arc::new(MockStreamingClient::new([42], None))),
+            IngestionConfig::default(),
+        );
+
+        assert_eq!(factory.latest_checkpoint_number().await.unwrap(), 42);
+
+        let first = factory.create(0);
+        let second = factory.create(1);
+        assert!(Arc::ptr_eq(&first.metrics, &metrics));
+        assert!(Arc::ptr_eq(&second.metrics, &metrics));
+        assert!(first.streaming_client.is_some());
+        assert!(second.streaming_client.is_some());
+
+        assert_eq!(factory.latest_checkpoint_number().await.unwrap(), FALLBACK);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -95,10 +95,6 @@ pub struct IngestionService {
     ingestion_client: IngestionClient,
     streaming_client: Option<ArcStreamingClient>,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
-    metrics: Arc<IngestionMetrics>,
-    /// The cohort this service belongs to, used to label its ingestion gauges so services running
-    /// for different cohorts don't overwrite each other's metrics.
-    cohort: usize,
 }
 
 /// Creates the [IngestionService]s that an indexer runs -- one per cohort of pipelines with
@@ -175,11 +171,9 @@ impl IngestionService {
     ) -> Self {
         Self {
             config,
-            metrics: ingestion_client.metrics().clone(),
             ingestion_client,
             streaming_client,
             subscribers: Vec::new(),
-            cohort: 0,
         }
     }
 
@@ -221,8 +215,6 @@ impl IngestionService {
             ingestion_client,
             streaming_client,
             subscribers,
-            metrics,
-            cohort,
         } = self;
 
         if subscribers.is_empty() {
@@ -235,8 +227,6 @@ impl IngestionService {
             config,
             ingestion_client,
             subscribers,
-            metrics,
-            cohort,
         ))
     }
 }
@@ -301,13 +291,11 @@ impl IngestionFactory {
     /// Create an ingestion service for `cohort` from the factory's clients. The cohort labels the
     /// service's ingestion gauges so concurrently-running services don't overwrite each other.
     pub(crate) fn create(&self, cohort: usize) -> IngestionService {
-        let mut service = IngestionService::with_clients(
+        IngestionService::with_clients(
             self.ingestion_client.for_cohort(cohort),
             self.streaming_client.clone(),
             self.config.clone(),
-        );
-        service.cohort = cohort;
-        service
+        )
     }
 }
 
@@ -686,8 +674,14 @@ mod tests {
 
         let first = factory.create(0);
         let second = factory.create(1);
-        assert!(Arc::ptr_eq(&first.metrics, factory.metrics()));
-        assert!(Arc::ptr_eq(&second.metrics, factory.metrics()));
+        assert!(Arc::ptr_eq(
+            first.ingestion_client.metrics(),
+            factory.metrics()
+        ));
+        assert!(Arc::ptr_eq(
+            second.ingestion_client.metrics(),
+            factory.metrics()
+        ));
         assert!(
             registry
                 .gather()
@@ -722,8 +716,8 @@ mod tests {
 
         let first = factory.create(0);
         let second = factory.create(1);
-        assert!(Arc::ptr_eq(&first.metrics, &metrics));
-        assert!(Arc::ptr_eq(&second.metrics, &metrics));
+        assert!(Arc::ptr_eq(first.ingestion_client.metrics(), &metrics));
+        assert!(Arc::ptr_eq(second.ingestion_client.metrics(), &metrics));
         assert!(first.streaming_client.is_some());
         assert!(second.streaming_client.is_some());
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -25,14 +25,14 @@ use crate::ingestion::streaming_client::GrpcStreamingClient;
 use crate::ingestion::streaming_client::StreamingClientArgs;
 use crate::metrics::IngestionMetrics;
 
-/// Type alias for a boxed [`CheckpointStreamingClient`] trait object,
+/// Type alias for a shared [`CheckpointStreamingClient`] trait object,
 /// the form [`IngestionService`] stores and the broadcaster consumes.
-/// Boxed (rather than `Arc`'d) because `CheckpointStreamingClient`'s
-/// methods take `&mut self`, so unique ownership is required. The
-/// `Send + Sync` bounds let the boxed client move across task
+/// `Arc`'d (rather than `Box`'d) because `CheckpointStreamingClient`'s
+/// methods take `&self`, so the client can be cheaply cloned and shared
+/// across owners. The `Send + Sync` bounds let it move across task
 /// boundaries and be shared behind a reference when an enclosing
 /// [`IngestionService`] is held across threads.
-pub type BoxedStreamingClient = Box<dyn CheckpointStreamingClient + Send + Sync>;
+pub type ArcStreamingClient = Arc<dyn CheckpointStreamingClient + Send + Sync>;
 
 mod broadcaster;
 mod byte_count;
@@ -84,7 +84,7 @@ pub struct IngestionConfig {
 pub struct IngestionService {
     config: IngestionConfig,
     ingestion_client: IngestionClient,
-    streaming_client: Option<BoxedStreamingClient>,
+    streaming_client: Option<ArcStreamingClient>,
     subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
     metrics: Arc<IngestionMetrics>,
 }
@@ -122,13 +122,13 @@ impl IngestionService {
     ) -> Result<Self> {
         let metrics = IngestionMetrics::new(metrics_prefix, registry);
         let ingestion_client = IngestionClient::new(args.ingestion, metrics.clone())?;
-        let streaming_client: Option<BoxedStreamingClient> =
+        let streaming_client: Option<ArcStreamingClient> =
             args.streaming.streaming_url.map(|uri| {
-                Box::new(GrpcStreamingClient::new(
+                Arc::new(GrpcStreamingClient::new(
                     uri,
                     config.streaming_connection_timeout(),
                     config.streaming_statement_timeout(),
-                )) as BoxedStreamingClient
+                )) as ArcStreamingClient
             });
         Ok(Self::from_clients(
             ingestion_client,
@@ -154,7 +154,7 @@ impl IngestionService {
     /// [`IngestionClientTrait`]: crate::ingestion::ingestion_client::IngestionClientTrait
     pub fn with_clients(
         ingestion_client: IngestionClient,
-        streaming_client: Option<BoxedStreamingClient>,
+        streaming_client: Option<ArcStreamingClient>,
         config: IngestionConfig,
         metrics: Arc<IngestionMetrics>,
     ) -> Self {
@@ -167,7 +167,7 @@ impl IngestionService {
     /// construction).
     fn from_clients(
         ingestion_client: IngestionClient,
-        streaming_client: Option<BoxedStreamingClient>,
+        streaming_client: Option<ArcStreamingClient>,
         config: IngestionConfig,
         metrics: Arc<IngestionMetrics>,
     ) -> Self {
@@ -188,7 +188,7 @@ impl IngestionService {
     /// Return the latest checkpoint number known to the ingestion service, preferably via the
     /// streaming client, and failing that via the ingestion client.
     pub async fn latest_checkpoint_number(&mut self) -> anyhow::Result<u64> {
-        if let Some(streaming_client) = self.streaming_client.as_deref_mut() {
+        if let Some(streaming_client) = self.streaming_client.as_deref() {
             match streaming_client.latest_checkpoint_number().await {
                 Ok(checkpoint_number) => return Ok(checkpoint_number),
                 Err(e) => {
@@ -376,11 +376,11 @@ mod tests {
     /// concrete mock clients (without having to build an `IngestionService`).
     #[cfg(test)]
     async fn latest_checkpoint_number<S>(
-        streaming_client: Option<&mut S>,
+        streaming_client: Option<&S>,
         ingestion_client: &IngestionClient,
     ) -> anyhow::Result<u64>
     where
-        S: CheckpointStreamingClient + Send + ?Sized,
+        S: CheckpointStreamingClient + Send + Sync + ?Sized,
     {
         if let Some(streaming_client) = streaming_client {
             match streaming_client.latest_checkpoint_number().await {
@@ -555,16 +555,16 @@ mod tests {
     #[tokio::test]
     async fn latest_checkpoint_number_no_streaming_client() {
         let client = mock_ingestion_client(FALLBACK);
-        let mut streaming: Option<MockStreamingClient> = None;
-        let result = latest_checkpoint_number(streaming.as_mut(), &client).await;
+        let streaming: Option<MockStreamingClient> = None;
+        let result = latest_checkpoint_number(streaming.as_ref(), &client).await;
         assert_eq!(result.unwrap(), FALLBACK);
     }
 
     #[tokio::test]
     async fn latest_checkpoint_number_from_stream() {
         let client = mock_ingestion_client(FALLBACK);
-        let mut streaming = Some(MockStreamingClient::new([42], None));
-        let result = latest_checkpoint_number(streaming.as_mut(), &client).await;
+        let streaming = Some(MockStreamingClient::new([42], None));
+        let result = latest_checkpoint_number(streaming.as_ref(), &client).await;
         assert_eq!(result.unwrap(), 42);
     }
 
@@ -573,26 +573,26 @@ mod tests {
         let client = mock_ingestion_client(FALLBACK);
         let mut mock = MockStreamingClient::new(std::iter::empty::<u64>(), None);
         mock.insert_error();
-        let mut streaming = Some(mock);
-        let result = latest_checkpoint_number(streaming.as_mut(), &client).await;
+        let streaming = Some(mock);
+        let result = latest_checkpoint_number(streaming.as_ref(), &client).await;
         assert_eq!(result.unwrap(), FALLBACK);
     }
 
     #[tokio::test]
     async fn latest_checkpoint_number_empty_stream_falls_back() {
         let client = mock_ingestion_client(FALLBACK);
-        let mut streaming = Some(MockStreamingClient::new(std::iter::empty::<u64>(), None));
-        let result = latest_checkpoint_number(streaming.as_mut(), &client).await;
+        let streaming = Some(MockStreamingClient::new(std::iter::empty::<u64>(), None));
+        let result = latest_checkpoint_number(streaming.as_ref(), &client).await;
         assert_eq!(result.unwrap(), FALLBACK);
     }
 
     #[tokio::test]
     async fn latest_checkpoint_number_connection_failure_falls_back() {
         let client = mock_ingestion_client(FALLBACK);
-        let mut streaming = Some(
+        let streaming = Some(
             MockStreamingClient::new(std::iter::empty::<u64>(), None).fail_connection_times(1),
         );
-        let result = latest_checkpoint_number(streaming.as_mut(), &client).await;
+        let result = latest_checkpoint_number(streaming.as_ref(), &client).await;
         assert_eq!(result.unwrap(), FALLBACK);
     }
 
@@ -621,7 +621,7 @@ mod tests {
                 }),
                 metrics.clone(),
             ),
-            Some(Box::new(MockStreamingClient::new([STREAM_LATEST], None))),
+            Some(Arc::new(MockStreamingClient::new([STREAM_LATEST], None))),
             IngestionConfig::default(),
             metrics,
         );

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -12,6 +12,7 @@ use sui_futures::service::Service;
 use tokio::sync::mpsc;
 use tracing::warn;
 
+use crate::cohort::DEFAULT_MIN_COHORT_BOUNDARY;
 pub use crate::config::ConcurrencyConfig as IngestConcurrencyConfig;
 use crate::ingestion::broadcaster::broadcaster;
 use crate::ingestion::error::Error;
@@ -29,9 +30,10 @@ use crate::metrics::IngestionMetrics;
 /// the form [`IngestionService`] stores and the broadcaster consumes.
 /// `Arc`'d (rather than `Box`'d) because `CheckpointStreamingClient`'s
 /// methods take `&self`, so the client can be cheaply cloned and shared
-/// across owners. The `Send + Sync` bounds let it move across task
-/// boundaries and be shared behind a reference when an enclosing
-/// [`IngestionService`] is held across threads.
+/// across owners -- each cohort's [`IngestionService`] gets its own clone.
+/// The `Send + Sync` bounds let it move across task boundaries and be
+/// shared behind a reference when an enclosing [`IngestionService`] is
+/// held across threads.
 pub type ArcStreamingClient = Arc<dyn CheckpointStreamingClient + Send + Sync>;
 
 mod broadcaster;
@@ -59,6 +61,7 @@ pub struct ClientArgs {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct IngestionConfig {
     /// Concurrency control for checkpoint ingestion. A plain integer gives fixed concurrency;
     /// an object with `initial`, `min`, and `max` fields enables adaptive concurrency that adjusts
@@ -79,6 +82,12 @@ pub struct IngestionConfig {
 
     /// Timeout for streaming statement (peek/next) operations in milliseconds.
     pub streaming_statement_timeout_ms: u64,
+
+    /// Minimum boundary (in checkpoints) for an ingestion cohort: the closest pipeline in a
+    /// cohort absorbs peers within `max(2 * its distance from the tip, this)`, so nearly
+    /// caught-up pipelines are not fragmented into many tiny cohorts. Defaults to 25,000
+    /// checkpoints when unset.
+    pub min_cohort_boundary: u64,
 }
 
 pub struct IngestionService {
@@ -92,12 +101,13 @@ pub struct IngestionService {
     cohort: usize,
 }
 
-/// Creates the [IngestionService]s that an indexer runs. The factory holds the clients services
-/// are made from; services are only constructed when requested through [Self::create], and every
-/// service is created the same way: it shares the factory's ingestion client (and so reports to
-/// the same metrics -- counters aggregate across services, while latest-checkpoint style gauges
-/// are labeled by cohort so concurrently-running services don't overwrite each other), and it
-/// gets its own clone of the streaming client, if there is one.
+/// Creates the [IngestionService]s that an indexer runs -- one per cohort of pipelines with
+/// similar distances from the network tip. The factory holds the clients services are made from;
+/// services are only constructed when requested through [Self::create], and every service is
+/// created the same way: it shares the factory's ingestion client (and so reports to the same
+/// metrics -- counters aggregate across services, while latest-checkpoint style gauges are labeled
+/// by cohort so concurrently-running services don't overwrite each other), and it gets its own
+/// clone of the streaming client, if there is one.
 pub(crate) struct IngestionFactory {
     /// The ingestion configuration shared by every service this factory creates.
     config: IngestionConfig,
@@ -283,6 +293,11 @@ impl IngestionFactory {
         self.ingestion_client.metrics()
     }
 
+    /// The ingestion configuration shared by every service this factory creates.
+    pub(crate) fn config(&self) -> &IngestionConfig {
+        &self.config
+    }
+
     /// Create an ingestion service for `cohort` from the factory's clients. The cohort labels the
     /// service's ingestion gauges so concurrently-running services don't overwrite each other.
     pub(crate) fn create(&self, cohort: usize) -> IngestionService {
@@ -311,6 +326,7 @@ impl Default for IngestionConfig {
             streaming_backoff_max_batch_size: 10000, // 10000 checkpoints, ~ 40 minutes
             streaming_connection_timeout_ms: 5000,   // 5 seconds
             streaming_statement_timeout_ms: 5000,    // 5 seconds
+            min_cohort_boundary: DEFAULT_MIN_COHORT_BOUNDARY,
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -32,10 +32,10 @@ pub struct CheckpointStream {
 #[async_trait]
 pub trait CheckpointStreamingClient {
     /// Returns the CheckpointStream and chain id.
-    async fn connect(&mut self) -> Result<CheckpointStream>;
+    async fn connect(&self) -> Result<CheckpointStream>;
 
     /// Returns the latest checkpoint number available from the streaming source.
-    async fn latest_checkpoint_number(&mut self) -> Result<u64> {
+    async fn latest_checkpoint_number(&self) -> Result<u64> {
         let mut stream = self.connect().await?;
 
         match stream.stream.next().await {
@@ -73,7 +73,7 @@ impl GrpcStreamingClient {
 
 #[async_trait]
 impl CheckpointStreamingClient for GrpcStreamingClient {
-    async fn connect(&mut self) -> Result<CheckpointStream> {
+    async fn connect(&self) -> Result<CheckpointStream> {
         let endpoint = Endpoint::from(self.uri.clone())
             .connect_timeout(self.connection_timeout)
             .timeout(self.connection_timeout);
@@ -196,7 +196,7 @@ mod tests {
 
         let timeout = Duration::from_millis(200);
         let uri: Uri = format!("http://{addr}").parse().unwrap();
-        let mut client = GrpcStreamingClient::new(uri, timeout, timeout);
+        let client = GrpcStreamingClient::new(uri, timeout, timeout);
 
         let start = std::time::Instant::now();
         let result = client.connect().await;
@@ -215,6 +215,8 @@ pub mod test_utils {
     use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
     use std::time::Instant;
 
@@ -288,8 +290,8 @@ pub mod test_utils {
     /// Mock streaming client for testing with predefined checkpoints.
     pub struct MockStreamingClient {
         actions: Arc<Mutex<Vec<StreamAction>>>,
-        connection_failures_remaining: usize,
-        connection_timeouts_remaining: usize,
+        connection_failures_remaining: AtomicUsize,
+        connection_timeouts_remaining: AtomicUsize,
         /// How long mock timeout actions hang (must be > statement_timeout for timeouts to fire).
         timeout_duration: Duration,
         /// Statement timeout applied to the stream wrapper.
@@ -313,8 +315,8 @@ pub mod test_utils {
                         .map(StreamAction::Checkpoint)
                         .collect(),
                 )),
-                connection_failures_remaining: 0,
-                connection_timeouts_remaining: 0,
+                connection_failures_remaining: AtomicUsize::new(0),
+                connection_timeouts_remaining: AtomicUsize::new(0),
                 statement_timeout: timeout_duration / 2,
                 timeout_duration,
             }
@@ -322,13 +324,13 @@ pub mod test_utils {
 
         /// Make `connect` fail for the next N calls
         pub fn fail_connection_times(mut self, times: usize) -> Self {
-            self.connection_failures_remaining = times;
+            self.connection_failures_remaining = AtomicUsize::new(times);
             self
         }
 
         /// Make `connect` timeout for the next N calls
         pub fn fail_connection_with_timeout(mut self, times: usize) -> Self {
-            self.connection_timeouts_remaining = times;
+            self.connection_timeouts_remaining = AtomicUsize::new(times);
             self
         }
 
@@ -368,17 +370,19 @@ pub mod test_utils {
 
     #[async_trait]
     impl CheckpointStreamingClient for MockStreamingClient {
-        async fn connect(&mut self) -> Result<CheckpointStream> {
-            if self.connection_timeouts_remaining > 0 {
-                self.connection_timeouts_remaining -= 1;
+        async fn connect(&self) -> Result<CheckpointStream> {
+            if self.connection_timeouts_remaining.load(Ordering::Relaxed) > 0 {
+                self.connection_timeouts_remaining
+                    .fetch_sub(1, Ordering::Relaxed);
                 // Simulate a connection timeout
                 tokio::time::sleep(self.timeout_duration).await;
                 return Err(Error::StreamingError(anyhow::anyhow!(
                     "Mock connection timeout"
                 )));
             }
-            if self.connection_failures_remaining > 0 {
-                self.connection_failures_remaining -= 1;
+            if self.connection_failures_remaining.load(Ordering::Relaxed) > 0 {
+                self.connection_failures_remaining
+                    .fetch_sub(1, Ordering::Relaxed);
                 return Err(Error::StreamingError(anyhow::anyhow!(
                     "Mock connection failure"
                 )));

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::bail;
 use anyhow::ensure;
+use cohort::cohorts;
 use ingestion::ArcStreamingClient;
 use ingestion::ClientArgs;
 use ingestion::IngestionConfig;
@@ -40,6 +41,7 @@ pub use sui_types as types;
 
 #[cfg(feature = "cluster")]
 pub mod cluster;
+mod cohort;
 pub mod config;
 pub mod ingestion;
 pub mod metrics;
@@ -117,8 +119,8 @@ pub struct Indexer<S: Store> {
     /// Prometheus Metrics.
     metrics: Arc<IndexerMetrics>,
 
-    /// Creates the ingestion service that downloads and disseminates checkpoint data. The service
-    /// is built when the indexer is run.
+    /// Creates the services that download and disseminate checkpoint data -- one per cohort of
+    /// pipelines with similar distances from the network tip, determined in [Self::run].
     ingestion_factory: IngestionFactory,
 
     /// Optional override of the checkpoint lowerbound. When set, pipelines without a committer
@@ -162,8 +164,8 @@ pub struct Indexer<S: Store> {
     /// with the same name isn't added twice.
     added_pipelines: BTreeSet<&'static str>,
 
-    /// Registered pipelines, waiting to be started against the ingestion service when the indexer
-    /// is run.
+    /// Registered pipelines, waiting to be grouped into ingestion cohorts and started when the
+    /// indexer is run.
     pipelines: Vec<PendingPipeline>,
 }
 
@@ -179,19 +181,22 @@ pub(crate) struct Task {
 }
 
 /// A pipeline that has been registered but whose tasks have not been started yet. Pipelines are
-/// held in this form until [Indexer::run], when the ingestion service they subscribe to is
-/// created.
+/// held in this form until [Indexer::run], when they are grouped into ingestion cohorts by how
+/// far behind the network tip they will resume from.
 struct PendingPipeline {
+    /// The pipeline's name, for logging cohort composition.
+    name: &'static str,
+
     /// The checkpoint this pipeline will resume processing from.
     next_checkpoint: u64,
 
-    /// Deferred constructor, invoked in [Indexer::run] once the ingestion service is available to
-    /// subscribe to.
+    /// Deferred constructor, invoked in [Indexer::run] once the pipeline's cohort has an
+    /// ingestion service to subscribe to.
     build: PipelineBuilder,
 }
 
-/// Subscribes a pipeline to the ingestion service and starts the pipeline's tasks, returning the
-/// service handle over those tasks.
+/// Subscribes a pipeline to its cohort's ingestion service and starts the pipeline's tasks,
+/// returning the service handle over those tasks.
 ///
 /// `Sync` is required (in addition to `Send`) because the `Indexer` holding these builders is kept
 /// alive across await points, and the simulator test runtime requires the resulting futures to be
@@ -251,7 +256,10 @@ impl<S: Store> Indexer<S> {
     /// [`ClientArgs`]-driven construction. Callers that supply their own
     /// [`IngestionClientTrait`] / [`CheckpointStreamingClient`] implementations — for example,
     /// when embedding the indexer in a fullnode that already has checkpoint data on hand — hand
-    /// them in here, and the indexer creates its ingestion service from them.
+    /// them in here, and the indexer creates its ingestion services from them.
+    ///
+    /// All the indexer's ingestion services clone `ingestion_client` and report to its metrics
+    /// handle, and each gets its own clone of the streaming client (if any).
     ///
     /// [`IngestionClientTrait`]: crate::ingestion::ingestion_client::IngestionClientTrait
     /// [`CheckpointStreamingClient`]: crate::ingestion::streaming_client::CheckpointStreamingClient
@@ -354,15 +362,20 @@ impl<S: Store> Indexer<S> {
         self.next_sequential_checkpoint
     }
 
-    /// Start ingesting checkpoints and run all the registered pipelines against a single ingestion
-    /// service. Each pipeline's tasks start here (idle until the service serves them checkpoint
-    /// data), and ingestion begins at the smallest `next_checkpoint` across the pipelines.
+    /// Group the registered pipelines into ingestion cohorts by how far behind the network tip
+    /// they will resume from, and start one ingestion service per cohort. Each cohort ingests
+    /// from the smallest `next_checkpoint` among its members, so pipelines near the tip are not
+    /// held back (through channel backpressure) by pipelines that have a long backfill ahead of
+    /// them.
     ///
     /// Ingestion will stop after consuming the configured `last_checkpoint` if one is provided.
+    /// Note that a pipeline dropping its checkpoint subscription only winds down its own
+    /// cohort's ingestion service; other cohorts keep running.
     pub async fn run(self) -> anyhow::Result<Service> {
         let Self {
             ingestion_factory,
             last_checkpoint,
+            latest_checkpoint,
             enabled_pipelines,
             pipelines,
             ..
@@ -378,26 +391,44 @@ impl<S: Store> Indexer<S> {
 
         ensure!(!pipelines.is_empty(), "No pipelines registered to run");
 
+        let groups = cohorts(
+            pipelines,
+            latest_checkpoint,
+            ingestion_factory.config().min_cohort_boundary,
+        );
+
+        info!(
+            cohorts = groups.len(),
+            latest_checkpoint, "Grouped pipelines into ingestion cohorts"
+        );
+
         let end = last_checkpoint.map_or(Bound::Unbounded, Bound::Included);
 
-        let mut ingestion = ingestion_factory.create(0);
+        let mut service = Service::new();
+        for (cohort, group) in groups.into_iter().enumerate() {
+            let mut ingestion = ingestion_factory.create(cohort);
 
-        let mut start = u64::MAX;
-        let mut members = Vec::with_capacity(pipelines.len());
-        for pending in pipelines {
-            start = start.min(pending.next_checkpoint);
-            members.push((pending.build)(&mut ingestion));
-        }
+            let mut start = u64::MAX;
+            let mut names = Vec::with_capacity(group.len());
+            let mut members = Vec::with_capacity(group.len());
+            for pending in group {
+                start = start.min(pending.next_checkpoint);
+                names.push(pending.name);
+                members.push((pending.build)(&mut ingestion));
+            }
 
-        info!(start, end = last_checkpoint, "Ingestion range");
+            info!(cohort, start, end = last_checkpoint, pipelines = ?names, "Ingestion range");
 
-        let mut service = ingestion
-            .run((Bound::Included(start), end))
-            .await
-            .context("Failed to start ingestion service")?;
+            let mut cohort_service = ingestion
+                .run((Bound::Included(start), end))
+                .await
+                .context("Failed to start ingestion service")?;
 
-        for member in members {
-            service = service.merge(member);
+            for member in members {
+                cohort_service = cohort_service.merge(member);
+            }
+
+            service = service.merge(cohort_service);
         }
 
         Ok(service)
@@ -462,7 +493,7 @@ impl<S: Store> Indexer<S> {
 
 impl<S: ConcurrentStore> Indexer<S> {
     /// Adds a new pipeline to this indexer. Its tasks are started when the indexer is run, and
-    /// will be idle until the ingestion service serves it checkpoint data.
+    /// will be idle until its cohort's ingestion service serves it checkpoint data.
     ///
     /// Concurrent pipelines commit checkpoint data out-of-order to maximise throughput, and they
     /// keep the watermark table up-to-date with the highest point they can guarantee all data
@@ -483,6 +514,7 @@ impl<S: ConcurrentStore> Indexer<S> {
         let task = self.task.clone();
         let metrics = self.metrics.clone();
         self.pipelines.push(PendingPipeline {
+            name: H::NAME,
             next_checkpoint,
             build: Box::new(move |ingestion| {
                 let checkpoint_rx =
@@ -505,7 +537,7 @@ impl<S: ConcurrentStore> Indexer<S> {
 
 impl<T: SequentialStore> Indexer<T> {
     /// Adds a new pipeline to this indexer. Its tasks are started when the indexer is run, and
-    /// will be idle until the ingestion service serves it checkpoint data.
+    /// will be idle until its cohort's ingestion service serves it checkpoint data.
     ///
     /// Sequential pipelines commit checkpoint data in-order which sacrifices throughput, but may be
     /// required to handle pipelines that modify data in-place (where each update is not an insert,
@@ -537,6 +569,7 @@ impl<T: SequentialStore> Indexer<T> {
         let store = self.store.clone();
         let metrics = self.metrics.clone();
         self.pipelines.push(PendingPipeline {
+            name: H::NAME,
             next_checkpoint,
             build: Box::new(move |ingestion| {
                 let checkpoint_rx =
@@ -801,6 +834,33 @@ mod tests {
             .sequential_pipeline(handler, SequentialConfig::default())
             .await
             .unwrap();
+    }
+
+    /// Seed `store` so `near` resumes just past a fake network tip of 100,000 (its distance
+    /// from the tip saturates to zero) while `far` resumes 99,990 checkpoints behind it, and
+    /// return an ingestion directory advertising that tip with checkpoints 0..60 on disk.
+    /// Cohorts are determined by distance from the advertised tip, but ingestion stops at
+    /// `last_checkpoint`. Checkpoint 0 must exist because the ingestion client derives the
+    /// chain identifier from it, and retries indefinitely until it appears.
+    async fn multi_cohort_setup(
+        store: &FallibleMockStore,
+        near: &str,
+        far: &str,
+    ) -> tempfile::TempDir {
+        let mut conn = store.connect().await.unwrap();
+        set_committer_watermark(&mut conn, near, 100_100).await;
+        set_committer_watermark(&mut conn, far, 9).await;
+
+        let temp_dir = init_ingestion_dir(Some(100_000));
+        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+            ingestion_dir: temp_dir.path().to_owned(),
+            starting_checkpoint: 0,
+            num_checkpoints: 60,
+            checkpoint_size: 1,
+        })
+        .await;
+
+        temp_dir
     }
 
     macro_rules! assert_out_of_order {
@@ -1694,5 +1754,226 @@ mod tests {
                 "Checkpoint {chkpt} should have been committed (baseline)"
             );
         }
+    }
+
+    /// Pipelines whose distances from the network tip are far apart are split into separate
+    /// ingestion cohorts, each served by its own ingestion service, and the indexer completes
+    /// even though the cohorts' ingestion services finish at different times.
+    #[tokio::test]
+    async fn test_multi_cohort_ingestion() {
+        let registry = Registry::new();
+        let store = FallibleMockStore::default();
+
+        test_pipeline!(A, "near_tip");
+        test_pipeline!(B, "far_behind");
+
+        let temp_dir = multi_cohort_setup(&store, A::NAME, B::NAME).await;
+
+        let mut indexer = Indexer::new(
+            store.clone(),
+            IndexerArgs {
+                last_checkpoint: Some(59),
+                ..Default::default()
+            },
+            ClientArgs {
+                ingestion: IngestionClientArgs {
+                    local_ingestion_path: Some(temp_dir.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            IngestionConfig::default(),
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+
+        let ingestion_metrics = indexer.ingestion_metrics().clone();
+        let indexer_metrics = indexer.indexer_metrics().clone();
+        indexer.run().await.unwrap().join().await.unwrap();
+
+        // Both cohorts' services report to the shared metrics; only the lagging cohort had
+        // anything to ingest (the near-tip cohort's range [100_101, 59] is empty).
+        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 50);
+
+        // The near-tip pipeline received no checkpoints at all, proving it was not subscribed
+        // to the lagging cohort's backfill (unsplit, it would have received all 50).
+        let received = |name| {
+            indexer_metrics
+                .total_handler_checkpoints_received
+                .get_metric_with_label_values(&[name])
+                .unwrap()
+                .get()
+        };
+        assert_eq!(received(A::NAME), 0);
+        assert_eq!(received(B::NAME), 50);
+
+        // The lagging pipeline committed everything up to `last_checkpoint`, while the near-tip
+        // pipeline had nothing to process.
+        let watermark = store.watermark(B::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(59));
+        let watermark = store.watermark(A::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(100_100));
+    }
+
+    /// The client-driven constructor groups pipelines into cohorts too, with all cohorts
+    /// sharing the supplied ingestion client and its metrics handle.
+    #[tokio::test]
+    async fn test_multi_cohort_ingestion_with_clients() {
+        let registry = Registry::new();
+        let store = FallibleMockStore::default();
+
+        test_pipeline!(A, "near_tip");
+        test_pipeline!(B, "far_behind");
+
+        let temp_dir = multi_cohort_setup(&store, A::NAME, B::NAME).await;
+
+        let ingestion_metrics = IngestionMetrics::new(None, &registry);
+        let ingestion_client = IngestionClient::new(
+            IngestionClientArgs {
+                local_ingestion_path: Some(temp_dir.path().to_owned()),
+                ..Default::default()
+            },
+            ingestion_metrics.clone(),
+        )
+        .unwrap();
+
+        let mut indexer = Indexer::with_ingestion_clients(
+            store.clone(),
+            IndexerArgs {
+                last_checkpoint: Some(59),
+                ..Default::default()
+            },
+            ingestion_client,
+            None,
+            IngestionConfig::default(),
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+
+        let indexer_metrics = indexer.indexer_metrics().clone();
+        indexer.run().await.unwrap().join().await.unwrap();
+
+        // Both cohorts' services report to the one shared metrics handle, and only the lagging
+        // cohort's pipeline received checkpoints.
+        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 50);
+        assert_eq!(
+            indexer_metrics
+                .total_handler_checkpoints_received
+                .get_metric_with_label_values(&[A::NAME])
+                .unwrap()
+                .get(),
+            0
+        );
+
+        let watermark = store.watermark(B::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(59));
+    }
+
+    /// Hard isolation: a pipeline at the tip runs to completion even while a far-behind pipeline in
+    /// a separate cohort is wedged and backpressuring its own ingestion service. Before cohorts,
+    /// both pipelines shared one ingestion service, so the far-behind pipeline's full subscriber
+    /// channel would have throttled the shared broadcaster and held the tip pipeline back too.
+    #[tokio::test]
+    async fn test_near_tip_cohort_progresses_while_far_behind_stalls() {
+        const TIP: u64 = 100;
+
+        let registry = Registry::new();
+        let store = FallibleMockStore::default();
+
+        test_pipeline!(A, "near_tip");
+
+        // The far-behind pipeline's handler blocks every checkpoint in its range (all > 9), so its
+        // cohort's ingestion service fills its subscriber channel and backpressures to a halt. Keep
+        // the release sender alive for the whole test -- dropping it would unblock the handler.
+        let (far_behind, _release) = ControllableHandler::with_limit(9);
+
+        let temp_dir = init_ingestion_dir(Some(TIP));
+        let mut conn = store.connect().await.unwrap();
+        set_committer_watermark(&mut conn, A::NAME, 94).await; // near tip: resumes at 95
+        set_committer_watermark(&mut conn, ControllableHandler::NAME, 9).await; // far behind: resumes at 10
+        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+            ingestion_dir: temp_dir.path().to_owned(),
+            starting_checkpoint: 0,
+            num_checkpoints: TIP + 1, // checkpoints [0, TIP]
+            checkpoint_size: 1,
+        })
+        .await;
+
+        let mut indexer = Indexer::new(
+            store.clone(),
+            IndexerArgs {
+                last_checkpoint: Some(TIP),
+                ..Default::default()
+            },
+            ClientArgs {
+                ingestion: IngestionClientArgs {
+                    local_ingestion_path: Some(temp_dir.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            // A small cohort boundary splits the near-tip and far-behind pipelines into separate
+            // cohorts without having to generate tens of thousands of checkpoints.
+            IngestionConfig {
+                min_cohort_boundary: 10,
+                ..Default::default()
+            },
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        // Near-tip pipeline: commit promptly so its watermark advances without waiting on the
+        // default collector/watermark intervals.
+        indexer
+            .concurrent_pipeline(
+                A,
+                ConcurrentConfig {
+                    committer: CommitterConfig {
+                        collect_interval_ms: 10,
+                        watermark_interval_ms: 10,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        // Far-behind pipeline: its handler blocks, so it never commits regardless of config.
+        add_concurrent(&mut indexer, far_behind).await;
+
+        let service = indexer.run().await.unwrap();
+
+        // The near-tip cohort ingests [95, 100] and commits to completion even though the
+        // far-behind cohort is wedged. Were the two not isolated, the far-behind pipeline's
+        // backpressure would stall this too and the wait would time out.
+        store
+            .wait_for_watermark(A::NAME, TIP, Duration::from_secs(10))
+            .await;
+
+        // The far-behind pipeline made no progress: still at its initial watermark, nothing
+        // committed -- it is stalled inside its own cohort, not holding the tip pipeline back.
+        assert_eq!(
+            store
+                .watermark(ControllableHandler::NAME)
+                .unwrap()
+                .checkpoint_hi_inclusive,
+            Some(9),
+        );
+        assert!(store.data.get(ControllableHandler::NAME).is_none());
+
+        // The merged service never completes on its own while a cohort is wedged; drop aborts it.
+        drop(service);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -9,8 +9,10 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::bail;
 use anyhow::ensure;
+use ingestion::ArcStreamingClient;
 use ingestion::ClientArgs;
 use ingestion::IngestionConfig;
+use ingestion::IngestionFactory;
 use ingestion::IngestionService;
 use ingestion::ingestion_client::IngestionClient;
 use metrics::IndexerMetrics;
@@ -115,8 +117,9 @@ pub struct Indexer<S: Store> {
     /// Prometheus Metrics.
     metrics: Arc<IndexerMetrics>,
 
-    /// Service for downloading and disseminating checkpoint data.
-    ingestion_service: IngestionService,
+    /// Creates the ingestion service that downloads and disseminates checkpoint data. The service
+    /// is built when the indexer is run.
+    ingestion_factory: IngestionFactory,
 
     /// Optional override of the checkpoint lowerbound. When set, pipelines without a committer
     /// watermark will start processing at this checkpoint.
@@ -159,8 +162,9 @@ pub struct Indexer<S: Store> {
     /// with the same name isn't added twice.
     added_pipelines: BTreeSet<&'static str>,
 
-    /// The service handles for every pipeline, used to manage lifetimes and graceful shutdown.
-    pipelines: Vec<Service>,
+    /// Registered pipelines, waiting to be started against the ingestion service when the indexer
+    /// is run.
+    pipelines: Vec<PendingPipeline>,
 }
 
 /// Configuration for a tasked indexer.
@@ -173,6 +177,27 @@ pub(crate) struct Task {
     /// pipeline's reader watermark.
     reader_interval: Duration,
 }
+
+/// A pipeline that has been registered but whose tasks have not been started yet. Pipelines are
+/// held in this form until [Indexer::run], when the ingestion service they subscribe to is
+/// created.
+struct PendingPipeline {
+    /// The checkpoint this pipeline will resume processing from.
+    next_checkpoint: u64,
+
+    /// Deferred constructor, invoked in [Indexer::run] once the ingestion service is available to
+    /// subscribe to.
+    build: PipelineBuilder,
+}
+
+/// Subscribes a pipeline to the ingestion service and starts the pipeline's tasks, returning the
+/// service handle over those tasks.
+///
+/// `Sync` is required (in addition to `Send`) because the `Indexer` holding these builders is kept
+/// alive across await points, and the simulator test runtime requires the resulting futures to be
+/// `Sync`. The builder closures only capture `Send + Sync` state (the handler, store, config, and
+/// metrics), so this bound is satisfied.
+type PipelineBuilder = Box<dyn FnOnce(&mut IngestionService) -> Service + Send + Sync>;
 
 impl TaskArgs {
     pub fn tasked(task: String, reader_interval_ms: u64) -> Self {
@@ -210,29 +235,53 @@ impl<S: Store> Indexer<S> {
         metrics_prefix: Option<&str>,
         registry: &Registry,
     ) -> anyhow::Result<Self> {
-        let ingestion_service =
-            IngestionService::new(client_args, ingestion_config, metrics_prefix, registry)?;
-        Self::with_ingestion_service(
+        let ingestion_factory =
+            IngestionFactory::new(client_args, ingestion_config, metrics_prefix, registry)?;
+        Self::with_ingestion_factory(
             store,
             indexer_args,
-            ingestion_service,
+            ingestion_factory,
             metrics_prefix,
             registry,
         )
         .await
     }
 
-    /// Variant of [`Self::new`] that accepts a pre-built
-    /// [`IngestionService`], bypassing [`ClientArgs`]-driven
-    /// construction. Callers that supply their own ingestion /
-    /// streaming clients — for example, when embedding the indexer
-    /// in a fullnode that already has checkpoint data on hand —
-    /// build the service via [`IngestionService::with_clients`] and
-    /// hand it in here.
-    pub async fn with_ingestion_service(
+    /// Variant of [`Self::new`] that accepts pre-built ingestion clients, bypassing
+    /// [`ClientArgs`]-driven construction. Callers that supply their own
+    /// [`IngestionClientTrait`] / [`CheckpointStreamingClient`] implementations — for example,
+    /// when embedding the indexer in a fullnode that already has checkpoint data on hand — hand
+    /// them in here, and the indexer creates its ingestion service from them.
+    ///
+    /// [`IngestionClientTrait`]: crate::ingestion::ingestion_client::IngestionClientTrait
+    /// [`CheckpointStreamingClient`]: crate::ingestion::streaming_client::CheckpointStreamingClient
+    pub async fn with_ingestion_clients(
         store: S,
         indexer_args: IndexerArgs,
-        mut ingestion_service: IngestionService,
+        ingestion_client: IngestionClient,
+        streaming_client: Option<ArcStreamingClient>,
+        ingestion_config: IngestionConfig,
+        metrics_prefix: Option<&str>,
+        registry: &Registry,
+    ) -> anyhow::Result<Self> {
+        let ingestion_factory =
+            IngestionFactory::with_clients(ingestion_client, streaming_client, ingestion_config);
+        Self::with_ingestion_factory(
+            store,
+            indexer_args,
+            ingestion_factory,
+            metrics_prefix,
+            registry,
+        )
+        .await
+    }
+
+    /// Common assembly point for [`Self::new`] and [`Self::with_ingestion_clients`]: probes the
+    /// network tip through the factory and stamps the fields onto the struct.
+    async fn with_ingestion_factory(
+        store: S,
+        indexer_args: IndexerArgs,
+        ingestion_factory: IngestionFactory,
         metrics_prefix: Option<&str>,
         registry: &Registry,
     ) -> anyhow::Result<Self> {
@@ -245,14 +294,14 @@ impl<S: Store> Indexer<S> {
 
         let metrics = IndexerMetrics::new(metrics_prefix, registry);
 
-        let latest_checkpoint = ingestion_service.latest_checkpoint_number().await?;
+        let latest_checkpoint = ingestion_factory.latest_checkpoint_number().await?;
 
         info!(latest_checkpoint);
 
         Ok(Self {
             store,
             metrics,
-            ingestion_service,
+            ingestion_factory,
             first_checkpoint,
             last_checkpoint,
             latest_checkpoint,
@@ -276,7 +325,7 @@ impl<S: Store> Indexer<S> {
 
     /// The ingestion client used by the indexer to fetch checkpoints.
     pub fn ingestion_client(&self) -> &IngestionClient {
-        self.ingestion_service.ingestion_client()
+        self.ingestion_factory.ingestion_client()
     }
 
     /// The indexer's metrics.
@@ -284,9 +333,9 @@ impl<S: Store> Indexer<S> {
         &self.metrics
     }
 
-    /// The ingestion service's metrics.
+    /// The ingestion metrics shared by all of this indexer's ingestion services.
     pub fn ingestion_metrics(&self) -> &Arc<IngestionMetrics> {
-        self.ingestion_service.metrics()
+        self.ingestion_factory.metrics()
     }
 
     /// The pipelines that this indexer will run.
@@ -305,13 +354,21 @@ impl<S: Store> Indexer<S> {
         self.next_sequential_checkpoint
     }
 
-    /// Start ingesting checkpoints from `next_checkpoint`. Individual pipelines
-    /// will start processing and committing once the ingestion service has caught up to their
-    /// respective watermarks.
+    /// Start ingesting checkpoints and run all the registered pipelines against a single ingestion
+    /// service. Each pipeline's tasks start here (idle until the service serves them checkpoint
+    /// data), and ingestion begins at the smallest `next_checkpoint` across the pipelines.
     ///
     /// Ingestion will stop after consuming the configured `last_checkpoint` if one is provided.
     pub async fn run(self) -> anyhow::Result<Service> {
-        if let Some(enabled_pipelines) = self.enabled_pipelines {
+        let Self {
+            ingestion_factory,
+            last_checkpoint,
+            enabled_pipelines,
+            pipelines,
+            ..
+        } = self;
+
+        if let Some(enabled_pipelines) = enabled_pipelines {
             ensure!(
                 enabled_pipelines.is_empty(),
                 "Tried to enable pipelines that this indexer does not know about: \
@@ -319,21 +376,28 @@ impl<S: Store> Indexer<S> {
             );
         }
 
-        let start = self.next_checkpoint;
-        let end = self.last_checkpoint;
-        info!(start, end, "Ingestion range");
+        ensure!(!pipelines.is_empty(), "No pipelines registered to run");
 
-        let mut service = self
-            .ingestion_service
-            .run((
-                Bound::Included(start),
-                end.map_or(Bound::Unbounded, Bound::Included),
-            ))
+        let end = last_checkpoint.map_or(Bound::Unbounded, Bound::Included);
+
+        let mut ingestion = ingestion_factory.create(0);
+
+        let mut start = u64::MAX;
+        let mut members = Vec::with_capacity(pipelines.len());
+        for pending in pipelines {
+            start = start.min(pending.next_checkpoint);
+            members.push((pending.build)(&mut ingestion));
+        }
+
+        info!(start, end = last_checkpoint, "Ingestion range");
+
+        let mut service = ingestion
+            .run((Bound::Included(start), end))
             .await
             .context("Failed to start ingestion service")?;
 
-        for pipeline in self.pipelines {
-            service = service.merge(pipeline);
+        for member in members {
+            service = service.merge(member);
         }
 
         Ok(service)
@@ -397,8 +461,8 @@ impl<S: Store> Indexer<S> {
 }
 
 impl<S: ConcurrentStore> Indexer<S> {
-    /// Adds a new pipeline to this indexer and starts it up. Although their tasks have started,
-    /// they will be idle until the ingestion service starts, and serves it checkpoint data.
+    /// Adds a new pipeline to this indexer. Its tasks are started when the indexer is run, and
+    /// will be idle until the ingestion service serves it checkpoint data.
     ///
     /// Concurrent pipelines commit checkpoint data out-of-order to maximise throughput, and they
     /// keep the watermark table up-to-date with the highest point they can guarantee all data
@@ -415,27 +479,33 @@ impl<S: ConcurrentStore> Indexer<S> {
             return Ok(());
         };
 
-        let checkpoint_rx = self
-            .ingestion_service
-            .subscribe_bounded(config.ingestion.subscriber_channel_size());
-
-        self.pipelines.push(concurrent::pipeline::<H>(
-            handler,
+        let store = self.store.clone();
+        let task = self.task.clone();
+        let metrics = self.metrics.clone();
+        self.pipelines.push(PendingPipeline {
             next_checkpoint,
-            config,
-            self.store.clone(),
-            self.task.clone(),
-            checkpoint_rx,
-            self.metrics.clone(),
-        ));
+            build: Box::new(move |ingestion| {
+                let checkpoint_rx =
+                    ingestion.subscribe_bounded(config.ingestion.subscriber_channel_size());
+                concurrent::pipeline::<H>(
+                    handler,
+                    next_checkpoint,
+                    config,
+                    store,
+                    task,
+                    checkpoint_rx,
+                    metrics,
+                )
+            }),
+        });
 
         Ok(())
     }
 }
 
 impl<T: SequentialStore> Indexer<T> {
-    /// Adds a new pipeline to this indexer and starts it up. Although their tasks have started,
-    /// they will be idle until the ingestion service starts, and serves it checkpoint data.
+    /// Adds a new pipeline to this indexer. Its tasks are started when the indexer is run, and
+    /// will be idle until the ingestion service serves it checkpoint data.
     ///
     /// Sequential pipelines commit checkpoint data in-order which sacrifices throughput, but may be
     /// required to handle pipelines that modify data in-place (where each update is not an insert,
@@ -464,18 +534,23 @@ impl<T: SequentialStore> Indexer<T> {
                 .map_or(next_checkpoint, |n| n.min(next_checkpoint)),
         );
 
-        let checkpoint_rx = self
-            .ingestion_service
-            .subscribe_bounded(config.ingestion.subscriber_channel_size());
-
-        self.pipelines.push(sequential::pipeline::<H>(
-            handler,
+        let store = self.store.clone();
+        let metrics = self.metrics.clone();
+        self.pipelines.push(PendingPipeline {
             next_checkpoint,
-            config,
-            self.store.clone(),
-            checkpoint_rx,
-            self.metrics.clone(),
-        ));
+            build: Box::new(move |ingestion| {
+                let checkpoint_rx =
+                    ingestion.subscribe_bounded(config.ingestion.subscriber_channel_size());
+                sequential::pipeline::<H>(
+                    handler,
+                    next_checkpoint,
+                    config,
+                    store,
+                    checkpoint_rx,
+                    metrics,
+                )
+            }),
+        });
 
         Ok(())
     }

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -1309,7 +1309,13 @@ mod tests {
 
         indexer.run().await.unwrap().join().await.unwrap();
 
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 24);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            24
+        );
         assert_out_of_order!(indexer_metrics, A::NAME, 0);
         assert_out_of_order!(indexer_metrics, B::NAME, 5);
         assert_out_of_order!(indexer_metrics, C::NAME, 10);
@@ -1350,7 +1356,13 @@ mod tests {
         let metrics = indexer.indexer_metrics().clone();
         indexer.run().await.unwrap().join().await.unwrap();
 
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 24);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            24
+        );
         assert_out_of_order!(metrics, A::NAME, 0);
         assert_out_of_order!(metrics, B::NAME, 5);
         assert_out_of_order!(metrics, C::NAME, 10);
@@ -1389,7 +1401,13 @@ mod tests {
         let metrics = indexer.indexer_metrics().clone();
         indexer.run().await.unwrap().join().await.unwrap();
 
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 30);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            30
+        );
         assert_out_of_order!(metrics, A::NAME, 0);
         assert_out_of_order!(metrics, B::NAME, 11);
         assert_out_of_order!(metrics, C::NAME, 16);
@@ -1429,7 +1447,13 @@ mod tests {
         let metrics = indexer.indexer_metrics().clone();
         indexer.run().await.unwrap().join().await.unwrap();
 
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 20);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            20
+        );
         assert_out_of_order!(metrics, A::NAME, 0);
         assert_out_of_order!(metrics, B::NAME, 1);
         assert_out_of_order!(metrics, C::NAME, 6);
@@ -1560,7 +1584,13 @@ mod tests {
 
         tasked_indexer.run().await.unwrap().join().await.unwrap();
 
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 16);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            16
+        );
         assert_eq!(
             metrics
                 .total_collector_skipped_checkpoints
@@ -1610,7 +1640,13 @@ mod tests {
 
         tasked_indexer.run().await.unwrap().join().await.unwrap();
 
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 17);
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            17
+        );
         assert_out_of_order!(metrics, "test", 0);
         assert_eq!(
             metrics
@@ -1796,9 +1832,23 @@ mod tests {
         let indexer_metrics = indexer.indexer_metrics().clone();
         indexer.run().await.unwrap().join().await.unwrap();
 
-        // Both cohorts' services report to the shared metrics; only the lagging cohort had
-        // anything to ingest (the near-tip cohort's range [100_101, 59] is empty).
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 50);
+        // Both cohorts' services report to the shared metrics, each under its own cohort label.
+        // Only the lagging cohort (1) had anything to ingest; the near-tip cohort (0)'s range
+        // [100_101, 59] is empty.
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["1"])
+                .get(),
+            50
+        );
 
         // The near-tip pipeline received no checkpoints at all, proving it was not subscribed
         // to the lagging cohort's backfill (unsplit, it would have received all 50).
@@ -1863,9 +1913,22 @@ mod tests {
         let indexer_metrics = indexer.indexer_metrics().clone();
         indexer.run().await.unwrap().join().await.unwrap();
 
-        // Both cohorts' services report to the one shared metrics handle, and only the lagging
-        // cohort's pipeline received checkpoints.
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 50);
+        // Both cohorts' services report to the one shared metrics handle, each under its own
+        // cohort label, and only the lagging cohort (1) ingested checkpoints.
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["1"])
+                .get(),
+            50
+        );
         assert_eq!(
             indexer_metrics
                 .total_handler_checkpoints_received

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -55,36 +55,74 @@ const BATCH_SIZE_BUCKETS: &[f64] = &[
 ];
 
 /// Metrics specific to the ingestion service.
+///
+/// Almost every metric is labeled by `cohort`: the framework mints one ingestion service per cohort,
+/// all sharing this handle, so the label keeps their series from colliding. The two exceptions are
+/// `total_ingested_bytes` (counted inside the checkpoint source, which is shared across cohorts) and
+/// `ingested_latest_checkpoint_latency` (recorded only by the factory's one-time tip probe, before
+/// any cohort exists).
 #[derive(Clone)]
 pub struct IngestionMetrics {
     // Statistics related to fetching data from the remote store.
-    pub total_ingested_checkpoints: IntCounter,
-    pub total_ingested_transactions: IntCounter,
-    pub total_ingested_events: IntCounter,
-    pub total_ingested_objects: IntCounter,
+    pub total_ingested_checkpoints: IntCounterVec,
+    pub total_ingested_transactions: IntCounterVec,
+    pub total_ingested_events: IntCounterVec,
+    pub total_ingested_objects: IntCounterVec,
     pub total_ingested_bytes: IntCounter,
     pub total_ingested_transient_retries: IntCounterVec,
-    pub total_ingested_not_found_retries: IntCounter,
-    pub total_streamed_checkpoints: IntCounter,
-    pub total_skipped_streamed_checkpoints: IntCounter,
-    pub total_out_of_order_streamed_checkpoints: IntCounter,
-    pub total_stream_disconnections: IntCounter,
-    pub total_streaming_connection_failures: IntCounter,
+    pub total_ingested_not_found_retries: IntCounterVec,
+    pub total_streamed_checkpoints: IntCounterVec,
+    pub total_skipped_streamed_checkpoints: IntCounterVec,
+    pub total_out_of_order_streamed_checkpoints: IntCounterVec,
+    pub total_stream_disconnections: IntCounterVec,
+    pub total_streaming_connection_failures: IntCounterVec,
 
-    // Checkpoint lag metrics for the ingestion pipeline. Labeled by cohort so that services minted
-    // for different cohorts report independently rather than overwriting each other's gauges.
+    // Checkpoint lag metrics for the ingestion pipeline.
     pub latest_ingested_checkpoint: IntGaugeVec,
     pub latest_streamed_checkpoint: IntGaugeVec,
     pub latest_skipped_streamed_checkpoint: IntGaugeVec,
     pub latest_ingested_checkpoint_timestamp_lag_ms: IntGaugeVec,
     pub ingested_checkpoint_timestamp_lag: HistogramVec,
 
-    pub ingested_checkpoint_latency: Histogram,
-    pub ingested_chain_id_latency: Histogram,
+    pub ingested_checkpoint_latency: HistogramVec,
+    pub ingested_chain_id_latency: HistogramVec,
     pub ingested_latest_checkpoint_latency: Histogram,
 
     pub ingestion_concurrency_limit: IntGaugeVec,
     pub ingestion_concurrency_inflight: IntGaugeVec,
+}
+
+/// A cohort's pre-bound view over [`IngestionMetrics`]. The framework mints one ingestion service
+/// per cohort; each binds its metrics' `cohort` label once, here, so emission sites stay plain
+/// `.inc()`/`.observe()`/`.set()` calls rather than repeating `.with_label_values(&[cohort])`.
+pub(crate) struct CohortMetrics {
+    pub(crate) total_ingested_checkpoints: IntCounter,
+    pub(crate) total_ingested_transactions: IntCounter,
+    pub(crate) total_ingested_events: IntCounter,
+    pub(crate) total_ingested_objects: IntCounter,
+    pub(crate) total_ingested_not_found_retries: IntCounter,
+    pub(crate) total_streamed_checkpoints: IntCounter,
+    pub(crate) total_skipped_streamed_checkpoints: IntCounter,
+    pub(crate) total_out_of_order_streamed_checkpoints: IntCounter,
+    pub(crate) total_stream_disconnections: IntCounter,
+    pub(crate) total_streaming_connection_failures: IntCounter,
+
+    pub(crate) ingested_checkpoint_latency: Histogram,
+    pub(crate) ingested_chain_id_latency: Histogram,
+
+    pub(crate) latest_streamed_checkpoint: IntGauge,
+    pub(crate) latest_skipped_streamed_checkpoint: IntGauge,
+    pub(crate) ingestion_concurrency_limit: IntGauge,
+    pub(crate) ingestion_concurrency_inflight: IntGauge,
+
+    /// Reports this cohort's checkpoint-lag gauges/histogram (with its own running-max state).
+    pub(crate) checkpoint_lag: Arc<CheckpointLagMetricReporter>,
+
+    /// Retries carry a `reason` label in addition to `cohort`, so this stays an unbound vector and
+    /// [`Self::inc_retry`] binds both labels.
+    total_ingested_transient_retries: IntCounterVec,
+    /// This client's `cohort` label value, for the two-label retry counter.
+    label: String,
 }
 
 #[derive(Clone)]
@@ -183,27 +221,31 @@ impl IngestionMetrics {
         let prefix = prefix.unwrap_or(DEFAULT_METRICS_PREFIX);
         let name = |n| format!("{prefix}_{n}");
         Arc::new(Self {
-            total_ingested_checkpoints: register_int_counter_with_registry!(
+            total_ingested_checkpoints: register_int_counter_vec_with_registry!(
                 name("total_ingested_checkpoints"),
                 "Total number of checkpoints fetched from the remote store",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_ingested_transactions: register_int_counter_with_registry!(
+            total_ingested_transactions: register_int_counter_vec_with_registry!(
                 name("total_ingested_transactions"),
                 "Total number of transactions fetched from the remote store",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_ingested_events: register_int_counter_with_registry!(
+            total_ingested_events: register_int_counter_vec_with_registry!(
                 name("total_ingested_events"),
                 "Total number of events fetched from the remote store",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_ingested_objects: register_int_counter_with_registry!(
+            total_ingested_objects: register_int_counter_vec_with_registry!(
                 name("total_ingested_objects"),
                 "Total number of objects in checkpoints fetched from the remote store",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
@@ -217,44 +259,50 @@ impl IngestionMetrics {
                 name("total_ingested_retries"),
                 "Total number of retries due to transient errors while fetching data from the \
                  remote store",
-                &["reason"],
+                &["reason", "cohort"],
                 registry,
             )
             .unwrap(),
-            total_ingested_not_found_retries: register_int_counter_with_registry!(
+            total_ingested_not_found_retries: register_int_counter_vec_with_registry!(
                 name("total_ingested_not_found_retries"),
                 "Total number of retries due to the not found errors while fetching data from the \
                  remote store",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_streamed_checkpoints: register_int_counter_with_registry!(
+            total_streamed_checkpoints: register_int_counter_vec_with_registry!(
                 name("total_streamed_checkpoints"),
                 "Total number of checkpoints received from gRPC streaming",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_skipped_streamed_checkpoints: register_int_counter_with_registry!(
+            total_skipped_streamed_checkpoints: register_int_counter_vec_with_registry!(
                 name("total_skipped_streamed_checkpoints"),
                 "Total number of streamed checkpoints skipped because they were already processed",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_out_of_order_streamed_checkpoints: register_int_counter_with_registry!(
+            total_out_of_order_streamed_checkpoints: register_int_counter_vec_with_registry!(
                 name("total_out_of_order_streamed_checkpoints"),
                 "Total number of streamed checkpoints received out of order",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_stream_disconnections: register_int_counter_with_registry!(
+            total_stream_disconnections: register_int_counter_vec_with_registry!(
                 name("total_stream_disconnections"),
                 "Total number of times the gRPC stream was disconnected",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            total_streaming_connection_failures: register_int_counter_with_registry!(
+            total_streaming_connection_failures: register_int_counter_vec_with_registry!(
                 name("total_streaming_connection_failures"),
                 "Total number of failures due to streaming service connection or peek failures",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
@@ -296,16 +344,18 @@ impl IngestionMetrics {
                 registry,
             )
             .unwrap(),
-            ingested_checkpoint_latency: register_histogram_with_registry!(
+            ingested_checkpoint_latency: register_histogram_vec_with_registry!(
                 name("ingested_checkpoint_latency"),
                 "Time taken to fetch a checkpoint from the remote store, including retries",
+                &["cohort"],
                 INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
-            ingested_chain_id_latency: register_histogram_with_registry!(
+            ingested_chain_id_latency: register_histogram_vec_with_registry!(
                 name("ingested_chain_id_latency"),
                 "Time taken to fetch the chain identifier, including retries",
+                &["cohort"],
                 INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -333,6 +383,61 @@ impl IngestionMetrics {
             .unwrap(),
         })
     }
+}
+
+impl CohortMetrics {
+    /// Bind every cohort-labeled ingestion metric to `label` once, so services minted for
+    /// different cohorts report under their own label without re-binding at each emission site.
+    pub(crate) fn new(metrics: &IngestionMetrics, label: &str) -> Arc<Self> {
+        let c = label;
+        let checkpoint_lag = CheckpointLagMetricReporter::with_label(
+            &metrics.ingested_checkpoint_timestamp_lag,
+            &metrics.latest_ingested_checkpoint_timestamp_lag_ms,
+            &metrics.latest_ingested_checkpoint,
+            c,
+        );
+        Arc::new(Self {
+            total_ingested_checkpoints: metrics.total_ingested_checkpoints.with_label_values(&[c]),
+            total_ingested_transactions: metrics
+                .total_ingested_transactions
+                .with_label_values(&[c]),
+            total_ingested_events: metrics.total_ingested_events.with_label_values(&[c]),
+            total_ingested_objects: metrics.total_ingested_objects.with_label_values(&[c]),
+            total_ingested_not_found_retries: metrics
+                .total_ingested_not_found_retries
+                .with_label_values(&[c]),
+            total_streamed_checkpoints: metrics.total_streamed_checkpoints.with_label_values(&[c]),
+            total_skipped_streamed_checkpoints: metrics
+                .total_skipped_streamed_checkpoints
+                .with_label_values(&[c]),
+            total_out_of_order_streamed_checkpoints: metrics
+                .total_out_of_order_streamed_checkpoints
+                .with_label_values(&[c]),
+            total_stream_disconnections: metrics
+                .total_stream_disconnections
+                .with_label_values(&[c]),
+            total_streaming_connection_failures: metrics
+                .total_streaming_connection_failures
+                .with_label_values(&[c]),
+            ingested_checkpoint_latency: metrics
+                .ingested_checkpoint_latency
+                .with_label_values(&[c]),
+            ingested_chain_id_latency: metrics.ingested_chain_id_latency.with_label_values(&[c]),
+            latest_streamed_checkpoint: metrics.latest_streamed_checkpoint.with_label_values(&[c]),
+            latest_skipped_streamed_checkpoint: metrics
+                .latest_skipped_streamed_checkpoint
+                .with_label_values(&[c]),
+            ingestion_concurrency_limit: metrics
+                .ingestion_concurrency_limit
+                .with_label_values(&[c]),
+            ingestion_concurrency_inflight: metrics
+                .ingestion_concurrency_inflight
+                .with_label_values(&[c]),
+            checkpoint_lag,
+            total_ingested_transient_retries: metrics.total_ingested_transient_retries.clone(),
+            label: label.to_string(),
+        })
+    }
 
     /// Register that we're retrying a checkpoint fetch due to a transient error, logging the
     /// reason and error.
@@ -350,7 +455,7 @@ impl IngestionMetrics {
         );
 
         self.total_ingested_transient_retries
-            .with_label_values(&[reason])
+            .with_label_values(&[reason, self.label.as_str()])
             .inc();
 
         backoff::Error::transient(error)

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -22,6 +22,9 @@ use tracing::warn;
 use crate::ingestion::error::Error;
 use crate::pipeline::Processor;
 
+/// Prefix used for metric names when no explicit prefix is provided.
+pub(crate) const DEFAULT_METRICS_PREFIX: &str = "indexer";
+
 /// Histogram buckets for the distribution of checkpoint fetching latencies.
 const INGESTION_LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0,
@@ -177,7 +180,7 @@ pub(crate) struct CheckpointLagMetricReporter {
 
 impl IngestionMetrics {
     pub fn new(prefix: Option<&str>, registry: &Registry) -> Arc<Self> {
-        let prefix = prefix.unwrap_or("indexer");
+        let prefix = prefix.unwrap_or(DEFAULT_METRICS_PREFIX);
         let name = |n| format!("{prefix}_{n}");
         Arc::new(Self {
             total_ingested_checkpoints: register_int_counter_with_registry!(
@@ -356,7 +359,7 @@ impl IngestionMetrics {
 
 impl IndexerMetrics {
     pub fn new(prefix: Option<&str>, registry: &Registry) -> Arc<Self> {
-        let prefix = prefix.unwrap_or("indexer");
+        let prefix = prefix.unwrap_or(DEFAULT_METRICS_PREFIX);
         let name = |n| format!("{prefix}_{n}");
         Arc::new(Self {
             total_handler_checkpoints_received: register_int_counter_vec_with_registry!(

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -900,10 +900,11 @@ impl CheckpointLagMetricReporter {
         latest_checkpoint_time_lag_gauge: &IntGaugeVec,
         latest_checkpoint_sequence_number_gauge: &IntGaugeVec,
     ) -> Arc<Self> {
-        Self::new(
-            checkpoint_time_lag_histogram.with_label_values(&[P::NAME]),
-            latest_checkpoint_time_lag_gauge.with_label_values(&[P::NAME]),
-            latest_checkpoint_sequence_number_gauge.with_label_values(&[P::NAME]),
+        Self::with_label(
+            checkpoint_time_lag_histogram,
+            latest_checkpoint_time_lag_gauge,
+            latest_checkpoint_sequence_number_gauge,
+            P::NAME,
         )
     }
 

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -17,7 +17,6 @@ use prometheus::register_histogram_with_registry;
 use prometheus::register_int_counter_vec_with_registry;
 use prometheus::register_int_counter_with_registry;
 use prometheus::register_int_gauge_vec_with_registry;
-use prometheus::register_int_gauge_with_registry;
 use tracing::warn;
 
 use crate::ingestion::error::Error;
@@ -69,19 +68,20 @@ pub struct IngestionMetrics {
     pub total_stream_disconnections: IntCounter,
     pub total_streaming_connection_failures: IntCounter,
 
-    // Checkpoint lag metrics for the ingestion pipeline.
-    pub latest_ingested_checkpoint: IntGauge,
-    pub latest_streamed_checkpoint: IntGauge,
-    pub latest_skipped_streamed_checkpoint: IntGauge,
-    pub latest_ingested_checkpoint_timestamp_lag_ms: IntGauge,
-    pub ingested_checkpoint_timestamp_lag: Histogram,
+    // Checkpoint lag metrics for the ingestion pipeline. Labeled by cohort so that services minted
+    // for different cohorts report independently rather than overwriting each other's gauges.
+    pub latest_ingested_checkpoint: IntGaugeVec,
+    pub latest_streamed_checkpoint: IntGaugeVec,
+    pub latest_skipped_streamed_checkpoint: IntGaugeVec,
+    pub latest_ingested_checkpoint_timestamp_lag_ms: IntGaugeVec,
+    pub ingested_checkpoint_timestamp_lag: HistogramVec,
 
     pub ingested_checkpoint_latency: Histogram,
     pub ingested_chain_id_latency: Histogram,
     pub ingested_latest_checkpoint_latency: Histogram,
 
-    pub ingestion_concurrency_limit: IntGauge,
-    pub ingestion_concurrency_inflight: IntGauge,
+    pub ingestion_concurrency_limit: IntGaugeVec,
+    pub ingestion_concurrency_inflight: IntGaugeVec,
 }
 
 #[derive(Clone)]
@@ -255,35 +255,40 @@ impl IngestionMetrics {
                 registry,
             )
             .unwrap(),
-            latest_ingested_checkpoint: register_int_gauge_with_registry!(
+            latest_ingested_checkpoint: register_int_gauge_vec_with_registry!(
                 name("latest_ingested_checkpoint"),
                 "Latest checkpoint sequence number fetched from the remote store",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            latest_streamed_checkpoint: register_int_gauge_with_registry!(
+            latest_streamed_checkpoint: register_int_gauge_vec_with_registry!(
                 name("latest_streamed_checkpoint"),
                 "Latest checkpoint sequence number received from gRPC streaming",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            latest_skipped_streamed_checkpoint: register_int_gauge_with_registry!(
+            latest_skipped_streamed_checkpoint: register_int_gauge_vec_with_registry!(
                 name("latest_skipped_streamed_checkpoint"),
                 "Latest streamed checkpoint sequence number skipped because it was already processed",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            latest_ingested_checkpoint_timestamp_lag_ms: register_int_gauge_with_registry!(
+            latest_ingested_checkpoint_timestamp_lag_ms: register_int_gauge_vec_with_registry!(
                 name("latest_ingested_checkpoint_timestamp_lag_ms"),
                 "Difference between the system timestamp when the latest checkpoint was fetched and the \
                  timestamp in the checkpoint, in milliseconds",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            ingested_checkpoint_timestamp_lag: register_histogram_with_registry!(
+            ingested_checkpoint_timestamp_lag: register_histogram_vec_with_registry!(
                 name("ingested_checkpoint_timestamp_lag"),
                 "Difference between the system timestamp when a checkpoint was fetched and the \
                  timestamp in each checkpoint, in seconds",
+                &["cohort"],
                 LAG_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -309,15 +314,17 @@ impl IngestionMetrics {
                 registry,
             )
             .unwrap(),
-            ingestion_concurrency_limit: register_int_gauge_with_registry!(
+            ingestion_concurrency_limit: register_int_gauge_vec_with_registry!(
                 name("ingestion_concurrency_limit"),
                 "Current adaptive concurrency limit for checkpoint ingestion",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
-            ingestion_concurrency_inflight: register_int_gauge_with_registry!(
+            ingestion_concurrency_inflight: register_int_gauge_vec_with_registry!(
                 name("ingestion_concurrency_inflight"),
                 "Current number of in-flight checkpoint ingestion tasks",
+                &["cohort"],
                 registry,
             )
             .unwrap(),
@@ -789,6 +796,21 @@ impl CheckpointLagMetricReporter {
             checkpoint_time_lag_histogram.with_label_values(&[P::NAME]),
             latest_checkpoint_time_lag_gauge.with_label_values(&[P::NAME]),
             latest_checkpoint_sequence_number_gauge.with_label_values(&[P::NAME]),
+        )
+    }
+
+    /// Bind a set of checkpoint-lag vecs to a single `label` value, so callers reporting under
+    /// different labels (e.g. one per cohort) don't overwrite each other's checkpoint-lag gauges.
+    pub fn with_label(
+        checkpoint_time_lag_histogram: &HistogramVec,
+        latest_checkpoint_time_lag_gauge: &IntGaugeVec,
+        latest_checkpoint_sequence_number_gauge: &IntGaugeVec,
+        label: &str,
+    ) -> Arc<Self> {
+        Self::new(
+            checkpoint_time_lag_histogram.with_label_values(&[label]),
+            latest_checkpoint_time_lag_gauge.with_label_values(&[label]),
+            latest_checkpoint_sequence_number_gauge.with_label_values(&[label]),
         )
     }
 

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -57,6 +57,7 @@ pub struct IngestionLayer {
     pub streaming_backoff_max_batch_size: Option<usize>,
     pub streaming_connection_timeout_ms: Option<u64>,
     pub streaming_statement_timeout_ms: Option<u64>,
+    pub min_cohort_boundary: Option<u64>,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -211,6 +212,7 @@ impl IngestionLayer {
             streaming_statement_timeout_ms: self
                 .streaming_statement_timeout_ms
                 .unwrap_or(base.streaming_statement_timeout_ms),
+            min_cohort_boundary: self.min_cohort_boundary.unwrap_or(base.min_cohort_boundary),
         })
     }
 }
@@ -362,6 +364,7 @@ impl Merge for IngestionLayer {
             streaming_statement_timeout_ms: other
                 .streaming_statement_timeout_ms
                 .or(self.streaming_statement_timeout_ms),
+            min_cohort_boundary: other.min_cohort_boundary.or(self.min_cohort_boundary),
             checkpoint_buffer_size: other.checkpoint_buffer_size.or(self.checkpoint_buffer_size),
         })
     }
@@ -487,6 +490,7 @@ impl From<IngestionConfig> for IngestionLayer {
             streaming_backoff_max_batch_size: Some(config.streaming_backoff_max_batch_size),
             streaming_connection_timeout_ms: Some(config.streaming_connection_timeout_ms),
             streaming_statement_timeout_ms: Some(config.streaming_statement_timeout_ms),
+            min_cohort_boundary: Some(config.min_cohort_boundary),
             checkpoint_buffer_size: None,
         }
     }

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -285,6 +285,7 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
+    pub min_cohort_boundary: u64,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -306,6 +307,7 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            min_cohort_boundary: config.min_cohort_boundary,
             checkpoint_buffer_size: None,
         }
     }
@@ -328,6 +330,7 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            min_cohort_boundary: config.min_cohort_boundary,
         }
     }
 }

--- a/crates/sui-rpc-store/src/indexer/mod.rs
+++ b/crates/sui-rpc-store/src/indexer/mod.rs
@@ -55,7 +55,6 @@ use sui_indexer_alt_framework as framework;
 use sui_indexer_alt_framework::IndexerArgs;
 use sui_indexer_alt_framework::ingestion::ArcStreamingClient;
 use sui_indexer_alt_framework::ingestion::IngestionConfig;
-use sui_indexer_alt_framework::ingestion::IngestionService;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClient;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::pipeline::sequential::SequentialConfig;
@@ -76,8 +75,7 @@ use crate::indexer::pruner::PrunerMetrics;
 /// underlying ingestion service. Surfaced as a constant so the
 /// prefix is consistent across the metrics built in [`Indexer::new`]
 /// and the ones the standalone-binary entry point builds when it
-/// constructs the [`IngestionClient`] / [`IngestionService`] from
-/// `ClientArgs`.
+/// constructs the [`IngestionClient`] from `ClientArgs`.
 pub const METRICS_PREFIX: &str = "rpc_store_indexer";
 
 /// The schema parameter the framework's `Store` / pipelines bind
@@ -314,18 +312,12 @@ impl Indexer {
             indexer_args.first_checkpoint,
         );
 
-        let ingestion_metrics = ingestion_client.metrics().clone();
-        let ingestion_service = IngestionService::with_clients(
+        let indexer = framework::Indexer::with_ingestion_clients(
+            store,
+            indexer_args,
             ingestion_client,
             streaming_client,
             ingestion_config,
-            ingestion_metrics,
-        );
-
-        let indexer = framework::Indexer::with_ingestion_service(
-            store,
-            indexer_args,
-            ingestion_service,
             metrics_prefix,
             registry,
         )

--- a/crates/sui-rpc-store/src/indexer/mod.rs
+++ b/crates/sui-rpc-store/src/indexer/mod.rs
@@ -53,7 +53,7 @@ use sui_consistent_store::Synchronizer;
 use sui_consistent_store::restore_state;
 use sui_indexer_alt_framework as framework;
 use sui_indexer_alt_framework::IndexerArgs;
-use sui_indexer_alt_framework::ingestion::BoxedStreamingClient;
+use sui_indexer_alt_framework::ingestion::ArcStreamingClient;
 use sui_indexer_alt_framework::ingestion::IngestionConfig;
 use sui_indexer_alt_framework::ingestion::IngestionService;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClient;
@@ -257,7 +257,7 @@ impl Indexer {
         path: impl AsRef<Path>,
         indexer_args: IndexerArgs,
         ingestion_client: IngestionClient,
-        streaming_client: Option<BoxedStreamingClient>,
+        streaming_client: Option<ArcStreamingClient>,
         consistency_config: crate::config::ConsistencyConfig,
         pruner_config: Option<PrunerConfig>,
         ingestion_config: IngestionConfig,
@@ -291,7 +291,7 @@ impl Indexer {
         store: Store,
         indexer_args: IndexerArgs,
         ingestion_client: IngestionClient,
-        streaming_client: Option<BoxedStreamingClient>,
+        streaming_client: Option<ArcStreamingClient>,
         consistency_config: crate::config::ConsistencyConfig,
         pruner_config: Option<PrunerConfig>,
         ingestion_config: IngestionConfig,

--- a/crates/sui-rpc-store/src/lib.rs
+++ b/crates/sui-rpc-store/src/lib.rs
@@ -24,11 +24,12 @@ pub mod reader;
 pub mod schema;
 
 use std::path::Path;
+use std::sync::Arc;
 
 use prometheus::Registry;
 use sui_consistent_store::DbOptions;
 use sui_indexer_alt_framework::IndexerArgs;
-use sui_indexer_alt_framework::ingestion::BoxedStreamingClient;
+use sui_indexer_alt_framework::ingestion::ArcStreamingClient;
 use sui_indexer_alt_framework::ingestion::ClientArgs;
 use sui_indexer_alt_framework::ingestion::IngestionConfig;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClient;
@@ -90,13 +91,13 @@ pub async fn start_indexer(
     // `registry`.
     let ingestion_metrics = IngestionMetrics::new(metrics_prefix, registry);
     let ingestion_client = IngestionClient::new(client_args.ingestion, ingestion_metrics)?;
-    let streaming_client: Option<BoxedStreamingClient> =
+    let streaming_client: Option<ArcStreamingClient> =
         client_args.streaming.streaming_url.map(|uri| {
-            Box::new(GrpcStreamingClient::new(
+            Arc::new(GrpcStreamingClient::new(
                 uri,
                 ingestion_config.streaming_connection_timeout(),
                 ingestion_config.streaming_statement_timeout(),
-            )) as BoxedStreamingClient
+            )) as ArcStreamingClient
         });
 
     let mut indexer = Indexer::new(


### PR DESCRIPTION
## Description

An indexer's pipelines all share one ingestion service that starts at the minimum watermark across them, so its slowest subscriber gates fetch concurrency for everyone — one far-behind pipeline (e.g. a backfill) holds back pipelines already at the tip. This groups pipelines into cohorts by how far behind the tip they resume and gives each cohort its own ingestion service, so a backfill only backpressures similarly-lagging peers. The earlier commits in the stack are supporting refactors: a shareable (`Arc`) streaming client, an `IngestionFactory` that mints services on demand, and per-cohort metric labels.

## Test plan

New unit tests for the cohort-grouping boundaries, plus end-to-end tests that a near-tip pipeline receives zero checkpoints while a far-behind cohort backfills to completion (through both the args- and client-driven constructors).

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] Indexing Framework: Pipelines are now grouped into cohorts by distance from the tip, each with its own ingestion service, so a lagging pipeline no longer throttles caught-up ones. New optional `IngestionConfig.min_cohort_boundary` (default 25,000 checkpoints) tunes the grouping; no action required.
