### PR TITLE
[graphql] Migrate `Checkpoint` and `Event` cursor to grpc format

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/paginate.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/paginate.snap
@@ -79,8 +79,8 @@ Response: {
   "data": {
     "allCheckpoints": {
       "pageInfo": {
-        "startCursor": "MA==",
-        "endCursor": "Ng==",
+        "startCursor": "KAEyAggA",
+        "endCursor": "KAEyAggG",
         "hasPreviousPage": false,
         "hasNextPage": false
       },
@@ -152,8 +152,8 @@ Response: {
     },
     "paginatedCheckpointsAtEpochHasNextPage": {
       "pageInfo": {
-        "startCursor": "NA==",
-        "endCursor": "NQ==",
+        "startCursor": "KAEyAggE",
+        "endCursor": "KAEyAggF",
         "hasPreviousPage": false,
         "hasNextPage": true
       },
@@ -180,8 +180,8 @@ Response: {
     },
     "paginatedCheckpointsAtEpochHasPreviousPage": {
       "pageInfo": {
-        "startCursor": "NQ==",
-        "endCursor": "Ng==",
+        "startCursor": "KAEyAggF",
+        "endCursor": "KAEyAggG",
         "hasPreviousPage": true,
         "hasNextPage": false
       },
@@ -224,8 +224,8 @@ Response: {
   "data": {
     "checkpointsAtEpoch1BeforeCp6FromBackHasNextPage": {
       "pageInfo": {
-        "startCursor": "NQ==",
-        "endCursor": "NQ==",
+        "startCursor": "KAEyAggF",
+        "endCursor": "KAEyAggF",
         "hasPreviousPage": true,
         "hasNextPage": true
       },
@@ -250,8 +250,8 @@ Response: {
   "data": {
     "checkpointsAfterCp0HasPreviousPreviousPage": {
       "pageInfo": {
-        "startCursor": "MQ==",
-        "endCursor": "MQ==",
+        "startCursor": "KAEyAggB",
+        "endCursor": "KAEyAggB",
         "hasPreviousPage": true,
         "hasNextPage": true
       },
@@ -276,8 +276,8 @@ Response: {
   "data": {
     "checkpointsBeforeCp4FromBack": {
       "pageInfo": {
-        "startCursor": "Mg==",
-        "endCursor": "Mw==",
+        "startCursor": "KAEyAggC",
+        "endCursor": "KAEyAggD",
         "hasPreviousPage": true,
         "hasNextPage": true
       },
@@ -311,8 +311,8 @@ Response: {
   "data": {
     "checkpointsAtEpoch0AfterCp0": {
       "pageInfo": {
-        "startCursor": "MQ==",
-        "endCursor": "Mw==",
+        "startCursor": "KAEyAggB",
+        "endCursor": "KAEyAggD",
         "hasPreviousPage": true,
         "hasNextPage": false
       },
@@ -355,8 +355,8 @@ Response: {
   "data": {
     "checkpointsAtEpoch0BeforeCp3": {
       "pageInfo": {
-        "startCursor": "MA==",
-        "endCursor": "Mg==",
+        "startCursor": "KAEyAggA",
+        "endCursor": "KAEyAggC",
         "hasPreviousPage": false,
         "hasNextPage": true
       },
@@ -399,8 +399,8 @@ Response: {
   "data": {
     "checkpointsAtEpoch0BetweenCp03FromFront": {
       "pageInfo": {
-        "startCursor": "MQ==",
-        "endCursor": "MQ==",
+        "startCursor": "KAEyAggB",
+        "endCursor": "KAEyAggB",
         "hasPreviousPage": true,
         "hasNextPage": true
       },
@@ -418,8 +418,8 @@ Response: {
     },
     "checkpointsAtEpoch0BetweenCp03FromBack": {
       "pageInfo": {
-        "startCursor": "Mg==",
-        "endCursor": "Mg==",
+        "startCursor": "KAEyAggC",
+        "endCursor": "KAEyAggC",
         "hasPreviousPage": true,
         "hasNextPage": true
       },
@@ -444,8 +444,8 @@ Response: {
   "data": {
     "checkpointsAtEpoch1BeforeCp6FromBack": {
       "pageInfo": {
-        "startCursor": "NA==",
-        "endCursor": "NQ==",
+        "startCursor": "KAEyAggE",
+        "endCursor": "KAEyAggF",
         "hasPreviousPage": false,
         "hasNextPage": true
       },
@@ -479,8 +479,8 @@ Response: {
   "data": {
     "checkpointsBeforeCp1": {
       "pageInfo": {
-        "startCursor": "MA==",
-        "endCursor": "MA==",
+        "startCursor": "KAEyAggA",
+        "endCursor": "KAEyAggA",
         "hasPreviousPage": false,
         "hasNextPage": true
       },

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/checkpoints.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/checkpoints.snap
@@ -81,8 +81,8 @@ Response: {
       "totalCheckpoints": 4,
       "checkpoints": {
         "pageInfo": {
-          "startCursor": "MA==",
-          "endCursor": "Mw==",
+          "startCursor": "KAEyAggA",
+          "endCursor": "KAEyAggD",
           "hasPreviousPage": false,
           "hasNextPage": false
         },
@@ -137,8 +137,8 @@ Response: {
       "totalCheckpoints": 4,
       "checkpoints": {
         "pageInfo": {
-          "startCursor": "Mg==",
-          "endCursor": "Mw==",
+          "startCursor": "KAEyAggC",
+          "endCursor": "KAEyAggD",
           "hasPreviousPage": true,
           "hasNextPage": false
         },

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/paginate.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/paginate.snap
@@ -48,8 +48,8 @@ Response: {
   "data": {
     "allEvents": {
       "pageInfo": {
-        "startCursor": "eyJ0IjoyLCJlIjowfQ==",
-        "endCursor": "eyJ0Ijo0LCJlIjo5fQ==",
+        "startCursor": "KAFCBggAEAIYAA==",
+        "endCursor": "KAFCBggAEAQYCQ==",
         "hasNextPage": false,
         "hasPreviousPage": false
       },
@@ -149,8 +149,8 @@ Response: {
     },
     "eventsHasNext": {
       "pageInfo": {
-        "startCursor": "eyJ0IjoyLCJlIjowfQ==",
-        "endCursor": "eyJ0IjozLCJlIjowfQ==",
+        "startCursor": "KAFCBggAEAIYAA==",
+        "endCursor": "KAFCBggAEAMYAA==",
         "hasNextPage": true,
         "hasPreviousPage": false
       },
@@ -173,8 +173,8 @@ Response: {
     },
     "eventsHasPrevious": {
       "pageInfo": {
-        "startCursor": "eyJ0Ijo0LCJlIjo4fQ==",
-        "endCursor": "eyJ0Ijo0LCJlIjo5fQ==",
+        "startCursor": "KAFCBggAEAQYCA==",
+        "endCursor": "KAFCBggAEAQYCQ==",
         "hasNextPage": false,
         "hasPreviousPage": true
       },
@@ -262,8 +262,8 @@ Response: {
   "data": {
     "eventsAfterTransaction2AndEvent0": {
       "pageInfo": {
-        "startCursor": "eyJ0IjozLCJlIjowfQ==",
-        "endCursor": "eyJ0IjozLCJlIjowfQ==",
+        "startCursor": "KAFCBggAEAMYAA==",
+        "endCursor": "KAFCBggAEAMYAA==",
         "hasNextPage": true,
         "hasPreviousPage": true
       },
@@ -286,8 +286,8 @@ Response: {
   "data": {
     "eventsBeforeTransaction3AndEvent0": {
       "pageInfo": {
-        "startCursor": "eyJ0IjoyLCJlIjowfQ==",
-        "endCursor": "eyJ0IjoyLCJlIjowfQ==",
+        "startCursor": "KAFCBggAEAIYAA==",
+        "endCursor": "KAFCBggAEAIYAA==",
         "hasNextPage": true,
         "hasPreviousPage": false
       },
@@ -310,8 +310,8 @@ Response: {
   "data": {
     "eventsBeforeTransaction3AndEvent1FromBack": {
       "pageInfo": {
-        "startCursor": "eyJ0IjoyLCJlIjowfQ==",
-        "endCursor": "eyJ0IjozLCJlIjowfQ==",
+        "startCursor": "KAFCBggAEAIYAA==",
+        "endCursor": "KAFCBggAEAMYAA==",
         "hasNextPage": true,
         "hasPreviousPage": false
       },

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
@@ -8,7 +8,7 @@
 
 use async_graphql::connection::CursorType;
 use serde_json::json;
-use sui_indexer_alt_graphql::CCheckpoint;
+use sui_indexer_alt_graphql::CheckpointToken;
 use tokio_stream::StreamExt;
 
 use crate::testing::SubscriptionTestCluster;
@@ -50,7 +50,7 @@ async fn test_subscription_cursor() {
         let edge = &item["data"]["checkpoints"];
         let cursor = edge["cursor"].as_str().unwrap();
         let seq = edge["node"]["sequenceNumber"].as_u64().unwrap();
-        assert_eq!(cursor, CCheckpoint::new(seq).encode_cursor());
+        assert_eq!(cursor, CheckpointToken::cursor(seq).encode_cursor());
     }
 }
 
@@ -480,7 +480,7 @@ async fn test_subscription_resume_with_after_cursor() {
     let cluster = SubscriptionTestCluster::new().await;
 
     let resume_seq = cluster.validator_checkpoint_tip();
-    let cursor = CCheckpoint::new(resume_seq).encode_cursor();
+    let cursor = CheckpointToken::cursor(resume_seq).encode_cursor();
     let query = format!(
         r#"subscription {{ checkpoints(after: "{cursor}") {{ node {{ sequenceNumber }} }} }}"#,
     );
@@ -546,7 +546,7 @@ async fn test_subscription_resume_with_both_args_uses_max() {
     assert_eq!(higher, lower + 1);
 
     // Resume must pick the higher of `after` (lower) and `afterCheckpoint` (higher).
-    let cursor = CCheckpoint::new(lower).encode_cursor();
+    let cursor = CheckpointToken::cursor(lower).encode_cursor();
     let query = format!(
         r#"subscription {{ checkpoints(after: "{cursor}", afterCheckpoint: {higher}) {{ node {{ sequenceNumber }} }} }}"#,
     );

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -9,19 +9,16 @@ use async_graphql::connection::Edge;
 use async_graphql::connection::EmptyFields;
 use futures::StreamExt;
 use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
-use sui_rpc_cursor::CursorToken;
-use sui_rpc_cursor::Position;
 
-use crate::api::scalars::cursor::OpaqueCursor;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
-use crate::api::types::event::CEvent;
+use crate::api::types::checkpoint::CheckpointToken;
 use crate::api::types::event::Event;
-use crate::api::types::event::EventCursor;
+use crate::api::types::event::EventToken;
 use crate::api::types::event::filter::EventFilter;
-use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::TransactionToken;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::config::Limits;
 use crate::config::SubscriptionConfig;
@@ -56,7 +53,10 @@ impl Subscription {
         let broadcast: &Arc<SubscriptionBroadcast> = ctx.data()?;
         let fetcher: &LedgerGrpcReader = ctx.data()?;
 
-        let resume_from: Option<u64> = match (after.map(|c| *c), after_checkpoint.map(u64::from)) {
+        let resume_from: Option<u64> = match (
+            after.map(|c| c.sequence_number()),
+            after_checkpoint.map(u64::from),
+        ) {
             (Some(a), Some(b)) => Some(a.max(b)),
             (a, b) => a.or(b),
         };
@@ -75,7 +75,7 @@ impl Subscription {
                     resolver_limits.clone(),
                     processed.clone(),
                 );
-                let cursor = CCheckpoint::new(sequence_number).encode_cursor();
+                let cursor = CheckpointToken::cursor(sequence_number).encode_cursor();
                 Edge::new(
                     cursor,
                     Checkpoint {
@@ -128,10 +128,10 @@ impl Subscription {
                             if !filter.matches(&tx.contents) {
                                 continue;
                             }
-                            let cursor = CTransaction::new(OpaqueCursor::new(CursorToken::item(Position::Transactions {
-                                checkpoint: processed.summary.sequence_number,
-                                tx_seq: tx.tx_sequence_number,
-                            })))
+                            let cursor = TransactionToken::cursor(
+                                processed.summary.sequence_number,
+                                tx.tx_sequence_number,
+                            )
                             .encode_cursor();
                             yield Transaction::with_contents(scope.clone(), tx.contents.clone())
                                 .map(|transaction| Edge::new(cursor, transaction));
@@ -190,10 +190,11 @@ impl Subscription {
                                 if !filter.matches(&native) {
                                     continue;
                                 }
-                                let cursor = CEvent::new(EventCursor {
-                                    tx_sequence_number: tx.tx_sequence_number,
-                                    ev_sequence_number: idx as u64,
-                                })
+                                let cursor = EventToken::cursor(
+                                    processed.summary.sequence_number,
+                                    tx.tx_sequence_number,
+                                    idx as u64,
+                                )
                                 .encode_cursor();
                                 yield Ok(Edge::new(
                                     cursor,

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -193,7 +193,7 @@ impl Subscription {
                                 let cursor = EventToken::cursor(
                                     processed.summary.sequence_number,
                                     tx.tx_sequence_number,
-                                    idx as u64,
+                                    idx as u32,
                                 )
                                 .encode_cursor();
                                 yield Ok(Edge::new(

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/filter.rs
@@ -139,8 +139,12 @@ pub(super) fn cp_unfiltered(cp_bounds: &RangeInclusive<u64>, page: &Page<CCheckp
     let cp_hi = *cp_bounds.end();
 
     // Inclusive cursor bounds
-    let pg_lo = page.after().map_or(cp_lo, |cursor| cursor.max(cp_lo));
-    let pg_hi_inclusive = page.before().map_or(cp_hi, |cursor| cursor.min(cp_hi));
+    let pg_lo = page
+        .after()
+        .map_or(cp_lo, |cursor| cursor.sequence_number().max(cp_lo));
+    let pg_hi_inclusive = page
+        .before()
+        .map_or(cp_hi, |cursor| cursor.sequence_number().min(cp_hi));
 
     if page.is_from_front() {
         (pg_lo..=pg_hi_inclusive)

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -8,6 +9,8 @@ use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
+use sui_rpc_cursor::CursorToken;
+use sui_rpc_cursor::Position;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::digests::CheckpointDigest;
 use sui_types::message_envelope::Message;
@@ -17,7 +20,10 @@ use sui_types::messages_checkpoint::CheckpointSummary;
 
 use crate::api::query::Query;
 use crate::api::scalars::base64::Base64;
+use crate::api::scalars::cursor::ByteCursor;
 use crate::api::scalars::cursor::JsonCursor;
+use crate::api::scalars::cursor::MultiCursor;
+use crate::api::scalars::cursor::OpaqueCursor;
 use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::uint53::UInt53;
@@ -70,7 +76,11 @@ struct CheckpointContents {
     streamed_data: Option<Arc<ProcessedCheckpoint>>,
 }
 
-pub type CCheckpoint = JsonCursor<u64>;
+/// Wrapper around a `CursorToken` that is validated at decode to carry a `Checkpoints` position.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckpointToken(CursorToken);
+
+pub type CCheckpoint = MultiCursor<OpaqueCursor<CheckpointToken>, JsonCursor<u64>>;
 
 /// Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
 #[Object]
@@ -339,7 +349,7 @@ impl Checkpoint {
 
         page.paginate_results(
             results,
-            |c| JsonCursor::new(*c),
+            |c| CheckpointToken::cursor(*c),
             |c| Ok(Self::with_sequence_number(scope.clone(), Some(c)).unwrap()),
         )
     }
@@ -381,5 +391,97 @@ impl CheckpointContents {
             )),
             streamed_data: Some(Arc::clone(processed)),
         })
+    }
+}
+
+impl CheckpointToken {
+    /// Mint the edge cursor for the checkpoint at the given sequence number.
+    pub fn cursor(checkpoint: u64) -> CCheckpoint {
+        MultiCursor::new(OpaqueCursor::new(Self(CursorToken::item(
+            Position::Checkpoints { checkpoint },
+        ))))
+    }
+}
+
+impl CCheckpoint {
+    pub(crate) fn sequence_number(&self) -> u64 {
+        match self {
+            CCheckpoint::Primary(c) => match c.position {
+                Position::Checkpoints { checkpoint } => checkpoint,
+                _ => unreachable!("validated at decode"),
+            },
+            CCheckpoint::Secondary(c) => **c,
+        }
+    }
+}
+
+impl ByteCursor for CheckpointToken {
+    fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
+        let token = CursorToken::decode(bytes)?;
+        if !matches!(token.position, Position::Checkpoints { .. }) {
+            anyhow::bail!("invalid cursor");
+        }
+        Ok(Self(token))
+    }
+
+    fn encode_cursor(&self) -> bytes::Bytes {
+        self.0.encode()
+    }
+}
+
+impl Deref for CheckpointToken {
+    type Target = CursorToken;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Eq for CCheckpoint {}
+
+/// Cursors minted by different paths can disagree on the kind, so pagination only compares the
+/// checkpoint coordinate.
+impl PartialEq for CCheckpoint {
+    fn eq(&self, other: &Self) -> bool {
+        self.sequence_number() == other.sequence_number()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_graphql::connection::CursorType;
+    use fastcrypto::encoding::Base64 as B64;
+    use fastcrypto::encoding::Encoding;
+
+    /// Legacy pg-style cursor: a bare JSON-encoded checkpoint sequence number.
+    fn legacy_cursor(checkpoint: u64) -> CCheckpoint {
+        MultiCursor::Secondary(JsonCursor::new(checkpoint))
+    }
+
+    #[test]
+    fn primary_cursor_roundtrips() {
+        let cursor = CheckpointToken::cursor(42);
+        let decoded = CCheckpoint::decode_cursor(&cursor.encode_cursor()).expect("valid cursor");
+        assert_eq!(decoded.sequence_number(), 42);
+        assert_eq!(decoded, cursor);
+    }
+
+    /// A legacy cursor paginates the same as a grpc cursor at the same sequence number.
+    #[test]
+    fn legacy_cursor_matches_primary() {
+        assert_eq!(legacy_cursor(42).sequence_number(), 42);
+        assert_eq!(legacy_cursor(42), CheckpointToken::cursor(42));
+    }
+
+    /// A token scoped to another endpoint must not decode as a checkpoint cursor.
+    #[test]
+    fn rejects_wrong_variant_cursor() {
+        let token = CursorToken::item(Position::Transactions {
+            checkpoint: 1,
+            tx_seq: 2,
+        });
+        let encoded = B64::encode(token.encode());
+        assert!(CCheckpoint::decode_cursor(&encoded).is_err());
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -9,6 +8,7 @@ use async_graphql::Context;
 use async_graphql::Object;
 use async_graphql::connection::Connection;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
+use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
@@ -76,10 +76,16 @@ struct CheckpointContents {
     streamed_data: Option<Arc<ProcessedCheckpoint>>,
 }
 
-/// Wrapper around a `CursorToken` that is validated at decode to carry a `Checkpoints` position.
+/// Validated checkpoint cursor coordinates.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CheckpointToken(CursorToken);
+pub struct CheckpointToken {
+    /// Tracks the originating `CursorToken`'s kind, so it can be reproduced on re-encode.
+    kind: CursorKind,
+    checkpoint: u64,
+}
 
+/// Compatibility dispatch over the on-wire cursor formats: `CursorToken` (primary) or the
+/// legacy JSON cursor (secondary).
 pub type CCheckpoint = MultiCursor<OpaqueCursor<CheckpointToken>, JsonCursor<u64>>;
 
 /// Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
@@ -397,19 +403,17 @@ impl CheckpointContents {
 impl CheckpointToken {
     /// Mint the edge cursor for the checkpoint at the given sequence number.
     pub fn cursor(checkpoint: u64) -> CCheckpoint {
-        MultiCursor::new(OpaqueCursor::new(Self(CursorToken::item(
-            Position::Checkpoints { checkpoint },
-        ))))
+        CCheckpoint::new(OpaqueCursor::new(Self {
+            kind: CursorKind::Item,
+            checkpoint,
+        }))
     }
 }
 
 impl CCheckpoint {
     pub(crate) fn sequence_number(&self) -> u64 {
         match self {
-            CCheckpoint::Primary(c) => match c.position {
-                Position::Checkpoints { checkpoint } => checkpoint,
-                _ => unreachable!("validated at decode"),
-            },
+            CCheckpoint::Primary(c) => c.checkpoint,
             CCheckpoint::Secondary(c) => **c,
         }
     }
@@ -417,23 +421,36 @@ impl CCheckpoint {
 
 impl ByteCursor for CheckpointToken {
     fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
-        let token = CursorToken::decode(bytes)?;
-        if !matches!(token.position, Position::Checkpoints { .. }) {
-            anyhow::bail!("invalid cursor");
-        }
-        Ok(Self(token))
+        CursorToken::decode(bytes)?.try_into()
     }
 
     fn encode_cursor(&self) -> bytes::Bytes {
-        self.0.encode()
+        CursorToken::from(self).encode()
     }
 }
 
-impl Deref for CheckpointToken {
-    type Target = CursorToken;
+impl From<&CheckpointToken> for CursorToken {
+    fn from(token: &CheckpointToken) -> Self {
+        CursorToken {
+            kind: token.kind,
+            position: Position::Checkpoints {
+                checkpoint: token.checkpoint,
+            },
+        }
+    }
+}
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl TryFrom<CursorToken> for CheckpointToken {
+    type Error = anyhow::Error;
+
+    fn try_from(token: CursorToken) -> anyhow::Result<Self> {
+        let Position::Checkpoints { checkpoint } = token.position else {
+            anyhow::bail!("invalid cursor");
+        };
+        Ok(Self {
+            kind: token.kind,
+            checkpoint,
+        })
     }
 }
 
@@ -456,7 +473,7 @@ mod tests {
 
     /// Legacy pg-style cursor: a bare JSON-encoded checkpoint sequence number.
     fn legacy_cursor(checkpoint: u64) -> CCheckpoint {
-        MultiCursor::Secondary(JsonCursor::new(checkpoint))
+        CCheckpoint::Secondary(JsonCursor::new(checkpoint))
     }
 
     #[test]

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
@@ -15,6 +15,7 @@ use crate::api::scalars::type_filter::TypeFilter;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::event::CEvent;
 use crate::api::types::lookups::CheckpointBounds;
+use crate::api::types::lookups::TxBoundsCursor;
 use crate::error::RpcError;
 use crate::error::feature_unavailable;
 use crate::pagination::Page;
@@ -194,16 +195,16 @@ pub(super) fn tx_ev_bounds(
     // Find start index from 'after' cursor, defaults to 0
     let ev_lo = page
         .after()
-        .filter(|c| c.tx_sequence_number == tx_sequence_number)
-        .map(|c| c.ev_sequence_number as usize)
+        .filter(|c| c.tx_sequence_number() == tx_sequence_number)
+        .map(|c| c.ev_sequence_number() as usize)
         .unwrap_or(0)
         .min(event_count);
 
     // Find exclusive end index from 'before' cursor, default to event_count
     let ev_hi = page
         .before()
-        .filter(|c| c.tx_sequence_number == tx_sequence_number)
-        .map(|c| (c.ev_sequence_number as usize).saturating_add(1))
+        .filter(|c| c.tx_sequence_number() == tx_sequence_number)
+        .map(|c| (c.ev_sequence_number() as usize).saturating_add(1))
         .unwrap_or(event_count)
         .max(ev_lo)
         .min(event_count);

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
@@ -79,9 +79,11 @@ fn tx_events_paginated<'e>(
         };
 
         for ev_sequence_number in bounds {
+            // Loop index into this transaction's events: bounded by `max_num_event_emit`
+            // (protocol config, VM-enforced), far below u32::MAX.
             let event_cursor = EventCursor {
                 tx_sequence_number,
-                ev_sequence_number: ev_sequence_number as u64,
+                ev_sequence_number: ev_sequence_number as u32,
             };
 
             let native = &events[ev_sequence_number];

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -13,13 +14,18 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use sui_indexer_alt_reader::pg_reader::PgReader;
+use sui_rpc_cursor::CursorToken;
+use sui_rpc_cursor::Position;
 use sui_sql_macro::query;
 use sui_types::base_types::SuiAddress as NativeSuiAddress;
 use sui_types::digests::TransactionDigest;
 use sui_types::event::Event as NativeEvent;
 
 use crate::api::scalars::base64::Base64;
+use crate::api::scalars::cursor::ByteCursor;
 use crate::api::scalars::cursor::JsonCursor;
+use crate::api::scalars::cursor::MultiCursor;
+use crate::api::scalars::cursor::OpaqueCursor;
 use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::address::Address;
@@ -49,7 +55,11 @@ pub struct EventCursor {
     pub ev_sequence_number: u64,
 }
 
-pub type CEvent = JsonCursor<EventCursor>;
+/// Wrapper around a `CursorToken` that is validated at decode to carry an `Events` position.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EventToken(CursorToken);
+
+pub type CEvent = MultiCursor<OpaqueCursor<EventToken>, JsonCursor<EventCursor>>;
 
 #[derive(Clone)]
 pub(crate) struct Event {
@@ -188,12 +198,128 @@ impl Event {
         )
         .await?;
 
-        page.paginate_results(events, |(c, _)| JsonCursor::new(*c), |(_, e)| Ok(e))
+        page.paginate_results(
+            events,
+            |(c, _)| EventToken::cursor(0, c.tx_sequence_number, c.ev_sequence_number),
+            |(_, e)| Ok(e),
+        )
+    }
+}
+
+impl EventToken {
+    /// Mint the edge cursor for the event at the given coordinates.
+    pub(crate) fn cursor(checkpoint: u64, tx_seq: u64, ev_sequence_number: u64) -> CEvent {
+        MultiCursor::new(OpaqueCursor::new(Self(CursorToken::item(
+            Position::Events {
+                checkpoint,
+                tx_seq,
+                // Event counts per transaction are protocol-bounded, far below u32::MAX.
+                event_index: ev_sequence_number
+                    .try_into()
+                    .expect("event index fits in u32"),
+            },
+        ))))
+    }
+}
+
+impl CEvent {
+    pub(crate) fn ev_sequence_number(&self) -> u64 {
+        match self {
+            CEvent::Primary(c) => match c.position {
+                Position::Events { event_index, .. } => event_index as u64,
+                _ => unreachable!("validated at decode"),
+            },
+            CEvent::Secondary(c) => c.ev_sequence_number,
+        }
+    }
+}
+
+impl ByteCursor for EventToken {
+    fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
+        let token = CursorToken::decode(bytes)?;
+        if !matches!(token.position, Position::Events { .. }) {
+            anyhow::bail!("invalid cursor");
+        }
+        Ok(Self(token))
+    }
+
+    fn encode_cursor(&self) -> bytes::Bytes {
+        self.0.encode()
+    }
+}
+
+impl Deref for EventToken {
+    type Target = CursorToken;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Eq for CEvent {}
+
+/// Cursors minted by different paths disagree on the checkpoint hint (and kind), so pagination
+/// only compares the event coordinates.
+impl PartialEq for CEvent {
+    fn eq(&self, other: &Self) -> bool {
+        (self.tx_sequence_number(), self.ev_sequence_number())
+            == (other.tx_sequence_number(), other.ev_sequence_number())
     }
 }
 
 impl TxBoundsCursor for CEvent {
     fn tx_sequence_number(&self) -> u64 {
-        self.tx_sequence_number
+        match self {
+            CEvent::Primary(c) => match c.position {
+                Position::Events { tx_seq, .. } => tx_seq,
+                _ => unreachable!("validated at decode"),
+            },
+            CEvent::Secondary(c) => c.tx_sequence_number,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_graphql::connection::CursorType;
+    use fastcrypto::encoding::Base64 as B64;
+    use fastcrypto::encoding::Encoding;
+
+    /// Legacy pg-style cursor: a JSON-encoded `EventCursor`.
+    fn legacy_cursor(tx_sequence_number: u64, ev_sequence_number: u64) -> CEvent {
+        MultiCursor::Secondary(JsonCursor::new(EventCursor {
+            tx_sequence_number,
+            ev_sequence_number,
+        }))
+    }
+
+    #[test]
+    fn primary_cursor_roundtrips() {
+        let cursor = EventToken::cursor(1, 2, 3);
+        let decoded = CEvent::decode_cursor(&cursor.encode_cursor()).expect("valid cursor");
+        assert_eq!(decoded.tx_sequence_number(), 2);
+        assert_eq!(decoded.ev_sequence_number(), 3);
+        assert_eq!(decoded, cursor);
+    }
+
+    /// Pagination equality keys off the event coordinates only: legacy cursors and grpc cursors
+    /// minted with different checkpoint hints all compare equal at the same position.
+    #[test]
+    fn equality_ignores_checkpoint_hint() {
+        assert_eq!(legacy_cursor(2, 3), EventToken::cursor(0, 2, 3));
+        assert_eq!(EventToken::cursor(7, 2, 3), EventToken::cursor(0, 2, 3));
+        assert_ne!(legacy_cursor(2, 4), EventToken::cursor(0, 2, 3));
+    }
+
+    /// A token scoped to another endpoint must not decode as an event cursor.
+    #[test]
+    fn rejects_wrong_variant_cursor() {
+        let token = CursorToken::item(Position::Transactions {
+            checkpoint: 1,
+            tx_seq: 2,
+        });
+        let encoded = B64::encode(token.encode());
+        assert!(CEvent::decode_cursor(&encoded).is_err());
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -51,8 +51,10 @@ mod lookups;
 pub struct EventCursor {
     #[serde(rename = "t")]
     pub tx_sequence_number: u64,
+    /// `u32` matches the primary format's `event_index` bound: legitimate values are event array
+    /// indices, capped by `max_num_event_emit` in the protocol config.
     #[serde(rename = "e")]
-    pub ev_sequence_number: u64,
+    pub ev_sequence_number: u32,
 }
 
 /// Validated event cursor coordinates.
@@ -208,9 +210,7 @@ impl Event {
 
         page.paginate_results(
             events,
-            // The ev_sequence_number is an index into the transaction's events (built by
-            // `tx_events_paginated`), so it is protocol-bounded, far below u32::MAX.
-            |(c, _)| EventToken::cursor(0, c.tx_sequence_number, c.ev_sequence_number as u32),
+            |(c, _)| EventToken::cursor(0, c.tx_sequence_number, c.ev_sequence_number),
             |(_, e)| Ok(e),
         )
     }
@@ -229,9 +229,9 @@ impl EventToken {
 }
 
 impl CEvent {
-    pub(crate) fn ev_sequence_number(&self) -> u64 {
+    pub(crate) fn ev_sequence_number(&self) -> u32 {
         match self {
-            CEvent::Primary(c) => c.event_index as u64,
+            CEvent::Primary(c) => c.event_index,
             CEvent::Secondary(c) => c.ev_sequence_number,
         }
     }
@@ -309,7 +309,7 @@ mod tests {
     use fastcrypto::encoding::Encoding;
 
     /// Legacy pg-style cursor: a JSON-encoded `EventCursor`.
-    fn legacy_cursor(tx_sequence_number: u64, ev_sequence_number: u64) -> CEvent {
+    fn legacy_cursor(tx_sequence_number: u64, ev_sequence_number: u32) -> CEvent {
         CEvent::Secondary(JsonCursor::new(EventCursor {
             tx_sequence_number,
             ev_sequence_number,
@@ -333,6 +333,16 @@ mod tests {
         assert_eq!(EventToken::cursor(7, 2, 3), EventToken::cursor(0, 2, 3));
         assert_eq!(legacy_cursor(2, 3), EventToken::cursor(100, 2, 3));
         assert_ne!(legacy_cursor(2, 4), EventToken::cursor(0, 2, 3));
+    }
+
+    /// Legacy cursors carrying an event index beyond `u32` were never minted by a server
+    /// (indices are capped by `max_num_event_emit`) and must fail to parse rather than
+    /// limp through the window clamps.
+    #[test]
+    fn rejects_oversized_legacy_event_index() {
+        let bytes = format!(r#"{{"t":2,"e":{}}}"#, u64::MAX);
+        let encoded = B64::encode(bytes.as_bytes());
+        assert!(CEvent::decode_cursor(&encoded).is_err());
     }
 
     /// A token scoped to another endpoint must not decode as an event cursor.

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -208,7 +208,9 @@ impl Event {
 
         page.paginate_results(
             events,
-            |(c, _)| EventToken::cursor(0, c.tx_sequence_number, c.ev_sequence_number),
+            // The ev_sequence_number is an index into the transaction's events (built by
+            // `tx_events_paginated`), so it is protocol-bounded, far below u32::MAX.
+            |(c, _)| EventToken::cursor(0, c.tx_sequence_number, c.ev_sequence_number as u32),
             |(_, e)| Ok(e),
         )
     }
@@ -216,15 +218,12 @@ impl Event {
 
 impl EventToken {
     /// Mint the edge cursor for the event at the given coordinates.
-    pub(crate) fn cursor(checkpoint: u64, tx_seq: u64, ev_sequence_number: u64) -> CEvent {
+    pub(crate) fn cursor(checkpoint: u64, tx_seq: u64, event_index: u32) -> CEvent {
         CEvent::new(OpaqueCursor::new(Self {
             kind: CursorKind::Item,
             checkpoint,
             tx_seq,
-            // Event counts per transaction are protocol-bounded, far below u32::MAX.
-            event_index: ev_sequence_number
-                .try_into()
-                .expect("event index fits in u32"),
+            event_index,
         }))
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -14,6 +13,7 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use sui_indexer_alt_reader::pg_reader::PgReader;
+use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_sql_macro::query;
@@ -55,10 +55,18 @@ pub struct EventCursor {
     pub ev_sequence_number: u64,
 }
 
-/// Wrapper around a `CursorToken` that is validated at decode to carry an `Events` position.
+/// Validated event cursor coordinates.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EventToken(CursorToken);
+pub struct EventToken {
+    /// Tracks the originating `CursorToken`'s kind, so it can be reproduced on re-encode.
+    kind: CursorKind,
+    checkpoint: u64,
+    tx_seq: u64,
+    event_index: u32,
+}
 
+/// Compatibility dispatch over the on-wire cursor formats: `CursorToken` (primary) or the
+/// legacy JSON cursor (secondary).
 pub type CEvent = MultiCursor<OpaqueCursor<EventToken>, JsonCursor<EventCursor>>;
 
 #[derive(Clone)]
@@ -209,26 +217,22 @@ impl Event {
 impl EventToken {
     /// Mint the edge cursor for the event at the given coordinates.
     pub(crate) fn cursor(checkpoint: u64, tx_seq: u64, ev_sequence_number: u64) -> CEvent {
-        MultiCursor::new(OpaqueCursor::new(Self(CursorToken::item(
-            Position::Events {
-                checkpoint,
-                tx_seq,
-                // Event counts per transaction are protocol-bounded, far below u32::MAX.
-                event_index: ev_sequence_number
-                    .try_into()
-                    .expect("event index fits in u32"),
-            },
-        ))))
+        CEvent::new(OpaqueCursor::new(Self {
+            kind: CursorKind::Item,
+            checkpoint,
+            tx_seq,
+            // Event counts per transaction are protocol-bounded, far below u32::MAX.
+            event_index: ev_sequence_number
+                .try_into()
+                .expect("event index fits in u32"),
+        }))
     }
 }
 
 impl CEvent {
     pub(crate) fn ev_sequence_number(&self) -> u64 {
         match self {
-            CEvent::Primary(c) => match c.position {
-                Position::Events { event_index, .. } => event_index as u64,
-                _ => unreachable!("validated at decode"),
-            },
+            CEvent::Primary(c) => c.event_index as u64,
             CEvent::Secondary(c) => c.ev_sequence_number,
         }
     }
@@ -236,23 +240,45 @@ impl CEvent {
 
 impl ByteCursor for EventToken {
     fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
-        let token = CursorToken::decode(bytes)?;
-        if !matches!(token.position, Position::Events { .. }) {
-            anyhow::bail!("invalid cursor");
-        }
-        Ok(Self(token))
+        CursorToken::decode(bytes)?.try_into()
     }
 
     fn encode_cursor(&self) -> bytes::Bytes {
-        self.0.encode()
+        CursorToken::from(self).encode()
     }
 }
 
-impl Deref for EventToken {
-    type Target = CursorToken;
+impl From<&EventToken> for CursorToken {
+    fn from(token: &EventToken) -> Self {
+        CursorToken {
+            kind: token.kind,
+            position: Position::Events {
+                checkpoint: token.checkpoint,
+                tx_seq: token.tx_seq,
+                event_index: token.event_index,
+            },
+        }
+    }
+}
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl TryFrom<CursorToken> for EventToken {
+    type Error = anyhow::Error;
+
+    fn try_from(token: CursorToken) -> anyhow::Result<Self> {
+        let Position::Events {
+            checkpoint,
+            tx_seq,
+            event_index,
+        } = token.position
+        else {
+            anyhow::bail!("invalid cursor");
+        };
+        Ok(Self {
+            kind: token.kind,
+            checkpoint,
+            tx_seq,
+            event_index,
+        })
     }
 }
 
@@ -270,10 +296,7 @@ impl PartialEq for CEvent {
 impl TxBoundsCursor for CEvent {
     fn tx_sequence_number(&self) -> u64 {
         match self {
-            CEvent::Primary(c) => match c.position {
-                Position::Events { tx_seq, .. } => tx_seq,
-                _ => unreachable!("validated at decode"),
-            },
+            CEvent::Primary(c) => c.tx_seq,
             CEvent::Secondary(c) => c.tx_sequence_number,
         }
     }
@@ -288,7 +311,7 @@ mod tests {
 
     /// Legacy pg-style cursor: a JSON-encoded `EventCursor`.
     fn legacy_cursor(tx_sequence_number: u64, ev_sequence_number: u64) -> CEvent {
-        MultiCursor::Secondary(JsonCursor::new(EventCursor {
+        CEvent::Secondary(JsonCursor::new(EventCursor {
             tx_sequence_number,
             ev_sequence_number,
         }))

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -309,6 +309,7 @@ mod tests {
     fn equality_ignores_checkpoint_hint() {
         assert_eq!(legacy_cursor(2, 3), EventToken::cursor(0, 2, 3));
         assert_eq!(EventToken::cursor(7, 2, 3), EventToken::cursor(0, 2, 3));
+        assert_eq!(legacy_cursor(2, 3), EventToken::cursor(100, 2, 3));
         assert_ne!(legacy_cursor(2, 4), EventToken::cursor(0, 2, 3));
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -22,6 +21,7 @@ use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionC
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_reader::tx_digests::TxDigestKey;
 use sui_pg_db::query::Query;
+use sui_rpc_cursor::CursorKind;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::Position;
 use sui_sql_macro::query;
@@ -74,10 +74,17 @@ pub(crate) struct TransactionContents {
     pub(crate) contents: Option<Arc<NativeTransactionContents>>,
 }
 
-/// Wrapper around a `CursorToken` that is validated at decode to carry a `Transactions` position.
+/// Validated transaction cursor coordinates.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TransactionToken(CursorToken);
+pub struct TransactionToken {
+    /// Tracks the originating `CursorToken`'s kind, so it can be reproduced on re-encode.
+    kind: CursorKind,
+    checkpoint: u64,
+    tx_seq: u64,
+}
 
+/// Compatibility dispatch over the on-wire cursor formats: `CursorToken` (primary) or the
+/// legacy JSON cursor (secondary).
 pub type CTransaction = MultiCursor<OpaqueCursor<TransactionToken>, JsonCursor<u64>>;
 
 /// Custom `Connection` for transactions to support partially-filled pages.
@@ -467,19 +474,18 @@ impl TransactionConnection {
 impl TransactionToken {
     /// Mint the edge cursor for the transaction at the given coordinates.
     pub(crate) fn cursor(checkpoint: u64, tx_seq: u64) -> CTransaction {
-        MultiCursor::new(OpaqueCursor::new(Self(CursorToken::item(
-            Position::Transactions { checkpoint, tx_seq },
-        ))))
+        CTransaction::new(OpaqueCursor::new(Self {
+            kind: CursorKind::Item,
+            checkpoint,
+            tx_seq,
+        }))
     }
 }
 
 impl TxBoundsCursor for CTransaction {
     fn tx_sequence_number(&self) -> u64 {
         match self {
-            CTransaction::Primary(c) => match c.position {
-                Position::Transactions { tx_seq, .. } => tx_seq,
-                _ => unreachable!("validated at decode"),
-            },
+            CTransaction::Primary(c) => c.tx_seq,
             CTransaction::Secondary(c) => **c,
         }
     }
@@ -487,23 +493,38 @@ impl TxBoundsCursor for CTransaction {
 
 impl ByteCursor for TransactionToken {
     fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
-        let token = CursorToken::decode(bytes)?;
-        if !matches!(token.position, Position::Transactions { .. }) {
-            anyhow::bail!("invalid cursor");
-        }
-        Ok(Self(token))
+        CursorToken::decode(bytes)?.try_into()
     }
 
     fn encode_cursor(&self) -> bytes::Bytes {
-        self.0.encode()
+        CursorToken::from(self).encode()
     }
 }
 
-impl Deref for TransactionToken {
-    type Target = CursorToken;
+impl From<&TransactionToken> for CursorToken {
+    fn from(token: &TransactionToken) -> Self {
+        CursorToken {
+            kind: token.kind,
+            position: Position::Transactions {
+                checkpoint: token.checkpoint,
+                tx_seq: token.tx_seq,
+            },
+        }
+    }
+}
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl TryFrom<CursorToken> for TransactionToken {
+    type Error = anyhow::Error;
+
+    fn try_from(token: CursorToken) -> anyhow::Result<Self> {
+        let Position::Transactions { checkpoint, tx_seq } = token.position else {
+            anyhow::bail!("invalid cursor");
+        };
+        Ok(Self {
+            kind: token.kind,
+            checkpoint,
+            tx_seq,
+        })
     }
 }
 
@@ -853,14 +874,14 @@ mod tests {
 
     /// Legacy pg-style cursor: a bare JSON-encoded `tx_sequence_number`.
     fn legacy_cursor(position: u64) -> CTransaction {
-        MultiCursor::Secondary(JsonCursor::new(position))
+        CTransaction::Secondary(JsonCursor::new(position))
     }
 
     /// Decode an edge cursor back into its `CursorToken`.
     fn edge_token(cursor: &str) -> CursorToken {
         match CTransaction::decode_cursor(cursor).expect("decodable edge cursor") {
-            MultiCursor::Primary(c) => (**c).clone(),
-            MultiCursor::Secondary(_) => panic!("expected grpc cursor, got legacy"),
+            CTransaction::Primary(c) => CursorToken::from(&*c),
+            CTransaction::Secondary(_) => panic!("expected grpc cursor, got legacy"),
         }
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -73,7 +74,11 @@ pub(crate) struct TransactionContents {
     pub(crate) contents: Option<Arc<NativeTransactionContents>>,
 }
 
-pub type CTransaction = MultiCursor<OpaqueCursor<CursorToken>, JsonCursor<u64>>;
+/// Wrapper around a `CursorToken` that is validated at decode to carry a `Transactions` position.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransactionToken(CursorToken);
+
+pub type CTransaction = MultiCursor<OpaqueCursor<TransactionToken>, JsonCursor<u64>>;
 
 /// Custom `Connection` for transactions to support partially-filled pages.
 pub(crate) struct TransactionConnection {
@@ -307,14 +312,7 @@ impl Transaction {
 
         page.paginate_results(
             filtered,
-            |tx| {
-                MultiCursor::new(OpaqueCursor::new(CursorToken::item(
-                    Position::Transactions {
-                        checkpoint: source_cp_sequence_number,
-                        tx_seq: tx.tx_sequence_number,
-                    },
-                )))
-            },
+            |tx| TransactionToken::cursor(source_cp_sequence_number, tx.tx_sequence_number),
             |tx| Transaction::with_contents(scope.clone(), tx.contents.clone()),
         )
         .map(Into::into)
@@ -388,14 +386,7 @@ impl Transaction {
 
         page.paginate_results(
             tx_digests(ctx, &tx_sequence_numbers).await?,
-            |(s, _)| {
-                MultiCursor::new(OpaqueCursor::new(CursorToken::item(
-                    Position::Transactions {
-                        checkpoint: 0,
-                        tx_seq: *s,
-                    },
-                )))
-            },
+            |(s, _)| TransactionToken::cursor(0, *s),
             |(_, d)| Ok(Self::with_digest(scope.clone(), d)),
         )
         .map(Into::into)
@@ -473,6 +464,15 @@ impl TransactionConnection {
     }
 }
 
+impl TransactionToken {
+    /// Mint the edge cursor for the transaction at the given coordinates.
+    pub(crate) fn cursor(checkpoint: u64, tx_seq: u64) -> CTransaction {
+        MultiCursor::new(OpaqueCursor::new(Self(CursorToken::item(
+            Position::Transactions { checkpoint, tx_seq },
+        ))))
+    }
+}
+
 impl TxBoundsCursor for CTransaction {
     fn tx_sequence_number(&self) -> u64 {
         match self {
@@ -485,17 +485,25 @@ impl TxBoundsCursor for CTransaction {
     }
 }
 
-impl ByteCursor for CursorToken {
+impl ByteCursor for TransactionToken {
     fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
-        let cursor = CursorToken::decode(bytes)?;
-        if !matches!(cursor.position, Position::Transactions { .. }) {
+        let token = CursorToken::decode(bytes)?;
+        if !matches!(token.position, Position::Transactions { .. }) {
             anyhow::bail!("invalid cursor");
         }
-        Ok(cursor)
+        Ok(Self(token))
     }
 
     fn encode_cursor(&self) -> bytes::Bytes {
-        self.encode()
+        self.0.encode()
+    }
+}
+
+impl Deref for TransactionToken {
+    type Target = CursorToken;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -840,12 +848,7 @@ mod tests {
     }
 
     fn primary_cursor(checkpoint: u64, position: u64) -> CTransaction {
-        MultiCursor::new(OpaqueCursor::new(CursorToken::item(
-            Position::Transactions {
-                checkpoint,
-                tx_seq: position,
-            },
-        )))
+        TransactionToken::cursor(checkpoint, position)
     }
 
     /// Legacy pg-style cursor: a bare JSON-encoded `tx_sequence_number`.
@@ -856,7 +859,7 @@ mod tests {
     /// Decode an edge cursor back into its `CursorToken`.
     fn edge_token(cursor: &str) -> CursorToken {
         match CTransaction::decode_cursor(cursor).expect("decodable edge cursor") {
-            MultiCursor::Primary(c) => (*c).clone(),
+            MultiCursor::Primary(c) => (**c).clone(),
             MultiCursor::Secondary(_) => panic!("expected grpc cursor, got legacy"),
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -82,6 +82,7 @@ const HEALTH_PATH: &str = "/graphql/health";
 mod api;
 pub use crate::api::scalars::cursor::JsonCursor;
 pub use crate::api::types::checkpoint::CCheckpoint;
+pub use crate::api::types::checkpoint::CheckpointToken;
 pub use crate::api::types::event::CEvent;
 pub use crate::api::types::event::EventCursor;
 pub use crate::api::types::transaction::CTransaction;


### PR DESCRIPTION
## Description 

Since multiple endpoints/ types share the same `CursorToken`, each module of `Checkpoint`, `Event`, `Transaction` adds a newtype wrapper over `CursorToken`, then use `MultiCursor` for backwards compatibility.


Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
