### PR TITLE
[cli] sets default flavor

### DIFF
--- a/crates/sui-move/src/lint.rs
+++ b/crates/sui-move/src/lint.rs
@@ -3,6 +3,7 @@
 
 use clap::Parser;
 use move_cli::base::lint;
+use move_compiler::editions::Flavor;
 use move_package_alt_compilation::build_config::BuildConfig;
 use std::path::Path;
 use sui_package_alt::SuiFlavor;
@@ -18,9 +19,15 @@ impl Lint {
     pub async fn execute(
         self,
         path: Option<&Path>,
-        build_config: BuildConfig,
+        mut build_config: BuildConfig,
         flavor: SuiFlavor,
     ) -> anyhow::Result<()> {
+        // Force the Sui compiler flavor (as `build` and `test` do) so that the Sui-specific
+        // linters are registered. Without this, `sui move lint` runs only the generic Move
+        // linters and silently skips the Sui object-model lints.
+        if build_config.default_flavor.is_none() {
+            build_config.default_flavor = Some(Flavor::Sui);
+        }
         self.lint.execute(path, build_config, flavor).await
     }
 }

--- a/crates/sui/tests/shell_tests/sui_move_lint/example/Move.toml
+++ b/crates/sui/tests/shell_tests/sui_move_lint/example/Move.toml
@@ -1,6 +1,13 @@
 [package]
 name = "example"
 edition = "2024.beta"
+# Depend on the framework locally (copied into the sandbox by the test harness) so the
+# test does not hit the network to resolve the implicit `sui`/`std` git dependencies.
+implicit-dependencies = false
 
 [addresses]
 example = "0x0"
+
+[dependencies]
+sui = { local = "../sui-framework" }
+std = { local = "../move-stdlib" }

--- a/crates/sui/tests/shell_tests/sui_move_lint/example/sources/example.move
+++ b/crates/sui/tests/shell_tests/sui_move_lint/example/sources/example.move
@@ -3,11 +3,14 @@
 
 module example::example;
 
-const VALUE: u64 = 42;
+public struct Obj has key, store {
+    id: UID,
+}
 
-// The `return` is unnecessary because the expression is already in tail position.
-// This triggers the `unneeded_return` lint, which only runs at the `All` lint level
-// that `sui move lint` enables; a plain `sui move build` does not report it.
-public fun value(): u64 {
-    return VALUE
+// Transferring a freshly created object to the transaction sender triggers the
+// Sui-specific `self_transfer` lint. This lint only runs when the compiler is in
+// Sui mode, which `sui move lint` must enable; a plain `sui move build` does not
+// report it.
+public fun mint(ctx: &mut TxContext) {
+    transfer::public_transfer(Obj { id: object::new(ctx) }, ctx.sender())
 }

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint.sh
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint.sh
@@ -1,7 +1,7 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Tests that `sui move lint` runs the extra linters (lint level `All`) and reports
-# warnings that a plain `sui move build` does not. `COLOR_MODE=NONE` disables ANSI
+# Tests that `sui move lint` enables Sui mode and runs the Sui-specific linters (here
+# `self_transfer`), not just the generic Move linters. `COLOR_MODE=NONE` disables ANSI
 # color codes in the compiler diagnostics so the snapshot is stable.
 COLOR_MODE=NONE sui move --client.config $CONFIG lint -p example

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint.snap
@@ -5,8 +5,8 @@ source: crates/sui/tests/shell_tests.rs
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Tests that `sui move lint` runs the extra linters (lint level `All`) and reports
-# warnings that a plain `sui move build` does not. `COLOR_MODE=NONE` disables ANSI
+# Tests that `sui move lint` enables Sui mode and runs the Sui-specific linters (here
+# `self_transfer`), not just the generic Move linters. `COLOR_MODE=NONE` disables ANSI
 # color codes in the compiler diagnostics so the snapshot is stable.
 COLOR_MODE=NONE sui move --client.config $CONFIG lint -p example
 
@@ -19,10 +19,15 @@ INCLUDING DEPENDENCY Sui
 BUILDING example
 
 ----- stderr -----
-warning[Lint W04004]: unneeded return
-   ┌─ ./sources/example.move:12:5
+warning[Lint W99001]: non-composable transfer to sender
+   ┌─ ./sources/example.move:15:5
    │
-12 │     return VALUE
-   │     ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
+14 │ public fun mint(ctx: &mut TxContext) {
+   │            ---- Returning an object from a function, allows a caller to use the object and enables composability via programmable transactions.
+15 │     transfer::public_transfer(Obj { id: object::new(ctx) }, ctx.sender())
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │     │                                                       │
+   │     │                                                       Transaction sender address coming from here
+   │     Transfer of an object to transaction sender address
    │
-   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')


### PR DESCRIPTION
## Description 

`sui move lint` is not firing sui-specific lints due to missed flavor setting.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
