### PR TITLE
Fix tidehunter build warnings and enforce them in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -181,9 +181,12 @@ jobs:
       - name: cargo test with tidehunter
         run: |
           RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo nextest run --profile ci --cargo-quiet -p sui-core -p typed-store --features typed-store/tidehunter
-      - name: cargo check sui-tool with tidehunter + tideconsole
+      - run: rustup component add clippy
+      # Same lint set as `cargo xclippy` (see .cargo/config.toml), denying warnings, but scoped
+      # to the crates whose build.rs emits cfg(tidehunter) so tidehunter-only code is linted too.
+      - name: cargo clippy with tidehunter
         run: |
-          RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo check --quiet -p sui-tool --features typed-store/tidehunter,sui-tool/tideconsole
+          USE_TIDEHUNTER=1 cargo clippy --all-targets -p sui-core -p sui-tool -p sui-benchmark -p typed-store -p consensus-core --features typed-store/tidehunter,sui-tool/tideconsole -- -Wclippy::all -Wclippy::disallowed_methods -Wclippy::disallowed_macros -Aclippy::unnecessary_get_then_check -D warnings
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -12,10 +12,12 @@ use consensus_config::AuthorityIndex;
 use consensus_types::block::{BlockDigest, BlockRef, Round, TransactionIndex};
 use mysten_common::ZipDebugEqIteratorExt;
 use sui_macros::fail_point;
+#[cfg(not(tidehunter))]
+use typed_store::rocks::{DBMapTableConfigMap, default_db_options};
 use typed_store::{
     DBMapUtils, Map as _,
     metrics::SamplingInterval,
-    rocks::{DBMap, DBMapTableConfigMap, MetricConf, default_db_options},
+    rocks::{DBMap, MetricConf},
 };
 
 use super::{CommitInfo, Store, WriteBatch};
@@ -107,7 +109,7 @@ impl RocksDBStore {
                 ThConfig::new_with_config_indexing(
                     index_index_digest_key.clone(),
                     mutexes,
-                    u32_prefix.clone(),
+                    u32_prefix,
                     KeySpaceConfig::new(),
                 ),
             ),
