### PR TITLE
Cherrypick [gql] reject invalid txn cursor upfront (#27154)

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -58,10 +58,13 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
         .await
         .unwrap();
     let events = bridge_test_cluster
-        .new_bridge_events(HashSet::from_iter([
-            TokenTransferApproved.get().unwrap().clone(),
-            TokenTransferClaimed.get().unwrap().clone(),
-        ]))
+        .new_bridge_events(
+            HashSet::from_iter([
+                TokenTransferApproved.get().unwrap().clone(),
+                TokenTransferClaimed.get().unwrap().clone(),
+            ]),
+            2,
+        )
         .await;
     // There are exactly 1 approved and 1 claimed event
     assert_eq!(events.len(), 2);
@@ -103,11 +106,14 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
     .await
     .unwrap();
     let events = bridge_test_cluster
-        .new_bridge_events(HashSet::from_iter([
-            SuiToEthTokenBridgeV1.get().unwrap().clone(),
-            TokenTransferApproved.get().unwrap().clone(),
-            TokenTransferClaimed.get().unwrap().clone(),
-        ]))
+        .new_bridge_events(
+            HashSet::from_iter([
+                SuiToEthTokenBridgeV1.get().unwrap().clone(),
+                TokenTransferApproved.get().unwrap().clone(),
+                TokenTransferClaimed.get().unwrap().clone(),
+            ]),
+            2,
+        )
         .await;
     // There are exactly 1 deposit and 1 approved event
     assert_eq!(events.len(), 2);
@@ -200,10 +206,13 @@ async fn test_bridge_from_eth_to_sui_to_eth_v2() {
         .await
         .unwrap();
     let events = bridge_test_cluster
-        .new_bridge_events(HashSet::from_iter([
-            TokenTransferApproved.get().unwrap().clone(),
-            TokenTransferClaimed.get().unwrap().clone(),
-        ]))
+        .new_bridge_events(
+            HashSet::from_iter([
+                TokenTransferApproved.get().unwrap().clone(),
+                TokenTransferClaimed.get().unwrap().clone(),
+            ]),
+            2,
+        )
         .await;
     assert_eq!(events.len(), 2);
 
@@ -243,11 +252,14 @@ async fn test_bridge_from_eth_to_sui_to_eth_v2() {
     .await
     .unwrap();
     let events = bridge_test_cluster
-        .new_bridge_events(HashSet::from_iter([
-            SuiToEthTokenBridgeV2.get().unwrap().clone(),
-            TokenTransferApproved.get().unwrap().clone(),
-            TokenTransferClaimed.get().unwrap().clone(),
-        ]))
+        .new_bridge_events(
+            HashSet::from_iter([
+                SuiToEthTokenBridgeV2.get().unwrap().clone(),
+                TokenTransferApproved.get().unwrap().clone(),
+                TokenTransferClaimed.get().unwrap().clone(),
+            ]),
+            2,
+        )
         .await;
     assert_eq!(events.len(), 2);
     info!(

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -374,33 +374,51 @@ impl BridgeTestCluster {
         );
     }
 
-    /// Returns events that are emitted in new bridge transaction and match `event_types`.
-    /// It advanaces the stored tx digest cursor.
-    pub async fn new_bridge_events(&mut self, event_types: HashSet<StructTag>) -> Vec<Event> {
+    /// Returns events that are emitted in new bridge transactions and match `event_types`,
+    /// polling until at least `expected_count` matching events are found or the timeout expires
+    /// (returning however many were found by then). It advances the stored checkpoint cursor.
+    ///
+    /// Polling is necessary because transaction execution (and therefore onchain bridge action
+    /// status) is observable before the transaction lands in a checkpoint, so at the time of the
+    /// call the events may not be in any checkpoint yet.
+    pub async fn new_bridge_events(
+        &mut self,
+        event_types: HashSet<StructTag>,
+        expected_count: usize,
+    ) -> Vec<Event> {
         let mut client = self.grpc_client();
+        let mut matched: Vec<Event> = Vec::new();
 
-        let target = client
-            .get_latest_checkpoint()
-            .await
-            .unwrap()
-            .sequence_number;
+        let deadline = Instant::now() + tokio::time::Duration::from_secs(30);
+        loop {
+            let target = client
+                .get_latest_checkpoint()
+                .await
+                .unwrap()
+                .sequence_number;
 
-        let mut events: Vec<Event> = Vec::new();
-        for checkpoint in self.events_cursor.unwrap_or(0)..=target {
-            let checkpoint = client.get_full_checkpoint(checkpoint).await.unwrap();
+            for checkpoint in self.events_cursor.unwrap_or(0)..=target {
+                let checkpoint = client.get_full_checkpoint(checkpoint).await.unwrap();
 
-            for tx in checkpoint.transactions {
-                if let Some(e) = tx.events {
-                    events.extend(e.data);
+                for tx in checkpoint.transactions {
+                    if let Some(e) = tx.events {
+                        matched.extend(
+                            e.data
+                                .into_iter()
+                                .filter(|e| event_types.contains(&e.type_)),
+                        );
+                    }
                 }
             }
-        }
 
-        self.events_cursor = Some(target);
-        events
-            .into_iter()
-            .filter(|e| event_types.contains(&e.type_))
-            .collect()
+            // `target` has already been scanned; start after it on the next call/iteration.
+            self.events_cursor = Some(target + 1);
+
+            if matched.len() >= expected_count || Instant::now() > deadline {
+                return matched;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
     }
 
     /// Upgrades the SuiBridge proxy to SuiBridgeV2.

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -636,12 +636,15 @@ pub mod tests {
             .await;
 
         let events = bridge_test_cluster
-            .new_bridge_events(HashSet::from_iter([
-                CommitteeMemberRegistration.get().unwrap().clone(),
-                CommitteeUpdateEvent.get().unwrap().clone(),
-                TokenRegistrationEvent.get().unwrap().clone(),
-                NewTokenEvent.get().unwrap().clone(),
-            ]))
+            .new_bridge_events(
+                HashSet::from_iter([
+                    CommitteeMemberRegistration.get().unwrap().clone(),
+                    CommitteeUpdateEvent.get().unwrap().clone(),
+                    TokenRegistrationEvent.get().unwrap().clone(),
+                    NewTokenEvent.get().unwrap().clone(),
+                ]),
+                4,
+            )
             .await;
         let mut mask = 0u8;
         for event in events.iter() {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -52,6 +52,7 @@ use crate::error::RpcError;
 use crate::error::bad_user_input;
 use crate::error::upcast;
 use crate::extensions::query_limits;
+use crate::pagination::Error as PaginationError;
 use crate::pagination::Page;
 use crate::scope::Scope;
 use crate::task::streaming::ProcessedTransaction;
@@ -353,6 +354,12 @@ impl Transaction {
         page: Page<CTransaction>,
         filter: TransactionFilter,
     ) -> Result<TransactionConnection, RpcError> {
+        // Reject cursors that don't decode as `CursorToken`s up front -- `TxBoundsCursor` for
+        // `CTransaction` assumes they are valid.
+        for cursor in page.after().into_iter().chain(page.before()) {
+            CursorToken::decode(cursor).map_err(|_| PaginationError::BadCursor)?;
+        }
+
         let watermarks: &Arc<Watermarks> = ctx.data()?;
         let available_range_key = AvailableRangeKey {
             type_: "Query".to_string(),

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -61,6 +61,9 @@ pub(crate) enum End {
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub(crate) enum Error {
+    #[error("Invalid input cursor")]
+    BadCursor,
+
     #[error("Cannot provide both 'first' and 'last' parameters for connection")]
     FirstAndLast,
 


### PR DESCRIPTION
## Description 

```
impl TxBoundsCursor for CTransaction {
    fn tx_sequence_number(&self) -> u64 {
        CursorToken::decode(self)
            .expect("cursor already validated as ByteCursor")
            .position
    }
}
```

The expect from above pops up when we receive a legacy cursor format, which is valid base64 but doesn't decode into a `CursorToken`. Before this, we should validate in `fn paginate` whether the cursor is indeed an encoded `CursorToken`.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
