### PR TITLE
Generate typed feature flag setters for testing

### DIFF
--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -1065,7 +1065,7 @@ mod tests {
             // Create a shared object for testing
             let shared_objects = vec![Object::shared_for_testing()];
             let mut config = ProtocolConfig::get_for_max_version_UNSAFE();
-            config.enable_accumulators_for_testing();
+            config.set_enable_accumulators_for_testing(true);
             let authority = TestAuthorityBuilder::new()
                 .with_starting_objects(&shared_objects)
                 .with_protocol_config(config)

--- a/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/e2e_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/e2e_tests.rs
@@ -61,7 +61,7 @@ async fn create_test_env(init_balances: BTreeMap<TypeTag, u64>) -> TestEnv {
     let account_objects = starting_objects.iter().map(|o| o.id()).collect();
     starting_objects.push(gas_object.clone());
     let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    protocol_config.enable_accumulators_for_testing();
+    protocol_config.set_enable_accumulators_for_testing(true);
     let state = TestAuthorityBuilder::new()
         .with_protocol_config(protocol_config)
         .with_starting_objects(&starting_objects)

--- a/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
@@ -421,7 +421,7 @@ async fn new_authority_and_publish(path: &str) -> TestEnv {
 
     let mut protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-    protocol_config.enable_accumulators_for_testing();
+    protocol_config.set_enable_accumulators_for_testing(true);
 
     let authority = TestAuthorityBuilder::new()
         .with_starting_objects(&[gas_object])

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -103,16 +103,16 @@ async fn test_accumulators_root_created() {
         .with_proto_override_cb(Box::new(|version, mut cfg| {
             if version == ProtocolVersion::MAX - 1 {
                 cfg.disable_accumulators_for_testing();
-                cfg.disable_create_root_accumulator_object_for_testing();
+                cfg.set_create_root_accumulator_object_for_testing(false);
             } else if version == ProtocolVersion::MAX {
                 // accumulators are enabled for devnet/tests, so we need to disable them to run
                 // this test
                 cfg.disable_accumulators_for_testing();
-                cfg.create_root_accumulator_object_for_testing();
+                cfg.set_create_root_accumulator_object_for_testing(true);
                 // for some reason all 4 nodes are not reliably submitting capability messages
                 cfg.set_buffer_stake_for_protocol_upgrade_bps_for_testing(0);
             } else if version == ProtocolVersion::MAX_ALLOWED {
-                cfg.enable_accumulators_for_testing();
+                cfg.set_enable_accumulators_for_testing(true);
             }
             cfg
         }))
@@ -186,16 +186,16 @@ async fn test_accumulators_disabled() {
         .with_proto_override_cb(Box::new(|version, mut cfg| {
             if version == ProtocolVersion::MAX - 1 {
                 cfg.disable_accumulators_for_testing();
-                cfg.disable_create_root_accumulator_object_for_testing();
+                cfg.set_create_root_accumulator_object_for_testing(false);
             } else if version == ProtocolVersion::MAX {
                 // accumulators are enabled for devnet/tests, so we need to disable them to run
                 // this test
                 cfg.disable_accumulators_for_testing();
-                cfg.create_root_accumulator_object_for_testing();
+                cfg.set_create_root_accumulator_object_for_testing(true);
                 // for some reason all 4 nodes are not reliably submitting capability messages
                 cfg.set_buffer_stake_for_protocol_upgrade_bps_for_testing(0);
             } else if version == ProtocolVersion::MAX_ALLOWED {
-                cfg.enable_accumulators_for_testing();
+                cfg.set_enable_accumulators_for_testing(true);
             }
             cfg
         }))
@@ -2032,8 +2032,8 @@ async fn test_soft_bundle_different_gas_payers() {
 async fn test_multiple_deposits_merged_in_effects() {
     let mut test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.create_root_accumulator_object_for_testing();
-            cfg.enable_accumulators_for_testing();
+            cfg.set_create_root_accumulator_object_for_testing(true);
+            cfg.set_enable_accumulators_for_testing(true);
             cfg
         }))
         .with_num_validators(1)
@@ -3097,7 +3097,7 @@ async fn publish_and_mint_trusted_coin(test_env: &mut TestEnv, sender: SuiAddres
 async fn test_reject_transaction_executed_in_previous_epoch() {
     let mut test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_multi_epoch_transaction_expiration_for_testing();
+            cfg.set_enable_multi_epoch_transaction_expiration_for_testing(true);
             cfg
         }))
         .with_num_validators(1)
@@ -3172,7 +3172,7 @@ async fn test_reject_transaction_executed_in_previous_epoch() {
 async fn test_transaction_executes_in_next_epoch_with_one_epoch_range() {
     let mut test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_multi_epoch_transaction_expiration_for_testing();
+            cfg.set_enable_multi_epoch_transaction_expiration_for_testing(true);
             cfg
         }))
         .with_num_validators(1)
@@ -3222,7 +3222,7 @@ async fn test_transaction_executes_in_next_epoch_with_one_epoch_range() {
 async fn test_reject_signing_transaction_executed_in_previous_epoch() {
     let mut test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
-            cfg.enable_multi_epoch_transaction_expiration_for_testing();
+            cfg.set_enable_multi_epoch_transaction_expiration_for_testing(true);
             cfg
         }))
         .with_num_validators(1)

--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -1236,7 +1236,7 @@ async fn authenticated_events_multiple_commits_per_checkpoint() {
             cfg.enable_authenticated_event_streams_for_testing();
             cfg.enable_address_balance_gas_payments_for_testing();
             cfg.set_min_checkpoint_interval_ms_for_testing(1000);
-            cfg.disable_randomize_checkpoint_tx_limit_for_testing();
+            cfg.set_randomize_checkpoint_tx_limit_in_tests_for_testing(false);
             cfg
         });
 

