### PR TITLE
Remove admission queue bypass mode

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1446,12 +1446,6 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_admission_queue_capacity_fraction")]
     pub admission_queue_capacity_fraction: f64,
 
-    // Fraction of max_pending_transactions below which the admission queue is
-    // bypassed (transactions are submitted directly to consensus). Above this
-    // threshold, transactions go through the priority queue.
-    #[serde(default = "default_admission_queue_bypass_fraction")]
-    pub admission_queue_bypass_fraction: f64,
-
     // Enables use of a gas-price-based priority queue for load shedding of
     // transactions at admission time. If false, when consensus is saturated, transactions
     // are rejected with TooManyTransactionsPendingConsensus.
@@ -1510,10 +1504,6 @@ fn default_admission_queue_capacity_fraction() -> f64 {
     0.5
 }
 
-fn default_admission_queue_bypass_fraction() -> f64 {
-    0.9
-}
-
 fn default_admission_queue_enabled() -> bool {
     true
 }
@@ -1538,7 +1528,6 @@ impl Default for AuthorityOverloadConfig {
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
             admission_queue_capacity_fraction: default_admission_queue_capacity_fraction(),
-            admission_queue_bypass_fraction: default_admission_queue_bypass_fraction(),
             admission_queue_enabled: default_admission_queue_enabled(),
             admission_queue_failover_timeout: default_admission_queue_failover_timeout(),
         }

