### PR TITLE
[sui-core] Remove dead builder_digest_to_checkpoint table

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -52,9 +52,7 @@ use sui_types::executable_transaction::{
 };
 use sui_types::execution::{ExecutionTimeObservationKey, ExecutionTiming};
 use sui_types::global_state_hash::GlobalStateHash;
-use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
-};
+use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary};
 use sui_types::messages_consensus::{
     AuthorityCapabilitiesV1, AuthorityCapabilitiesV2, AuthorityIndex, ConsensusPosition,
     ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind, TimestampMs,
@@ -468,9 +466,6 @@ pub struct AuthorityEpochTables {
     /// Validators that have sent EndOfPublish message in this epoch
     end_of_publish: DBMap<AuthorityName, ()>,
 
-    /// Checkpoint builder maintains internal list of transactions it included in checkpoints here
-    builder_digest_to_checkpoint: DBMap<TransactionDigest, CheckpointSequenceNumber>,
-
     /// Maps non-digest TransactionKeys to the corresponding digest after execution, for use
     /// by checkpoint builder.
     transaction_key_to_digest: DBMap<TransactionKey, TransactionDigest>,
@@ -645,16 +640,6 @@ impl AuthorityEpochTables {
             (
                 "end_of_publish".to_string(),
                 ThConfig::new(104, 1, KeyType::uniform(1)),
-            ),
-            (
-                "builder_digest_to_checkpoint".to_string(),
-                ThConfig::new_with_rm_prefix_indexing(
-                    tx_digest_indexing.clone(),
-                    mutexes * 4,
-                    uniform_key,
-                    lru_bloom_config.clone(),
-                    digest_prefix.clone(),
-                ),
             ),
             (
                 "transaction_key_to_digest".to_string(),
@@ -3115,10 +3100,9 @@ impl AuthorityPerEpochStore {
     pub fn process_constructed_checkpoint(
         &self,
         commit_height: CheckpointHeight,
-        content_info: (CheckpointSummary, CheckpointContents),
+        summary: CheckpointSummary,
     ) {
         let mut consensus_quarantine = self.consensus_quarantine.write();
-        let (summary, transactions) = content_info;
         let sequence_number = summary.sequence_number;
         let summary = BuilderCheckpointSummary {
             summary,
@@ -3126,7 +3110,7 @@ impl AuthorityPerEpochStore {
             position_in_commit: 0,
         };
 
-        consensus_quarantine.insert_builder_summary(sequence_number, summary, transactions);
+        consensus_quarantine.insert_builder_summary(sequence_number, summary);
 
         // Because builder can run behind state sync, the data may be immediately ready to be committed.
         consensus_quarantine
@@ -3135,22 +3119,7 @@ impl AuthorityPerEpochStore {
     }
 
     /// Register genesis checkpoint in builder DB
-    pub fn put_genesis_checkpoint_in_builder(
-        &self,
-        summary: &CheckpointSummary,
-        contents: &CheckpointContents,
-    ) -> SuiResult<()> {
-        let sequence = summary.sequence_number;
-        for transaction in contents.iter() {
-            let digest = transaction.transaction;
-            debug!(
-                "Manually inserting genesis transaction in checkpoint DB: {:?}",
-                digest
-            );
-            self.tables()?
-                .builder_digest_to_checkpoint
-                .insert(&digest, &sequence)?;
-        }
+    pub fn put_genesis_checkpoint_in_builder(&self, summary: &CheckpointSummary) -> SuiResult<()> {
         let builder_summary = BuilderCheckpointSummary {
             summary: summary.clone(),
             checkpoint_height: None,

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -25,7 +25,7 @@ use sui_types::executable_transaction::{
     TrustedExecutableTransactionWithAliases, VerifiedExecutableTransactionWithAliases,
 };
 use sui_types::execution::ExecutionTimeObservationKey;
-use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber};
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::messages_consensus::AuthorityIndex;
 use sui_types::{
     base_types::{ConsensusObjectSequenceKey, ObjectID},
@@ -489,10 +489,7 @@ pub(crate) struct ConsensusOutputQuarantine {
     highest_executed_checkpoint: CheckpointSequenceNumber,
 
     // Checkpoint Builder output
-    builder_checkpoint_summary:
-        BTreeMap<CheckpointSequenceNumber, (BuilderCheckpointSummary, CheckpointContents)>,
-
-    builder_digest_to_checkpoint: HashMap<TransactionDigest, CheckpointSequenceNumber>,
+    builder_checkpoint_summary: BTreeMap<CheckpointSequenceNumber, BuilderCheckpointSummary>,
 
     // Any un-committed next versions are stored here.
     shared_object_next_versions: RefCountedHashMap<ConsensusObjectSequenceKey, SequenceNumber>,
@@ -521,7 +518,6 @@ impl ConsensusOutputQuarantine {
 
             output_queue: VecDeque::new(),
             builder_checkpoint_summary: BTreeMap::new(),
-            builder_digest_to_checkpoint: HashMap::new(),
             shared_object_next_versions: RefCountedHashMap::new(),
             processed_consensus_messages: RefCountedHashMap::new(),
             congestion_control_randomness_object_debts: RefCountedHashMap::new(),
@@ -561,15 +557,10 @@ impl ConsensusOutputQuarantine {
         &mut self,
         sequence_number: CheckpointSequenceNumber,
         summary: BuilderCheckpointSummary,
-        contents: CheckpointContents,
     ) {
         debug!(?sequence_number, "inserting builder summary {:?}", summary);
-        for tx in contents.iter() {
-            self.builder_digest_to_checkpoint
-                .insert(tx.transaction, sequence_number);
-        }
         self.builder_checkpoint_summary
-            .insert(sequence_number, (summary, contents));
+            .insert(sequence_number, summary);
     }
 }
 
@@ -616,28 +607,7 @@ impl ConsensusOutputQuarantine {
             .map(|(seq, _)| *seq <= self.highest_executed_checkpoint)
             == Some(true)
         {
-            let (seq, (builder_summary, contents)) =
-                self.builder_checkpoint_summary.pop_first().unwrap();
-
-            for tx in contents.iter() {
-                let digest = &tx.transaction;
-                assert_eq!(
-                    self.builder_digest_to_checkpoint
-                        .remove(digest)
-                        .unwrap_or_else(|| {
-                            panic!(
-                                "transaction {:?} not found in builder_digest_to_checkpoint",
-                                digest
-                            )
-                        }),
-                    seq
-                );
-            }
-
-            batch.insert_batch(
-                &tables.builder_digest_to_checkpoint,
-                contents.iter().map(|tx| (tx.transaction, seq)),
-            )?;
+            let (seq, builder_summary) = self.builder_checkpoint_summary.pop_first().unwrap();
 
             batch.insert_batch(
                 &tables.builder_checkpoint_summary_v2,
@@ -780,19 +750,14 @@ impl ConsensusOutputQuarantine {
 // be found in the database.
 impl ConsensusOutputQuarantine {
     pub(super) fn last_built_summary(&self) -> Option<&BuilderCheckpointSummary> {
-        self.builder_checkpoint_summary
-            .values()
-            .last()
-            .map(|(summary, _)| summary)
+        self.builder_checkpoint_summary.values().last()
     }
 
     pub(super) fn get_built_summary(
         &self,
         sequence: CheckpointSequenceNumber,
     ) -> Option<&BuilderCheckpointSummary> {
-        self.builder_checkpoint_summary
-            .get(&sequence)
-            .map(|(summary, _)| summary)
+        self.builder_checkpoint_summary.get(&sequence)
     }
 
     pub(super) fn is_consensus_message_processed(
@@ -1090,6 +1055,7 @@ mod tests {
     use crate::authority::test_authority_builder::TestAuthorityBuilder;
     use sui_types::base_types::ExecutionDigests;
     use sui_types::gas::GasCostSummary;
+    use sui_types::messages_checkpoint::CheckpointContents;
 
     fn make_output(height: u64, round: u64, drained: bool) -> ConsensusCommitOutput {
         let mut output = ConsensusCommitOutput::new(round);
@@ -1105,7 +1071,7 @@ mod tests {
         seq: CheckpointSequenceNumber,
         height: CheckpointHeight,
         protocol_config: &ProtocolConfig,
-    ) -> (BuilderCheckpointSummary, CheckpointContents) {
+    ) -> BuilderCheckpointSummary {
         let contents =
             CheckpointContents::new_with_digests_only_for_tests([ExecutionDigests::random()]);
         let summary = CheckpointSummary::new(
@@ -1121,12 +1087,11 @@ mod tests {
             vec![],
             vec![],
         );
-        let builder_summary = BuilderCheckpointSummary {
+        BuilderCheckpointSummary {
             summary,
             checkpoint_height: Some(height),
             position_in_commit: 0,
-        };
-        (builder_summary, contents)
+        }
     }
 
     #[tokio::test]
@@ -1150,8 +1115,8 @@ mod tests {
         // Insert builder summaries for checkpoints 1-4 with checkpoint_height = seq
         let pc = epoch_store.protocol_config();
         for seq in 1..=4 {
-            let (summary, contents) = make_builder_summary(seq, seq, pc);
-            quarantine.insert_builder_summary(seq, summary, contents);
+            let summary = make_builder_summary(seq, seq, pc);
+            quarantine.insert_builder_summary(seq, summary);
         }
 
         // Certify up to checkpoint 4
@@ -1186,8 +1151,8 @@ mod tests {
         // Insert builder summaries for checkpoints 1-5 with checkpoint_height = seq
         let pc = epoch_store.protocol_config();
         for seq in 1..=5 {
-            let (summary, contents) = make_builder_summary(seq, seq, pc);
-            quarantine.insert_builder_summary(seq, summary, contents);
+            let summary = make_builder_summary(seq, seq, pc);
+            quarantine.insert_builder_summary(seq, summary);
         }
 
         // Certify up to checkpoint 5

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -399,7 +399,7 @@ impl CheckpointStore {
             None => {
                 if epoch_store.epoch() == checkpoint.epoch {
                     epoch_store
-                        .put_genesis_checkpoint_in_builder(checkpoint.data(), &contents)
+                        .put_genesis_checkpoint_in_builder(checkpoint.data())
                         .unwrap();
                 } else {
                     debug!(
@@ -1791,7 +1791,7 @@ impl CheckpointBuilder {
 
         self.notify_aggregator.notify_one();
         self.epoch_store
-            .process_constructed_checkpoint(height, new_checkpoint);
+            .process_constructed_checkpoint(height, new_checkpoint.0);
         Ok(())
     }
 


### PR DESCRIPTION
## Description

The last readers of `builder_digest_to_checkpoint` were removed in #26988, leaving both the epoch table and the quarantine's in-memory copy write-only. Remove them. With the digest map gone, the `CheckpointContents` held in the quarantine had no remaining readers either, so it is dropped as well.

Dropping the column family declaration is safe: typed_store reopens on-disk column families the schema no longer declares (same as #26988/#27130), and epoch tables are recreated each epoch anyway.

## Test plan

Covered by existing tests (`sui-core` unit suite, including `consensus_quarantine` tests).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: