### PR TITLE
[gql] Transaction connections understand the legacy `JsonCursor<u64>`

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
@@ -73,6 +73,19 @@ fn window(edges: &[graphql::Edge<TxNode>]) -> Vec<(String, Option<u64>)> {
         .collect()
 }
 
+/// A cursor as minted before the `CursorToken` migration: Base64 of the JSON-encoded
+/// `tx_sequence_number`.
+fn legacy_cursor(position: u64) -> String {
+    Base64::encode(serde_json::to_vec(&position).unwrap())
+}
+
+/// The `tx_sequence_number` a response cursor points at.
+fn cursor_position(cursor: &str) -> u64 {
+    CursorToken::decode(&Base64::decode(cursor).unwrap())
+        .expect("response cursors are CursorTokens")
+        .position
+}
+
 #[tokio::test]
 async fn test_transactions_query_cursor_pagination() {
     let mut cluster = FullCluster::new().await.unwrap();
@@ -172,4 +185,76 @@ async fn test_transactions_query_cursor_pagination() {
         .unwrap();
     assert!(page.edges.is_empty());
     assert!(!page.page_info.has_next_page);
+}
+
+/// Cursors minted before the `CursorToken` migration are still accepted as `after`/`before`
+/// bounds, while response cursors are always minted in the current format.
+#[tokio::test]
+async fn test_transactions_query_legacy_cursors() {
+    let mut cluster = FullCluster::new().await.unwrap();
+
+    let (a, kp, mut gas) = cluster
+        .funded_account(DEFAULT_GAS_BUDGET * 40)
+        .expect("Failed to fund account");
+    cluster.create_checkpoint().await;
+    for amount in [10u64, 11, 12, 13, 14, 15] {
+        gas = send_sui(&mut cluster, a, &kp, gas, amount).0;
+    }
+    cluster.create_checkpoint().await;
+
+    // Ground truth, paginated without any legacy cursors involved.
+    let all = transactions(&cluster, Some(50), None, None, None)
+        .await
+        .unwrap();
+    let n = all.edges.len();
+    assert!(n >= 6, "expected enough transactions to paginate, got {n}");
+
+    // Spoof legacy encodings of the 1st and 6th transactions' cursors.
+    let after = legacy_cursor(cursor_position(&all.edges[0].cursor));
+    let before = legacy_cursor(cursor_position(&all.edges[5].cursor));
+
+    // Legacy `after` and `before` bound the page like their current-format equivalents, picking
+    // from the front...
+    let page = transactions(
+        &cluster,
+        Some(2),
+        None,
+        Some(after.clone()),
+        Some(before.clone()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(window(&page.edges), window(&all.edges[1..3]));
+    assert!(page.page_info.has_previous_page);
+    assert!(page.page_info.has_next_page);
+
+    // ...and from the back.
+    let page = transactions(
+        &cluster,
+        None,
+        Some(2),
+        Some(after.clone()),
+        Some(before.clone()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(window(&page.edges), window(&all.edges[3..5]));
+    assert!(page.page_info.has_previous_page);
+    assert!(page.page_info.has_next_page);
+
+    // Response cursors decode as `CursorToken`s, even when the request was bounded by legacy
+    // cursors. (The `window` comparisons above already match them against ground-truth cursors.)
+    for edge in &page.edges {
+        cursor_position(&edge.cursor);
+    }
+
+    // A cursor that is neither a `CursorToken` nor a legacy JSON number is rejected cleanly.
+    let garbage = Base64::encode(b"not a cursor");
+    let err = transactions(&cluster, Some(2), None, Some(garbage), None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("Invalid cursor"),
+        "unexpected error: {err}"
+    );
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -245,7 +245,7 @@ impl CheckpointContents {
                 return Ok(Some(Transaction::paginate_preloaded_transactions(
                     self.scope.clone(),
                     &streamed.transactions,
-                    &page,
+                    page,
                     filter,
                 )?));
             }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -52,6 +52,7 @@ use crate::error::RpcError;
 use crate::error::bad_user_input;
 use crate::error::upcast;
 use crate::extensions::query_limits;
+use crate::pagination::Error as PaginationError;
 use crate::pagination::Page;
 use crate::scope::Scope;
 use crate::task::streaming::ProcessedTransaction;
@@ -286,9 +287,16 @@ impl Transaction {
     pub(crate) fn paginate_preloaded_transactions(
         scope: Scope,
         transactions: &[ProcessedTransaction],
-        page: &Page<CTransaction>,
+        mut page: Page<CTransaction>,
         filter: TransactionFilter,
     ) -> Result<TransactionConnection, RpcError<Error>> {
+        if let Some(after) = page.after().map(remap_legacy_cursor).transpose()? {
+            page.set_after(after);
+        }
+        if let Some(before) = page.before().map(remap_legacy_cursor).transpose()? {
+            page.set_before(before);
+        }
+
         let after = page
             .after()
             .map(|c| CursorToken::decode(c))
@@ -350,9 +358,16 @@ impl Transaction {
     pub(crate) async fn paginate(
         ctx: &Context<'_>,
         scope: Scope,
-        page: Page<CTransaction>,
+        mut page: Page<CTransaction>,
         filter: TransactionFilter,
     ) -> Result<TransactionConnection, RpcError> {
+        if let Some(after) = page.after().map(remap_legacy_cursor).transpose()? {
+            page.set_after(after);
+        }
+        if let Some(before) = page.before().map(remap_legacy_cursor).transpose()? {
+            page.set_before(before);
+        }
+
         let watermarks: &Arc<Watermarks> = ctx.data()?;
         let available_range_key = AvailableRangeKey {
             type_: "Query".to_string(),
@@ -479,7 +494,7 @@ impl TransactionConnection {
 impl TxBoundsCursor for CTransaction {
     fn tx_sequence_number(&self) -> u64 {
         CursorToken::decode(self)
-            .expect("cursor already validated as ByteCursor")
+            .expect("valid transaction cursor")
             .position
     }
 }
@@ -760,4 +775,70 @@ async fn tx_unfiltered(
 
     let tx_sequence_numbers = (tx_lo..tx_hi).collect();
     Ok(tx_sequence_numbers)
+}
+
+/// Re-encode an input cursor of the legacy format, a base64-encoded `JsonCursor<u64>`, into the
+/// current `CursorToken`.
+fn remap_legacy_cursor(cursor: &CTransaction) -> Result<CTransaction, PaginationError> {
+    if CursorToken::decode(cursor).is_ok() {
+        return Ok(cursor.clone());
+    }
+
+    let position: u64 = serde_json::from_slice(cursor).map_err(|_| PaginationError::BadCursor)?;
+    Ok(ByteCursor::new(
+        CursorToken::item(QueryType::Transactions, 0, position)
+            .encode()
+            .to_vec(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use async_graphql::connection::CursorType;
+
+    use crate::api::scalars::cursor::JsonCursor;
+
+    use super::*;
+
+    /// The previous definition of `CTransaction` -- cursors handed out before the migration are
+    /// encoded in this format.
+    type LegacyCTransaction = JsonCursor<u64>;
+
+    /// A cursor as minted by the current implementation.
+    fn token_cursor(position: u64) -> CTransaction {
+        ByteCursor::new(
+            CursorToken::item(QueryType::Transactions, 0, position)
+                .encode()
+                .to_vec(),
+        )
+    }
+
+    /// A cursor as minted by the legacy implementation.
+    fn legacy_cursor(position: u64) -> LegacyCTransaction {
+        JsonCursor::new(position)
+    }
+
+    /// Parse a cursor string the way the current scalar accepts it off the wire.
+    fn decode_input(encoded: &str) -> CTransaction {
+        ByteCursor::decode_cursor(encoded).unwrap()
+    }
+
+    #[test]
+    fn test_normalize_legacy_cursor() {
+        let received = decode_input(&legacy_cursor(42).encode_cursor());
+        let normalized = remap_legacy_cursor(&received).unwrap();
+        assert_eq!(normalized, token_cursor(42));
+        assert_eq!(normalized.tx_sequence_number(), 42);
+    }
+
+    #[test]
+    fn test_normalize_current_cursor_unchanged() {
+        let cursor = token_cursor(42);
+        assert_eq!(remap_legacy_cursor(&cursor).unwrap(), cursor);
+    }
+
+    #[test]
+    fn test_normalize_garbage_cursor() {
+        assert!(remap_legacy_cursor(&ByteCursor::new(b"not a cursor".to_vec())).is_err());
+    }
 }

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -61,6 +61,9 @@ pub(crate) enum End {
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub(crate) enum Error {
+    #[error("Invalid cursor for connection")]
+    BadCursor,
+
     #[error("Cannot provide both 'first' and 'last' parameters for connection")]
     FirstAndLast,
 
@@ -153,6 +156,14 @@ impl<C> Page<C> {
 
     pub(crate) fn before(&self) -> Option<&C> {
         self.before.as_ref()
+    }
+
+    pub(crate) fn set_after(&mut self, cursor: C) {
+        self.after = Some(cursor);
+    }
+
+    pub(crate) fn set_before(&mut self, cursor: C) {
+        self.before = Some(cursor);
     }
 
     pub(crate) fn limit(&self) -> usize {


### PR DESCRIPTION
## Description 

After the migration to the new cursor format, we can still support the previous `JsonCursor<u64>` format. The connection will always return a cursor in the new format.

## Test plan 

New integration and e2e tests
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
