### PR TITLE
graphql: backwards compatible cursor

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_transactions_query_tests.rs
@@ -172,4 +172,17 @@ async fn test_transactions_query_cursor_pagination() {
         .unwrap();
     assert!(page.edges.is_empty());
     assert!(!page.page_info.has_next_page);
+
+    // Legacy cursor support -- the service accepts the old Base64-encoded JSON transaction
+    // sequence number format, but outputs the new format only.
+    let after = Base64::encode(serde_json::to_vec(&0u64).unwrap());
+    let before = Base64::encode(serde_json::to_vec(&6u64).unwrap());
+
+    let page = transactions(&cluster, None, Some(2), Some(after), Some(before))
+        .await
+        .unwrap();
+
+    assert_eq!(window(&page.edges), window(&all.edges[4..=5]));
+    assert!(page.page_info.has_previous_page);
+    assert!(page.page_info.has_next_page);
 }

--- a/crates/sui-indexer-alt-graphql/src/api/scalars/cursor.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/cursor.rs
@@ -36,6 +36,18 @@ pub struct JsonCursor<C>(C);
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub(crate) struct BcsCursor<C>(C);
 
+/// Cursor that can be either a primary or secondary format.
+///
+/// When decoding, the primary format is attempted first, and if that fails, the secondary format
+/// is attempted.
+///
+/// TODO: Remove once cursors have fully migrated to the new format.
+#[derive(Clone, Debug)]
+pub enum MultiCursor<P, S> {
+    Primary(P),
+    Secondary(S),
+}
+
 /// Cursor whose value uses an opaque, custom byte encoding, then encoded as Base64.
 ///
 /// In the GraphQL schema this will show up as a `String`.
@@ -55,6 +67,9 @@ pub enum Error {
 
     #[error("Invalid encoding: {0:#}")]
     BadEncoding(#[from] anyhow::Error),
+
+    #[error("'{0}' and '{1}'")]
+    BadMulti(Box<Error>, Box<Error>),
 }
 
 impl<C> JsonCursor<C> {
@@ -66,6 +81,12 @@ impl<C> JsonCursor<C> {
 impl<C> BcsCursor<C> {
     pub(crate) fn new(cursor: C) -> Self {
         Self(cursor)
+    }
+}
+
+impl<P, S> MultiCursor<P, S> {
+    pub(crate) fn new(cursor: P) -> Self {
+        Self::Primary(cursor)
     }
 }
 
@@ -104,6 +125,32 @@ impl<C> ScalarType for BcsCursor<C>
 where
     C: Send + Sync,
     C: Serialize + DeserializeOwned,
+{
+    fn parse(value: Value) -> InputValueResult<Self> {
+        if let Value::String(s) = value {
+            Self::decode_cursor(&s).map_err(InputValueError::custom)
+        } else {
+            Err(InputValueError::expected_type(value))
+        }
+    }
+
+    /// Just check that the value is a string, as we'll do more involved tests during parsing.
+    fn is_valid(value: &Value) -> bool {
+        matches!(value, Value::String(_))
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.encode_cursor())
+    }
+}
+
+#[Scalar(name = "String", visible = false)]
+impl<P, S> ScalarType for MultiCursor<P, S>
+where
+    P: Send + Sync,
+    P: CursorType<Error = Error>,
+    S: Send + Sync,
+    S: CursorType<Error = Error>,
 {
     fn parse(value: Value) -> InputValueResult<Self> {
         if let Value::String(s) = value {
@@ -180,6 +227,35 @@ where
 
     fn encode_cursor(&self) -> String {
         Base64::encode(bcs::to_bytes(&self.0).unwrap_or_default())
+    }
+}
+
+impl<P, S> CursorType for MultiCursor<P, S>
+where
+    P: CursorType<Error = Error>,
+    S: CursorType<Error = Error>,
+{
+    type Error = Error;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        let errp = match P::decode_cursor(s) {
+            Ok(cursor) => return Ok(Self::Primary(cursor)),
+            Err(e) => Box::new(e),
+        };
+
+        let errs = match S::decode_cursor(s) {
+            Ok(cursor) => return Ok(Self::Secondary(cursor)),
+            Err(e) => Box::new(e),
+        };
+
+        Err(Error::BadMulti(errp, errs))
+    }
+
+    fn encode_cursor(&self) -> String {
+        match self {
+            Self::Primary(c) => c.encode_cursor(),
+            Self::Secondary(c) => c.encode_cursor(),
+        }
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -12,6 +12,7 @@ use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_rpc_cursor::CursorToken;
 use sui_rpc_cursor::QueryType;
 
+use crate::api::scalars::cursor::OpaqueCursor;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::checkpoint::CCheckpoint;
 use crate::api::types::checkpoint::Checkpoint;
@@ -127,9 +128,12 @@ impl Subscription {
                             if !filter.matches(&tx.contents) {
                                 continue;
                             }
-                            let cursor = CTransaction::new(
-                                CursorToken::item(QueryType::Transactions, processed.summary.sequence_number, tx.tx_sequence_number)
-                            ).encode_cursor();
+                            let cursor = CTransaction::new(OpaqueCursor::new(CursorToken::item(
+                                QueryType::Transactions,
+                                processed.summary.sequence_number,
+                                tx.tx_sequence_number,
+                            )))
+                            .encode_cursor();
                             yield Transaction::with_contents(scope.clone(), tx.contents.clone())
                                 .map(|transaction| Edge::new(cursor, transaction));
                         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -31,6 +31,8 @@ use sui_types::transaction::TransactionExpiration;
 
 use crate::api::scalars::base64::Base64;
 use crate::api::scalars::cursor::ByteCursor;
+use crate::api::scalars::cursor::JsonCursor;
+use crate::api::scalars::cursor::MultiCursor;
 use crate::api::scalars::cursor::OpaqueCursor;
 use crate::api::scalars::digest::Digest;
 use crate::api::scalars::fq_name_filter::FqNameFilter;
@@ -71,7 +73,7 @@ pub(crate) struct TransactionContents {
     pub(crate) contents: Option<Arc<NativeTransactionContents>>,
 }
 
-pub type CTransaction = OpaqueCursor<CursorToken>;
+pub type CTransaction = MultiCursor<OpaqueCursor<CursorToken>, JsonCursor<u64>>;
 
 pub(crate) struct TransactionConnection {
     pub edges: Vec<Edge<String, Transaction, EmptyFields>>,
@@ -283,8 +285,8 @@ impl Transaction {
         page: &Page<CTransaction>,
         filter: TransactionFilter,
     ) -> Result<TransactionConnection, RpcError> {
-        let after = page.after().map(|c| c.position);
-        let before = page.before().map(|c| c.position);
+        let after = page.after().map(|c| c.tx_sequence_number());
+        let before = page.before().map(|c| c.tx_sequence_number());
 
         let filtered: Vec<_> = transactions
             .iter()
@@ -297,11 +299,11 @@ impl Transaction {
         page.paginate_results(
             filtered,
             |tx| {
-                OpaqueCursor::new(CursorToken::item(
+                MultiCursor::new(OpaqueCursor::new(CursorToken::item(
                     QueryType::Transactions,
                     0,
                     tx.tx_sequence_number,
-                ))
+                )))
             },
             |tx| Transaction::with_contents(scope.clone(), tx.contents.clone()),
         )
@@ -376,7 +378,13 @@ impl Transaction {
 
         page.paginate_results(
             tx_digests(ctx, &tx_sequence_numbers).await?,
-            |(s, _)| OpaqueCursor::new(CursorToken::item(QueryType::Transactions, 0, *s)),
+            |(s, _)| {
+                MultiCursor::new(OpaqueCursor::new(CursorToken::item(
+                    QueryType::Transactions,
+                    0,
+                    *s,
+                )))
+            },
             |(_, d)| Ok(Self::with_digest(scope.clone(), d)),
         )
         .map(Into::into)
@@ -456,7 +464,10 @@ impl TransactionConnection {
 
 impl TxBoundsCursor for CTransaction {
     fn tx_sequence_number(&self) -> u64 {
-        self.position
+        match self {
+            CTransaction::Primary(c) => c.position,
+            CTransaction::Secondary(c) => **c,
+        }
     }
 }
 
@@ -467,6 +478,13 @@ impl ByteCursor for CursorToken {
 
     fn encode_cursor(&self) -> bytes::Bytes {
         self.encode()
+    }
+}
+
+impl Eq for CTransaction {}
+impl PartialEq for CTransaction {
+    fn eq(&self, other: &Self) -> bool {
+        self.tx_sequence_number() == other.tx_sequence_number()
     }
 }
 


### PR DESCRIPTION
## Description

Introduce an abstraction for handling cursors with multiple formats. The abstraction handles:

- Trying formats in order of precedence during parsing.
- Serializing always to the "primary" format.
- Not offering a derived equality operator -- users need to define an equality operator for their cursor type that handles normalization between cursor types.

## Test plan

Updated the E2E test:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests --test graphql_transactions_query_tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