--- a/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
@@ -32,7 +32,7 @@ async fn setup_test_cluster_with_auth_events() -> TestCluster {
 async fn setup_test_cluster_with_auth_events_disabled() -> TestCluster {
     let _guard: sui_protocol_config::OverrideGuard =
         ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
-            cfg.disable_authenticated_event_streams_for_testing();
+            cfg.set_enable_authenticated_event_streams_for_testing(false);
             cfg
         });
 

--- a/crates/sui-e2e-tests/tests/checkpoint_rate_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_rate_tests.rs
@@ -10,7 +10,7 @@ use tracing::info;
 #[sim_test]
 async fn test_checkpoint_rate() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.disable_randomize_checkpoint_tx_limit_for_testing();
+        config.set_randomize_checkpoint_tx_limit_in_tests_for_testing(false);
         config
     });
 

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -297,7 +297,7 @@ impl UserValidationMethod for MyUserValidationMethod {
 #[sim_test]
 async fn test_upgraded_multisig_feature_deny() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_upgraded_multisig_for_testing(false);
+        config.set_upgraded_multisig_supported_for_testing(false);
         config
     });
 
@@ -314,7 +314,7 @@ async fn test_upgraded_multisig_feature_deny() {
 #[sim_test]
 async fn test_upgraded_multisig_feature_allow() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_upgraded_multisig_for_testing(true);
+        config.set_upgraded_multisig_supported_for_testing(true);
         config
     });
 

--- a/crates/sui-e2e-tests/tests/object_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/object_balance_tests.rs
@@ -13,8 +13,8 @@ use test_cluster::TestClusterBuilder;
 #[sim_test]
 async fn test_object_balance_withdraw_stress() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
-        cfg.create_root_accumulator_object_for_testing();
-        cfg.enable_accumulators_for_testing();
+        cfg.set_create_root_accumulator_object_for_testing(true);
+        cfg.set_enable_accumulators_for_testing(true);
         cfg.set_enable_object_funds_withdraw_for_testing(true);
         cfg
     });

--- a/crates/sui-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/protocol_version_tests.rs
@@ -843,7 +843,7 @@ mod sim_only_tests {
     #[sim_test]
     async fn test_safe_mode_recovery() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_disable_bridge_for_testing();
+            config.set_bridge_for_testing(false);
             config
         });
 
@@ -896,7 +896,7 @@ mod sim_only_tests {
     #[sim_test]
     async fn sui_system_mock_smoke_test() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_disable_bridge_for_testing();
+            config.set_bridge_for_testing(false);
             config
         });
 
@@ -915,7 +915,7 @@ mod sim_only_tests {
     #[sim_test]
     async fn sui_system_state_shallow_upgrade_test() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_disable_bridge_for_testing();
+            config.set_bridge_for_testing(false);
             config
         });
 
@@ -952,7 +952,7 @@ mod sim_only_tests {
     #[sim_test]
     async fn sui_system_state_deep_upgrade_test() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_disable_bridge_for_testing();
+            config.set_bridge_for_testing(false);
             config
         });
 

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -107,7 +107,7 @@ async fn test_passive_reconfig_determinism() {
 async fn do_test_passive_reconfig(chain: Option<Chain>) {
     telemetry_subscribers::init_for_testing();
     let _commit_root_state_digest = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_commit_root_state_digest_supported_for_testing(true);
+        config.set_commit_root_state_digest_for_testing(true);
         config
     });
     ProtocolConfig::poison_get_for_min_version();

--- a/crates/sui-e2e-tests/tests/rpc/v2/state_service/balance.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/state_service/balance.rs
@@ -87,8 +87,8 @@ async fn test_balance_changes_on_transfer() {
 #[sim_test]
 async fn test_address_balance() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
-        cfg.create_root_accumulator_object_for_testing();
-        cfg.enable_accumulators_for_testing();
+        cfg.set_create_root_accumulator_object_for_testing(true);
+        cfg.set_enable_accumulators_for_testing(true);
         cfg
     });
 
@@ -137,8 +137,8 @@ async fn test_address_balance() {
 #[sim_test]
 async fn test_address_balance_account_with_only_address_balance() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
-        cfg.create_root_accumulator_object_for_testing();
-        cfg.enable_accumulators_for_testing();
+        cfg.set_create_root_accumulator_object_for_testing(true);
+        cfg.set_enable_accumulators_for_testing(true);
         cfg
     });
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -755,7 +755,7 @@ async fn resolve_transaction_shared_object_with_generic_type_parameter() {
 #[sim_test]
 async fn test_gas_selection_with_address_balance() {
     let _guard = sui_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
-        cfg.create_root_accumulator_object_for_testing();
+        cfg.set_create_root_accumulator_object_for_testing(true);
         cfg.enable_address_balance_gas_payments_for_testing();
         cfg
     });
@@ -868,7 +868,7 @@ async fn test_gas_selection_with_address_balance() {
 #[sim_test]
 async fn simulate_transaction_with_valid_during_expiration() {
     let _guard = sui_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
-        cfg.create_root_accumulator_object_for_testing();
+        cfg.set_create_root_accumulator_object_for_testing(true);
         cfg.enable_address_balance_gas_payments_for_testing();
         cfg
     });

--- a/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
+++ b/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
@@ -21,7 +21,7 @@ async fn receive_object_feature_deny() {
     use sui_protocol_config::ProtocolConfig;
 
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_receive_object_for_testing(false);
+        config.set_receive_objects_for_testing(false);
         config
     });
 

