### PR TITLE
[typed-store] Update tidehunter, use native exists() for contains_key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8484,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=e22a81b6adace0d20022f679eaf6480a81035192#e22a81b6adace0d20022f679eaf6480a81035192"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f379adad280f869fb4b6148d1212a13fbcf3539d#f379adad280f869fb4b6148d1212a13fbcf3539d"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18197,7 +18197,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=e22a81b6adace0d20022f679eaf6480a81035192#e22a81b6adace0d20022f679eaf6480a81035192"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f379adad280f869fb4b6148d1212a13fbcf3539d#f379adad280f869fb4b6148d1212a13fbcf3539d"
 dependencies = [
  "anyhow",
  "clap",
@@ -18212,7 +18212,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=e22a81b6adace0d20022f679eaf6480a81035192#e22a81b6adace0d20022f679eaf6480a81035192"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f379adad280f869fb4b6148d1212a13fbcf3539d#f379adad280f869fb4b6148d1212a13fbcf3539d"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -55,7 +55,7 @@ sui-tls.workspace = true
 bin-version.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "e22a81b6adace0d20022f679eaf6480a81035192", package = "tideconsole", optional = true}
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f379adad280f869fb4b6148d1212a13fbcf3539d", package = "tideconsole", optional = true}
 rhai = { version = "1", optional = true }
 rustyline = { version = "14", optional = true }
 parking_lot = { workspace = true, optional = true }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "e22a81b6adace0d20022f679eaf6480a81035192", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f379adad280f869fb4b6148d1212a13fbcf3539d", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -422,24 +422,6 @@ impl Database {
         ret
     }
 
-    pub fn key_may_exist_cf<K: AsRef<[u8]>>(
-        &self,
-        cf_name: &str,
-        key: K,
-        readopts: &ReadOptions,
-    ) -> bool {
-        match &self.storage {
-            // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
-            // but no false negatives. We use it to short-circuit the absent case
-            Storage::Rocks(rocks) => {
-                rocks
-                    .underlying
-                    .key_may_exist_cf_opt(&rocks_cf(rocks, cf_name), key, readopts)
-            }
-            _ => true,
-        }
-    }
-
     pub(crate) fn write_opt_internal(
         &self,
         batch: StorageWriteBatch,
@@ -1776,9 +1758,27 @@ where
     where
         J: Borrow<K>,
     {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_multiget_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.multiget_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
         let keys_bytes = keys.into_iter().map(|k| be_fix_int_ser(k.borrow()));
-        self.db
-            .multi_contains(&self.column_family, keys_bytes, &self.opts.readopts())
+        let result = self
+            .db
+            .multi_contains(&self.column_family, keys_bytes, &self.opts.readopts());
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(&self.cf);
+        }
+        result
     }
 
     #[instrument(level = "trace", skip_all, err)]

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -262,6 +262,36 @@ impl Database {
         }
     }
 
+    /// Multi-key variant of [`Self::contains`]. On tidehunter each key uses the
+    /// native `exists` presence check, avoiding the value-record reads that
+    /// `multi_get` performs. Other backends answer via `multi_get`.
+    fn multi_contains<I, K>(
+        &self,
+        cf: &ColumnFamily,
+        keys: I,
+        readopts: &ReadOptions,
+    ) -> Result<Vec<bool>, TypedStoreError>
+    where
+        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]>,
+    {
+        match (&self.storage, cf) {
+            #[cfg(tidehunter)]
+            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => keys
+                .into_iter()
+                .map(|k| {
+                    db.exists(*ks, &transform_th_key(k.as_ref(), prefix))
+                        .map_err(typed_store_error_from_th_error)
+                })
+                .collect(),
+            _ => self
+                .multi_get(cf, keys, readopts)
+                .into_iter()
+                .map(|r| r.map(|v| v.is_some()))
+                .collect(),
+        }
+    }
+
     fn multi_get<I, K>(
         &self,
         cf: &ColumnFamily,
@@ -1746,8 +1776,9 @@ where
     where
         J: Borrow<K>,
     {
-        let values = self.multi_get_pinned(keys)?;
-        Ok(values.into_iter().map(|v| v.is_some()).collect())
+        let keys_bytes = keys.into_iter().map(|k| be_fix_int_ser(k.borrow()));
+        self.db
+            .multi_contains(&self.column_family, keys_bytes, &self.opts.readopts())
     }
 
     #[instrument(level = "trace", skip_all, err)]

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -227,6 +227,41 @@ impl Database {
         }
     }
 
