### PR TITLE
graphql: OpaqueCursor<C>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15426,6 +15426,7 @@ dependencies = [
  "backoff",
  "bcs",
  "bin-version",
+ "bytes",
  "chrono",
  "clap",
  "const-str",

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -26,6 +26,7 @@ backoff.workspace = true
 axum = { version = "0.7", default-features = false, features = [ "macros", "tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", ] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
 bcs.workspace = true
+bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true
 const-str.workspace = true

--- a/crates/sui-indexer-alt-graphql/src/api/scalars/cursor.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/cursor.rs
@@ -9,10 +9,20 @@ use async_graphql::Scalar;
 use async_graphql::ScalarType;
 use async_graphql::Value;
 use async_graphql::connection::CursorType;
+use bytes::Bytes;
 use fastcrypto::encoding::Base64;
 use fastcrypto::encoding::Encoding;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+
+/// Custom byte encoding for cursors.
+///
+/// Factors out the conversion to and from bytes for opaque cursors. Those bytes are further
+/// decoded to and from Base64 to form an opaque cursor.
+pub trait ByteCursor: Sized {
+    fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self>;
+    fn encode_cursor(&self) -> Bytes;
+}
 
 /// Cursor that hides its value by encoding it as JSON and then Base64.
 ///
@@ -26,14 +36,11 @@ pub struct JsonCursor<C>(C);
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub(crate) struct BcsCursor<C>(C);
 
-/// Cursor whose value is an opaque byte sequence, encoded as Base64.
-///
-/// Use this when the inner bytes already carry their own stable encoding (e.g. BCS), to avoid
-/// wrapping them in a second layer of BCS via [`BcsCursor`].
+/// Cursor whose value uses an opaque, custom byte encoding, then encoded as Base64.
 ///
 /// In the GraphQL schema this will show up as a `String`.
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct ByteCursor(Vec<u8>);
+pub struct OpaqueCursor<C>(C);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -45,6 +52,9 @@ pub enum Error {
 
     #[error("Invalid JSON")]
     BadJson,
+
+    #[error("Invalid encoding: {0:#}")]
+    BadEncoding(#[from] anyhow::Error),
 }
 
 impl<C> JsonCursor<C> {
@@ -59,9 +69,9 @@ impl<C> BcsCursor<C> {
     }
 }
 
-impl ByteCursor {
-    pub(crate) fn new(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+impl<C: ByteCursor> OpaqueCursor<C> {
+    pub(crate) fn new(inner: C) -> Self {
+        Self(inner)
     }
 }
 
@@ -114,7 +124,11 @@ where
 }
 
 #[Scalar(name = "String", visible = false)]
-impl ScalarType for ByteCursor {
+impl<C> ScalarType for OpaqueCursor<C>
+where
+    C: Send + Sync,
+    C: ByteCursor,
+{
     fn parse(value: Value) -> InputValueResult<Self> {
         if let Value::String(s) = value {
             Self::decode_cursor(&s).map_err(InputValueError::custom)
@@ -169,16 +183,20 @@ where
     }
 }
 
-impl CursorType for ByteCursor {
+impl<C> CursorType for OpaqueCursor<C>
+where
+    C: Send + Sync,
+    C: ByteCursor,
+{
     type Error = Error;
 
     fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
         let bytes = Base64::decode(s).map_err(|_| Error::BadBase64)?;
-        Ok(ByteCursor(bytes))
+        Ok(OpaqueCursor(C::decode_cursor(&bytes)?))
     }
 
     fn encode_cursor(&self) -> String {
-        Base64::encode(&self.0)
+        Base64::encode(self.0.encode_cursor())
     }
 }
 
@@ -200,8 +218,8 @@ impl<C> Deref for BcsCursor<C> {
     }
 }
 
-impl Deref for ByteCursor {
-    type Target = [u8];
+impl<C> Deref for OpaqueCursor<C> {
+    type Target = C;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -12,7 +12,6 @@ use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::QueryType;
 
-use crate::api::scalars::cursor::ByteCursor;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
@@ -20,6 +19,7 @@ use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
 use crate::api::types::event::EventCursor;
 use crate::api::types::event::filter::EventFilter;
+use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::config::Limits;
@@ -127,9 +127,8 @@ impl Subscription {
                             if !filter.matches(&tx.contents) {
                                 continue;
                             }
-                            let cursor = ByteCursor::new(
+                            let cursor = CTransaction::new(
                                 CursorToken::item(QueryType::Transactions, processed.summary.sequence_number, tx.tx_sequence_number)
-                                .encode().to_vec()
                             ).encode_cursor();
                             yield Transaction::with_contents(scope.clone(), tx.contents.clone())
                                 .map(|transaction| Edge::new(cursor, transaction));

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -28,7 +28,6 @@ use crate::api::types::checkpoint::filter::cp_by_epoch;
 use crate::api::types::checkpoint::filter::cp_unfiltered;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::gas::GasCostSummary;
-use crate::api::types::transaction;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionConnection;
@@ -224,7 +223,7 @@ impl CheckpointContents {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Option<Result<TransactionConnection, RpcError<transaction::Error>>> {
+    ) -> Option<Result<TransactionConnection, RpcError>> {
         async {
             let Some((summary, _, _)) = &self.contents else {
                 return Ok(None);

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -31,6 +31,7 @@ use sui_types::transaction::TransactionExpiration;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::cursor::ByteCursor;
+use crate::api::scalars::cursor::OpaqueCursor;
 use crate::api::scalars::digest::Digest;
 use crate::api::scalars::fq_name_filter::FqNameFilter;
 use crate::api::scalars::id::Id;
@@ -49,10 +50,8 @@ use crate::api::types::transaction_effects::TransactionEffects;
 use crate::api::types::transaction_kind::TransactionKind;
 use crate::api::types::user_signature::UserSignature;
 use crate::error::RpcError;
-use crate::error::bad_user_input;
 use crate::error::upcast;
 use crate::extensions::query_limits;
-use crate::pagination::Error as PaginationError;
 use crate::pagination::Page;
 use crate::scope::Scope;
 use crate::task::streaming::ProcessedTransaction;
@@ -72,17 +71,11 @@ pub(crate) struct TransactionContents {
     pub(crate) contents: Option<Arc<NativeTransactionContents>>,
 }
 
-pub type CTransaction = ByteCursor;
+pub type CTransaction = OpaqueCursor<CursorToken>;
 
 pub(crate) struct TransactionConnection {
     pub edges: Vec<Edge<String, Transaction, EmptyFields>>,
     pub page_info: PageInfo,
-}
-
-#[derive(thiserror::Error, Debug, Clone)]
-pub(crate) enum Error {
-    #[error("Invalid input cursor")]
-    BadCursor,
 }
 
 /// Description of a transaction, the unit of activity on Sui.
@@ -289,19 +282,9 @@ impl Transaction {
         transactions: &[ProcessedTransaction],
         page: &Page<CTransaction>,
         filter: TransactionFilter,
-    ) -> Result<TransactionConnection, RpcError<Error>> {
-        let after = page
-            .after()
-            .map(|c| CursorToken::decode(c))
-            .transpose()
-            .map_err(|_| bad_user_input(Error::BadCursor))?
-            .map(|c| c.position);
-        let before = page
-            .before()
-            .map(|c| CursorToken::decode(c))
-            .transpose()
-            .map_err(|_| bad_user_input(Error::BadCursor))?
-            .map(|c| c.position);
+    ) -> Result<TransactionConnection, RpcError> {
+        let after = page.after().map(|c| c.position);
+        let before = page.before().map(|c| c.position);
 
         let filtered: Vec<_> = transactions
             .iter()
@@ -314,11 +297,11 @@ impl Transaction {
         page.paginate_results(
             filtered,
             |tx| {
-                ByteCursor::new(
-                    CursorToken::item(QueryType::Transactions, 0, tx.tx_sequence_number)
-                        .encode()
-                        .to_vec(),
-                )
+                OpaqueCursor::new(CursorToken::item(
+                    QueryType::Transactions,
+                    0,
+                    tx.tx_sequence_number,
+                ))
             },
             |tx| Transaction::with_contents(scope.clone(), tx.contents.clone()),
         )
@@ -354,12 +337,6 @@ impl Transaction {
         page: Page<CTransaction>,
         filter: TransactionFilter,
     ) -> Result<TransactionConnection, RpcError> {
-        // Reject cursors that don't decode as `CursorToken`s up front -- `TxBoundsCursor` for
-        // `CTransaction` assumes they are valid.
-        for cursor in page.after().into_iter().chain(page.before()) {
-            CursorToken::decode(cursor).map_err(|_| PaginationError::BadCursor)?;
-        }
-
         let watermarks: &Arc<Watermarks> = ctx.data()?;
         let available_range_key = AvailableRangeKey {
             type_: "Query".to_string(),
@@ -399,13 +376,7 @@ impl Transaction {
 
         page.paginate_results(
             tx_digests(ctx, &tx_sequence_numbers).await?,
-            |(s, _)| {
-                ByteCursor::new(
-                    CursorToken::item(QueryType::Transactions, 0, *s)
-                        .encode()
-                        .to_vec(),
-                )
-            },
+            |(s, _)| OpaqueCursor::new(CursorToken::item(QueryType::Transactions, 0, *s)),
             |(_, d)| Ok(Self::with_digest(scope.clone(), d)),
         )
         .map(Into::into)
@@ -485,9 +456,17 @@ impl TransactionConnection {
 
 impl TxBoundsCursor for CTransaction {
     fn tx_sequence_number(&self) -> u64 {
-        CursorToken::decode(self)
-            .expect("cursor already validated as ByteCursor")
-            .position
+        self.position
+    }
+}
+
+impl ByteCursor for CursorToken {
+    fn decode_cursor(bytes: &[u8]) -> anyhow::Result<Self> {
+        CursorToken::decode(bytes)
+    }
+
+    fn encode_cursor(&self) -> bytes::Bytes {
+        self.encode()
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -61,9 +61,6 @@ pub(crate) enum End {
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub(crate) enum Error {
-    #[error("Invalid input cursor")]
-    BadCursor,
-
     #[error("Cannot provide both 'first' and 'last' parameters for connection")]
     FirstAndLast,
 

--- a/crates/sui-rpc-cursor/src/lib.rs
+++ b/crates/sui-rpc-cursor/src/lib.rs
@@ -7,9 +7,7 @@ use prost::Message as _;
 
 mod proto;
 
-use proto::sui::rpc::cursor::v1::{
-    CursorKind as ProtoCursorKind, CursorToken as ProtoCursorToken, QueryType as ProtoQueryType,
-};
+use proto::sui::rpc::cursor::v1 as grpc;
 
 /// Pagination cursor for the bitmap-backed ledger-history endpoints.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -56,11 +54,11 @@ impl CursorToken {
     }
 
     pub fn encode(&self) -> Bytes {
-        ProtoCursorToken::from(self).encode_to_vec().into()
+        grpc::CursorToken::from(self).encode_to_vec().into()
     }
 
     pub fn decode(bytes: &[u8]) -> anyhow::Result<Self> {
-        Self::try_from(ProtoCursorToken::decode(bytes)?)
+        Self::try_from(grpc::CursorToken::decode(bytes)?)
     }
 
     pub fn after_position_start(&self) -> Option<u64> {
@@ -79,42 +77,42 @@ impl CursorToken {
 }
 
 impl QueryType {
-    fn to_proto(self) -> ProtoQueryType {
+    fn to_proto(self) -> grpc::QueryType {
         match self {
-            QueryType::Checkpoints => ProtoQueryType::Checkpoints,
-            QueryType::Transactions => ProtoQueryType::Transactions,
-            QueryType::Events => ProtoQueryType::Events,
+            QueryType::Checkpoints => grpc::QueryType::Checkpoints,
+            QueryType::Transactions => grpc::QueryType::Transactions,
+            QueryType::Events => grpc::QueryType::Events,
         }
     }
 
-    fn from_proto(value: ProtoQueryType) -> Option<Self> {
+    fn from_proto(value: grpc::QueryType) -> Option<Self> {
         match value {
-            ProtoQueryType::Checkpoints => Some(QueryType::Checkpoints),
-            ProtoQueryType::Transactions => Some(QueryType::Transactions),
-            ProtoQueryType::Events => Some(QueryType::Events),
-            ProtoQueryType::Unspecified => None,
+            grpc::QueryType::Checkpoints => Some(QueryType::Checkpoints),
+            grpc::QueryType::Transactions => Some(QueryType::Transactions),
+            grpc::QueryType::Events => Some(QueryType::Events),
+            grpc::QueryType::Unspecified => None,
         }
     }
 }
 
 impl CursorKind {
-    fn to_proto(self) -> ProtoCursorKind {
+    fn to_proto(self) -> grpc::CursorKind {
         match self {
-            CursorKind::Item => ProtoCursorKind::Item,
-            CursorKind::Boundary => ProtoCursorKind::Boundary,
+            CursorKind::Item => grpc::CursorKind::Item,
+            CursorKind::Boundary => grpc::CursorKind::Boundary,
         }
     }
 
-    fn from_proto(value: ProtoCursorKind) -> Option<Self> {
+    fn from_proto(value: grpc::CursorKind) -> Option<Self> {
         match value {
-            ProtoCursorKind::Item => Some(CursorKind::Item),
-            ProtoCursorKind::Boundary => Some(CursorKind::Boundary),
-            ProtoCursorKind::Unspecified => None,
+            grpc::CursorKind::Item => Some(CursorKind::Item),
+            grpc::CursorKind::Boundary => Some(CursorKind::Boundary),
+            grpc::CursorKind::Unspecified => None,
         }
     }
 }
 
-impl From<&CursorToken> for ProtoCursorToken {
+impl From<&CursorToken> for grpc::CursorToken {
     fn from(cursor: &CursorToken) -> Self {
         Self {
             query_type: cursor.query_type.to_proto() as i32,
@@ -125,15 +123,15 @@ impl From<&CursorToken> for ProtoCursorToken {
     }
 }
 
-impl TryFrom<ProtoCursorToken> for CursorToken {
+impl TryFrom<grpc::CursorToken> for CursorToken {
     type Error = anyhow::Error;
 
-    fn try_from(proto: ProtoCursorToken) -> anyhow::Result<Self> {
-        let query_type = ProtoQueryType::try_from(proto.query_type)
+    fn try_from(proto: grpc::CursorToken) -> anyhow::Result<Self> {
+        let query_type = grpc::QueryType::try_from(proto.query_type)
             .ok()
             .and_then(QueryType::from_proto)
             .with_context(|| format!("unknown cursor query_type: {}", proto.query_type))?;
-        let kind = ProtoCursorKind::try_from(proto.kind)
+        let kind = grpc::CursorKind::try_from(proto.kind)
             .ok()
             .and_then(CursorKind::from_proto)
             .with_context(|| format!("unknown cursor kind: {}", proto.kind))?;


### PR DESCRIPTION
## Description

Introduce a cursor type that supports custom byte encodings, but performs encoding/decoding as part of parsing, so that the rest of the system can trust that the cursor is valid.

## Test plan

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
