### PR TITLE
[sui-core] Remove dead AuthorityEpochTables tables and their callers

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -179,7 +179,7 @@ use typed_store::rocks::StagedBatch;
 
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard};
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
-use crate::authority::authority_store::{ExecutionLockReadGuard, ObjectLockStatus};
+use crate::authority::authority_store::ExecutionLockReadGuard;
 use crate::authority::authority_store_pruner::{
     AuthorityStorePruner, EPOCH_DURATION_MS_FOR_TESTING,
 };
@@ -279,7 +279,6 @@ pub struct AuthorityMetrics {
     // TODO: this tracks consensus object tx, not just shared. Consider renaming.
     pub shared_obj_tx: IntCounter,
     sponsored_tx: IntCounter,
-    tx_already_processed: IntCounter,
     num_input_objs: Histogram,
     // TODO: this tracks consensus object count, not just shared. Consider renaming.
     num_shared_objects: Histogram,
@@ -446,12 +445,6 @@ impl AuthorityMetrics {
             )
             .unwrap(),
 
-            tx_already_processed: register_int_counter_with_registry!(
-                "num_tx_already_processed",
-                "Number of transaction orders already processed previously",
-                registry,
-            )
-            .unwrap(),
             num_input_objs: register_histogram_with_registry!(
                 "num_input_objects",
                 "Distribution of number of input TX objects per TX",
@@ -3376,8 +3369,6 @@ impl AuthorityState {
         &self,
         request: ObjectInfoRequest,
     ) -> SuiResult<ObjectInfoResponse> {
-        let epoch_store = self.load_epoch_store_one_call_per_task();
-
         let requested_object_seq = match request.request_kind {
             ObjectInfoRequestKind::LatestObjectInfo => {
                 let (_, seq, _) =
@@ -3420,18 +3411,12 @@ impl AuthorityState {
             None
         };
 
-        let lock = if !object.is_address_owned() {
-            // Only address owned objects have locks.
-            None
-        } else {
-            self.get_transaction_lock(&object.compute_object_reference(), &epoch_store)?
-                .map(|s| s.into_inner())
-        };
-
         Ok(ObjectInfoResponse {
             object,
             layout,
-            lock_for_debugging: lock,
+            // Validators no longer store signed transactions, so the locking
+            // transaction cannot be returned.
+            lock_for_debugging: None,
         })
     }
 
@@ -5207,13 +5192,9 @@ impl AuthorityState {
                 debug!(tx_digest=?transaction_digest, "Signed effects exist but no transaction found");
             }
         }
-        if let Some(signed) = epoch_store.get_signed_transaction(transaction_digest)? {
-            self.metrics.tx_already_processed.inc();
-            let (transaction, sig) = signed.into_inner().into_data_and_sig();
-            Ok(Some((transaction, TransactionStatus::Signed(sig))))
-        } else {
-            Ok(None)
-        }
+        // Validators no longer sign transactions before execution, so there is no
+        // TransactionStatus::Signed state to report.
+        Ok(None)
     }
 
     /// Get the signed effects of the given transaction. If the effects was signed in a previous
@@ -5351,39 +5332,6 @@ impl AuthorityState {
         }
 
         Some((input_coin_objects, written_coin_objects))
-    }
-
-    /// Get the TransactionEnvelope that currently locks the given object, if any.
-    /// Since object locks are only valid for one epoch, we also need the epoch_id in the query.
-    /// Returns UserInputError::ObjectNotFound if no lock records for the given object can be found.
-    /// Returns UserInputError::ObjectVersionUnavailableForConsumption if the object record is at a different version.
-    /// Returns Some(VerifiedEnvelope) if the given ObjectRef is locked by a certain transaction.
-    /// Returns None if a lock record is initialized for the given ObjectRef but not yet locked by any transaction,
-    ///     or cannot find the transaction in transaction table, because of data race etc.
-    #[instrument(level = "trace", skip_all)]
-    pub fn get_transaction_lock(
-        &self,
-        object_ref: &ObjectRef,
-        epoch_store: &AuthorityPerEpochStore,
-    ) -> SuiResult<Option<VerifiedSignedTransaction>> {
-        let lock_info = self
-            .get_object_cache_reader()
-            .get_lock(*object_ref, epoch_store)?;
-        let lock_info = match lock_info {
-            ObjectLockStatus::LockedAtDifferentVersion { locked_ref } => {
-                return Err(UserInputError::ObjectVersionUnavailableForConsumption {
-                    provided_obj_ref: *object_ref,
-                    current_version: locked_ref.1,
-                }
-                .into());
-            }
-            ObjectLockStatus::Initialized => {
-                return Ok(None);
-            }
-            ObjectLockStatus::LockedToTx { locked_by_tx } => locked_by_tx,
-        };
-
-        epoch_store.get_signed_transaction(&lock_info.tx_digest)
     }
 
     pub fn get_objects(&self, objects: &[ObjectID]) -> Vec<Option<Object>> {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -47,12 +47,11 @@ use sui_types::dynamic_field::get_dynamic_field_from_store;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::{SuiError, SuiErrorKind, SuiResult};
 use sui_types::executable_transaction::{
-    TrustedExecutableTransaction, TrustedExecutableTransactionWithAliases,
-    VerifiedExecutableTransaction, VerifiedExecutableTransactionWithAliases,
+    TrustedExecutableTransactionWithAliases, VerifiedExecutableTransaction,
+    VerifiedExecutableTransactionWithAliases,
 };
 use sui_types::execution::{ExecutionTimeObservationKey, ExecutionTiming};
 use sui_types::global_state_hash::GlobalStateHash;
-use sui_types::message_envelope::TrustedEnvelope;
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
 };
@@ -69,10 +68,10 @@ use sui_types::sui_system_state::epoch_start_sui_system_state::{
 };
 use sui_types::sui_system_state::{self, SuiSystemState};
 use sui_types::transaction::{
-    AuthenticatorStateUpdate, DeprecatedWithAliases, InputObjectKind, ProgrammableTransaction,
-    SenderSignedData, StoredExecutionTimeObservations, Transaction, TransactionData,
-    TransactionDataAPI, TransactionKey, TransactionKind, TxValidityCheckContext,
-    VerifiedSignedTransaction, VerifiedTransaction, VerifiedTransactionWithAliases, WithAliases,
+    AuthenticatorStateUpdate, InputObjectKind, ProgrammableTransaction,
+    StoredExecutionTimeObservations, Transaction, TransactionData, TransactionDataAPI,
+    TransactionKey, TransactionKind, TxValidityCheckContext, VerifiedTransaction,
+    VerifiedTransactionWithAliases, WithAliases,
 };
 use tap::TapOptional;
 use tokio::sync::{OnceCell, mpsc};
@@ -277,7 +276,7 @@ impl PartialOrd for ExecutionIndices {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ExecutionIndicesWithStats {
+pub struct ExecutionIndicesWithStatsV2 {
     pub index: ExecutionIndices,
     /// Height watermark assigned to this commit.
     /// We use this to determine if a commit has been fully executed.
@@ -285,27 +284,8 @@ pub struct ExecutionIndicesWithStats {
     /// height, we've fully executed the commit.
     pub height: u64,
     pub stats: ConsensusStats,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ExecutionIndicesWithStatsV2 {
-    pub index: ExecutionIndices,
-    pub height: u64,
-    pub stats: ConsensusStats,
     pub last_checkpoint_flush_timestamp: u64,
     pub checkpoint_seq: u64,
-}
-
-impl From<ExecutionIndicesWithStats> for ExecutionIndicesWithStatsV2 {
-    fn from(v1: ExecutionIndicesWithStats) -> Self {
-        Self {
-            index: v1.index,
-            height: v1.height,
-            stats: v1.stats,
-            last_checkpoint_flush_timestamp: 0,
-            checkpoint_seq: 0,
-        }
-    }
 }
 
 type ExecutionModuleCache = SyncModuleCache<ResolverWrapper>;
@@ -445,11 +425,6 @@ pub struct AuthorityPerEpochStore {
 #[derive(DBMapUtils)]
 #[cfg_attr(tidehunter, tidehunter)]
 pub struct AuthorityEpochTables {
-    /// This is map between the transaction digest and transactions found in the `transaction_lock`.
-    #[default_options_override_fn = "signed_transactions_table_default_config"]
-    signed_transactions:
-        DBMap<TransactionDigest, TrustedEnvelope<SenderSignedData, AuthoritySignInfo>>,
-
     /// Map from ObjectRef to transaction locking that object
     #[default_options_override_fn = "owned_object_transaction_locks_table_default_config"]
     owned_object_locked_transactions: DBMap<ObjectRef, LockDetailsWrapper>,
@@ -468,12 +443,6 @@ pub struct AuthorityEpochTables {
     /// to disk.
     signed_effects_digests: DBMap<TransactionDigest, TransactionEffectsDigest>,
 
-    /// No longer used.
-    #[allow(dead_code)]
-    #[deprecated(note = "column family retained only for tidehunter backward compatibility")]
-    transaction_cert_signatures:
-        DBMap<TransactionDigest, sui_types::crypto::AuthorityStrongQuorumSignInfo>,
-
     /// Next available shared object versions for each shared object.
     next_shared_object_versions_v2: DBMap<ConsensusObjectSequenceKey, SequenceNumber>,
 
@@ -491,8 +460,6 @@ pub struct AuthorityEpochTables {
     /// represents the index of the latest consensus message this authority processed, running hash of
     /// transactions, and accumulated stats of consensus output.
     /// This field is written by a single process (consensus handler).
-    last_consensus_stats: DBMap<u64, ExecutionIndicesWithStats>,
-
     last_consensus_stats_v2: DBMap<u64, ExecutionIndicesWithStatsV2>,
 
     /// This table contains current reconfiguration state for validator for current epoch
@@ -523,8 +490,6 @@ pub struct AuthorityEpochTables {
     #[rename = "running_root_accumulators"]
     pub running_root_state_hash: DBMap<CheckpointSequenceNumber, GlobalStateHash>,
 
-    #[cfg(tidehunter)] // tidehunter does not support table deletion yet
-    authority_capabilities: DBMap<AuthorityName, AuthorityCapabilitiesV1>,
     /// Record of the capabilities advertised by each authority.
     authority_capabilities_v2: DBMap<AuthorityName, AuthorityCapabilitiesV2>,
 
@@ -545,9 +510,6 @@ pub struct AuthorityEpochTables {
     /// find all Jwks for a given round
     active_jwks: DBMap<(u64, (JwkId, JWK)), ()>,
 
-    /// Transactions that are being deferred until some future time
-    deferred_transactions_v2: DBMap<DeferralKey, Vec<TrustedExecutableTransaction>>,
-
     // Tables for recording state for RandomnessManager.
     /// Records messages processed from other nodes. Updated when receiving a new dkg::Message
     /// via consensus.
@@ -560,9 +522,6 @@ pub struct AuthorityEpochTables {
     /// Records confirmations received from other nodes. Updated when receiving a new
     /// dkg::Confirmation via consensus.
     pub(crate) dkg_confirmations_v2: DBMap<PartyId, VersionedDkgConfirmation>,
-    /// Records the final output of DKG after completion, including the public VSS key and
-    /// any local private shares.
-    pub(crate) dkg_output: DBMap<u64, dkg_v1::Output<PkG, EncG>>,
     /// Holds the value of the next RandomnessRound to be generated.
     pub(crate) randomness_next_round: DBMap<u64, RandomnessRound>,
     /// Holds the value of the highest completed RandomnessRound (as reported to RandomnessReporter).
@@ -577,17 +536,12 @@ pub struct AuthorityEpochTables {
     /// Execution time observations for congestion control.
     pub(crate) execution_time_observations:
         DBMap<(u64, AuthorityIndex), Vec<(ExecutionTimeObservationKey, Duration)>>,
-    deferred_transactions_with_aliases_v2:
-        DBMap<DeferralKey, Vec<DeprecatedWithAliases<TrustedExecutableTransaction>>>,
+    /// Transactions that are being deferred until some future time
     deferred_transactions_with_aliases_v3:
         DBMap<DeferralKey, Vec<TrustedExecutableTransactionWithAliases>>,
+    /// Records the final output of DKG after completion, including the public VSS key and
+    /// any local private shares. `None` indicates DKG completed as a failure.
     pub(crate) dkg_output_v2: DBMap<u64, Option<dkg_v1::Output<PkG, EncG>>>,
-}
-
-fn signed_transactions_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(1 << 10)
 }
 
 fn owned_object_transaction_locks_table_default_config() -> DBOptions {
@@ -639,16 +593,6 @@ impl AuthorityEpochTables {
         let sequence_key = KeyType::from_prefix_bits(6 * 8 + 4);
         let configs = vec![
             (
-                "signed_transactions".to_string(),
-                ThConfig::new_with_rm_prefix_indexing(
-                    tx_digest_indexing.clone(),
-                    mutexes,
-                    uniform_key,
-                    lru_bloom_config.clone(),
-                    digest_prefix.clone(),
-                ),
-            ),
-            (
                 "owned_object_locked_transactions".to_string(),
                 ThConfig::new_with_config_indexing(
                     object_ref_indexing,
@@ -678,16 +622,6 @@ impl AuthorityEpochTables {
                 ),
             ),
             (
-                "transaction_cert_signatures".to_string(),
-                ThConfig::new_with_rm_prefix_indexing(
-                    tx_digest_indexing.clone(),
-                    mutexes,
-                    uniform_key,
-                    lru_bloom_config.clone(),
-                    digest_prefix.clone(),
-                ),
-            ),
-            (
                 "next_shared_object_versions_v2".to_string(),
                 ThConfig::new_with_config(32 + 8, mutexes, uniform_key, lru_only_config.clone()),
             ),
@@ -699,10 +633,6 @@ impl AuthorityEpochTables {
                     uniform_key,
                     bloom_config.clone(),
                 ),
-            ),
-            (
-                "last_consensus_stats".to_string(),
-                ThConfig::new(8, 1, KeyType::uniform(1)),
             ),
             (
                 "last_consensus_stats_v2".to_string(),
@@ -753,10 +683,6 @@ impl AuthorityEpochTables {
                 ThConfig::new_with_config(8, mutexes, sequence_key, bloom_config.clone()),
             ),
             (
-                "authority_capabilities".to_string(),
-                ThConfig::new(104, mutexes, uniform_key),
-            ),
-            (
                 "authority_capabilities_v2".to_string(),
                 ThConfig::new(104, 1, KeyType::uniform(1)),
             ),
@@ -793,18 +719,6 @@ impl AuthorityEpochTables {
                 ),
             ),
             (
-                "deferred_transactions".to_string(),
-                ThConfig::new_with_indexing(KeyIndexing::Hash, mutexes, uniform_key),
-            ),
-            (
-                "deferred_transactions_v2".to_string(),
-                ThConfig::new_with_indexing(KeyIndexing::Hash, mutexes, uniform_key),
-            ),
-            (
-                "deferred_transactions_with_aliases_v2".to_string(),
-                ThConfig::new_with_indexing(KeyIndexing::Hash, mutexes, uniform_key),
-            ),
-            (
                 "deferred_transactions_with_aliases_v3".to_string(),
                 ThConfig::new_with_indexing(KeyIndexing::Hash, mutexes, uniform_key),
             ),
@@ -819,10 +733,6 @@ impl AuthorityEpochTables {
             (
                 "dkg_confirmations_v2".to_string(),
                 ThConfig::new(2, 1, KeyType::uniform(1)),
-            ),
-            (
-                "dkg_output".to_string(),
-                ThConfig::new(8, 1, KeyType::uniform(1)),
             ),
             (
                 "randomness_next_round".to_string(),
@@ -889,22 +799,15 @@ impl AuthorityEpochTables {
 
     pub fn get_last_consensus_index(&self) -> SuiResult<Option<ExecutionIndices>> {
         Ok(self
-            .last_consensus_stats
+            .last_consensus_stats_v2
             .get(&LAST_CONSENSUS_STATS_ADDR)?
             .map(|s| s.index))
     }
 
     pub fn get_last_consensus_stats(&self) -> SuiResult<Option<ExecutionIndicesWithStatsV2>> {
-        if let Some(v2) = self
-            .last_consensus_stats_v2
-            .get(&LAST_CONSENSUS_STATS_ADDR)?
-        {
-            return Ok(Some(v2));
-        }
         Ok(self
-            .last_consensus_stats
-            .get(&LAST_CONSENSUS_STATS_ADDR)?
-            .map(Into::into))
+            .last_consensus_stats_v2
+            .get(&LAST_CONSENSUS_STATS_ADDR)?)
     }
 
     pub fn get_locked_transaction(&self, obj_ref: &ObjectRef) -> SuiResult<Option<LockDetails>> {
@@ -926,65 +829,13 @@ impl AuthorityEpochTables {
             .collect())
     }
 
-    fn get_all_deferred_transactions_v2(
+    fn get_all_deferred_transactions(
         &self,
     ) -> SuiResult<BTreeMap<DeferralKey, Vec<VerifiedExecutableTransactionWithAliases>>> {
         Ok(self
-            .deferred_transactions_v2
+            .deferred_transactions_with_aliases_v3
             .safe_iter()
-            // Load any old items from the deprecated table. These must all have no aliases.
-            .map(|item| {
-                item.map(|(key, txs)| {
-                    (
-                        key,
-                        txs.into_iter()
-                            .map(|tx| {
-                                VerifiedExecutableTransactionWithAliases::no_aliases(tx.into())
-                            })
-                            .collect(),
-                    )
-                })
-            })
-            .chain(
-                self.deferred_transactions_with_aliases_v2
-                    .safe_iter()
-                    // The v2 table contains the deprecated format with SuiAddress instead of u8.
-                    // We convert by preserving the sequence numbers, but using 0 for the indexes.
-                    // This is safe because as long as the fix_checkpoint_signature_mapping flag is
-                    // false (which it must be for all builds that write to the v2 table),
-                    // the indexes will be thrown out when mapping signatures to alias config
-                    // versions.
-                    .map(
-                        |item: Result<
-                            (
-                                DeferralKey,
-                                Vec<DeprecatedWithAliases<TrustedExecutableTransaction>>,
-                            ),
-                            _,
-                        >| {
-                            item.map(|(key, txs)| {
-                                (
-                                    key,
-                                    txs.into_iter()
-                                        .map(|tx| {
-                                            let (inner, aliases) = tx.into_inner();
-                                            let new_aliases =
-                                                aliases.map(|(_addr, seq)| (0u8, seq));
-                                            WithAliases::new(inner, new_aliases).into()
-                                        })
-                                        .collect(),
-                                )
-                            })
-                        },
-                    ),
-            )
-            .chain(
-                self.deferred_transactions_with_aliases_v3
-                    .safe_iter()
-                    .map(|item| {
-                        item.map(|(key, txs)| (key, txs.into_iter().map(Into::into).collect()))
-                    }),
-            )
+            .map(|item| item.map(|(key, txs)| (key, txs.into_iter().map(Into::into).collect())))
             .collect::<Result<_, _>>()?)
     }
 }
@@ -1798,22 +1649,6 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    pub fn insert_signed_transaction(&self, transaction: VerifiedSignedTransaction) -> SuiResult {
-        Ok(self
-            .tables()?
-            .signed_transactions
-            .insert(transaction.digest(), transaction.serializable_ref())?)
-    }
-
-    #[cfg(test)]
-    pub fn delete_signed_transaction_for_test(&self, transaction: &TransactionDigest) {
-        self.tables()
-            .expect("test should not cross epoch boundary")
-            .signed_transactions
-            .remove(transaction)
-            .unwrap();
-    }
-
     #[cfg(test)]
     pub fn delete_object_locks_for_test(&self, objects: &[ObjectRef]) {
         for object in objects {
@@ -1834,17 +1669,6 @@ impl AuthorityPerEpochStore {
                 .insert(object, &LockDetailsWrapper::from(*digest))
                 .unwrap();
         }
-    }
-
-    pub fn get_signed_transaction(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> SuiResult<Option<VerifiedSignedTransaction>> {
-        Ok(self
-            .tables()?
-            .signed_transactions
-            .get(tx_digest)?
-            .map(|t| t.into()))
     }
 
     /// Record that a transaction has been executed in the current epoch.
@@ -3147,7 +2971,7 @@ impl AuthorityPerEpochStore {
     }
 
     fn db_batch(&self) -> SuiResult<DBBatch> {
-        Ok(self.tables()?.last_consensus_stats.batch())
+        Ok(self.tables()?.last_consensus_stats_v2.batch())
     }
 
     #[cfg(test)]

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -316,14 +316,6 @@ impl ConsensusCommitOutput {
         }
 
         batch.delete_batch(
-            &tables.deferred_transactions_v2,
-            &self.deleted_deferred_txns,
-        )?;
-        batch.delete_batch(
-            &tables.deferred_transactions_with_aliases_v2,
-            &self.deleted_deferred_txns,
-        )?;
-        batch.delete_batch(
             &tables.deferred_transactions_with_aliases_v3,
             &self.deleted_deferred_txns,
         )?;
@@ -437,7 +429,7 @@ pub(crate) struct ConsensusOutputCache {
 impl ConsensusOutputCache {
     pub(crate) fn new(tables: &AuthorityEpochTables) -> Self {
         let deferred_transactions = tables
-            .get_all_deferred_transactions_v2()
+            .get_all_deferred_transactions()
             .expect("load deferred transactions cannot fail");
 
         let executed_in_epoch_cache_capacity = 50_000;

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -445,18 +445,10 @@ impl RandomnessManager {
             highest_completed_round: Arc::new(Mutex::new(highest_completed_round)),
             randomness_receiver_handle,
         };
-        let dkg_output = match tables
+        let dkg_output = tables
             .dkg_output_v2
             .get(&SINGLETON_KEY)
-            .expect("typed_store should not fail")
-        {
-            Some(dkg_output) => Some(dkg_output),
-            None => tables
-                .dkg_output
-                .get(&SINGLETON_KEY)
-                .expect("typed_store should not fail")
-                .map(Some),
-        };
+            .expect("typed_store should not fail");
         match dkg_output {
             Some(Some(dkg_output)) => {
                 info!(
@@ -1619,8 +1611,8 @@ mod tests {
 
         let tables = epoch_store.tables().unwrap();
         tables
-            .dkg_output
-            .insert(&SINGLETON_KEY, &expected_dkg_output)
+            .dkg_output_v2
+            .insert(&SINGLETON_KEY, &Some(expected_dkg_output))
             .unwrap();
         tables
             .randomness_next_round

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -63,6 +63,7 @@ use sui_types::{
 use sui_types::{SUI_CLOCK_OBJECT_SHARED_VERSION, digests::Digest};
 use sui_types::{dynamic_field::DynamicFieldType, messages_consensus::ConsensusTransaction};
 
+use crate::authority::authority_store::ObjectLockStatus;
 use crate::authority::shared_object_congestion_tracker::SharedObjectCongestionTracker;
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::transaction_deferral::DeferralKey;
@@ -1210,24 +1211,15 @@ async fn test_handle_transfer_transaction_bad_signature() {
     // assert_eq!(metrics.signature_errors.get(), 1);
 
     let object = authority_state.get_object(&object_id).unwrap();
-    assert!(
+    assert_eq!(
         authority_state
-            .get_transaction_lock(
-                &object.compute_object_reference(),
+            .get_object_cache_reader()
+            .get_lock(
+                object.compute_object_reference(),
                 &authority_state.epoch_store_for_testing()
             )
-            .unwrap()
-            .is_none()
-    );
-
-    assert!(
-        authority_state
-            .get_transaction_lock(
-                &object.compute_object_reference(),
-                &authority_state.epoch_store_for_testing()
-            )
-            .unwrap()
-            .is_none()
+            .unwrap(),
+        ObjectLockStatus::Initialized
     );
 }
 
@@ -1305,24 +1297,15 @@ async fn test_handle_transfer_transaction_unknown_sender() {
     );
 
     let object = authority_state.get_object(&object_id).unwrap();
-    assert!(
+    assert_eq!(
         authority_state
-            .get_transaction_lock(
-                &object.compute_object_reference(),
+            .get_object_cache_reader()
+            .get_lock(
+                object.compute_object_reference(),
                 &authority_state.epoch_store_for_testing()
             )
-            .unwrap()
-            .is_none()
-    );
-
-    assert!(
-        authority_state
-            .get_transaction_lock(
-                &object.compute_object_reference(),
-                &authority_state.epoch_store_for_testing()
-            )
-            .unwrap()
-            .is_none()
+            .unwrap(),
+        ObjectLockStatus::Initialized
     );
 }
 
@@ -2222,22 +2205,27 @@ async fn test_handle_confirmation_transaction_ok() {
     assert_eq!(next_sequence_number, new_account.version());
 
     // Check locks are set and archived correctly
-    assert!(
+    assert_eq!(
         authority_state
-            .get_transaction_lock(
-                &(object_id, 1.into(), old_account.digest()),
+            .get_object_cache_reader()
+            .get_lock(
+                (object_id, 1.into(), old_account.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .is_err()
+            .unwrap(),
+        ObjectLockStatus::LockedAtDifferentVersion {
+            locked_ref: (object_id, 2.into(), new_account.digest())
+        }
     );
-    assert!(
+    assert_eq!(
         authority_state
-            .get_transaction_lock(
-                &(object_id, 2.into(), new_account.digest()),
+            .get_object_cache_reader()
+            .get_lock(
+                (object_id, 2.into(), new_account.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .expect("Exists")
-            .is_none()
+            .unwrap(),
+        ObjectLockStatus::Initialized
     );
 }
 

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::AuthorityState;
+use crate::authority::authority_store::ObjectLockStatus;
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use fastcrypto::{ed25519::Ed25519KeyPair, traits::KeyPair};
 use fastcrypto_zkp::bn254::zk_login::{OIDCProvider, ZkLoginInputs, parse_jwks};
@@ -918,14 +919,15 @@ async fn do_zklogin_transaction_test(
 async fn check_locks(authority_state: Arc<AuthorityState>, object_ids: Vec<ObjectID>) {
     for object_id in object_ids {
         let object = authority_state.get_object(&object_id).unwrap();
-        assert!(
+        assert_eq!(
             authority_state
-                .get_transaction_lock(
-                    &object.compute_object_reference(),
+                .get_object_cache_reader()
+                .get_lock(
+                    object.compute_object_reference(),
                     &authority_state.epoch_store_for_testing()
                 )
-                .unwrap()
-                .is_none()
+                .unwrap(),
+            ObjectLockStatus::Initialized
         );
     }
 }


### PR DESCRIPTION
## Description

An audit of `AuthorityEpochTables` found several tables with no remaining writers: `signed_transactions` (its only writer, `insert_signed_transaction`, had no callers, so reads could only return `None`), `last_consensus_stats`, `dkg_output`, `deferred_transactions_v2`, and `deferred_transactions_with_aliases_v2` (all superseded by v2/v3 tables), plus the already-deprecated `transaction_cert_signatures` and `authority_capabilities`. This removes the tables and the caller code that could only ever observe empty results — including the `TransactionStatus::Signed` fallback in `get_transaction_status`, `AuthorityState::get_transaction_lock`, and the v1 fallback/migration reads.

Tables are deleted outright from both backends: tidehunter now supports table deletion, and typed-store's rocksdb open handles pre-existing undeclared column families, so mid-epoch restarts across the upgrade are safe in both cases.

Note for review: dropping the fallback reads assumes all currently deployed versions already write the v2/v3 tables, i.e. no supported upgrade path crosses an epoch with data only in the old format.

## Test plan

- `test_randomness_manager_crash_recovery_v1` now recovers from `dkg_output_v2`, giving the production DKG recovery path direct coverage it previously lacked (only the v1 fallback was tested).
- Lock-status asserts previously routed through the removed `get_transaction_lock` now check `ObjectLockStatus` directly, which is strictly stronger (the old asserts passed for both "unlocked" and "locked", since the signed-transaction lookup always returned `None`).
- Epoch store, deferral, and randomness tests also run against the tidehunter backend with the reduced key shape: `USE_TIDEHUNTER=1 cargo nextest run -p sui-core --lib --features typed-store/tidehunter -E 'test(epoch_store) or test(randomness_manager) or test(consensus_quarantine) or test(deferr)'`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 