+    /// Returns whether `key` exists, without materializing the value. On tidehunter
+    /// this uses the native `exists` (an index/bloom presence check), which avoids
+    /// the value-record read that `get` performs and is therefore much cheaper.
+    fn contains(
+        &self,
+        cf: &ColumnFamily,
+        key: &[u8],
+        readopts: &ReadOptions,
+    ) -> Result<bool, TypedStoreError> {
+        match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
+                let rocks_cf = cf.rocks_cf(db);
+                // `key_may_exist_cf_opt` can return false positives but never false
+                // negatives, so it short-circuits the common absent case before the
+                // real point lookup.
+                Ok(db.underlying.key_may_exist_cf_opt(&rocks_cf, key, readopts)
+                    && db
+                        .underlying
+                        .get_pinned_cf_opt(&rocks_cf, key, readopts)
+                        .map_err(typed_store_err_from_rocks_err)?
+                        .is_some())
+            }
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
+                Ok(db.get(cf_name, key).is_some())
+            }
+            #[cfg(tidehunter)]
+            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => db
+                .exists(*ks, &transform_th_key(key, prefix))
+                .map_err(typed_store_error_from_th_error),
+            _ => Err(TypedStoreError::RocksDBError(
+                "typed store invariant violation".to_string(),
+            )),
+        }
+    }
+
     fn multi_get<I, K>(
         &self,
         cf: &ColumnFamily,
@@ -1699,12 +1734,8 @@ where
     #[instrument(level = "trace", skip_all, err)]
     fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
         let key_buf = be_fix_int_ser(key);
-        let readopts = self.opts.readopts();
-        Ok(self.db.key_may_exist_cf(&self.cf, &key_buf, &readopts)
-            && self
-                .db
-                .get(&self.column_family, &key_buf, &readopts)?
-                .is_some())
+        self.db
+            .contains(&self.column_family, &key_buf, &self.opts.readopts())
     }
 
     #[instrument(level = "trace", skip_all, err)]


### PR DESCRIPTION
## Description

Three changes:

1. **Update tidehunter to `f379adad`** — pulls in [MystenLabs/tidehunter@f379adad](https://github.com/MystenLabs/tidehunter/commit/f379adad280f869fb4b6148d1212a13fbcf3539d), which makes `exists()` collision-safe for key-reduction keyspaces: on an index hit it now reads the record and compares the full key instead of trusting the reduced-key match, mirroring what `get()` already did. Keyspaces without key reduction keep the read-free fast path.

2. **Cherry-pick: route `contains_key` through tidehunter's native `exists()`** (3a8e76ee). `contains_key` previously did `get().is_some()`, which on tidehunter reads the value record. The new `Database::contains` uses `exists()` (presence check, no value read). RocksDB keeps `key_may_exist` + point lookup; in-memory unchanged. The tidehunter bump above is what makes this safe for key-reduction keyspaces. `Database::key_may_exist_cf` lost its last caller in this move and is removed.

3. **Route `multi_contains_keys` through native `exists()` as well.** It previously went through `multi_get_pinned` and materialized every value just to call `is_some()`. New `Database::multi_contains` answers each key with tidehunter's `exists()`; RocksDB and in-memory keep answering via `multi_get`. The `rocksdb_multiget_latency_seconds` timer and perf-context sampling that `multi_get_pinned` provided are kept in `multi_contains_keys`; the `rocksdb_multiget_bytes` observation is intentionally dropped for this path since presence checks no longer return (and on tidehunter no longer read) values.

Note for reviewers: on key-reduction keyspaces (e.g. `executed_transactions_to_checkpoint`, `executed_effects`), `exists()` still performs the WAL record read on cold index hits to rule out reduced-key collisions — the read-free win applies to Hash/Fixed keyspaces (e.g. `consensus_message_processed`), LRU/flat hits, and absent keys.

## Test plan

`USE_TIDEHUNTER=1 cargo check -p typed-store --features tidehunter` and plain `cargo check -p typed-store` both pass; `USE_TIDEHUNTER=1 cargo test -p typed-store --features tidehunter` passes (40 tests). Tidehunter-side change is covered by the tidehunter test suite (329 tests) at the pinned rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)