### PR TITLE
[consensus adapter] end submission when transaction is rejected or dropped

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -330,7 +330,7 @@ pub struct AuthorityMetrics {
     pub consensus_handler_congested_transactions: IntCounter,
     pub consensus_handler_unpaid_amplification_deferrals: IntCounter,
     pub consensus_handler_cancelled_transactions: IntCounter,
-    pub consensus_handler_dropped_transactions: IntCounter,
+    pub consensus_handler_dropped_transactions: IntCounterVec,
     pub consensus_handler_max_object_costs: IntGaugeVec,
     pub consensus_committed_subdags: IntCounterVec,
     pub accumulator_deposits: IntCounter,
@@ -678,9 +678,10 @@ impl AuthorityMetrics {
                 "Number of transactions cancelled by consensus handler",
                 registry,
             ).unwrap(),
-            consensus_handler_dropped_transactions: register_int_counter_with_registry!(
+            consensus_handler_dropped_transactions: register_int_counter_vec_with_registry!(
                 "consensus_handler_dropped_transactions",
-                "Number of transactions dropped by consensus handler",
+                "Number of transactions dropped by consensus handler, by drop reason",
+                &["reason"],
                 registry,
             ).unwrap(),
             consensus_handler_max_object_costs: register_int_gauge_vec_with_registry!(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1825,6 +1825,17 @@ impl AuthorityPerEpochStore {
         }
     }
 
+    #[cfg(test)]
+    pub fn insert_object_locks_for_test(&self, locks: &[(ObjectRef, TransactionDigest)]) {
+        for (object, digest) in locks {
+            self.tables()
+                .expect("test should not cross epoch boundary")
+                .owned_object_locked_transactions
+                .insert(object, &LockDetailsWrapper::from(*digest))
+                .unwrap();
+        }
+    }
+
     pub fn get_signed_transaction(
         &self,
         tx_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -27,8 +27,11 @@ pub(crate) enum ConsensusTxStatus {
     // Transaction is dropped post-consensus.
     // This decision must be consistent across all validators.
     //
-    // Currently, only invalid owned object inputs (using stale versions)
-    // can cause a transaction to be dropped without execution.
+    // A transaction is dropped without execution when it has invalid owned object
+    // inputs (stale versions or conflicts with a locked object), or when it is
+    // ignored during epoch close (consensus certs no longer accepted, or its block
+    // author already sent EndOfPublish). All causes are deterministic functions of
+    // the transaction and prior consensus commits.
     Dropped,
 }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -970,13 +970,50 @@ impl ValidatorService {
 
             // Suppress resubmission of transactions consensus already processed this epoch:
             // executed transactions whose effects details could not be reconstructed above (e.g.
-            // objects pruned), and sequenced-but-deferred transactions. Rejected is imperfect for
-            // the deferred case, but acceptable since well-behaved clients get Executed before
-            // pruning; this mainly sheds continuous resubmissions from faulty clients.
+            // objects pruned), sequenced-but-deferred transactions, and dropped transactions.
             let consensus_key = SequencedConsensusTransactionKey::External(
                 ConsensusTransactionKey::Certificate(tx_digest),
             );
             if epoch_store.is_consensus_message_processed(&consensus_key)? {
+                // Prefer a concrete, non-retriable validation error over the generic,
+                // retriable TransactionProcessing suppression. A processed-but-unexecuted
+                // digest is commonly a dropped owned-object conflict loser whose winner has
+                // executed by now; validating against live state surfaces the terminal
+                // stale-version error so the client stops retrying, instead of polling for
+                // effects that will never come.
+                if let Err(error) =
+                    state.handle_vote_transaction(&epoch_store, verified_transaction.tx().clone())
+                {
+                    // The transaction may have executed while being validated (e.g. it was
+                    // deferred rather than dropped).
+                    if let Some(effects) = state
+                        .get_transaction_cache_reader()
+                        .get_executed_effects(&tx_digest)
+                    {
+                        let effects_digest = effects.digest();
+                        if let Ok(executed_data) = self.complete_executed_data(effects).await {
+                            results[idx] = Some(SubmitTxResult::Executed {
+                                effects_digest,
+                                details: Some(executed_data),
+                            });
+                            continue;
+                        }
+                    }
+                    debug!(
+                        ?tx_digest,
+                        "handle_submit_transaction: processed transaction rejected on revalidation: {error}"
+                    );
+                    metrics
+                        .submission_rejected_transactions
+                        .with_label_values(&[error.to_variant_name()])
+                        .inc();
+                    results[idx] = Some(SubmitTxResult::Rejected { error });
+                    continue;
+                }
+                // Validation passed, so the transaction is pending (deferred) or executed
+                // with pruned effects details. Rejected is imperfect for the deferred case,
+                // but acceptable since well-behaved clients get Executed before pruning;
+                // this mainly sheds continuous resubmissions from faulty clients.
                 metrics
                     .submission_suppressed_already_processed
                     .with_label_values(&[req_type])

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -19,7 +19,7 @@ use prometheus::{
     register_int_counter_with_registry, register_int_gauge_with_registry,
 };
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
@@ -975,12 +975,59 @@ impl ValidatorService {
                 ConsensusTransactionKey::Certificate(tx_digest),
             );
             if epoch_store.is_consensus_message_processed(&consensus_key)? {
-                // Prefer a concrete, non-retriable validation error over the generic,
-                // retriable TransactionProcessing suppression. A processed-but-unexecuted
-                // digest is commonly a dropped owned-object conflict loser whose winner has
-                // executed by now; validating against live state surfaces the terminal
-                // stale-version error so the client stops retrying, instead of polling for
-                // effects that will never come.
+                // Prefer a concrete, non-retriable error over the generic, retriable
+                // TransactionProcessing suppression. A processed-but-unexecuted digest is
+                // commonly a dropped owned-object conflict loser; surfacing the terminal
+                // error lets the client stop retrying instead of polling for effects that
+                // will never come.
+                //
+                // First check the epoch owned-object lock table with the same conflict
+                // logic the consensus handler uses post-consensus. Locks are never
+                // released within an epoch, so this reports the conflict even before the
+                // winner executes, while the loser's input versions still validate as
+                // live.
+                if let Ok(input_objects) = verified_transaction
+                    .tx()
+                    .data()
+                    .transaction_data()
+                    .input_objects()
+                {
+                    let immutable_object_ids = self
+                        .collect_immutable_object_ids(verified_transaction.tx(), state)
+                        .await?;
+                    let owned_object_refs: Vec<_> = input_objects
+                        .iter()
+                        .filter_map(|obj| match obj {
+                            InputObjectKind::ImmOrOwnedMoveObject(obj_ref)
+                                if !immutable_object_ids.contains(&obj_ref.0) =>
+                            {
+                                Some(*obj_ref)
+                            }
+                            _ => None,
+                        })
+                        .collect();
+                    let existing_locks =
+                        epoch_store.get_owned_object_locks_map(&owned_object_refs)?;
+                    if let Err(error) = epoch_store.try_acquire_owned_object_locks_post_consensus(
+                        &owned_object_refs,
+                        tx_digest,
+                        &HashMap::new(),
+                        &existing_locks,
+                    ) {
+                        debug!(
+                            ?tx_digest,
+                            "handle_submit_transaction: processed transaction rejected on lock conflict: {error}"
+                        );
+                        metrics
+                            .submission_rejected_transactions
+                            .with_label_values(&[error.to_variant_name()])
+                            .inc();
+                        results[idx] = Some(SubmitTxResult::Rejected { error });
+                        continue;
+                    }
+                }
+                // Then revalidate against live state, which surfaces the terminal
+                // stale-version error once the conflict winner has executed.
                 if let Err(error) =
                     state.handle_vote_transaction(&epoch_store, verified_transaction.tx().clone())
                 {
@@ -1010,10 +1057,9 @@ impl ValidatorService {
                     results[idx] = Some(SubmitTxResult::Rejected { error });
                     continue;
                 }
-                // Validation passed, so the transaction is pending (deferred) or executed
-                // with pruned effects details. Rejected is imperfect for the deferred case,
-                // but acceptable since well-behaved clients get Executed before pruning;
-                // this mainly sheds continuous resubmissions from faulty clients.
+                // Validation passed, so this processed digest may still be executable.
+                // Return retriable TransactionProcessing rather than resubmitting it to consensus.
+                // A later client retry can observe effects or a concrete terminal validation error.
                 metrics
                     .submission_suppressed_already_processed
                     .with_label_values(&[req_type])

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use consensus_core::BlockStatus;
 use futures::FutureExt;
 use futures::StreamExt;
-use futures::future::{self, Either, select};
+use futures::future::{self, Either, join_all, select};
 use futures::stream::FuturesUnordered;
 use mysten_common::debug_fatal;
 use mysten_metrics::{
@@ -44,6 +44,9 @@ use tokio::time::{self};
 use tracing::{Instrument, debug, debug_span, info, instrument, warn};
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::consensus_tx_status_cache::{
+    ConsensusTxStatus, NotifyReadConsensusTxStatusResult,
+};
 use crate::checkpoints::CheckpointStore;
 use crate::consensus_handler::{SequencedConsensusTransactionKey, classify};
 use crate::epoch::reconfiguration::{ReconfigState, ReconfigurationInitiator};
@@ -58,6 +61,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_certificate_success: IntCounterVec,
     pub sequencing_certificate_failures: IntCounterVec,
     pub sequencing_certificate_status: IntCounterVec,
+    pub sequencing_certificate_settled_status: IntCounterVec,
     pub sequencing_certificate_inflight: IntGaugeVec,
     pub sequencing_acknowledge_latency: HistogramVec,
     pub sequencing_certificate_latency: HistogramVec,
@@ -96,6 +100,13 @@ impl ConsensusAdapterMetrics {
                 sequencing_certificate_status: register_int_counter_vec_with_registry!(
                 "sequencing_certificate_status",
                 "The status of the certificate sequencing as reported by consensus. The status can be either sequenced or garbage collected.",
+                &["tx_type", "status"],
+                registry,
+            )
+                .unwrap(),
+            sequencing_certificate_settled_status: register_int_counter_vec_with_registry!(
+                "sequencing_certificate_settled_status",
+                "The terminal per-position consensus status (finalized, rejected or dropped) of transactions whose submission settled via position status.",
                 &["tx_type", "status"],
                 registry,
             )
@@ -512,7 +523,7 @@ impl ConsensusAdapter {
                 .unwrap_or_default();
             SuiErrorKind::TransactionProcessing {
                 digest,
-                status: format!("processed via {}", method.processed_via()),
+                status: format!("processed via {}", method.method_name()),
             }
             .into()
         };
@@ -601,7 +612,7 @@ impl ConsensusAdapter {
                         // consensus adapter due to an error or GC. They can handle retries
                         // as needed if the consensus position does not return the desired
                         // results (e.g. not sequenced due to garbage collection).
-                        let _ = tx_consensus_positions.send(Ok(consensus_positions));
+                        let _ = tx_consensus_positions.send(Ok(consensus_positions.clone()));
                     }
 
                     match status_waiter.await {
@@ -612,11 +623,48 @@ impl ConsensusAdapter {
                                 .sequencing_certificate_status
                                 .with_label_values(&[tx_type, "sequenced"])
                                 .inc();
-                            // Block has been sequenced. Nothing more to do, we do have guarantees that the transaction will appear in consensus output.
                             debug!(
                                 "Transaction {transaction_keys:?} has been sequenced by consensus."
                             );
-                            break;
+                            if is_system_message {
+                                // System messages have consensus positions too, but the
+                                // commit handler only assigns per-position statuses to
+                                // user transactions, so their completion is signaled by
+                                // the processed flag instead.
+                                break SequencingOutcome::BlockSequenced;
+                            }
+                            if consensus_positions.len() != transactions.len() {
+                                debug_fatal!(
+                                    "Consensus client returned {} positions for {} transactions",
+                                    consensus_positions.len(),
+                                    transactions.len()
+                                );
+                                break SequencingOutcome::BlockSequenced;
+                            }
+                            // The block is committed, and the commit handler assigns every
+                            // user transaction position a terminal status.
+                            match self
+                                .wait_for_position_statuses(&consensus_positions, epoch_store)
+                                .await
+                            {
+                                Some(statuses) => break SequencingOutcome::Sequenced(statuses),
+                                None => {
+                                    // When positions expired before its status was read,
+                                    // resubmit like garbage collection.
+                                    // Duplicates are deduplicated post-consensus,
+                                    // and the processed waiter cancels this loop if the
+                                    // transaction has already finalized.
+                                    debug!(
+                                        "Transaction {transaction_keys:?} status expired before being read. Will be retried."
+                                    );
+                                    self.metrics
+                                        .sequencing_certificate_status
+                                        .with_label_values(&[tx_type, "status_expired"])
+                                        .inc();
+                                    time::sleep(RETRY_DELAY_STEP).await;
+                                    continue;
+                                }
+                            }
                         }
                         Ok(status @ BlockStatus::GarbageCollected(_)) => {
                             tracing::Span::current()
@@ -660,7 +708,17 @@ impl ConsensusAdapter {
                     processed_via_notify = true;
                     observed
                 }
-                Either::Right(((), processed_waiter)) => {
+                Either::Right((SequencingOutcome::Sequenced(statuses), _processed_waiter)) => {
+                    processed_via_notify = false;
+                    for status in statuses {
+                        self.metrics
+                            .sequencing_certificate_settled_status
+                            .with_label_values(&[tx_type, status_label(status)])
+                            .inc();
+                    }
+                    ProcessedMethod::ConsensusStatusReceived
+                }
+                Either::Right((SequencingOutcome::BlockSequenced, processed_waiter)) => {
                     debug!("Submitted {transaction_keys:?} to consensus");
                     processed_via_notify = false;
                     processed_waiter.await
@@ -679,7 +737,7 @@ impl ConsensusAdapter {
         }
         debug!(
             "{transaction_keys:?} processed via {}",
-            guard.processed_method.processed_via()
+            guard.processed_method.method_name()
         );
 
         // After a user transaction or soft bundle submission,
@@ -842,9 +900,9 @@ impl ConsensusAdapter {
         }
 
         if seen_checkpoint {
-            Some(ProcessedMethod::Checkpoint)
+            Some(ProcessedMethod::CheckpointExecuted)
         } else {
-            Some(ProcessedMethod::Consensus)
+            Some(ProcessedMethod::ConsensusMessageProcessed)
         }
     }
 
@@ -883,15 +941,14 @@ impl ConsensusAdapter {
                 Either::Right(future::pending())
             };
 
-            // We wait for each transaction individually to be processed by consensus or executed in a checkpoint. We could equally just
-            // get notified in aggregate when all transactions are processed, but with this approach can get notified in a more fine-grained way
-            // as transactions can be marked as processed in different ways. This is mostly a concern for the soft-bundle transactions.
+            // Wait for each key individually so soft bundles can complete even
+            // when different transactions are observed through different paths.
             notifications.push(async move {
                 tokio::select! {
                     processed = epoch_store.consensus_messages_processed_notify(vec![transaction_key]) => {
                         processed.expect("Storage error when waiting for consensus message processed");
                         self.metrics.sequencing_certificate_processed.with_label_values(&["consensus"]).inc();
-                        return ProcessedMethod::Consensus;
+                        return ProcessedMethod::ConsensusMessageProcessed;
                     },
                     processed = epoch_store.transactions_executed_in_checkpoint_notify(transaction_digests), if !transaction_digests.is_empty() => {
                         processed.expect("Storage error when waiting for transaction executed in checkpoint");
@@ -901,17 +958,39 @@ impl ConsensusAdapter {
                         self.metrics.sequencing_certificate_processed.with_label_values(&["synced_checkpoint"]).inc();
                     }
                 }
-                ProcessedMethod::Checkpoint
+                ProcessedMethod::CheckpointExecuted
             });
         }
 
         let processed_methods = notifications.collect::<Vec<ProcessedMethod>>().await;
         for method in processed_methods {
-            if method == ProcessedMethod::Checkpoint {
-                return ProcessedMethod::Checkpoint;
+            if method == ProcessedMethod::CheckpointExecuted {
+                return ProcessedMethod::CheckpointExecuted;
             }
         }
-        ProcessedMethod::Consensus
+        ProcessedMethod::ConsensusMessageProcessed
+    }
+
+    /// Waits until every consensus position reaches a terminal status (Finalized, Rejected or Dropped).
+    /// Returns `None` if any position expired from the status cache before its status was read,
+    /// in which case the submission's outcome is unknown and the caller should resubmit.
+    async fn wait_for_position_statuses(
+        &self,
+        consensus_positions: &[ConsensusPosition],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> Option<Vec<ConsensusTxStatus>> {
+        join_all(consensus_positions.iter().map(|position| {
+            epoch_store
+                .consensus_tx_status_cache
+                .notify_read_transaction_status(*position)
+        }))
+        .await
+        .into_iter()
+        .map(|result| match result {
+            NotifyReadConsensusTxStatusResult::Status(status) => Some(status),
+            NotifyReadConsensusTxStatusResult::Expired(_) => None,
+        })
+        .collect()
     }
 }
 
@@ -959,118 +1038,6 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
                 info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             }
         }
-    }
-}
-
-struct CancelOnDrop<T>(JoinHandle<T>);
-
-impl<T> Deref for CancelOnDrop<T> {
-    type Target = JoinHandle<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> Drop for CancelOnDrop<T> {
-    fn drop(&mut self) {
-        self.0.abort();
-    }
-}
-
-/// Tracks number of inflight consensus requests and relevant metrics
-struct InflightDropGuard<'a> {
-    adapter: &'a ConsensusAdapter,
-    start: Instant,
-    submitted: bool,
-    tx_type: &'static str,
-    processed_method: ProcessedMethod,
-    /// Number of transactions this guard accounts for.
-    /// > 1 for soft bundles.
-    inflight_count: u64,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-enum ProcessedMethod {
-    Consensus,
-    Checkpoint,
-}
-
-impl ProcessedMethod {
-    fn processed_via(self) -> &'static str {
-        match self {
-            ProcessedMethod::Consensus => "consensus output",
-            ProcessedMethod::Checkpoint => "checkpoint execution",
-        }
-    }
-
-    fn latency_metric_label(self) -> &'static str {
-        match self {
-            ProcessedMethod::Consensus => "processed_via_consensus",
-            ProcessedMethod::Checkpoint => "processed_via_checkpoint",
-        }
-    }
-}
-
-impl<'a> InflightDropGuard<'a> {
-    pub fn acquire(
-        adapter: &'a ConsensusAdapter,
-        tx_type: &'static str,
-        inflight_count: u64,
-    ) -> Self {
-        adapter
-            .num_inflight_transactions
-            .fetch_add(inflight_count, Ordering::SeqCst);
-        adapter
-            .metrics
-            .sequencing_certificate_inflight
-            .with_label_values(&[tx_type])
-            .inc();
-        adapter
-            .metrics
-            .sequencing_certificate_attempt
-            .with_label_values(&[tx_type])
-            .inc();
-        Self {
-            adapter,
-            start: Instant::now(),
-            submitted: false,
-            tx_type,
-            processed_method: ProcessedMethod::Consensus,
-            inflight_count,
-        }
-    }
-}
-
-impl Drop for InflightDropGuard<'_> {
-    fn drop(&mut self) {
-        self.adapter
-            .num_inflight_transactions
-            .fetch_sub(self.inflight_count, Ordering::SeqCst);
-        self.adapter
-            .metrics
-            .sequencing_certificate_inflight
-            .with_label_values(&[self.tx_type])
-            .dec();
-        // Wake the admission queue drainer so it can submit more transactions.
-        self.adapter.inflight_slot_freed_notify.notify_one();
-
-        let latency = self.start.elapsed();
-        let submitted = if self.submitted {
-            "submitted"
-        } else {
-            "skipped"
-        };
-
-        self.adapter
-            .metrics
-            .sequencing_certificate_latency
-            .with_label_values(&[
-                submitted,
-                self.tx_type,
-                self.processed_method.latency_metric_label(),
-            ])
-            .observe(latency.as_secs_f64());
     }
 }
 
@@ -1131,5 +1098,137 @@ impl SubmitToConsensus for Arc<ConsensusAdapter> {
         let epoch_store = epoch_store.clone();
         spawn_monitored_task!(epoch_store.within_alive_epoch(async_stage));
         Ok(())
+    }
+}
+
+struct CancelOnDrop<T>(JoinHandle<T>);
+
+impl<T> Deref for CancelOnDrop<T> {
+    type Target = JoinHandle<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Drop for CancelOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Tracks number of inflight consensus requests and relevant metrics
+struct InflightDropGuard<'a> {
+    adapter: &'a ConsensusAdapter,
+    start: Instant,
+    submitted: bool,
+    tx_type: &'static str,
+    processed_method: ProcessedMethod,
+    /// Number of transactions this guard accounts for.
+    /// > 1 for soft bundles.
+    inflight_count: u64,
+}
+
+impl<'a> InflightDropGuard<'a> {
+    pub fn acquire(
+        adapter: &'a ConsensusAdapter,
+        tx_type: &'static str,
+        inflight_count: u64,
+    ) -> Self {
+        adapter
+            .num_inflight_transactions
+            .fetch_add(inflight_count, Ordering::SeqCst);
+        adapter
+            .metrics
+            .sequencing_certificate_inflight
+            .with_label_values(&[tx_type])
+            .inc();
+        adapter
+            .metrics
+            .sequencing_certificate_attempt
+            .with_label_values(&[tx_type])
+            .inc();
+        Self {
+            adapter,
+            start: Instant::now(),
+            submitted: false,
+            tx_type,
+            processed_method: ProcessedMethod::ConsensusMessageProcessed,
+            inflight_count,
+        }
+    }
+}
+
+impl Drop for InflightDropGuard<'_> {
+    fn drop(&mut self) {
+        self.adapter
+            .num_inflight_transactions
+            .fetch_sub(self.inflight_count, Ordering::SeqCst);
+        self.adapter
+            .metrics
+            .sequencing_certificate_inflight
+            .with_label_values(&[self.tx_type])
+            .dec();
+        // Wake the admission queue drainer so it can submit more transactions.
+        self.adapter.inflight_slot_freed_notify.notify_one();
+
+        let latency = self.start.elapsed();
+        let submitted = if self.submitted {
+            "submitted"
+        } else {
+            "skipped"
+        };
+
+        self.adapter
+            .metrics
+            .sequencing_certificate_latency
+            .with_label_values(&[
+                submitted,
+                self.tx_type,
+                self.processed_method.metric_label(),
+            ])
+            .observe(latency.as_secs_f64());
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum ProcessedMethod {
+    ConsensusMessageProcessed,
+    ConsensusStatusReceived,
+    CheckpointExecuted,
+}
+
+impl ProcessedMethod {
+    fn method_name(self) -> &'static str {
+        match self {
+            ProcessedMethod::ConsensusMessageProcessed => "consensus (processed message)",
+            ProcessedMethod::ConsensusStatusReceived => "consensus (transaction status)",
+            ProcessedMethod::CheckpointExecuted => "checkpoint execution",
+        }
+    }
+
+    fn metric_label(self) -> &'static str {
+        match self {
+            ProcessedMethod::ConsensusMessageProcessed => "consensus_message",
+            ProcessedMethod::ConsensusStatusReceived => "consensus_status",
+            ProcessedMethod::CheckpointExecuted => "checkpoint_execution",
+        }
+    }
+}
+
+/// Outcome of the submit loop in `submit_and_wait_inner`.
+enum SequencingOutcome {
+    /// A user-transaction submission that was sequenced and whose positions all
+    /// reached a terminal consensus status; nothing further to wait for.
+    Sequenced(Vec<ConsensusTxStatus>),
+    /// A system-message submission whose block was sequenced.
+    BlockSequenced,
+}
+
+fn status_label(status: ConsensusTxStatus) -> &'static str {
+    match status {
+        ConsensusTxStatus::Finalized => "finalized",
+        ConsensusTxStatus::Rejected => "rejected",
+        ConsensusTxStatus::Dropped => "dropped",
     }
 }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -649,20 +649,23 @@ impl ConsensusAdapter {
                             {
                                 Some(statuses) => break SequencingOutcome::Sequenced(statuses),
                                 None => {
-                                    // When positions expired before its status was read,
-                                    // resubmit like garbage collection.
-                                    // Duplicates are deduplicated post-consensus,
-                                    // and the processed waiter cancels this loop if the
-                                    // transaction has already finalized.
+                                    // A position expired from the status cache before it
+                                    // was read: the block was committed and its commit
+                                    // processed more than the retention window ago, so a
+                                    // terminal status existed and was merely missed. End
+                                    // the submission instead of resubmitting — a missed
+                                    // Finalized outcome needs nothing further from this
+                                    // task (the digest is durably recorded as processed
+                                    // and will execute), the other outcomes are terminal,
+                                    // and transaction-level retries belong to the client.
                                     debug!(
-                                        "Transaction {transaction_keys:?} status expired before being read. Will be retried."
+                                        "Transaction {transaction_keys:?} status expired before being read. Ending submission."
                                     );
                                     self.metrics
                                         .sequencing_certificate_status
                                         .with_label_values(&[tx_type, "status_expired"])
                                         .inc();
-                                    time::sleep(RETRY_DELAY_STEP).await;
-                                    continue;
+                                    break SequencingOutcome::StatusExpired;
                                 }
                             }
                         }
@@ -717,6 +720,10 @@ impl ConsensusAdapter {
                             .inc();
                     }
                     ProcessedMethod::ConsensusStatusReceived
+                }
+                Either::Right((SequencingOutcome::StatusExpired, _processed_waiter)) => {
+                    processed_via_notify = false;
+                    ProcessedMethod::ConsensusStatusExpired
                 }
                 Either::Right((SequencingOutcome::BlockSequenced, processed_waiter)) => {
                     debug!("Submitted {transaction_keys:?} to consensus");
@@ -1195,6 +1202,7 @@ impl Drop for InflightDropGuard<'_> {
 enum ProcessedMethod {
     ConsensusMessageProcessed,
     ConsensusStatusReceived,
+    ConsensusStatusExpired,
     CheckpointExecuted,
 }
 
@@ -1203,6 +1211,7 @@ impl ProcessedMethod {
         match self {
             ProcessedMethod::ConsensusMessageProcessed => "consensus (processed message)",
             ProcessedMethod::ConsensusStatusReceived => "consensus (transaction status)",
+            ProcessedMethod::ConsensusStatusExpired => "consensus (status expired)",
             ProcessedMethod::CheckpointExecuted => "checkpoint execution",
         }
     }
@@ -1211,6 +1220,7 @@ impl ProcessedMethod {
         match self {
             ProcessedMethod::ConsensusMessageProcessed => "consensus_message",
             ProcessedMethod::ConsensusStatusReceived => "consensus_status",
+            ProcessedMethod::ConsensusStatusExpired => "consensus_status_expired",
             ProcessedMethod::CheckpointExecuted => "checkpoint_execution",
         }
     }
@@ -1223,6 +1233,10 @@ enum SequencingOutcome {
     Sequenced(Vec<ConsensusTxStatus>),
     /// A system-message submission whose block was sequenced.
     BlockSequenced,
+    /// A user-transaction submission whose block was sequenced, but at least one
+    /// position expired from the status cache before its status was read. The
+    /// terminal outcome existed and was missed; nothing further to wait for.
+    StatusExpired,
 }
 
 fn status_label(status: ConsensusTxStatus) -> &'static str {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -980,7 +980,8 @@ impl ConsensusAdapter {
 
     /// Waits until every consensus position reaches a terminal status (Finalized, Rejected or Dropped).
     /// Returns `None` if any position expired from the status cache before its status was read,
-    /// in which case the submission's outcome is unknown and the caller should resubmit.
+    /// in which case the submit loop treats the sequenced block as already handled and settles with
+    /// `StatusExpired`.
     async fn wait_for_position_statuses(
         &self,
         consensus_positions: &[ConsensusPosition],

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -2672,6 +2672,9 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 {
                     let tx = tx_with_claims.tx();
                     let Some(owned_object_refs) = owned_object_refs_to_lock(tx_with_claims) else {
+                        // Invalid input object error is deterministic across all validators.
+                        status_updates.push((position, ConsensusTxStatus::Dropped));
+                        dropped_transaction_keys.push(parsed.transaction.key());
                         debug_fatal!("Invalid input objects for transaction {}", tx.digest());
                         continue;
                     };
@@ -3816,6 +3819,60 @@ mod tests {
                 .is_consensus_message_processed(&loser_key)
                 .unwrap()
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_rejected_transaction_sets_status_and_is_not_marked_processed() {
+        telemetry_subscribers::init_for_testing();
+
+        let (sender, keypair) = deterministic_random_account_key();
+        let gas_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+        let owned_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+
+        let state = TestAuthorityBuilder::new()
+            .with_starting_objects(&[gas_object.clone(), owned_object.clone()])
+            .skip_rpc_index_init()
+            .skip_genesis_owner_index()
+            .build()
+            .await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        let transaction =
+            test_user_transaction(&state, sender, &keypair, gas_object, vec![owned_object]).await;
+        let consensus_tx =
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+        let key = SequencedConsensusTransactionKey::External(consensus_tx.key());
+
+        let round = 100;
+        let commit = TestConsensusCommit::new(vec![consensus_tx], round as u64, 1_000, 10)
+            .with_rejected_indices([0]);
+        let mut setup = setup_consensus_handler_for_testing(&state).await;
+        setup
+            .consensus_handler
+            .handle_consensus_commit_for_test(commit)
+            .await;
+
+        // The rejected position receives a terminal Rejected status.
+        let block = BlockRef {
+            author: consensus_config::AuthorityIndex::ZERO,
+            round,
+            digest: Default::default(),
+        };
+        assert!(matches!(
+            epoch_store
+                .consensus_tx_status_cache
+                .notify_read_transaction_status(ConsensusPosition {
+                    epoch: epoch_store.epoch(),
+                    block,
+                    index: 0,
+                })
+                .await,
+            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Rejected)
+        ));
+        // Unlike dropped transactions, a rejected transaction must NOT be marked
+        // consensus-processed: rejection is per-position, and the digest must stay
+        // resubmittable within the epoch so a later occurrence can be finalized.
+        assert!(!epoch_store.is_consensus_message_processed(&key).unwrap());
     }
 
     fn to_short_strings(txs: Vec<VerifiedExecutableTransactionWithAliases>) -> Vec<String> {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -2601,6 +2601,19 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         // Note: we no longer have to check protocol_config.ignore_execution_time_observations_after_certs_closed()
                         | ConsensusTransactionKind::ExecutionTimeObservation(_)
                         | ConsensusTransactionKind::NewJWKFetched(_, _, _) => {
+                            // Deterministic drop: the reconfig state is derived from prior
+                            // commits, so all validators ignore this transaction. Record a
+                            // terminal status for user transactions so status waiters are
+                            // not leaked — no consensus-processed signal will ever come for
+                            // them, and epoch termination (the only other backstop) can
+                            // itself stall when reconfiguration is stuck.
+                            if parsed.transaction.is_user_transaction() {
+                                status_updates.push((position, ConsensusTxStatus::Dropped));
+                                self.metrics
+                                    .consensus_handler_dropped_transactions
+                                    .with_label_values(&["end_of_epoch"])
+                                    .inc();
+                            }
                             debug!(
                                 "Ignoring consensus transaction {:?} because of end of epoch",
                                 parsed.transaction.key()
@@ -2653,6 +2666,14 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         // In some edge cases, consensus might resend previously seen certificate after EndOfPublish
                         // An honest validator should not send a new transaction after EndOfPublish. Whether the
                         // transaction is duplicate or not, we filter it out here.
+                        // Deterministic drop (the EndOfPublish set is accumulated from
+                        // prior commits): record a terminal status so waiters are not
+                        // leaked, as with the certs-closed drop above.
+                        status_updates.push((position, ConsensusTxStatus::Dropped));
+                        self.metrics
+                            .consensus_handler_dropped_transactions
+                            .with_label_values(&["end_of_publish"])
+                            .inc();
                         warn!(
                             "Ignoring consensus transaction {:?} from authority {:?}, which already sent EndOfPublish message to consensus",
                             author_name.concise(),
@@ -2673,6 +2694,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     let tx = tx_with_claims.tx();
                     let Some(owned_object_refs) = owned_object_refs_to_lock(tx_with_claims) else {
                         // Invalid input object error is deterministic across all validators.
+                        self.metrics
+                            .consensus_handler_dropped_transactions
+                            .with_label_values(&["invalid_input"])
+                            .inc();
                         status_updates.push((position, ConsensusTxStatus::Dropped));
                         dropped_transaction_keys.push(parsed.transaction.key());
                         debug_fatal!("Invalid input objects for transaction {}", tx.digest());
@@ -2695,7 +2720,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         }
                         Err(e) => {
                             debug!("Dropping transaction {}: {}", tx.digest(), e);
-                            self.metrics.consensus_handler_dropped_transactions.inc();
+                            self.metrics
+                                .consensus_handler_dropped_transactions
+                                .with_label_values(&["lock_conflict"])
+                                .inc();
                             status_updates.push((position, ConsensusTxStatus::Dropped));
                             self.epoch_store.set_rejection_vote_reason(position, &e);
                             dropped_transaction_keys.push(parsed.transaction.key());
@@ -3773,6 +3801,7 @@ mod tests {
                 .consensus_handler
                 .metrics
                 .consensus_handler_dropped_transactions
+                .with_label_values(&["lock_conflict"])
                 .get(),
             1
         );
@@ -3873,6 +3902,149 @@ mod tests {
         // consensus-processed: rejection is per-position, and the digest must stay
         // resubmittable within the epoch so a later occurrence can be finalized.
         assert!(!epoch_store.is_consensus_message_processed(&key).unwrap());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_user_transaction_ignored_at_epoch_close_sets_dropped_status() {
+        telemetry_subscribers::init_for_testing();
+
+        let (sender, keypair) = deterministic_random_account_key();
+        let gas_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+        let owned_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+
+        let state = TestAuthorityBuilder::new()
+            .with_starting_objects(&[gas_object.clone(), owned_object.clone()])
+            .skip_rpc_index_init()
+            .skip_genesis_owner_index()
+            .build()
+            .await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        let transaction =
+            test_user_transaction(&state, sender, &keypair, gas_object, vec![owned_object]).await;
+        let consensus_tx =
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+        let key = SequencedConsensusTransactionKey::External(consensus_tx.key());
+
+        // Close the epoch to the point where consensus certs are no longer accepted.
+        {
+            let mut guard = epoch_store.get_reconfig_state_write_lock_guard();
+            guard.close_all_certs();
+        }
+
+        let round = 100;
+        let commit = TestConsensusCommit::new(vec![consensus_tx], round as u64, 1_000, 10);
+        let mut setup = setup_consensus_handler_for_testing(&state).await;
+        setup
+            .consensus_handler
+            .handle_consensus_commit_for_test(commit)
+            .await;
+
+        // The ignored position receives a terminal Dropped status so submission and
+        // effects waiters are not leaked until epoch termination.
+        let block = BlockRef {
+            author: consensus_config::AuthorityIndex::ZERO,
+            round,
+            digest: Default::default(),
+        };
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            epoch_store
+                .consensus_tx_status_cache
+                .notify_read_transaction_status(ConsensusPosition {
+                    epoch: epoch_store.epoch(),
+                    block,
+                    index: 0,
+                }),
+        )
+        .await
+        .expect("transaction ignored at epoch close should receive a terminal status");
+        assert!(matches!(
+            status,
+            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Dropped)
+        ));
+        assert!(!epoch_store.is_consensus_message_processed(&key).unwrap());
+        assert_eq!(
+            setup
+                .consensus_handler
+                .metrics
+                .consensus_handler_dropped_transactions
+                .with_label_values(&["end_of_epoch"])
+                .get(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_user_transaction_after_end_of_publish_sets_dropped_status() {
+        telemetry_subscribers::init_for_testing();
+
+        let (sender, keypair) = deterministic_random_account_key();
+        let gas_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+        let owned_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+
+        let state = TestAuthorityBuilder::new()
+            .with_starting_objects(&[gas_object.clone(), owned_object.clone()])
+            .skip_rpc_index_init()
+            .skip_genesis_owner_index()
+            .build()
+            .await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        let transaction =
+            test_user_transaction(&state, sender, &keypair, gas_object, vec![owned_object]).await;
+        let consensus_tx =
+            ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+        let key = SequencedConsensusTransactionKey::External(consensus_tx.key());
+
+        // Record that this authority (the block author in TestConsensusCommit) already
+        // sent EndOfPublish, without advancing the reconfig state, so the commit below
+        // exercises the post-EndOfPublish author filter rather than the certs-closed one.
+        epoch_store
+            .end_of_publish
+            .try_lock()
+            .unwrap()
+            .insert_generic(state.name, ());
+
+        let round = 100;
+        let commit = TestConsensusCommit::new(vec![consensus_tx], round as u64, 1_000, 10);
+        let mut setup = setup_consensus_handler_for_testing(&state).await;
+        setup
+            .consensus_handler
+            .handle_consensus_commit_for_test(commit)
+            .await;
+
+        let block = BlockRef {
+            author: consensus_config::AuthorityIndex::ZERO,
+            round,
+            digest: Default::default(),
+        };
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            epoch_store
+                .consensus_tx_status_cache
+                .notify_read_transaction_status(ConsensusPosition {
+                    epoch: epoch_store.epoch(),
+                    block,
+                    index: 0,
+                }),
+        )
+        .await
+        .expect("transaction ignored after EndOfPublish should receive a terminal status");
+        assert!(matches!(
+            status,
+            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Dropped)
+        ));
+        assert!(!epoch_store.is_consensus_message_processed(&key).unwrap());
+        assert_eq!(
+            setup
+                .consensus_handler
+                .metrics
+                .consensus_handler_dropped_transactions
+                .with_label_values(&["end_of_publish"])
+                .get(),
+            1
+        );
     }
 
     fn to_short_strings(txs: Vec<VerifiedExecutableTransactionWithAliases>) -> Vec<String> {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -3848,6 +3848,15 @@ mod tests {
                 .is_consensus_message_processed(&loser_key)
                 .unwrap()
         );
+        // The processed notification resolves for the dropped key as well — this is
+        // the signal consensus adapter waiters block on.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            epoch_store.consensus_messages_processed_notify(vec![loser_key]),
+        )
+        .await
+        .expect("processed notification for dropped transaction should resolve")
+        .unwrap();
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -2699,6 +2699,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                             .with_label_values(&["invalid_input"])
                             .inc();
                         status_updates.push((position, ConsensusTxStatus::Dropped));
+                        // Record the concrete input error as the reject reason so effects
+                        // waiters get a terminal, non-retriable error instead of a bare
+                        // Dropped with no reason (which clients treat as retriable).
+                        if let Err(e) = tx.transaction_data().input_objects() {
+                            self.epoch_store
+                                .set_rejection_vote_reason(position, &e.into());
+                        }
                         dropped_transaction_keys.push(parsed.transaction.key());
                         debug_fatal!("Invalid input objects for transaction {}", tx.digest());
                         continue;

--- a/crates/sui-core/src/unit_tests/consensus_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/consensus_test_utils.rs
@@ -43,6 +43,8 @@ pub struct TestConsensusCommit {
     pub round: u64,
     pub timestamp_ms: u64,
     pub sub_dag_index: u64,
+    /// Indices into `transactions` reported as rejected by consensus voting.
+    rejected_indices: HashSet<usize>,
 }
 
 impl TestConsensusCommit {
@@ -57,16 +59,17 @@ impl TestConsensusCommit {
             round,
             timestamp_ms,
             sub_dag_index,
+            rejected_indices: HashSet::new(),
         }
     }
 
     pub fn empty(round: u64, timestamp_ms: u64, sub_dag_index: u64) -> Self {
-        Self {
-            transactions: vec![],
-            round,
-            timestamp_ms,
-            sub_dag_index,
-        }
+        Self::new(vec![], round, timestamp_ms, sub_dag_index)
+    }
+
+    pub fn with_rejected_indices(mut self, indices: impl IntoIterator<Item = usize>) -> Self {
+        self.rejected_indices = indices.into_iter().collect();
+        self
     }
 }
 
@@ -111,9 +114,10 @@ impl ConsensusCommitAPI for TestConsensusCommit {
         let parsed_txs: Vec<ParsedTransaction> = self
             .transactions
             .iter()
-            .map(|tx| ParsedTransaction {
+            .enumerate()
+            .map(|(i, tx)| ParsedTransaction {
                 transaction: tx.clone(),
-                rejected: false,
+                rejected: self.rejected_indices.contains(&i),
                 serialized_len: 0,
             })
             .collect();

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -7,8 +7,12 @@ use std::time::Duration;
 use super::*;
 use crate::authority::{AuthorityState, authority_tests::init_state_with_objects};
 
+use crate::authority::consensus_tx_status_cache::{
+    CONSENSUS_STATUS_RETENTION_ROUNDS, ConsensusTxStatus,
+};
 use crate::consensus_test_utils::{
     make_consensus_adapter_for_test, make_consensus_adapter_for_test_with_submit_limit,
+    make_consensus_adapter_with_client_for_test,
 };
 use crate::mock_consensus::with_block_status;
 use consensus_core::BlockStatus;
@@ -505,4 +509,246 @@ async fn submit_already_processed_transaction_returns_processing_error() {
             panic!("expected TransactionProcessing error, got positions: {positions:?}")
         }
     }
+}
+
+fn test_block_ref(round: u32) -> BlockRef {
+    BlockRef {
+        author: consensus_config::AuthorityIndex::ZERO,
+        round,
+        digest: Default::default(),
+    }
+}
+
+fn test_position(
+    epoch: sui_types::base_types::EpochId,
+    round: u32,
+    index: u16,
+) -> ConsensusPosition {
+    ConsensusPosition {
+        epoch,
+        block: test_block_ref(round),
+        index,
+    }
+}
+
+/// Test client that sequences every submission but never fires processed notifications,
+/// mimicking the real consensus path for a transaction that reaches consensus output
+/// without being finalized (voted rejected, or dropped post-consensus): the commit
+/// handler assigns the position a terminal status but never records the digest as
+/// consensus-processed. The nth submission lands in a block with `block_rounds[n]`
+/// (clamped to the last entry), making resubmissions observable as distinct positions.
+struct SequenceOnlyClient {
+    block_rounds: Vec<u32>,
+    submission_count: std::sync::atomic::AtomicUsize,
+}
+
+impl SequenceOnlyClient {
+    fn new(block_rounds: Vec<u32>) -> Self {
+        Self {
+            block_rounds,
+            submission_count: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn submissions(&self) -> usize {
+        self.submission_count
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsensusClient for SequenceOnlyClient {
+    async fn submit(
+        &self,
+        transactions: &[ConsensusTransaction],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult<(Vec<ConsensusPosition>, BlockStatusReceiver)> {
+        let n = self
+            .submission_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let round = self.block_rounds[n.min(self.block_rounds.len() - 1)];
+        let positions = (0..transactions.len())
+            .map(|index| test_position(epoch_store.epoch(), round, index as u16))
+            .collect();
+        Ok((
+            positions,
+            with_block_status(BlockStatus::Sequenced(test_block_ref(round))),
+        ))
+    }
+}
+
+async fn wait_for_condition(mut condition: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !condition() {
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("condition not reached in time");
+}
+
+// A transaction that consensus sequences but votes to reject never gets its digest
+// recorded as consensus-processed. The adapter must settle the submission via the
+// per-position Rejected status instead of holding its inflight slot and submit
+// semaphore permit until end of epoch.
+#[tokio::test]
+async fn adapter_settles_submission_on_rejected_position_status() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let transaction = test_user_transactions(&state, shared_object)
+        .await
+        .pop()
+        .unwrap();
+    let epoch_store = state.epoch_store_for_testing();
+
+    let client = Arc::new(SequenceOnlyClient::new(vec![1]));
+    let adapter = make_consensus_adapter_with_client_for_test(&state, client, 100);
+
+    let consensus_tx =
+        ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+    let waiter = adapter
+        .submit(
+            consensus_tx,
+            Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+            &epoch_store,
+            None,
+            None,
+        )
+        .unwrap();
+
+    // The commit handler's side of the contract: the sequenced position receives a
+    // terminal status.
+    epoch_store
+        .consensus_tx_status_cache
+        .set_transaction_status(
+            test_position(epoch_store.epoch(), 1, 0),
+            ConsensusTxStatus::Rejected,
+        );
+
+    tokio::time::timeout(Duration::from_secs(10), waiter)
+        .await
+        .expect("adapter task should settle when its position is rejected")
+        .unwrap();
+    assert_eq!(adapter.num_inflight_transactions(), 0);
+}
+
+// A soft bundle settles once every position has a terminal status, even when the
+// outcomes are mixed and some transactions are never recorded as processed.
+#[tokio::test]
+async fn adapter_settles_soft_bundle_on_mixed_position_statuses() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let transactions = test_user_transactions(&state, shared_object).await;
+    let epoch_store = state.epoch_store_for_testing();
+
+    let client = Arc::new(SequenceOnlyClient::new(vec![1]));
+    let adapter = make_consensus_adapter_with_client_for_test(&state, client, 100);
+
+    let consensus_transactions = transactions
+        .into_iter()
+        .take(2)
+        .map(|tx| ConsensusTransaction::new_user_transaction_v2_message(&state.name, tx.into()))
+        .collect::<Vec<_>>();
+    let waiter = adapter
+        .submit_batch(
+            &consensus_transactions,
+            Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+            &epoch_store,
+            None,
+            None,
+        )
+        .unwrap();
+
+    epoch_store
+        .consensus_tx_status_cache
+        .set_transaction_status(
+            test_position(epoch_store.epoch(), 1, 0),
+            ConsensusTxStatus::Finalized,
+        );
+    epoch_store
+        .consensus_tx_status_cache
+        .set_transaction_status(
+            test_position(epoch_store.epoch(), 1, 1),
+            ConsensusTxStatus::Rejected,
+        );
+
+    tokio::time::timeout(Duration::from_secs(10), waiter)
+        .await
+        .expect("adapter task should settle when all bundle positions have terminal statuses")
+        .unwrap();
+    assert_eq!(adapter.num_inflight_transactions(), 0);
+}
+
+// If a position expires from the status cache before its status is read (the validator
+// lagged more than the retention window behind consensus), the adapter must handle it
+// like garbage collection and resubmit rather than waiting forever.
+#[tokio::test]
+async fn adapter_resubmits_on_expired_position_status() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let transaction = test_user_transactions(&state, shared_object)
+        .await
+        .pop()
+        .unwrap();
+    let epoch_store = state.epoch_store_for_testing();
+
+    // First submission lands in block round 1; the resubmission in a much later round
+    // immune to the expiry below.
+    let client = Arc::new(SequenceOnlyClient::new(vec![1, 10_000]));
+    let adapter = make_consensus_adapter_with_client_for_test(&state, client.clone(), 100);
+
+    let consensus_tx =
+        ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+    let waiter = adapter
+        .submit(
+            consensus_tx,
+            Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+            &epoch_store,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let client_clone = client.clone();
+    wait_for_condition(move || client_clone.submissions() == 1).await;
+
+    // Expire the first position without ever setting its status. The expiry watch
+    // publishes the previous committed leader round, so two updates are needed for
+    // round 1 to fall out of the retention window.
+    epoch_store
+        .consensus_tx_status_cache
+        .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 100);
+    epoch_store
+        .consensus_tx_status_cache
+        .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 101);
+
+    // The adapter treats the expired position like garbage collection and resubmits.
+    let client_clone = client.clone();
+    wait_for_condition(move || client_clone.submissions() == 2).await;
+
+    // Settle the resubmitted position.
+    epoch_store
+        .consensus_tx_status_cache
+        .set_transaction_status(
+            test_position(epoch_store.epoch(), 10_000, 0),
+            ConsensusTxStatus::Finalized,
+        );
+
+    tokio::time::timeout(Duration::from_secs(10), waiter)
+        .await
+        .expect("adapter task should settle after resubmission")
+        .unwrap();
+    assert_eq!(adapter.num_inflight_transactions(), 0);
 }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -688,10 +688,12 @@ async fn adapter_settles_soft_bundle_on_mixed_position_statuses() {
 }
 
 // If a position expires from the status cache before its status is read (the validator
-// lagged more than the retention window behind consensus), the adapter must handle it
-// like garbage collection and resubmit rather than waiting forever.
+// lagged more than the retention window behind consensus), the submission ends without
+// resubmitting: the block was committed and its commit processed long ago, so a
+// terminal outcome existed and was merely missed. A finalized transaction needs
+// nothing further from this task, and transaction-level retries belong to the client.
 #[tokio::test]
-async fn adapter_resubmits_on_expired_position_status() {
+async fn adapter_settles_without_retry_on_expired_position_status() {
     telemetry_subscribers::init_for_testing();
 
     let mut objects = test_gas_objects();
@@ -704,9 +706,7 @@ async fn adapter_resubmits_on_expired_position_status() {
         .unwrap();
     let epoch_store = state.epoch_store_for_testing();
 
-    // First submission lands in block round 1; the resubmission in a much later round
-    // immune to the expiry below.
-    let client = Arc::new(SequenceOnlyClient::new(vec![1, 10_000]));
+    let client = Arc::new(SequenceOnlyClient::new(vec![1]));
     let adapter = make_consensus_adapter_with_client_for_test(&state, client.clone(), 100);
 
     let consensus_tx =
@@ -724,9 +724,9 @@ async fn adapter_resubmits_on_expired_position_status() {
     let client_clone = client.clone();
     wait_for_condition(move || client_clone.submissions() == 1).await;
 
-    // Expire the first position without ever setting its status. The expiry watch
-    // publishes the previous committed leader round, so two updates are needed for
-    // round 1 to fall out of the retention window.
+    // Expire the position without ever setting its status. The expiry watch publishes
+    // the previous committed leader round, so two updates are needed for round 1 to
+    // fall out of the retention window.
     epoch_store
         .consensus_tx_status_cache
         .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 100);
@@ -734,21 +734,10 @@ async fn adapter_resubmits_on_expired_position_status() {
         .consensus_tx_status_cache
         .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 101);
 
-    // The adapter treats the expired position like garbage collection and resubmits.
-    let client_clone = client.clone();
-    wait_for_condition(move || client_clone.submissions() == 2).await;
-
-    // Settle the resubmitted position.
-    epoch_store
-        .consensus_tx_status_cache
-        .set_transaction_status(
-            test_position(epoch_store.epoch(), 10_000, 0),
-            ConsensusTxStatus::Finalized,
-        );
-
     tokio::time::timeout(Duration::from_secs(10), waiter)
         .await
-        .expect("adapter task should settle after resubmission")
+        .expect("adapter task should settle when its position status expires")
         .unwrap();
+    assert_eq!(client.submissions(), 1);
     assert_eq!(adapter.num_inflight_transactions(), 0);
 }

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -490,6 +490,70 @@ async fn test_submit_transaction_consensus_message_processed() {
     };
 }
 
+// Test that resubmitting a consensus-processed transaction whose owned inputs are no
+// longer live (e.g. a dropped owned-object conflict loser after the winner executed)
+// returns the concrete, non-retriable validation error instead of the generic,
+// retriable TransactionProcessing suppression.
+#[tokio::test]
+async fn test_submit_transaction_consensus_message_processed_with_stale_inputs() {
+    let test_context = TestContext::new().await;
+    let epoch_store = test_context.state.epoch_store_for_testing();
+
+    // The "loser" spends the gas object at its current version.
+    let loser = test_context.build_test_transaction();
+    let loser_digest = *loser.digest();
+    let request = test_context.build_submit_request(loser);
+
+    // Execute a different transaction spending the same gas object, advancing its
+    // version past the loser's input.
+    let winner_data = TestTransactionBuilder::new(
+        test_context.sender,
+        test_context.gas_object_ref,
+        test_context
+            .state
+            .reference_gas_price_for_testing()
+            .unwrap(),
+    )
+    .transfer_sui(Some(1), test_context.sender)
+    .build();
+    let winner = to_sender_signed_transaction(winner_data, &test_context.keypair);
+    assert_ne!(*winner.digest(), loser_digest);
+    let winner = VerifiedExecutableTransaction::new_from_checkpoint(
+        VerifiedTransaction::new_unchecked(winner),
+        epoch_store.epoch(),
+        1,
+    );
+    test_context
+        .state
+        .try_execute_immediately(&winner, ExecutionEnv::new(), &epoch_store)
+        .unwrap();
+
+    // Mark the loser as consensus-processed, as the commit handler does for dropped
+    // transactions.
+    epoch_store.test_insert_user_signature(loser_digest, vec![]);
+
+    let response = test_context
+        .client
+        .submit_transaction(request, None)
+        .await
+        .unwrap();
+    assert_eq!(response.results.len(), 1);
+    match &response.results[0] {
+        SubmitTxResult::Rejected { error } => {
+            assert!(
+                matches!(
+                    error.as_inner(),
+                    SuiErrorKind::UserInputError {
+                        error: UserInputError::ObjectVersionUnavailableForConsumption { .. }
+                    }
+                ),
+                "expected stale-version rejection, got: {error}"
+            );
+        }
+        other => panic!("Expected Rejected response, got {other:?}"),
+    };
+}
+
 #[tokio::test]
 async fn test_submit_transaction_wrong_epoch() {
     let test_context = TestContext::new().await;

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -554,6 +554,45 @@ async fn test_submit_transaction_consensus_message_processed_with_stale_inputs()
     };
 }
 
+// Test that resubmitting a consensus-processed transaction whose owned input is locked
+// by a different transaction (a dropped conflict loser whose winner has not executed
+// yet, so version validation alone still passes) returns the terminal
+// ObjectLockConflict instead of the retriable TransactionProcessing suppression.
+#[tokio::test]
+async fn test_submit_transaction_consensus_message_processed_with_lock_conflict() {
+    let test_context = TestContext::new().await;
+    let epoch_store = test_context.state.epoch_store_for_testing();
+
+    let loser = test_context.build_test_transaction();
+    let loser_digest = *loser.digest();
+    let request = test_context.build_submit_request(loser);
+
+    // The winner holds the epoch lock on the shared gas object but has not executed.
+    let winner_digest = sui_types::digests::TransactionDigest::random();
+    epoch_store.insert_object_locks_for_test(&[(test_context.gas_object_ref, winner_digest)]);
+    epoch_store.test_insert_user_signature(loser_digest, vec![]);
+
+    let response = test_context
+        .client
+        .submit_transaction(request, None)
+        .await
+        .unwrap();
+    assert_eq!(response.results.len(), 1);
+    match &response.results[0] {
+        SubmitTxResult::Rejected { error } => {
+            assert!(
+                matches!(
+                    error.as_inner(),
+                    SuiErrorKind::ObjectLockConflict { pending_transaction, .. }
+                        if *pending_transaction == winner_digest
+                ),
+                "expected lock-conflict rejection, got: {error}"
+            );
+        }
+        other => panic!("Expected Rejected response, got {other:?}"),
+    };
+}
+
 #[tokio::test]
 async fn test_submit_transaction_wrong_epoch() {
     let test_context = TestContext::new().await;


### PR DESCRIPTION
## Description

A consensus adapter submission only completes when its transaction key is recorded as consensus-processed, which never happens for user transactions that consensus votes to reject or that the commit handler drops. Each such submission parks until end of epoch holding an inflight slot and a submit-semaphore permit, so sustained rejections can clog the adapter. #27133 covers the lock-conflict dropped case by marking those digests processed, but that mechanism cannot cover rejections — rejection is per-position and a rejected digest must stay resubmittable, while a processed digest is suppressed at resubmission and skipped by post-consensus dedup.

Instead, settle user-transaction submissions on the per-position `ConsensusTxStatus` (Finalized / Rejected / Dropped) that the commit handler assigns once the block is sequenced. To make that signal total, the commit handler now assigns a terminal `Dropped` status on the user-transaction drop paths that previously emitted no signal: invalid input objects (also marked consensus-processed), and transactions ignored at epoch close (consensus certs no longer accepted, or the block author already sent EndOfPublish) — the epoch-close paths previously relied solely on epoch termination for cleanup, which can itself stall when reconfiguration is stuck. A position whose status expires from the cache before it is read ends the submission rather than resubmitting: the block was committed and its commit processed long ago, so a terminal outcome existed and was merely missed, and transaction-level retries belong to the client. System messages receive no per-position statuses and keep the processed-notification path, and the race against the processed/checkpoint notifications remains as the cross-position and state-sync backstop.

Also, per review feedback on #27133: a digest-keyed resubmission of a consensus-processed transaction is now checked against the epoch owned-object lock table (same conflict logic as post-consensus, covering the window before the conflict winner executes) and revalidated against live state, returning the concrete non-retriable error (`ObjectLockConflict`, or stale owned-object version once the winner executed) instead of the retriable `TransactionProcessing` suppression; the invalid-input drop path records a terminal reject reason; and `consensus_handler_dropped_transactions` is labeled by drop reason (`lock_conflict`, `invalid_input`, `end_of_epoch`, `end_of_publish`).

## Test plan

New tests: the adapter settles (releasing its inflight slot) when its position is rejected, when a soft bundle has mixed terminal statuses, and when a position status expires — without resubmitting; commit-handler tests that a voting-rejected transaction gets a Rejected status without being marked consensus-processed, and that transactions ignored at epoch close (certs closed, and post-EndOfPublish author) get a Dropped status and per-reason drop counts; submission tests that resubmitting a processed transaction returns the lock-conflict error while the winner holds the lock, and the stale-version validation error after the winner executed, rather than TransactionProcessing.
