### PR TITLE
docs: strip PR review lines from release notes and add SDK v2 object handling

### DIFF
--- a/docs/content/develop/testing-debugging/common-errors.mdx
+++ b/docs/content/develop/testing-debugging/common-errors.mdx
@@ -551,3 +551,54 @@ tx.pure.string(name);
 tx.pure.bool(flag);
 tx.pure.vector('u8', bytes);
 ```
+
+---
+
+#### Non-existent object handling changed in SDK v2
+
+In the TypeScript SDK v1, `getObject` returned a `SuiObjectResponse` with `{ data, error }` fields, so a missing object came back as a response with an `error` field rather than throwing. In v2, `getObject` throws directly when the object does not exist.
+
+The same change applies to multi-get methods like `getObjects`. In v1, these returned `SuiObjectResponse[]`, a `{ data, error }` wrapper per item. In v2, they return `(Object | Error)[]`, where a missing object appears as an `Error` entry in the array instead of a response wrapper.
+
+##### Solution
+
+For single-get calls, wrap the call in a `try`/`catch`:
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+  network: 'mainnet',
+});
+
+try {
+  const object = await client.core.getObject({ objectId: '0x123...' });
+  // Use object directly — no .data wrapper
+} catch (error) {
+  // Object does not exist or is pruned
+  console.error('Object not found:', error);
+}
+```
+
+For multi-get calls, guard each element with `instanceof Error`:
+
+```typescript
+const results = await client.core.getObjects({
+  objectIds: ['0xabc...', '0xdef...', '0x999...'],
+});
+
+for (const result of results) {
+  if (result instanceof Error) {
+    // This object does not exist or could not be fetched
+    console.error('Missing object:', result.message);
+  } else {
+    // Use the object directly
+    console.log('Found object:', result.objectId);
+  }
+}
+```
+
+**Resources**
+
+- [TypeScript SDK migration guide](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/json-rpc-migration)

--- a/docs/site/src/shared/js/convert-release-notes.cjs
+++ b/docs/site/src/shared/js/convert-release-notes.cjs
@@ -167,6 +167,14 @@ function sanitizeForMDX(content) {
   return content;
 }
 
+function stripReviewRequests(content) {
+  // Remove PR title/author lines like "PR #27067: [framework] future proofing type_name in coin by @Damir (Damir Shamanaev)"
+  content = content.replace(/^PR #\d+:.*by @.+$/gim, '');
+  // Clean up excess blank lines left behind
+  content = content.replace(/\n{3,}/g, '\n\n');
+  return content.trim();
+}
+
 function convertGitHubHeadingsToH3(content) {
   return content.replace(/^(#{1,6})\s+(.*)$/gm, (match, hashes, text) => {
     const trimmedText = text.trim();
@@ -414,7 +422,8 @@ async function consolidateReleaseNotes() {
       }
 
       // Process content
-      let processedGitHubContent = sanitizeForMDX(releaseToUse.content);
+      let processedGitHubContent = stripReviewRequests(releaseToUse.content);
+      processedGitHubContent = sanitizeForMDX(processedGitHubContent);
       processedGitHubContent = convertGitHubHeadingsToH3(processedGitHubContent);
       processedGitHubContent = processedGitHubContent.replace(/\n{3,}/g, '\n\n');
 

--- a/docs/site/src/shared/js/convert-release-notes.js
+++ b/docs/site/src/shared/js/convert-release-notes.js
@@ -165,6 +165,14 @@ function sanitizeForMDX(content) {
   return content;
 }
 
+function stripReviewRequests(content) {
+  // Remove PR title/author lines like "PR #27067: [framework] future proofing type_name in coin by @Damir (Damir Shamanaev)"
+  content = content.replace(/^PR #\d+:.*by @.+$/gim, '');
+  // Clean up excess blank lines left behind
+  content = content.replace(/\n{3,}/g, '\n\n');
+  return content.trim();
+}
+
 function convertGitHubHeadingsToH3(content) {
   return content.replace(/^(#{1,6})\s+(.*)$/gm, (match, hashes, text) => {
     const trimmedText = text.trim();
@@ -358,7 +366,8 @@ async function consolidateReleaseNotes() {
       }
 
       // Process content
-      let processedGitHubContent = sanitizeForMDX(releaseToUse.content);
+      let processedGitHubContent = stripReviewRequests(releaseToUse.content);
+      processedGitHubContent = sanitizeForMDX(processedGitHubContent);
       processedGitHubContent = convertGitHubHeadingsToH3(processedGitHubContent);
       processedGitHubContent = processedGitHubContent.replace(/\n{3,}/g, '\n\n');
 


### PR DESCRIPTION
## Summary
- Strip internal PR title/author lines (e.g. `PR #27067: [framework] future proofing type_name in coin by @Damir (Damir Shamanaev)`) from generated release notes so review metadata does not appear on the published page.
- Document SDK v2 behavior change for non-existent objects in `common-errors.mdx`: `getObject` now throws instead of returning a `{ data, error }` wrapper, and multi-get methods like `getObjects` return `(Object | Error)[]` instead of `SuiObjectResponse[]`.

## Test plan
- [ ] Run `node docs/site/src/shared/js/convert-release-notes.cjs` and verify PR title/author lines are stripped from output
- [ ] Verify `common-errors.mdx` renders correctly in the docs site
- [ ] Confirm code examples in the new section are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)