### PR TITLE
[consensus handler] fix test build after TestAuthorityBuilder API change

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -3875,7 +3875,6 @@ mod tests {
 
         let state = TestAuthorityBuilder::new()
             .with_starting_objects(&[gas_object.clone(), owned_object.clone()])
-            .skip_rpc_index_init()
             .skip_genesis_owner_index()
             .build()
             .await;
@@ -3929,7 +3928,6 @@ mod tests {
 
         let state = TestAuthorityBuilder::new()
             .with_starting_objects(&[gas_object.clone(), owned_object.clone()])
-            .skip_rpc_index_init()
             .skip_genesis_owner_index()
             .build()
             .await;
@@ -4000,7 +3998,6 @@ mod tests {
 
         let state = TestAuthorityBuilder::new()
             .with_starting_objects(&[gas_object.clone(), owned_object.clone()])
-            .skip_rpc_index_init()
             .skip_genesis_owner_index()
             .build()
             .await;


### PR DESCRIPTION
## Description

Tests merged in #27138 call `TestAuthorityBuilder::skip_rpc_index_init()`, which a concurrently merged change removed, breaking the sui-core test build on main.

## Test plan

`cargo nextest run -p sui-core --lib -E 'test(consensus_handler::tests::)'` — all 19 pass.
