### PR TITLE
[move-ide] Follow Move conventions for auto-imports and quick-fixes

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.44",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.44",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,8 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.44",
-  "preview": true,
+  "version": "2.0.0",
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",
     "type": "git"

--- a/external-crates/move/crates/move-analyzer/src/code_action.rs
+++ b/external-crates/move/crates/move-analyzer/src/code_action.rs
@@ -5,6 +5,7 @@ use crate::{
     completions::utils::{
         addr_to_ide_string, all_mod_enums_to_import, all_mod_functions_to_import,
         all_mod_structs_to_import, auto_import_text_edit, compute_cursor, import_insertion_info,
+        module_import_info,
     },
     context::Context,
     symbols::{
@@ -36,7 +37,7 @@ use move_compiler::{
     expansion::ast::ModuleIdent,
     linters::LintLevel,
     parser::ast::{LeadingNameAccess_, NameAccessChain_},
-    shared::{Identifier, Name},
+    shared::{Identifier, Name, ide::AliasAutocompleteInfo},
 };
 use move_package_alt::MoveFlavor;
 
@@ -149,7 +150,7 @@ fn access_chain_autofix_actions<F: MoveFlavor>(
         LintLevel::None,
         move_flavor,
         flavor,
-        None,
+        Some(&file_path),
     ) else {
         return code_actions;
     };
@@ -192,6 +193,9 @@ pub fn access_chain_autofix_actions_for_error(
     {
         return;
     }
+    if let Some(autocomplete_info) = compiled_pkg_info.compiler_autocomplete_info.clone() {
+        symbols.compiler_autocomplete_info = autocomplete_info;
+    }
     // compute cursor and update symbols with it
     let Some(file_path) = canonical_path_from_uri(&file_url) else {
         return;
@@ -231,7 +235,7 @@ pub fn access_chain_autofix_actions_for_error(
                 }
                 SingleElementChainDiagPrefix::UnboundFunction => {
                     if err_msg.starts_with(prefix.as_str()) {
-                        single_element_access_chain_autofixes(
+                        single_element_function_autofixes(
                             code_actions,
                             symbols,
                             cursor,
@@ -311,7 +315,7 @@ fn single_element_access_chain_autofixes<I, K>(
             let title = format!("Qualify as `{}{}`", autofix_prefix, unbound_name);
             code_actions.push(access_chain_code_action(
                 title,
-                text_edit,
+                vec![text_edit],
                 diag.clone(),
                 file_url.clone(),
             ));
@@ -321,7 +325,7 @@ fn single_element_access_chain_autofixes<I, K>(
                 let text_edit = auto_import_text_edit(import_text, import_insertion_info);
                 code_actions.push(access_chain_code_action(
                     title,
-                    text_edit,
+                    vec![text_edit],
                     diag.clone(),
                     file_url.clone(),
                 ));
@@ -345,7 +349,7 @@ fn single_element_access_chain_autofixes<I, K>(
                 let title = format!("Qualify as `{}{}`", autofix_prefix, unbound_name);
                 code_actions.push(access_chain_code_action(
                     title,
-                    text_edit,
+                    vec![text_edit],
                     diag.clone(),
                     file_url.clone(),
                 ));
@@ -355,7 +359,111 @@ fn single_element_access_chain_autofixes<I, K>(
                     let text_edit = auto_import_text_edit(import_text, import_insertion_info);
                     code_actions.push(access_chain_code_action(
                         title,
-                        text_edit,
+                        vec![text_edit],
+                        diag.clone(),
+                        file_url.clone(),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Create auto-fixes for a single unbound function using module-qualified call style.
+/// For `f()`, when the target is `foo::f`, the code action should end up with `foo::f()`
+/// and auto-inserted `use pkg::foo;`.
+fn single_element_function_autofixes<I, K>(
+    code_actions: &mut Vec<CodeAction>,
+    symbols: &Symbols,
+    cursor: &CursorContext,
+    file_url: Url,
+    unbound_name: Name,
+    mod_functions: I,
+    diag: Option<Diagnostic>,
+) where
+    I: Iterator<Item = (ModuleIdent, K)>,
+    K: Iterator<Item = Symbol>,
+{
+    let Some(unbound_name_lsp_pos) =
+        loc_start_to_lsp_position_opt(&symbols.files, &unbound_name.loc)
+    else {
+        return;
+    };
+    let info = symbols
+        .compiler_autocomplete_info
+        .get_path_autocomplete_info(&unbound_name.loc)
+        .cloned()
+        .unwrap_or_else(AliasAutocompleteInfo::new);
+    for (mod_ident, mod_functions) in mod_functions {
+        for function_name in mod_functions {
+            if function_name != unbound_name.value {
+                continue;
+            }
+
+            // Always offer full qualification; it is valid even when a module import would clash.
+            let qualified_prefix = format!(
+                "{}::{}::",
+                addr_to_ide_string(&mod_ident.value.address),
+                mod_ident.value.module
+            );
+            let text_edit = TextEdit {
+                range: Range {
+                    start: unbound_name_lsp_pos,
+                    end: unbound_name_lsp_pos,
+                },
+                new_text: qualified_prefix.clone(),
+            };
+            let title = format!("Qualify as `{}{}`", qualified_prefix, unbound_name);
+            code_actions.push(access_chain_code_action(
+                title,
+                vec![text_edit],
+                diag.clone(),
+                file_url.clone(),
+            ));
+
+            // Then offer the Move-style fix: import the module and qualify the call through it.
+            // `module_import_info` returns `None` if the module name is already bound to a
+            // different module, in which case the full-qualification fix above is the only one.
+            let Some(import_info) = module_import_info(mod_ident, &info.modules) else {
+                continue;
+            };
+            let prefix_edit = TextEdit {
+                range: Range {
+                    start: unbound_name_lsp_pos,
+                    end: unbound_name_lsp_pos,
+                },
+                new_text: format!("{}::", import_info.module_prefix),
+            };
+            match import_info.import_text {
+                Some(import_text) => {
+                    // The module is not in scope yet, so apply both edits as one code action.
+                    let Some(import_insertion_info) = import_insertion_info(symbols, cursor) else {
+                        continue;
+                    };
+                    let import_edit =
+                        auto_import_text_edit(import_text.clone(), import_insertion_info);
+                    let title = format!(
+                        "Import `{}` and use `{}::{}`",
+                        import_text.trim_start_matches("use "),
+                        import_info.module_prefix,
+                        unbound_name
+                    );
+                    code_actions.push(access_chain_code_action(
+                        title,
+                        vec![prefix_edit, import_edit],
+                        diag.clone(),
+                        file_url.clone(),
+                    ));
+                }
+                None => {
+                    // The module is already in scope, possibly under an alias; only qualify the call.
+                    let title = format!(
+                        "Qualify as `{}::{}`",
+                        import_info.module_prefix, unbound_name
+                    );
+                    code_actions.push(access_chain_code_action(
+                        title,
+                        vec![prefix_edit],
                         diag.clone(),
                         file_url.clone(),
                     ));
@@ -407,7 +515,7 @@ fn two_element_access_chain_autofixes<I, K>(
                 );
                 code_actions.push(access_chain_code_action(
                     title,
-                    text_edit,
+                    vec![text_edit],
                     diag.clone(),
                     file_url.clone(),
                 ));
@@ -430,7 +538,7 @@ fn two_element_access_chain_autofixes<I, K>(
                 );
                 code_actions.push(access_chain_code_action(
                     title,
-                    text_edit,
+                    vec![text_edit],
                     diag.clone(),
                     file_url.clone(),
                 ));
@@ -442,12 +550,12 @@ fn two_element_access_chain_autofixes<I, K>(
 /// Create code action for fixing access chain.
 fn access_chain_code_action(
     title: String,
-    text_edit: TextEdit,
+    text_edits: Vec<TextEdit>,
     diag: Option<Diagnostic>,
     file_url: Url,
 ) -> CodeAction {
     let mut changes = HashMap::new();
-    changes.insert(file_url.clone(), vec![text_edit]);
+    changes.insert(file_url.clone(), text_edits);
     CodeAction {
         title,
         kind: Some(CodeActionKind::QUICKFIX),

--- a/external-crates/move/crates/move-analyzer/src/code_action.rs
+++ b/external-crates/move/crates/move-analyzer/src/code_action.rs
@@ -319,6 +319,9 @@ fn single_element_access_chain_autofixes<I, K>(
                 diag.clone(),
                 file_url.clone(),
             ));
+            // No conflict check is needed for this module import: the unbound-name error
+            // fires only when nothing in the leading-name namespace has this name, and a
+            // module import only affects that namespace.
             if let Some(import_insertion_info) = import_insertion_info(symbols, cursor) {
                 let title = format!("Import as `{}{}`", autofix_prefix, unbound_name);
                 let import_text = format!("use {}{}", autofix_prefix, unbound_name);
@@ -427,8 +430,9 @@ fn single_element_function_autofixes<I, K>(
                 continue;
             };
             // `module_import_info` returns `None` if the module name is already bound to a
-            // different module, in which case the full-qualification fix above is the only one.
-            let Some(import_info) = module_import_info(mod_ident, &info.modules) else {
+            // different module, a member alias, a named address, or a type parameter, in
+            // which case the full-qualification fix above is the only one.
+            let Some(import_info) = module_import_info(mod_ident, info) else {
                 continue;
             };
             let prefix_edit = TextEdit {

--- a/external-crates/move/crates/move-analyzer/src/code_action.rs
+++ b/external-crates/move/crates/move-analyzer/src/code_action.rs
@@ -37,7 +37,7 @@ use move_compiler::{
     expansion::ast::ModuleIdent,
     linters::LintLevel,
     parser::ast::{LeadingNameAccess_, NameAccessChain_},
-    shared::{Identifier, Name, ide::AliasAutocompleteInfo},
+    shared::{Identifier, Name},
 };
 use move_package_alt::MoveFlavor;
 
@@ -389,11 +389,9 @@ fn single_element_function_autofixes<I, K>(
     else {
         return;
     };
-    let info = symbols
+    let info_opt = symbols
         .compiler_autocomplete_info
-        .get_path_autocomplete_info(&unbound_name.loc)
-        .cloned()
-        .unwrap_or_else(AliasAutocompleteInfo::new);
+        .get_path_autocomplete_info(&unbound_name.loc);
     for (mod_ident, mod_functions) in mod_functions {
         for function_name in mod_functions {
             if function_name != unbound_name.value {
@@ -422,6 +420,12 @@ fn single_element_function_autofixes<I, K>(
             ));
 
             // Then offer the Move-style fix: import the module and qualify the call through it.
+            // Without alias info recorded at this location we cannot tell whether the module
+            // is already imported (possibly under a different name), and inserting an import
+            // blindly could create a duplicate or conflicting `use`, so offer nothing more.
+            let Some(info) = info_opt else {
+                continue;
+            };
             // `module_import_info` returns `None` if the module name is already bound to a
             // different module, in which case the full-qualification fix above is the only one.
             let Some(import_info) = module_import_info(mod_ident, &info.modules) else {

--- a/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
@@ -15,7 +15,7 @@
 use crate::{
     completions::utils::{
         PRIMITIVE_TYPE_COMPLETIONS, addr_to_ide_string, call_completion_item, completion_item,
-        import_insertion_info, mod_defs,
+        import_insertion_info, mod_defs, module_import_info,
     },
     symbols::{
         Symbols,
@@ -175,6 +175,7 @@ pub fn name_chain_completions(
                 symbols,
                 cursor,
                 &info.members,
+                &info.modules,
                 chain_kind,
                 import_insertion_info_opt,
             ));
@@ -651,6 +652,7 @@ fn all_single_name_member_completions(
     symbols: &Symbols,
     cursor: &CursorContext,
     members_info: &BTreeMap<(ModuleIdent, Symbol), BTreeSet<Symbol>>,
+    modules_info: &BTreeMap<Symbol, ModuleIdent>,
     chain_kind: ChainCompletionKind,
     import_insertion_info_opt: Option<AutoImportInsertionInfo>,
 ) -> Vec<CompletionItem> {
@@ -673,8 +675,30 @@ fn all_single_name_member_completions(
     }
     // member auto-imports
     if let Some(auto_import_pos) = import_insertion_info_opt {
-        let all_mod_members = all_mod_functions_to_import(symbols, cursor)
-            .chain(all_mod_structs_to_import(symbols, cursor))
+        // Functions follow Move style by importing the module and qualifying the inserted call.
+        for (mod_ident, import_functions) in all_mod_functions_to_import(symbols, cursor) {
+            let Some(mod_defs) = mod_defs(symbols, &mod_ident.value) else {
+                continue;
+            };
+            for function_name in import_functions {
+                // exclude functions that are already imported
+                if members_info.contains_key(&(mod_ident, function_name)) {
+                    continue;
+                }
+                let function_imports = function_auto_imports_with_module_import(
+                    symbols,
+                    cursor,
+                    mod_defs,
+                    &function_name,
+                    modules_info,
+                    chain_kind,
+                    auto_import_pos,
+                );
+                completions.extend(function_imports);
+            }
+        }
+
+        let all_mod_members = all_mod_structs_to_import(symbols, cursor)
             .chain(all_mod_enums_to_import(symbols, cursor))
             .chain(all_mod_consts_to_import(symbols, cursor));
         for (mod_ident, import_members) in all_mod_members {
@@ -700,6 +724,41 @@ fn all_single_name_member_completions(
     }
 
     completions
+}
+
+/// Returns function auto-import completions that follow module-qualified call style.
+/// For `with_def`, when completing `with_defining_ids`, the algorithm should end up with
+/// auto-completed `type_name::with_defining_ids()` and auto-inserted `use std::type_name;`.
+fn function_auto_imports_with_module_import(
+    symbols: &Symbols,
+    cursor: &CursorContext,
+    mod_defs: &ModuleDefs,
+    function_name: &Symbol,
+    modules_info: &BTreeMap<Symbol, ModuleIdent>,
+    chain_kind: ChainCompletionKind,
+    auto_import_pos: AutoImportInsertionInfo,
+) -> Vec<CompletionItem> {
+    let mod_ident = sp(mod_defs.name_loc, mod_defs.ident);
+    let Some(import_info) = module_import_info(mod_ident, modules_info) else {
+        return vec![];
+    };
+    let mut function_completions = single_name_member_completion(
+        symbols,
+        cursor,
+        mod_defs,
+        function_name,
+        function_name,
+        chain_kind,
+    );
+    function_completions.iter_mut().for_each(|item| {
+        if let Some(insert_text) = item.insert_text.as_mut() {
+            *insert_text = format!("{}::{}", import_info.module_prefix, insert_text);
+        }
+        if let Some(import_text) = import_info.import_text.clone() {
+            add_auto_import_to_completion_item(item, import_text, auto_import_pos);
+        }
+    });
+    function_completions
 }
 
 /// Returns list of completion items that represent module members

--- a/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
@@ -689,6 +689,19 @@ fn all_single_name_member_completions(
             let Some(mod_defs) = mod_defs(symbols, &mod_ident.value) else {
                 continue;
             };
+            // The import info only depends on the module - compute it once for all of its
+            // functions. If importing the module would conflict with a name already in
+            // scope, fall back to a fully qualified call, which stays closest to the
+            // module-qualified style and makes the conflict visible at the use site.
+            let import_info = module_import_info(sp(mod_defs.name_loc, mod_defs.ident), info)
+                .unwrap_or_else(|| ModuleImportInfo {
+                    module_prefix: format!(
+                        "{}::{}",
+                        addr_to_ide_string(&mod_defs.ident.address),
+                        mod_defs.ident.module
+                    ),
+                    import_text: None,
+                });
             for function_name in import_functions {
                 // exclude functions that are already imported
                 if info.members.contains_key(&(mod_ident, function_name)) {
@@ -699,7 +712,7 @@ fn all_single_name_member_completions(
                     cursor,
                     mod_defs,
                     &function_name,
-                    info,
+                    &import_info,
                     chain_kind,
                     auto_import_pos,
                 );
@@ -744,25 +757,10 @@ fn function_auto_imports_with_module_import(
     cursor: &CursorContext,
     mod_defs: &ModuleDefs,
     function_name: &Symbol,
-    info: &AliasAutocompleteInfo,
+    import_info: &ModuleImportInfo,
     chain_kind: ChainCompletionKind,
     auto_import_pos: AutoImportInsertionInfo,
 ) -> Vec<CompletionItem> {
-    let mod_ident = sp(mod_defs.name_loc, mod_defs.ident);
-    let import_info = match module_import_info(mod_ident, info) {
-        Some(import_info) => import_info,
-        None => ModuleImportInfo {
-            // If importing the module would conflict with a name already in scope, fall back
-            // to a fully qualified call, which stays closest to the module-qualified style
-            // and makes the conflict visible at the use site.
-            module_prefix: format!(
-                "{}::{}",
-                addr_to_ide_string(&mod_ident.value.address),
-                mod_ident.value.module
-            ),
-            import_text: None,
-        },
-    };
     let mut function_completions = single_name_member_completion(
         symbols,
         cursor,

--- a/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/name_chain.rs
@@ -14,8 +14,8 @@
 
 use crate::{
     completions::utils::{
-        PRIMITIVE_TYPE_COMPLETIONS, addr_to_ide_string, call_completion_item, completion_item,
-        import_insertion_info, mod_defs, module_import_info,
+        ModuleImportInfo, PRIMITIVE_TYPE_COMPLETIONS, addr_to_ide_string, call_completion_item,
+        completion_item, import_insertion_info, mod_defs, module_import_info, name_taken_in_scope,
     },
     symbols::{
         Symbols,
@@ -34,7 +34,7 @@ use move_compiler::{
 };
 use move_ir_types::location::{Loc, sp};
 use move_symbol_pool::Symbol;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use super::utils::{
     all_mod_consts_to_import, all_mod_enums_to_import, all_mod_functions_to_import,
@@ -143,30 +143,41 @@ pub fn name_chain_completions(
             );
             // module auto-imports
             if let Some(import_insertion_info) = import_insertion_info_opt {
-                let in_scope_modules = info
-                    .modules
-                    .values()
-                    .map(|sp!(_, mi)| mi)
-                    .collect::<BTreeSet<_>>();
-                for mod_ident in symbols.file_mods.values().flatten().map(|mdef| &mdef.ident) {
-                    // exclude modules that are already imported
-                    if in_scope_modules.contains(&mod_ident) {
-                        continue;
-                    }
+                for mod_defs in symbols.file_mods.values().flatten() {
+                    let mod_ident = sp(mod_defs.name_loc, mod_defs.ident);
                     let mut item = completion_item(
-                        mod_ident.module.value().as_str(),
+                        mod_defs.ident.module.value().as_str(),
                         CompletionItemKind::MODULE,
                     );
-                    let auto_import_text = format!(
-                        "use {}::{}",
-                        addr_to_ide_string(&mod_ident.address),
-                        mod_ident.module
-                    );
-                    add_auto_import_to_completion_item(
-                        &mut item,
-                        auto_import_text,
-                        import_insertion_info,
-                    );
+                    match module_import_info(mod_ident, &info) {
+                        Some(import_info) => {
+                            let Some(import_text) = import_info.import_text else {
+                                // the module is already in scope and has been offered
+                                // as a completion under its (aliased) name already
+                                continue;
+                            };
+                            add_auto_import_to_completion_item(
+                                &mut item,
+                                import_text,
+                                import_insertion_info,
+                            );
+                        }
+                        None => {
+                            // Importing the module would conflict with a name already in
+                            // scope; fall back to inserting a fully qualified module path,
+                            // which also makes the conflict visible at the use site.
+                            let qualified_module = format!(
+                                "{}::{}",
+                                addr_to_ide_string(&mod_defs.ident.address),
+                                mod_defs.ident.module
+                            );
+                            set_completion_item_detail(
+                                &mut item,
+                                format!("({})", qualified_module),
+                            );
+                            item.insert_text = Some(qualified_module);
+                        }
+                    }
                     completions.push(item);
                 }
             }
@@ -174,8 +185,7 @@ pub fn name_chain_completions(
             completions.extend(all_single_name_member_completions(
                 symbols,
                 cursor,
-                &info.members,
-                &info.modules,
+                &info,
                 chain_kind,
                 import_insertion_info_opt,
             ));
@@ -651,13 +661,12 @@ fn single_name_member_completion(
 fn all_single_name_member_completions(
     symbols: &Symbols,
     cursor: &CursorContext,
-    members_info: &BTreeMap<(ModuleIdent, Symbol), BTreeSet<Symbol>>,
-    modules_info: &BTreeMap<Symbol, ModuleIdent>,
+    info: &AliasAutocompleteInfo,
     chain_kind: ChainCompletionKind,
     import_insertion_info_opt: Option<AutoImportInsertionInfo>,
 ) -> Vec<CompletionItem> {
     let mut completions = vec![];
-    for ((sp!(_, mod_ident), member_name), member_aliases) in members_info {
+    for ((sp!(_, mod_ident), member_name), member_aliases) in &info.members {
         let Some(mod_defs) = mod_defs(symbols, mod_ident) else {
             return completions;
         };
@@ -682,7 +691,7 @@ fn all_single_name_member_completions(
             };
             for function_name in import_functions {
                 // exclude functions that are already imported
-                if members_info.contains_key(&(mod_ident, function_name)) {
+                if info.members.contains_key(&(mod_ident, function_name)) {
                     continue;
                 }
                 let function_imports = function_auto_imports_with_module_import(
@@ -690,7 +699,7 @@ fn all_single_name_member_completions(
                     cursor,
                     mod_defs,
                     &function_name,
-                    modules_info,
+                    info,
                     chain_kind,
                     auto_import_pos,
                 );
@@ -707,7 +716,7 @@ fn all_single_name_member_completions(
             };
             for member_name in import_members {
                 // exclude members that are already imported
-                if members_info.contains_key(&(mod_ident, member_name)) {
+                if info.members.contains_key(&(mod_ident, member_name)) {
                     continue;
                 }
                 let member_imports = member_auto_imports(
@@ -715,6 +724,7 @@ fn all_single_name_member_completions(
                     cursor,
                     mod_defs,
                     &member_name,
+                    info,
                     chain_kind,
                     auto_import_pos,
                 );
@@ -734,13 +744,24 @@ fn function_auto_imports_with_module_import(
     cursor: &CursorContext,
     mod_defs: &ModuleDefs,
     function_name: &Symbol,
-    modules_info: &BTreeMap<Symbol, ModuleIdent>,
+    info: &AliasAutocompleteInfo,
     chain_kind: ChainCompletionKind,
     auto_import_pos: AutoImportInsertionInfo,
 ) -> Vec<CompletionItem> {
     let mod_ident = sp(mod_defs.name_loc, mod_defs.ident);
-    let Some(import_info) = module_import_info(mod_ident, modules_info) else {
-        return vec![];
+    let import_info = match module_import_info(mod_ident, info) {
+        Some(import_info) => import_info,
+        None => ModuleImportInfo {
+            // If importing the module would conflict with a name already in scope, fall back
+            // to a fully qualified call, which stays closest to the module-qualified style
+            // and makes the conflict visible at the use site.
+            module_prefix: format!(
+                "{}::{}",
+                addr_to_ide_string(&mod_ident.value.address),
+                mod_ident.value.module
+            ),
+            import_text: None,
+        },
     };
     let mut function_completions = single_name_member_completion(
         symbols,
@@ -770,6 +791,7 @@ fn member_auto_imports(
     cursor: &CursorContext,
     mod_defs: &ModuleDefs,
     member_name: &Symbol,
+    info: &AliasAutocompleteInfo,
     chain_kind: ChainCompletionKind,
     auto_import_pos: AutoImportInsertionInfo,
 ) -> Vec<CompletionItem> {
@@ -782,15 +804,29 @@ fn member_auto_imports(
         chain_kind,
     );
     let mod_ident = mod_defs.ident;
-    member_completions.iter_mut().for_each(|item| {
-        let auto_import_text = format!(
-            "use {}::{}::{}",
-            addr_to_ide_string(&mod_ident.address),
-            mod_ident.module,
-            member_name,
-        );
-        add_auto_import_to_completion_item(item, auto_import_text, auto_import_pos);
-    });
+    let module_qualifier = format!(
+        "{}::{}",
+        addr_to_ide_string(&mod_ident.address),
+        mod_ident.module,
+    );
+    if name_taken_in_scope(info, *member_name) {
+        // Importing the member would conflict with a name already in scope (e.g., a
+        // same-named member from another module); fall back to inserting a fully
+        // qualified path, which also makes the conflict visible at the use site.
+        member_completions.iter_mut().for_each(|item| {
+            let insert_text = item
+                .insert_text
+                .clone()
+                .unwrap_or_else(|| item.label.clone());
+            item.insert_text = Some(format!("{}::{}", module_qualifier, insert_text));
+            set_completion_item_detail(item, format!("({}::{})", module_qualifier, member_name));
+        });
+    } else {
+        member_completions.iter_mut().for_each(|item| {
+            let auto_import_text = format!("use {}::{}", module_qualifier, member_name);
+            add_auto_import_to_completion_item(item, auto_import_text, auto_import_pos);
+        });
+    }
     member_completions
 }
 
@@ -820,21 +856,27 @@ fn member_completions_with_module_import(
     member_completions
 }
 
+/// Annotates a completion item with a detail displayed next to its label
+/// on the completion list.
+fn set_completion_item_detail(item: &mut CompletionItem, detail: String) {
+    if let Some(ref mut d) = item.label_details {
+        d.detail = Some(detail.clone());
+    } else {
+        item.label_details = Some(CompletionItemLabelDetails {
+            detail: Some(detail.clone()),
+            description: None,
+        });
+    }
+    item.detail = Some(detail);
+}
+
 /// Adds additional edit to a completion item at a given position
 fn add_auto_import_to_completion_item(
     item: &mut CompletionItem,
     import_text: String,
     import_insertion_info: AutoImportInsertionInfo,
 ) {
-    if let Some(ref mut d) = item.label_details {
-        d.detail = Some(format!("({})", import_text));
-    } else {
-        item.label_details = Some(CompletionItemLabelDetails {
-            detail: Some(format!("({})", import_text)),
-            description: None,
-        });
-    }
-    item.detail = Some(format!("({})", import_text));
+    set_completion_item_detail(item, format!("({})", import_text));
     item.additional_text_edits = Some(vec![auto_import_text_edit(
         import_text,
         import_insertion_info,
@@ -1030,8 +1072,10 @@ fn imports_for_name_chain_entry(
         let P::LeadingNameAccess_::Name(name) = leading_name.value else {
             return;
         };
-        // If the prefix already resolves to a module, regular member completion covers this chain.
-        if info.modules.contains_key(&name.value) {
+        // If the prefix already resolves to a module, regular member completion covers this
+        // chain. If its name is taken by anything else, a module import would conflict, and
+        // there is nothing sensible to offer for the already-typed prefix.
+        if name_taken_in_scope(info, name.value) {
             return;
         }
         for mod_defs in symbols.file_mods.values().flatten() {

--- a/external-crates/move/crates/move-analyzer/src/completions/utils.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/utils.rs
@@ -22,12 +22,12 @@ use move_compiler::{
     expansion::ast::{Address, ModuleIdent, ModuleIdent_, Visibility},
     naming::ast::{Type, TypeInner},
     parser::keywords::PRIMITIVE_TYPES,
-    shared::{Identifier, Name},
+    shared::{Identifier, Name, ide::AliasAutocompleteInfo},
 };
 use move_ir_types::location::sp;
 use move_symbol_pool::Symbol;
 
-use std::{collections::BTreeMap, path::PathBuf, sync::LazyLock};
+use std::{path::PathBuf, sync::LazyLock};
 
 /// Describes how a module should be referenced from an auto-imported completion or quick fix.
 pub struct ModuleImportInfo {
@@ -102,13 +102,34 @@ pub fn auto_import_text_edit(
     }
 }
 
+/// Checks if a name is already bound in scope to a module, a member alias, a named
+/// address, or a type parameter. Inserting an import with such a name would either
+/// produce a duplicate-alias error (same-scope aliases) or silently shadow the
+/// existing binding for the rest of the module (named addresses, as modules and
+/// addresses share the leading-name namespace).
+///
+/// The member alias check is conservative: only struct and enum aliases share the
+/// leading-name namespace, but alias info does not carry the member kind, so all
+/// member aliases are treated as conflicts (the cost is falling back to a fully
+/// qualified fix or completion).
+pub fn name_taken_in_scope(info: &AliasAutocompleteInfo, name: Symbol) -> bool {
+    info.modules.contains_key(&name)
+        || info.addresses.contains_key(&name)
+        || info.type_params.contains(&name)
+        || info
+            .members
+            .values()
+            .flatten()
+            .any(|member_alias| *member_alias == name)
+}
+
 /// Computes a module prefix and optional module import for a target module.
-/// Returns `None` if importing the module would conflict with an existing module alias.
+/// Returns `None` if importing the module would conflict with a name already in scope.
 pub fn module_import_info(
     mod_ident: ModuleIdent,
-    in_scope_modules: &BTreeMap<Symbol, ModuleIdent>,
+    info: &AliasAutocompleteInfo,
 ) -> Option<ModuleImportInfo> {
-    for (alias, in_scope_mod_ident) in in_scope_modules {
+    for (alias, in_scope_mod_ident) in &info.modules {
         if in_scope_mod_ident.value == mod_ident.value {
             return Some(ModuleImportInfo {
                 module_prefix: alias.to_string(),
@@ -118,7 +139,7 @@ pub fn module_import_info(
     }
 
     let module_name = mod_ident.value.module.value();
-    if in_scope_modules.contains_key(&module_name) {
+    if name_taken_in_scope(info, module_name) {
         return None;
     }
 

--- a/external-crates/move/crates/move-analyzer/src/completions/utils.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/utils.rs
@@ -22,12 +22,20 @@ use move_compiler::{
     expansion::ast::{Address, ModuleIdent, ModuleIdent_, Visibility},
     naming::ast::{Type, TypeInner},
     parser::keywords::PRIMITIVE_TYPES,
-    shared::Name,
+    shared::{Identifier, Name},
 };
 use move_ir_types::location::sp;
 use move_symbol_pool::Symbol;
 
-use std::{path::PathBuf, sync::LazyLock};
+use std::{collections::BTreeMap, path::PathBuf, sync::LazyLock};
+
+/// Describes how a module should be referenced from an auto-imported completion or quick fix.
+pub struct ModuleImportInfo {
+    /// Prefix to insert at the use site, usually the module name or an existing alias.
+    pub module_prefix: String,
+    /// Import to insert for the module, or `None` if the module is already in scope.
+    pub import_text: Option<String>,
+}
 
 /// List of completion items of Move's primitive types.
 pub static PRIMITIVE_TYPE_COMPLETIONS: LazyLock<Vec<CompletionItem>> = LazyLock::new(|| {
@@ -92,6 +100,36 @@ pub fn auto_import_text_edit(
             ),
         },
     }
+}
+
+/// Computes a module prefix and optional module import for a target module.
+/// Returns `None` if importing the module would conflict with an existing module alias.
+pub fn module_import_info(
+    mod_ident: ModuleIdent,
+    in_scope_modules: &BTreeMap<Symbol, ModuleIdent>,
+) -> Option<ModuleImportInfo> {
+    for (alias, in_scope_mod_ident) in in_scope_modules {
+        if in_scope_mod_ident.value == mod_ident.value {
+            return Some(ModuleImportInfo {
+                module_prefix: alias.to_string(),
+                import_text: None,
+            });
+        }
+    }
+
+    let module_name = mod_ident.value.module.value();
+    if in_scope_modules.contains_key(&module_name) {
+        return None;
+    }
+
+    Some(ModuleImportInfo {
+        module_prefix: module_name.to_string(),
+        import_text: Some(format!(
+            "use {}::{}",
+            addr_to_ide_string(&mod_ident.value.address),
+            mod_ident.value.module,
+        )),
+    })
 }
 
 /// Returns an iterator over module identifiers and function names defined in these modules.

--- a/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
@@ -109,7 +109,7 @@ pub struct CompiledPkgInfo {
     /// Compiler analysis info
     pub compiler_analysis_info: CompilerAnalysisInfo,
     /// Compiler autocomplete info
-    pub compiler_autocomplete_info: Option<CompilerAutocompleteInfo>,
+    pub compiler_autocomplete_info: Option<Arc<CompilerAutocompleteInfo>>,
     /// IDE diagnostics related to the package
     pub lsp_diags: Arc<BTreeMap<PathBuf, Vec<Diagnostic>>>,
 }
@@ -751,15 +751,16 @@ pub fn get_compiled_pkg<F: MoveFlavor>(
                 // Filter autocomplete info based on cursor file
                 // - If cursor_file_opt is None: no autocomplete needed, use empty info
                 // - If cursor_file_opt is Some: only keep autocomplete info for that file
-                compiler_autocomplete_info_opt = Some(if let Some(cursor_file) = cursor_file_opt {
-                    filter_autocomplete_for_file(
-                        autocomplete_info,
-                        cursor_file,
-                        mapped_files_data.files.file_name_mapping(),
-                    )
-                } else {
-                    CompilerAutocompleteInfo::new()
-                });
+                compiler_autocomplete_info_opt =
+                    Some(Arc::new(if let Some(cursor_file) = cursor_file_opt {
+                        filter_autocomplete_for_file(
+                            autocomplete_info,
+                            cursor_file,
+                            mapped_files_data.files.file_name_mapping(),
+                        )
+                    } else {
+                        CompilerAutocompleteInfo::new()
+                    }));
                 // compile to CFGIR for accurate diags
                 eprintln!("compiling to CFGIR");
                 let compilation_result = compiler.at_typing(typed_program).run::<PASS_CFGIR>();

--- a/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
@@ -129,7 +129,7 @@ pub struct Symbols {
     /// Additional information about definitions
     pub def_info: DefMap,
     /// IDE Autocomplete Information from the Compiler
-    pub compiler_autocomplete_info: CompilerAutocompleteInfo,
+    pub compiler_autocomplete_info: Arc<CompilerAutocompleteInfo>,
     /// Cursor information gathered up during analysis
     pub cursor_context: Option<CursorContext>,
 }
@@ -727,7 +727,7 @@ pub fn empty_symbols() -> Symbols {
         mod_parsing_info: BTreeMap::new(),
         def_info: BTreeMap::new(),
         files: MappedFiles::empty(),
-        compiler_autocomplete_info: CompilerAutocompleteInfo::new(),
+        compiler_autocomplete_info: Arc::new(CompilerAutocompleteInfo::new()),
         cursor_context: None,
     }
 }

--- a/external-crates/move/crates/move-analyzer/tests/autofix/sources/function_import_convention.move
+++ b/external-crates/move/crates/move-analyzer/tests/autofix/sources/function_import_convention.move
@@ -1,0 +1,25 @@
+module Autofix::function_import_convention {
+
+    // Function quick fixes should import the module and qualify the function call.
+    fun function_quick_fix(): Autofix::dep::PubStruct {
+        create_struct()
+    }
+
+    // Type quick fixes should keep direct member imports.
+    fun type_quick_fix(_s: PubStruct) {
+    }
+
+    // If the function's module is already imported under an alias, quick fixes should use it.
+    fun function_quick_fix_with_alias(): d::PubStruct {
+        use Autofix::dep as d;
+
+        create_struct()
+    }
+
+    // If the target module name is already taken, quick fixes should not add a conflicting import.
+    fun function_quick_fix_with_conflict(): Autofix::dep::PubStruct {
+        use Autofix::another_dep as dep;
+
+        create_struct()
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/autofix/sources/function_import_convention.move
+++ b/external-crates/move/crates/move-analyzer/tests/autofix/sources/function_import_convention.move
@@ -10,7 +10,7 @@ module Autofix::function_import_convention {
     }
 
     // If the function's module is already imported under an alias, quick fixes should use it.
-    fun function_quick_fix_with_alias(): d::PubStruct {
+    fun function_quick_fix_with_alias(): Autofix::dep::PubStruct {
         use Autofix::dep as d;
 
         create_struct()
@@ -21,5 +21,13 @@ module Autofix::function_import_convention {
         use Autofix::another_dep as dep;
 
         create_struct()
+    }
+
+    // If the target module's name is taken by a member alias, quick fixes should not
+    // add a conflicting import.
+    fun function_quick_fix_with_member_alias_conflict() {
+        use Autofix::another_dep::AnotherDepStruct as UpperDep;
+
+        create_upper();
     }
 }

--- a/external-crates/move/crates/move-analyzer/tests/autofix/sources/upper_dep.move
+++ b/external-crates/move/crates/move-analyzer/tests/autofix/sources/upper_dep.move
@@ -1,0 +1,9 @@
+module Autofix::UpperDep {
+
+    public struct UpperDepStruct has copy, drop {
+    }
+
+    public fun create_upper(): UpperDepStruct {
+        UpperDepStruct { }
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.ide
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.ide
@@ -49,6 +49,12 @@
           "err_line": 23,
           "err_col": 9,
           "err_msg": "Unbound function 'create_struct' in current scope"
+        },
+        // member aliases taking the module's name also prevent module-import quick fixes
+        {
+          "err_line": 31,
+          "err_col": 9,
+          "err_msg": "Unbound function 'create_upper' in current scope"
         }
       ]
     }

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.ide
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.ide
@@ -24,6 +24,32 @@
           "err_col": 29,
           "err_msg": "Could not resolve the name 'another_dep'"
         }
+      ],
+      "function_import_convention.move": [
+        // functions are fixed by importing the module and qualifying the call
+        {
+          "err_line": 5,
+          "err_col": 9,
+          "err_msg": "Unbound function 'create_struct' in current scope"
+        },
+        // types are fixed by importing the type directly
+        {
+          "err_line": 9,
+          "err_col": 28,
+          "err_msg": "Unbound type 'PubStruct' in current scope"
+        },
+        // existing module aliases are used to qualify function calls
+        {
+          "err_line": 16,
+          "err_col": 9,
+          "err_msg": "Unbound function 'create_struct' in current scope"
+        },
+        // conflicting module names prevent module-import quick fixes
+        {
+          "err_line": 23,
+          "err_col": 9,
+          "err_msg": "Unbound function 'create_struct' in current scope"
+        }
       ]
     }
   }

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.snap
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.snap
@@ -4,13 +4,48 @@ source: crates/move-analyzer/tests/ide_testsuite.rs
 == colon_colon.move ========================================================
 -- test 0 -------------------
 CODE ACTION: Qualify as `Autofix::dep::PubStruct`
+    EDIT: 'Autofix::dep::'
 CODE ACTION: Import as `Autofix::dep::PubStruct`
+    EDIT: '
+    use Autofix::dep::PubStruct;'
 -- test 1 -------------------
 CODE ACTION: Qualify as `Autofix::dep::create_struct`
-CODE ACTION: Import as `Autofix::dep::create_struct`
+    EDIT: 'Autofix::dep::'
+CODE ACTION: Qualify as `dep::create_struct`
+    EDIT: 'dep::'
 -- test 2 -------------------
 CODE ACTION: Qualify as `Autofix::another_dep`
+    EDIT: 'Autofix::'
 CODE ACTION: Import as `Autofix::another_dep`
+    EDIT: '
+    use Autofix::another_dep;'
 -- test 3 -------------------
 CODE ACTION: Qualify as `Autofix::another_dep::AnotherDepStruct`
+    EDIT: 'Autofix::'
 CODE ACTION: Import `Autofix::another_dep` for `another_dep::AnotherDepStruct`
+    EDIT: '
+    use Autofix::another_dep;'
+== function_import_convention.move ========================================================
+-- test 0 -------------------
+CODE ACTION: Qualify as `Autofix::dep::create_struct`
+    EDIT: 'Autofix::dep::'
+CODE ACTION: Import `Autofix::dep` and use `dep::create_struct`
+    EDIT: 'dep::'
+    EDIT: 'use Autofix::dep;
+
+    '
+-- test 1 -------------------
+CODE ACTION: Qualify as `Autofix::dep::PubStruct`
+    EDIT: 'Autofix::dep::'
+CODE ACTION: Import as `Autofix::dep::PubStruct`
+    EDIT: 'use Autofix::dep::PubStruct;
+
+    '
+-- test 2 -------------------
+CODE ACTION: Qualify as `Autofix::dep::create_struct`
+    EDIT: 'Autofix::dep::'
+CODE ACTION: Qualify as `d::create_struct`
+    EDIT: 'd::'
+-- test 3 -------------------
+CODE ACTION: Qualify as `Autofix::dep::create_struct`
+    EDIT: 'Autofix::dep::'

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.snap
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_autofix.snap
@@ -49,3 +49,6 @@ CODE ACTION: Qualify as `d::create_struct`
 -- test 3 -------------------
 CODE ACTION: Qualify as `Autofix::dep::create_struct`
     EDIT: 'Autofix::dep::'
+-- test 4 -------------------
+CODE ACTION: Qualify as `Autofix::UpperDep::create_upper`
+    EDIT: 'Autofix::UpperDep::'

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_import.ide
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_import.ide
@@ -33,6 +33,18 @@
           "use_line": 10,
           "use_col": 23
         }
+      ],
+      "function_import_convention.move": [
+        // functions are imported through their module and inserted as module-qualified calls
+        {
+          "use_line": 5,
+          "use_col": 9
+        },
+        // types are imported directly and inserted unqualified
+        {
+          "use_line": 10,
+          "use_col": 17
+        }
       ]
     }
   }

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_import.snap
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_import.snap
@@ -14,6 +14,10 @@ Module 'another_dep'
     TARGET     : '(use Import::another_dep)'
     ADDITIONAL EDIT: '
     use Import::another_dep;'
+Module 'function_import_convention'
+    TARGET     : '(use Import::function_import_convention)'
+    ADDITIONAL EDIT: '
+    use Import::function_import_convention;'
 Module 'Import'
     TARGET     : '(use Import::Import)'
     ADDITIONAL EDIT: '
@@ -39,23 +43,17 @@ Method 'foo()'
     TARGET     : '(Import::colon_colon::foo)'
     TYPE       : 'fun ()'
 Method 'bar()'
-    INSERT TEXT: 'bar()'
-    TARGET     : '(use Import::dep::bar)'
+    INSERT TEXT: 'dep::bar()'
+    TARGET     : '(Import::dep::bar)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: '
-    use Import::dep::bar;'
 Method 'pkg_fun()'
-    INSERT TEXT: 'pkg_fun()'
-    TARGET     : '(use Import::dep::pkg_fun)'
+    INSERT TEXT: 'dep::pkg_fun()'
+    TARGET     : '(Import::dep::pkg_fun)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: '
-    use Import::dep::pkg_fun;'
 Method 'pub_fun()'
-    INSERT TEXT: 'pub_fun()'
-    TARGET     : '(use Import::dep::pub_fun)'
+    INSERT TEXT: 'dep::pub_fun()'
+    TARGET     : '(Import::dep::pub_fun)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: '
-    use Import::dep::pub_fun;'
 Struct 'AnotherDepStruct'
     TARGET     : '(use Import::another_dep::AnotherDepStruct)'
     ADDITIONAL EDIT: '
@@ -120,6 +118,11 @@ Module 'colon_colon'
     ADDITIONAL EDIT: 'use Import::colon_colon;
 
     '
+Module 'function_import_convention'
+    TARGET     : '(use Import::function_import_convention)'
+    ADDITIONAL EDIT: 'use Import::function_import_convention;
+
+    '
 Module 'Import'
     TARGET     : '(use Import::Import)'
     ADDITIONAL EDIT: 'use Import::Import;
@@ -160,6 +163,158 @@ Struct 'SomeStruct'
 
     '
 
+== function_import_convention.move ========================================================
+-- test 0 -------------------
+use line: 5, use_col: 9
+Unit '0xCAFE'
+Unit '0xCAFE2'
+Unit 'Import'
+Unit 'SamePkgAddr'
+Module 'Self'
+Module 'another_dep'
+    TARGET     : '(use Import::another_dep)'
+    ADDITIONAL EDIT: 'use Import::another_dep;
+
+    '
+Module 'colon_colon'
+    TARGET     : '(use Import::colon_colon)'
+    ADDITIONAL EDIT: 'use Import::colon_colon;
+
+    '
+Module 'dep'
+    TARGET     : '(use Import::dep)'
+    ADDITIONAL EDIT: 'use Import::dep;
+
+    '
+Module 'Import'
+    TARGET     : '(use Import::Import)'
+    ADDITIONAL EDIT: 'use Import::Import;
+
+    '
+Module 'empty'
+    TARGET     : '(use SamePkgAddr::empty)'
+    ADDITIONAL EDIT: 'use SamePkgAddr::empty;
+
+    '
+Method 'function_auto_import()'
+    INSERT TEXT: 'function_auto_import()'
+    TARGET     : '(Import::function_import_convention::function_auto_import)'
+    TYPE       : 'fun ()'
+Method 'type_auto_import()'
+    INSERT TEXT: 'type_auto_import()'
+    TARGET     : '(Import::function_import_convention::type_auto_import)'
+    TYPE       : 'fun ()'
+Method 'foo()'
+    INSERT TEXT: 'colon_colon::foo()'
+    TARGET     : '(use Import::colon_colon)'
+    TYPE       : 'fun ()'
+    ADDITIONAL EDIT: 'use Import::colon_colon;
+
+    '
+Method 'bar()'
+    INSERT TEXT: 'dep::bar()'
+    TARGET     : '(use Import::dep)'
+    TYPE       : 'fun ()'
+    ADDITIONAL EDIT: 'use Import::dep;
+
+    '
+Method 'pkg_fun()'
+    INSERT TEXT: 'dep::pkg_fun()'
+    TARGET     : '(use Import::dep)'
+    TYPE       : 'fun ()'
+    ADDITIONAL EDIT: 'use Import::dep;
+
+    '
+Method 'pub_fun()'
+    INSERT TEXT: 'dep::pub_fun()'
+    TARGET     : '(use Import::dep)'
+    TYPE       : 'fun ()'
+    ADDITIONAL EDIT: 'use Import::dep;
+
+    '
+Struct 'AnotherDepStruct'
+    TARGET     : '(use Import::another_dep::AnotherDepStruct)'
+    ADDITIONAL EDIT: 'use Import::another_dep::AnotherDepStruct;
+
+    '
+Struct 'PubStruct'
+    TARGET     : '(use Import::dep::PubStruct)'
+    ADDITIONAL EDIT: 'use Import::dep::PubStruct;
+
+    '
+Struct 'SomeStruct'
+    TARGET     : '(use Import::Import::SomeStruct)'
+    ADDITIONAL EDIT: 'use Import::Import::SomeStruct;
+
+    '
+Enum 'PubEnum'
+    TARGET     : '(use Import::dep::PubEnum)'
+    ADDITIONAL EDIT: 'use Import::dep::PubEnum;
+
+    '
+
+-- test 1 -------------------
+use line: 10, use_col: 17
+Unit '0xCAFE'
+Unit '0xCAFE2'
+Unit 'Import'
+Unit 'SamePkgAddr'
+Module 'Self'
+Module 'another_dep'
+    TARGET     : '(use Import::another_dep)'
+    ADDITIONAL EDIT: 'use Import::another_dep;
+
+    '
+Module 'colon_colon'
+    TARGET     : '(use Import::colon_colon)'
+    ADDITIONAL EDIT: 'use Import::colon_colon;
+
+    '
+Module 'dep'
+    TARGET     : '(use Import::dep)'
+    ADDITIONAL EDIT: 'use Import::dep;
+
+    '
+Module 'Import'
+    TARGET     : '(use Import::Import)'
+    ADDITIONAL EDIT: 'use Import::Import;
+
+    '
+Module 'empty'
+    TARGET     : '(use SamePkgAddr::empty)'
+    ADDITIONAL EDIT: 'use SamePkgAddr::empty;
+
+    '
+Struct 'AnotherDepStruct'
+    TARGET     : '(use Import::another_dep::AnotherDepStruct)'
+    ADDITIONAL EDIT: 'use Import::another_dep::AnotherDepStruct;
+
+    '
+Struct 'PubStruct'
+    TARGET     : '(use Import::dep::PubStruct)'
+    ADDITIONAL EDIT: 'use Import::dep::PubStruct;
+
+    '
+Struct 'SomeStruct'
+    TARGET     : '(use Import::Import::SomeStruct)'
+    ADDITIONAL EDIT: 'use Import::Import::SomeStruct;
+
+    '
+Enum 'PubEnum'
+    TARGET     : '(use Import::dep::PubEnum)'
+    ADDITIONAL EDIT: 'use Import::dep::PubEnum;
+
+    '
+Keyword 'u8'
+Keyword 'u16'
+Keyword 'u32'
+Keyword 'u64'
+Keyword 'u128'
+Keyword 'u256'
+Keyword 'bool'
+Keyword 'vector'
+Keyword 'address'
+
 == import.move ========================================================
 -- test 0 -------------------
 use line: 10, use_col: 23
@@ -167,6 +322,7 @@ Module 'Import'
 Module 'another_dep'
 Module 'colon_colon'
 Module 'dep'
+Module 'function_import_convention'
 Struct 'SomeStruct'
     TARGET     : '(use Import::Import)'
     ADDITIONAL EDIT: 'use Import::Import;

--- a/external-crates/move/crates/move-analyzer/tests/colon_colon_import.snap
+++ b/external-crates/move/crates/move-analyzer/tests/colon_colon_import.snap
@@ -19,9 +19,8 @@ Module 'function_import_convention'
     ADDITIONAL EDIT: '
     use Import::function_import_convention;'
 Module 'Import'
-    TARGET     : '(use Import::Import)'
-    ADDITIONAL EDIT: '
-    use Import::Import;'
+    INSERT TEXT: 'Import::Import'
+    TARGET     : '(Import::Import)'
 Module 'empty'
     TARGET     : '(use SamePkgAddr::empty)'
     ADDITIONAL EDIT: '
@@ -124,10 +123,8 @@ Module 'function_import_convention'
 
     '
 Module 'Import'
-    TARGET     : '(use Import::Import)'
-    ADDITIONAL EDIT: 'use Import::Import;
-
-    '
+    INSERT TEXT: 'Import::Import'
+    TARGET     : '(Import::Import)'
 Module 'empty'
     TARGET     : '(use SamePkgAddr::empty)'
     ADDITIONAL EDIT: 'use SamePkgAddr::empty;
@@ -187,10 +184,8 @@ Module 'dep'
 
     '
 Module 'Import'
-    TARGET     : '(use Import::Import)'
-    ADDITIONAL EDIT: 'use Import::Import;
-
-    '
+    INSERT TEXT: 'Import::Import'
+    TARGET     : '(Import::Import)'
 Module 'empty'
     TARGET     : '(use SamePkgAddr::empty)'
     ADDITIONAL EDIT: 'use SamePkgAddr::empty;
@@ -276,10 +271,8 @@ Module 'dep'
 
     '
 Module 'Import'
-    TARGET     : '(use Import::Import)'
-    ADDITIONAL EDIT: 'use Import::Import;
-
-    '
+    INSERT TEXT: 'Import::Import'
+    TARGET     : '(Import::Import)'
 Module 'empty'
     TARGET     : '(use SamePkgAddr::empty)'
     ADDITIONAL EDIT: 'use SamePkgAddr::empty;
@@ -323,8 +316,3 @@ Module 'another_dep'
 Module 'colon_colon'
 Module 'dep'
 Module 'function_import_convention'
-Struct 'SomeStruct'
-    TARGET     : '(use Import::Import)'
-    ADDITIONAL EDIT: 'use Import::Import;
-
-    '

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -396,6 +396,15 @@ impl AccessChainQuickFixTest {
         );
         for action in code_actions {
             writeln!(output, "CODE ACTION: {}", action.title)?;
+            if let Some(edit) = action.edit
+                && let Some(changes) = edit.changes
+            {
+                for text_edits in changes.values() {
+                    for text_edit in text_edits {
+                        writeln!(output, "    EDIT: '{}'", text_edit.new_text)?;
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -721,6 +730,32 @@ fn test_symbols_for_autocomplete<F: MoveFlavor + Default>(
     Ok(symbols)
 }
 
+/// Compute symbols for code-action tests with autocomplete information for the target file.
+/// The code-action test computes the exact cursor position separately for each diagnostic.
+fn test_symbols_for_code_action<F: MoveFlavor + Default>(
+    packages_info: Arc<Mutex<CachedPackages>>,
+    ide_files_root: VfsPath,
+    project_path: PathBuf,
+    cursor_path: &PathBuf,
+) -> anyhow::Result<(CompiledPkgInfo, Symbols)> {
+    let move_flavor = Arc::new(F::default());
+    let (compiled_pkg_info_opt, _) = get_compiled_pkg::<F>(
+        packages_info.clone(),
+        ide_files_root,
+        project_path.as_path(),
+        LintLevel::None,
+        move_flavor,
+        Some(Flavor::Sui),
+        Some(cursor_path),
+    )?;
+
+    let compiled_pkg_info =
+        compiled_pkg_info_opt.ok_or_else(|| anyhow::anyhow!("PACKAGE COMPILATION FAILED"))?;
+    let symbols = compute_symbols(packages_info, compiled_pkg_info.clone(), None);
+
+    Ok((compiled_pkg_info, symbols))
+}
+
 fn use_def_test_suite<F: MoveFlavor + Default>(
     project: String,
     file_tests: BTreeMap<String, Vec<UseDefTest>>,
@@ -988,14 +1023,6 @@ fn access_chain_quick_fix_test_suite<F: MoveFlavor + Default>(
     let packages_info = Arc::new(Mutex::new(CachedPackages::new()));
     let ide_files_root: VfsPath = MemoryFS::new().into();
 
-    // Compile once at suite level
-    let (mut compiled_pkg_info, mut symbols) = test_symbols_with_optional_modifications::<F>(
-        packages_info.clone(),
-        ide_files_root.clone(),
-        project_path.clone(),
-        None,
-    )?;
-
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
 
@@ -1009,6 +1036,16 @@ fn access_chain_quick_fix_test_suite<F: MoveFlavor + Default>(
 
         fpath.push(format!("sources/{file}"));
         let cpath = canonicalize_path(fpath.clone());
+
+        // Compile per file to get autocomplete/alias info for that file. The exact cursor position
+        // is computed later for each diagnostic triggerring a quick fix action, so it does not
+        // need to happen per test.
+        let (mut compiled_pkg_info, mut symbols) = test_symbols_for_code_action::<F>(
+            packages_info.clone(),
+            ide_files_root.clone(),
+            project_path.clone(),
+            &cpath,
+        )?;
 
         for (idx, test) in tests.iter().enumerate() {
             test.test(idx, &mut compiled_pkg_info, &mut symbols, writer, &cpath)?;

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -598,12 +598,12 @@ fn completion_test<F: MoveFlavor + Default>(
 
     // Generate fresh symbols with cursor position using shared cache
     let cursor_path = use_file_path.to_path_buf();
-    let symbols = test_symbols_for_autocomplete::<F>(
+    let (_, symbols) = test_symbols_with_cursor::<F>(
         packages_info,
         ide_files_root,
         project_path.to_path_buf(),
         &cursor_path,
-        use_pos,
+        Some(use_pos),
     )?;
 
     let items = compute_completions_with_symbols(&symbols, &cursor_path, use_pos, auto_import);
@@ -695,16 +695,16 @@ fn test_symbols_with_optional_modifications<F: MoveFlavor + Default>(
     Ok((compiled_pkg_info, symbols))
 }
 
-/// Compute symbols for a specific cursor position in autocomplete tests.
-/// This generates fresh CompilerAutocompleteInfo for the cursor position
-/// while leveraging cached CompilerAnalysisInfo and dependencies.
-fn test_symbols_for_autocomplete<F: MoveFlavor + Default>(
+/// Compute symbols for a specific cursor position needed by tests that use autocomplete
+/// information for the target file. This generates fresh CompilerAutocompleteInfo for
+/// the cursor position while leveraging cached CompilerAnalysisInfo and dependencies.
+fn test_symbols_with_cursor<F: MoveFlavor + Default>(
     packages_info: Arc<Mutex<CachedPackages>>,
     ide_files_root: VfsPath,
     project_path: PathBuf,
     cursor_path: &PathBuf,
-    cursor_pos: Position,
-) -> anyhow::Result<Symbols> {
+    cursor_pos: Option<Position>,
+) -> anyhow::Result<(CompiledPkgInfo, Symbols)> {
     let move_flavor = Arc::new(F::default());
     // Single compilation with cursor position (no retry loop)
     let (compiled_pkg_info_opt, _) = get_compiled_pkg::<F>(
@@ -719,39 +719,11 @@ fn test_symbols_for_autocomplete<F: MoveFlavor + Default>(
 
     let compiled_pkg_info =
         compiled_pkg_info_opt.ok_or_else(|| anyhow::anyhow!("PACKAGE COMPILATION FAILED"))?;
-
-    // Compute symbols with cursor position
     let symbols = compute_symbols(
         packages_info,
-        compiled_pkg_info,
-        Some((cursor_path, cursor_pos)),
+        compiled_pkg_info.clone(),
+        cursor_pos.map(|pos| (cursor_path, pos)),
     );
-
-    Ok(symbols)
-}
-
-/// Compute symbols for code-action tests with autocomplete information for the target file.
-/// The code-action test computes the exact cursor position separately for each diagnostic.
-fn test_symbols_for_code_action<F: MoveFlavor + Default>(
-    packages_info: Arc<Mutex<CachedPackages>>,
-    ide_files_root: VfsPath,
-    project_path: PathBuf,
-    cursor_path: &PathBuf,
-) -> anyhow::Result<(CompiledPkgInfo, Symbols)> {
-    let move_flavor = Arc::new(F::default());
-    let (compiled_pkg_info_opt, _) = get_compiled_pkg::<F>(
-        packages_info.clone(),
-        ide_files_root,
-        project_path.as_path(),
-        LintLevel::None,
-        move_flavor,
-        Some(Flavor::Sui),
-        Some(cursor_path),
-    )?;
-
-    let compiled_pkg_info =
-        compiled_pkg_info_opt.ok_or_else(|| anyhow::anyhow!("PACKAGE COMPILATION FAILED"))?;
-    let symbols = compute_symbols(packages_info, compiled_pkg_info.clone(), None);
 
     Ok((compiled_pkg_info, symbols))
 }
@@ -1038,13 +1010,14 @@ fn access_chain_quick_fix_test_suite<F: MoveFlavor + Default>(
         let cpath = canonicalize_path(fpath.clone());
 
         // Compile per file to get autocomplete/alias info for that file. The exact cursor position
-        // is computed later for each diagnostic triggerring a quick fix action, so it does not
+        // is computed later for each diagnostic triggering a quick fix action, so it does not
         // need to happen per test.
-        let (mut compiled_pkg_info, mut symbols) = test_symbols_for_code_action::<F>(
+        let (mut compiled_pkg_info, mut symbols) = test_symbols_with_cursor::<F>(
             packages_info.clone(),
             ide_files_root.clone(),
             project_path.clone(),
             &cpath,
+            None,
         )?;
 
         for (idx, test) in tests.iter().enumerate() {

--- a/external-crates/move/crates/move-analyzer/tests/import-conflict/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/import-conflict/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ImportConflict"
+edition = "2024.beta"
+
+[addresses]
+ImportConflict = "0xCAFE3"

--- a/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/another_dep.move
+++ b/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/another_dep.move
@@ -1,0 +1,5 @@
+module ImportConflict::another_dep {
+
+    public struct AnotherDepStruct {
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/conflict.move
+++ b/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/conflict.move
@@ -1,0 +1,30 @@
+// Tests auto-imports whose inserted name would conflict with a name already in
+// scope (another alias or a named address): no `use` is inserted, and completions
+// fall back to fully qualified paths.
+module ImportConflict::conflict {
+
+    fun member_alias_conflict() {
+        use ImportConflict::another_dep::AnotherDepStruct as UpperDep;
+
+        pub
+    }
+
+    // Same conflict, but with a module alias taking the name.
+    fun module_alias_conflict() {
+        use ImportConflict::another_dep as UpperDep;
+
+        pub
+    }
+
+    // The name of an auto-imported type is taken by another member alias.
+    fun member_name_conflict() {
+        use ImportConflict::another_dep::AnotherDepStruct as UpperDepStruct;
+
+        let _s: Upper
+    }
+
+    // The name of module `ImportConflict` is taken by the package address.
+    fun address_conflict() {
+        pub
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/import_conflict_mod.move
+++ b/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/import_conflict_mod.move
@@ -1,0 +1,7 @@
+// A module whose name is the same as the package's named address (as in `sui::sui`):
+// importing it would silently shadow the address for the rest of the module.
+module ImportConflict::ImportConflict {
+
+    public fun pub_pkg() {
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/upper_dep.move
+++ b/external-crates/move/crates/move-analyzer/tests/import-conflict/sources/upper_dep.move
@@ -1,0 +1,10 @@
+// A module whose name can be taken by a member alias (member aliases must start
+// with 'A'..'Z', so only an upper-case module name can conflict with one).
+module ImportConflict::UpperDep {
+
+    public struct UpperDepStruct {
+    }
+
+    public fun pub_upper() {
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/import/sources/function_import_convention.move
+++ b/external-crates/move/crates/move-analyzer/tests/import/sources/function_import_convention.move
@@ -1,0 +1,12 @@
+module Import::function_import_convention {
+
+    // Function auto-imports should import the module and qualify the inserted call.
+    fun function_auto_import() {
+        pub
+    }
+
+    // Type auto-imports should still import the type directly and leave the use site unqualified.
+    fun type_auto_import() {
+        let _s: Pub
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/import_conflict.ide
+++ b/external-crates/move/crates/move-analyzer/tests/import_conflict.ide
@@ -1,0 +1,33 @@
+// Tests auto-import completions when a module's name is taken by a member alias
+{
+  "AutoImport": {
+    "project": "tests/import-conflict",
+    "file_tests": {
+      "conflict.move": [
+        // module and function auto-imports fall back to fully qualified paths instead
+        // of inserting a module import conflicting with the member alias
+        {
+          "use_line": 9,
+          "use_col": 9
+        },
+        // same fallback when the module's name is taken by a module alias
+        {
+          "use_line": 16,
+          "use_col": 9
+        },
+        // type auto-imports fall back to fully qualified paths when the type's name
+        // is taken by another member alias
+        {
+          "use_line": 23,
+          "use_col": 17
+        },
+        // module and function auto-imports fall back to fully qualified paths when
+        // the module's name is taken by a named address
+        {
+          "use_line": 28,
+          "use_col": 9
+        }
+      ]
+    }
+  }
+}

--- a/external-crates/move/crates/move-analyzer/tests/import_conflict.snap
+++ b/external-crates/move/crates/move-analyzer/tests/import_conflict.snap
@@ -1,0 +1,185 @@
+---
+source: crates/move-analyzer/tests/ide_testsuite.rs
+---
+== conflict.move ========================================================
+-- test 0 -------------------
+use line: 9, use_col: 9
+Unit '0xCAFE3'
+Unit 'ImportConflict'
+Module 'Self'
+Module 'another_dep'
+    TARGET     : '(use ImportConflict::another_dep)'
+    ADDITIONAL EDIT: 'use ImportConflict::another_dep;
+
+    '
+Module 'ImportConflict'
+    INSERT TEXT: 'ImportConflict::ImportConflict'
+    TARGET     : '(ImportConflict::ImportConflict)'
+Module 'UpperDep'
+    INSERT TEXT: 'ImportConflict::UpperDep'
+    TARGET     : '(ImportConflict::UpperDep)'
+Struct 'UpperDep'
+Method 'address_conflict()'
+    INSERT TEXT: 'address_conflict()'
+    TARGET     : '(ImportConflict::conflict::address_conflict)'
+    TYPE       : 'fun ()'
+Method 'member_alias_conflict()'
+    INSERT TEXT: 'member_alias_conflict()'
+    TARGET     : '(ImportConflict::conflict::member_alias_conflict)'
+    TYPE       : 'fun ()'
+Method 'member_name_conflict()'
+    INSERT TEXT: 'member_name_conflict()'
+    TARGET     : '(ImportConflict::conflict::member_name_conflict)'
+    TYPE       : 'fun ()'
+Method 'module_alias_conflict()'
+    INSERT TEXT: 'module_alias_conflict()'
+    TARGET     : '(ImportConflict::conflict::module_alias_conflict)'
+    TYPE       : 'fun ()'
+Method 'pub_pkg()'
+    INSERT TEXT: 'ImportConflict::ImportConflict::pub_pkg()'
+    TARGET     : '(ImportConflict::ImportConflict::pub_pkg)'
+    TYPE       : 'fun ()'
+Method 'pub_upper()'
+    INSERT TEXT: 'ImportConflict::UpperDep::pub_upper()'
+    TARGET     : '(ImportConflict::UpperDep::pub_upper)'
+    TYPE       : 'fun ()'
+Struct 'UpperDepStruct'
+    TARGET     : '(use ImportConflict::UpperDep::UpperDepStruct)'
+    ADDITIONAL EDIT: 'use ImportConflict::UpperDep::UpperDepStruct;
+
+    '
+
+-- test 1 -------------------
+use line: 16, use_col: 9
+Unit '0xCAFE3'
+Unit 'ImportConflict'
+Module 'Self'
+Module 'UpperDep'
+Module 'ImportConflict'
+    INSERT TEXT: 'ImportConflict::ImportConflict'
+    TARGET     : '(ImportConflict::ImportConflict)'
+Module 'UpperDep'
+    INSERT TEXT: 'ImportConflict::UpperDep'
+    TARGET     : '(ImportConflict::UpperDep)'
+Method 'address_conflict()'
+    INSERT TEXT: 'address_conflict()'
+    TARGET     : '(ImportConflict::conflict::address_conflict)'
+    TYPE       : 'fun ()'
+Method 'member_alias_conflict()'
+    INSERT TEXT: 'member_alias_conflict()'
+    TARGET     : '(ImportConflict::conflict::member_alias_conflict)'
+    TYPE       : 'fun ()'
+Method 'member_name_conflict()'
+    INSERT TEXT: 'member_name_conflict()'
+    TARGET     : '(ImportConflict::conflict::member_name_conflict)'
+    TYPE       : 'fun ()'
+Method 'module_alias_conflict()'
+    INSERT TEXT: 'module_alias_conflict()'
+    TARGET     : '(ImportConflict::conflict::module_alias_conflict)'
+    TYPE       : 'fun ()'
+Method 'pub_pkg()'
+    INSERT TEXT: 'ImportConflict::ImportConflict::pub_pkg()'
+    TARGET     : '(ImportConflict::ImportConflict::pub_pkg)'
+    TYPE       : 'fun ()'
+Method 'pub_upper()'
+    INSERT TEXT: 'ImportConflict::UpperDep::pub_upper()'
+    TARGET     : '(ImportConflict::UpperDep::pub_upper)'
+    TYPE       : 'fun ()'
+Struct 'AnotherDepStruct'
+    TARGET     : '(use ImportConflict::another_dep::AnotherDepStruct)'
+    ADDITIONAL EDIT: 'use ImportConflict::another_dep::AnotherDepStruct;
+
+    '
+Struct 'UpperDepStruct'
+    TARGET     : '(use ImportConflict::UpperDep::UpperDepStruct)'
+    ADDITIONAL EDIT: 'use ImportConflict::UpperDep::UpperDepStruct;
+
+    '
+
+-- test 2 -------------------
+use line: 23, use_col: 17
+Unit '0xCAFE3'
+Unit 'ImportConflict'
+Module 'Self'
+Module 'another_dep'
+    TARGET     : '(use ImportConflict::another_dep)'
+    ADDITIONAL EDIT: 'use ImportConflict::another_dep;
+
+    '
+Module 'ImportConflict'
+    INSERT TEXT: 'ImportConflict::ImportConflict'
+    TARGET     : '(ImportConflict::ImportConflict)'
+Module 'UpperDep'
+    TARGET     : '(use ImportConflict::UpperDep)'
+    ADDITIONAL EDIT: 'use ImportConflict::UpperDep;
+
+    '
+Struct 'UpperDepStruct'
+Struct 'UpperDepStruct'
+    INSERT TEXT: 'ImportConflict::UpperDep::UpperDepStruct'
+    TARGET     : '(ImportConflict::UpperDep::UpperDepStruct)'
+Keyword 'u8'
+Keyword 'u16'
+Keyword 'u32'
+Keyword 'u64'
+Keyword 'u128'
+Keyword 'u256'
+Keyword 'bool'
+Keyword 'vector'
+Keyword 'address'
+
+-- test 3 -------------------
+use line: 28, use_col: 9
+Unit '0xCAFE3'
+Unit 'ImportConflict'
+Module 'Self'
+Module 'another_dep'
+    TARGET     : '(use ImportConflict::another_dep)'
+    ADDITIONAL EDIT: 'use ImportConflict::another_dep;
+
+    '
+Module 'ImportConflict'
+    INSERT TEXT: 'ImportConflict::ImportConflict'
+    TARGET     : '(ImportConflict::ImportConflict)'
+Module 'UpperDep'
+    TARGET     : '(use ImportConflict::UpperDep)'
+    ADDITIONAL EDIT: 'use ImportConflict::UpperDep;
+
+    '
+Method 'address_conflict()'
+    INSERT TEXT: 'address_conflict()'
+    TARGET     : '(ImportConflict::conflict::address_conflict)'
+    TYPE       : 'fun ()'
+Method 'member_alias_conflict()'
+    INSERT TEXT: 'member_alias_conflict()'
+    TARGET     : '(ImportConflict::conflict::member_alias_conflict)'
+    TYPE       : 'fun ()'
+Method 'member_name_conflict()'
+    INSERT TEXT: 'member_name_conflict()'
+    TARGET     : '(ImportConflict::conflict::member_name_conflict)'
+    TYPE       : 'fun ()'
+Method 'module_alias_conflict()'
+    INSERT TEXT: 'module_alias_conflict()'
+    TARGET     : '(ImportConflict::conflict::module_alias_conflict)'
+    TYPE       : 'fun ()'
+Method 'pub_pkg()'
+    INSERT TEXT: 'ImportConflict::ImportConflict::pub_pkg()'
+    TARGET     : '(ImportConflict::ImportConflict::pub_pkg)'
+    TYPE       : 'fun ()'
+Method 'pub_upper()'
+    INSERT TEXT: 'UpperDep::pub_upper()'
+    TARGET     : '(use ImportConflict::UpperDep)'
+    TYPE       : 'fun ()'
+    ADDITIONAL EDIT: 'use ImportConflict::UpperDep;
+
+    '
+Struct 'AnotherDepStruct'
+    TARGET     : '(use ImportConflict::another_dep::AnotherDepStruct)'
+    ADDITIONAL EDIT: 'use ImportConflict::another_dep::AnotherDepStruct;
+
+    '
+Struct 'UpperDepStruct'
+    TARGET     : '(use ImportConflict::UpperDep::UpperDepStruct)'
+    ADDITIONAL EDIT: 'use ImportConflict::UpperDep::UpperDepStruct;
+
+    '

--- a/external-crates/move/crates/move-analyzer/tests/module_ext_completion.snap
+++ b/external-crates/move/crates/move-analyzer/tests/module_ext_completion.snap
@@ -267,2084 +267,1853 @@ Method 'int_match_function()'
     TARGET     : '(Enums::int_match::int_match_function)'
     TYPE       : 'fun (u64)'
 Method 'bam()'
-    INSERT TEXT: 'bam()'
-    TARGET     : '(use Enums::int_match::bam)'
+    INSERT TEXT: 'int_match::bam()'
+    TARGET     : '(use Enums::int_match)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use Enums::int_match::bam;
+    ADDITIONAL EDIT: 'use Enums::int_match;
 
     '
 Method 'bam()'
-    INSERT TEXT: 'bam()'
-    TARGET     : '(use Enums::int_match::bam)'
+    INSERT TEXT: 'int_match::bam()'
+    TARGET     : '(use Enums::int_match)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use Enums::int_match::bam;
+    ADDITIONAL EDIT: 'use Enums::int_match;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length()'
-    TARGET     : '(use std::address::length)'
+    INSERT TEXT: 'address::length()'
+    TARGET     : '(use std::address)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::address::length;
+    ADDITIONAL EDIT: 'use std::address;
 
     '
 Method 'all_characters_printable()'
-    INSERT TEXT: 'all_characters_printable(${1:string})'
-    TARGET     : '(use std::ascii::all_characters_printable)'
+    INSERT TEXT: 'ascii::all_characters_printable(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::ascii::all_characters_printable;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'append()'
-    INSERT TEXT: 'append(${1:string}, ${2:other})'
-    TARGET     : '(use std::ascii::append)'
+    INSERT TEXT: 'ascii::append(${1:string}, ${2:other})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, String)'
-    ADDITIONAL EDIT: 'use std::ascii::append;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'as_bytes()'
-    INSERT TEXT: 'as_bytes(${1:string})'
-    TARGET     : '(use std::ascii::as_bytes)'
+    INSERT TEXT: 'ascii::as_bytes(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::ascii::as_bytes;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'byte()'
-    INSERT TEXT: 'byte(${1:char})'
-    TARGET     : '(use std::ascii::byte)'
+    INSERT TEXT: 'ascii::byte(${1:char})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (Char): u8'
-    ADDITIONAL EDIT: 'use std::ascii::byte;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'char()'
-    INSERT TEXT: 'char(${1:byte})'
-    TARGET     : '(use std::ascii::char)'
+    INSERT TEXT: 'ascii::char(${1:byte})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): Char'
-    ADDITIONAL EDIT: 'use std::ascii::char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:string}, ${2:substr})'
-    TARGET     : '(use std::ascii::index_of)'
+    INSERT TEXT: 'ascii::index_of(${1:string}, ${2:substr})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String, &String): u64'
-    ADDITIONAL EDIT: 'use std::ascii::index_of;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:s}, ${2:at}, ${3:o})'
-    TARGET     : '(use std::ascii::insert)'
+    INSERT TEXT: 'ascii::insert(${1:s}, ${2:at}, ${3:o})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, u64, String)'
-    ADDITIONAL EDIT: 'use std::ascii::insert;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'into_bytes()'
-    INSERT TEXT: 'into_bytes(${1:string})'
-    TARGET     : '(use std::ascii::into_bytes)'
+    INSERT TEXT: 'ascii::into_bytes(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (String): vector<u8>'
-    ADDITIONAL EDIT: 'use std::ascii::into_bytes;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:string})'
-    TARGET     : '(use std::ascii::is_empty)'
+    INSERT TEXT: 'ascii::is_empty(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_empty;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_printable_char()'
-    INSERT TEXT: 'is_printable_char(${1:byte})'
-    TARGET     : '(use std::ascii::is_printable_char)'
+    INSERT TEXT: 'ascii::is_printable_char(${1:byte})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_printable_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_valid_char()'
-    INSERT TEXT: 'is_valid_char(${1:b})'
-    TARGET     : '(use std::ascii::is_valid_char)'
+    INSERT TEXT: 'ascii::is_valid_char(${1:b})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_valid_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:string})'
-    TARGET     : '(use std::ascii::length)'
+    INSERT TEXT: 'ascii::length(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): u64'
-    ADDITIONAL EDIT: 'use std::ascii::length;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'pop_char()'
-    INSERT TEXT: 'pop_char(${1:string})'
-    TARGET     : '(use std::ascii::pop_char)'
+    INSERT TEXT: 'ascii::pop_char(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String): Char'
-    ADDITIONAL EDIT: 'use std::ascii::pop_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'push_char()'
-    INSERT TEXT: 'push_char(${1:string}, ${2:char})'
-    TARGET     : '(use std::ascii::push_char)'
+    INSERT TEXT: 'ascii::push_char(${1:string}, ${2:char})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, Char)'
-    ADDITIONAL EDIT: 'use std::ascii::push_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'string()'
-    INSERT TEXT: 'string(${1:bytes})'
-    TARGET     : '(use std::ascii::string)'
+    INSERT TEXT: 'ascii::string(${1:bytes})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (vector<u8>): String'
-    ADDITIONAL EDIT: 'use std::ascii::string;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'substring()'
-    INSERT TEXT: 'substring(${1:string}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::ascii::substring)'
+    INSERT TEXT: 'ascii::substring(${1:string}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::ascii::substring;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_lowercase()'
-    INSERT TEXT: 'to_lowercase(${1:string})'
-    TARGET     : '(use std::ascii::to_lowercase)'
+    INSERT TEXT: 'ascii::to_lowercase(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): String'
-    ADDITIONAL EDIT: 'use std::ascii::to_lowercase;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_uppercase()'
-    INSERT TEXT: 'to_uppercase(${1:string})'
-    TARGET     : '(use std::ascii::to_uppercase)'
+    INSERT TEXT: 'ascii::to_uppercase(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): String'
-    ADDITIONAL EDIT: 'use std::ascii::to_uppercase;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'try_string()'
-    INSERT TEXT: 'try_string(${1:bytes})'
-    TARGET     : '(use std::ascii::try_string)'
+    INSERT TEXT: 'ascii::try_string(${1:bytes})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (vector<u8>): Option'
-    ADDITIONAL EDIT: 'use std::ascii::try_string;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_bytes()'
-    INSERT TEXT: 'to_bytes(${1:v})'
-    TARGET     : '(use std::bcs::to_bytes)'
+    INSERT TEXT: 'bcs::to_bytes(${1:v})'
+    TARGET     : '(use std::bcs)'
     TYPE       : 'fun <MoveValue>(&MoveValue): vector<u8>'
-    ADDITIONAL EDIT: 'use std::bcs::to_bytes;
+    ADDITIONAL EDIT: 'use std::bcs;
 
     '
 Method 'is_index_set()'
-    INSERT TEXT: 'is_index_set(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::is_index_set)'
+    INSERT TEXT: 'bit_vector::is_index_set(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector, u64): bool'
-    ADDITIONAL EDIT: 'use std::bit_vector::is_index_set;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:bitvector})'
-    TARGET     : '(use std::bit_vector::length)'
+    INSERT TEXT: 'bit_vector::length(${1:bitvector})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::length;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'longest_set_sequence_starting_at()'
-    INSERT TEXT: 'longest_set_sequence_starting_at(${1:bitvector}, ${2:start_index})'
-    TARGET     : '(use std::bit_vector::longest_set_sequence_starting_at)'
+    INSERT TEXT: 'bit_vector::longest_set_sequence_starting_at(${1:bitvector}, ${2:start_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector, u64): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::longest_set_sequence_starting_at;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'new()'
-    INSERT TEXT: 'new(${1:length})'
-    TARGET     : '(use std::bit_vector::new)'
+    INSERT TEXT: 'bit_vector::new(${1:length})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (u64): BitVector'
-    ADDITIONAL EDIT: 'use std::bit_vector::new;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'set()'
-    INSERT TEXT: 'set(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::set)'
+    INSERT TEXT: 'bit_vector::set(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::set;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'shift_left()'
-    INSERT TEXT: 'shift_left(${1:bitvector}, ${2:amount})'
-    TARGET     : '(use std::bit_vector::shift_left)'
+    INSERT TEXT: 'bit_vector::shift_left(${1:bitvector}, ${2:amount})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::shift_left;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'unset()'
-    INSERT TEXT: 'unset(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::unset)'
+    INSERT TEXT: 'bit_vector::unset(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::unset;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'word_size()'
-    INSERT TEXT: 'word_size()'
-    TARGET     : '(use std::bit_vector::word_size)'
+    INSERT TEXT: 'bit_vector::word_size()'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::word_size;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'print()'
-    INSERT TEXT: 'print(${1:x})'
-    TARGET     : '(use std::debug::print)'
+    INSERT TEXT: 'debug::print(${1:x})'
+    TARGET     : '(use std::debug)'
     TYPE       : 'fun <T>(&T)'
-    ADDITIONAL EDIT: 'use std::debug::print;
+    ADDITIONAL EDIT: 'use std::debug;
 
     '
 Method 'print_stack_trace()'
-    INSERT TEXT: 'print_stack_trace()'
-    TARGET     : '(use std::debug::print_stack_trace)'
+    INSERT TEXT: 'debug::print_stack_trace()'
+    TARGET     : '(use std::debug)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: 'use std::debug::print_stack_trace;
+    ADDITIONAL EDIT: 'use std::debug;
 
     '
 Method 'create_from_rational()'
-    INSERT TEXT: 'create_from_rational(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::fixed_point32::create_from_rational)'
+    INSERT TEXT: 'fixed_point32::create_from_rational(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, u64): FixedPoint32'
-    ADDITIONAL EDIT: 'use std::fixed_point32::create_from_rational;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'create_from_raw_value()'
-    INSERT TEXT: 'create_from_raw_value(${1:value})'
-    TARGET     : '(use std::fixed_point32::create_from_raw_value)'
+    INSERT TEXT: 'fixed_point32::create_from_raw_value(${1:value})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64): FixedPoint32'
-    ADDITIONAL EDIT: 'use std::fixed_point32::create_from_raw_value;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'divide_u64()'
-    INSERT TEXT: 'divide_u64(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::fixed_point32::divide_u64)'
+    INSERT TEXT: 'fixed_point32::divide_u64(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::divide_u64;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'get_raw_value()'
-    INSERT TEXT: 'get_raw_value(${1:num})'
-    TARGET     : '(use std::fixed_point32::get_raw_value)'
+    INSERT TEXT: 'fixed_point32::get_raw_value(${1:num})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::get_raw_value;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'is_zero()'
-    INSERT TEXT: 'is_zero(${1:num})'
-    TARGET     : '(use std::fixed_point32::is_zero)'
+    INSERT TEXT: 'fixed_point32::is_zero(${1:num})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (FixedPoint32): bool'
-    ADDITIONAL EDIT: 'use std::fixed_point32::is_zero;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'multiply_u64()'
-    INSERT TEXT: 'multiply_u64(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::fixed_point32::multiply_u64)'
+    INSERT TEXT: 'fixed_point32::multiply_u64(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::multiply_u64;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'sha2_256()'
-    INSERT TEXT: 'sha2_256(${1:data})'
-    TARGET     : '(use std::hash::sha2_256)'
+    INSERT TEXT: 'hash::sha2_256(${1:data})'
+    TARGET     : '(use std::hash)'
     TYPE       : 'fun (vector<u8>): vector<u8>'
-    ADDITIONAL EDIT: 'use std::hash::sha2_256;
+    ADDITIONAL EDIT: 'use std::hash;
 
     '
 Method 'sha3_256()'
-    INSERT TEXT: 'sha3_256(${1:data})'
-    TARGET     : '(use std::hash::sha3_256)'
+    INSERT TEXT: 'hash::sha3_256(${1:data})'
+    TARGET     : '(use std::hash)'
     TYPE       : 'fun (vector<u8>): vector<u8>'
-    ADDITIONAL EDIT: 'use std::hash::sha3_256;
+    ADDITIONAL EDIT: 'use std::hash;
 
     '
 Method 'permit()'
-    INSERT TEXT: 'permit()'
-    TARGET     : '(use std::internal::permit)'
+    INSERT TEXT: 'internal::permit()'
+    TARGET     : '(internal::permit)'
     TYPE       : 'fun <T>(): Permit'
-    ADDITIONAL EDIT: 'use std::internal::permit;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::macros::do)'
+    INSERT TEXT: 'macros::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::do;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::macros::do_eq)'
+    INSERT TEXT: 'macros::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::do_eq;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_diff!()'
-    INSERT TEXT: 'num_diff!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_diff)'
+    INSERT TEXT: 'macros::num_diff!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_diff;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_divide_and_round_up!()'
-    INSERT TEXT: 'num_divide_and_round_up!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_divide_and_round_up)'
+    INSERT TEXT: 'macros::num_divide_and_round_up!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_max!()'
-    INSERT TEXT: 'num_max!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_max)'
+    INSERT TEXT: 'macros::num_max!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_max;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_min!()'
-    INSERT TEXT: 'num_min!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_min)'
+    INSERT TEXT: 'macros::num_min!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_min;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_pow!()'
-    INSERT TEXT: 'num_pow!(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::macros::num_pow)'
+    INSERT TEXT: 'macros::num_pow!(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_, u8): _'
-    ADDITIONAL EDIT: 'use std::macros::num_pow;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_sqrt!()'
-    INSERT TEXT: 'num_sqrt!(${1:x}, ${2:bitsize})'
-    TARGET     : '(use std::macros::num_sqrt)'
+    INSERT TEXT: 'macros::num_sqrt!(${1:x}, ${2:bitsize})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, u8): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_sqrt;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_to_string!()'
-    INSERT TEXT: 'num_to_string!(${1:x})'
-    TARGET     : '(use std::macros::num_to_string)'
+    INSERT TEXT: 'macros::num_to_string!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): String'
-    ADDITIONAL EDIT: 'use std::macros::num_to_string;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::macros::range_do)'
+    INSERT TEXT: 'macros::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, $T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::range_do;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::macros::range_do_eq)'
+    INSERT TEXT: 'macros::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, $T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::range_do_eq;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u128!()'
-    INSERT TEXT: 'try_as_u128!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u128)'
+    INSERT TEXT: 'macros::try_as_u128!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u128;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u16!()'
-    INSERT TEXT: 'try_as_u16!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u16)'
+    INSERT TEXT: 'macros::try_as_u16!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u16;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u32!()'
-    INSERT TEXT: 'try_as_u32!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u32)'
+    INSERT TEXT: 'macros::try_as_u32!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u32;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u64!()'
-    INSERT TEXT: 'try_as_u64!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u64)'
+    INSERT TEXT: 'macros::try_as_u64!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u64;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u8!()'
-    INSERT TEXT: 'try_as_u8!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u8)'
+    INSERT TEXT: 'macros::try_as_u8!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u8;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_add!()'
-    INSERT TEXT: 'uq_add!(${1:a}, ${2:b}, ${3:max_t}, ${4:abort_overflow})'
-    TARGET     : '(use std::macros::uq_add)'
+    INSERT TEXT: 'macros::uq_add!(${1:a}, ${2:b}, ${3:max_t}, ${4:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_add;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_from_int!()'
-    INSERT TEXT: 'uq_from_int!(${1:integer}, ${2:fractional_bits})'
-    TARGET     : '(use std::macros::uq_from_int)'
+    INSERT TEXT: 'macros::uq_from_int!(${1:integer}, ${2:fractional_bits})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, u8): $U'
-    ADDITIONAL EDIT: 'use std::macros::uq_from_int;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_from_quotient!()'
-    INSERT TEXT: 'uq_from_quotient!(${1:numerator}, ${2:denominator}, ${3:max_t}, ${4:t_bits}, ${5:fractional_bits}, ${6:abort_denominator}, ${7:abort_quotient_too_small}, ${8:abort_quotient_too_large})'
-    TARGET     : '(use std::macros::uq_from_quotient)'
+    INSERT TEXT: 'macros::uq_from_quotient!(${1:numerator}, ${2:denominator}, ${3:max_t}, ${4:t_bits}, ${5:fractional_bits}, ${6:abort_denominator}, ${7:abort_quotient_too_small}, ${8:abort_quotient_too_large})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, u8, _, _, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_from_quotient;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_int_div!()'
-    INSERT TEXT: 'uq_int_div!(${1:val}, ${2:divisor}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_division_by_zero}, ${6:abort_overflow})'
-    TARGET     : '(use std::macros::uq_int_div)'
+    INSERT TEXT: 'macros::uq_int_div!(${1:val}, ${2:divisor}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_division_by_zero}, ${6:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, _, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_int_div;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_int_mul!()'
-    INSERT TEXT: 'uq_int_mul!(${1:val}, ${2:multiplier}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_overflow})'
-    TARGET     : '(use std::macros::uq_int_mul)'
+    INSERT TEXT: 'macros::uq_int_mul!(${1:val}, ${2:multiplier}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_int_mul;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_sub!()'
-    INSERT TEXT: 'uq_sub!(${1:a}, ${2:b}, ${3:abort_overflow})'
-    TARGET     : '(use std::macros::uq_sub)'
+    INSERT TEXT: 'macros::uq_sub!(${1:a}, ${2:b}, ${3:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_sub;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_to_int!()'
-    INSERT TEXT: 'uq_to_int!(${1:a}, ${2:fractional_bits})'
-    TARGET     : '(use std::macros::uq_to_int)'
+    INSERT TEXT: 'macros::uq_to_int!(${1:a}, ${2:fractional_bits})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($U, u8): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_to_int;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'and!()'
-    INSERT TEXT: 'and!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::and)'
+    INSERT TEXT: 'option::and!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::and)'
     TYPE       : 'fun <$T, $U>(Option, |$T| -> Option): Option'
-    ADDITIONAL EDIT: 'use std::option::and;
-
-    '
 Method 'and_ref!()'
-    INSERT TEXT: 'and_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::and_ref)'
+    INSERT TEXT: 'option::and_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::and_ref)'
     TYPE       : 'fun <$T, $U>(&Option, |&$T| -> Option): Option'
-    ADDITIONAL EDIT: 'use std::option::and_ref;
-
-    '
 Method 'borrow()'
-    INSERT TEXT: 'borrow(${1:t})'
-    TARGET     : '(use std::option::borrow)'
+    INSERT TEXT: 'option::borrow(${1:t})'
+    TARGET     : '(option::borrow)'
     TYPE       : 'fun <Element>(&Option): &Element'
-    ADDITIONAL EDIT: 'use std::option::borrow;
-
-    '
 Method 'borrow_mut()'
-    INSERT TEXT: 'borrow_mut(${1:t})'
-    TARGET     : '(use std::option::borrow_mut)'
+    INSERT TEXT: 'option::borrow_mut(${1:t})'
+    TARGET     : '(option::borrow_mut)'
     TYPE       : 'fun <Element>(&mut Option): &mut Element'
-    ADDITIONAL EDIT: 'use std::option::borrow_mut;
-
-    '
 Method 'borrow_with_default()'
-    INSERT TEXT: 'borrow_with_default(${1:t}, ${2:default_ref})'
-    TARGET     : '(use std::option::borrow_with_default)'
+    INSERT TEXT: 'option::borrow_with_default(${1:t}, ${2:default_ref})'
+    TARGET     : '(option::borrow_with_default)'
     TYPE       : 'fun <Element>(&Option, &Element): &Element'
-    ADDITIONAL EDIT: 'use std::option::borrow_with_default;
-
-    '
 Method 'contains()'
-    INSERT TEXT: 'contains(${1:t}, ${2:e_ref})'
-    TARGET     : '(use std::option::contains)'
+    INSERT TEXT: 'option::contains(${1:t}, ${2:e_ref})'
+    TARGET     : '(option::contains)'
     TYPE       : 'fun <Element>(&Option, &Element): bool'
-    ADDITIONAL EDIT: 'use std::option::contains;
-
-    '
 Method 'destroy!()'
-    INSERT TEXT: 'destroy!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::destroy)'
+    INSERT TEXT: 'option::destroy!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::destroy)'
     TYPE       : 'fun <$T, $R>(Option, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::destroy;
-
-    '
 Method 'destroy_none()'
-    INSERT TEXT: 'destroy_none(${1:t})'
-    TARGET     : '(use std::option::destroy_none)'
+    INSERT TEXT: 'option::destroy_none(${1:t})'
+    TARGET     : '(option::destroy_none)'
     TYPE       : 'fun <Element>(Option)'
-    ADDITIONAL EDIT: 'use std::option::destroy_none;
-
-    '
 Method 'destroy_or!()'
-    INSERT TEXT: 'destroy_or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::destroy_or)'
+    INSERT TEXT: 'option::destroy_or!(${1:o}, ${2:default})'
+    TARGET     : '(option::destroy_or)'
     TYPE       : 'fun <$T>(Option, $T): $T'
-    ADDITIONAL EDIT: 'use std::option::destroy_or;
-
-    '
 Method 'destroy_some()'
-    INSERT TEXT: 'destroy_some(${1:t})'
-    TARGET     : '(use std::option::destroy_some)'
+    INSERT TEXT: 'option::destroy_some(${1:t})'
+    TARGET     : '(option::destroy_some)'
     TYPE       : 'fun <Element>(Option): Element'
-    ADDITIONAL EDIT: 'use std::option::destroy_some;
-
-    '
 Method 'destroy_with_default()'
-    INSERT TEXT: 'destroy_with_default(${1:t}, ${2:default})'
-    TARGET     : '(use std::option::destroy_with_default)'
+    INSERT TEXT: 'option::destroy_with_default(${1:t}, ${2:default})'
+    TARGET     : '(option::destroy_with_default)'
     TYPE       : 'fun <Element>(Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::destroy_with_default;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do)'
+    INSERT TEXT: 'option::do!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do)'
     TYPE       : 'fun <$T, $R>(Option, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do;
-
-    '
 Method 'do_mut!()'
-    INSERT TEXT: 'do_mut!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do_mut)'
+    INSERT TEXT: 'option::do_mut!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do_mut)'
     TYPE       : 'fun <$T, $R>(&mut Option, |&mut $T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do_mut;
-
-    '
 Method 'do_ref!()'
-    INSERT TEXT: 'do_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do_ref)'
+    INSERT TEXT: 'option::do_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do_ref)'
     TYPE       : 'fun <$T, $R>(&Option, |&$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do_ref;
-
-    '
 Method 'extract()'
-    INSERT TEXT: 'extract(${1:t})'
-    TARGET     : '(use std::option::extract)'
+    INSERT TEXT: 'option::extract(${1:t})'
+    TARGET     : '(option::extract)'
     TYPE       : 'fun <Element>(&mut Option): Element'
-    ADDITIONAL EDIT: 'use std::option::extract;
-
-    '
 Method 'extract_or!()'
-    INSERT TEXT: 'extract_or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::extract_or)'
+    INSERT TEXT: 'option::extract_or!(${1:o}, ${2:default})'
+    TARGET     : '(option::extract_or)'
     TYPE       : 'fun <$T>(&mut Option, $T): $T'
-    ADDITIONAL EDIT: 'use std::option::extract_or;
-
-    '
 Method 'fill()'
-    INSERT TEXT: 'fill(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::fill)'
+    INSERT TEXT: 'option::fill(${1:t}, ${2:e})'
+    TARGET     : '(option::fill)'
     TYPE       : 'fun <Element>(&mut Option, Element)'
-    ADDITIONAL EDIT: 'use std::option::fill;
-
-    '
 Method 'filter!()'
-    INSERT TEXT: 'filter!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::filter)'
+    INSERT TEXT: 'option::filter!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::filter)'
     TYPE       : 'fun <$T>(Option, |&$T| -> bool): Option'
-    ADDITIONAL EDIT: 'use std::option::filter;
-
-    '
 Method 'get_with_default()'
-    INSERT TEXT: 'get_with_default(${1:t}, ${2:default})'
-    TARGET     : '(use std::option::get_with_default)'
+    INSERT TEXT: 'option::get_with_default(${1:t}, ${2:default})'
+    TARGET     : '(option::get_with_default)'
     TYPE       : 'fun <Element>(&Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::get_with_default;
-
-    '
 Method 'is_none()'
-    INSERT TEXT: 'is_none(${1:t})'
-    TARGET     : '(use std::option::is_none)'
+    INSERT TEXT: 'option::is_none(${1:t})'
+    TARGET     : '(option::is_none)'
     TYPE       : 'fun <Element>(&Option): bool'
-    ADDITIONAL EDIT: 'use std::option::is_none;
-
-    '
 Method 'is_some()'
-    INSERT TEXT: 'is_some(${1:t})'
-    TARGET     : '(use std::option::is_some)'
+    INSERT TEXT: 'option::is_some(${1:t})'
+    TARGET     : '(option::is_some)'
     TYPE       : 'fun <Element>(&Option): bool'
-    ADDITIONAL EDIT: 'use std::option::is_some;
-
-    '
 Method 'is_some_and!()'
-    INSERT TEXT: 'is_some_and!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::is_some_and)'
+    INSERT TEXT: 'option::is_some_and!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::is_some_and)'
     TYPE       : 'fun <$T>(&Option, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::option::is_some_and;
-
-    '
 Method 'map!()'
-    INSERT TEXT: 'map!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::map)'
+    INSERT TEXT: 'option::map!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::map)'
     TYPE       : 'fun <$T, $U>(Option, |$T| -> $U): Option'
-    ADDITIONAL EDIT: 'use std::option::map;
-
-    '
 Method 'map_ref!()'
-    INSERT TEXT: 'map_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::map_ref)'
+    INSERT TEXT: 'option::map_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::map_ref)'
     TYPE       : 'fun <$T, $U>(&Option, |&$T| -> $U): Option'
-    ADDITIONAL EDIT: 'use std::option::map_ref;
-
-    '
 Method 'none()'
-    INSERT TEXT: 'none()'
-    TARGET     : '(use std::option::none)'
+    INSERT TEXT: 'option::none()'
+    TARGET     : '(option::none)'
     TYPE       : 'fun <Element>(): Option'
-    ADDITIONAL EDIT: 'use std::option::none;
-
-    '
 Method 'or!()'
-    INSERT TEXT: 'or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::or)'
+    INSERT TEXT: 'option::or!(${1:o}, ${2:default})'
+    TARGET     : '(option::or)'
     TYPE       : 'fun <$T>(Option, Option): Option'
-    ADDITIONAL EDIT: 'use std::option::or;
-
-    '
 Method 'some()'
-    INSERT TEXT: 'some(${1:e})'
-    TARGET     : '(use std::option::some)'
+    INSERT TEXT: 'option::some(${1:e})'
+    TARGET     : '(option::some)'
     TYPE       : 'fun <Element>(Element): Option'
-    ADDITIONAL EDIT: 'use std::option::some;
-
-    '
 Method 'swap()'
-    INSERT TEXT: 'swap(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::swap)'
+    INSERT TEXT: 'option::swap(${1:t}, ${2:e})'
+    TARGET     : '(option::swap)'
     TYPE       : 'fun <Element>(&mut Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::swap;
-
-    '
 Method 'swap_or_fill()'
-    INSERT TEXT: 'swap_or_fill(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::swap_or_fill)'
+    INSERT TEXT: 'option::swap_or_fill(${1:t}, ${2:e})'
+    TARGET     : '(option::swap_or_fill)'
     TYPE       : 'fun <Element>(&mut Option, Element): Option'
-    ADDITIONAL EDIT: 'use std::option::swap_or_fill;
-
-    '
 Method 'to_vec()'
-    INSERT TEXT: 'to_vec(${1:t})'
-    TARGET     : '(use std::option::to_vec)'
+    INSERT TEXT: 'option::to_vec(${1:t})'
+    TARGET     : '(option::to_vec)'
     TYPE       : 'fun <Element>(Option): vector<Element>'
-    ADDITIONAL EDIT: 'use std::option::to_vec;
-
-    '
 Method 'append()'
-    INSERT TEXT: 'append(${1:s}, ${2:r})'
-    TARGET     : '(use std::string::append)'
+    INSERT TEXT: 'string::append(${1:s}, ${2:r})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, String)'
-    ADDITIONAL EDIT: 'use std::string::append;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'append_utf8()'
-    INSERT TEXT: 'append_utf8(${1:s}, ${2:bytes})'
-    TARGET     : '(use std::string::append_utf8)'
+    INSERT TEXT: 'string::append_utf8(${1:s}, ${2:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, vector<u8>)'
-    ADDITIONAL EDIT: 'use std::string::append_utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'as_bytes()'
-    INSERT TEXT: 'as_bytes(${1:s})'
-    TARGET     : '(use std::string::as_bytes)'
+    INSERT TEXT: 'string::as_bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::as_bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'bytes()'
-    INSERT TEXT: 'bytes(${1:s})'
-    TARGET     : '(use std::string::bytes)'
+    INSERT TEXT: 'string::bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'from_ascii()'
-    INSERT TEXT: 'from_ascii(${1:s})'
-    TARGET     : '(use std::string::from_ascii)'
+    INSERT TEXT: 'string::from_ascii(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): String'
-    ADDITIONAL EDIT: 'use std::string::from_ascii;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:s}, ${2:r})'
-    TARGET     : '(use std::string::index_of)'
+    INSERT TEXT: 'string::index_of(${1:s}, ${2:r})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, &String): u64'
-    ADDITIONAL EDIT: 'use std::string::index_of;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:s}, ${2:at}, ${3:o})'
-    TARGET     : '(use std::string::insert)'
+    INSERT TEXT: 'string::insert(${1:s}, ${2:at}, ${3:o})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, u64, String)'
-    ADDITIONAL EDIT: 'use std::string::insert;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'internal_sub_string_for_testing()'
-    INSERT TEXT: 'internal_sub_string_for_testing(${1:v}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::internal_sub_string_for_testing)'
+    INSERT TEXT: 'string::internal_sub_string_for_testing(${1:v}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&vector<u8>, u64, u64): vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::internal_sub_string_for_testing;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'into_bytes()'
-    INSERT TEXT: 'into_bytes(${1:s})'
-    TARGET     : '(use std::string::into_bytes)'
+    INSERT TEXT: 'string::into_bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::into_bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:s})'
-    TARGET     : '(use std::string::is_empty)'
+    INSERT TEXT: 'string::is_empty(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::string::is_empty;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:s})'
-    TARGET     : '(use std::string::length)'
+    INSERT TEXT: 'string::length(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): u64'
-    ADDITIONAL EDIT: 'use std::string::length;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'sub_string()'
-    INSERT TEXT: 'sub_string(${1:s}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::sub_string)'
+    INSERT TEXT: 'string::sub_string(${1:s}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::string::sub_string;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'substring()'
-    INSERT TEXT: 'substring(${1:s}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::substring)'
+    INSERT TEXT: 'string::substring(${1:s}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::string::substring;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'to_ascii()'
-    INSERT TEXT: 'to_ascii(${1:s})'
-    TARGET     : '(use std::string::to_ascii)'
+    INSERT TEXT: 'string::to_ascii(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): String'
-    ADDITIONAL EDIT: 'use std::string::to_ascii;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'try_utf8()'
-    INSERT TEXT: 'try_utf8(${1:bytes})'
-    TARGET     : '(use std::string::try_utf8)'
+    INSERT TEXT: 'string::try_utf8(${1:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (vector<u8>): Option'
-    ADDITIONAL EDIT: 'use std::string::try_utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'utf8()'
-    INSERT TEXT: 'utf8(${1:bytes})'
-    TARGET     : '(use std::string::utf8)'
+    INSERT TEXT: 'string::utf8(${1:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (vector<u8>): String'
-    ADDITIONAL EDIT: 'use std::string::utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'address_string()'
-    INSERT TEXT: 'address_string(${1:self})'
-    TARGET     : '(use std::type_name::address_string)'
+    INSERT TEXT: 'type_name::address_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::address_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'as_string()'
-    INSERT TEXT: 'as_string(${1:self})'
-    TARGET     : '(use std::type_name::as_string)'
+    INSERT TEXT: 'type_name::as_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): &String'
-    ADDITIONAL EDIT: 'use std::type_name::as_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'borrow_string()'
-    INSERT TEXT: 'borrow_string(${1:self})'
-    TARGET     : '(use std::type_name::borrow_string)'
+    INSERT TEXT: 'type_name::borrow_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): &String'
-    ADDITIONAL EDIT: 'use std::type_name::borrow_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'defining_id()'
-    INSERT TEXT: 'defining_id()'
-    TARGET     : '(use std::type_name::defining_id)'
+    INSERT TEXT: 'type_name::defining_id()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): address'
-    ADDITIONAL EDIT: 'use std::type_name::defining_id;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get()'
-    INSERT TEXT: 'get()'
-    TARGET     : '(use std::type_name::get)'
+    INSERT TEXT: 'type_name::get()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::get;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_address()'
-    INSERT TEXT: 'get_address(${1:self})'
-    TARGET     : '(use std::type_name::get_address)'
+    INSERT TEXT: 'type_name::get_address(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::get_address;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_module()'
-    INSERT TEXT: 'get_module(${1:self})'
-    TARGET     : '(use std::type_name::get_module)'
+    INSERT TEXT: 'type_name::get_module(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::get_module;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_with_original_ids()'
-    INSERT TEXT: 'get_with_original_ids()'
-    TARGET     : '(use std::type_name::get_with_original_ids)'
+    INSERT TEXT: 'type_name::get_with_original_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::get_with_original_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'into_string()'
-    INSERT TEXT: 'into_string(${1:self})'
-    TARGET     : '(use std::type_name::into_string)'
+    INSERT TEXT: 'type_name::into_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::into_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'is_primitive()'
-    INSERT TEXT: 'is_primitive(${1:self})'
-    TARGET     : '(use std::type_name::is_primitive)'
+    INSERT TEXT: 'type_name::is_primitive(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): bool'
-    ADDITIONAL EDIT: 'use std::type_name::is_primitive;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'module_string()'
-    INSERT TEXT: 'module_string(${1:self})'
-    TARGET     : '(use std::type_name::module_string)'
+    INSERT TEXT: 'type_name::module_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::module_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'original_id()'
-    INSERT TEXT: 'original_id()'
-    TARGET     : '(use std::type_name::original_id)'
+    INSERT TEXT: 'type_name::original_id()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): address'
-    ADDITIONAL EDIT: 'use std::type_name::original_id;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'with_defining_ids()'
-    INSERT TEXT: 'with_defining_ids()'
-    TARGET     : '(use std::type_name::with_defining_ids)'
+    INSERT TEXT: 'type_name::with_defining_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::with_defining_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'with_original_ids()'
-    INSERT TEXT: 'with_original_ids()'
-    TARGET     : '(use std::type_name::with_original_ids)'
+    INSERT TEXT: 'type_name::with_original_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::with_original_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u128::bitwise_not)'
+    INSERT TEXT: 'u128::bitwise_not(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::diff)'
+    INSERT TEXT: 'u128::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::diff;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::divide_and_round_up)'
+    INSERT TEXT: 'u128::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u128::do)'
+    INSERT TEXT: 'u128::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::do;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u128::do_eq)'
+    INSERT TEXT: 'u128::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::do_eq;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::max)'
+    INSERT TEXT: 'u128::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::max;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u128::max_value)'
+    INSERT TEXT: 'u128::max_value!()'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (): u128'
-    ADDITIONAL EDIT: 'use std::u128::max_value;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::min)'
+    INSERT TEXT: 'u128::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::min;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u128::pow)'
+    INSERT TEXT: 'u128::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u8): u128'
-    ADDITIONAL EDIT: 'use std::u128::pow;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u128::range_do)'
+    INSERT TEXT: 'u128::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::range_do;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u128::range_do_eq)'
+    INSERT TEXT: 'u128::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u128::sqrt)'
+    INSERT TEXT: 'u128::sqrt(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::sqrt;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u128::to_string)'
+    INSERT TEXT: 'u128::to_string(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): String'
-    ADDITIONAL EDIT: 'use std::u128::to_string;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u128::try_as_u16)'
+    INSERT TEXT: 'u128::try_as_u16(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u128::try_as_u32)'
+    INSERT TEXT: 'u128::try_as_u32(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u64()'
-    INSERT TEXT: 'try_as_u64(${1:x})'
-    TARGET     : '(use std::u128::try_as_u64)'
+    INSERT TEXT: 'u128::try_as_u64(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u64;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u128::try_as_u8)'
+    INSERT TEXT: 'u128::try_as_u8(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u16::bitwise_not)'
+    INSERT TEXT: 'u16::bitwise_not(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::diff)'
+    INSERT TEXT: 'u16::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::diff;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::divide_and_round_up)'
+    INSERT TEXT: 'u16::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u16::do)'
+    INSERT TEXT: 'u16::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::do;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u16::do_eq)'
+    INSERT TEXT: 'u16::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::do_eq;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::max)'
+    INSERT TEXT: 'u16::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::max;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u16::max_value)'
+    INSERT TEXT: 'u16::max_value!()'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (): u16'
-    ADDITIONAL EDIT: 'use std::u16::max_value;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::min)'
+    INSERT TEXT: 'u16::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::min;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u16::pow)'
+    INSERT TEXT: 'u16::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u8): u16'
-    ADDITIONAL EDIT: 'use std::u16::pow;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u16::range_do)'
+    INSERT TEXT: 'u16::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::range_do;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u16::range_do_eq)'
+    INSERT TEXT: 'u16::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u16::sqrt)'
+    INSERT TEXT: 'u16::sqrt(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::sqrt;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u16::to_string)'
+    INSERT TEXT: 'u16::to_string(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): String'
-    ADDITIONAL EDIT: 'use std::u16::to_string;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u16::try_as_u8)'
+    INSERT TEXT: 'u16::try_as_u8(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): Option'
-    ADDITIONAL EDIT: 'use std::u16::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u256::bitwise_not)'
+    INSERT TEXT: 'u256::bitwise_not(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::diff)'
+    INSERT TEXT: 'u256::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::diff;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::divide_and_round_up)'
+    INSERT TEXT: 'u256::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u256::do)'
+    INSERT TEXT: 'u256::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::do;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u256::do_eq)'
+    INSERT TEXT: 'u256::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::do_eq;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::max)'
+    INSERT TEXT: 'u256::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::max;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u256::max_value)'
+    INSERT TEXT: 'u256::max_value!()'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (): u256'
-    ADDITIONAL EDIT: 'use std::u256::max_value;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::min)'
+    INSERT TEXT: 'u256::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::min;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u256::pow)'
+    INSERT TEXT: 'u256::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u8): u256'
-    ADDITIONAL EDIT: 'use std::u256::pow;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u256::range_do)'
+    INSERT TEXT: 'u256::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::range_do;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u256::range_do_eq)'
+    INSERT TEXT: 'u256::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u256::to_string)'
+    INSERT TEXT: 'u256::to_string(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): String'
-    ADDITIONAL EDIT: 'use std::u256::to_string;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u128()'
-    INSERT TEXT: 'try_as_u128(${1:x})'
-    TARGET     : '(use std::u256::try_as_u128)'
+    INSERT TEXT: 'u256::try_as_u128(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u128;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u256::try_as_u16)'
+    INSERT TEXT: 'u256::try_as_u16(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u256::try_as_u32)'
+    INSERT TEXT: 'u256::try_as_u32(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u64()'
-    INSERT TEXT: 'try_as_u64(${1:x})'
-    TARGET     : '(use std::u256::try_as_u64)'
+    INSERT TEXT: 'u256::try_as_u64(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u64;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u256::try_as_u8)'
+    INSERT TEXT: 'u256::try_as_u8(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u32::bitwise_not)'
+    INSERT TEXT: 'u32::bitwise_not(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::diff)'
+    INSERT TEXT: 'u32::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::diff;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::divide_and_round_up)'
+    INSERT TEXT: 'u32::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u32::do)'
+    INSERT TEXT: 'u32::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::do;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u32::do_eq)'
+    INSERT TEXT: 'u32::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::do_eq;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::max)'
+    INSERT TEXT: 'u32::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::max;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u32::max_value)'
+    INSERT TEXT: 'u32::max_value!()'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (): u32'
-    ADDITIONAL EDIT: 'use std::u32::max_value;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::min)'
+    INSERT TEXT: 'u32::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::min;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u32::pow)'
+    INSERT TEXT: 'u32::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u8): u32'
-    ADDITIONAL EDIT: 'use std::u32::pow;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u32::range_do)'
+    INSERT TEXT: 'u32::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::range_do;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u32::range_do_eq)'
+    INSERT TEXT: 'u32::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u32::sqrt)'
+    INSERT TEXT: 'u32::sqrt(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::sqrt;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u32::to_string)'
+    INSERT TEXT: 'u32::to_string(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): String'
-    ADDITIONAL EDIT: 'use std::u32::to_string;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u32::try_as_u16)'
+    INSERT TEXT: 'u32::try_as_u16(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): Option'
-    ADDITIONAL EDIT: 'use std::u32::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u32::try_as_u8)'
+    INSERT TEXT: 'u32::try_as_u8(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): Option'
-    ADDITIONAL EDIT: 'use std::u32::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u64::bitwise_not)'
+    INSERT TEXT: 'u64::bitwise_not(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::diff)'
+    INSERT TEXT: 'u64::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::diff;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::divide_and_round_up)'
+    INSERT TEXT: 'u64::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u64::do)'
+    INSERT TEXT: 'u64::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::do;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u64::do_eq)'
+    INSERT TEXT: 'u64::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::do_eq;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::max)'
+    INSERT TEXT: 'u64::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::max;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u64::max_value)'
+    INSERT TEXT: 'u64::max_value!()'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::u64::max_value;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::min)'
+    INSERT TEXT: 'u64::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::min;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u64::pow)'
+    INSERT TEXT: 'u64::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u8): u64'
-    ADDITIONAL EDIT: 'use std::u64::pow;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u64::range_do)'
+    INSERT TEXT: 'u64::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::range_do;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u64::range_do_eq)'
+    INSERT TEXT: 'u64::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u64::sqrt)'
+    INSERT TEXT: 'u64::sqrt(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::sqrt;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u64::to_string)'
+    INSERT TEXT: 'u64::to_string(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): String'
-    ADDITIONAL EDIT: 'use std::u64::to_string;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u64::try_as_u16)'
+    INSERT TEXT: 'u64::try_as_u16(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u64::try_as_u32)'
+    INSERT TEXT: 'u64::try_as_u32(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u64::try_as_u8)'
+    INSERT TEXT: 'u64::try_as_u8(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u8::bitwise_not)'
+    INSERT TEXT: 'u8::bitwise_not(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::diff)'
+    INSERT TEXT: 'u8::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::diff;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::divide_and_round_up)'
+    INSERT TEXT: 'u8::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u8::do)'
+    INSERT TEXT: 'u8::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::do;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u8::do_eq)'
+    INSERT TEXT: 'u8::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::do_eq;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::max)'
+    INSERT TEXT: 'u8::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::max;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u8::max_value)'
+    INSERT TEXT: 'u8::max_value!()'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (): u8'
-    ADDITIONAL EDIT: 'use std::u8::max_value;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::min)'
+    INSERT TEXT: 'u8::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::min;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u8::pow)'
+    INSERT TEXT: 'u8::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::pow;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u8::range_do)'
+    INSERT TEXT: 'u8::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::range_do;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u8::range_do_eq)'
+    INSERT TEXT: 'u8::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u8::sqrt)'
+    INSERT TEXT: 'u8::sqrt(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::sqrt;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u8::to_string)'
+    INSERT TEXT: 'u8::to_string(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): String'
-    ADDITIONAL EDIT: 'use std::u8::to_string;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'assert_eq!()'
-    INSERT TEXT: 'assert_eq!(${1:t1}, ${2:t2})'
-    TARGET     : '(use std::unit_test::assert_eq)'
+    INSERT TEXT: 'unit_test::assert_eq!(${1:t1}, ${2:t2})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <$T>($T, $T)'
-    ADDITIONAL EDIT: 'use std::unit_test::assert_eq;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'assert_ref_eq!()'
-    INSERT TEXT: 'assert_ref_eq!(${1:t1}, ${2:t2})'
-    TARGET     : '(use std::unit_test::assert_ref_eq)'
+    INSERT TEXT: 'unit_test::assert_ref_eq!(${1:t1}, ${2:t2})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <$T>(&$T, &$T)'
-    ADDITIONAL EDIT: 'use std::unit_test::assert_ref_eq;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'destroy()'
-    INSERT TEXT: 'destroy(${1:v})'
-    TARGET     : '(use std::unit_test::destroy)'
+    INSERT TEXT: 'unit_test::destroy(${1:v})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <T>(T)'
-    ADDITIONAL EDIT: 'use std::unit_test::destroy;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'poison()'
-    INSERT TEXT: 'poison()'
-    TARGET     : '(use std::unit_test::poison)'
+    INSERT TEXT: 'unit_test::poison()'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: 'use std::unit_test::poison;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'add()'
-    INSERT TEXT: 'add(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::add)'
+    INSERT TEXT: 'uq32_32::add(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::add;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'div()'
-    INSERT TEXT: 'div(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::div)'
+    INSERT TEXT: 'uq32_32::div(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::div;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_int()'
-    INSERT TEXT: 'from_int(${1:integer})'
-    TARGET     : '(use std::uq32_32::from_int)'
+    INSERT TEXT: 'uq32_32::from_int(${1:integer})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_int;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_quotient()'
-    INSERT TEXT: 'from_quotient(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::uq32_32::from_quotient)'
+    INSERT TEXT: 'uq32_32::from_quotient(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, u64): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_quotient;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_raw()'
-    INSERT TEXT: 'from_raw(${1:raw_value})'
-    TARGET     : '(use std::uq32_32::from_raw)'
+    INSERT TEXT: 'uq32_32::from_raw(${1:raw_value})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_raw;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'ge()'
-    INSERT TEXT: 'ge(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::ge)'
+    INSERT TEXT: 'uq32_32::ge(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::ge;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'gt()'
-    INSERT TEXT: 'gt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::gt)'
+    INSERT TEXT: 'uq32_32::gt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::gt;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'int_div()'
-    INSERT TEXT: 'int_div(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::uq32_32::int_div)'
+    INSERT TEXT: 'uq32_32::int_div(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::int_div;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'int_mul()'
-    INSERT TEXT: 'int_mul(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::uq32_32::int_mul)'
+    INSERT TEXT: 'uq32_32::int_mul(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::int_mul;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'le()'
-    INSERT TEXT: 'le(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::le)'
+    INSERT TEXT: 'uq32_32::le(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::le;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'lt()'
-    INSERT TEXT: 'lt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::lt)'
+    INSERT TEXT: 'uq32_32::lt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::lt;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'mul()'
-    INSERT TEXT: 'mul(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::mul)'
+    INSERT TEXT: 'uq32_32::mul(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::mul;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'sub()'
-    INSERT TEXT: 'sub(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::sub)'
+    INSERT TEXT: 'uq32_32::sub(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::sub;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'to_int()'
-    INSERT TEXT: 'to_int(${1:a})'
-    TARGET     : '(use std::uq32_32::to_int)'
+    INSERT TEXT: 'uq32_32::to_int(${1:a})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32): u32'
-    ADDITIONAL EDIT: 'use std::uq32_32::to_int;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'to_raw()'
-    INSERT TEXT: 'to_raw(${1:a})'
-    TARGET     : '(use std::uq32_32::to_raw)'
+    INSERT TEXT: 'uq32_32::to_raw(${1:a})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::to_raw;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'add()'
-    INSERT TEXT: 'add(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::add)'
+    INSERT TEXT: 'uq64_64::add(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::add;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'div()'
-    INSERT TEXT: 'div(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::div)'
+    INSERT TEXT: 'uq64_64::div(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::div;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_int()'
-    INSERT TEXT: 'from_int(${1:integer})'
-    TARGET     : '(use std::uq64_64::from_int)'
+    INSERT TEXT: 'uq64_64::from_int(${1:integer})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_int;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_quotient()'
-    INSERT TEXT: 'from_quotient(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::uq64_64::from_quotient)'
+    INSERT TEXT: 'uq64_64::from_quotient(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, u128): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_quotient;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_raw()'
-    INSERT TEXT: 'from_raw(${1:raw_value})'
-    TARGET     : '(use std::uq64_64::from_raw)'
+    INSERT TEXT: 'uq64_64::from_raw(${1:raw_value})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_raw;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'ge()'
-    INSERT TEXT: 'ge(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::ge)'
+    INSERT TEXT: 'uq64_64::ge(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::ge;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'gt()'
-    INSERT TEXT: 'gt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::gt)'
+    INSERT TEXT: 'uq64_64::gt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::gt;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'int_div()'
-    INSERT TEXT: 'int_div(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::uq64_64::int_div)'
+    INSERT TEXT: 'uq64_64::int_div(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::int_div;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'int_mul()'
-    INSERT TEXT: 'int_mul(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::uq64_64::int_mul)'
+    INSERT TEXT: 'uq64_64::int_mul(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::int_mul;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'le()'
-    INSERT TEXT: 'le(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::le)'
+    INSERT TEXT: 'uq64_64::le(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::le;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'lt()'
-    INSERT TEXT: 'lt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::lt)'
+    INSERT TEXT: 'uq64_64::lt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::lt;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'mul()'
-    INSERT TEXT: 'mul(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::mul)'
+    INSERT TEXT: 'uq64_64::mul(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::mul;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'sub()'
-    INSERT TEXT: 'sub(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::sub)'
+    INSERT TEXT: 'uq64_64::sub(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::sub;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'to_int()'
-    INSERT TEXT: 'to_int(${1:a})'
-    TARGET     : '(use std::uq64_64::to_int)'
+    INSERT TEXT: 'uq64_64::to_int(${1:a})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64): u64'
-    ADDITIONAL EDIT: 'use std::uq64_64::to_int;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'to_raw()'
-    INSERT TEXT: 'to_raw(${1:a})'
-    TARGET     : '(use std::uq64_64::to_raw)'
+    INSERT TEXT: 'uq64_64::to_raw(${1:a})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::to_raw;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'all!()'
-    INSERT TEXT: 'all!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::all)'
+    INSERT TEXT: 'vector::all!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::all)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::all;
-
-    '
 Method 'any!()'
-    INSERT TEXT: 'any!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::any)'
+    INSERT TEXT: 'vector::any!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::any)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::any;
-
-    '
 Method 'append()'
-    INSERT TEXT: 'append(${1:lhs}, ${2:other})'
-    TARGET     : '(use std::vector::append)'
+    INSERT TEXT: 'vector::append(${1:lhs}, ${2:other})'
+    TARGET     : '(vector::append)'
     TYPE       : 'fun <Element>(&mut vector<Element>, vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::append;
-
-    '
 Method 'borrow()'
-    INSERT TEXT: 'borrow(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::borrow)'
+    INSERT TEXT: 'vector::borrow(${1:v}, ${2:i})'
+    TARGET     : '(vector::borrow)'
     TYPE       : 'fun <Element>(&vector<Element>, u64): &Element'
-    ADDITIONAL EDIT: 'use std::vector::borrow;
-
-    '
 Method 'borrow_mut()'
-    INSERT TEXT: 'borrow_mut(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::borrow_mut)'
+    INSERT TEXT: 'vector::borrow_mut(${1:v}, ${2:i})'
+    TARGET     : '(vector::borrow_mut)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): &mut Element'
-    ADDITIONAL EDIT: 'use std::vector::borrow_mut;
-
-    '
 Method 'contains()'
-    INSERT TEXT: 'contains(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::contains)'
+    INSERT TEXT: 'vector::contains(${1:v}, ${2:e})'
+    TARGET     : '(vector::contains)'
     TYPE       : 'fun <Element>(&vector<Element>, &Element): bool'
-    ADDITIONAL EDIT: 'use std::vector::contains;
-
-    '
 Method 'count!()'
-    INSERT TEXT: 'count!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::count)'
+    INSERT TEXT: 'vector::count!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::count)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): u64'
-    ADDITIONAL EDIT: 'use std::vector::count;
-
-    '
 Method 'destroy!()'
-    INSERT TEXT: 'destroy!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::destroy)'
+    INSERT TEXT: 'vector::destroy!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::destroy)'
     TYPE       : 'fun <$T, $R>(vector<$T>, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::destroy;
-
-    '
 Method 'destroy_empty()'
-    INSERT TEXT: 'destroy_empty(${1:v})'
-    TARGET     : '(use std::vector::destroy_empty)'
+    INSERT TEXT: 'vector::destroy_empty(${1:v})'
+    TARGET     : '(vector::destroy_empty)'
     TYPE       : 'fun <Element>(vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::destroy_empty;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do)'
+    INSERT TEXT: 'vector::do!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do)'
     TYPE       : 'fun <$T, $R>(vector<$T>, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do;
-
-    '
 Method 'do_mut!()'
-    INSERT TEXT: 'do_mut!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do_mut)'
+    INSERT TEXT: 'vector::do_mut!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do_mut)'
     TYPE       : 'fun <$T, $R>(&mut vector<$T>, |&mut $T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do_mut;
-
-    '
 Method 'do_ref!()'
-    INSERT TEXT: 'do_ref!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do_ref)'
+    INSERT TEXT: 'vector::do_ref!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do_ref)'
     TYPE       : 'fun <$T, $R>(&vector<$T>, |&$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do_ref;
-
-    '
 Method 'empty()'
-    INSERT TEXT: 'empty()'
-    TARGET     : '(use std::vector::empty)'
+    INSERT TEXT: 'vector::empty()'
+    TARGET     : '(vector::empty)'
     TYPE       : 'fun <Element>(): vector<Element>'
-    ADDITIONAL EDIT: 'use std::vector::empty;
-
-    '
 Method 'filter!()'
-    INSERT TEXT: 'filter!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::filter)'
+    INSERT TEXT: 'vector::filter!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::filter)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::filter;
-
-    '
 Method 'find_index!()'
-    INSERT TEXT: 'find_index!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::find_index)'
+    INSERT TEXT: 'vector::find_index!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::find_index)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): Option'
-    ADDITIONAL EDIT: 'use std::vector::find_index;
-
-    '
 Method 'find_indices!()'
-    INSERT TEXT: 'find_indices!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::find_indices)'
+    INSERT TEXT: 'vector::find_indices!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::find_indices)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): vector<u64>'
-    ADDITIONAL EDIT: 'use std::vector::find_indices;
-
-    '
 Method 'flatten()'
-    INSERT TEXT: 'flatten(${1:v})'
-    TARGET     : '(use std::vector::flatten)'
+    INSERT TEXT: 'vector::flatten(${1:v})'
+    TARGET     : '(vector::flatten)'
     TYPE       : 'fun <T>(vector<vector<T>>): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::flatten;
-
-    '
 Method 'fold!()'
-    INSERT TEXT: 'fold!(${1:v}, ${2:init}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::fold)'
+    INSERT TEXT: 'vector::fold!(${1:v}, ${2:init}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::fold)'
     TYPE       : 'fun <$T, $Acc>(vector<$T>, $Acc, |$Acc, $T| -> $Acc): $Acc'
-    ADDITIONAL EDIT: 'use std::vector::fold;
-
-    '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::index_of)'
+    INSERT TEXT: 'vector::index_of(${1:v}, ${2:e})'
+    TARGET     : '(vector::index_of)'
     TYPE       : 'fun <Element>(&vector<Element>, &Element): (bool, u64)'
-    ADDITIONAL EDIT: 'use std::vector::index_of;
-
-    '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:v}, ${2:e}, ${3:i})'
-    TARGET     : '(use std::vector::insert)'
+    INSERT TEXT: 'vector::insert(${1:v}, ${2:e}, ${3:i})'
+    TARGET     : '(vector::insert)'
     TYPE       : 'fun <Element>(&mut vector<Element>, Element, u64)'
-    ADDITIONAL EDIT: 'use std::vector::insert;
-
-    '
 Method 'insertion_sort_by!()'
-    INSERT TEXT: 'insertion_sort_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::insertion_sort_by)'
+    INSERT TEXT: 'vector::insertion_sort_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::insertion_sort_by)'
     TYPE       : 'fun <$T>(&mut vector<$T>, |&$T, &$T| -> bool)'
-    ADDITIONAL EDIT: 'use std::vector::insertion_sort_by;
-
-    '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:v})'
-    TARGET     : '(use std::vector::is_empty)'
+    INSERT TEXT: 'vector::is_empty(${1:v})'
+    TARGET     : '(vector::is_empty)'
     TYPE       : 'fun <Element>(&vector<Element>): bool'
-    ADDITIONAL EDIT: 'use std::vector::is_empty;
-
-    '
 Method 'is_sorted_by!()'
-    INSERT TEXT: 'is_sorted_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::is_sorted_by)'
+    INSERT TEXT: 'vector::is_sorted_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::is_sorted_by)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T, &$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::is_sorted_by;
-
-    '
 Method 'length()'
-    INSERT TEXT: 'length(${1:v})'
-    TARGET     : '(use std::vector::length)'
+    INSERT TEXT: 'vector::length(${1:v})'
+    TARGET     : '(vector::length)'
     TYPE       : 'fun <Element>(&vector<Element>): u64'
-    ADDITIONAL EDIT: 'use std::vector::length;
-
-    '
 Method 'map!()'
-    INSERT TEXT: 'map!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::map)'
+    INSERT TEXT: 'vector::map!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::map)'
     TYPE       : 'fun <$T, $U>(vector<$T>, |$T| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::map;
-
-    '
 Method 'map_ref!()'
-    INSERT TEXT: 'map_ref!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::map_ref)'
+    INSERT TEXT: 'vector::map_ref!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::map_ref)'
     TYPE       : 'fun <$T, $U>(&vector<$T>, |&$T| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::map_ref;
-
-    '
 Method 'merge_sort_by!()'
-    INSERT TEXT: 'merge_sort_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::merge_sort_by)'
+    INSERT TEXT: 'vector::merge_sort_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::merge_sort_by)'
     TYPE       : 'fun <$T>(&mut vector<$T>, |&$T, &$T| -> bool)'
-    ADDITIONAL EDIT: 'use std::vector::merge_sort_by;
-
-    '
 Method 'partition!()'
-    INSERT TEXT: 'partition!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::partition)'
+    INSERT TEXT: 'vector::partition!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::partition)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): (vector<$T>, vector<$T>)'
-    ADDITIONAL EDIT: 'use std::vector::partition;
-
-    '
 Method 'pop_back()'
-    INSERT TEXT: 'pop_back(${1:v})'
-    TARGET     : '(use std::vector::pop_back)'
+    INSERT TEXT: 'vector::pop_back(${1:v})'
+    TARGET     : '(vector::pop_back)'
     TYPE       : 'fun <Element>(&mut vector<Element>): Element'
-    ADDITIONAL EDIT: 'use std::vector::pop_back;
-
-    '
 Method 'push_back()'
-    INSERT TEXT: 'push_back(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::push_back)'
+    INSERT TEXT: 'vector::push_back(${1:v}, ${2:e})'
+    TARGET     : '(vector::push_back)'
     TYPE       : 'fun <Element>(&mut vector<Element>, Element)'
-    ADDITIONAL EDIT: 'use std::vector::push_back;
-
-    '
 Method 'remove()'
-    INSERT TEXT: 'remove(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::remove)'
+    INSERT TEXT: 'vector::remove(${1:v}, ${2:i})'
+    TARGET     : '(vector::remove)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): Element'
-    ADDITIONAL EDIT: 'use std::vector::remove;
-
-    '
 Method 'reverse()'
-    INSERT TEXT: 'reverse(${1:v})'
-    TARGET     : '(use std::vector::reverse)'
+    INSERT TEXT: 'vector::reverse(${1:v})'
+    TARGET     : '(vector::reverse)'
     TYPE       : 'fun <Element>(&mut vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::reverse;
-
-    '
 Method 'singleton()'
-    INSERT TEXT: 'singleton(${1:e})'
-    TARGET     : '(use std::vector::singleton)'
+    INSERT TEXT: 'vector::singleton(${1:e})'
+    TARGET     : '(vector::singleton)'
     TYPE       : 'fun <Element>(Element): vector<Element>'
-    ADDITIONAL EDIT: 'use std::vector::singleton;
-
-    '
 Method 'skip()'
-    INSERT TEXT: 'skip(${1:v}, ${2:n})'
-    TARGET     : '(use std::vector::skip)'
+    INSERT TEXT: 'vector::skip(${1:v}, ${2:n})'
+    TARGET     : '(vector::skip)'
     TYPE       : 'fun <T>(vector<T>, u64): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::skip;
-
-    '
 Method 'skip_while!()'
-    INSERT TEXT: 'skip_while!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::skip_while)'
+    INSERT TEXT: 'vector::skip_while!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::skip_while)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::skip_while;
-
-    '
 Method 'swap()'
-    INSERT TEXT: 'swap(${1:v}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::vector::swap)'
+    INSERT TEXT: 'vector::swap(${1:v}, ${2:i}, ${3:j})'
+    TARGET     : '(vector::swap)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64, u64)'
-    ADDITIONAL EDIT: 'use std::vector::swap;
-
-    '
 Method 'swap_remove()'
-    INSERT TEXT: 'swap_remove(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::swap_remove)'
+    INSERT TEXT: 'vector::swap_remove(${1:v}, ${2:i})'
+    TARGET     : '(vector::swap_remove)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): Element'
-    ADDITIONAL EDIT: 'use std::vector::swap_remove;
-
-    '
 Method 'tabulate!()'
-    INSERT TEXT: 'tabulate!(${1:n}, |${2}| ${3})'
-    TARGET     : '(use std::vector::tabulate)'
+    INSERT TEXT: 'vector::tabulate!(${1:n}, |${2}| ${3})'
+    TARGET     : '(vector::tabulate)'
     TYPE       : 'fun <$T>(u64, |u64| -> $T): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::tabulate;
-
-    '
 Method 'take()'
-    INSERT TEXT: 'take(${1:v}, ${2:n})'
-    TARGET     : '(use std::vector::take)'
+    INSERT TEXT: 'vector::take(${1:v}, ${2:n})'
+    TARGET     : '(vector::take)'
     TYPE       : 'fun <T>(vector<T>, u64): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::take;
-
-    '
 Method 'take_while!()'
-    INSERT TEXT: 'take_while!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::take_while)'
+    INSERT TEXT: 'vector::take_while!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::take_while)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::take_while;
-
-    '
 Method 'zip_do!()'
-    INSERT TEXT: 'zip_do!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do)'
+    INSERT TEXT: 'vector::zip_do!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do)'
     TYPE       : 'fun <$T1, $T2, $R>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do;
-
-    '
 Method 'zip_do_mut!()'
-    INSERT TEXT: 'zip_do_mut!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_mut)'
+    INSERT TEXT: 'vector::zip_do_mut!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_mut)'
     TYPE       : 'fun <$T1, $T2, $R>(&mut vector<$T1>, &mut vector<$T2>, |&mut $T1, &mut $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_mut;
-
-    '
 Method 'zip_do_ref!()'
-    INSERT TEXT: 'zip_do_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_ref)'
+    INSERT TEXT: 'vector::zip_do_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_ref)'
     TYPE       : 'fun <$T1, $T2, $R>(&vector<$T1>, &vector<$T2>, |&$T1, &$T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_ref;
-
-    '
 Method 'zip_do_reverse!()'
-    INSERT TEXT: 'zip_do_reverse!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_reverse)'
+    INSERT TEXT: 'vector::zip_do_reverse!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_reverse)'
     TYPE       : 'fun <$T1, $T2, $R>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_reverse;
-
-    '
 Method 'zip_map!()'
-    INSERT TEXT: 'zip_map!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_map)'
+    INSERT TEXT: 'vector::zip_map!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_map)'
     TYPE       : 'fun <$T1, $T2, $U>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::zip_map;
-
-    '
 Method 'zip_map_ref!()'
-    INSERT TEXT: 'zip_map_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_map_ref)'
+    INSERT TEXT: 'vector::zip_map_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_map_ref)'
     TYPE       : 'fun <$T1, $T2, $U>(&vector<$T1>, &vector<$T2>, |&$T1, &$T2| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::zip_map_ref;
-
-    '
 
 -- test 4 -------------------
 use line: 28, use_col: 9
@@ -2583,2112 +2352,1881 @@ Method 'int_match_function()'
     TARGET     : '(Enums::int_match::int_match_function)'
     TYPE       : 'fun (u64)'
 Method 'bam()'
-    INSERT TEXT: 'bam()'
-    TARGET     : '(use Enums::int_match::bam)'
+    INSERT TEXT: 'int_match::bam()'
+    TARGET     : '(use Enums::int_match)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use Enums::int_match::bam;
+    ADDITIONAL EDIT: 'use Enums::int_match;
 
     '
 Method 'bam()'
-    INSERT TEXT: 'bam()'
-    TARGET     : '(use Enums::int_match::bam)'
+    INSERT TEXT: 'int_match::bam()'
+    TARGET     : '(use Enums::int_match)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use Enums::int_match::bam;
+    ADDITIONAL EDIT: 'use Enums::int_match;
 
     '
 Method 'bar()'
-    INSERT TEXT: 'bar()'
-    TARGET     : '(use ModuleExt::M2::bar)'
+    INSERT TEXT: 'M2::bar()'
+    TARGET     : '(use ModuleExt::M2)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use ModuleExt::M2::bar;
+    ADDITIONAL EDIT: 'use ModuleExt::M2;
 
     '
 Method 'foo()'
-    INSERT TEXT: 'foo()'
-    TARGET     : '(use ModuleExt::M2::foo)'
+    INSERT TEXT: 'M2::foo()'
+    TARGET     : '(use ModuleExt::M2)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use ModuleExt::M2::foo;
+    ADDITIONAL EDIT: 'use ModuleExt::M2;
 
     '
 Method 'bar()'
-    INSERT TEXT: 'bar()'
-    TARGET     : '(use ModuleExt::M2::bar)'
+    INSERT TEXT: 'M2::bar()'
+    TARGET     : '(use ModuleExt::M2)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use ModuleExt::M2::bar;
+    ADDITIONAL EDIT: 'use ModuleExt::M2;
 
     '
 Method 'foo()'
-    INSERT TEXT: 'foo()'
-    TARGET     : '(use ModuleExt::M2::foo)'
+    INSERT TEXT: 'M2::foo()'
+    TARGET     : '(use ModuleExt::M2)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use ModuleExt::M2::foo;
+    ADDITIONAL EDIT: 'use ModuleExt::M2;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length()'
-    TARGET     : '(use std::address::length)'
+    INSERT TEXT: 'address::length()'
+    TARGET     : '(use std::address)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::address::length;
+    ADDITIONAL EDIT: 'use std::address;
 
     '
 Method 'all_characters_printable()'
-    INSERT TEXT: 'all_characters_printable(${1:string})'
-    TARGET     : '(use std::ascii::all_characters_printable)'
+    INSERT TEXT: 'ascii::all_characters_printable(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::ascii::all_characters_printable;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'append()'
-    INSERT TEXT: 'append(${1:string}, ${2:other})'
-    TARGET     : '(use std::ascii::append)'
+    INSERT TEXT: 'ascii::append(${1:string}, ${2:other})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, String)'
-    ADDITIONAL EDIT: 'use std::ascii::append;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'as_bytes()'
-    INSERT TEXT: 'as_bytes(${1:string})'
-    TARGET     : '(use std::ascii::as_bytes)'
+    INSERT TEXT: 'ascii::as_bytes(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::ascii::as_bytes;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'byte()'
-    INSERT TEXT: 'byte(${1:char})'
-    TARGET     : '(use std::ascii::byte)'
+    INSERT TEXT: 'ascii::byte(${1:char})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (Char): u8'
-    ADDITIONAL EDIT: 'use std::ascii::byte;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'char()'
-    INSERT TEXT: 'char(${1:byte})'
-    TARGET     : '(use std::ascii::char)'
+    INSERT TEXT: 'ascii::char(${1:byte})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): Char'
-    ADDITIONAL EDIT: 'use std::ascii::char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:string}, ${2:substr})'
-    TARGET     : '(use std::ascii::index_of)'
+    INSERT TEXT: 'ascii::index_of(${1:string}, ${2:substr})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String, &String): u64'
-    ADDITIONAL EDIT: 'use std::ascii::index_of;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:s}, ${2:at}, ${3:o})'
-    TARGET     : '(use std::ascii::insert)'
+    INSERT TEXT: 'ascii::insert(${1:s}, ${2:at}, ${3:o})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, u64, String)'
-    ADDITIONAL EDIT: 'use std::ascii::insert;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'into_bytes()'
-    INSERT TEXT: 'into_bytes(${1:string})'
-    TARGET     : '(use std::ascii::into_bytes)'
+    INSERT TEXT: 'ascii::into_bytes(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (String): vector<u8>'
-    ADDITIONAL EDIT: 'use std::ascii::into_bytes;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:string})'
-    TARGET     : '(use std::ascii::is_empty)'
+    INSERT TEXT: 'ascii::is_empty(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_empty;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_printable_char()'
-    INSERT TEXT: 'is_printable_char(${1:byte})'
-    TARGET     : '(use std::ascii::is_printable_char)'
+    INSERT TEXT: 'ascii::is_printable_char(${1:byte})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_printable_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_valid_char()'
-    INSERT TEXT: 'is_valid_char(${1:b})'
-    TARGET     : '(use std::ascii::is_valid_char)'
+    INSERT TEXT: 'ascii::is_valid_char(${1:b})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_valid_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:string})'
-    TARGET     : '(use std::ascii::length)'
+    INSERT TEXT: 'ascii::length(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): u64'
-    ADDITIONAL EDIT: 'use std::ascii::length;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'pop_char()'
-    INSERT TEXT: 'pop_char(${1:string})'
-    TARGET     : '(use std::ascii::pop_char)'
+    INSERT TEXT: 'ascii::pop_char(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String): Char'
-    ADDITIONAL EDIT: 'use std::ascii::pop_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'push_char()'
-    INSERT TEXT: 'push_char(${1:string}, ${2:char})'
-    TARGET     : '(use std::ascii::push_char)'
+    INSERT TEXT: 'ascii::push_char(${1:string}, ${2:char})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, Char)'
-    ADDITIONAL EDIT: 'use std::ascii::push_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'string()'
-    INSERT TEXT: 'string(${1:bytes})'
-    TARGET     : '(use std::ascii::string)'
+    INSERT TEXT: 'ascii::string(${1:bytes})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (vector<u8>): String'
-    ADDITIONAL EDIT: 'use std::ascii::string;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'substring()'
-    INSERT TEXT: 'substring(${1:string}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::ascii::substring)'
+    INSERT TEXT: 'ascii::substring(${1:string}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::ascii::substring;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_lowercase()'
-    INSERT TEXT: 'to_lowercase(${1:string})'
-    TARGET     : '(use std::ascii::to_lowercase)'
+    INSERT TEXT: 'ascii::to_lowercase(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): String'
-    ADDITIONAL EDIT: 'use std::ascii::to_lowercase;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_uppercase()'
-    INSERT TEXT: 'to_uppercase(${1:string})'
-    TARGET     : '(use std::ascii::to_uppercase)'
+    INSERT TEXT: 'ascii::to_uppercase(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): String'
-    ADDITIONAL EDIT: 'use std::ascii::to_uppercase;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'try_string()'
-    INSERT TEXT: 'try_string(${1:bytes})'
-    TARGET     : '(use std::ascii::try_string)'
+    INSERT TEXT: 'ascii::try_string(${1:bytes})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (vector<u8>): Option'
-    ADDITIONAL EDIT: 'use std::ascii::try_string;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_bytes()'
-    INSERT TEXT: 'to_bytes(${1:v})'
-    TARGET     : '(use std::bcs::to_bytes)'
+    INSERT TEXT: 'bcs::to_bytes(${1:v})'
+    TARGET     : '(use std::bcs)'
     TYPE       : 'fun <MoveValue>(&MoveValue): vector<u8>'
-    ADDITIONAL EDIT: 'use std::bcs::to_bytes;
+    ADDITIONAL EDIT: 'use std::bcs;
 
     '
 Method 'is_index_set()'
-    INSERT TEXT: 'is_index_set(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::is_index_set)'
+    INSERT TEXT: 'bit_vector::is_index_set(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector, u64): bool'
-    ADDITIONAL EDIT: 'use std::bit_vector::is_index_set;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:bitvector})'
-    TARGET     : '(use std::bit_vector::length)'
+    INSERT TEXT: 'bit_vector::length(${1:bitvector})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::length;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'longest_set_sequence_starting_at()'
-    INSERT TEXT: 'longest_set_sequence_starting_at(${1:bitvector}, ${2:start_index})'
-    TARGET     : '(use std::bit_vector::longest_set_sequence_starting_at)'
+    INSERT TEXT: 'bit_vector::longest_set_sequence_starting_at(${1:bitvector}, ${2:start_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector, u64): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::longest_set_sequence_starting_at;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'new()'
-    INSERT TEXT: 'new(${1:length})'
-    TARGET     : '(use std::bit_vector::new)'
+    INSERT TEXT: 'bit_vector::new(${1:length})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (u64): BitVector'
-    ADDITIONAL EDIT: 'use std::bit_vector::new;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'set()'
-    INSERT TEXT: 'set(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::set)'
+    INSERT TEXT: 'bit_vector::set(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::set;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'shift_left()'
-    INSERT TEXT: 'shift_left(${1:bitvector}, ${2:amount})'
-    TARGET     : '(use std::bit_vector::shift_left)'
+    INSERT TEXT: 'bit_vector::shift_left(${1:bitvector}, ${2:amount})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::shift_left;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'unset()'
-    INSERT TEXT: 'unset(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::unset)'
+    INSERT TEXT: 'bit_vector::unset(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::unset;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'word_size()'
-    INSERT TEXT: 'word_size()'
-    TARGET     : '(use std::bit_vector::word_size)'
+    INSERT TEXT: 'bit_vector::word_size()'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::word_size;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'print()'
-    INSERT TEXT: 'print(${1:x})'
-    TARGET     : '(use std::debug::print)'
+    INSERT TEXT: 'debug::print(${1:x})'
+    TARGET     : '(use std::debug)'
     TYPE       : 'fun <T>(&T)'
-    ADDITIONAL EDIT: 'use std::debug::print;
+    ADDITIONAL EDIT: 'use std::debug;
 
     '
 Method 'print_stack_trace()'
-    INSERT TEXT: 'print_stack_trace()'
-    TARGET     : '(use std::debug::print_stack_trace)'
+    INSERT TEXT: 'debug::print_stack_trace()'
+    TARGET     : '(use std::debug)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: 'use std::debug::print_stack_trace;
+    ADDITIONAL EDIT: 'use std::debug;
 
     '
 Method 'create_from_rational()'
-    INSERT TEXT: 'create_from_rational(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::fixed_point32::create_from_rational)'
+    INSERT TEXT: 'fixed_point32::create_from_rational(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, u64): FixedPoint32'
-    ADDITIONAL EDIT: 'use std::fixed_point32::create_from_rational;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'create_from_raw_value()'
-    INSERT TEXT: 'create_from_raw_value(${1:value})'
-    TARGET     : '(use std::fixed_point32::create_from_raw_value)'
+    INSERT TEXT: 'fixed_point32::create_from_raw_value(${1:value})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64): FixedPoint32'
-    ADDITIONAL EDIT: 'use std::fixed_point32::create_from_raw_value;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'divide_u64()'
-    INSERT TEXT: 'divide_u64(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::fixed_point32::divide_u64)'
+    INSERT TEXT: 'fixed_point32::divide_u64(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::divide_u64;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'get_raw_value()'
-    INSERT TEXT: 'get_raw_value(${1:num})'
-    TARGET     : '(use std::fixed_point32::get_raw_value)'
+    INSERT TEXT: 'fixed_point32::get_raw_value(${1:num})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::get_raw_value;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'is_zero()'
-    INSERT TEXT: 'is_zero(${1:num})'
-    TARGET     : '(use std::fixed_point32::is_zero)'
+    INSERT TEXT: 'fixed_point32::is_zero(${1:num})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (FixedPoint32): bool'
-    ADDITIONAL EDIT: 'use std::fixed_point32::is_zero;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'multiply_u64()'
-    INSERT TEXT: 'multiply_u64(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::fixed_point32::multiply_u64)'
+    INSERT TEXT: 'fixed_point32::multiply_u64(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::multiply_u64;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'sha2_256()'
-    INSERT TEXT: 'sha2_256(${1:data})'
-    TARGET     : '(use std::hash::sha2_256)'
+    INSERT TEXT: 'hash::sha2_256(${1:data})'
+    TARGET     : '(use std::hash)'
     TYPE       : 'fun (vector<u8>): vector<u8>'
-    ADDITIONAL EDIT: 'use std::hash::sha2_256;
+    ADDITIONAL EDIT: 'use std::hash;
 
     '
 Method 'sha3_256()'
-    INSERT TEXT: 'sha3_256(${1:data})'
-    TARGET     : '(use std::hash::sha3_256)'
+    INSERT TEXT: 'hash::sha3_256(${1:data})'
+    TARGET     : '(use std::hash)'
     TYPE       : 'fun (vector<u8>): vector<u8>'
-    ADDITIONAL EDIT: 'use std::hash::sha3_256;
+    ADDITIONAL EDIT: 'use std::hash;
 
     '
 Method 'permit()'
-    INSERT TEXT: 'permit()'
-    TARGET     : '(use std::internal::permit)'
+    INSERT TEXT: 'internal::permit()'
+    TARGET     : '(internal::permit)'
     TYPE       : 'fun <T>(): Permit'
-    ADDITIONAL EDIT: 'use std::internal::permit;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::macros::do)'
+    INSERT TEXT: 'macros::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::do;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::macros::do_eq)'
+    INSERT TEXT: 'macros::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::do_eq;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_diff!()'
-    INSERT TEXT: 'num_diff!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_diff)'
+    INSERT TEXT: 'macros::num_diff!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_diff;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_divide_and_round_up!()'
-    INSERT TEXT: 'num_divide_and_round_up!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_divide_and_round_up)'
+    INSERT TEXT: 'macros::num_divide_and_round_up!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_max!()'
-    INSERT TEXT: 'num_max!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_max)'
+    INSERT TEXT: 'macros::num_max!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_max;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_min!()'
-    INSERT TEXT: 'num_min!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_min)'
+    INSERT TEXT: 'macros::num_min!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_min;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_pow!()'
-    INSERT TEXT: 'num_pow!(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::macros::num_pow)'
+    INSERT TEXT: 'macros::num_pow!(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_, u8): _'
-    ADDITIONAL EDIT: 'use std::macros::num_pow;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_sqrt!()'
-    INSERT TEXT: 'num_sqrt!(${1:x}, ${2:bitsize})'
-    TARGET     : '(use std::macros::num_sqrt)'
+    INSERT TEXT: 'macros::num_sqrt!(${1:x}, ${2:bitsize})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, u8): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_sqrt;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_to_string!()'
-    INSERT TEXT: 'num_to_string!(${1:x})'
-    TARGET     : '(use std::macros::num_to_string)'
+    INSERT TEXT: 'macros::num_to_string!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): String'
-    ADDITIONAL EDIT: 'use std::macros::num_to_string;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::macros::range_do)'
+    INSERT TEXT: 'macros::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, $T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::range_do;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::macros::range_do_eq)'
+    INSERT TEXT: 'macros::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, $T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::range_do_eq;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u128!()'
-    INSERT TEXT: 'try_as_u128!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u128)'
+    INSERT TEXT: 'macros::try_as_u128!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u128;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u16!()'
-    INSERT TEXT: 'try_as_u16!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u16)'
+    INSERT TEXT: 'macros::try_as_u16!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u16;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u32!()'
-    INSERT TEXT: 'try_as_u32!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u32)'
+    INSERT TEXT: 'macros::try_as_u32!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u32;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u64!()'
-    INSERT TEXT: 'try_as_u64!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u64)'
+    INSERT TEXT: 'macros::try_as_u64!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u64;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u8!()'
-    INSERT TEXT: 'try_as_u8!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u8)'
+    INSERT TEXT: 'macros::try_as_u8!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u8;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_add!()'
-    INSERT TEXT: 'uq_add!(${1:a}, ${2:b}, ${3:max_t}, ${4:abort_overflow})'
-    TARGET     : '(use std::macros::uq_add)'
+    INSERT TEXT: 'macros::uq_add!(${1:a}, ${2:b}, ${3:max_t}, ${4:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_add;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_from_int!()'
-    INSERT TEXT: 'uq_from_int!(${1:integer}, ${2:fractional_bits})'
-    TARGET     : '(use std::macros::uq_from_int)'
+    INSERT TEXT: 'macros::uq_from_int!(${1:integer}, ${2:fractional_bits})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, u8): $U'
-    ADDITIONAL EDIT: 'use std::macros::uq_from_int;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_from_quotient!()'
-    INSERT TEXT: 'uq_from_quotient!(${1:numerator}, ${2:denominator}, ${3:max_t}, ${4:t_bits}, ${5:fractional_bits}, ${6:abort_denominator}, ${7:abort_quotient_too_small}, ${8:abort_quotient_too_large})'
-    TARGET     : '(use std::macros::uq_from_quotient)'
+    INSERT TEXT: 'macros::uq_from_quotient!(${1:numerator}, ${2:denominator}, ${3:max_t}, ${4:t_bits}, ${5:fractional_bits}, ${6:abort_denominator}, ${7:abort_quotient_too_small}, ${8:abort_quotient_too_large})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, u8, _, _, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_from_quotient;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_int_div!()'
-    INSERT TEXT: 'uq_int_div!(${1:val}, ${2:divisor}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_division_by_zero}, ${6:abort_overflow})'
-    TARGET     : '(use std::macros::uq_int_div)'
+    INSERT TEXT: 'macros::uq_int_div!(${1:val}, ${2:divisor}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_division_by_zero}, ${6:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, _, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_int_div;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_int_mul!()'
-    INSERT TEXT: 'uq_int_mul!(${1:val}, ${2:multiplier}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_overflow})'
-    TARGET     : '(use std::macros::uq_int_mul)'
+    INSERT TEXT: 'macros::uq_int_mul!(${1:val}, ${2:multiplier}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_int_mul;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_sub!()'
-    INSERT TEXT: 'uq_sub!(${1:a}, ${2:b}, ${3:abort_overflow})'
-    TARGET     : '(use std::macros::uq_sub)'
+    INSERT TEXT: 'macros::uq_sub!(${1:a}, ${2:b}, ${3:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_sub;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_to_int!()'
-    INSERT TEXT: 'uq_to_int!(${1:a}, ${2:fractional_bits})'
-    TARGET     : '(use std::macros::uq_to_int)'
+    INSERT TEXT: 'macros::uq_to_int!(${1:a}, ${2:fractional_bits})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($U, u8): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_to_int;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'and!()'
-    INSERT TEXT: 'and!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::and)'
+    INSERT TEXT: 'option::and!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::and)'
     TYPE       : 'fun <$T, $U>(Option, |$T| -> Option): Option'
-    ADDITIONAL EDIT: 'use std::option::and;
-
-    '
 Method 'and_ref!()'
-    INSERT TEXT: 'and_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::and_ref)'
+    INSERT TEXT: 'option::and_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::and_ref)'
     TYPE       : 'fun <$T, $U>(&Option, |&$T| -> Option): Option'
-    ADDITIONAL EDIT: 'use std::option::and_ref;
-
-    '
 Method 'borrow()'
-    INSERT TEXT: 'borrow(${1:t})'
-    TARGET     : '(use std::option::borrow)'
+    INSERT TEXT: 'option::borrow(${1:t})'
+    TARGET     : '(option::borrow)'
     TYPE       : 'fun <Element>(&Option): &Element'
-    ADDITIONAL EDIT: 'use std::option::borrow;
-
-    '
 Method 'borrow_mut()'
-    INSERT TEXT: 'borrow_mut(${1:t})'
-    TARGET     : '(use std::option::borrow_mut)'
+    INSERT TEXT: 'option::borrow_mut(${1:t})'
+    TARGET     : '(option::borrow_mut)'
     TYPE       : 'fun <Element>(&mut Option): &mut Element'
-    ADDITIONAL EDIT: 'use std::option::borrow_mut;
-
-    '
 Method 'borrow_with_default()'
-    INSERT TEXT: 'borrow_with_default(${1:t}, ${2:default_ref})'
-    TARGET     : '(use std::option::borrow_with_default)'
+    INSERT TEXT: 'option::borrow_with_default(${1:t}, ${2:default_ref})'
+    TARGET     : '(option::borrow_with_default)'
     TYPE       : 'fun <Element>(&Option, &Element): &Element'
-    ADDITIONAL EDIT: 'use std::option::borrow_with_default;
-
-    '
 Method 'contains()'
-    INSERT TEXT: 'contains(${1:t}, ${2:e_ref})'
-    TARGET     : '(use std::option::contains)'
+    INSERT TEXT: 'option::contains(${1:t}, ${2:e_ref})'
+    TARGET     : '(option::contains)'
     TYPE       : 'fun <Element>(&Option, &Element): bool'
-    ADDITIONAL EDIT: 'use std::option::contains;
-
-    '
 Method 'destroy!()'
-    INSERT TEXT: 'destroy!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::destroy)'
+    INSERT TEXT: 'option::destroy!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::destroy)'
     TYPE       : 'fun <$T, $R>(Option, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::destroy;
-
-    '
 Method 'destroy_none()'
-    INSERT TEXT: 'destroy_none(${1:t})'
-    TARGET     : '(use std::option::destroy_none)'
+    INSERT TEXT: 'option::destroy_none(${1:t})'
+    TARGET     : '(option::destroy_none)'
     TYPE       : 'fun <Element>(Option)'
-    ADDITIONAL EDIT: 'use std::option::destroy_none;
-
-    '
 Method 'destroy_or!()'
-    INSERT TEXT: 'destroy_or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::destroy_or)'
+    INSERT TEXT: 'option::destroy_or!(${1:o}, ${2:default})'
+    TARGET     : '(option::destroy_or)'
     TYPE       : 'fun <$T>(Option, $T): $T'
-    ADDITIONAL EDIT: 'use std::option::destroy_or;
-
-    '
 Method 'destroy_some()'
-    INSERT TEXT: 'destroy_some(${1:t})'
-    TARGET     : '(use std::option::destroy_some)'
+    INSERT TEXT: 'option::destroy_some(${1:t})'
+    TARGET     : '(option::destroy_some)'
     TYPE       : 'fun <Element>(Option): Element'
-    ADDITIONAL EDIT: 'use std::option::destroy_some;
-
-    '
 Method 'destroy_with_default()'
-    INSERT TEXT: 'destroy_with_default(${1:t}, ${2:default})'
-    TARGET     : '(use std::option::destroy_with_default)'
+    INSERT TEXT: 'option::destroy_with_default(${1:t}, ${2:default})'
+    TARGET     : '(option::destroy_with_default)'
     TYPE       : 'fun <Element>(Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::destroy_with_default;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do)'
+    INSERT TEXT: 'option::do!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do)'
     TYPE       : 'fun <$T, $R>(Option, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do;
-
-    '
 Method 'do_mut!()'
-    INSERT TEXT: 'do_mut!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do_mut)'
+    INSERT TEXT: 'option::do_mut!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do_mut)'
     TYPE       : 'fun <$T, $R>(&mut Option, |&mut $T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do_mut;
-
-    '
 Method 'do_ref!()'
-    INSERT TEXT: 'do_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do_ref)'
+    INSERT TEXT: 'option::do_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do_ref)'
     TYPE       : 'fun <$T, $R>(&Option, |&$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do_ref;
-
-    '
 Method 'extract()'
-    INSERT TEXT: 'extract(${1:t})'
-    TARGET     : '(use std::option::extract)'
+    INSERT TEXT: 'option::extract(${1:t})'
+    TARGET     : '(option::extract)'
     TYPE       : 'fun <Element>(&mut Option): Element'
-    ADDITIONAL EDIT: 'use std::option::extract;
-
-    '
 Method 'extract_or!()'
-    INSERT TEXT: 'extract_or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::extract_or)'
+    INSERT TEXT: 'option::extract_or!(${1:o}, ${2:default})'
+    TARGET     : '(option::extract_or)'
     TYPE       : 'fun <$T>(&mut Option, $T): $T'
-    ADDITIONAL EDIT: 'use std::option::extract_or;
-
-    '
 Method 'fill()'
-    INSERT TEXT: 'fill(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::fill)'
+    INSERT TEXT: 'option::fill(${1:t}, ${2:e})'
+    TARGET     : '(option::fill)'
     TYPE       : 'fun <Element>(&mut Option, Element)'
-    ADDITIONAL EDIT: 'use std::option::fill;
-
-    '
 Method 'filter!()'
-    INSERT TEXT: 'filter!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::filter)'
+    INSERT TEXT: 'option::filter!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::filter)'
     TYPE       : 'fun <$T>(Option, |&$T| -> bool): Option'
-    ADDITIONAL EDIT: 'use std::option::filter;
-
-    '
 Method 'get_with_default()'
-    INSERT TEXT: 'get_with_default(${1:t}, ${2:default})'
-    TARGET     : '(use std::option::get_with_default)'
+    INSERT TEXT: 'option::get_with_default(${1:t}, ${2:default})'
+    TARGET     : '(option::get_with_default)'
     TYPE       : 'fun <Element>(&Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::get_with_default;
-
-    '
 Method 'is_none()'
-    INSERT TEXT: 'is_none(${1:t})'
-    TARGET     : '(use std::option::is_none)'
+    INSERT TEXT: 'option::is_none(${1:t})'
+    TARGET     : '(option::is_none)'
     TYPE       : 'fun <Element>(&Option): bool'
-    ADDITIONAL EDIT: 'use std::option::is_none;
-
-    '
 Method 'is_some()'
-    INSERT TEXT: 'is_some(${1:t})'
-    TARGET     : '(use std::option::is_some)'
+    INSERT TEXT: 'option::is_some(${1:t})'
+    TARGET     : '(option::is_some)'
     TYPE       : 'fun <Element>(&Option): bool'
-    ADDITIONAL EDIT: 'use std::option::is_some;
-
-    '
 Method 'is_some_and!()'
-    INSERT TEXT: 'is_some_and!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::is_some_and)'
+    INSERT TEXT: 'option::is_some_and!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::is_some_and)'
     TYPE       : 'fun <$T>(&Option, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::option::is_some_and;
-
-    '
 Method 'map!()'
-    INSERT TEXT: 'map!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::map)'
+    INSERT TEXT: 'option::map!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::map)'
     TYPE       : 'fun <$T, $U>(Option, |$T| -> $U): Option'
-    ADDITIONAL EDIT: 'use std::option::map;
-
-    '
 Method 'map_ref!()'
-    INSERT TEXT: 'map_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::map_ref)'
+    INSERT TEXT: 'option::map_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::map_ref)'
     TYPE       : 'fun <$T, $U>(&Option, |&$T| -> $U): Option'
-    ADDITIONAL EDIT: 'use std::option::map_ref;
-
-    '
 Method 'none()'
-    INSERT TEXT: 'none()'
-    TARGET     : '(use std::option::none)'
+    INSERT TEXT: 'option::none()'
+    TARGET     : '(option::none)'
     TYPE       : 'fun <Element>(): Option'
-    ADDITIONAL EDIT: 'use std::option::none;
-
-    '
 Method 'or!()'
-    INSERT TEXT: 'or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::or)'
+    INSERT TEXT: 'option::or!(${1:o}, ${2:default})'
+    TARGET     : '(option::or)'
     TYPE       : 'fun <$T>(Option, Option): Option'
-    ADDITIONAL EDIT: 'use std::option::or;
-
-    '
 Method 'some()'
-    INSERT TEXT: 'some(${1:e})'
-    TARGET     : '(use std::option::some)'
+    INSERT TEXT: 'option::some(${1:e})'
+    TARGET     : '(option::some)'
     TYPE       : 'fun <Element>(Element): Option'
-    ADDITIONAL EDIT: 'use std::option::some;
-
-    '
 Method 'swap()'
-    INSERT TEXT: 'swap(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::swap)'
+    INSERT TEXT: 'option::swap(${1:t}, ${2:e})'
+    TARGET     : '(option::swap)'
     TYPE       : 'fun <Element>(&mut Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::swap;
-
-    '
 Method 'swap_or_fill()'
-    INSERT TEXT: 'swap_or_fill(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::swap_or_fill)'
+    INSERT TEXT: 'option::swap_or_fill(${1:t}, ${2:e})'
+    TARGET     : '(option::swap_or_fill)'
     TYPE       : 'fun <Element>(&mut Option, Element): Option'
-    ADDITIONAL EDIT: 'use std::option::swap_or_fill;
-
-    '
 Method 'to_vec()'
-    INSERT TEXT: 'to_vec(${1:t})'
-    TARGET     : '(use std::option::to_vec)'
+    INSERT TEXT: 'option::to_vec(${1:t})'
+    TARGET     : '(option::to_vec)'
     TYPE       : 'fun <Element>(Option): vector<Element>'
-    ADDITIONAL EDIT: 'use std::option::to_vec;
-
-    '
 Method 'append()'
-    INSERT TEXT: 'append(${1:s}, ${2:r})'
-    TARGET     : '(use std::string::append)'
+    INSERT TEXT: 'string::append(${1:s}, ${2:r})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, String)'
-    ADDITIONAL EDIT: 'use std::string::append;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'append_utf8()'
-    INSERT TEXT: 'append_utf8(${1:s}, ${2:bytes})'
-    TARGET     : '(use std::string::append_utf8)'
+    INSERT TEXT: 'string::append_utf8(${1:s}, ${2:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, vector<u8>)'
-    ADDITIONAL EDIT: 'use std::string::append_utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'as_bytes()'
-    INSERT TEXT: 'as_bytes(${1:s})'
-    TARGET     : '(use std::string::as_bytes)'
+    INSERT TEXT: 'string::as_bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::as_bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'bytes()'
-    INSERT TEXT: 'bytes(${1:s})'
-    TARGET     : '(use std::string::bytes)'
+    INSERT TEXT: 'string::bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'from_ascii()'
-    INSERT TEXT: 'from_ascii(${1:s})'
-    TARGET     : '(use std::string::from_ascii)'
+    INSERT TEXT: 'string::from_ascii(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): String'
-    ADDITIONAL EDIT: 'use std::string::from_ascii;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:s}, ${2:r})'
-    TARGET     : '(use std::string::index_of)'
+    INSERT TEXT: 'string::index_of(${1:s}, ${2:r})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, &String): u64'
-    ADDITIONAL EDIT: 'use std::string::index_of;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:s}, ${2:at}, ${3:o})'
-    TARGET     : '(use std::string::insert)'
+    INSERT TEXT: 'string::insert(${1:s}, ${2:at}, ${3:o})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, u64, String)'
-    ADDITIONAL EDIT: 'use std::string::insert;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'internal_sub_string_for_testing()'
-    INSERT TEXT: 'internal_sub_string_for_testing(${1:v}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::internal_sub_string_for_testing)'
+    INSERT TEXT: 'string::internal_sub_string_for_testing(${1:v}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&vector<u8>, u64, u64): vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::internal_sub_string_for_testing;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'into_bytes()'
-    INSERT TEXT: 'into_bytes(${1:s})'
-    TARGET     : '(use std::string::into_bytes)'
+    INSERT TEXT: 'string::into_bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::into_bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:s})'
-    TARGET     : '(use std::string::is_empty)'
+    INSERT TEXT: 'string::is_empty(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::string::is_empty;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:s})'
-    TARGET     : '(use std::string::length)'
+    INSERT TEXT: 'string::length(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): u64'
-    ADDITIONAL EDIT: 'use std::string::length;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'sub_string()'
-    INSERT TEXT: 'sub_string(${1:s}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::sub_string)'
+    INSERT TEXT: 'string::sub_string(${1:s}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::string::sub_string;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'substring()'
-    INSERT TEXT: 'substring(${1:s}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::substring)'
+    INSERT TEXT: 'string::substring(${1:s}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::string::substring;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'to_ascii()'
-    INSERT TEXT: 'to_ascii(${1:s})'
-    TARGET     : '(use std::string::to_ascii)'
+    INSERT TEXT: 'string::to_ascii(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): String'
-    ADDITIONAL EDIT: 'use std::string::to_ascii;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'try_utf8()'
-    INSERT TEXT: 'try_utf8(${1:bytes})'
-    TARGET     : '(use std::string::try_utf8)'
+    INSERT TEXT: 'string::try_utf8(${1:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (vector<u8>): Option'
-    ADDITIONAL EDIT: 'use std::string::try_utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'utf8()'
-    INSERT TEXT: 'utf8(${1:bytes})'
-    TARGET     : '(use std::string::utf8)'
+    INSERT TEXT: 'string::utf8(${1:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (vector<u8>): String'
-    ADDITIONAL EDIT: 'use std::string::utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'address_string()'
-    INSERT TEXT: 'address_string(${1:self})'
-    TARGET     : '(use std::type_name::address_string)'
+    INSERT TEXT: 'type_name::address_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::address_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'as_string()'
-    INSERT TEXT: 'as_string(${1:self})'
-    TARGET     : '(use std::type_name::as_string)'
+    INSERT TEXT: 'type_name::as_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): &String'
-    ADDITIONAL EDIT: 'use std::type_name::as_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'borrow_string()'
-    INSERT TEXT: 'borrow_string(${1:self})'
-    TARGET     : '(use std::type_name::borrow_string)'
+    INSERT TEXT: 'type_name::borrow_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): &String'
-    ADDITIONAL EDIT: 'use std::type_name::borrow_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'defining_id()'
-    INSERT TEXT: 'defining_id()'
-    TARGET     : '(use std::type_name::defining_id)'
+    INSERT TEXT: 'type_name::defining_id()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): address'
-    ADDITIONAL EDIT: 'use std::type_name::defining_id;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get()'
-    INSERT TEXT: 'get()'
-    TARGET     : '(use std::type_name::get)'
+    INSERT TEXT: 'type_name::get()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::get;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_address()'
-    INSERT TEXT: 'get_address(${1:self})'
-    TARGET     : '(use std::type_name::get_address)'
+    INSERT TEXT: 'type_name::get_address(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::get_address;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_module()'
-    INSERT TEXT: 'get_module(${1:self})'
-    TARGET     : '(use std::type_name::get_module)'
+    INSERT TEXT: 'type_name::get_module(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::get_module;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_with_original_ids()'
-    INSERT TEXT: 'get_with_original_ids()'
-    TARGET     : '(use std::type_name::get_with_original_ids)'
+    INSERT TEXT: 'type_name::get_with_original_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::get_with_original_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'into_string()'
-    INSERT TEXT: 'into_string(${1:self})'
-    TARGET     : '(use std::type_name::into_string)'
+    INSERT TEXT: 'type_name::into_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::into_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'is_primitive()'
-    INSERT TEXT: 'is_primitive(${1:self})'
-    TARGET     : '(use std::type_name::is_primitive)'
+    INSERT TEXT: 'type_name::is_primitive(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): bool'
-    ADDITIONAL EDIT: 'use std::type_name::is_primitive;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'module_string()'
-    INSERT TEXT: 'module_string(${1:self})'
-    TARGET     : '(use std::type_name::module_string)'
+    INSERT TEXT: 'type_name::module_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::module_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'original_id()'
-    INSERT TEXT: 'original_id()'
-    TARGET     : '(use std::type_name::original_id)'
+    INSERT TEXT: 'type_name::original_id()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): address'
-    ADDITIONAL EDIT: 'use std::type_name::original_id;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'with_defining_ids()'
-    INSERT TEXT: 'with_defining_ids()'
-    TARGET     : '(use std::type_name::with_defining_ids)'
+    INSERT TEXT: 'type_name::with_defining_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::with_defining_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'with_original_ids()'
-    INSERT TEXT: 'with_original_ids()'
-    TARGET     : '(use std::type_name::with_original_ids)'
+    INSERT TEXT: 'type_name::with_original_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::with_original_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u128::bitwise_not)'
+    INSERT TEXT: 'u128::bitwise_not(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::diff)'
+    INSERT TEXT: 'u128::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::diff;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::divide_and_round_up)'
+    INSERT TEXT: 'u128::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u128::do)'
+    INSERT TEXT: 'u128::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::do;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u128::do_eq)'
+    INSERT TEXT: 'u128::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::do_eq;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::max)'
+    INSERT TEXT: 'u128::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::max;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u128::max_value)'
+    INSERT TEXT: 'u128::max_value!()'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (): u128'
-    ADDITIONAL EDIT: 'use std::u128::max_value;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::min)'
+    INSERT TEXT: 'u128::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::min;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u128::pow)'
+    INSERT TEXT: 'u128::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u8): u128'
-    ADDITIONAL EDIT: 'use std::u128::pow;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u128::range_do)'
+    INSERT TEXT: 'u128::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::range_do;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u128::range_do_eq)'
+    INSERT TEXT: 'u128::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u128::sqrt)'
+    INSERT TEXT: 'u128::sqrt(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::sqrt;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u128::to_string)'
+    INSERT TEXT: 'u128::to_string(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): String'
-    ADDITIONAL EDIT: 'use std::u128::to_string;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u128::try_as_u16)'
+    INSERT TEXT: 'u128::try_as_u16(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u128::try_as_u32)'
+    INSERT TEXT: 'u128::try_as_u32(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u64()'
-    INSERT TEXT: 'try_as_u64(${1:x})'
-    TARGET     : '(use std::u128::try_as_u64)'
+    INSERT TEXT: 'u128::try_as_u64(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u64;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u128::try_as_u8)'
+    INSERT TEXT: 'u128::try_as_u8(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u16::bitwise_not)'
+    INSERT TEXT: 'u16::bitwise_not(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::diff)'
+    INSERT TEXT: 'u16::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::diff;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::divide_and_round_up)'
+    INSERT TEXT: 'u16::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u16::do)'
+    INSERT TEXT: 'u16::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::do;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u16::do_eq)'
+    INSERT TEXT: 'u16::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::do_eq;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::max)'
+    INSERT TEXT: 'u16::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::max;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u16::max_value)'
+    INSERT TEXT: 'u16::max_value!()'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (): u16'
-    ADDITIONAL EDIT: 'use std::u16::max_value;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::min)'
+    INSERT TEXT: 'u16::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::min;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u16::pow)'
+    INSERT TEXT: 'u16::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u8): u16'
-    ADDITIONAL EDIT: 'use std::u16::pow;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u16::range_do)'
+    INSERT TEXT: 'u16::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::range_do;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u16::range_do_eq)'
+    INSERT TEXT: 'u16::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u16::sqrt)'
+    INSERT TEXT: 'u16::sqrt(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::sqrt;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u16::to_string)'
+    INSERT TEXT: 'u16::to_string(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): String'
-    ADDITIONAL EDIT: 'use std::u16::to_string;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u16::try_as_u8)'
+    INSERT TEXT: 'u16::try_as_u8(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): Option'
-    ADDITIONAL EDIT: 'use std::u16::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u256::bitwise_not)'
+    INSERT TEXT: 'u256::bitwise_not(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::diff)'
+    INSERT TEXT: 'u256::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::diff;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::divide_and_round_up)'
+    INSERT TEXT: 'u256::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u256::do)'
+    INSERT TEXT: 'u256::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::do;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u256::do_eq)'
+    INSERT TEXT: 'u256::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::do_eq;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::max)'
+    INSERT TEXT: 'u256::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::max;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u256::max_value)'
+    INSERT TEXT: 'u256::max_value!()'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (): u256'
-    ADDITIONAL EDIT: 'use std::u256::max_value;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::min)'
+    INSERT TEXT: 'u256::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::min;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u256::pow)'
+    INSERT TEXT: 'u256::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u8): u256'
-    ADDITIONAL EDIT: 'use std::u256::pow;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u256::range_do)'
+    INSERT TEXT: 'u256::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::range_do;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u256::range_do_eq)'
+    INSERT TEXT: 'u256::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u256::to_string)'
+    INSERT TEXT: 'u256::to_string(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): String'
-    ADDITIONAL EDIT: 'use std::u256::to_string;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u128()'
-    INSERT TEXT: 'try_as_u128(${1:x})'
-    TARGET     : '(use std::u256::try_as_u128)'
+    INSERT TEXT: 'u256::try_as_u128(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u128;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u256::try_as_u16)'
+    INSERT TEXT: 'u256::try_as_u16(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u256::try_as_u32)'
+    INSERT TEXT: 'u256::try_as_u32(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u64()'
-    INSERT TEXT: 'try_as_u64(${1:x})'
-    TARGET     : '(use std::u256::try_as_u64)'
+    INSERT TEXT: 'u256::try_as_u64(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u64;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u256::try_as_u8)'
+    INSERT TEXT: 'u256::try_as_u8(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u32::bitwise_not)'
+    INSERT TEXT: 'u32::bitwise_not(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::diff)'
+    INSERT TEXT: 'u32::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::diff;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::divide_and_round_up)'
+    INSERT TEXT: 'u32::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u32::do)'
+    INSERT TEXT: 'u32::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::do;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u32::do_eq)'
+    INSERT TEXT: 'u32::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::do_eq;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::max)'
+    INSERT TEXT: 'u32::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::max;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u32::max_value)'
+    INSERT TEXT: 'u32::max_value!()'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (): u32'
-    ADDITIONAL EDIT: 'use std::u32::max_value;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::min)'
+    INSERT TEXT: 'u32::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::min;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u32::pow)'
+    INSERT TEXT: 'u32::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u8): u32'
-    ADDITIONAL EDIT: 'use std::u32::pow;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u32::range_do)'
+    INSERT TEXT: 'u32::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::range_do;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u32::range_do_eq)'
+    INSERT TEXT: 'u32::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u32::sqrt)'
+    INSERT TEXT: 'u32::sqrt(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::sqrt;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u32::to_string)'
+    INSERT TEXT: 'u32::to_string(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): String'
-    ADDITIONAL EDIT: 'use std::u32::to_string;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u32::try_as_u16)'
+    INSERT TEXT: 'u32::try_as_u16(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): Option'
-    ADDITIONAL EDIT: 'use std::u32::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u32::try_as_u8)'
+    INSERT TEXT: 'u32::try_as_u8(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): Option'
-    ADDITIONAL EDIT: 'use std::u32::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u64::bitwise_not)'
+    INSERT TEXT: 'u64::bitwise_not(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::diff)'
+    INSERT TEXT: 'u64::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::diff;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::divide_and_round_up)'
+    INSERT TEXT: 'u64::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u64::do)'
+    INSERT TEXT: 'u64::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::do;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u64::do_eq)'
+    INSERT TEXT: 'u64::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::do_eq;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::max)'
+    INSERT TEXT: 'u64::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::max;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u64::max_value)'
+    INSERT TEXT: 'u64::max_value!()'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::u64::max_value;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::min)'
+    INSERT TEXT: 'u64::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::min;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u64::pow)'
+    INSERT TEXT: 'u64::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u8): u64'
-    ADDITIONAL EDIT: 'use std::u64::pow;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u64::range_do)'
+    INSERT TEXT: 'u64::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::range_do;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u64::range_do_eq)'
+    INSERT TEXT: 'u64::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u64::sqrt)'
+    INSERT TEXT: 'u64::sqrt(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::sqrt;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u64::to_string)'
+    INSERT TEXT: 'u64::to_string(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): String'
-    ADDITIONAL EDIT: 'use std::u64::to_string;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u64::try_as_u16)'
+    INSERT TEXT: 'u64::try_as_u16(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u64::try_as_u32)'
+    INSERT TEXT: 'u64::try_as_u32(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u64::try_as_u8)'
+    INSERT TEXT: 'u64::try_as_u8(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u8::bitwise_not)'
+    INSERT TEXT: 'u8::bitwise_not(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::diff)'
+    INSERT TEXT: 'u8::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::diff;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::divide_and_round_up)'
+    INSERT TEXT: 'u8::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u8::do)'
+    INSERT TEXT: 'u8::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::do;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u8::do_eq)'
+    INSERT TEXT: 'u8::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::do_eq;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::max)'
+    INSERT TEXT: 'u8::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::max;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u8::max_value)'
+    INSERT TEXT: 'u8::max_value!()'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (): u8'
-    ADDITIONAL EDIT: 'use std::u8::max_value;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::min)'
+    INSERT TEXT: 'u8::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::min;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u8::pow)'
+    INSERT TEXT: 'u8::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::pow;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u8::range_do)'
+    INSERT TEXT: 'u8::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::range_do;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u8::range_do_eq)'
+    INSERT TEXT: 'u8::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u8::sqrt)'
+    INSERT TEXT: 'u8::sqrt(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::sqrt;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u8::to_string)'
+    INSERT TEXT: 'u8::to_string(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): String'
-    ADDITIONAL EDIT: 'use std::u8::to_string;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'assert_eq!()'
-    INSERT TEXT: 'assert_eq!(${1:t1}, ${2:t2})'
-    TARGET     : '(use std::unit_test::assert_eq)'
+    INSERT TEXT: 'unit_test::assert_eq!(${1:t1}, ${2:t2})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <$T>($T, $T)'
-    ADDITIONAL EDIT: 'use std::unit_test::assert_eq;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'assert_ref_eq!()'
-    INSERT TEXT: 'assert_ref_eq!(${1:t1}, ${2:t2})'
-    TARGET     : '(use std::unit_test::assert_ref_eq)'
+    INSERT TEXT: 'unit_test::assert_ref_eq!(${1:t1}, ${2:t2})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <$T>(&$T, &$T)'
-    ADDITIONAL EDIT: 'use std::unit_test::assert_ref_eq;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'destroy()'
-    INSERT TEXT: 'destroy(${1:v})'
-    TARGET     : '(use std::unit_test::destroy)'
+    INSERT TEXT: 'unit_test::destroy(${1:v})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <T>(T)'
-    ADDITIONAL EDIT: 'use std::unit_test::destroy;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'poison()'
-    INSERT TEXT: 'poison()'
-    TARGET     : '(use std::unit_test::poison)'
+    INSERT TEXT: 'unit_test::poison()'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: 'use std::unit_test::poison;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'add()'
-    INSERT TEXT: 'add(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::add)'
+    INSERT TEXT: 'uq32_32::add(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::add;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'div()'
-    INSERT TEXT: 'div(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::div)'
+    INSERT TEXT: 'uq32_32::div(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::div;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_int()'
-    INSERT TEXT: 'from_int(${1:integer})'
-    TARGET     : '(use std::uq32_32::from_int)'
+    INSERT TEXT: 'uq32_32::from_int(${1:integer})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_int;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_quotient()'
-    INSERT TEXT: 'from_quotient(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::uq32_32::from_quotient)'
+    INSERT TEXT: 'uq32_32::from_quotient(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, u64): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_quotient;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_raw()'
-    INSERT TEXT: 'from_raw(${1:raw_value})'
-    TARGET     : '(use std::uq32_32::from_raw)'
+    INSERT TEXT: 'uq32_32::from_raw(${1:raw_value})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_raw;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'ge()'
-    INSERT TEXT: 'ge(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::ge)'
+    INSERT TEXT: 'uq32_32::ge(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::ge;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'gt()'
-    INSERT TEXT: 'gt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::gt)'
+    INSERT TEXT: 'uq32_32::gt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::gt;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'int_div()'
-    INSERT TEXT: 'int_div(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::uq32_32::int_div)'
+    INSERT TEXT: 'uq32_32::int_div(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::int_div;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'int_mul()'
-    INSERT TEXT: 'int_mul(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::uq32_32::int_mul)'
+    INSERT TEXT: 'uq32_32::int_mul(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::int_mul;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'le()'
-    INSERT TEXT: 'le(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::le)'
+    INSERT TEXT: 'uq32_32::le(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::le;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'lt()'
-    INSERT TEXT: 'lt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::lt)'
+    INSERT TEXT: 'uq32_32::lt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::lt;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'mul()'
-    INSERT TEXT: 'mul(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::mul)'
+    INSERT TEXT: 'uq32_32::mul(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::mul;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'sub()'
-    INSERT TEXT: 'sub(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::sub)'
+    INSERT TEXT: 'uq32_32::sub(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::sub;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'to_int()'
-    INSERT TEXT: 'to_int(${1:a})'
-    TARGET     : '(use std::uq32_32::to_int)'
+    INSERT TEXT: 'uq32_32::to_int(${1:a})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32): u32'
-    ADDITIONAL EDIT: 'use std::uq32_32::to_int;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'to_raw()'
-    INSERT TEXT: 'to_raw(${1:a})'
-    TARGET     : '(use std::uq32_32::to_raw)'
+    INSERT TEXT: 'uq32_32::to_raw(${1:a})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::to_raw;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'add()'
-    INSERT TEXT: 'add(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::add)'
+    INSERT TEXT: 'uq64_64::add(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::add;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'div()'
-    INSERT TEXT: 'div(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::div)'
+    INSERT TEXT: 'uq64_64::div(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::div;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_int()'
-    INSERT TEXT: 'from_int(${1:integer})'
-    TARGET     : '(use std::uq64_64::from_int)'
+    INSERT TEXT: 'uq64_64::from_int(${1:integer})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_int;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_quotient()'
-    INSERT TEXT: 'from_quotient(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::uq64_64::from_quotient)'
+    INSERT TEXT: 'uq64_64::from_quotient(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, u128): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_quotient;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_raw()'
-    INSERT TEXT: 'from_raw(${1:raw_value})'
-    TARGET     : '(use std::uq64_64::from_raw)'
+    INSERT TEXT: 'uq64_64::from_raw(${1:raw_value})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_raw;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'ge()'
-    INSERT TEXT: 'ge(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::ge)'
+    INSERT TEXT: 'uq64_64::ge(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::ge;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'gt()'
-    INSERT TEXT: 'gt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::gt)'
+    INSERT TEXT: 'uq64_64::gt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::gt;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'int_div()'
-    INSERT TEXT: 'int_div(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::uq64_64::int_div)'
+    INSERT TEXT: 'uq64_64::int_div(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::int_div;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'int_mul()'
-    INSERT TEXT: 'int_mul(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::uq64_64::int_mul)'
+    INSERT TEXT: 'uq64_64::int_mul(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::int_mul;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'le()'
-    INSERT TEXT: 'le(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::le)'
+    INSERT TEXT: 'uq64_64::le(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::le;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'lt()'
-    INSERT TEXT: 'lt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::lt)'
+    INSERT TEXT: 'uq64_64::lt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::lt;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'mul()'
-    INSERT TEXT: 'mul(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::mul)'
+    INSERT TEXT: 'uq64_64::mul(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::mul;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'sub()'
-    INSERT TEXT: 'sub(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::sub)'
+    INSERT TEXT: 'uq64_64::sub(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::sub;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'to_int()'
-    INSERT TEXT: 'to_int(${1:a})'
-    TARGET     : '(use std::uq64_64::to_int)'
+    INSERT TEXT: 'uq64_64::to_int(${1:a})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64): u64'
-    ADDITIONAL EDIT: 'use std::uq64_64::to_int;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'to_raw()'
-    INSERT TEXT: 'to_raw(${1:a})'
-    TARGET     : '(use std::uq64_64::to_raw)'
+    INSERT TEXT: 'uq64_64::to_raw(${1:a})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::to_raw;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'all!()'
-    INSERT TEXT: 'all!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::all)'
+    INSERT TEXT: 'vector::all!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::all)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::all;
-
-    '
 Method 'any!()'
-    INSERT TEXT: 'any!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::any)'
+    INSERT TEXT: 'vector::any!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::any)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::any;
-
-    '
 Method 'append()'
-    INSERT TEXT: 'append(${1:lhs}, ${2:other})'
-    TARGET     : '(use std::vector::append)'
+    INSERT TEXT: 'vector::append(${1:lhs}, ${2:other})'
+    TARGET     : '(vector::append)'
     TYPE       : 'fun <Element>(&mut vector<Element>, vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::append;
-
-    '
 Method 'borrow()'
-    INSERT TEXT: 'borrow(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::borrow)'
+    INSERT TEXT: 'vector::borrow(${1:v}, ${2:i})'
+    TARGET     : '(vector::borrow)'
     TYPE       : 'fun <Element>(&vector<Element>, u64): &Element'
-    ADDITIONAL EDIT: 'use std::vector::borrow;
-
-    '
 Method 'borrow_mut()'
-    INSERT TEXT: 'borrow_mut(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::borrow_mut)'
+    INSERT TEXT: 'vector::borrow_mut(${1:v}, ${2:i})'
+    TARGET     : '(vector::borrow_mut)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): &mut Element'
-    ADDITIONAL EDIT: 'use std::vector::borrow_mut;
-
-    '
 Method 'contains()'
-    INSERT TEXT: 'contains(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::contains)'
+    INSERT TEXT: 'vector::contains(${1:v}, ${2:e})'
+    TARGET     : '(vector::contains)'
     TYPE       : 'fun <Element>(&vector<Element>, &Element): bool'
-    ADDITIONAL EDIT: 'use std::vector::contains;
-
-    '
 Method 'count!()'
-    INSERT TEXT: 'count!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::count)'
+    INSERT TEXT: 'vector::count!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::count)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): u64'
-    ADDITIONAL EDIT: 'use std::vector::count;
-
-    '
 Method 'destroy!()'
-    INSERT TEXT: 'destroy!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::destroy)'
+    INSERT TEXT: 'vector::destroy!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::destroy)'
     TYPE       : 'fun <$T, $R>(vector<$T>, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::destroy;
-
-    '
 Method 'destroy_empty()'
-    INSERT TEXT: 'destroy_empty(${1:v})'
-    TARGET     : '(use std::vector::destroy_empty)'
+    INSERT TEXT: 'vector::destroy_empty(${1:v})'
+    TARGET     : '(vector::destroy_empty)'
     TYPE       : 'fun <Element>(vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::destroy_empty;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do)'
+    INSERT TEXT: 'vector::do!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do)'
     TYPE       : 'fun <$T, $R>(vector<$T>, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do;
-
-    '
 Method 'do_mut!()'
-    INSERT TEXT: 'do_mut!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do_mut)'
+    INSERT TEXT: 'vector::do_mut!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do_mut)'
     TYPE       : 'fun <$T, $R>(&mut vector<$T>, |&mut $T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do_mut;
-
-    '
 Method 'do_ref!()'
-    INSERT TEXT: 'do_ref!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do_ref)'
+    INSERT TEXT: 'vector::do_ref!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do_ref)'
     TYPE       : 'fun <$T, $R>(&vector<$T>, |&$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do_ref;
-
-    '
 Method 'empty()'
-    INSERT TEXT: 'empty()'
-    TARGET     : '(use std::vector::empty)'
+    INSERT TEXT: 'vector::empty()'
+    TARGET     : '(vector::empty)'
     TYPE       : 'fun <Element>(): vector<Element>'
-    ADDITIONAL EDIT: 'use std::vector::empty;
-
-    '
 Method 'filter!()'
-    INSERT TEXT: 'filter!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::filter)'
+    INSERT TEXT: 'vector::filter!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::filter)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::filter;
-
-    '
 Method 'find_index!()'
-    INSERT TEXT: 'find_index!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::find_index)'
+    INSERT TEXT: 'vector::find_index!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::find_index)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): Option'
-    ADDITIONAL EDIT: 'use std::vector::find_index;
-
-    '
 Method 'find_indices!()'
-    INSERT TEXT: 'find_indices!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::find_indices)'
+    INSERT TEXT: 'vector::find_indices!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::find_indices)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): vector<u64>'
-    ADDITIONAL EDIT: 'use std::vector::find_indices;
-
-    '
 Method 'flatten()'
-    INSERT TEXT: 'flatten(${1:v})'
-    TARGET     : '(use std::vector::flatten)'
+    INSERT TEXT: 'vector::flatten(${1:v})'
+    TARGET     : '(vector::flatten)'
     TYPE       : 'fun <T>(vector<vector<T>>): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::flatten;
-
-    '
 Method 'fold!()'
-    INSERT TEXT: 'fold!(${1:v}, ${2:init}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::fold)'
+    INSERT TEXT: 'vector::fold!(${1:v}, ${2:init}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::fold)'
     TYPE       : 'fun <$T, $Acc>(vector<$T>, $Acc, |$Acc, $T| -> $Acc): $Acc'
-    ADDITIONAL EDIT: 'use std::vector::fold;
-
-    '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::index_of)'
+    INSERT TEXT: 'vector::index_of(${1:v}, ${2:e})'
+    TARGET     : '(vector::index_of)'
     TYPE       : 'fun <Element>(&vector<Element>, &Element): (bool, u64)'
-    ADDITIONAL EDIT: 'use std::vector::index_of;
-
-    '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:v}, ${2:e}, ${3:i})'
-    TARGET     : '(use std::vector::insert)'
+    INSERT TEXT: 'vector::insert(${1:v}, ${2:e}, ${3:i})'
+    TARGET     : '(vector::insert)'
     TYPE       : 'fun <Element>(&mut vector<Element>, Element, u64)'
-    ADDITIONAL EDIT: 'use std::vector::insert;
-
-    '
 Method 'insertion_sort_by!()'
-    INSERT TEXT: 'insertion_sort_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::insertion_sort_by)'
+    INSERT TEXT: 'vector::insertion_sort_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::insertion_sort_by)'
     TYPE       : 'fun <$T>(&mut vector<$T>, |&$T, &$T| -> bool)'
-    ADDITIONAL EDIT: 'use std::vector::insertion_sort_by;
-
-    '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:v})'
-    TARGET     : '(use std::vector::is_empty)'
+    INSERT TEXT: 'vector::is_empty(${1:v})'
+    TARGET     : '(vector::is_empty)'
     TYPE       : 'fun <Element>(&vector<Element>): bool'
-    ADDITIONAL EDIT: 'use std::vector::is_empty;
-
-    '
 Method 'is_sorted_by!()'
-    INSERT TEXT: 'is_sorted_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::is_sorted_by)'
+    INSERT TEXT: 'vector::is_sorted_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::is_sorted_by)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T, &$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::is_sorted_by;
-
-    '
 Method 'length()'
-    INSERT TEXT: 'length(${1:v})'
-    TARGET     : '(use std::vector::length)'
+    INSERT TEXT: 'vector::length(${1:v})'
+    TARGET     : '(vector::length)'
     TYPE       : 'fun <Element>(&vector<Element>): u64'
-    ADDITIONAL EDIT: 'use std::vector::length;
-
-    '
 Method 'map!()'
-    INSERT TEXT: 'map!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::map)'
+    INSERT TEXT: 'vector::map!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::map)'
     TYPE       : 'fun <$T, $U>(vector<$T>, |$T| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::map;
-
-    '
 Method 'map_ref!()'
-    INSERT TEXT: 'map_ref!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::map_ref)'
+    INSERT TEXT: 'vector::map_ref!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::map_ref)'
     TYPE       : 'fun <$T, $U>(&vector<$T>, |&$T| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::map_ref;
-
-    '
 Method 'merge_sort_by!()'
-    INSERT TEXT: 'merge_sort_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::merge_sort_by)'
+    INSERT TEXT: 'vector::merge_sort_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::merge_sort_by)'
     TYPE       : 'fun <$T>(&mut vector<$T>, |&$T, &$T| -> bool)'
-    ADDITIONAL EDIT: 'use std::vector::merge_sort_by;
-
-    '
 Method 'partition!()'
-    INSERT TEXT: 'partition!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::partition)'
+    INSERT TEXT: 'vector::partition!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::partition)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): (vector<$T>, vector<$T>)'
-    ADDITIONAL EDIT: 'use std::vector::partition;
-
-    '
 Method 'pop_back()'
-    INSERT TEXT: 'pop_back(${1:v})'
-    TARGET     : '(use std::vector::pop_back)'
+    INSERT TEXT: 'vector::pop_back(${1:v})'
+    TARGET     : '(vector::pop_back)'
     TYPE       : 'fun <Element>(&mut vector<Element>): Element'
-    ADDITIONAL EDIT: 'use std::vector::pop_back;
-
-    '
 Method 'push_back()'
-    INSERT TEXT: 'push_back(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::push_back)'
+    INSERT TEXT: 'vector::push_back(${1:v}, ${2:e})'
+    TARGET     : '(vector::push_back)'
     TYPE       : 'fun <Element>(&mut vector<Element>, Element)'
-    ADDITIONAL EDIT: 'use std::vector::push_back;
-
-    '
 Method 'remove()'
-    INSERT TEXT: 'remove(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::remove)'
+    INSERT TEXT: 'vector::remove(${1:v}, ${2:i})'
+    TARGET     : '(vector::remove)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): Element'
-    ADDITIONAL EDIT: 'use std::vector::remove;
-
-    '
 Method 'reverse()'
-    INSERT TEXT: 'reverse(${1:v})'
-    TARGET     : '(use std::vector::reverse)'
+    INSERT TEXT: 'vector::reverse(${1:v})'
+    TARGET     : '(vector::reverse)'
     TYPE       : 'fun <Element>(&mut vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::reverse;
-
-    '
 Method 'singleton()'
-    INSERT TEXT: 'singleton(${1:e})'
-    TARGET     : '(use std::vector::singleton)'
+    INSERT TEXT: 'vector::singleton(${1:e})'
+    TARGET     : '(vector::singleton)'
     TYPE       : 'fun <Element>(Element): vector<Element>'
-    ADDITIONAL EDIT: 'use std::vector::singleton;
-
-    '
 Method 'skip()'
-    INSERT TEXT: 'skip(${1:v}, ${2:n})'
-    TARGET     : '(use std::vector::skip)'
+    INSERT TEXT: 'vector::skip(${1:v}, ${2:n})'
+    TARGET     : '(vector::skip)'
     TYPE       : 'fun <T>(vector<T>, u64): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::skip;
-
-    '
 Method 'skip_while!()'
-    INSERT TEXT: 'skip_while!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::skip_while)'
+    INSERT TEXT: 'vector::skip_while!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::skip_while)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::skip_while;
-
-    '
 Method 'swap()'
-    INSERT TEXT: 'swap(${1:v}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::vector::swap)'
+    INSERT TEXT: 'vector::swap(${1:v}, ${2:i}, ${3:j})'
+    TARGET     : '(vector::swap)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64, u64)'
-    ADDITIONAL EDIT: 'use std::vector::swap;
-
-    '
 Method 'swap_remove()'
-    INSERT TEXT: 'swap_remove(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::swap_remove)'
+    INSERT TEXT: 'vector::swap_remove(${1:v}, ${2:i})'
+    TARGET     : '(vector::swap_remove)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): Element'
-    ADDITIONAL EDIT: 'use std::vector::swap_remove;
-
-    '
 Method 'tabulate!()'
-    INSERT TEXT: 'tabulate!(${1:n}, |${2}| ${3})'
-    TARGET     : '(use std::vector::tabulate)'
+    INSERT TEXT: 'vector::tabulate!(${1:n}, |${2}| ${3})'
+    TARGET     : '(vector::tabulate)'
     TYPE       : 'fun <$T>(u64, |u64| -> $T): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::tabulate;
-
-    '
 Method 'take()'
-    INSERT TEXT: 'take(${1:v}, ${2:n})'
-    TARGET     : '(use std::vector::take)'
+    INSERT TEXT: 'vector::take(${1:v}, ${2:n})'
+    TARGET     : '(vector::take)'
     TYPE       : 'fun <T>(vector<T>, u64): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::take;
-
-    '
 Method 'take_while!()'
-    INSERT TEXT: 'take_while!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::take_while)'
+    INSERT TEXT: 'vector::take_while!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::take_while)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::take_while;
-
-    '
 Method 'zip_do!()'
-    INSERT TEXT: 'zip_do!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do)'
+    INSERT TEXT: 'vector::zip_do!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do)'
     TYPE       : 'fun <$T1, $T2, $R>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do;
-
-    '
 Method 'zip_do_mut!()'
-    INSERT TEXT: 'zip_do_mut!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_mut)'
+    INSERT TEXT: 'vector::zip_do_mut!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_mut)'
     TYPE       : 'fun <$T1, $T2, $R>(&mut vector<$T1>, &mut vector<$T2>, |&mut $T1, &mut $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_mut;
-
-    '
 Method 'zip_do_ref!()'
-    INSERT TEXT: 'zip_do_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_ref)'
+    INSERT TEXT: 'vector::zip_do_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_ref)'
     TYPE       : 'fun <$T1, $T2, $R>(&vector<$T1>, &vector<$T2>, |&$T1, &$T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_ref;
-
-    '
 Method 'zip_do_reverse!()'
-    INSERT TEXT: 'zip_do_reverse!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_reverse)'
+    INSERT TEXT: 'vector::zip_do_reverse!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_reverse)'
     TYPE       : 'fun <$T1, $T2, $R>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_reverse;
-
-    '
 Method 'zip_map!()'
-    INSERT TEXT: 'zip_map!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_map)'
+    INSERT TEXT: 'vector::zip_map!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_map)'
     TYPE       : 'fun <$T1, $T2, $U>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::zip_map;
-
-    '
 Method 'zip_map_ref!()'
-    INSERT TEXT: 'zip_map_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_map_ref)'
+    INSERT TEXT: 'vector::zip_map_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_map_ref)'
     TYPE       : 'fun <$T1, $T2, $U>(&vector<$T1>, &vector<$T2>, |&$T1, &$T2| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::zip_map_ref;
-
-    '
 
 -- test 5 -------------------
 use line: 39, use_col: 9
@@ -4921,2067 +4459,1836 @@ Method 'int_match_function()'
     TARGET     : '(Enums::int_match::int_match_function)'
     TYPE       : 'fun (u64)'
 Method 'length()'
-    INSERT TEXT: 'length()'
-    TARGET     : '(use std::address::length)'
+    INSERT TEXT: 'address::length()'
+    TARGET     : '(use std::address)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::address::length;
+    ADDITIONAL EDIT: 'use std::address;
 
     '
 Method 'all_characters_printable()'
-    INSERT TEXT: 'all_characters_printable(${1:string})'
-    TARGET     : '(use std::ascii::all_characters_printable)'
+    INSERT TEXT: 'ascii::all_characters_printable(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::ascii::all_characters_printable;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'append()'
-    INSERT TEXT: 'append(${1:string}, ${2:other})'
-    TARGET     : '(use std::ascii::append)'
+    INSERT TEXT: 'ascii::append(${1:string}, ${2:other})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, String)'
-    ADDITIONAL EDIT: 'use std::ascii::append;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'as_bytes()'
-    INSERT TEXT: 'as_bytes(${1:string})'
-    TARGET     : '(use std::ascii::as_bytes)'
+    INSERT TEXT: 'ascii::as_bytes(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::ascii::as_bytes;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'byte()'
-    INSERT TEXT: 'byte(${1:char})'
-    TARGET     : '(use std::ascii::byte)'
+    INSERT TEXT: 'ascii::byte(${1:char})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (Char): u8'
-    ADDITIONAL EDIT: 'use std::ascii::byte;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'char()'
-    INSERT TEXT: 'char(${1:byte})'
-    TARGET     : '(use std::ascii::char)'
+    INSERT TEXT: 'ascii::char(${1:byte})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): Char'
-    ADDITIONAL EDIT: 'use std::ascii::char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:string}, ${2:substr})'
-    TARGET     : '(use std::ascii::index_of)'
+    INSERT TEXT: 'ascii::index_of(${1:string}, ${2:substr})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String, &String): u64'
-    ADDITIONAL EDIT: 'use std::ascii::index_of;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:s}, ${2:at}, ${3:o})'
-    TARGET     : '(use std::ascii::insert)'
+    INSERT TEXT: 'ascii::insert(${1:s}, ${2:at}, ${3:o})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, u64, String)'
-    ADDITIONAL EDIT: 'use std::ascii::insert;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'into_bytes()'
-    INSERT TEXT: 'into_bytes(${1:string})'
-    TARGET     : '(use std::ascii::into_bytes)'
+    INSERT TEXT: 'ascii::into_bytes(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (String): vector<u8>'
-    ADDITIONAL EDIT: 'use std::ascii::into_bytes;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:string})'
-    TARGET     : '(use std::ascii::is_empty)'
+    INSERT TEXT: 'ascii::is_empty(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_empty;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_printable_char()'
-    INSERT TEXT: 'is_printable_char(${1:byte})'
-    TARGET     : '(use std::ascii::is_printable_char)'
+    INSERT TEXT: 'ascii::is_printable_char(${1:byte})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_printable_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'is_valid_char()'
-    INSERT TEXT: 'is_valid_char(${1:b})'
-    TARGET     : '(use std::ascii::is_valid_char)'
+    INSERT TEXT: 'ascii::is_valid_char(${1:b})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (u8): bool'
-    ADDITIONAL EDIT: 'use std::ascii::is_valid_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:string})'
-    TARGET     : '(use std::ascii::length)'
+    INSERT TEXT: 'ascii::length(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): u64'
-    ADDITIONAL EDIT: 'use std::ascii::length;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'pop_char()'
-    INSERT TEXT: 'pop_char(${1:string})'
-    TARGET     : '(use std::ascii::pop_char)'
+    INSERT TEXT: 'ascii::pop_char(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String): Char'
-    ADDITIONAL EDIT: 'use std::ascii::pop_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'push_char()'
-    INSERT TEXT: 'push_char(${1:string}, ${2:char})'
-    TARGET     : '(use std::ascii::push_char)'
+    INSERT TEXT: 'ascii::push_char(${1:string}, ${2:char})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&mut String, Char)'
-    ADDITIONAL EDIT: 'use std::ascii::push_char;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'string()'
-    INSERT TEXT: 'string(${1:bytes})'
-    TARGET     : '(use std::ascii::string)'
+    INSERT TEXT: 'ascii::string(${1:bytes})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (vector<u8>): String'
-    ADDITIONAL EDIT: 'use std::ascii::string;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'substring()'
-    INSERT TEXT: 'substring(${1:string}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::ascii::substring)'
+    INSERT TEXT: 'ascii::substring(${1:string}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::ascii::substring;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_lowercase()'
-    INSERT TEXT: 'to_lowercase(${1:string})'
-    TARGET     : '(use std::ascii::to_lowercase)'
+    INSERT TEXT: 'ascii::to_lowercase(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): String'
-    ADDITIONAL EDIT: 'use std::ascii::to_lowercase;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_uppercase()'
-    INSERT TEXT: 'to_uppercase(${1:string})'
-    TARGET     : '(use std::ascii::to_uppercase)'
+    INSERT TEXT: 'ascii::to_uppercase(${1:string})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (&String): String'
-    ADDITIONAL EDIT: 'use std::ascii::to_uppercase;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'try_string()'
-    INSERT TEXT: 'try_string(${1:bytes})'
-    TARGET     : '(use std::ascii::try_string)'
+    INSERT TEXT: 'ascii::try_string(${1:bytes})'
+    TARGET     : '(use std::ascii)'
     TYPE       : 'fun (vector<u8>): Option'
-    ADDITIONAL EDIT: 'use std::ascii::try_string;
+    ADDITIONAL EDIT: 'use std::ascii;
 
     '
 Method 'to_bytes()'
-    INSERT TEXT: 'to_bytes(${1:v})'
-    TARGET     : '(use std::bcs::to_bytes)'
+    INSERT TEXT: 'bcs::to_bytes(${1:v})'
+    TARGET     : '(use std::bcs)'
     TYPE       : 'fun <MoveValue>(&MoveValue): vector<u8>'
-    ADDITIONAL EDIT: 'use std::bcs::to_bytes;
+    ADDITIONAL EDIT: 'use std::bcs;
 
     '
 Method 'is_index_set()'
-    INSERT TEXT: 'is_index_set(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::is_index_set)'
+    INSERT TEXT: 'bit_vector::is_index_set(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector, u64): bool'
-    ADDITIONAL EDIT: 'use std::bit_vector::is_index_set;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:bitvector})'
-    TARGET     : '(use std::bit_vector::length)'
+    INSERT TEXT: 'bit_vector::length(${1:bitvector})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::length;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'longest_set_sequence_starting_at()'
-    INSERT TEXT: 'longest_set_sequence_starting_at(${1:bitvector}, ${2:start_index})'
-    TARGET     : '(use std::bit_vector::longest_set_sequence_starting_at)'
+    INSERT TEXT: 'bit_vector::longest_set_sequence_starting_at(${1:bitvector}, ${2:start_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&BitVector, u64): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::longest_set_sequence_starting_at;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'new()'
-    INSERT TEXT: 'new(${1:length})'
-    TARGET     : '(use std::bit_vector::new)'
+    INSERT TEXT: 'bit_vector::new(${1:length})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (u64): BitVector'
-    ADDITIONAL EDIT: 'use std::bit_vector::new;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'set()'
-    INSERT TEXT: 'set(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::set)'
+    INSERT TEXT: 'bit_vector::set(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::set;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'shift_left()'
-    INSERT TEXT: 'shift_left(${1:bitvector}, ${2:amount})'
-    TARGET     : '(use std::bit_vector::shift_left)'
+    INSERT TEXT: 'bit_vector::shift_left(${1:bitvector}, ${2:amount})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::shift_left;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'unset()'
-    INSERT TEXT: 'unset(${1:bitvector}, ${2:bit_index})'
-    TARGET     : '(use std::bit_vector::unset)'
+    INSERT TEXT: 'bit_vector::unset(${1:bitvector}, ${2:bit_index})'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (&mut BitVector, u64)'
-    ADDITIONAL EDIT: 'use std::bit_vector::unset;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'word_size()'
-    INSERT TEXT: 'word_size()'
-    TARGET     : '(use std::bit_vector::word_size)'
+    INSERT TEXT: 'bit_vector::word_size()'
+    TARGET     : '(use std::bit_vector)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::bit_vector::word_size;
+    ADDITIONAL EDIT: 'use std::bit_vector;
 
     '
 Method 'print()'
-    INSERT TEXT: 'print(${1:x})'
-    TARGET     : '(use std::debug::print)'
+    INSERT TEXT: 'debug::print(${1:x})'
+    TARGET     : '(use std::debug)'
     TYPE       : 'fun <T>(&T)'
-    ADDITIONAL EDIT: 'use std::debug::print;
+    ADDITIONAL EDIT: 'use std::debug;
 
     '
 Method 'print_stack_trace()'
-    INSERT TEXT: 'print_stack_trace()'
-    TARGET     : '(use std::debug::print_stack_trace)'
+    INSERT TEXT: 'debug::print_stack_trace()'
+    TARGET     : '(use std::debug)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: 'use std::debug::print_stack_trace;
+    ADDITIONAL EDIT: 'use std::debug;
 
     '
 Method 'create_from_rational()'
-    INSERT TEXT: 'create_from_rational(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::fixed_point32::create_from_rational)'
+    INSERT TEXT: 'fixed_point32::create_from_rational(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, u64): FixedPoint32'
-    ADDITIONAL EDIT: 'use std::fixed_point32::create_from_rational;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'create_from_raw_value()'
-    INSERT TEXT: 'create_from_raw_value(${1:value})'
-    TARGET     : '(use std::fixed_point32::create_from_raw_value)'
+    INSERT TEXT: 'fixed_point32::create_from_raw_value(${1:value})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64): FixedPoint32'
-    ADDITIONAL EDIT: 'use std::fixed_point32::create_from_raw_value;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'divide_u64()'
-    INSERT TEXT: 'divide_u64(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::fixed_point32::divide_u64)'
+    INSERT TEXT: 'fixed_point32::divide_u64(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::divide_u64;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'get_raw_value()'
-    INSERT TEXT: 'get_raw_value(${1:num})'
-    TARGET     : '(use std::fixed_point32::get_raw_value)'
+    INSERT TEXT: 'fixed_point32::get_raw_value(${1:num})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::get_raw_value;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'is_zero()'
-    INSERT TEXT: 'is_zero(${1:num})'
-    TARGET     : '(use std::fixed_point32::is_zero)'
+    INSERT TEXT: 'fixed_point32::is_zero(${1:num})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (FixedPoint32): bool'
-    ADDITIONAL EDIT: 'use std::fixed_point32::is_zero;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'multiply_u64()'
-    INSERT TEXT: 'multiply_u64(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::fixed_point32::multiply_u64)'
+    INSERT TEXT: 'fixed_point32::multiply_u64(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::fixed_point32)'
     TYPE       : 'fun (u64, FixedPoint32): u64'
-    ADDITIONAL EDIT: 'use std::fixed_point32::multiply_u64;
+    ADDITIONAL EDIT: 'use std::fixed_point32;
 
     '
 Method 'sha2_256()'
-    INSERT TEXT: 'sha2_256(${1:data})'
-    TARGET     : '(use std::hash::sha2_256)'
+    INSERT TEXT: 'hash::sha2_256(${1:data})'
+    TARGET     : '(use std::hash)'
     TYPE       : 'fun (vector<u8>): vector<u8>'
-    ADDITIONAL EDIT: 'use std::hash::sha2_256;
+    ADDITIONAL EDIT: 'use std::hash;
 
     '
 Method 'sha3_256()'
-    INSERT TEXT: 'sha3_256(${1:data})'
-    TARGET     : '(use std::hash::sha3_256)'
+    INSERT TEXT: 'hash::sha3_256(${1:data})'
+    TARGET     : '(use std::hash)'
     TYPE       : 'fun (vector<u8>): vector<u8>'
-    ADDITIONAL EDIT: 'use std::hash::sha3_256;
+    ADDITIONAL EDIT: 'use std::hash;
 
     '
 Method 'permit()'
-    INSERT TEXT: 'permit()'
-    TARGET     : '(use std::internal::permit)'
+    INSERT TEXT: 'internal::permit()'
+    TARGET     : '(internal::permit)'
     TYPE       : 'fun <T>(): Permit'
-    ADDITIONAL EDIT: 'use std::internal::permit;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::macros::do)'
+    INSERT TEXT: 'macros::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::do;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::macros::do_eq)'
+    INSERT TEXT: 'macros::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::do_eq;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_diff!()'
-    INSERT TEXT: 'num_diff!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_diff)'
+    INSERT TEXT: 'macros::num_diff!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_diff;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_divide_and_round_up!()'
-    INSERT TEXT: 'num_divide_and_round_up!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_divide_and_round_up)'
+    INSERT TEXT: 'macros::num_divide_and_round_up!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_max!()'
-    INSERT TEXT: 'num_max!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_max)'
+    INSERT TEXT: 'macros::num_max!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_max;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_min!()'
-    INSERT TEXT: 'num_min!(${1:x}, ${2:y})'
-    TARGET     : '(use std::macros::num_min)'
+    INSERT TEXT: 'macros::num_min!(${1:x}, ${2:y})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_min;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_pow!()'
-    INSERT TEXT: 'num_pow!(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::macros::num_pow)'
+    INSERT TEXT: 'macros::num_pow!(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_, u8): _'
-    ADDITIONAL EDIT: 'use std::macros::num_pow;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_sqrt!()'
-    INSERT TEXT: 'num_sqrt!(${1:x}, ${2:bitsize})'
-    TARGET     : '(use std::macros::num_sqrt)'
+    INSERT TEXT: 'macros::num_sqrt!(${1:x}, ${2:bitsize})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, u8): $T'
-    ADDITIONAL EDIT: 'use std::macros::num_sqrt;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'num_to_string!()'
-    INSERT TEXT: 'num_to_string!(${1:x})'
-    TARGET     : '(use std::macros::num_to_string)'
+    INSERT TEXT: 'macros::num_to_string!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): String'
-    ADDITIONAL EDIT: 'use std::macros::num_to_string;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::macros::range_do)'
+    INSERT TEXT: 'macros::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, $T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::range_do;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::macros::range_do_eq)'
+    INSERT TEXT: 'macros::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $R>($T, $T, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::macros::range_do_eq;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u128!()'
-    INSERT TEXT: 'try_as_u128!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u128)'
+    INSERT TEXT: 'macros::try_as_u128!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u128;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u16!()'
-    INSERT TEXT: 'try_as_u16!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u16)'
+    INSERT TEXT: 'macros::try_as_u16!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u16;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u32!()'
-    INSERT TEXT: 'try_as_u32!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u32)'
+    INSERT TEXT: 'macros::try_as_u32!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u32;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u64!()'
-    INSERT TEXT: 'try_as_u64!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u64)'
+    INSERT TEXT: 'macros::try_as_u64!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u64;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'try_as_u8!()'
-    INSERT TEXT: 'try_as_u8!(${1:x})'
-    TARGET     : '(use std::macros::try_as_u8)'
+    INSERT TEXT: 'macros::try_as_u8!(${1:x})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun (_): Option'
-    ADDITIONAL EDIT: 'use std::macros::try_as_u8;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_add!()'
-    INSERT TEXT: 'uq_add!(${1:a}, ${2:b}, ${3:max_t}, ${4:abort_overflow})'
-    TARGET     : '(use std::macros::uq_add)'
+    INSERT TEXT: 'macros::uq_add!(${1:a}, ${2:b}, ${3:max_t}, ${4:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_add;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_from_int!()'
-    INSERT TEXT: 'uq_from_int!(${1:integer}, ${2:fractional_bits})'
-    TARGET     : '(use std::macros::uq_from_int)'
+    INSERT TEXT: 'macros::uq_from_int!(${1:integer}, ${2:fractional_bits})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, u8): $U'
-    ADDITIONAL EDIT: 'use std::macros::uq_from_int;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_from_quotient!()'
-    INSERT TEXT: 'uq_from_quotient!(${1:numerator}, ${2:denominator}, ${3:max_t}, ${4:t_bits}, ${5:fractional_bits}, ${6:abort_denominator}, ${7:abort_quotient_too_small}, ${8:abort_quotient_too_large})'
-    TARGET     : '(use std::macros::uq_from_quotient)'
+    INSERT TEXT: 'macros::uq_from_quotient!(${1:numerator}, ${2:denominator}, ${3:max_t}, ${4:t_bits}, ${5:fractional_bits}, ${6:abort_denominator}, ${7:abort_quotient_too_small}, ${8:abort_quotient_too_large})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, u8, _, _, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_from_quotient;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_int_div!()'
-    INSERT TEXT: 'uq_int_div!(${1:val}, ${2:divisor}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_division_by_zero}, ${6:abort_overflow})'
-    TARGET     : '(use std::macros::uq_int_div)'
+    INSERT TEXT: 'macros::uq_int_div!(${1:val}, ${2:divisor}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_division_by_zero}, ${6:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, _, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_int_div;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_int_mul!()'
-    INSERT TEXT: 'uq_int_mul!(${1:val}, ${2:multiplier}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_overflow})'
-    TARGET     : '(use std::macros::uq_int_mul)'
+    INSERT TEXT: 'macros::uq_int_mul!(${1:val}, ${2:multiplier}, ${3:max_t}, ${4:fractional_bits}, ${5:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($T, $T, $T, u8, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_int_mul;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_sub!()'
-    INSERT TEXT: 'uq_sub!(${1:a}, ${2:b}, ${3:abort_overflow})'
-    TARGET     : '(use std::macros::uq_sub)'
+    INSERT TEXT: 'macros::uq_sub!(${1:a}, ${2:b}, ${3:abort_overflow})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T>($T, $T, _): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_sub;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'uq_to_int!()'
-    INSERT TEXT: 'uq_to_int!(${1:a}, ${2:fractional_bits})'
-    TARGET     : '(use std::macros::uq_to_int)'
+    INSERT TEXT: 'macros::uq_to_int!(${1:a}, ${2:fractional_bits})'
+    TARGET     : '(use std::macros)'
     TYPE       : 'fun <$T, $U>($U, u8): $T'
-    ADDITIONAL EDIT: 'use std::macros::uq_to_int;
+    ADDITIONAL EDIT: 'use std::macros;
 
     '
 Method 'and!()'
-    INSERT TEXT: 'and!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::and)'
+    INSERT TEXT: 'option::and!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::and)'
     TYPE       : 'fun <$T, $U>(Option, |$T| -> Option): Option'
-    ADDITIONAL EDIT: 'use std::option::and;
-
-    '
 Method 'and_ref!()'
-    INSERT TEXT: 'and_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::and_ref)'
+    INSERT TEXT: 'option::and_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::and_ref)'
     TYPE       : 'fun <$T, $U>(&Option, |&$T| -> Option): Option'
-    ADDITIONAL EDIT: 'use std::option::and_ref;
-
-    '
 Method 'borrow()'
-    INSERT TEXT: 'borrow(${1:t})'
-    TARGET     : '(use std::option::borrow)'
+    INSERT TEXT: 'option::borrow(${1:t})'
+    TARGET     : '(option::borrow)'
     TYPE       : 'fun <Element>(&Option): &Element'
-    ADDITIONAL EDIT: 'use std::option::borrow;
-
-    '
 Method 'borrow_mut()'
-    INSERT TEXT: 'borrow_mut(${1:t})'
-    TARGET     : '(use std::option::borrow_mut)'
+    INSERT TEXT: 'option::borrow_mut(${1:t})'
+    TARGET     : '(option::borrow_mut)'
     TYPE       : 'fun <Element>(&mut Option): &mut Element'
-    ADDITIONAL EDIT: 'use std::option::borrow_mut;
-
-    '
 Method 'borrow_with_default()'
-    INSERT TEXT: 'borrow_with_default(${1:t}, ${2:default_ref})'
-    TARGET     : '(use std::option::borrow_with_default)'
+    INSERT TEXT: 'option::borrow_with_default(${1:t}, ${2:default_ref})'
+    TARGET     : '(option::borrow_with_default)'
     TYPE       : 'fun <Element>(&Option, &Element): &Element'
-    ADDITIONAL EDIT: 'use std::option::borrow_with_default;
-
-    '
 Method 'contains()'
-    INSERT TEXT: 'contains(${1:t}, ${2:e_ref})'
-    TARGET     : '(use std::option::contains)'
+    INSERT TEXT: 'option::contains(${1:t}, ${2:e_ref})'
+    TARGET     : '(option::contains)'
     TYPE       : 'fun <Element>(&Option, &Element): bool'
-    ADDITIONAL EDIT: 'use std::option::contains;
-
-    '
 Method 'destroy!()'
-    INSERT TEXT: 'destroy!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::destroy)'
+    INSERT TEXT: 'option::destroy!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::destroy)'
     TYPE       : 'fun <$T, $R>(Option, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::destroy;
-
-    '
 Method 'destroy_none()'
-    INSERT TEXT: 'destroy_none(${1:t})'
-    TARGET     : '(use std::option::destroy_none)'
+    INSERT TEXT: 'option::destroy_none(${1:t})'
+    TARGET     : '(option::destroy_none)'
     TYPE       : 'fun <Element>(Option)'
-    ADDITIONAL EDIT: 'use std::option::destroy_none;
-
-    '
 Method 'destroy_or!()'
-    INSERT TEXT: 'destroy_or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::destroy_or)'
+    INSERT TEXT: 'option::destroy_or!(${1:o}, ${2:default})'
+    TARGET     : '(option::destroy_or)'
     TYPE       : 'fun <$T>(Option, $T): $T'
-    ADDITIONAL EDIT: 'use std::option::destroy_or;
-
-    '
 Method 'destroy_some()'
-    INSERT TEXT: 'destroy_some(${1:t})'
-    TARGET     : '(use std::option::destroy_some)'
+    INSERT TEXT: 'option::destroy_some(${1:t})'
+    TARGET     : '(option::destroy_some)'
     TYPE       : 'fun <Element>(Option): Element'
-    ADDITIONAL EDIT: 'use std::option::destroy_some;
-
-    '
 Method 'destroy_with_default()'
-    INSERT TEXT: 'destroy_with_default(${1:t}, ${2:default})'
-    TARGET     : '(use std::option::destroy_with_default)'
+    INSERT TEXT: 'option::destroy_with_default(${1:t}, ${2:default})'
+    TARGET     : '(option::destroy_with_default)'
     TYPE       : 'fun <Element>(Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::destroy_with_default;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do)'
+    INSERT TEXT: 'option::do!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do)'
     TYPE       : 'fun <$T, $R>(Option, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do;
-
-    '
 Method 'do_mut!()'
-    INSERT TEXT: 'do_mut!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do_mut)'
+    INSERT TEXT: 'option::do_mut!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do_mut)'
     TYPE       : 'fun <$T, $R>(&mut Option, |&mut $T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do_mut;
-
-    '
 Method 'do_ref!()'
-    INSERT TEXT: 'do_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::do_ref)'
+    INSERT TEXT: 'option::do_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::do_ref)'
     TYPE       : 'fun <$T, $R>(&Option, |&$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::option::do_ref;
-
-    '
 Method 'extract()'
-    INSERT TEXT: 'extract(${1:t})'
-    TARGET     : '(use std::option::extract)'
+    INSERT TEXT: 'option::extract(${1:t})'
+    TARGET     : '(option::extract)'
     TYPE       : 'fun <Element>(&mut Option): Element'
-    ADDITIONAL EDIT: 'use std::option::extract;
-
-    '
 Method 'extract_or!()'
-    INSERT TEXT: 'extract_or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::extract_or)'
+    INSERT TEXT: 'option::extract_or!(${1:o}, ${2:default})'
+    TARGET     : '(option::extract_or)'
     TYPE       : 'fun <$T>(&mut Option, $T): $T'
-    ADDITIONAL EDIT: 'use std::option::extract_or;
-
-    '
 Method 'fill()'
-    INSERT TEXT: 'fill(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::fill)'
+    INSERT TEXT: 'option::fill(${1:t}, ${2:e})'
+    TARGET     : '(option::fill)'
     TYPE       : 'fun <Element>(&mut Option, Element)'
-    ADDITIONAL EDIT: 'use std::option::fill;
-
-    '
 Method 'filter!()'
-    INSERT TEXT: 'filter!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::filter)'
+    INSERT TEXT: 'option::filter!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::filter)'
     TYPE       : 'fun <$T>(Option, |&$T| -> bool): Option'
-    ADDITIONAL EDIT: 'use std::option::filter;
-
-    '
 Method 'get_with_default()'
-    INSERT TEXT: 'get_with_default(${1:t}, ${2:default})'
-    TARGET     : '(use std::option::get_with_default)'
+    INSERT TEXT: 'option::get_with_default(${1:t}, ${2:default})'
+    TARGET     : '(option::get_with_default)'
     TYPE       : 'fun <Element>(&Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::get_with_default;
-
-    '
 Method 'is_none()'
-    INSERT TEXT: 'is_none(${1:t})'
-    TARGET     : '(use std::option::is_none)'
+    INSERT TEXT: 'option::is_none(${1:t})'
+    TARGET     : '(option::is_none)'
     TYPE       : 'fun <Element>(&Option): bool'
-    ADDITIONAL EDIT: 'use std::option::is_none;
-
-    '
 Method 'is_some()'
-    INSERT TEXT: 'is_some(${1:t})'
-    TARGET     : '(use std::option::is_some)'
+    INSERT TEXT: 'option::is_some(${1:t})'
+    TARGET     : '(option::is_some)'
     TYPE       : 'fun <Element>(&Option): bool'
-    ADDITIONAL EDIT: 'use std::option::is_some;
-
-    '
 Method 'is_some_and!()'
-    INSERT TEXT: 'is_some_and!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::is_some_and)'
+    INSERT TEXT: 'option::is_some_and!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::is_some_and)'
     TYPE       : 'fun <$T>(&Option, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::option::is_some_and;
-
-    '
 Method 'map!()'
-    INSERT TEXT: 'map!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::map)'
+    INSERT TEXT: 'option::map!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::map)'
     TYPE       : 'fun <$T, $U>(Option, |$T| -> $U): Option'
-    ADDITIONAL EDIT: 'use std::option::map;
-
-    '
 Method 'map_ref!()'
-    INSERT TEXT: 'map_ref!(${1:o}, |${2}| ${3})'
-    TARGET     : '(use std::option::map_ref)'
+    INSERT TEXT: 'option::map_ref!(${1:o}, |${2}| ${3})'
+    TARGET     : '(option::map_ref)'
     TYPE       : 'fun <$T, $U>(&Option, |&$T| -> $U): Option'
-    ADDITIONAL EDIT: 'use std::option::map_ref;
-
-    '
 Method 'none()'
-    INSERT TEXT: 'none()'
-    TARGET     : '(use std::option::none)'
+    INSERT TEXT: 'option::none()'
+    TARGET     : '(option::none)'
     TYPE       : 'fun <Element>(): Option'
-    ADDITIONAL EDIT: 'use std::option::none;
-
-    '
 Method 'or!()'
-    INSERT TEXT: 'or!(${1:o}, ${2:default})'
-    TARGET     : '(use std::option::or)'
+    INSERT TEXT: 'option::or!(${1:o}, ${2:default})'
+    TARGET     : '(option::or)'
     TYPE       : 'fun <$T>(Option, Option): Option'
-    ADDITIONAL EDIT: 'use std::option::or;
-
-    '
 Method 'some()'
-    INSERT TEXT: 'some(${1:e})'
-    TARGET     : '(use std::option::some)'
+    INSERT TEXT: 'option::some(${1:e})'
+    TARGET     : '(option::some)'
     TYPE       : 'fun <Element>(Element): Option'
-    ADDITIONAL EDIT: 'use std::option::some;
-
-    '
 Method 'swap()'
-    INSERT TEXT: 'swap(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::swap)'
+    INSERT TEXT: 'option::swap(${1:t}, ${2:e})'
+    TARGET     : '(option::swap)'
     TYPE       : 'fun <Element>(&mut Option, Element): Element'
-    ADDITIONAL EDIT: 'use std::option::swap;
-
-    '
 Method 'swap_or_fill()'
-    INSERT TEXT: 'swap_or_fill(${1:t}, ${2:e})'
-    TARGET     : '(use std::option::swap_or_fill)'
+    INSERT TEXT: 'option::swap_or_fill(${1:t}, ${2:e})'
+    TARGET     : '(option::swap_or_fill)'
     TYPE       : 'fun <Element>(&mut Option, Element): Option'
-    ADDITIONAL EDIT: 'use std::option::swap_or_fill;
-
-    '
 Method 'to_vec()'
-    INSERT TEXT: 'to_vec(${1:t})'
-    TARGET     : '(use std::option::to_vec)'
+    INSERT TEXT: 'option::to_vec(${1:t})'
+    TARGET     : '(option::to_vec)'
     TYPE       : 'fun <Element>(Option): vector<Element>'
-    ADDITIONAL EDIT: 'use std::option::to_vec;
-
-    '
 Method 'append()'
-    INSERT TEXT: 'append(${1:s}, ${2:r})'
-    TARGET     : '(use std::string::append)'
+    INSERT TEXT: 'string::append(${1:s}, ${2:r})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, String)'
-    ADDITIONAL EDIT: 'use std::string::append;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'append_utf8()'
-    INSERT TEXT: 'append_utf8(${1:s}, ${2:bytes})'
-    TARGET     : '(use std::string::append_utf8)'
+    INSERT TEXT: 'string::append_utf8(${1:s}, ${2:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, vector<u8>)'
-    ADDITIONAL EDIT: 'use std::string::append_utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'as_bytes()'
-    INSERT TEXT: 'as_bytes(${1:s})'
-    TARGET     : '(use std::string::as_bytes)'
+    INSERT TEXT: 'string::as_bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::as_bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'bytes()'
-    INSERT TEXT: 'bytes(${1:s})'
-    TARGET     : '(use std::string::bytes)'
+    INSERT TEXT: 'string::bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): &vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'from_ascii()'
-    INSERT TEXT: 'from_ascii(${1:s})'
-    TARGET     : '(use std::string::from_ascii)'
+    INSERT TEXT: 'string::from_ascii(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): String'
-    ADDITIONAL EDIT: 'use std::string::from_ascii;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:s}, ${2:r})'
-    TARGET     : '(use std::string::index_of)'
+    INSERT TEXT: 'string::index_of(${1:s}, ${2:r})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, &String): u64'
-    ADDITIONAL EDIT: 'use std::string::index_of;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:s}, ${2:at}, ${3:o})'
-    TARGET     : '(use std::string::insert)'
+    INSERT TEXT: 'string::insert(${1:s}, ${2:at}, ${3:o})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&mut String, u64, String)'
-    ADDITIONAL EDIT: 'use std::string::insert;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'internal_sub_string_for_testing()'
-    INSERT TEXT: 'internal_sub_string_for_testing(${1:v}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::internal_sub_string_for_testing)'
+    INSERT TEXT: 'string::internal_sub_string_for_testing(${1:v}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&vector<u8>, u64, u64): vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::internal_sub_string_for_testing;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'into_bytes()'
-    INSERT TEXT: 'into_bytes(${1:s})'
-    TARGET     : '(use std::string::into_bytes)'
+    INSERT TEXT: 'string::into_bytes(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): vector<u8>'
-    ADDITIONAL EDIT: 'use std::string::into_bytes;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:s})'
-    TARGET     : '(use std::string::is_empty)'
+    INSERT TEXT: 'string::is_empty(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): bool'
-    ADDITIONAL EDIT: 'use std::string::is_empty;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'length()'
-    INSERT TEXT: 'length(${1:s})'
-    TARGET     : '(use std::string::length)'
+    INSERT TEXT: 'string::length(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String): u64'
-    ADDITIONAL EDIT: 'use std::string::length;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'sub_string()'
-    INSERT TEXT: 'sub_string(${1:s}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::sub_string)'
+    INSERT TEXT: 'string::sub_string(${1:s}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::string::sub_string;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'substring()'
-    INSERT TEXT: 'substring(${1:s}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::string::substring)'
+    INSERT TEXT: 'string::substring(${1:s}, ${2:i}, ${3:j})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (&String, u64, u64): String'
-    ADDITIONAL EDIT: 'use std::string::substring;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'to_ascii()'
-    INSERT TEXT: 'to_ascii(${1:s})'
-    TARGET     : '(use std::string::to_ascii)'
+    INSERT TEXT: 'string::to_ascii(${1:s})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (String): String'
-    ADDITIONAL EDIT: 'use std::string::to_ascii;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'try_utf8()'
-    INSERT TEXT: 'try_utf8(${1:bytes})'
-    TARGET     : '(use std::string::try_utf8)'
+    INSERT TEXT: 'string::try_utf8(${1:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (vector<u8>): Option'
-    ADDITIONAL EDIT: 'use std::string::try_utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'utf8()'
-    INSERT TEXT: 'utf8(${1:bytes})'
-    TARGET     : '(use std::string::utf8)'
+    INSERT TEXT: 'string::utf8(${1:bytes})'
+    TARGET     : '(use std::string)'
     TYPE       : 'fun (vector<u8>): String'
-    ADDITIONAL EDIT: 'use std::string::utf8;
+    ADDITIONAL EDIT: 'use std::string;
 
     '
 Method 'address_string()'
-    INSERT TEXT: 'address_string(${1:self})'
-    TARGET     : '(use std::type_name::address_string)'
+    INSERT TEXT: 'type_name::address_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::address_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'as_string()'
-    INSERT TEXT: 'as_string(${1:self})'
-    TARGET     : '(use std::type_name::as_string)'
+    INSERT TEXT: 'type_name::as_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): &String'
-    ADDITIONAL EDIT: 'use std::type_name::as_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'borrow_string()'
-    INSERT TEXT: 'borrow_string(${1:self})'
-    TARGET     : '(use std::type_name::borrow_string)'
+    INSERT TEXT: 'type_name::borrow_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): &String'
-    ADDITIONAL EDIT: 'use std::type_name::borrow_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'defining_id()'
-    INSERT TEXT: 'defining_id()'
-    TARGET     : '(use std::type_name::defining_id)'
+    INSERT TEXT: 'type_name::defining_id()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): address'
-    ADDITIONAL EDIT: 'use std::type_name::defining_id;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get()'
-    INSERT TEXT: 'get()'
-    TARGET     : '(use std::type_name::get)'
+    INSERT TEXT: 'type_name::get()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::get;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_address()'
-    INSERT TEXT: 'get_address(${1:self})'
-    TARGET     : '(use std::type_name::get_address)'
+    INSERT TEXT: 'type_name::get_address(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::get_address;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_module()'
-    INSERT TEXT: 'get_module(${1:self})'
-    TARGET     : '(use std::type_name::get_module)'
+    INSERT TEXT: 'type_name::get_module(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::get_module;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'get_with_original_ids()'
-    INSERT TEXT: 'get_with_original_ids()'
-    TARGET     : '(use std::type_name::get_with_original_ids)'
+    INSERT TEXT: 'type_name::get_with_original_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::get_with_original_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'into_string()'
-    INSERT TEXT: 'into_string(${1:self})'
-    TARGET     : '(use std::type_name::into_string)'
+    INSERT TEXT: 'type_name::into_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::into_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'is_primitive()'
-    INSERT TEXT: 'is_primitive(${1:self})'
-    TARGET     : '(use std::type_name::is_primitive)'
+    INSERT TEXT: 'type_name::is_primitive(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): bool'
-    ADDITIONAL EDIT: 'use std::type_name::is_primitive;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'module_string()'
-    INSERT TEXT: 'module_string(${1:self})'
-    TARGET     : '(use std::type_name::module_string)'
+    INSERT TEXT: 'type_name::module_string(${1:self})'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun (&TypeName): String'
-    ADDITIONAL EDIT: 'use std::type_name::module_string;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'original_id()'
-    INSERT TEXT: 'original_id()'
-    TARGET     : '(use std::type_name::original_id)'
+    INSERT TEXT: 'type_name::original_id()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): address'
-    ADDITIONAL EDIT: 'use std::type_name::original_id;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'with_defining_ids()'
-    INSERT TEXT: 'with_defining_ids()'
-    TARGET     : '(use std::type_name::with_defining_ids)'
+    INSERT TEXT: 'type_name::with_defining_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::with_defining_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'with_original_ids()'
-    INSERT TEXT: 'with_original_ids()'
-    TARGET     : '(use std::type_name::with_original_ids)'
+    INSERT TEXT: 'type_name::with_original_ids()'
+    TARGET     : '(use std::type_name)'
     TYPE       : 'fun <T>(): TypeName'
-    ADDITIONAL EDIT: 'use std::type_name::with_original_ids;
+    ADDITIONAL EDIT: 'use std::type_name;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u128::bitwise_not)'
+    INSERT TEXT: 'u128::bitwise_not(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::diff)'
+    INSERT TEXT: 'u128::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::diff;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::divide_and_round_up)'
+    INSERT TEXT: 'u128::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u128::do)'
+    INSERT TEXT: 'u128::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::do;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u128::do_eq)'
+    INSERT TEXT: 'u128::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::do_eq;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::max)'
+    INSERT TEXT: 'u128::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::max;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u128::max_value)'
+    INSERT TEXT: 'u128::max_value!()'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (): u128'
-    ADDITIONAL EDIT: 'use std::u128::max_value;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u128::min)'
+    INSERT TEXT: 'u128::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::min;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u128::pow)'
+    INSERT TEXT: 'u128::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128, u8): u128'
-    ADDITIONAL EDIT: 'use std::u128::pow;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u128::range_do)'
+    INSERT TEXT: 'u128::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::range_do;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u128::range_do_eq)'
+    INSERT TEXT: 'u128::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun <$R>(u128, u128, |u128| -> $R)'
-    ADDITIONAL EDIT: 'use std::u128::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u128::sqrt)'
+    INSERT TEXT: 'u128::sqrt(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): u128'
-    ADDITIONAL EDIT: 'use std::u128::sqrt;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u128::to_string)'
+    INSERT TEXT: 'u128::to_string(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): String'
-    ADDITIONAL EDIT: 'use std::u128::to_string;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u128::try_as_u16)'
+    INSERT TEXT: 'u128::try_as_u16(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u128::try_as_u32)'
+    INSERT TEXT: 'u128::try_as_u32(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u64()'
-    INSERT TEXT: 'try_as_u64(${1:x})'
-    TARGET     : '(use std::u128::try_as_u64)'
+    INSERT TEXT: 'u128::try_as_u64(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u64;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u128::try_as_u8)'
+    INSERT TEXT: 'u128::try_as_u8(${1:x})'
+    TARGET     : '(use std::u128)'
     TYPE       : 'fun (u128): Option'
-    ADDITIONAL EDIT: 'use std::u128::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u128;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u16::bitwise_not)'
+    INSERT TEXT: 'u16::bitwise_not(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::diff)'
+    INSERT TEXT: 'u16::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::diff;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::divide_and_round_up)'
+    INSERT TEXT: 'u16::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u16::do)'
+    INSERT TEXT: 'u16::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::do;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u16::do_eq)'
+    INSERT TEXT: 'u16::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::do_eq;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::max)'
+    INSERT TEXT: 'u16::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::max;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u16::max_value)'
+    INSERT TEXT: 'u16::max_value!()'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (): u16'
-    ADDITIONAL EDIT: 'use std::u16::max_value;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u16::min)'
+    INSERT TEXT: 'u16::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::min;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u16::pow)'
+    INSERT TEXT: 'u16::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16, u8): u16'
-    ADDITIONAL EDIT: 'use std::u16::pow;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u16::range_do)'
+    INSERT TEXT: 'u16::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::range_do;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u16::range_do_eq)'
+    INSERT TEXT: 'u16::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun <$R>(u16, u16, |u16| -> $R)'
-    ADDITIONAL EDIT: 'use std::u16::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u16::sqrt)'
+    INSERT TEXT: 'u16::sqrt(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): u16'
-    ADDITIONAL EDIT: 'use std::u16::sqrt;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u16::to_string)'
+    INSERT TEXT: 'u16::to_string(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): String'
-    ADDITIONAL EDIT: 'use std::u16::to_string;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u16::try_as_u8)'
+    INSERT TEXT: 'u16::try_as_u8(${1:x})'
+    TARGET     : '(use std::u16)'
     TYPE       : 'fun (u16): Option'
-    ADDITIONAL EDIT: 'use std::u16::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u16;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u256::bitwise_not)'
+    INSERT TEXT: 'u256::bitwise_not(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::diff)'
+    INSERT TEXT: 'u256::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::diff;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::divide_and_round_up)'
+    INSERT TEXT: 'u256::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u256::do)'
+    INSERT TEXT: 'u256::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::do;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u256::do_eq)'
+    INSERT TEXT: 'u256::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::do_eq;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::max)'
+    INSERT TEXT: 'u256::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::max;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u256::max_value)'
+    INSERT TEXT: 'u256::max_value!()'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (): u256'
-    ADDITIONAL EDIT: 'use std::u256::max_value;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u256::min)'
+    INSERT TEXT: 'u256::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u256): u256'
-    ADDITIONAL EDIT: 'use std::u256::min;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u256::pow)'
+    INSERT TEXT: 'u256::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256, u8): u256'
-    ADDITIONAL EDIT: 'use std::u256::pow;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u256::range_do)'
+    INSERT TEXT: 'u256::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::range_do;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u256::range_do_eq)'
+    INSERT TEXT: 'u256::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun <$R>(u256, u256, |u256| -> $R)'
-    ADDITIONAL EDIT: 'use std::u256::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u256::to_string)'
+    INSERT TEXT: 'u256::to_string(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): String'
-    ADDITIONAL EDIT: 'use std::u256::to_string;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u128()'
-    INSERT TEXT: 'try_as_u128(${1:x})'
-    TARGET     : '(use std::u256::try_as_u128)'
+    INSERT TEXT: 'u256::try_as_u128(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u128;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u256::try_as_u16)'
+    INSERT TEXT: 'u256::try_as_u16(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u256::try_as_u32)'
+    INSERT TEXT: 'u256::try_as_u32(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u64()'
-    INSERT TEXT: 'try_as_u64(${1:x})'
-    TARGET     : '(use std::u256::try_as_u64)'
+    INSERT TEXT: 'u256::try_as_u64(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u64;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u256::try_as_u8)'
+    INSERT TEXT: 'u256::try_as_u8(${1:x})'
+    TARGET     : '(use std::u256)'
     TYPE       : 'fun (u256): Option'
-    ADDITIONAL EDIT: 'use std::u256::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u256;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u32::bitwise_not)'
+    INSERT TEXT: 'u32::bitwise_not(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::diff)'
+    INSERT TEXT: 'u32::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::diff;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::divide_and_round_up)'
+    INSERT TEXT: 'u32::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u32::do)'
+    INSERT TEXT: 'u32::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::do;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u32::do_eq)'
+    INSERT TEXT: 'u32::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::do_eq;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::max)'
+    INSERT TEXT: 'u32::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::max;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u32::max_value)'
+    INSERT TEXT: 'u32::max_value!()'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (): u32'
-    ADDITIONAL EDIT: 'use std::u32::max_value;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u32::min)'
+    INSERT TEXT: 'u32::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::min;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u32::pow)'
+    INSERT TEXT: 'u32::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32, u8): u32'
-    ADDITIONAL EDIT: 'use std::u32::pow;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u32::range_do)'
+    INSERT TEXT: 'u32::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::range_do;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u32::range_do_eq)'
+    INSERT TEXT: 'u32::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun <$R>(u32, u32, |u32| -> $R)'
-    ADDITIONAL EDIT: 'use std::u32::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u32::sqrt)'
+    INSERT TEXT: 'u32::sqrt(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): u32'
-    ADDITIONAL EDIT: 'use std::u32::sqrt;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u32::to_string)'
+    INSERT TEXT: 'u32::to_string(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): String'
-    ADDITIONAL EDIT: 'use std::u32::to_string;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u32::try_as_u16)'
+    INSERT TEXT: 'u32::try_as_u16(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): Option'
-    ADDITIONAL EDIT: 'use std::u32::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u32::try_as_u8)'
+    INSERT TEXT: 'u32::try_as_u8(${1:x})'
+    TARGET     : '(use std::u32)'
     TYPE       : 'fun (u32): Option'
-    ADDITIONAL EDIT: 'use std::u32::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u32;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u64::bitwise_not)'
+    INSERT TEXT: 'u64::bitwise_not(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::diff)'
+    INSERT TEXT: 'u64::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::diff;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::divide_and_round_up)'
+    INSERT TEXT: 'u64::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u64::do)'
+    INSERT TEXT: 'u64::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::do;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u64::do_eq)'
+    INSERT TEXT: 'u64::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::do_eq;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::max)'
+    INSERT TEXT: 'u64::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::max;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u64::max_value)'
+    INSERT TEXT: 'u64::max_value!()'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (): u64'
-    ADDITIONAL EDIT: 'use std::u64::max_value;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u64::min)'
+    INSERT TEXT: 'u64::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::min;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u64::pow)'
+    INSERT TEXT: 'u64::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64, u8): u64'
-    ADDITIONAL EDIT: 'use std::u64::pow;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u64::range_do)'
+    INSERT TEXT: 'u64::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::range_do;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u64::range_do_eq)'
+    INSERT TEXT: 'u64::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun <$R>(u64, u64, |u64| -> $R)'
-    ADDITIONAL EDIT: 'use std::u64::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u64::sqrt)'
+    INSERT TEXT: 'u64::sqrt(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): u64'
-    ADDITIONAL EDIT: 'use std::u64::sqrt;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u64::to_string)'
+    INSERT TEXT: 'u64::to_string(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): String'
-    ADDITIONAL EDIT: 'use std::u64::to_string;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u16()'
-    INSERT TEXT: 'try_as_u16(${1:x})'
-    TARGET     : '(use std::u64::try_as_u16)'
+    INSERT TEXT: 'u64::try_as_u16(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u16;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u32()'
-    INSERT TEXT: 'try_as_u32(${1:x})'
-    TARGET     : '(use std::u64::try_as_u32)'
+    INSERT TEXT: 'u64::try_as_u32(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u32;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'try_as_u8()'
-    INSERT TEXT: 'try_as_u8(${1:x})'
-    TARGET     : '(use std::u64::try_as_u8)'
+    INSERT TEXT: 'u64::try_as_u8(${1:x})'
+    TARGET     : '(use std::u64)'
     TYPE       : 'fun (u64): Option'
-    ADDITIONAL EDIT: 'use std::u64::try_as_u8;
+    ADDITIONAL EDIT: 'use std::u64;
 
     '
 Method 'bitwise_not()'
-    INSERT TEXT: 'bitwise_not(${1:x})'
-    TARGET     : '(use std::u8::bitwise_not)'
+    INSERT TEXT: 'u8::bitwise_not(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::bitwise_not;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'diff()'
-    INSERT TEXT: 'diff(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::diff)'
+    INSERT TEXT: 'u8::diff(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::diff;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'divide_and_round_up()'
-    INSERT TEXT: 'divide_and_round_up(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::divide_and_round_up)'
+    INSERT TEXT: 'u8::divide_and_round_up(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::divide_and_round_up;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u8::do)'
+    INSERT TEXT: 'u8::do!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::do;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'do_eq!()'
-    INSERT TEXT: 'do_eq!(${1:stop}, |${2}| ${3})'
-    TARGET     : '(use std::u8::do_eq)'
+    INSERT TEXT: 'u8::do_eq!(${1:stop}, |${2}| ${3})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::do_eq;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'max()'
-    INSERT TEXT: 'max(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::max)'
+    INSERT TEXT: 'u8::max(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::max;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'max_value!()'
-    INSERT TEXT: 'max_value!()'
-    TARGET     : '(use std::u8::max_value)'
+    INSERT TEXT: 'u8::max_value!()'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (): u8'
-    ADDITIONAL EDIT: 'use std::u8::max_value;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'min()'
-    INSERT TEXT: 'min(${1:x}, ${2:y})'
-    TARGET     : '(use std::u8::min)'
+    INSERT TEXT: 'u8::min(${1:x}, ${2:y})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::min;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'pow()'
-    INSERT TEXT: 'pow(${1:base}, ${2:exponent})'
-    TARGET     : '(use std::u8::pow)'
+    INSERT TEXT: 'u8::pow(${1:base}, ${2:exponent})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8, u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::pow;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'range_do!()'
-    INSERT TEXT: 'range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u8::range_do)'
+    INSERT TEXT: 'u8::range_do!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::range_do;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'range_do_eq!()'
-    INSERT TEXT: 'range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
-    TARGET     : '(use std::u8::range_do_eq)'
+    INSERT TEXT: 'u8::range_do_eq!(${1:start}, ${2:stop}, |${3}| ${4})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun <$R>(u8, u8, |u8| -> $R)'
-    ADDITIONAL EDIT: 'use std::u8::range_do_eq;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'sqrt()'
-    INSERT TEXT: 'sqrt(${1:x})'
-    TARGET     : '(use std::u8::sqrt)'
+    INSERT TEXT: 'u8::sqrt(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): u8'
-    ADDITIONAL EDIT: 'use std::u8::sqrt;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'to_string()'
-    INSERT TEXT: 'to_string(${1:x})'
-    TARGET     : '(use std::u8::to_string)'
+    INSERT TEXT: 'u8::to_string(${1:x})'
+    TARGET     : '(use std::u8)'
     TYPE       : 'fun (u8): String'
-    ADDITIONAL EDIT: 'use std::u8::to_string;
+    ADDITIONAL EDIT: 'use std::u8;
 
     '
 Method 'assert_eq!()'
-    INSERT TEXT: 'assert_eq!(${1:t1}, ${2:t2})'
-    TARGET     : '(use std::unit_test::assert_eq)'
+    INSERT TEXT: 'unit_test::assert_eq!(${1:t1}, ${2:t2})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <$T>($T, $T)'
-    ADDITIONAL EDIT: 'use std::unit_test::assert_eq;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'assert_ref_eq!()'
-    INSERT TEXT: 'assert_ref_eq!(${1:t1}, ${2:t2})'
-    TARGET     : '(use std::unit_test::assert_ref_eq)'
+    INSERT TEXT: 'unit_test::assert_ref_eq!(${1:t1}, ${2:t2})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <$T>(&$T, &$T)'
-    ADDITIONAL EDIT: 'use std::unit_test::assert_ref_eq;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'destroy()'
-    INSERT TEXT: 'destroy(${1:v})'
-    TARGET     : '(use std::unit_test::destroy)'
+    INSERT TEXT: 'unit_test::destroy(${1:v})'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun <T>(T)'
-    ADDITIONAL EDIT: 'use std::unit_test::destroy;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'poison()'
-    INSERT TEXT: 'poison()'
-    TARGET     : '(use std::unit_test::poison)'
+    INSERT TEXT: 'unit_test::poison()'
+    TARGET     : '(use std::unit_test)'
     TYPE       : 'fun ()'
-    ADDITIONAL EDIT: 'use std::unit_test::poison;
+    ADDITIONAL EDIT: 'use std::unit_test;
 
     '
 Method 'add()'
-    INSERT TEXT: 'add(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::add)'
+    INSERT TEXT: 'uq32_32::add(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::add;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'div()'
-    INSERT TEXT: 'div(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::div)'
+    INSERT TEXT: 'uq32_32::div(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::div;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_int()'
-    INSERT TEXT: 'from_int(${1:integer})'
-    TARGET     : '(use std::uq32_32::from_int)'
+    INSERT TEXT: 'uq32_32::from_int(${1:integer})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_int;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_quotient()'
-    INSERT TEXT: 'from_quotient(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::uq32_32::from_quotient)'
+    INSERT TEXT: 'uq32_32::from_quotient(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, u64): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_quotient;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'from_raw()'
-    INSERT TEXT: 'from_raw(${1:raw_value})'
-    TARGET     : '(use std::uq32_32::from_raw)'
+    INSERT TEXT: 'uq32_32::from_raw(${1:raw_value})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::from_raw;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'ge()'
-    INSERT TEXT: 'ge(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::ge)'
+    INSERT TEXT: 'uq32_32::ge(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::ge;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'gt()'
-    INSERT TEXT: 'gt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::gt)'
+    INSERT TEXT: 'uq32_32::gt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::gt;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'int_div()'
-    INSERT TEXT: 'int_div(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::uq32_32::int_div)'
+    INSERT TEXT: 'uq32_32::int_div(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::int_div;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'int_mul()'
-    INSERT TEXT: 'int_mul(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::uq32_32::int_mul)'
+    INSERT TEXT: 'uq32_32::int_mul(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (u64, UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::int_mul;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'le()'
-    INSERT TEXT: 'le(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::le)'
+    INSERT TEXT: 'uq32_32::le(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::le;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'lt()'
-    INSERT TEXT: 'lt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::lt)'
+    INSERT TEXT: 'uq32_32::lt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): bool'
-    ADDITIONAL EDIT: 'use std::uq32_32::lt;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'mul()'
-    INSERT TEXT: 'mul(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::mul)'
+    INSERT TEXT: 'uq32_32::mul(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::mul;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'sub()'
-    INSERT TEXT: 'sub(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq32_32::sub)'
+    INSERT TEXT: 'uq32_32::sub(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32, UQ32_32): UQ32_32'
-    ADDITIONAL EDIT: 'use std::uq32_32::sub;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'to_int()'
-    INSERT TEXT: 'to_int(${1:a})'
-    TARGET     : '(use std::uq32_32::to_int)'
+    INSERT TEXT: 'uq32_32::to_int(${1:a})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32): u32'
-    ADDITIONAL EDIT: 'use std::uq32_32::to_int;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'to_raw()'
-    INSERT TEXT: 'to_raw(${1:a})'
-    TARGET     : '(use std::uq32_32::to_raw)'
+    INSERT TEXT: 'uq32_32::to_raw(${1:a})'
+    TARGET     : '(use std::uq32_32)'
     TYPE       : 'fun (UQ32_32): u64'
-    ADDITIONAL EDIT: 'use std::uq32_32::to_raw;
+    ADDITIONAL EDIT: 'use std::uq32_32;
 
     '
 Method 'add()'
-    INSERT TEXT: 'add(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::add)'
+    INSERT TEXT: 'uq64_64::add(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::add;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'div()'
-    INSERT TEXT: 'div(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::div)'
+    INSERT TEXT: 'uq64_64::div(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::div;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_int()'
-    INSERT TEXT: 'from_int(${1:integer})'
-    TARGET     : '(use std::uq64_64::from_int)'
+    INSERT TEXT: 'uq64_64::from_int(${1:integer})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_int;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_quotient()'
-    INSERT TEXT: 'from_quotient(${1:numerator}, ${2:denominator})'
-    TARGET     : '(use std::uq64_64::from_quotient)'
+    INSERT TEXT: 'uq64_64::from_quotient(${1:numerator}, ${2:denominator})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, u128): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_quotient;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'from_raw()'
-    INSERT TEXT: 'from_raw(${1:raw_value})'
-    TARGET     : '(use std::uq64_64::from_raw)'
+    INSERT TEXT: 'uq64_64::from_raw(${1:raw_value})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::from_raw;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'ge()'
-    INSERT TEXT: 'ge(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::ge)'
+    INSERT TEXT: 'uq64_64::ge(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::ge;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'gt()'
-    INSERT TEXT: 'gt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::gt)'
+    INSERT TEXT: 'uq64_64::gt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::gt;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'int_div()'
-    INSERT TEXT: 'int_div(${1:val}, ${2:divisor})'
-    TARGET     : '(use std::uq64_64::int_div)'
+    INSERT TEXT: 'uq64_64::int_div(${1:val}, ${2:divisor})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::int_div;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'int_mul()'
-    INSERT TEXT: 'int_mul(${1:val}, ${2:multiplier})'
-    TARGET     : '(use std::uq64_64::int_mul)'
+    INSERT TEXT: 'uq64_64::int_mul(${1:val}, ${2:multiplier})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (u128, UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::int_mul;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'le()'
-    INSERT TEXT: 'le(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::le)'
+    INSERT TEXT: 'uq64_64::le(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::le;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'lt()'
-    INSERT TEXT: 'lt(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::lt)'
+    INSERT TEXT: 'uq64_64::lt(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): bool'
-    ADDITIONAL EDIT: 'use std::uq64_64::lt;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'mul()'
-    INSERT TEXT: 'mul(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::mul)'
+    INSERT TEXT: 'uq64_64::mul(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::mul;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'sub()'
-    INSERT TEXT: 'sub(${1:a}, ${2:b})'
-    TARGET     : '(use std::uq64_64::sub)'
+    INSERT TEXT: 'uq64_64::sub(${1:a}, ${2:b})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64, UQ64_64): UQ64_64'
-    ADDITIONAL EDIT: 'use std::uq64_64::sub;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'to_int()'
-    INSERT TEXT: 'to_int(${1:a})'
-    TARGET     : '(use std::uq64_64::to_int)'
+    INSERT TEXT: 'uq64_64::to_int(${1:a})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64): u64'
-    ADDITIONAL EDIT: 'use std::uq64_64::to_int;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'to_raw()'
-    INSERT TEXT: 'to_raw(${1:a})'
-    TARGET     : '(use std::uq64_64::to_raw)'
+    INSERT TEXT: 'uq64_64::to_raw(${1:a})'
+    TARGET     : '(use std::uq64_64)'
     TYPE       : 'fun (UQ64_64): u128'
-    ADDITIONAL EDIT: 'use std::uq64_64::to_raw;
+    ADDITIONAL EDIT: 'use std::uq64_64;
 
     '
 Method 'all!()'
-    INSERT TEXT: 'all!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::all)'
+    INSERT TEXT: 'vector::all!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::all)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::all;
-
-    '
 Method 'any!()'
-    INSERT TEXT: 'any!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::any)'
+    INSERT TEXT: 'vector::any!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::any)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::any;
-
-    '
 Method 'append()'
-    INSERT TEXT: 'append(${1:lhs}, ${2:other})'
-    TARGET     : '(use std::vector::append)'
+    INSERT TEXT: 'vector::append(${1:lhs}, ${2:other})'
+    TARGET     : '(vector::append)'
     TYPE       : 'fun <Element>(&mut vector<Element>, vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::append;
-
-    '
 Method 'borrow()'
-    INSERT TEXT: 'borrow(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::borrow)'
+    INSERT TEXT: 'vector::borrow(${1:v}, ${2:i})'
+    TARGET     : '(vector::borrow)'
     TYPE       : 'fun <Element>(&vector<Element>, u64): &Element'
-    ADDITIONAL EDIT: 'use std::vector::borrow;
-
-    '
 Method 'borrow_mut()'
-    INSERT TEXT: 'borrow_mut(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::borrow_mut)'
+    INSERT TEXT: 'vector::borrow_mut(${1:v}, ${2:i})'
+    TARGET     : '(vector::borrow_mut)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): &mut Element'
-    ADDITIONAL EDIT: 'use std::vector::borrow_mut;
-
-    '
 Method 'contains()'
-    INSERT TEXT: 'contains(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::contains)'
+    INSERT TEXT: 'vector::contains(${1:v}, ${2:e})'
+    TARGET     : '(vector::contains)'
     TYPE       : 'fun <Element>(&vector<Element>, &Element): bool'
-    ADDITIONAL EDIT: 'use std::vector::contains;
-
-    '
 Method 'count!()'
-    INSERT TEXT: 'count!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::count)'
+    INSERT TEXT: 'vector::count!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::count)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): u64'
-    ADDITIONAL EDIT: 'use std::vector::count;
-
-    '
 Method 'destroy!()'
-    INSERT TEXT: 'destroy!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::destroy)'
+    INSERT TEXT: 'vector::destroy!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::destroy)'
     TYPE       : 'fun <$T, $R>(vector<$T>, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::destroy;
-
-    '
 Method 'destroy_empty()'
-    INSERT TEXT: 'destroy_empty(${1:v})'
-    TARGET     : '(use std::vector::destroy_empty)'
+    INSERT TEXT: 'vector::destroy_empty(${1:v})'
+    TARGET     : '(vector::destroy_empty)'
     TYPE       : 'fun <Element>(vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::destroy_empty;
-
-    '
 Method 'do!()'
-    INSERT TEXT: 'do!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do)'
+    INSERT TEXT: 'vector::do!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do)'
     TYPE       : 'fun <$T, $R>(vector<$T>, |$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do;
-
-    '
 Method 'do_mut!()'
-    INSERT TEXT: 'do_mut!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do_mut)'
+    INSERT TEXT: 'vector::do_mut!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do_mut)'
     TYPE       : 'fun <$T, $R>(&mut vector<$T>, |&mut $T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do_mut;
-
-    '
 Method 'do_ref!()'
-    INSERT TEXT: 'do_ref!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::do_ref)'
+    INSERT TEXT: 'vector::do_ref!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::do_ref)'
     TYPE       : 'fun <$T, $R>(&vector<$T>, |&$T| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::do_ref;
-
-    '
 Method 'empty()'
-    INSERT TEXT: 'empty()'
-    TARGET     : '(use std::vector::empty)'
+    INSERT TEXT: 'vector::empty()'
+    TARGET     : '(vector::empty)'
     TYPE       : 'fun <Element>(): vector<Element>'
-    ADDITIONAL EDIT: 'use std::vector::empty;
-
-    '
 Method 'filter!()'
-    INSERT TEXT: 'filter!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::filter)'
+    INSERT TEXT: 'vector::filter!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::filter)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::filter;
-
-    '
 Method 'find_index!()'
-    INSERT TEXT: 'find_index!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::find_index)'
+    INSERT TEXT: 'vector::find_index!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::find_index)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): Option'
-    ADDITIONAL EDIT: 'use std::vector::find_index;
-
-    '
 Method 'find_indices!()'
-    INSERT TEXT: 'find_indices!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::find_indices)'
+    INSERT TEXT: 'vector::find_indices!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::find_indices)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T| -> bool): vector<u64>'
-    ADDITIONAL EDIT: 'use std::vector::find_indices;
-
-    '
 Method 'flatten()'
-    INSERT TEXT: 'flatten(${1:v})'
-    TARGET     : '(use std::vector::flatten)'
+    INSERT TEXT: 'vector::flatten(${1:v})'
+    TARGET     : '(vector::flatten)'
     TYPE       : 'fun <T>(vector<vector<T>>): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::flatten;
-
-    '
 Method 'fold!()'
-    INSERT TEXT: 'fold!(${1:v}, ${2:init}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::fold)'
+    INSERT TEXT: 'vector::fold!(${1:v}, ${2:init}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::fold)'
     TYPE       : 'fun <$T, $Acc>(vector<$T>, $Acc, |$Acc, $T| -> $Acc): $Acc'
-    ADDITIONAL EDIT: 'use std::vector::fold;
-
-    '
 Method 'index_of()'
-    INSERT TEXT: 'index_of(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::index_of)'
+    INSERT TEXT: 'vector::index_of(${1:v}, ${2:e})'
+    TARGET     : '(vector::index_of)'
     TYPE       : 'fun <Element>(&vector<Element>, &Element): (bool, u64)'
-    ADDITIONAL EDIT: 'use std::vector::index_of;
-
-    '
 Method 'insert()'
-    INSERT TEXT: 'insert(${1:v}, ${2:e}, ${3:i})'
-    TARGET     : '(use std::vector::insert)'
+    INSERT TEXT: 'vector::insert(${1:v}, ${2:e}, ${3:i})'
+    TARGET     : '(vector::insert)'
     TYPE       : 'fun <Element>(&mut vector<Element>, Element, u64)'
-    ADDITIONAL EDIT: 'use std::vector::insert;
-
-    '
 Method 'insertion_sort_by!()'
-    INSERT TEXT: 'insertion_sort_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::insertion_sort_by)'
+    INSERT TEXT: 'vector::insertion_sort_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::insertion_sort_by)'
     TYPE       : 'fun <$T>(&mut vector<$T>, |&$T, &$T| -> bool)'
-    ADDITIONAL EDIT: 'use std::vector::insertion_sort_by;
-
-    '
 Method 'is_empty()'
-    INSERT TEXT: 'is_empty(${1:v})'
-    TARGET     : '(use std::vector::is_empty)'
+    INSERT TEXT: 'vector::is_empty(${1:v})'
+    TARGET     : '(vector::is_empty)'
     TYPE       : 'fun <Element>(&vector<Element>): bool'
-    ADDITIONAL EDIT: 'use std::vector::is_empty;
-
-    '
 Method 'is_sorted_by!()'
-    INSERT TEXT: 'is_sorted_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::is_sorted_by)'
+    INSERT TEXT: 'vector::is_sorted_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::is_sorted_by)'
     TYPE       : 'fun <$T>(&vector<$T>, |&$T, &$T| -> bool): bool'
-    ADDITIONAL EDIT: 'use std::vector::is_sorted_by;
-
-    '
 Method 'length()'
-    INSERT TEXT: 'length(${1:v})'
-    TARGET     : '(use std::vector::length)'
+    INSERT TEXT: 'vector::length(${1:v})'
+    TARGET     : '(vector::length)'
     TYPE       : 'fun <Element>(&vector<Element>): u64'
-    ADDITIONAL EDIT: 'use std::vector::length;
-
-    '
 Method 'map!()'
-    INSERT TEXT: 'map!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::map)'
+    INSERT TEXT: 'vector::map!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::map)'
     TYPE       : 'fun <$T, $U>(vector<$T>, |$T| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::map;
-
-    '
 Method 'map_ref!()'
-    INSERT TEXT: 'map_ref!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::map_ref)'
+    INSERT TEXT: 'vector::map_ref!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::map_ref)'
     TYPE       : 'fun <$T, $U>(&vector<$T>, |&$T| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::map_ref;
-
-    '
 Method 'merge_sort_by!()'
-    INSERT TEXT: 'merge_sort_by!(${1:v}, |${2}, ${3}| ${4})'
-    TARGET     : '(use std::vector::merge_sort_by)'
+    INSERT TEXT: 'vector::merge_sort_by!(${1:v}, |${2}, ${3}| ${4})'
+    TARGET     : '(vector::merge_sort_by)'
     TYPE       : 'fun <$T>(&mut vector<$T>, |&$T, &$T| -> bool)'
-    ADDITIONAL EDIT: 'use std::vector::merge_sort_by;
-
-    '
 Method 'partition!()'
-    INSERT TEXT: 'partition!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::partition)'
+    INSERT TEXT: 'vector::partition!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::partition)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): (vector<$T>, vector<$T>)'
-    ADDITIONAL EDIT: 'use std::vector::partition;
-
-    '
 Method 'pop_back()'
-    INSERT TEXT: 'pop_back(${1:v})'
-    TARGET     : '(use std::vector::pop_back)'
+    INSERT TEXT: 'vector::pop_back(${1:v})'
+    TARGET     : '(vector::pop_back)'
     TYPE       : 'fun <Element>(&mut vector<Element>): Element'
-    ADDITIONAL EDIT: 'use std::vector::pop_back;
-
-    '
 Method 'push_back()'
-    INSERT TEXT: 'push_back(${1:v}, ${2:e})'
-    TARGET     : '(use std::vector::push_back)'
+    INSERT TEXT: 'vector::push_back(${1:v}, ${2:e})'
+    TARGET     : '(vector::push_back)'
     TYPE       : 'fun <Element>(&mut vector<Element>, Element)'
-    ADDITIONAL EDIT: 'use std::vector::push_back;
-
-    '
 Method 'remove()'
-    INSERT TEXT: 'remove(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::remove)'
+    INSERT TEXT: 'vector::remove(${1:v}, ${2:i})'
+    TARGET     : '(vector::remove)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): Element'
-    ADDITIONAL EDIT: 'use std::vector::remove;
-
-    '
 Method 'reverse()'
-    INSERT TEXT: 'reverse(${1:v})'
-    TARGET     : '(use std::vector::reverse)'
+    INSERT TEXT: 'vector::reverse(${1:v})'
+    TARGET     : '(vector::reverse)'
     TYPE       : 'fun <Element>(&mut vector<Element>)'
-    ADDITIONAL EDIT: 'use std::vector::reverse;
-
-    '
 Method 'singleton()'
-    INSERT TEXT: 'singleton(${1:e})'
-    TARGET     : '(use std::vector::singleton)'
+    INSERT TEXT: 'vector::singleton(${1:e})'
+    TARGET     : '(vector::singleton)'
     TYPE       : 'fun <Element>(Element): vector<Element>'
-    ADDITIONAL EDIT: 'use std::vector::singleton;
-
-    '
 Method 'skip()'
-    INSERT TEXT: 'skip(${1:v}, ${2:n})'
-    TARGET     : '(use std::vector::skip)'
+    INSERT TEXT: 'vector::skip(${1:v}, ${2:n})'
+    TARGET     : '(vector::skip)'
     TYPE       : 'fun <T>(vector<T>, u64): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::skip;
-
-    '
 Method 'skip_while!()'
-    INSERT TEXT: 'skip_while!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::skip_while)'
+    INSERT TEXT: 'vector::skip_while!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::skip_while)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::skip_while;
-
-    '
 Method 'swap()'
-    INSERT TEXT: 'swap(${1:v}, ${2:i}, ${3:j})'
-    TARGET     : '(use std::vector::swap)'
+    INSERT TEXT: 'vector::swap(${1:v}, ${2:i}, ${3:j})'
+    TARGET     : '(vector::swap)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64, u64)'
-    ADDITIONAL EDIT: 'use std::vector::swap;
-
-    '
 Method 'swap_remove()'
-    INSERT TEXT: 'swap_remove(${1:v}, ${2:i})'
-    TARGET     : '(use std::vector::swap_remove)'
+    INSERT TEXT: 'vector::swap_remove(${1:v}, ${2:i})'
+    TARGET     : '(vector::swap_remove)'
     TYPE       : 'fun <Element>(&mut vector<Element>, u64): Element'
-    ADDITIONAL EDIT: 'use std::vector::swap_remove;
-
-    '
 Method 'tabulate!()'
-    INSERT TEXT: 'tabulate!(${1:n}, |${2}| ${3})'
-    TARGET     : '(use std::vector::tabulate)'
+    INSERT TEXT: 'vector::tabulate!(${1:n}, |${2}| ${3})'
+    TARGET     : '(vector::tabulate)'
     TYPE       : 'fun <$T>(u64, |u64| -> $T): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::tabulate;
-
-    '
 Method 'take()'
-    INSERT TEXT: 'take(${1:v}, ${2:n})'
-    TARGET     : '(use std::vector::take)'
+    INSERT TEXT: 'vector::take(${1:v}, ${2:n})'
+    TARGET     : '(vector::take)'
     TYPE       : 'fun <T>(vector<T>, u64): vector<T>'
-    ADDITIONAL EDIT: 'use std::vector::take;
-
-    '
 Method 'take_while!()'
-    INSERT TEXT: 'take_while!(${1:v}, |${2}| ${3})'
-    TARGET     : '(use std::vector::take_while)'
+    INSERT TEXT: 'vector::take_while!(${1:v}, |${2}| ${3})'
+    TARGET     : '(vector::take_while)'
     TYPE       : 'fun <$T>(vector<$T>, |&$T| -> bool): vector<$T>'
-    ADDITIONAL EDIT: 'use std::vector::take_while;
-
-    '
 Method 'zip_do!()'
-    INSERT TEXT: 'zip_do!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do)'
+    INSERT TEXT: 'vector::zip_do!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do)'
     TYPE       : 'fun <$T1, $T2, $R>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do;
-
-    '
 Method 'zip_do_mut!()'
-    INSERT TEXT: 'zip_do_mut!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_mut)'
+    INSERT TEXT: 'vector::zip_do_mut!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_mut)'
     TYPE       : 'fun <$T1, $T2, $R>(&mut vector<$T1>, &mut vector<$T2>, |&mut $T1, &mut $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_mut;
-
-    '
 Method 'zip_do_ref!()'
-    INSERT TEXT: 'zip_do_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_ref)'
+    INSERT TEXT: 'vector::zip_do_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_ref)'
     TYPE       : 'fun <$T1, $T2, $R>(&vector<$T1>, &vector<$T2>, |&$T1, &$T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_ref;
-
-    '
 Method 'zip_do_reverse!()'
-    INSERT TEXT: 'zip_do_reverse!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_do_reverse)'
+    INSERT TEXT: 'vector::zip_do_reverse!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_do_reverse)'
     TYPE       : 'fun <$T1, $T2, $R>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $R)'
-    ADDITIONAL EDIT: 'use std::vector::zip_do_reverse;
-
-    '
 Method 'zip_map!()'
-    INSERT TEXT: 'zip_map!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_map)'
+    INSERT TEXT: 'vector::zip_map!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_map)'
     TYPE       : 'fun <$T1, $T2, $U>(vector<$T1>, vector<$T2>, |$T1, $T2| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::zip_map;
-
-    '
 Method 'zip_map_ref!()'
-    INSERT TEXT: 'zip_map_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
-    TARGET     : '(use std::vector::zip_map_ref)'
+    INSERT TEXT: 'vector::zip_map_ref!(${1:v1}, ${2:v2}, |${3}, ${4}| ${5})'
+    TARGET     : '(vector::zip_map_ref)'
     TYPE       : 'fun <$T1, $T2, $U>(&vector<$T1>, &vector<$T2>, |&$T1, &$T2| -> $U): vector<$U>'
-    ADDITIONAL EDIT: 'use std::vector::zip_map_ref;
-
-    '


### PR DESCRIPTION
## Description 

This PR implements a refinement to auto-imports and quick-fix algorithms to follow Move coding conventions better. The description below is for auto-completion but quick-fix update follows the same strategy.

When suggesting auto-completion for single words, we used to import package/module and leave the single word in the code regardless of the type. For example, to auto-complete on letter `f` towards a function `foo` in module `mod` in package `pkg`, we would insert the following:
```
use pkg::mod::foo;

...
foo()
...
```

This is technically correct and follows Move convention for structs and enums but not for functions. For functions, it is customary to prefix their name with module name. As a result, a better auto-import (or quick-fix) experience is to insert the following:
```
use pkg::mod;

...
mod::foo()
...
```

Of course we should not insert module import more than once. Instead we should check if it's already in scope. This was already easily done for auto-imports but for quick-fixes we had to make some additional changes to make this information available

## Test plan 

New tests have been added. All tests must pass. Also tested manually