--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -324,7 +324,6 @@ impl AdmissionQueueHandle {
 /// with the new epoch store to create a fresh actor and handle.
 pub struct AdmissionQueueManager {
     capacity: usize,
-    bypass_threshold: usize,
     failover_timeout: Duration,
     metrics: Arc<AdmissionQueueMetrics>,
     consensus_adapter: Arc<ConsensusAdapter>,
@@ -336,7 +335,6 @@ impl AdmissionQueueManager {
         consensus_adapter: Arc<ConsensusAdapter>,
         metrics: Arc<AdmissionQueueMetrics>,
         capacity_fraction: f64,
-        bypass_fraction: f64,
         failover_timeout: Duration,
         slot_freed_notify: Arc<tokio::sync::Notify>,
     ) -> Self {
@@ -348,7 +346,6 @@ impl AdmissionQueueManager {
         );
         Self {
             capacity,
-            bypass_threshold: (max_pending as f64 * bypass_fraction) as usize,
             failover_timeout,
             metrics,
             consensus_adapter,
@@ -362,7 +359,6 @@ impl AdmissionQueueManager {
     ) -> Self {
         Self {
             capacity: 10_000,
-            bypass_threshold: usize::MAX,
             failover_timeout: Duration::from_secs(30),
             metrics: Arc::new(AdmissionQueueMetrics::new_for_tests()),
             consensus_adapter,
@@ -372,10 +368,6 @@ impl AdmissionQueueManager {
 
     pub fn metrics(&self) -> &Arc<AdmissionQueueMetrics> {
         &self.metrics
-    }
-
-    pub(crate) fn bypass_threshold(&self) -> usize {
-        self.bypass_threshold
     }
 
     /// Spawns a new per-epoch admission queue actor and returns a handle.
@@ -432,10 +424,6 @@ impl AdmissionQueueContext {
     /// The old actor shuts down when its handle is dropped.
     pub fn rotate_for_epoch(&self, epoch_store: Arc<AuthorityPerEpochStore>) {
         self.swap.store(Arc::new(self.manager.spawn(epoch_store)));
-    }
-
-    pub(crate) fn bypass_threshold(&self) -> usize {
-        self.manager.bypass_threshold()
     }
 
     pub(crate) fn load(&self) -> arc_swap::Guard<Arc<AdmissionQueueHandle>> {
@@ -908,7 +896,6 @@ mod tests {
             adapter,
             Arc::new(AdmissionQueueMetrics::new_for_tests()),
             0.5,
-            0.9,
             Duration::from_millis(10),
             notify,
         );

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -215,7 +215,6 @@ pub struct ValidatorServiceMetrics {
     x_forwarded_for_num_hops: Gauge,
     pub gasless_rate_limited_count: IntCounter,
     pub gasless_submission_outcomes: IntCounterVec,
-    admission_queue_direct_bypasses: IntCounter,
 }
 
 impl ValidatorServiceMetrics {
@@ -394,12 +393,6 @@ impl ValidatorServiceMetrics {
                 registry,
             )
             .unwrap(),
-            admission_queue_direct_bypasses: register_int_counter_with_registry!(
-                "validator_service_admission_queue_direct_bypasses",
-                "Number of transactions that bypassed the queue (system not overloaded)",
-                registry,
-            )
-            .unwrap(),
         }
     }
 
@@ -411,14 +404,13 @@ impl ValidatorServiceMetrics {
 
 /// Where `handle_submit_transaction` routes a request.
 enum AdmissionQueueSubmitMode {
-    /// System has capacity: submit directly to consensus, skipping the queue.
-    Bypass,
-    /// System is overloaded: admit via the priority queue.
+    /// Admit via the gas-price priority queue.
     Queue,
-    /// Queue is not available — either turned off by config or temporarily
-    /// disabled by failover. Submit directly to consensus, but reject
-    /// individual txs when consensus is saturated (pre-queue behavior).
-    Disabled,
+    /// Submit directly to consensus, bypassing the queue — used when the queue
+    /// is turned off by config, temporarily disabled by failover, or for a ping
+    /// request. Individual txs are rejected when consensus is saturated
+    /// (pre-queue behavior).
+    Direct,
 }
 
 #[derive(Clone)]
@@ -869,9 +861,9 @@ impl ValidatorService {
                 continue;
             }
 
-            // Use the pre-queue per-tx consensus overload reject when the
-            // queue is disabled or in failover.
-            if matches!(submit_mode, AdmissionQueueSubmitMode::Disabled)
+            // Use the pre-queue per-tx consensus overload reject on the direct
+            // submission path (queue off, failover, or ping).
+            if matches!(submit_mode, AdmissionQueueSubmitMode::Direct)
                 && let Err(error) = self.consensus_adapter.check_consensus_overload()
             {
                 state.update_overload_metrics("consensus");
@@ -1310,10 +1302,7 @@ impl ValidatorService {
         // any other error fails the whole request, after all groups have settled.
         // Soft bundles submit as a single group; individual transactions submit one group each.
         let group_results = match submit_mode {
-            AdmissionQueueSubmitMode::Bypass | AdmissionQueueSubmitMode::Disabled => {
-                if matches!(submit_mode, AdmissionQueueSubmitMode::Bypass) {
-                    self.metrics.admission_queue_direct_bypasses.inc();
-                }
+            AdmissionQueueSubmitMode::Direct => {
                 let futures = tx_groups.into_iter().map(|txns| {
                     debug!(
                         "handle_submit_transaction: submitting consensus transactions ({}): {}",
@@ -1500,22 +1489,19 @@ impl ValidatorService {
 
     fn classify_submit_mode(&self, is_ping_request: bool) -> AdmissionQueueSubmitMode {
         let Some(aq) = &self.admission_queue else {
-            return AdmissionQueueSubmitMode::Disabled;
+            return AdmissionQueueSubmitMode::Direct;
         };
 
+        // Ping requests carry no transactions and must not wait behind queued
+        // work; submit them directly to consensus.
         if is_ping_request {
-            return AdmissionQueueSubmitMode::Bypass;
+            return AdmissionQueueSubmitMode::Direct;
         }
 
-        let inflight = usize::try_from(self.consensus_adapter.num_inflight_transactions()).unwrap();
-        if inflight < aq.bypass_threshold() {
-            return AdmissionQueueSubmitMode::Bypass;
-        }
-
-        // Failover is consulted only on the overloaded path so the hot path
-        // avoids the ArcSwap load.
+        // If the queue actor is stuck, fall back to direct submission with the
+        // pre-queue saturation reject until it resumes making progress.
         if aq.load().failover_tripped() {
-            return AdmissionQueueSubmitMode::Disabled;
+            return AdmissionQueueSubmitMode::Direct;
         }
 
         AdmissionQueueSubmitMode::Queue

--- a/crates/sui-e2e-tests/tests/admission_queue_tests.rs
+++ b/crates/sui-e2e-tests/tests/admission_queue_tests.rs
@@ -48,7 +48,6 @@ async fn make_transfer_tx_with_gas(
 async fn test_admission_queue_basic() {
     let config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.001,
         ..Default::default()
     };
@@ -76,7 +75,6 @@ async fn test_admission_queue_basic() {
 async fn test_admission_queue_eviction_and_rejection() {
     let overload_config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         // capacity = 20_000 * 0.0001 = 2
         admission_queue_capacity_fraction: 0.0001,
         ..Default::default()
@@ -207,7 +205,6 @@ async fn test_admission_queue_eviction_and_rejection() {
 async fn test_admission_queue_epoch_boundary_cleanup() {
     let config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.001,
         ..Default::default()
     };
@@ -255,7 +252,6 @@ async fn test_admission_queue_epoch_boundary_cleanup() {
 async fn test_admission_queue_reconfig_with_pending_entries() {
     let overload_config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.0001,
         ..Default::default()
     };

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1651,7 +1651,6 @@ impl SuiNode {
                 consensus_adapter.clone(),
                 Arc::new(AdmissionQueueMetrics::new(prometheus_registry)),
                 overload_config.admission_queue_capacity_fraction,
-                overload_config.admission_queue_bypass_fraction,
                 overload_config.admission_queue_failover_timeout,
                 inflight_slot_freed_notify,
             ));

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -153,7 +153,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
@@ -332,7 +331,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
@@ -511,7 +509,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
@@ -690,7 +687,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
@@ -869,7 +865,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
@@ -1048,7 +1043,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30
@@ -1227,7 +1221,6 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
         secs: 30


### PR DESCRIPTION
## Description

Follow-up to the `sui_mainnet_high_traffic` incidents ([CORE-198](https://linear.app/mysten-labs/issue/CORE-198/refactor-admission-queue)). Bypass let a transaction skip the gas-price priority queue whenever consensus inflight was below a threshold, so admission prioritization and load-shedding were bypassed for effectively all steady-state traffic — and during the transient where inflight dipped, a low-gas transaction could jump straight to consensus ahead of higher-gas entries still waiting in the queue. Remove bypass entirely so all user transactions are admitted through the queue. The only remaining direct-to-consensus paths are: queue turned off by config, failover (queue actor stalled), and ping requests.

## Test plan

Covered by the existing admission queue e2e tests in `sui-e2e-tests/tests/admission_queue_tests.rs` (admission, eviction, rejection, reconfig), which previously forced queue mode via `bypass_fraction: 0.0` and now exercise the only behavior.

---

## Release notes

- [x] Nodes (Validators and Full nodes): Removes the `admission-queue-bypass-fraction` validator config field; all transactions are now admitted through the gas-price priority queue. The removed field is ignored if still present in a config file, but should be deleted.