--- a/crates/sui-protocol-config-macros/src/lib.rs
+++ b/crates/sui-protocol-config-macros/src/lib.rs
@@ -486,7 +486,7 @@ pub fn feature_flag_getters_macro(input: TokenStream) -> TokenStream {
                                 .last()
                                 .is_some_and(|segment| segment.ident == "bool") =>
                         {
-                            let protocol_config_getter = if skip_protocol_config_accessor {
+                            let getter = if skip_protocol_config_accessor {
                                 quote! {}
                             } else {
                                 quote! {
@@ -494,6 +494,15 @@ pub fn feature_flag_getters_macro(input: TokenStream) -> TokenStream {
                                     pub fn #field_name(&self) -> #field_type {
                                         self.feature_flags.#field_name
                                     }
+                                }
+                            };
+                            let setter_name: proc_macro2::TokenStream =
+                                format!("set_{}_for_testing", field_name).parse().unwrap();
+                            let protocol_config_getter = quote! {
+                                #getter
+
+                                pub fn #setter_name(&mut self, val: bool) {
+                                    self.feature_flags.#field_name = val;
                                 }
                             };
                             Some((

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -4719,48 +4719,6 @@ impl ProtocolConfig {
 // This is only needed for feature_flags. Please suffix each setter with `_for_testing`.
 // Non-feature_flags should already have test setters defined through macros.
 impl ProtocolConfig {
-    pub fn set_advance_to_highest_supported_protocol_version_for_testing(&mut self, val: bool) {
-        self.feature_flags
-            .advance_to_highest_supported_protocol_version = val
-    }
-    pub fn set_commit_root_state_digest_supported_for_testing(&mut self, val: bool) {
-        self.feature_flags.commit_root_state_digest = val
-    }
-    pub fn set_zklogin_auth_for_testing(&mut self, val: bool) {
-        self.feature_flags.zklogin_auth = val
-    }
-    pub fn set_enable_jwk_consensus_updates_for_testing(&mut self, val: bool) {
-        self.feature_flags.enable_jwk_consensus_updates = val
-    }
-    pub fn set_random_beacon_for_testing(&mut self, val: bool) {
-        self.feature_flags.random_beacon = val
-    }
-
-    pub fn set_upgraded_multisig_for_testing(&mut self, val: bool) {
-        self.feature_flags.upgraded_multisig_supported = val
-    }
-    pub fn set_accept_zklogin_in_multisig_for_testing(&mut self, val: bool) {
-        self.feature_flags.accept_zklogin_in_multisig = val
-    }
-
-    pub fn set_shared_object_deletion_for_testing(&mut self, val: bool) {
-        self.feature_flags.shared_object_deletion = val;
-    }
-
-    pub fn set_narwhal_new_leader_election_schedule_for_testing(&mut self, val: bool) {
-        self.feature_flags.narwhal_new_leader_election_schedule = val;
-    }
-
-    pub fn set_receive_object_for_testing(&mut self, val: bool) {
-        self.feature_flags.receive_objects = val
-    }
-    pub fn set_narwhal_certificate_v2_for_testing(&mut self, val: bool) {
-        self.feature_flags.narwhal_certificate_v2 = val
-    }
-    pub fn set_verify_legacy_zklogin_address_for_testing(&mut self, val: bool) {
-        self.feature_flags.verify_legacy_zklogin_address = val
-    }
-
     pub fn set_per_object_congestion_control_mode_for_testing(
         &mut self,
         val: PerObjectCongestionControlMode,
@@ -4780,83 +4738,8 @@ impl ProtocolConfig {
         self.feature_flags.zklogin_max_epoch_upper_bound_delta = val
     }
 
-    pub fn set_disable_bridge_for_testing(&mut self) {
-        self.feature_flags.bridge = false
-    }
-
     pub fn set_mysticeti_num_leaders_per_round_for_testing(&mut self, val: Option<usize>) {
         self.feature_flags.mysticeti_num_leaders_per_round = val;
-    }
-
-    pub fn set_enable_soft_bundle_for_testing(&mut self, val: bool) {
-        self.feature_flags.soft_bundle = val;
-    }
-
-    pub fn set_passkey_auth_for_testing(&mut self, val: bool) {
-        self.feature_flags.passkey_auth = val
-    }
-
-    pub fn set_enable_party_transfer_for_testing(&mut self, val: bool) {
-        self.feature_flags.enable_party_transfer = val
-    }
-
-    pub fn set_enable_unified_linkage_for_testing(&mut self, val: bool) {
-        self.feature_flags.enable_unified_linkage = val
-    }
-
-    pub fn set_consensus_distributed_vote_scoring_strategy_for_testing(&mut self, val: bool) {
-        self.feature_flags
-            .consensus_distributed_vote_scoring_strategy = val;
-    }
-
-    pub fn set_consensus_round_prober_for_testing(&mut self, val: bool) {
-        self.feature_flags.consensus_round_prober = val;
-    }
-
-    pub fn set_disallow_new_modules_in_deps_only_packages_for_testing(&mut self, val: bool) {
-        self.feature_flags
-            .disallow_new_modules_in_deps_only_packages = val;
-    }
-
-    pub fn set_correct_gas_payment_limit_check_for_testing(&mut self, val: bool) {
-        self.feature_flags.correct_gas_payment_limit_check = val;
-    }
-
-    pub fn set_address_aliases_for_testing(&mut self, val: bool) {
-        self.feature_flags.address_aliases = val;
-    }
-
-    pub fn set_consensus_round_prober_probe_accepted_rounds(&mut self, val: bool) {
-        self.feature_flags
-            .consensus_round_prober_probe_accepted_rounds = val;
-    }
-
-    pub fn set_mysticeti_fastpath_for_testing(&mut self, val: bool) {
-        self.feature_flags.mysticeti_fastpath = val;
-    }
-
-    pub fn set_accept_passkey_in_multisig_for_testing(&mut self, val: bool) {
-        self.feature_flags.accept_passkey_in_multisig = val;
-    }
-
-    pub fn set_consensus_batched_block_sync_for_testing(&mut self, val: bool) {
-        self.feature_flags.consensus_batched_block_sync = val;
-    }
-
-    pub fn set_record_time_estimate_processed_for_testing(&mut self, val: bool) {
-        self.feature_flags.record_time_estimate_processed = val;
-    }
-
-    pub fn set_prepend_prologue_tx_in_consensus_commit_in_checkpoints_for_testing(
-        &mut self,
-        val: bool,
-    ) {
-        self.feature_flags
-            .prepend_prologue_tx_in_consensus_commit_in_checkpoints = val;
-    }
-
-    pub fn enable_accumulators_for_testing(&mut self) {
-        self.feature_flags.enable_accumulators = true;
     }
 
     pub fn disable_accumulators_for_testing(&mut self) {
@@ -4879,14 +4762,6 @@ impl ProtocolConfig {
             .convert_withdrawal_compatibility_ptb_arguments = false;
     }
 
-    pub fn create_root_accumulator_object_for_testing(&mut self) {
-        self.feature_flags.create_root_accumulator_object = true;
-    }
-
-    pub fn disable_create_root_accumulator_object_for_testing(&mut self) {
-        self.feature_flags.create_root_accumulator_object = false;
-    }
-
     pub fn enable_address_balance_gas_payments_for_testing(&mut self) {
         self.feature_flags.enable_accumulators = true;
         self.feature_flags.allow_private_accumulator_entrypoints = true;
@@ -4894,10 +4769,6 @@ impl ProtocolConfig {
         self.feature_flags.address_balance_gas_check_rgp_at_signing = true;
         self.feature_flags.address_balance_gas_reject_gas_coin_arg = false;
         self.execution_version = Some(self.execution_version.map_or(4, |v| v.max(4)))
-    }
-
-    pub fn disable_address_balance_gas_payments_for_testing(&mut self) {
-        self.feature_flags.enable_address_balance_gas_payments = false;
     }
 
     pub fn enable_gasless_for_testing(&mut self) {
@@ -4916,88 +4787,12 @@ impl ProtocolConfig {
         self.gasless_allowed_token_types = None;
     }
 
-    pub fn enable_multi_epoch_transaction_expiration_for_testing(&mut self) {
-        self.feature_flags.enable_multi_epoch_transaction_expiration = true;
-    }
-
     pub fn enable_authenticated_event_streams_for_testing(&mut self) {
-        self.enable_accumulators_for_testing();
+        self.feature_flags.enable_accumulators = true;
         self.feature_flags.enable_authenticated_event_streams = true;
         self.feature_flags
             .include_checkpoint_artifacts_digest_in_summary = true;
         self.feature_flags.split_checkpoints_in_consensus_handler = true;
-    }
-
-    pub fn disable_authenticated_event_streams_for_testing(&mut self) {
-        self.feature_flags.enable_authenticated_event_streams = false;
-    }
-
-    pub fn disable_randomize_checkpoint_tx_limit_for_testing(&mut self) {
-        self.feature_flags.randomize_checkpoint_tx_limit_in_tests = false;
-    }
-
-    pub fn enable_non_exclusive_writes_for_testing(&mut self) {
-        self.feature_flags.enable_non_exclusive_writes = true;
-    }
-
-    pub fn set_relax_valid_during_for_owned_inputs_for_testing(&mut self, val: bool) {
-        self.feature_flags.relax_valid_during_for_owned_inputs = val;
-    }
-
-    pub fn set_ignore_execution_time_observations_after_certs_closed_for_testing(
-        &mut self,
-        val: bool,
-    ) {
-        self.feature_flags
-            .ignore_execution_time_observations_after_certs_closed = val;
-    }
-
-    pub fn set_consensus_checkpoint_signature_key_includes_digest_for_testing(
-        &mut self,
-        val: bool,
-    ) {
-        self.feature_flags
-            .consensus_checkpoint_signature_key_includes_digest = val;
-    }
-
-    pub fn set_cancel_for_failed_dkg_early_for_testing(&mut self, val: bool) {
-        self.feature_flags.cancel_for_failed_dkg_early = val;
-    }
-
-    pub fn set_always_advance_dkg_to_resolution_for_testing(&mut self, val: bool) {
-        self.feature_flags.always_advance_dkg_to_resolution = val;
-    }
-
-    pub fn set_use_mfp_txns_in_load_initial_object_debts_for_testing(&mut self, val: bool) {
-        self.feature_flags.use_mfp_txns_in_load_initial_object_debts = val;
-    }
-
-    pub fn set_authority_capabilities_v2_for_testing(&mut self, val: bool) {
-        self.feature_flags.authority_capabilities_v2 = val;
-    }
-
-    pub fn allow_references_in_ptbs_for_testing(&mut self) {
-        self.feature_flags.allow_references_in_ptbs = true;
-    }
-
-    pub fn set_consensus_skip_gced_accept_votes_for_testing(&mut self, val: bool) {
-        self.feature_flags.consensus_skip_gced_accept_votes = val;
-    }
-
-    pub fn set_enable_object_funds_withdraw_for_testing(&mut self, val: bool) {
-        self.feature_flags.enable_object_funds_withdraw = val;
-    }
-
-    pub fn set_record_net_unsettled_object_withdraws_for_testing(&mut self, val: bool) {
-        self.feature_flags.record_net_unsettled_object_withdraws = val;
-    }
-
-    pub fn set_split_checkpoints_in_consensus_handler_for_testing(&mut self, val: bool) {
-        self.feature_flags.split_checkpoints_in_consensus_handler = val;
-    }
-
-    pub fn set_merge_randomness_into_checkpoint_for_testing(&mut self, val: bool) {
-        self.feature_flags.merge_randomness_into_checkpoint = val;
     }
 }
 

--- a/crates/sui-types/src/unit_tests/address_balance_gas_tests.rs
+++ b/crates/sui-types/src/unit_tests/address_balance_gas_tests.rs
@@ -137,8 +137,8 @@ fn test_address_balance_payment_requires_accumulators_enabled() {
 #[test]
 fn test_address_balance_payment_requires_feature_flag() {
     let mut config = ProtocolConfig::get_for_max_version_UNSAFE();
-    config.enable_accumulators_for_testing();
-    config.disable_address_balance_gas_payments_for_testing();
+    config.set_enable_accumulators_for_testing(true);
+    config.set_enable_address_balance_gas_payments_for_testing(false);
 
     let tx_data = create_test_transaction_data(
         vec![],

--- a/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
+++ b/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
@@ -21,7 +21,7 @@ use crate::{
 
 fn protocol_config() -> ProtocolConfig {
     let mut cfg = ProtocolConfig::get_for_max_version_UNSAFE();
-    cfg.enable_accumulators_for_testing();
+    cfg.set_enable_accumulators_for_testing(true);
     cfg
 }
 


### PR DESCRIPTION
## Description

Stacked on #27158. `ProtocolConfig` had ~50 hand-written `set_*_for_testing` methods that just assign one boolean feature flag. Generate a typed `set_<flag>_for_testing(&mut self, val: bool)` from the feature-flags derive for every boolean flag instead, and delete the hand-written ones (including a few whose method name didn't match the flag name — their call sites are renamed to the canonical generated name). Compound setters that touch multiple flags or non-flag config (e.g. `enable_gasless_for_testing`) remain hand-written.

## Test plan

No behavior change: the generated setters are byte-for-byte equivalent to the deleted hand-written ones, and all call-site rewrites are mechanical renames. Covered by the existing protocol-config unit tests and the sui-core/sui-types tests at the rewritten call sites (coin deny list, object funds checker, shared object version manager, balance withdraw).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes are not required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
