### PR TITLE
Fix nondeterministic fail-point registration in large consensus commit prologue test

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -737,8 +737,6 @@ mod test {
     // simtest has low timeout tolerance and it is not designed to test performance.
     #[sim_test(config = "test_config_low_latency()")]
     async fn test_simulated_load_large_consensus_commit_prologue_size() {
-        let test_cluster = build_test_cluster(4, 10_000, 1).await;
-
         let mut additional_cancelled_txns = Vec::new();
         let num_txns = thread_rng().gen_range(500..2000);
         info!("Adding additional {num_txns} cancelled txns in consensus commit prologue.");
@@ -758,9 +756,19 @@ mod test {
             additional_cancelled_txns.push((TransactionDigest::random(), assigned_object_versions));
         }
 
+        // Register the fail point before the cluster starts processing any consensus commits.
+        // `register_fail_point_arg` mutates process-global state with no synchronization to
+        // consensus rounds; registering it after `build_test_cluster` had already let validators
+        // start committing meant different validators could observe it becoming active on
+        // different rounds (whichever round each validator happened to be processing at the
+        // moment the registration landed), causing them to build different (but individually
+        // self-consistent) ConsensusCommitPrologue transactions for the same round - a real
+        // checkpoint fork.
         register_fail_point_arg("additional_cancelled_txns_for_tests", move || {
             Some(additional_cancelled_txns.clone())
         });
+
+        let test_cluster = build_test_cluster(4, 10_000, 1).await;
 
         test_simulated_load(test_cluster.clone(), 30).await;
     }


### PR DESCRIPTION
## Description

`test_simulated_load_large_consensus_commit_prologue_size` was intermittently forking in CI (e.g. https://github.com/MystenLabs/sui/actions/runs/28621761234/job/84879475583). The test registers a fail point to inject a large fake cancelled-transaction list into the consensus commit prologue, but did so *after* `build_test_cluster` had already let validators start committing. Since `register_fail_point_arg` mutates process-global state with no synchronization to consensus rounds, different validators could observe it becoming active on different rounds, causing them to build different (but individually self-consistent) `ConsensusCommitPrologue` transactions for the same round — a genuine checkpoint fork. This is a test-harness-only issue; fail points are inert in production, so the real cancelled-transaction list there is always a deterministic function of consensus-replicated data.

Moves the fail-point registration before `build_test_cluster`, so it's active identically for every validator before any of them process their first consensus commit.

## Test plan

Reproduced the fork deterministically (`MSIM_TEST_SEED=11807830860363070719 SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet`, matching the failing CI run) and root-caused it with targeted tracing showing one validator's round-2 prologue transaction diverging from the other three's due to the fail-point registration race described above. With the fix, the same seed now passes consistently (verified across multiple repeated runs) where it previously failed reliably under the same conditions.

## Release notes

Test-only change; no boxes apply.