@@ -116,30 +118,30 @@ impl RocksDBStore {
                 ThConfig::new_with_config_indexing(
                     index_index_digest_key.clone(),
                     mutexes,
-                    u64_prefix.clone(),
+                    u64_prefix,
                     KeySpaceConfig::new(),
                 ),
             ),
             (
                 Self::COMMITS_CF.to_string(),
-                ThConfig::new_with_indexing(index_digest_key.clone(), mutexes, u32_prefix.clone()),
+                ThConfig::new_with_indexing(index_digest_key.clone(), mutexes, u32_prefix),
             ),
             (
                 Self::COMMIT_VOTES_CF.to_string(),
                 ThConfig::new_with_config_indexing(
                     commit_vote_key,
                     mutexes,
-                    u32_prefix.clone(),
+                    u32_prefix,
                     KeySpaceConfig::new(),
                 ),
             ),
             (
                 Self::COMMIT_INFO_CF.to_string(),
-                ThConfig::new_with_indexing(index_digest_key.clone(), mutexes, u32_prefix.clone()),
+                ThConfig::new_with_indexing(index_digest_key.clone(), mutexes, u32_prefix),
             ),
             (
                 Self::FINALIZED_COMMITS_CF.to_string(),
-                ThConfig::new_with_indexing(index_digest_key.clone(), mutexes, u32_prefix.clone()),
+                ThConfig::new_with_indexing(index_digest_key.clone(), mutexes, u32_prefix),
             ),
         ];
         Self::open_tables_read_write(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -78,10 +78,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::DBMapUtils;
 use typed_store::Map;
-use typed_store::rocks::{DBBatch, DBMap, DBOptions, MetricConf, default_db_options};
-use typed_store::rocks::{ReadWriteOptions, read_size_from_env};
+use typed_store::rocks::{DBBatch, DBMap, MetricConf};
+#[cfg(not(tidehunter))]
+use typed_store::rocks::{DBOptions, ReadWriteOptions, default_db_options, read_size_from_env};
 use typed_store::rocksdb::Options;
 
+#[cfg(not(tidehunter))]
 use super::authority_store_tables::ENV_VAR_LOCKS_BLOCK_CACHE_SIZE;
 use super::consensus_tx_status_cache::{ConsensusTxStatus, ConsensusTxStatusCache};
 use super::epoch_start_configuration::EpochStartConfigTrait;
@@ -539,6 +541,7 @@ pub struct AuthorityEpochTables {
     pub(crate) dkg_output_v2: DBMap<u64, Option<dkg_v1::Output<PkG, EncG>>>,
 }
 
+#[cfg(not(tidehunter))]
 fn owned_object_transaction_locks_table_default_config() -> DBOptions {
     DBOptions {
         options: default_db_options()
@@ -561,12 +564,12 @@ impl AuthorityEpochTables {
     }
 
     #[cfg(tidehunter)]
-    pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
-        Self::open_with_path(&Self::path(epoch, parent_path), db_options)
+    pub fn open(epoch: EpochId, parent_path: &Path, _db_options: Option<Options>) -> Self {
+        Self::open_with_path(&Self::path(epoch, parent_path))
     }
 
     #[cfg(tidehunter)]
-    pub fn open_with_path(path: &PathBuf, db_options: Option<Options>) -> Self {
+    pub fn open_with_path(path: &Path) -> Self {
         tracing::warn!("AuthorityEpochTables using tidehunter");
         use typed_store::tidehunter_util::{
             KeyIndexing, KeySpaceConfig, KeyType, ThConfig, default_cells_per_mutex,

--- a/crates/sui-core/src/authority/authority_per_epoch_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store_pruner.rs
@@ -77,12 +77,11 @@ impl AuthorityPerEpochStorePruner {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(tidehunter)))]
 mod tests {
     use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
     use std::fs;
 
-    #[cfg(not(tidehunter))]
     #[tokio::test]
     async fn test_basic_epoch_pruner() {
         let parent_directory = tempfile::tempdir().unwrap().keep();

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -5,7 +5,10 @@ use super::authority_store_tables::AuthorityPerpetualTables;
 use crate::checkpoints::{CheckpointStore, CheckpointWatermark};
 use crate::jsonrpc_index::IndexStore;
 use anyhow::anyhow;
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::monitored_scope;
+#[cfg(not(tidehunter))]
+use mysten_metrics::spawn_monitored_task;
+#[cfg(not(tidehunter))]
 use once_cell::sync::Lazy;
 use prometheus::{
     IntCounter, IntGauge, Registry, register_int_counter_with_registry,
@@ -13,14 +16,21 @@ use prometheus::{
 };
 #[cfg(tidehunter)]
 use serde::de::DeserializeOwned;
-use std::cmp::{max, min};
+#[cfg(not(tidehunter))]
+use std::cmp::max;
+use std::cmp::min;
+#[cfg(not(tidehunter))]
 use std::collections::{BTreeSet, HashMap};
+#[cfg(not(tidehunter))]
 use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
+#[cfg(not(tidehunter))]
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{sync::Arc, time::Duration};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_rpc_store::Store as RpcStore;
+#[cfg(not(tidehunter))]
+use sui_types::base_types::VersionNumber;
 use sui_types::committee::EpochId;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
@@ -29,15 +39,17 @@ use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointDigest, CheckpointSequenceNumber,
 };
 use sui_types::{
-    base_types::{ObjectID, SequenceNumber, TransactionDigest, VersionNumber},
+    base_types::{ObjectID, SequenceNumber, TransactionDigest},
     storage::ObjectKey,
 };
 use tokio::sync::oneshot::{self, Sender};
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
+#[cfg(not(tidehunter))]
 use typed_store::rocksdb::LiveFile;
 use typed_store::{Map, TypedStoreError};
 
+#[cfg(not(tidehunter))]
 static PERIODIC_PRUNING_TABLES: Lazy<BTreeSet<String>> = Lazy::new(|| {
     [
         "objects",
@@ -596,6 +608,7 @@ impl AuthorityStorePruner {
         Ok(())
     }
 
+    #[cfg(not(tidehunter))]
     fn prune_indexes(
         indexes: Option<&IndexStore>,
         config: &AuthorityStorePruningConfig,
@@ -622,6 +635,7 @@ impl AuthorityStorePruner {
         Ok(())
     }
 
+    #[cfg(not(tidehunter))]
     async fn prune_executed_tx_digests(
         perpetual_db: &Arc<AuthorityPerpetualTables>,
         checkpoint_store: &Arc<CheckpointStore>,
@@ -764,6 +778,7 @@ impl AuthorityStorePruner {
         Ok(())
     }
 
+    #[cfg(not(tidehunter))]
     fn compact_next_sst_file(
         perpetual_db: Arc<AuthorityPerpetualTables>,
         delay_days: usize,
@@ -884,6 +899,8 @@ impl AuthorityStorePruner {
 
         #[cfg(tidehunter)]
         {
+            // Index pruning is only implemented for the rocksdb backend.
+            let _ = jsonrpc_index;
             if let Some(num_epochs_to_retain) = config.num_epochs_to_retain_for_checkpoints() {
                 let prune_objects = config.num_epochs_to_retain != u64::MAX;
                 tokio::task::spawn(async move {
@@ -1044,10 +1061,10 @@ pub(crate) fn apply_relocation_filter<T: DeserializeOwned>(
             bincode::DefaultOptions::new()
                 .with_big_endian()
                 .with_fixint_encoding()
-                .deserialize(&key)
+                .deserialize(key)
                 .expect("relocation filter deserialization error")
         } else {
-            bcs::from_bytes(&value).expect("relocation filter deserialization error")
+            bcs::from_bytes(value).expect("relocation filter deserialization error")
         };
         if extractor(data) < pruner_watermark.load(Ordering::Relaxed) {
             Decision::Remove
@@ -1060,16 +1077,19 @@ pub(crate) fn apply_relocation_filter<T: DeserializeOwned>(
 #[cfg(test)]
 mod tests {
     use more_asserts as ma;
+    #[cfg(not(tidehunter))]
+    use std::collections::HashSet;
     use std::path::Path;
+    use std::sync::Arc;
+    #[cfg(not(tidehunter))]
     use std::time::Duration;
-    use std::{collections::HashSet, sync::Arc};
     use tracing::log::info;
 
     use crate::authority::authority_store_pruner::AuthorityStorePruningMetrics;
     use crate::authority::authority_store_tables::AuthorityPerpetualTables;
-    use crate::authority::authority_store_types::{
-        StoreObject, StoreObjectWrapper, get_store_object,
-    };
+    use crate::authority::authority_store_types::get_store_object;
+    #[cfg(not(tidehunter))]
+    use crate::authority::authority_store_types::{StoreObject, StoreObjectWrapper};
     use prometheus::Registry;
     use sui_types::base_types::ObjectDigest;
     use sui_types::effects::TransactionEffects;
@@ -1080,10 +1100,12 @@ mod tests {
         storage::ObjectKey,
     };
     use typed_store::Map;
+    #[cfg(not(tidehunter))]
     use typed_store::rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options};
 
     use super::AuthorityStorePruner;
 
+    #[cfg(not(tidehunter))]
     fn get_keys_after_pruning(path: &Path) -> anyhow::Result<HashSet<ObjectKey>> {
         let perpetual_db_path = path.join(Path::new("perpetual"));
         let cf_names = AuthorityPerpetualTables::describe_tables();
@@ -1114,8 +1136,10 @@ mod tests {
         Ok(after_pruning)
     }
 
+    #[cfg(not(tidehunter))]
     type GenerateTestDataResult = (Vec<ObjectKey>, Vec<ObjectKey>, Vec<ObjectKey>);
 
+    #[cfg(not(tidehunter))]
     fn generate_test_data(
         db: Arc<AuthorityPerpetualTables>,
         num_versions_per_object: u64,
@@ -1172,6 +1196,7 @@ mod tests {
         Ok((to_keep, to_delete, tombstones))
     }
 
+    #[cfg(not(tidehunter))]
     async fn run_pruner(
         path: &Path,
         num_versions_per_object: u64,

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -14,10 +14,9 @@ use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::storage::MarkerValue;
 use typed_store::metrics::SamplingInterval;
-use typed_store::rocks::{
-    DBBatch, DBMap, DBMapTableConfigMap, DBOptions, MetricConf, default_db_options,
-    read_size_from_env,
-};
+use typed_store::rocks::{DBBatch, DBMap, MetricConf};
+#[cfg(not(tidehunter))]
+use typed_store::rocks::{DBMapTableConfigMap, DBOptions, default_db_options, read_size_from_env};
 use typed_store::traits::Map;
 
 use crate::authority::authority_store_types::{
@@ -26,9 +25,13 @@ use crate::authority::authority_store_types::{
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use typed_store::{DBMapUtils, DbIterator};
 
+#[cfg(not(tidehunter))]
 const ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE: &str = "OBJECTS_BLOCK_CACHE_MB";
+#[cfg(not(tidehunter))]
 pub(crate) const ENV_VAR_LOCKS_BLOCK_CACHE_SIZE: &str = "LOCKS_BLOCK_CACHE_MB";
+#[cfg(not(tidehunter))]
 const ENV_VAR_TRANSACTIONS_BLOCK_CACHE_SIZE: &str = "TRANSACTIONS_BLOCK_CACHE_MB";
+#[cfg(not(tidehunter))]
 const ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE: &str = "EFFECTS_BLOCK_CACHE_MB";
 
 /// Options to apply to every column family of the `perpetual` DB.
@@ -43,6 +46,7 @@ pub struct AuthorityPerpetualTablesOptions {
 }
 
 impl AuthorityPerpetualTablesOptions {
+    #[cfg(not(tidehunter))]
     fn apply_to(&self, mut db_options: DBOptions) -> DBOptions {
         if !self.enable_write_stall {
             db_options = db_options.disable_write_throttling();
@@ -230,10 +234,10 @@ impl AuthorityPerpetualTables {
             let mut previous: Option<&[u8]> = None;
             const OID_SIZE: usize = 32;
             for key in iter.rev() {
-                if let Some(prev) = previous {
-                    if prev == &key[..OID_SIZE] {
-                        continue;
-                    }
+                if let Some(prev) = previous
+                    && prev == &key[..OID_SIZE]
+                {
+                    continue;
                 }
                 previous = Some(&key[..OID_SIZE]);
                 retain.insert(key.clone());
@@ -944,6 +948,7 @@ impl Iterator for LiveSetIter<'_> {
 }
 
 // These functions are used to initialize the DB tables
+#[cfg(not(tidehunter))]
 fn owned_object_transaction_locks_table_config(db_options: DBOptions) -> DBOptions {
     DBOptions {
         options: db_options
@@ -955,12 +960,14 @@ fn owned_object_transaction_locks_table_config(db_options: DBOptions) -> DBOptio
     }
 }
 
+#[cfg(not(tidehunter))]
 fn objects_table_config(db_options: DBOptions) -> DBOptions {
     db_options
         .optimize_for_write_throughput()
         .optimize_for_read(read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024))
 }
 
+#[cfg(not(tidehunter))]
 fn transactions_table_config(db_options: DBOptions) -> DBOptions {
     db_options
         .optimize_for_write_throughput()
@@ -969,6 +976,7 @@ fn transactions_table_config(db_options: DBOptions) -> DBOptions {
         )
 }
 
+#[cfg(not(tidehunter))]
 fn effects_table_config(db_options: DBOptions) -> DBOptions {
     db_options
         .optimize_for_write_throughput()

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -41,6 +41,7 @@ use sui_types::messages_checkpoint::{
 };
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use tokio::sync::{mpsc, watch};
+#[cfg(not(tidehunter))]
 use typed_store::rocks::{DBOptions, ReadWriteOptions, default_db_options};
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -185,6 +186,7 @@ pub struct CheckpointStoreTables {
     full_checkpoint_content_v2: DBMap<CheckpointSequenceNumber, VersionedFullCheckpointContents>,
 }
 
+#[cfg(not(tidehunter))]
 fn full_checkpoint_content_table_default_config() -> DBOptions {
     DBOptions {
         options: default_db_options().options,

--- a/crates/sui-core/src/epoch/consensus_store_pruner.rs
+++ b/crates/sui-core/src/epoch/consensus_store_pruner.rs
@@ -11,7 +11,9 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::{sync::mpsc, time::Instant};
-use tracing::{error, info, warn};
+#[cfg(not(tidehunter))]
+use tracing::warn;
+use tracing::{error, info};
 use typed_store::rocks::safe_drop_db;
 
 struct Metrics {

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::default_registry;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+#[cfg(not(tidehunter))]
+use rand::Rng;
+use rand::{SeedableRng, rngs::StdRng};
+#[cfg(not(tidehunter))]
+use std::time::{Duration, Instant};
 use std::{
     collections::{BTreeMap, BTreeSet},
     future::Future,
@@ -11,7 +15,6 @@ use std::{
         Arc,
         atomic::{AtomicU32, Ordering},
     },
-    time::{Duration, Instant},
 };
 use sui_framework::BuiltInFramework;
 use sui_test_transaction_builder::TestTransactionBuilder;

--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Ok, anyhow};
 use clap::{Parser, ValueEnum};
+#[cfg(not(tidehunter))]
 use comfy_table::{Cell, ContentArrangement, Row, Table};
 use prometheus::Registry;
 use std::collections::BTreeMap;
@@ -159,6 +160,9 @@ pub fn print_table_metadata(
 
         eprintln!("{}", table);
     }
+    // Table metadata is only available for the rocksdb backend.
+    #[cfg(tidehunter)]
+    let _ = (store_name, epoch, db_path, table_name);
     Ok(())
 }
 

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -16,7 +16,9 @@ use sui_types::base_types::{EpochId, ObjectID};
 use sui_types::digests::{CheckpointContentsDigest, TransactionDigest};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::messages_checkpoint::{CheckpointDigest, CheckpointSequenceNumber};
-use typed_store::rocks::{MetricConf, safe_drop_db};
+#[cfg(not(tidehunter))]
+use typed_store::rocks::MetricConf;
+use typed_store::rocks::safe_drop_db;
 pub mod db_dump;
 mod index_search;
 
@@ -249,7 +251,7 @@ pub fn print_last_consensus_index(path: &Path) -> anyhow::Result<()> {
         None,
     );
     #[cfg(tidehunter)]
-    let epoch_tables = AuthorityEpochTables::open_with_path(&path.to_path_buf(), None);
+    let epoch_tables = AuthorityEpochTables::open_with_path(path);
     let last_index = epoch_tables.get_last_consensus_index()?;
     println!("Last consensus index is {:?}", last_index);
     Ok(())


### PR DESCRIPTION
## Description

Builds with `USE_TIDEHUNTER=1` produced ~25 warnings (unused imports/variables and dead rocksdb-only helpers that are compiled out under `cfg(tidehunter)`), and nothing in CI caught them. Fix all of them — mostly by `#[cfg(not(tidehunter))]`-gating rocksdb-only items — and add a clippy step to the `test-tidehunter` job that runs the `cargo xclippy` lint set with `-D warnings` over the crates whose build.rs emits `cfg(tidehunter)`, so both cfg variants are now lint-enforced.

## Test plan

Both cfg variants pass the new CI clippy command locally:

```
USE_TIDEHUNTER=1 cargo clippy --all-targets -p sui-core -p sui-tool -p sui-benchmark -p typed-store -p consensus-core --features typed-store/tidehunter,sui-tool/tideconsole -- -Wclippy::all -Wclippy::disallowed_methods -Wclippy::disallowed_macros -Aclippy::unnecessary_get_then_check -D warnings
```

(and the same without `USE_TIDEHUNTER` using `--all-features`). Tidehunter unit tests in the touched areas (pruner, store tables, writeback cache) pass under `USE_TIDEHUNTER=1`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: