### PR TITLE
Support setting boolean feature flags by name in transactional tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_gas.move
@@ -4,7 +4,7 @@
 // Tests that --address-balance-gas pays for gas from the address balance,
 // leaving owned gas objects untouched.
 
-//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-accumulators
+//# init --addresses test=0x0 --accounts A
 
 // View gas coin before any transactions
 //# view-object 0,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_gas_simple_txn.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_gas_simple_txn.move
@@ -3,7 +3,7 @@
 
 // Test send_funds and redeem_funds from sui::balance
 
-//# init --protocol-version 108 --addresses test=0x0 --accounts A B C --enable-accumulators --enable-address-balance-gas-payments
+//# init --addresses test=0x0 --accounts A B C
 
 // Send 1000000000 from A to B
 //# programmable --sender A --inputs 1000000000 @B

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_gas_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_gas_transfer.move
@@ -3,7 +3,7 @@
 
 // Tests using the GasCoin when using --address-balance-gas.
 
-//# init --addresses test=0x0 --accounts A B C  --enable-address-balance-gas-payments --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C 
 
 //# programmable --sender A --inputs 10000000000 @A
 // First send funds to A's address balance so we can pay for gas from it

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.move
@@ -7,7 +7,7 @@
 // and the post-reset accumulator event is emitted cleanly without
 // duplication.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# publish
 module test::oog;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/balance_read.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/balance_read.move
@@ -3,7 +3,7 @@
 
 // Test settled_funds_value from sui::balance
 
-//# init --addresses test=0x0 --accounts A B C D --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C D
 
 //# publish
 module test::balance_read;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.move
@@ -8,7 +8,7 @@
 //   - the reservation emits a single Split accumulator event,
 //   - the smash target is mutated with the summed value.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# view-object 0,0
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_reservation_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_reservation_gas.move
@@ -4,7 +4,7 @@
 // Tests gas payment using withdrawals (drawing from address balance) combined
 // with real coin objects.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# view-object 0,0
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.move
@@ -9,7 +9,7 @@
 //   - a single accumulator event is emitted for the merged reservation,
 //   - leftover reservation lands in the gas coin (not refunded to the balance).
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# view-object 0,0
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/gas_coin_send_funds.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/gas_coin_send_funds.move
@@ -3,7 +3,7 @@
 
 // Tests passing Gas by value to sui::coin::send_funds in various scenarios.
 
-//# init --addresses test=0x0 --accounts A B C D E --enable-accumulators --enable-address-balance-gas-payments
+//# init --addresses test=0x0 --accounts A B C D E
 
 //# programmable --sender A --inputs @B --gas-budget 10000000
 // Send gas coin to another address via send_funds

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/insufficient_gas_payment.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/insufficient_gas_payment.move
@@ -4,7 +4,7 @@
 // Tests that transactions fail appropriately when gas payment is insufficient
 // for all possible forms of gas payment.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 // setup: send funds to A's address balance
 //# programmable --sender A --inputs 200000000 @A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/large_balance_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/large_balance_transfer.move
@@ -6,7 +6,7 @@
 // sends both amounts to address A, then attempts to withdraw both amounts in a single PTB.
 // The withdraw operation fails with arithmetic error because the total exceeds u64::MAX.
 
-//# init --addresses test=0x0 --accounts A B --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# publish --sender A
 module test::large_balance {

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.move
@@ -11,7 +11,7 @@
 //   - 10 explicit reservations: at boundary, passes.
 //   - 11 explicit reservations: over limit, rejects.
 
-//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A
 
 // Seed A's address balance with plenty.
 //# programmable --sender A --inputs 1000000000000 @A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.move
@@ -7,7 +7,7 @@
 // accumulator event and gas coin charge reflect the post-abort state, not
 // the pre-abort attempt.
 
-//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A
 
 //# publish
 module test::boom;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.move
@@ -6,7 +6,7 @@
 // value and clear the secondary's Split withdraw accumulator event; re-smash
 // must re-mutate and re-emit consistently.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# publish
 module test::oog;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.move
@@ -12,7 +12,7 @@
 // (3 coins' balance values folded into AB, minus the 100 MIST routed out to
 // B as a new coin).
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 // Seed A's address balance.
 //# programmable --sender A --inputs 100000000000 @A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.move
@@ -9,7 +9,7 @@
 //   - the gas charge against the address balance happens at final charging
 //     time via a separate Split event.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# view-object 0,0
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.move
@@ -7,7 +7,7 @@
 // Also clears the Merge deposit-back accumulator event before it's
 // re-emitted.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# publish
 module test::oog;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.move
@@ -7,7 +7,7 @@
 // The snapshot must show only one withdrawal-side accumulator event for the
 // merged reservation (not two), confirming the dedup happens upfront.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# view-object 0,0
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_bench.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_bench.move
@@ -4,7 +4,7 @@
 // Benchmark the send_funds command with a SUI withdrawal from A's address balance
 // sent to B, with gas also paid from A's address balance.
 
-//# init --addresses test=0x0 --accounts A B C D E --enable-accumulators --enable-address-balance-gas-payments
+//# init --addresses test=0x0 --accounts A B C D E
 
 // Seed A's address balance so it can both fund the withdrawal and pay for gas.
 //# programmable --sender A --inputs 20000000000 @A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random.move
@@ -16,7 +16,7 @@
 // Combined: A sends reservation + coin_value to C through smash+send_funds;
 // C nets out paying the gas.
 
-//# init --addresses test=0x0 --accounts A B C --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C
 
 // Seed A's address balance.
 //# programmable --sender A --inputs 100000000000 @A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random_oog.move
@@ -7,7 +7,7 @@
 // transfer) and re-smash undoes the override. The gas charge falls back to
 // A's AB (the original smash-target location); C is not charged.
 
-//# init --addresses test=0x0 --accounts A B C --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C
 
 //# publish
 module test::big;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sender.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sender.move
@@ -7,7 +7,7 @@
 // overridden to the recipient's AB -- the same address as the original
 // payer, so the override is logically a no-op.
 
-//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A
 
 // Seed A's address balance.
 //# programmable --sender A --inputs 100000000000 @A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor.move
@@ -6,7 +6,7 @@
 // override redirects the final charge from sponsor's Coin to sponsor's AB.
 // Net: B's AB ends with +coin_value - net_gas; A is untouched.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 // Sponsored tx: sender = A, sponsor = B. Default gas payment uses B's gas
 // coin (object 0,1). Workload `send_funds(Gas, @B)` transfers the gas coin

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor_oog.move
@@ -7,7 +7,7 @@
 // re-smash undoes the override. The gas charge falls back to the original
 // smash-target location -- sponsor's Coin -- not the recipient's AB.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 //# publish
 module test::big;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.move
@@ -13,7 +13,7 @@
 // confirming X's pre-tx version is folded into the tx's lamport timestamp
 // even though X itself is deleted.
 
-//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A
 
 //# publish
 module test::obj;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.move
@@ -21,7 +21,7 @@
 // `gas summary` / `accumulators_written` lines is attributable to smash
 // order alone.
 
-//# init --addresses test=0x0 --accounts A B C --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C
 
 // Seed A's and B's address balances identically.
 //# programmable --sender A --inputs 100000000000 @A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/sponsor_withdraw_rejected.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/sponsor_withdraw_rejected.move
@@ -3,7 +3,7 @@
 
 // A sponsored transaction cannot pay gas via an address-balance withdrawal.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 // Seed B's address balance so a hypothetical sponsor-side withdrawal would
 // have funds available.

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.move
@@ -12,7 +12,7 @@
 // can't be paid, forcing the fallback. The snapshot shows A's address
 // balance dropping by exactly the budget.
 
-//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A
 
 //# publish
 module test::big;

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/transfer_gas_to_sponsor.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/transfer_gas_to_sponsor.move
@@ -7,7 +7,7 @@
 // location was already Coin. Verifies the gas coin ends up still owned by
 // the sponsor (which already owned it) with value reduced by net_gas.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 // Sponsored tx: sender = A, sponsor = B. Default gas payment uses B's gas
 // coin (0,1). Workload transfers Gas back to B; final gas charge is debited

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/withdraw_and_send_account.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/withdraw_and_send_account.move
@@ -3,7 +3,7 @@
 
 // Test send_funds and redeem_funds from sui::balance
 
-//# init --addresses test=0x0 --accounts A B --enable-accumulators
+//# init --addresses test=0x0 --accounts A B
 
 // Send 1000 from A to B
 //# programmable --sender A --inputs 1000 @B

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_address_balance_receiver.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_address_balance_receiver.move
@@ -6,7 +6,7 @@
 // `balance::send_funds` is callable from PTBs, then confirm the receiver transitions through
 // allowed, denied-after-epoch, and re-enabled states.
 
-//# init --accounts A B --addresses test=0x0 --enable-accumulators
+//# init --accounts A B --addresses test=0x0
 
 //# publish --sender A
 module test::regulated_coin;

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid.move
@@ -3,7 +3,7 @@
 
 // tests invalid writes of mut references using coin operations
 
-//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 module test::m {

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid.move
@@ -3,7 +3,7 @@
 
 // tests valid writes of mut references using coin operations
 
-//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 module test::m {

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.move
@@ -3,7 +3,7 @@
 
 // tests returning a reference without any inputs
 
-//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 module test::m {

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.move
@@ -3,7 +3,7 @@
 
 // tests valid transfers/writes of mut references
 
-//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 module test::m {

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop.move
@@ -4,7 +4,7 @@
 // tests valid transfers/writes of mut references, which are valid only because of automatically
 // dropping references
 
-//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 module test::m {

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.move
@@ -3,7 +3,7 @@
 
 // tests adding a shared object as a dynamic field
 
-//# init --addresses test=0x0 --accounts A --shared-object-deletion true
+//# init --addresses test=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/hot_locations.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/hot_locations.move
@@ -3,7 +3,7 @@
 
 // Simple test of hot value rules each location and usage
 
-//# init --addresses test=0x0 a=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 a=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/hot_locations_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/hot_locations_invalid.move
@@ -3,7 +3,7 @@
 
 // Simple test of hot value rules each location and usage
 
-//# init --addresses test=0x0 a=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 a=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/hot_locations_invalid_via_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/hot_locations_invalid_via_shared.move
@@ -3,7 +3,7 @@
 
 // Simple test of hot value rules each location and usage
 
-//# init --addresses test=0x0 a=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 a=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
@@ -3,7 +3,7 @@
 
 // tests vector of objects
 
-//# init --addresses Test=0x0 --accounts A --shared-object-deletion true
+//# init --addresses Test=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 module Test::M {

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.move
@@ -3,7 +3,7 @@
 
 // tests vector of objects where operations involve generics (type parameters)
 
-//# init --addresses Test=0x0 --accounts A --shared-object-deletion true
+//# init --addresses Test=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 module Test::M {

--- a/crates/sui-adapter-transactional-tests/tests/event_streams/emit_authenticated.move
+++ b/crates/sui-adapter-transactional-tests/tests/event_streams/emit_authenticated.move
@@ -4,7 +4,7 @@
 // Exercise test functions that emit authenticated events
 
 // Protocol version pinned to avoid snapshot churn from genesis changes
-//# init --addresses test=0x0 --accounts A B --enable-authenticated-event-streams
+//# init --addresses test=0x0 --accounts A B
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/event_streams/emit_authenticated_multi_command_ptb.move
+++ b/crates/sui-adapter-transactional-tests/tests/event_streams/emit_authenticated_multi_command_ptb.move
@@ -3,7 +3,7 @@
 
 // Verify authenticated events used in multi-command ptbs.
 
-//# init --addresses test=0x0 --accounts A --enable-authenticated-event-streams
+//# init --addresses test=0x0 --accounts A
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_allowed_functions.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_allowed_functions.move
@@ -6,7 +6,7 @@
 // - balance::redeem_funds
 // - funds_accumulator::withdrawal_split
 
-//# init --addresses test=0x0 --accounts A B --enable-gasless --enable-accumulators
+//# init --addresses test=0x0 --accounts A B --enable-gasless
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_coin.move
@@ -3,7 +3,7 @@
 
 // Tests gasless transactions with coin object inputs, MergeCoins, and SplitCoins.
 
-//# init --addresses test=0x0 --accounts A B C --enable-gasless --enable-accumulators --shared-object-deletion true
+//# init --addresses test=0x0 --accounts A B C --enable-gasless --enable-feature-flags shared_object_deletion
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_min_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_min_transfer.move
@@ -3,7 +3,7 @@
 
 // Tests minimum transfer amount enforcement for gasless transactions.
 
-//# init --addresses test=0x0 --accounts A B C --enable-gasless --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C --enable-gasless
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_multi_recipient.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_multi_recipient.move
@@ -3,7 +3,7 @@
 
 // Tests gasless multi-recipient transfer using withdrawal_split.
 
-//# init --addresses test=0x0 --accounts A B C --enable-gasless --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C --enable-gasless
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_reject.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_reject.move
@@ -3,7 +3,7 @@
 
 // Tests gasless transaction validation rejects invalid transactions.
 
-//# init --addresses test=0x0 --accounts A B --enable-gasless --enable-accumulators
+//# init --addresses test=0x0 --accounts A B --enable-gasless
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_accept.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_accept.move
@@ -4,7 +4,7 @@
 // Tests that gasless withdrawals not leaving a balance below the minimum are accepted.
 // gasless_verify_remaining_balance is enabled by --enable-gasless.
 
-//# init --addresses test=0x0 --accounts A B --enable-gasless --enable-accumulators
+//# init --addresses test=0x0 --accounts A B --enable-gasless
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_reject.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_reject.move
@@ -4,7 +4,7 @@
 // Tests that gasless withdrawals leaving a balance below the minimum are rejected.
 // gasless_verify_remaining_balance is enabled by --enable-gasless.
 
-//# init --addresses test=0x0 --accounts A B --enable-gasless --enable-accumulators
+//# init --addresses test=0x0 --accounts A B --enable-gasless
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_transfer.move
@@ -3,7 +3,7 @@
 
 // Tests gasless balance transfer using a custom stablecoin.
 
-//# init --addresses test=0x0 --accounts A B --enable-gasless --enable-accumulators
+//# init --addresses test=0x0 --accounts A B --enable-gasless
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_unused_inputs.move
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_unused_inputs.move
@@ -8,7 +8,7 @@
 // 3. Unused Object inputs (always rejected)
 // 4. Pure inputs that exceed the size limit (32 bytes)
 
-//# init --addresses test=0x0 --accounts A B --enable-gasless --enable-accumulators --gasless-max-pure-input-bytes 32 --gasless-max-unused-inputs 1
+//# init --addresses test=0x0 --accounts A B --enable-gasless --gasless-max-pure-input-bytes 32 --gasless-max-unused-inputs 1
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_value.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_value.move
@@ -3,7 +3,7 @@
 
 // tests valid gas coin usage by value
 
-//# init --addresses test=0x0 --accounts A B --enable-accumulators --enable-address-balance-gas-payments
+//# init --addresses test=0x0 --accounts A B
 
 //# programmable --sender A --inputs @B
 //> TransferObjects([Gas], Input(0))

--- a/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_value_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_value_invalid.move
@@ -3,7 +3,7 @@
 
 // tests invalid gas coin usage by value
 
-//# init --addresses test=0x0 --accounts A --enable-accumulators --enable-address-balance-gas-payments
+//# init --addresses test=0x0 --accounts A
 
 //# publish
 module test::m1 {

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
@@ -3,7 +3,7 @@
 
 // tests that pure arguments have distinct values/locals per type usage
 
-//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
+//# init --addresses test=0x0 --accounts A --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 module test::m1 {

--- a/crates/sui-adapter-transactional-tests/tests/programmable/tx_context_result_borrow_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/tx_context_result_borrow_invalid.move
@@ -3,7 +3,7 @@
 
 // tests invalid attempts at manually supplying &mut/&TxContext
 
-//# init --addresses test=0x0 --allow-references-in-ptbs
+//# init --addresses test=0x0 --enable-feature-flags allow_references_in_ptbs
 
 //# publish
 module test::m;

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.move
@@ -3,7 +3,7 @@
 
 // tests shared object scenarios as part of programmable transactions
 
-//# init --addresses t2=0x0 --accounts A B --shared-object-deletion true
+//# init --addresses t2=0x0 --accounts A B --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.move
@@ -3,7 +3,7 @@
 
 // test invalid usages of shared coin
 
-//# init --addresses test=0x0 --accounts A --shared-object-deletion true
+//# init --addresses test=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.move
@@ -3,7 +3,7 @@
 
 // test valid usages of shared coin
 
-//# init --addresses test=0x0 --accounts A --shared-object-deletion true
+//# init --addresses test=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/add_dynamic_field.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/add_dynamic_field.move
@@ -4,7 +4,7 @@
 // tests that shared objects can have dynamic fields added
 // dynamic fields can be added and removed in the same transaction
 
-//# init --addresses a=0x0 --accounts A --shared-object-deletion true
+//# init --addresses a=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 module a::m {

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.move
@@ -4,7 +4,7 @@
 // tests that shared objects cannot become dynamic fields and that a shared object
 // dynamic field added and removed in the same transaction does not error
 
-//# init --addresses a=0x0 --accounts A --shared-object-deletion true
+//# init --addresses a=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 module a::m {

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.move
@@ -4,7 +4,7 @@
 // tests that shared objects cannot become dynamic fields and that a shared object
 // dynamic field added and removed in the same transaction does not error
 
-//# init --addresses a=0x0 --accounts A --shared-object-deletion true
+//# init --addresses a=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 module a::m {

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.move
@@ -4,7 +4,7 @@
 // tests that shared objects can be deleted by passing by value
 // in both the defining module and in a module that did not define the type
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails_v90.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails_v90.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true --protocol-version 90
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion --protocol-version 90
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_v90.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_v90.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true --protocol-version 90
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion --protocol-version 90
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --accounts A --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 // Merge:
 // shared into owned -> Can do anything, SO is deleted

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --accounts A --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 // Merge:
 // shared into owned -> Can do anything, SO is deleted

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails_v90.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails_v90.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true --protocol-version 90
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion --protocol-version 90
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_v90.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_v90.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true --protocol-version 90
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion --protocol-version 90
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/freeze.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/freeze.move
@@ -3,7 +3,7 @@
 
 // tests that shared objects cannot be freezed
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/non_exclusive_write.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/non_exclusive_write.move
@@ -4,7 +4,7 @@
 // tests that shared objects can have dynamic fields added
 // dynamic fields can be added and removed in the same transaction
 
-//# init --addresses a=0x0 --accounts A --shared-object-deletion true --enable-non-exclusive-write-objects
+//# init --addresses a=0x0 --accounts A --enable-feature-flags shared_object_deletion --enable-feature-flags enable_non_exclusive_writes
 
 //# publish
 module a::m;

--- a/crates/sui-adapter-transactional-tests/tests/shared/transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/transfer.move
@@ -4,7 +4,7 @@
 // tests that shared objects cannot be transfered in a way that will result
 // in their ownership no longer being shared
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/wrap.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/wrap.move
@@ -3,7 +3,7 @@
 
 // tests that shared objects cannot be wrapped
 
-//# init --addresses t1=0x0 t2=0x0 --shared-object-deletion true
+//# init --addresses t1=0x0 t2=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.move
@@ -3,7 +3,7 @@
 
 // test that freezing prevents transfers/mutations
 
-//# init --addresses test=0x0 --accounts A --shared-object-deletion true
+//# init --addresses test=0x0 --accounts A --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze_v20.move
@@ -3,7 +3,7 @@
 
 // test that freezing prevents transfers/mutations
 
-//# init --addresses test=0x0 --accounts A --shared-object-deletion false
+//# init --addresses test=0x0 --accounts A --disable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.move
@@ -3,7 +3,7 @@
 
 // tests TransferObject should fail for an immutable object
 
-//# init --accounts A B --addresses test=0x0 --shared-object-deletion true
+//# init --accounts A B --addresses test=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable_v20.move
@@ -3,7 +3,7 @@
 
 // tests TransferObject should fail for an immutable object
 
-//# init --accounts A B --addresses test=0x0 --shared-object-deletion false
+//# init --accounts A B --addresses test=0x0 --disable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.move
@@ -3,7 +3,7 @@
 
 // tests TransferObject should fail for a shared object with and without store
 
-//# init --accounts A B --addresses test=0x0 --shared-object-deletion true
+//# init --accounts A B --addresses test=0x0 --enable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared_v20.move
@@ -3,7 +3,7 @@
 
 // tests TransferObject should fail for a shared object
 
-//# init --accounts A B --addresses test=0x0 --shared-object-deletion false
+//# init --accounts A B --addresses test=0x0 --disable-feature-flags shared_object_deletion
 
 //# publish
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/balances.move
@@ -3,7 +3,7 @@
 
 // Simple e2e test of coin, address, and total balance queries.
 
-//# init --protocol-version 108 --accounts A B --addresses T=0x0 --simulator --enable-accumulators
+//# init --protocol-version 108 --accounts A B --addresses T=0x0 --simulator
 
 //# publish --sender A
 #[allow(deprecated_usage)]

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_changes.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_changes.move
@@ -3,7 +3,7 @@
 
 // Test send_funds and redeem_funds from sui::balance
 
-//# init --protocol-version 108 --addresses test=0x0 --accounts A B C --enable-accumulators --simulator --enable-address-balance-gas-payments
+//# init --protocol-version 128 --addresses test=0x0 --accounts A B C --simulator
 
 // Send 1000000000 from A to B and A to C
 //# programmable --sender A --inputs 1000000000 @B @C

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_gas_effects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_gas_effects.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 108 --accounts A --addresses test=0x0 --enable-accumulators --simulator --enable-address-balance-gas-payments
+//# init --protocol-version 128 --accounts A --addresses test=0x0 --simulator
 
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_address.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_address.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 108 --addresses Test=0x0 --accounts A B C --simulator --enable-accumulators
+//# init --protocol-version 108 --addresses Test=0x0 --accounts A B C --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-protocol-config-macros/src/lib.rs
+++ b/crates/sui-protocol-config-macros/src/lib.rs
@@ -502,9 +502,14 @@ pub fn feature_flag_getters_macro(input: TokenStream) -> TokenStream {
                                     quote! {
                                         stringify!(#field_name) => Some(self.#field_name),
                                     },
-                                    quote! {
-                                        stringify!(#field_name)
-                                    },
+                                    (
+                                        quote! {
+                                            stringify!(#field_name) => self.#field_name = val,
+                                        },
+                                        quote! {
+                                            stringify!(#field_name)
+                                        },
+                                    ),
                                 ),
                             ))
                         }
@@ -519,10 +524,13 @@ pub fn feature_flag_getters_macro(input: TokenStream) -> TokenStream {
 
     let mut protocol_config_getters = Vec::new();
     let mut string_name_getters = Vec::new();
+    let mut string_name_setters = Vec::new();
     let mut field_names = Vec::new();
-    for (protocol_config_getter, (string_name_getter, field_name)) in getters {
+    for (protocol_config_getter, (string_name_getter, (string_name_setter, field_name))) in getters
+    {
         protocol_config_getters.push(protocol_config_getter);
         string_name_getters.push(string_name_getter);
+        string_name_setters.push(string_name_setter);
         field_names.push(field_name);
     }
 
@@ -533,6 +541,14 @@ pub fn feature_flag_getters_macro(input: TokenStream) -> TokenStream {
                 match value.as_str() {
                     #(#string_name_getters)*
                     _ => None,
+                }
+            }
+
+            /// Set a feature flag by its string representation
+            pub fn set_attr_for_testing(&mut self, attr: String, val: bool) {
+                match attr.as_str() {
+                    #(#string_name_setters)*
+                    _ => panic!("Attempting to set unknown feature flag: {}", attr),
                 }
             }
 
@@ -547,6 +563,11 @@ pub fn feature_flag_getters_macro(input: TokenStream) -> TokenStream {
 
         impl ProtocolConfig {
             #(#protocol_config_getters)*
+
+            /// Set a feature flag by its string representation
+            pub fn set_feature_flag_for_testing(&mut self, flag: String, val: bool) {
+                self.feature_flags.set_attr_for_testing(flag, val)
+            }
         }
     };
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -5168,6 +5168,25 @@ mod test {
     }
 
     #[test]
+    fn test_feature_flag_setter_by_string() {
+        let mut prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Unknown);
+        assert!(!prot.zklogin_auth());
+        prot.set_feature_flag_for_testing("zklogin_auth".to_string(), true);
+        assert!(prot.zklogin_auth());
+        prot.set_feature_flag_for_testing("zklogin_auth".to_string(), false);
+        assert!(!prot.zklogin_auth());
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown feature flag")]
+    fn test_feature_flag_setter_unknown_flag() {
+        let mut prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Unknown);
+        prot.set_feature_flag_for_testing("some random string".to_string(), true);
+    }
+
+    #[test]
     fn test_get_for_version_if_supported_applies_test_overrides() {
         let before =
             ProtocolConfig::get_for_version_if_supported(ProtocolVersion::new(1), Chain::Unknown)

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use crate::test_adapter::{FakeID, SuiTestAdapter};
 use anyhow::{bail, ensure};
 use clap;
-use clap::{Args, Parser};
+use clap::{ArgAction, Args, Parser};
 use move_compiler::editions::Flavor;
 use move_core_types::parsing::{
     parser::Parser as MoveCLParser,
@@ -68,8 +68,6 @@ pub struct SuiInitArgs {
     pub chain: Option<Chain>,
     #[clap(long = "max-gas")]
     pub max_gas: Option<u64>,
-    #[clap(long = "shared-object-deletion")]
-    pub shared_object_deletion: Option<bool>,
     #[clap(long = "simulator")]
     pub simulator: bool,
     #[clap(long = "num-custom-validator-accounts")]
@@ -89,24 +87,6 @@ pub struct SuiInitArgs {
     /// URL for the Sui REST API. To be passed to the offchain indexer and reader.
     #[clap(long)]
     pub rest_api_url: Option<String>,
-    /// Enable accumulator features for testing (e.g., authenticated event streams)
-    #[clap(long = "enable-accumulators")]
-    pub enable_accumulators: bool,
-    /// Enable authenticated event streams for testing
-    #[clap(long = "enable-authenticated-event-streams")]
-    pub enable_authenticated_event_streams: bool,
-    /// Enable references in PTBs
-    #[clap(long = "allow-references-in-ptbs")]
-    pub allow_references_in_ptbs: bool,
-    /// Enable non-exclusive write objects for testing
-    #[clap(long = "enable-non-exclusive-write-objects")]
-    pub enable_non_exclusive_writes: bool,
-    /// Enable using address balance as gas payments feature for testing
-    #[clap(long = "enable-address-balance-gas-payments")]
-    pub enable_address_balance_gas_payments: bool,
-    /// Enable coin reservations for gas payment
-    #[clap(long = "enable-coin-reservations")]
-    pub enable_coin_reservations: bool,
     /// Override the file format version used when serializing compiled modules
     #[clap(long = "file-format")]
     pub file_format_version: Option<u32>,
@@ -119,6 +99,14 @@ pub struct SuiInitArgs {
     /// Set maximum number of unused Pure inputs in gasless transactions
     #[clap(long = "gasless-max-unused-inputs")]
     pub gasless_max_unused_inputs: Option<u64>,
+    /// Enable a boolean protocol feature flag by name, e.g.
+    /// `--enable-feature-flags zklogin_auth --enable-feature-flags enable_party_transfer`.
+    /// Flag names match the field names of `FeatureFlags` in the sui-protocol-config crate.
+    #[clap(long = "enable-feature-flags", action = ArgAction::Append)]
+    pub enable_feature_flags: Vec<String>,
+    /// Disable a boolean protocol feature flag by name.
+    #[clap(long = "disable-feature-flags", action = ArgAction::Append)]
+    pub disable_feature_flags: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -261,7 +261,6 @@ impl AdapterInitConfig {
             protocol_version,
             chain,
             max_gas,
-            shared_object_deletion,
             simulator,
             num_custom_validator_accounts,
             reference_gas_price,
@@ -270,16 +269,12 @@ impl AdapterInitConfig {
             consistent_range,
             data_ingestion_path,
             rest_api_url,
-            enable_accumulators,
-            enable_authenticated_event_streams,
-            allow_references_in_ptbs,
-            enable_non_exclusive_writes,
-            enable_address_balance_gas_payments,
-            enable_coin_reservations,
             file_format_version,
             enable_gasless,
             gasless_max_pure_input_bytes,
             gasless_max_unused_inputs,
+            enable_feature_flags,
+            disable_feature_flags,
         } = sui_args;
 
         let map = verify_and_create_named_address_mapping(named_addresses).unwrap();
@@ -304,27 +299,6 @@ impl AdapterInitConfig {
         } else {
             ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain)
         };
-        if enable_accumulators {
-            protocol_config.enable_accumulators_for_testing();
-        }
-        if enable_authenticated_event_streams {
-            protocol_config.enable_authenticated_event_streams_for_testing();
-        }
-        if allow_references_in_ptbs {
-            protocol_config.allow_references_in_ptbs_for_testing();
-        }
-        if enable_non_exclusive_writes {
-            protocol_config.enable_non_exclusive_writes_for_testing();
-        }
-        if let Some(enable) = shared_object_deletion {
-            protocol_config.set_shared_object_deletion_for_testing(enable);
-        }
-        if enable_address_balance_gas_payments {
-            protocol_config.enable_address_balance_gas_payments_for_testing();
-        }
-        if enable_coin_reservations {
-            protocol_config.enable_coin_reservation_for_testing();
-        }
         if enable_gasless {
             protocol_config.enable_gasless_for_testing();
         }
@@ -341,6 +315,12 @@ impl AdapterInitConfig {
                 "gasless-max-unused-inputs requires --enable-gasless"
             );
             protocol_config.set_gasless_max_unused_inputs_for_testing(max_unused);
+        }
+        for flag in enable_feature_flags {
+            protocol_config.set_feature_flag_for_testing(flag, true);
+        }
+        for flag in disable_feature_flags {
+            protocol_config.set_feature_flag_for_testing(flag, false);
         }
         // Older protocol versions use deprecated congestion control modes. Override to use
         // ExecutionTimeEstimate mode which is the only supported mode.


### PR DESCRIPTION
## Description

Enabling a boolean feature flag in a transactional test currently requires adding a dedicated init arg to the test runner and a hand-written `set_*_for_testing` method on `ProtocolConfig`, per flag. Stacked on #26976, this generates a string-based setter from the feature-flags derive (`ProtocolConfig::set_feature_flag_for_testing(name, bool)`, mirroring the existing scalar `set_attr_for_testing`) and exposes it in the test runner as generic `--enable-feature-flags` / `--disable-feature-flags` init args, so new flags are settable from .move tests with no runner changes.

Existing bespoke init args are migrated:
- Dropped where the flags are already on by default at the protocol versions the tests run (verified against config snapshots): `--enable-accumulators`, `--enable-authenticated-event-streams`, `--enable-coin-reservations`, `--enable-address-balance-gas-payments`. Three tests pinning `--protocol-version 108` solely because it was current when they were written are unpinned to make the last of these droppable.
- Replaced with the generic args where not default: `--shared-object-deletion`, `--allow-references-in-ptbs`, `--enable-non-exclusive-write-objects`.
- Kept: `--enable-gasless`, which sets scalar limits (e.g. `gasless_max_tps`) not expressible as bool flags.

## Test plan

New unit tests cover setting a flag by name (round-trip true/false) and panicking on an unknown flag name. The migration is validated by the full `sui-adapter-transactional-tests` suite and the migrated `sui-indexer-alt-e2e-tests` graphql tests passing with zero expectation/snapshot changes, confirming the dropped args and unpinned protocol versions are behavior-preserving, including the shared-object-deletion tests still pinning version 90.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes are not required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
