### PR TITLE
Reserve a priority lane in consensus input for system transactions

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -253,8 +253,10 @@ where
             .protocol_version
             .set(context.protocol_config.protocol_version() as i64);
 
-        let (tx_client, tx_receiver) = TransactionClient::new(context.clone());
-        let tx_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (tx_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let tx_consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
 
         let (core_signals, signals_receivers) = CoreSignals::new(context.clone());
 
@@ -643,7 +645,7 @@ mod tests {
     use crate::{
         CommittedSubDag,
         block::{BlockAPI as _, GENESIS_ROUND},
-        transaction::NoopTransactionVerifier,
+        transaction::{NoopTransactionVerifier, Priority},
     };
 
     #[rstest]
@@ -855,7 +857,7 @@ mod tests {
             submitted_transactions.insert(txn.clone());
             authorities[i as usize % authorities.len()]
                 .transaction_client()
-                .submit(vec![txn])
+                .submit(vec![txn], Priority::Normal)
                 .await
                 .unwrap();
         }
@@ -1036,7 +1038,7 @@ mod tests {
             submitted_transactions.insert(txn.clone());
             authorities[i as usize % authorities.len()]
                 .transaction_client()
-                .submit(vec![txn])
+                .submit(vec![txn], Priority::Normal)
                 .await
                 .unwrap();
         }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1044,8 +1044,10 @@ impl CoreTestFixture {
             LeaderSchedule::from_store(context.clone(), dag_state.clone())
                 .with_num_commits_per_schedule(10),
         );
-        let (transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (transaction_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let transaction_consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),
@@ -1122,7 +1124,7 @@ mod test {
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
         test_dag_parser::parse_dag,
-        transaction::{BlockStatus, TransactionClient},
+        transaction::{BlockStatus, Priority, TransactionClient},
     };
 
     /// Recover Core and continue proposing from the last round which forms a quorum.
@@ -1132,8 +1134,10 @@ mod test {
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
-        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (_transaction_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let transaction_consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
         let mut block_status_subscriptions = FuturesUnordered::new();
 
         // Create test blocks for all the authorities for 4 rounds and populate them in store
@@ -1374,7 +1378,7 @@ mod test {
             index += 1;
             let _w = fixture
                 .transaction_client
-                .submit_no_wait(vec![transaction])
+                .submit_no_wait(vec![transaction], Priority::Normal)
                 .await
                 .unwrap();
 
@@ -1511,8 +1515,10 @@ mod test {
         let context = Arc::new(context);
 
         let store = Arc::new(MemStore::new());
-        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (_transaction_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let transaction_consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
         let mut block_status_subscriptions = FuturesUnordered::new();
 
         let dag_str = "DAG {
@@ -2826,8 +2832,10 @@ mod test {
                 .with_num_commits_per_schedule(10),
         );
 
-        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (_transaction_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let transaction_consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -404,8 +404,10 @@ mod test {
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
-        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (_transaction_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let transaction_consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),
@@ -493,8 +495,10 @@ mod test {
         assert_eq!(dag_state.read().threshold_clock_round(), 3);
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
-        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (_transaction_client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new(context.clone());
+        let transaction_consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -71,7 +71,7 @@ pub use context::Clock;
 pub use metrics::Metrics;
 pub use network::RandomnessSignatureHandler;
 pub use transaction::{
-    BlockStatus, ClientError, TransactionClient, TransactionVerifier, ValidationError,
+    BlockStatus, ClientError, Priority, TransactionClient, TransactionVerifier, ValidationError,
 };
 
 // Exported API for benchmarking

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -122,6 +122,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) core_check_block_refs_batch_size: Histogram,
     pub(crate) core_lock_dequeued: IntCounter,
     pub(crate) core_lock_enqueued: IntCounter,
+    pub(crate) priority_submission_backpressure: IntCounter,
     pub(crate) core_skipped_proposals: IntCounterVec,
     pub(crate) handler_received_block_missing_ancestors: IntCounterVec,
     pub(crate) highest_accepted_authority_round: IntGaugeVec,
@@ -355,6 +356,11 @@ impl NodeMetrics {
             core_lock_enqueued: register_int_counter_with_registry!(
                 "core_lock_enqueued",
                 "Number of enqueued core requests",
+                registry,
+            ).unwrap(),
+            priority_submission_backpressure: register_int_counter_with_registry!(
+                "priority_submission_backpressure",
+                "Number of high-priority submissions that found the reserved priority input channel full and had to wait for capacity",
                 registry,
             ).unwrap(),
             core_skipped_proposals: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -297,6 +297,7 @@ pub enum ClientError {
 }
 
 impl TransactionClient {
+    /// Returns the client and the receivers for normal and priority transactions, in that order.
     pub(crate) fn new(
         context: Arc<Context>,
     ) -> (
@@ -311,6 +312,7 @@ impl TransactionClient {
         )
     }
 
+    /// Returns the client and the receivers for normal and priority transactions, in that order.
     fn new_with_max_pending_transactions(
         context: Arc<Context>,
         max_pending_transactions: usize,

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -19,6 +19,19 @@ use crate::{block::Transaction, context::Context};
 /// The maximum number of transactions pending to the queue to be pulled for block proposal
 const MAX_PENDING_TRANSACTIONS: usize = 2_000;
 
+/// Priority of a submission to consensus. Consensus is agnostic to transaction type; the
+/// submitter decides the priority. `High` submissions use a dedicated, reserved lane and
+/// are pulled ahead of `Normal` ones for block proposal.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Priority {
+    Normal,
+    High,
+}
+
+/// Reserved capacity for the local validator's own high-priority submissions, which are
+/// low-volume and pulled ahead of normal-priority ones for block proposal.
+const MAX_PENDING_PRIORITY_TRANSACTIONS: usize = 128;
+
 /// The guard acts as an acknowledgment mechanism for the inclusion of the transactions to a block.
 /// When its last transaction is included to a block then `included_in_block_ack` will be signalled.
 /// If the guard is dropped without getting acknowledged that means the transactions have not been
@@ -45,6 +58,9 @@ pub(crate) struct TransactionsGuard {
 /// and are pulled every time the `next` method is called.
 pub(crate) struct TransactionConsumer {
     tx_receiver: Receiver<TransactionsGuard>,
+    // Reserved lane for the local validator's own high-priority submissions, drained
+    // ahead of `tx_receiver` so they are never delayed behind a normal-priority backlog.
+    priority_tx_receiver: Receiver<TransactionsGuard>,
     max_transactions_in_block_bytes: u64,
     max_num_transactions_in_block: u64,
     pending_transactions: Option<TransactionsGuard>,
@@ -72,7 +88,11 @@ pub enum LimitReached {
 }
 
 impl TransactionConsumer {
-    pub(crate) fn new(tx_receiver: Receiver<TransactionsGuard>, context: Arc<Context>) -> Self {
+    pub(crate) fn new(
+        tx_receiver: Receiver<TransactionsGuard>,
+        priority_tx_receiver: Receiver<TransactionsGuard>,
+        context: Arc<Context>,
+    ) -> Self {
         // max_num_transactions_in_block - 1 is the max possible transaction index in a block.
         // TransactionIndex::MAX is reserved for the ping transaction.
         // Indexes down to TransactionIndex::MAX - 8 are also reserved for future use.
@@ -89,6 +109,7 @@ impl TransactionConsumer {
 
         Self {
             tx_receiver,
+            priority_tx_receiver,
             max_transactions_in_block_bytes: context
                 .protocol_config
                 .max_transactions_in_block_bytes(),
@@ -155,13 +176,16 @@ impl TransactionConsumer {
             );
         }
 
-        // Until we have reached the limit for the pull.
-        // We may have already reached limit in the first iteration above, in which case we stop immediately.
-        while self.pending_transactions.is_none() {
-            if let Ok(t) = self.tx_receiver.try_recv() {
-                self.pending_transactions = handle_txs(t);
-            } else {
-                break;
+        // Pull until we reach the block limit (which may already be reached above).
+        // The reserved priority lane is drained first, so this validator's own
+        // high-priority submissions get block space ahead of a normal-priority backlog.
+        for receiver in [&mut self.priority_tx_receiver, &mut self.tx_receiver] {
+            while self.pending_transactions.is_none() {
+                if let Ok(t) = receiver.try_recv() {
+                    self.pending_transactions = handle_txs(t);
+                } else {
+                    break;
+                }
             }
         }
 
@@ -236,9 +260,11 @@ impl TransactionConsumer {
         if self.pending_transactions.is_some() {
             return false;
         }
-        if let Ok(t) = self.tx_receiver.try_recv() {
-            self.pending_transactions = Some(t);
-            return false;
+        for receiver in [&mut self.priority_tx_receiver, &mut self.tx_receiver] {
+            if let Ok(t) = receiver.try_recv() {
+                self.pending_transactions = Some(t);
+                return false;
+            }
         }
         true
     }
@@ -248,6 +274,8 @@ impl TransactionConsumer {
 pub struct TransactionClient {
     context: Arc<Context>,
     sender: Sender<TransactionsGuard>,
+    // Reserved channel for the local validator's own high-priority submissions.
+    priority_sender: Sender<TransactionsGuard>,
     max_transaction_size: u64,
     max_transactions_in_block_bytes: u64,
     max_transactions_in_block_count: u64,
@@ -269,18 +297,38 @@ pub enum ClientError {
 }
 
 impl TransactionClient {
-    pub(crate) fn new(context: Arc<Context>) -> (Self, Receiver<TransactionsGuard>) {
-        Self::new_with_max_pending_transactions(context, MAX_PENDING_TRANSACTIONS)
+    pub(crate) fn new(
+        context: Arc<Context>,
+    ) -> (
+        Self,
+        Receiver<TransactionsGuard>,
+        Receiver<TransactionsGuard>,
+    ) {
+        Self::new_with_max_pending_transactions(
+            context,
+            MAX_PENDING_TRANSACTIONS,
+            MAX_PENDING_PRIORITY_TRANSACTIONS,
+        )
     }
 
     fn new_with_max_pending_transactions(
         context: Arc<Context>,
         max_pending_transactions: usize,
-    ) -> (Self, Receiver<TransactionsGuard>) {
+        max_pending_priority_transactions: usize,
+    ) -> (
+        Self,
+        Receiver<TransactionsGuard>,
+        Receiver<TransactionsGuard>,
+    ) {
         let (sender, receiver) = channel("consensus_input", max_pending_transactions);
+        let (priority_sender, priority_receiver) = channel(
+            "consensus_input_priority",
+            max_pending_priority_transactions,
+        );
         (
             Self {
                 sender,
+                priority_sender,
                 max_transaction_size: context.protocol_config.max_transaction_size_bytes(),
 
                 max_transactions_in_block_bytes: context
@@ -292,6 +340,7 @@ impl TransactionClient {
                 context: context.clone(),
             },
             receiver,
+            priority_receiver,
         )
     }
 
@@ -309,6 +358,7 @@ impl TransactionClient {
     pub async fn submit(
         &self,
         transactions: Vec<Vec<u8>>,
+        priority: Priority,
     ) -> Result<
         (
             BlockRef,
@@ -317,7 +367,7 @@ impl TransactionClient {
         ),
         ClientError,
     > {
-        let included_in_block = self.submit_no_wait(transactions).await?;
+        let included_in_block = self.submit_no_wait(transactions, priority).await?;
         included_in_block
             .await
             .tap_err(|e| warn!("Transaction acknowledge failed with {:?}", e))
@@ -336,6 +386,7 @@ impl TransactionClient {
     pub(crate) async fn submit_no_wait(
         &self,
         transactions: Vec<Vec<u8>>,
+        priority: Priority,
     ) -> Result<
         oneshot::Receiver<(
             BlockRef,
@@ -376,7 +427,20 @@ impl TransactionClient {
             transactions: transactions.into_iter().map(Transaction::new).collect(),
             included_in_block_ack: included_in_block_ack_send,
         };
-        self.sender
+        let sender = match priority {
+            Priority::High => &self.priority_sender,
+            Priority::Normal => &self.sender,
+        };
+        // A full reserved priority lane means a high-priority submission has to wait —
+        // silently reintroducing the buffering the lane exists to avoid. Record it.
+        if priority == Priority::High && sender.capacity() == 0 {
+            self.context
+                .metrics
+                .node_metrics
+                .priority_submission_backpressure
+                .inc();
+        }
+        sender
             .send(t)
             .await
             .tap_err(|e| error!("Submit transactions failed with {:?}", e))
@@ -448,7 +512,10 @@ mod tests {
     use crate::{
         block_verifier::SignedBlockVerifier,
         context::Context,
-        transaction::{BlockStatus, LimitReached, TransactionClient, TransactionConsumer},
+        transaction::{
+            BlockStatus, LimitReached, MAX_PENDING_PRIORITY_TRANSACTIONS, Priority,
+            TransactionClient, TransactionConsumer,
+        },
     };
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -461,8 +528,9 @@ mod tests {
             .protocol_config
             .set_max_transactions_in_block_bytes_for_testing(2_000);
         let context = Arc::new(context);
-        let (client, tx_receiver) = TransactionClient::new(context.clone());
-        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
 
         // submit asynchronously the transactions and keep the waiters
         let mut included_in_block_waiters = FuturesUnordered::new();
@@ -470,7 +538,7 @@ mod tests {
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
             let w = client
-                .submit_no_wait(vec![transaction])
+                .submit_no_wait(vec![transaction], Priority::Normal)
                 .await
                 .expect("Shouldn't submit successfully transaction");
             included_in_block_waiters.push(w);
@@ -505,6 +573,219 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn high_priority_transactions_included_first() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_max_transaction_size_bytes_for_testing(2_000);
+        context
+            .protocol_config
+            .set_max_transactions_in_block_bytes_for_testing(2_000);
+        let context = Arc::new(context);
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+
+        // Submit normal transactions first, then a high-priority one.
+        for i in 0..3 {
+            let t = bcs::to_bytes(&format!("normal {i}")).unwrap();
+            client
+                .submit_no_wait(vec![t], Priority::Normal)
+                .await
+                .unwrap();
+        }
+        let high = bcs::to_bytes(&"high".to_string()).unwrap();
+        client
+            .submit_no_wait(vec![high], Priority::High)
+            .await
+            .unwrap();
+
+        // The high-priority transaction is pulled ahead of the normal backlog.
+        let (transactions, _ack, _limit) = consumer.next();
+        let decoded: Vec<String> = transactions
+            .iter()
+            .map(|t| bcs::from_bytes(t.data()).unwrap())
+            .collect();
+        assert_eq!(decoded, vec!["high", "normal 0", "normal 1", "normal 2"]);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn high_priority_bypasses_full_normal_lane() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_max_transaction_size_bytes_for_testing(2_000);
+        context
+            .protocol_config
+            .set_max_transactions_in_block_bytes_for_testing(2_000);
+        let context = Arc::new(context);
+        // Each lane holds a single entry. The receivers are held (never drained) so
+        // the lanes stay full once an entry is buffered.
+        let (client, _tx_receiver, _priority_tx_receiver) =
+            TransactionClient::new_with_max_pending_transactions(context.clone(), 1, 1);
+
+        // Fill the normal lane.
+        let n0 = bcs::to_bytes(&"n0".to_string()).unwrap();
+        client
+            .submit_no_wait(vec![n0], Priority::Normal)
+            .await
+            .unwrap();
+
+        // A further normal submission blocks on the full normal lane.
+        let n1 = bcs::to_bytes(&"n1".to_string()).unwrap();
+        assert!(
+            timeout(
+                Duration::from_millis(100),
+                client.submit_no_wait(vec![n1], Priority::Normal)
+            )
+            .await
+            .is_err(),
+            "normal lane is full, so this submission must block"
+        );
+
+        // A high-priority submission uses the reserved lane and is not blocked.
+        let h = bcs::to_bytes(&"h".to_string()).unwrap();
+        timeout(
+            Duration::from_millis(100),
+            client.submit_no_wait(vec![h], Priority::High),
+        )
+        .await
+        .expect("high-priority submission must not block on a full normal lane")
+        .expect("high-priority submission should succeed");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn priority_overflow_held_and_drained_before_normal() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_max_transaction_size_bytes_for_testing(2_000);
+        context
+            .protocol_config
+            .set_max_transactions_in_block_bytes_for_testing(2_000);
+        // Only two transactions fit per block.
+        context
+            .protocol_config
+            .set_max_num_transactions_in_block_for_testing(2);
+        let context = Arc::new(context);
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+
+        for i in 0..3 {
+            let t = bcs::to_bytes(&format!("p{i}")).unwrap();
+            client
+                .submit_no_wait(vec![t], Priority::High)
+                .await
+                .unwrap();
+        }
+        let n = bcs::to_bytes(&"n0".to_string()).unwrap();
+        client
+            .submit_no_wait(vec![n], Priority::Normal)
+            .await
+            .unwrap();
+
+        // Block 1: only the first two priority txns fit; the rest is held.
+        let (txs, ack, limit) = consumer.next();
+        let got: Vec<String> = txs
+            .iter()
+            .map(|t| bcs::from_bytes(t.data()).unwrap())
+            .collect();
+        assert_eq!(got, vec!["p0", "p1"]);
+        assert_eq!(limit, LimitReached::MaxNumOfTransactions);
+        ack(BlockRef::MIN);
+
+        // Block 2: the held priority txn is drained ahead of the normal one.
+        let (txs, ack, _) = consumer.next();
+        let got: Vec<String> = txs
+            .iter()
+            .map(|t| bcs::from_bytes(t.data()).unwrap())
+            .collect();
+        assert_eq!(got, vec!["p2", "n0"]);
+        ack(BlockRef::MIN);
+        assert!(consumer.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn priority_overflow_by_bytes_held_and_re_offered() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_max_transaction_size_bytes_for_testing(2_000);
+        // Each payload below is 11 bytes; only one fits in a 15-byte block.
+        context
+            .protocol_config
+            .set_max_transactions_in_block_bytes_for_testing(15);
+        let context = Arc::new(context);
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+
+        for p in ["AAAAAAAAAA", "BBBBBBBBBB"] {
+            let t = bcs::to_bytes(&p.to_string()).unwrap();
+            assert_eq!(t.len(), 11);
+            client
+                .submit_no_wait(vec![t], Priority::High)
+                .await
+                .unwrap();
+        }
+
+        // Block 1: only the first priority txn fits (byte limit); the second is held.
+        let (txs, ack, limit) = consumer.next();
+        let got: Vec<String> = txs
+            .iter()
+            .map(|t| bcs::from_bytes(t.data()).unwrap())
+            .collect();
+        assert_eq!(got, vec!["AAAAAAAAAA"]);
+        assert_eq!(limit, LimitReached::MaxBytes);
+        ack(BlockRef::MIN);
+
+        // Block 2: the held priority txn is re-offered first.
+        let (txs, ack, _) = consumer.next();
+        let got: Vec<String> = txs
+            .iter()
+            .map(|t| bcs::from_bytes(t.data()).unwrap())
+            .collect();
+        assert_eq!(got, vec!["BBBBBBBBBB"]);
+        ack(BlockRef::MIN);
+        assert!(consumer.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn interleaved_submissions_ordered_priority_first_then_fifo() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_max_transaction_size_bytes_for_testing(2_000);
+        context
+            .protocol_config
+            .set_max_transactions_in_block_bytes_for_testing(2_000);
+        let context = Arc::new(context);
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
+
+        // Interleave the two lanes.
+        for (payload, priority) in [
+            ("n0", Priority::Normal),
+            ("p0", Priority::High),
+            ("n1", Priority::Normal),
+            ("p1", Priority::High),
+        ] {
+            let t = bcs::to_bytes(&payload.to_string()).unwrap();
+            client.submit_no_wait(vec![t], priority).await.unwrap();
+        }
+
+        // All priority txns first (in submission order), then all normal txns.
+        let (txs, _ack, _) = consumer.next();
+        let got: Vec<String> = txs
+            .iter()
+            .map(|t| bcs::from_bytes(t.data()).unwrap())
+            .collect();
+        assert_eq!(got, vec!["p0", "p1", "n0", "n1"]);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn block_status_update() {
         let (mut context, _) = Context::new_for_test(4);
         context
@@ -515,8 +796,9 @@ mod tests {
             .set_max_transactions_in_block_bytes_for_testing(2_000);
         context.protocol_config.set_gc_depth_for_testing(10);
         let context = Arc::new(context);
-        let (client, tx_receiver) = TransactionClient::new(context.clone());
-        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
 
         // submit the transactions and include 2 of each on a new block
         let mut included_in_block_waiters = FuturesUnordered::new();
@@ -524,7 +806,7 @@ mod tests {
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
             let w = client
-                .submit_no_wait(vec![transaction])
+                .submit_no_wait(vec![transaction], Priority::Normal)
                 .await
                 .expect("Shouldn't submit successfully transaction");
             included_in_block_waiters.push(w);
@@ -594,15 +876,16 @@ mod tests {
             .protocol_config
             .set_max_transactions_in_block_bytes_for_testing(100);
         let context = Arc::new(context);
-        let (client, tx_receiver) = TransactionClient::new(context.clone());
-        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
 
         // submit some transactions
         for i in 0..10 {
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
             let _w = client
-                .submit_no_wait(vec![transaction])
+                .submit_no_wait(vec![transaction], Priority::Normal)
                 .await
                 .expect("Shouldn't submit successfully transaction");
         }
@@ -653,15 +936,16 @@ mod tests {
             .protocol_config
             .set_max_transactions_in_block_bytes_for_testing(200);
         let context = Arc::new(context);
-        let (client, tx_receiver) = TransactionClient::new(context.clone());
-        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
         let mut all_receivers = Vec::new();
         // submit a few transactions individually.
         for i in 0..10 {
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
             let w = client
-                .submit_no_wait(vec![transaction])
+                .submit_no_wait(vec![transaction], Priority::Normal)
                 .await
                 .expect("Should submit successfully transaction");
             all_receivers.push(w);
@@ -676,7 +960,7 @@ mod tests {
                 })
                 .collect();
             let w = client
-                .submit_no_wait(transactions)
+                .submit_no_wait(transactions, Priority::Normal)
                 .await
                 .expect("Should submit successfully transaction");
             all_receivers.push(w);
@@ -688,7 +972,7 @@ mod tests {
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
             let w = client
-                .submit_no_wait(vec![transaction])
+                .submit_no_wait(vec![transaction], Priority::Normal)
                 .await
                 .expect("Shouldn't submit successfully transaction");
             all_receivers.push(w);
@@ -702,7 +986,10 @@ mod tests {
                         .expect("Serialization should not fail.")
                 })
                 .collect();
-            let result = client.submit_no_wait(transactions).await.unwrap_err();
+            let result = client
+                .submit_no_wait(transactions, Priority::Normal)
+                .await
+                .unwrap_err();
             assert_eq!(
                 result.to_string(),
                 "Transaction bundle size (210B) is over limit (200B)"
@@ -780,8 +1067,10 @@ mod tests {
                 .protocol_config
                 .set_max_transactions_in_block_bytes_for_testing(300);
             let context = Arc::new(context);
-            let (client, tx_receiver) = TransactionClient::new(context.clone());
-            let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+            let (client, tx_receiver, priority_tx_receiver) =
+                TransactionClient::new(context.clone());
+            let mut consumer =
+                TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
             let mut all_receivers = Vec::new();
 
             // create enough transactions
@@ -791,7 +1080,7 @@ mod tests {
                 let transaction = bcs::to_bytes(&format!("transaction {i}"))
                     .expect("Serialization should not fail.");
                 let w = client
-                    .submit_no_wait(vec![transaction])
+                    .submit_no_wait(vec![transaction], Priority::Normal)
                     .await
                     .expect("Should submit successfully transaction");
                 all_receivers.push(w);
@@ -826,8 +1115,10 @@ mod tests {
                 .protocol_config
                 .set_max_transactions_in_block_bytes_for_testing(300);
             let context = Arc::new(context);
-            let (client, tx_receiver) = TransactionClient::new(context.clone());
-            let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+            let (client, tx_receiver, priority_tx_receiver) =
+                TransactionClient::new(context.clone());
+            let mut consumer =
+                TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
             let mut all_receivers = Vec::new();
 
             let max_transactions_in_block_bytes =
@@ -838,7 +1129,7 @@ mod tests {
                     .expect("Serialization should not fail.");
                 total_size += transaction.len() as u64;
                 let w = client
-                    .submit_no_wait(vec![transaction])
+                    .submit_no_wait(vec![transaction], Priority::Normal)
                     .await
                     .expect("Should submit successfully transaction");
                 all_receivers.push(w);
@@ -883,18 +1174,19 @@ mod tests {
             .protocol_config
             .set_max_transactions_in_block_bytes_for_testing(200);
         let context = Arc::new(context);
-        let (client, tx_receiver) = TransactionClient::new(context.clone());
-        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (client, tx_receiver, priority_tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
 
         let w_no_transactions = client
-            .submit_no_wait(vec![])
+            .submit_no_wait(vec![], Priority::Normal)
             .await
             .expect("Should submit successfully empty array of transactions");
 
         let transaction =
             bcs::to_bytes(&"transaction".to_string()).expect("Serialization should not fail.");
         let w_with_transactions = client
-            .submit_no_wait(vec![transaction])
+            .submit_no_wait(vec![transaction], Priority::Normal)
             .await
             .expect("Should submit successfully transaction");
 
@@ -939,11 +1231,14 @@ mod tests {
             .protocol_config
             .set_max_num_transactions_in_block_for_testing(MAX_NUM_TRANSACTIONS_IN_BLOCK);
         let context = Arc::new(context);
-        let (client, tx_receiver) = TransactionClient::new_with_max_pending_transactions(
-            context.clone(),
-            MAX_PENDING_TRANSACTIONS,
-        );
-        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (client, tx_receiver, priority_tx_receiver) =
+            TransactionClient::new_with_max_pending_transactions(
+                context.clone(),
+                MAX_PENDING_TRANSACTIONS,
+                MAX_PENDING_PRIORITY_TRANSACTIONS,
+            );
+        let mut consumer =
+            TransactionConsumer::new(tx_receiver, priority_tx_receiver, context.clone());
 
         // Add 10 more transactions than the max number of transactions in a block.
         for i in 0..MAX_NUM_TRANSACTIONS_IN_BLOCK + 10 {
@@ -951,7 +1246,7 @@ mod tests {
             let transaction =
                 bcs::to_bytes(&format!("t {i}")).expect("Serialization should not fail.");
             let _w = client
-                .submit_no_wait(vec![transaction])
+                .submit_no_wait(vec![transaction], Priority::Normal)
                 .await
                 .expect("Shouldn't submit successfully transaction");
         }

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -11,7 +11,7 @@ mod consensus_tests {
         NetworkKeyPair, Parameters, ProtocolKeyPair, Stake,
     };
     use consensus_core::NoopTransactionVerifier;
-    use consensus_core::{BlockAPI, BlockStatus, TransactionVerifier, ValidationError};
+    use consensus_core::{BlockAPI, BlockStatus, Priority, TransactionVerifier, ValidationError};
     use consensus_simtests::node::{AuthorityNode, Config};
     use consensus_types::block::{BlockRef, TransactionIndex};
     use fastcrypto::traits::{KeyPair as _, ToFromBytes as _};
@@ -105,7 +105,7 @@ mod consensus_tests {
             for i in 0..NUM_TRANSACTIONS {
                 let txn = vec![i as u8; 16];
                 transaction_clients_clone[i as usize % transaction_clients_clone.len()]
-                    .submit(vec![txn])
+                    .submit(vec![txn], Priority::Normal)
                     .await
                     .unwrap();
             }
@@ -218,7 +218,7 @@ mod consensus_tests {
             let index =
                 (transaction_index - num_of_transactions) as usize % transaction_clients.len();
             let (_block_ref, _indexes, status_waiter) = transaction_clients[index]
-                .submit(transactions)
+                .submit(transactions, Priority::Normal)
                 .await
                 .unwrap();
 
@@ -498,7 +498,7 @@ mod consensus_tests {
         for i in 0..NUM_TRANSACTIONS {
             let txn = vec![i as u8; 16];
             transaction_clients[i as usize % transaction_clients.len()]
-                .submit(vec![txn])
+                .submit(vec![txn], Priority::Normal)
                 .await
                 .unwrap();
             if i % 50 == 0 {

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -4,7 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use arc_swap::{ArcSwapOption, Guard};
-use consensus_core::{ClientError, TransactionClient};
+use consensus_core::{ClientError, Priority, TransactionClient};
 use sui_types::{
     error::{SuiErrorKind, SuiResult},
     messages_consensus::{ConsensusPosition, ConsensusTransaction, ConsensusTransactionKind},
@@ -92,8 +92,15 @@ impl ConsensusClient for LazyMysticetiClient {
             .iter()
             .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
             .collect::<Vec<_>>();
+        // Only a lone system message uses the reserved priority lane; batches (soft
+        // bundles) and pings are user traffic. Keeps user transactions out of the lane.
+        let priority = if transactions.len() == 1 && !transactions[0].is_user_transaction() {
+            Priority::High
+        } else {
+            Priority::Normal
+        };
         let (block_ref, tx_indices, status_waiter) = client
-            .submit(transactions_bytes)
+            .submit(transactions_bytes, priority)
             .await
             .tap_err(|err| {
                 // Will be logged by caller as well.


### PR DESCRIPTION
## Description

Follow-up to the consensus-adapter change that let system messages bypass the submit semaphore: consensus's single input channel is the remaining place a validator's own system messages (checkpoint signatures, `EndOfPublish`, randomness DKG, …) can queue behind a user backlog under load.

Adds a reserved, drained-first priority lane to the consensus input and routes system messages to it. Consensus stays agnostic to transaction type — the submitter picks a `Priority`; Sui maps a lone system message to `High`.

## Test plan

New consensus-core unit tests: priority-first ordering, reserved capacity (a full normal lane blocks a normal send but not a high one), and count/byte overflow held and drained first.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
