### PR TITLE
Fix cargo-deny advisories failing CI on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,12 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
-dependencies = [
- "backtrace",
-]
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "append-only-vec"

--- a/deny.toml
+++ b/deny.toml
@@ -64,6 +64,15 @@ ignore = [
     # `http-types` ASCII invariant notice, no safe upgrade — dev-dependency only,
     # via wiremock 0.5 test mocks; not used to construct auth headers
     "RUSTSEC-2026-0174",
+    # quick-xml 0.38: quadratic duplicate-attribute check (0194) and unbounded
+    # namespace-declaration allocation DoS (0195). Fixed only in quick-xml >= 0.41,
+    # but quick-xml is transitive via object_store, whose latest release (0.14.0)
+    # still requires ^0.40 — no upgrade path yet. In Sui, quick-xml only parses
+    # XML API responses from cloud storage providers (S3/GCS/Azure) via
+    # object_store, not attacker-controlled input. Remove once object_store
+    # releases with quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "append-only-vec"


### PR DESCRIPTION
## Description

The cargo-deny advisories check has been failing on main, blocking CI on all PRs (e.g. #27135), due to three new RustSec advisories:

- [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) (`anyhow` `Error::downcast_mut()` unsoundness) — fixed by updating anyhow to 1.0.103 in both the root workspace (1.0.86) and the `external-crates/move` workspace (1.0.95), since `external.yml` runs cargo-deny against the Move lockfile too.
- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) / [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) (`quick-xml` 0.38 quadratic attribute check and namespace-allocation DoS) — patched only in quick-xml ≥ 0.41, but quick-xml is transitive via `object_store`, whose latest release (0.14.0) still requires ^0.40, so there is no upgrade path. Added deny.toml ignores; in Sui, quick-xml only parses cloud storage provider API responses via object_store, not attacker-controlled input. The Move workspace has no quick-xml dependency, so no ignores needed there.

## Test plan

`cargo deny check` passes locally in both the root workspace and `external-crates/move` (advisories, bans, licenses, sources).

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: