### PR TITLE
rust-sdk: bump pointer and migrate merged filter literal change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14743,7 +14743,7 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f74b321245d9fa0506cf71441e465b07b90722d7#f74b321245d9fa0506cf71441e465b07b90722d7"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=c34e7a65b5983600937f965553fa373593c149d4#c34e7a65b5983600937f965553fa373593c149d4"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -16728,7 +16728,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f74b321245d9fa0506cf71441e465b07b90722d7#f74b321245d9fa0506cf71441e465b07b90722d7"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=c34e7a65b5983600937f965553fa373593c149d4#c34e7a65b5983600937f965553fa373593c149d4"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -16961,7 +16961,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f74b321245d9fa0506cf71441e465b07b90722d7#f74b321245d9fa0506cf71441e465b07b90722d7"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=c34e7a65b5983600937f965553fa373593c149d4#c34e7a65b5983600937f965553fa373593c149d4"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -646,9 +646,9 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "b1bda3f855
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b1bda3f8555c5594a4966e850170cc11ecfcf557" }
 
 # core-types from the new sdk for use in gRPC
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f74b321245d9fa0506cf71441e465b07b90722d7", features = [ "hash", "serde" ] }
-sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f74b321245d9fa0506cf71441e465b07b90722d7", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
-sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f74b321245d9fa0506cf71441e465b07b90722d7", features = [ "unstable" ] }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "c34e7a65b5983600937f965553fa373593c149d4", features = [ "hash", "serde" ] }
+sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "c34e7a65b5983600937f965553fa373593c149d4", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
+sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "c34e7a65b5983600937f965553fa373593c149d4", features = [ "unstable" ] }
 
 ### Workspace Members ###
 anemo-benchmark = { path = "crates/anemo-benchmark" }

--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -19,11 +19,11 @@ use sui_rpc::proto::sui::rpc::v2::{GetCheckpointRequest, GetEpochRequest};
 use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient as V2AlphaLedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2alpha::proof_service_client::ProofServiceClient;
 use sui_rpc::proto::sui::rpc::v2alpha::{
-    AffectedObjectFilter, EventFilter, EventLiteral, EventPredicate, EventStreamHeadFilter,
-    EventTerm, GetCheckpointObjectProofRequest, GetCheckpointObjectProofResponse,
-    ListEventsRequest, ListTransactionsRequest, QueryEndReason, QueryOptions, TransactionFilter,
-    TransactionLiteral, TransactionPredicate, TransactionTerm,
-    get_checkpoint_object_proof_response, list_events_response, list_transactions_response,
+    AffectedObjectFilter, EventFilter, EventLiteral, EventStreamHeadFilter, EventTerm,
+    GetCheckpointObjectProofRequest, GetCheckpointObjectProofResponse, ListEventsRequest,
+    ListTransactionsRequest, QueryEndReason, QueryOptions, TransactionFilter, TransactionLiteral,
+    TransactionTerm, get_checkpoint_object_proof_response, list_events_response,
+    list_transactions_response,
 };
 use sui_rpc_api::client::ExecutedTransaction;
 use sui_sdk_types::ValidatorCommittee;
@@ -171,17 +171,15 @@ where
 
 fn build_event_stream_head_filter(stream_id: SuiAddress) -> EventFilter {
     let head_filter = EventStreamHeadFilter::default().with_stream_id(stream_id.to_string());
-    let predicate = EventPredicate::default().with_event_stream_head(head_filter);
-    let literal = EventLiteral::default().with_include(predicate);
+    let literal = EventLiteral::default().with_event_stream_head(head_filter);
     let term = EventTerm::default().with_literals(vec![literal]);
     EventFilter::default().with_terms(vec![term])
 }
 
 fn build_affected_object_filter(object_id: ObjectID) -> TransactionFilter {
-    let predicate = TransactionPredicate::default().with_affected_object(
+    let literal = TransactionLiteral::default().with_affected_object(
         AffectedObjectFilter::default().with_object_id(object_id.to_string()),
     );
-    let literal = TransactionLiteral::default().with_include(predicate);
     let term = TransactionTerm::default().with_literals(vec![literal]);
     TransactionFilter::default().with_terms(vec![term])
 }

--- a/crates/sui-e2e-tests/tests/rpc/restore.rs
+++ b/crates/sui-e2e-tests/tests/rpc/restore.rs
@@ -46,12 +46,10 @@ use sui_rpc::proto::sui::rpc::v2alpha::QueryOptions;
 use sui_rpc::proto::sui::rpc::v2alpha::SenderFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionLiteral;
-use sui_rpc::proto::sui::rpc::v2alpha::TransactionPredicate;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionTerm;
 use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2alpha::list_transactions_response;
 use sui_rpc::proto::sui::rpc::v2alpha::transaction_literal;
-use sui_rpc::proto::sui::rpc::v2alpha::transaction_predicate;
 use sui_test_transaction_builder::make_transfer_sui_transaction;
 use sui_types::base_types::AuthorityName;
 use sui_types::base_types::SuiAddress;
@@ -255,10 +253,8 @@ async fn sui_balance(rpc_url: &str, owner: SuiAddress) -> u64 {
 fn sender_filter(sender: SuiAddress) -> TransactionFilter {
     let mut sender_filter = SenderFilter::default();
     sender_filter.address = Some(sender.to_string());
-    let mut predicate = TransactionPredicate::default();
-    predicate.predicate = Some(transaction_predicate::Predicate::Sender(sender_filter));
     let mut literal = TransactionLiteral::default();
-    literal.polarity = Some(transaction_literal::Polarity::Include(predicate));
+    literal.predicate = Some(transaction_literal::Predicate::Sender(sender_filter));
     let mut term = TransactionTerm::default();
     term.literals = vec![literal];
     let mut filter = TransactionFilter::default();

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
@@ -20,7 +20,6 @@ use sui_rpc::proto::sui::rpc::v2alpha::EmitModuleFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventItem;
 use sui_rpc::proto::sui::rpc::v2alpha::EventLiteral;
-use sui_rpc::proto::sui::rpc::v2alpha::EventPredicate;
 use sui_rpc::proto::sui::rpc::v2alpha::EventStreamHeadFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventTerm;
 use sui_rpc::proto::sui::rpc::v2alpha::EventTypeFilter;
@@ -36,17 +35,14 @@ use sui_rpc::proto::sui::rpc::v2alpha::SenderFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionItem;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionLiteral;
-use sui_rpc::proto::sui::rpc::v2alpha::TransactionPredicate;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionTerm;
 use sui_rpc::proto::sui::rpc::v2alpha::Watermark;
 use sui_rpc::proto::sui::rpc::v2alpha::event_literal;
-use sui_rpc::proto::sui::rpc::v2alpha::event_predicate;
 use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient as AlphaLedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2alpha::list_checkpoints_response;
 use sui_rpc::proto::sui::rpc::v2alpha::list_events_response;
 use sui_rpc::proto::sui::rpc::v2alpha::list_transactions_response;
 use sui_rpc::proto::sui::rpc::v2alpha::transaction_literal;
-use sui_rpc::proto::sui::rpc::v2alpha::transaction_predicate;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SuiAddress;
@@ -676,60 +672,57 @@ fn ev_not_sender_only_filter(addr: SuiAddress) -> EventFilter {
     filter
 }
 
-fn tx_include(predicate: transaction_predicate::Predicate) -> TransactionLiteral {
-    let mut p = TransactionPredicate::default();
-    p.predicate = Some(predicate);
+fn tx_include(predicate: transaction_literal::Predicate) -> TransactionLiteral {
     let mut literal = TransactionLiteral::default();
-    literal.polarity = Some(transaction_literal::Polarity::Include(p));
+    literal.predicate = Some(predicate);
     literal
 }
 
-fn tx_exclude(predicate: transaction_predicate::Predicate) -> TransactionLiteral {
-    let mut p = TransactionPredicate::default();
-    p.predicate = Some(predicate);
+fn tx_exclude(predicate: transaction_literal::Predicate) -> TransactionLiteral {
     let mut literal = TransactionLiteral::default();
-    literal.polarity = Some(transaction_literal::Polarity::Exclude(p));
+    literal.predicate = Some(predicate);
+    literal.negated = true;
     literal
 }
 
 fn tx_sender_literal(addr: SuiAddress) -> TransactionLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    tx_include(transaction_predicate::Predicate::Sender(s))
+    tx_include(transaction_literal::Predicate::Sender(s))
 }
 
 fn tx_not_sender_literal(addr: SuiAddress) -> TransactionLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    tx_exclude(transaction_predicate::Predicate::Sender(s))
+    tx_exclude(transaction_literal::Predicate::Sender(s))
 }
 
 fn tx_move_call_literal(path: &str) -> TransactionLiteral {
     let mut mc = MoveCallFilter::default();
     mc.function = Some(path.to_string());
-    tx_include(transaction_predicate::Predicate::MoveCall(mc))
+    tx_include(transaction_literal::Predicate::MoveCall(mc))
 }
 
 fn tx_emit_module_literal(path: &str) -> TransactionLiteral {
     let mut em = EmitModuleFilter::default();
     em.module = Some(path.to_string());
-    tx_include(transaction_predicate::Predicate::EmitModule(em))
+    tx_include(transaction_literal::Predicate::EmitModule(em))
 }
 
 fn tx_event_type_literal(path: &str) -> TransactionLiteral {
     let mut et = EventTypeFilter::default();
     et.event_type = Some(path.to_string());
-    tx_include(transaction_predicate::Predicate::EventType(et))
+    tx_include(transaction_literal::Predicate::EventType(et))
 }
 
 fn tx_event_stream_head_literal(stream_id: ObjectID) -> TransactionLiteral {
     let mut esh = EventStreamHeadFilter::default();
     esh.stream_id = Some(stream_id.to_canonical_string(true));
-    tx_include(transaction_predicate::Predicate::EventStreamHead(esh))
+    tx_include(transaction_literal::Predicate::EventStreamHead(esh))
 }
 
 fn tx_package_write_literal() -> TransactionLiteral {
-    tx_include(transaction_predicate::Predicate::PackageWrite(
+    tx_include(transaction_literal::Predicate::PackageWrite(
         PackageWriteFilter::default(),
     ))
 }
@@ -768,38 +761,35 @@ fn tx_and(filters: Vec<TransactionFilter>) -> TransactionFilter {
     tx_filter(literals)
 }
 
-fn ev_include(predicate: event_predicate::Predicate) -> EventLiteral {
-    let mut p = EventPredicate::default();
-    p.predicate = Some(predicate);
+fn ev_include(predicate: event_literal::Predicate) -> EventLiteral {
     let mut literal = EventLiteral::default();
-    literal.polarity = Some(event_literal::Polarity::Include(p));
+    literal.predicate = Some(predicate);
     literal
 }
 
-fn ev_exclude(predicate: event_predicate::Predicate) -> EventLiteral {
-    let mut p = EventPredicate::default();
-    p.predicate = Some(predicate);
+fn ev_exclude(predicate: event_literal::Predicate) -> EventLiteral {
     let mut literal = EventLiteral::default();
-    literal.polarity = Some(event_literal::Polarity::Exclude(p));
+    literal.predicate = Some(predicate);
+    literal.negated = true;
     literal
 }
 
 fn ev_sender_literal(addr: SuiAddress) -> EventLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    ev_include(event_predicate::Predicate::Sender(s))
+    ev_include(event_literal::Predicate::Sender(s))
 }
 
 fn ev_not_sender_literal(addr: SuiAddress) -> EventLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    ev_exclude(event_predicate::Predicate::Sender(s))
+    ev_exclude(event_literal::Predicate::Sender(s))
 }
 
 fn ev_event_stream_head_literal(stream_id: ObjectID) -> EventLiteral {
     let mut esh = EventStreamHeadFilter::default();
     esh.stream_id = Some(stream_id.to_canonical_string(true));
-    ev_include(event_predicate::Predicate::EventStreamHead(esh))
+    ev_include(event_literal::Predicate::EventStreamHead(esh))
 }
 
 fn ev_sender(addr: SuiAddress) -> EventFilter {
@@ -809,13 +799,13 @@ fn ev_sender(addr: SuiAddress) -> EventFilter {
 fn ev_emit_module(path: &str) -> EventFilter {
     let mut em = EmitModuleFilter::default();
     em.module = Some(path.to_string());
-    ev_filter(vec![ev_include(event_predicate::Predicate::EmitModule(em))])
+    ev_filter(vec![ev_include(event_literal::Predicate::EmitModule(em))])
 }
 
 fn ev_event_type(path: &str) -> EventFilter {
     let mut et = EventTypeFilter::default();
     et.event_type = Some(path.to_string());
-    ev_filter(vec![ev_include(event_predicate::Predicate::EventType(et))])
+    ev_filter(vec![ev_include(event_literal::Predicate::EventType(et))])
 }
 
 fn ev_event_stream_head(stream_id: ObjectID) -> EventFilter {
@@ -1222,7 +1212,7 @@ async fn test_list_transactions_combinators_and_affected_filters() {
     let mut req = ListTransactionsRequest::default();
     req.read_mask = Some(FieldMask::from_paths(["digest"]));
     req.filter = Some(tx_filter(vec![tx_include(
-        transaction_predicate::Predicate::AffectedAddress(affected_address),
+        transaction_literal::Predicate::AffectedAddress(affected_address),
     )]));
     req.options = Some(query_options(100));
     let resp = list_transactions_result(&mut client, req).await;
@@ -1236,7 +1226,7 @@ async fn test_list_transactions_combinators_and_affected_filters() {
     let mut req = ListTransactionsRequest::default();
     req.read_mask = Some(FieldMask::from_paths(["digest"]));
     req.filter = Some(tx_filter(vec![tx_include(
-        transaction_predicate::Predicate::AffectedObject(affected_object),
+        transaction_literal::Predicate::AffectedObject(affected_object),
     )]));
     req.options = Some(query_options(100));
     let resp = list_transactions_result(&mut client, req).await;

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -27,7 +27,6 @@ use sui_rpc::proto::sui::rpc::v2alpha::EmitModuleFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventItem;
 use sui_rpc::proto::sui::rpc::v2alpha::EventLiteral;
-use sui_rpc::proto::sui::rpc::v2alpha::EventPredicate;
 use sui_rpc::proto::sui::rpc::v2alpha::EventStreamHeadFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventTerm;
 use sui_rpc::proto::sui::rpc::v2alpha::EventTypeFilter;
@@ -43,17 +42,14 @@ use sui_rpc::proto::sui::rpc::v2alpha::SenderFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionItem;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionLiteral;
-use sui_rpc::proto::sui::rpc::v2alpha::TransactionPredicate;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionTerm;
 use sui_rpc::proto::sui::rpc::v2alpha::Watermark;
 use sui_rpc::proto::sui::rpc::v2alpha::event_literal;
-use sui_rpc::proto::sui::rpc::v2alpha::event_predicate;
 use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient as KvLedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2alpha::list_checkpoints_response;
 use sui_rpc::proto::sui::rpc::v2alpha::list_events_response;
 use sui_rpc::proto::sui::rpc::v2alpha::list_transactions_response;
 use sui_rpc::proto::sui::rpc::v2alpha::transaction_literal;
-use sui_rpc::proto::sui::rpc::v2alpha::transaction_predicate;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
@@ -701,60 +697,57 @@ fn ev_not_sender_only_filter(addr: SuiAddress) -> EventFilter {
     filter
 }
 
-fn tx_include(predicate: transaction_predicate::Predicate) -> TransactionLiteral {
-    let mut p = TransactionPredicate::default();
-    p.predicate = Some(predicate);
+fn tx_include(predicate: transaction_literal::Predicate) -> TransactionLiteral {
     let mut literal = TransactionLiteral::default();
-    literal.polarity = Some(transaction_literal::Polarity::Include(p));
+    literal.predicate = Some(predicate);
     literal
 }
 
-fn tx_exclude(predicate: transaction_predicate::Predicate) -> TransactionLiteral {
-    let mut p = TransactionPredicate::default();
-    p.predicate = Some(predicate);
+fn tx_exclude(predicate: transaction_literal::Predicate) -> TransactionLiteral {
     let mut literal = TransactionLiteral::default();
-    literal.polarity = Some(transaction_literal::Polarity::Exclude(p));
+    literal.predicate = Some(predicate);
+    literal.negated = true;
     literal
 }
 
 fn tx_sender_literal(addr: SuiAddress) -> TransactionLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    tx_include(transaction_predicate::Predicate::Sender(s))
+    tx_include(transaction_literal::Predicate::Sender(s))
 }
 
 fn tx_not_sender_literal(addr: SuiAddress) -> TransactionLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    tx_exclude(transaction_predicate::Predicate::Sender(s))
+    tx_exclude(transaction_literal::Predicate::Sender(s))
 }
 
 fn tx_move_call_literal(path: &str) -> TransactionLiteral {
     let mut mc = MoveCallFilter::default();
     mc.function = Some(path.to_string());
-    tx_include(transaction_predicate::Predicate::MoveCall(mc))
+    tx_include(transaction_literal::Predicate::MoveCall(mc))
 }
 
 fn tx_emit_module_literal(path: &str) -> TransactionLiteral {
     let mut em = EmitModuleFilter::default();
     em.module = Some(path.to_string());
-    tx_include(transaction_predicate::Predicate::EmitModule(em))
+    tx_include(transaction_literal::Predicate::EmitModule(em))
 }
 
 fn tx_event_type_literal(path: &str) -> TransactionLiteral {
     let mut et = EventTypeFilter::default();
     et.event_type = Some(path.to_string());
-    tx_include(transaction_predicate::Predicate::EventType(et))
+    tx_include(transaction_literal::Predicate::EventType(et))
 }
 
 fn tx_event_stream_head_literal(stream_id: ObjectID) -> TransactionLiteral {
     let mut esh = EventStreamHeadFilter::default();
     esh.stream_id = Some(stream_id.to_canonical_string(true));
-    tx_include(transaction_predicate::Predicate::EventStreamHead(esh))
+    tx_include(transaction_literal::Predicate::EventStreamHead(esh))
 }
 
 fn tx_package_write_literal() -> TransactionLiteral {
-    tx_include(transaction_predicate::Predicate::PackageWrite(
+    tx_include(transaction_literal::Predicate::PackageWrite(
         PackageWriteFilter::default(),
     ))
 }
@@ -793,38 +786,35 @@ fn tx_and(filters: Vec<TransactionFilter>) -> TransactionFilter {
     tx_filter(literals)
 }
 
-fn ev_include(predicate: event_predicate::Predicate) -> EventLiteral {
-    let mut p = EventPredicate::default();
-    p.predicate = Some(predicate);
+fn ev_include(predicate: event_literal::Predicate) -> EventLiteral {
     let mut literal = EventLiteral::default();
-    literal.polarity = Some(event_literal::Polarity::Include(p));
+    literal.predicate = Some(predicate);
     literal
 }
 
-fn ev_exclude(predicate: event_predicate::Predicate) -> EventLiteral {
-    let mut p = EventPredicate::default();
-    p.predicate = Some(predicate);
+fn ev_exclude(predicate: event_literal::Predicate) -> EventLiteral {
     let mut literal = EventLiteral::default();
-    literal.polarity = Some(event_literal::Polarity::Exclude(p));
+    literal.predicate = Some(predicate);
+    literal.negated = true;
     literal
 }
 
 fn ev_sender_literal(addr: SuiAddress) -> EventLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    ev_include(event_predicate::Predicate::Sender(s))
+    ev_include(event_literal::Predicate::Sender(s))
 }
 
 fn ev_not_sender_literal(addr: SuiAddress) -> EventLiteral {
     let mut s = SenderFilter::default();
     s.address = Some(addr.to_string());
-    ev_exclude(event_predicate::Predicate::Sender(s))
+    ev_exclude(event_literal::Predicate::Sender(s))
 }
 
 fn ev_event_stream_head_literal(stream_id: ObjectID) -> EventLiteral {
     let mut esh = EventStreamHeadFilter::default();
     esh.stream_id = Some(stream_id.to_canonical_string(true));
-    ev_include(event_predicate::Predicate::EventStreamHead(esh))
+    ev_include(event_literal::Predicate::EventStreamHead(esh))
 }
 
 fn ev_sender(addr: SuiAddress) -> EventFilter {
@@ -834,13 +824,13 @@ fn ev_sender(addr: SuiAddress) -> EventFilter {
 fn ev_emit_module(path: &str) -> EventFilter {
     let mut em = EmitModuleFilter::default();
     em.module = Some(path.to_string());
-    ev_filter(vec![ev_include(event_predicate::Predicate::EmitModule(em))])
+    ev_filter(vec![ev_include(event_literal::Predicate::EmitModule(em))])
 }
 
 fn ev_event_type(path: &str) -> EventFilter {
     let mut et = EventTypeFilter::default();
     et.event_type = Some(path.to_string());
-    ev_filter(vec![ev_include(event_predicate::Predicate::EventType(et))])
+    ev_filter(vec![ev_include(event_literal::Predicate::EventType(et))])
 }
 
 fn ev_event_stream_head(stream_id: ObjectID) -> EventFilter {
@@ -1575,7 +1565,7 @@ async fn test_list_events_with_emit_module_filter() {
         "{}::emit_test_event",
         pkg_id.to_canonical_string(true)
     ));
-    let filter = ev_filter(vec![ev_include(event_predicate::Predicate::EmitModule(
+    let filter = ev_filter(vec![ev_include(event_literal::Predicate::EmitModule(
         emit_mod,
     ))]);
 
@@ -1638,7 +1628,7 @@ async fn test_list_events_query_options() {
     // Use emit_module filter to find only events from our package.
     let mut emit_mod = sui_rpc::proto::sui::rpc::v2alpha::EmitModuleFilter::default();
     emit_mod.module = Some(pkg_id.to_canonical_string(true));
-    let ev_filter = ev_filter(vec![ev_include(event_predicate::Predicate::EmitModule(
+    let ev_filter = ev_filter(vec![ev_include(event_literal::Predicate::EmitModule(
         emit_mod,
     ))]);
 
@@ -2310,7 +2300,7 @@ async fn test_list_transactions_recipient_and_affected_object() {
     let mut req = ListTransactionsRequest::default();
     req.read_mask = Some(FieldMask::from_paths(["digest"]));
     req.filter = Some(tx_filter(vec![tx_include(
-        transaction_predicate::Predicate::AffectedAddress(r),
+        transaction_literal::Predicate::AffectedAddress(r),
     )]));
     req.options = Some(query_options(100));
     let resp = list_transactions_result(&mut client, req).await;
@@ -2329,7 +2319,7 @@ async fn test_list_transactions_recipient_and_affected_object() {
     let mut req = ListTransactionsRequest::default();
     req.read_mask = Some(FieldMask::from_paths(["digest"]));
     req.filter = Some(tx_filter(vec![tx_include(
-        transaction_predicate::Predicate::AffectedObject(ao),
+        transaction_literal::Predicate::AffectedObject(ao),
     )]));
     req.options = Some(query_options(100));
     let resp = list_transactions_result(&mut client, req).await;
@@ -2540,7 +2530,7 @@ async fn test_list_events_combinator_or_not() {
         .await
         .unwrap();
 
-    // Anchored DNF: sender A and not sender B — exercises EventLiteral::Exclude.
+    // Anchored DNF: sender A and not sender B — exercises a negated EventLiteral.
     let filter = ev_filter(vec![
         ev_sender_literal(sender_a),
         ev_not_sender_literal(sender_b),

--- a/crates/sui-light-client/src/authenticated_events/stream.rs
+++ b/crates/sui-light-client/src/authenticated_events/stream.rs
@@ -10,10 +10,9 @@ use std::sync::Arc;
 use sui_rpc::field::{FieldMask, FieldMaskUtil};
 use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient as V2AlphaLedgerServiceClient;
 use sui_rpc::proto::sui::rpc::v2alpha::{
-    AffectedObjectFilter, EventFilter, EventLiteral, EventPredicate, EventStreamHeadFilter,
-    EventTerm, ListEventsRequest, ListTransactionsRequest, QueryEndReason, QueryOptions,
-    TransactionFilter, TransactionLiteral, TransactionPredicate, TransactionTerm,
-    list_events_response, list_transactions_response,
+    AffectedObjectFilter, EventFilter, EventLiteral, EventStreamHeadFilter, EventTerm,
+    ListEventsRequest, ListTransactionsRequest, QueryEndReason, QueryOptions, TransactionFilter,
+    TransactionLiteral, TransactionTerm, list_events_response, list_transactions_response,
 };
 use sui_types::accumulator_root::{EventCommitment, EventStreamHead};
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -475,16 +474,14 @@ async fn fetch_settlements_for_range(
 
 fn build_affected_object_filter(object_id: ObjectID) -> TransactionFilter {
     let object_filter = AffectedObjectFilter::default().with_object_id(object_id.to_string());
-    let predicate = TransactionPredicate::default().with_affected_object(object_filter);
-    let literal = TransactionLiteral::default().with_include(predicate);
+    let literal = TransactionLiteral::default().with_affected_object(object_filter);
     let term = TransactionTerm::default().with_literals(vec![literal]);
     TransactionFilter::default().with_terms(vec![term])
 }
 
 fn build_event_stream_head_filter(stream_id: SuiAddress) -> EventFilter {
     let head_filter = EventStreamHeadFilter::default().with_stream_id(stream_id.to_string());
-    let predicate = EventPredicate::default().with_event_stream_head(head_filter);
-    let literal = EventLiteral::default().with_include(predicate);
+    let literal = EventLiteral::default().with_event_stream_head(head_filter);
     let term = EventTerm::default().with_literals(vec![literal]);
     EventFilter::default().with_terms(vec![term])
 }

--- a/crates/sui-rpc-api/src/ledger_history/filter.rs
+++ b/crates/sui-rpc-api/src/ledger_history/filter.rs
@@ -17,7 +17,6 @@ use sui_rpc::proto::sui::rpc::v2alpha::AffectedObjectFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EmitModuleFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventLiteral;
-use sui_rpc::proto::sui::rpc::v2alpha::EventPredicate;
 use sui_rpc::proto::sui::rpc::v2alpha::EventStreamHeadFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::EventTerm;
 use sui_rpc::proto::sui::rpc::v2alpha::EventTypeFilter;
@@ -26,12 +25,9 @@ use sui_rpc::proto::sui::rpc::v2alpha::PackageWriteFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::SenderFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionFilter;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionLiteral;
-use sui_rpc::proto::sui::rpc::v2alpha::TransactionPredicate;
 use sui_rpc::proto::sui::rpc::v2alpha::TransactionTerm;
 use sui_rpc::proto::sui::rpc::v2alpha::event_literal;
-use sui_rpc::proto::sui::rpc::v2alpha::event_predicate;
 use sui_rpc::proto::sui::rpc::v2alpha::transaction_literal;
-use sui_rpc::proto::sui::rpc::v2alpha::transaction_predicate;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
 
@@ -125,12 +121,7 @@ fn validate_literal_fanout(
 }
 
 fn transaction_term_to_query(term: &TransactionTerm) -> Result<BitmapTerm, RpcError> {
-    let has_include = term.literals.iter().any(|literal| {
-        matches!(
-            literal.polarity,
-            Some(transaction_literal::Polarity::Include(_))
-        )
-    });
+    let has_include = term.literals.iter().any(|literal| !literal.negated);
 
     let mut literals = Vec::with_capacity(term.literals.len() + usize::from(!has_include));
     // Unanchored negation: a term with only excludes resolves as
@@ -161,10 +152,7 @@ fn transaction_term_to_query(term: &TransactionTerm) -> Result<BitmapTerm, RpcEr
 }
 
 fn event_term_to_query(term: &EventTerm) -> Result<BitmapTerm, RpcError> {
-    let has_include = term
-        .literals
-        .iter()
-        .any(|literal| matches!(literal.polarity, Some(event_literal::Polarity::Include(_))));
+    let has_include = term.literals.iter().any(|literal| !literal.negated);
 
     let mut literals = Vec::with_capacity(term.literals.len() + usize::from(!has_include));
     // Unanchored negation: a term with only excludes resolves as
@@ -199,104 +187,75 @@ fn convert_transaction_literal(
     literal: &TransactionLiteral,
     field_prefix: &str,
 ) -> Result<BitmapLiteral, RpcError> {
-    let polarity = literal.polarity.as_ref().ok_or_else(|| {
+    let predicate = literal.predicate.as_ref().ok_or_else(|| {
         FieldViolation::new(field_prefix)
-            .with_description("literal polarity is required")
+            .with_description("predicate variant is required")
             .with_reason(ErrorReason::FieldMissing)
     })?;
-    match polarity {
-        transaction_literal::Polarity::Include(predicate) => {
-            let key = convert_transaction_predicate(predicate, &format!("{field_prefix}.include"))?;
-            BitmapLiteral::include(key).map_err(|e| {
-                FieldViolation::new(field_prefix)
-                    .with_description(e.to_string())
-                    .with_reason(ErrorReason::FieldInvalid)
-                    .into()
-            })
-        }
-        transaction_literal::Polarity::Exclude(predicate) => {
-            let key = convert_transaction_predicate(predicate, &format!("{field_prefix}.exclude"))?;
-            BitmapLiteral::exclude(key).map_err(|e| {
-                FieldViolation::new(field_prefix)
-                    .with_description(e.to_string())
-                    .with_reason(ErrorReason::FieldInvalid)
-                    .into()
-            })
-        }
-        _ => Err(FieldViolation::new(field_prefix)
-            .with_description("unknown literal polarity")
+    let key = convert_transaction_predicate(predicate, field_prefix)?;
+    let bitmap = if literal.negated {
+        BitmapLiteral::exclude(key)
+    } else {
+        BitmapLiteral::include(key)
+    };
+    bitmap.map_err(|e| {
+        FieldViolation::new(field_prefix)
+            .with_description(e.to_string())
             .with_reason(ErrorReason::FieldInvalid)
-            .into()),
-    }
+            .into()
+    })
 }
 
 fn convert_event_literal(
     literal: &EventLiteral,
     field_prefix: &str,
 ) -> Result<BitmapLiteral, RpcError> {
-    let polarity = literal.polarity.as_ref().ok_or_else(|| {
-        FieldViolation::new(field_prefix)
-            .with_description("literal polarity is required")
-            .with_reason(ErrorReason::FieldMissing)
-    })?;
-    match polarity {
-        event_literal::Polarity::Include(predicate) => {
-            let key = convert_event_predicate(predicate, &format!("{field_prefix}.include"))?;
-            BitmapLiteral::include(key).map_err(|e| {
-                FieldViolation::new(field_prefix)
-                    .with_description(e.to_string())
-                    .with_reason(ErrorReason::FieldInvalid)
-                    .into()
-            })
-        }
-        event_literal::Polarity::Exclude(predicate) => {
-            let key = convert_event_predicate(predicate, &format!("{field_prefix}.exclude"))?;
-            BitmapLiteral::exclude(key).map_err(|e| {
-                FieldViolation::new(field_prefix)
-                    .with_description(e.to_string())
-                    .with_reason(ErrorReason::FieldInvalid)
-                    .into()
-            })
-        }
-        _ => Err(FieldViolation::new(field_prefix)
-            .with_description("unknown literal polarity")
-            .with_reason(ErrorReason::FieldInvalid)
-            .into()),
-    }
-}
-
-fn convert_transaction_predicate(
-    predicate: &TransactionPredicate,
-    field_prefix: &str,
-) -> Result<Vec<u8>, RpcError> {
-    let predicate = predicate.predicate.as_ref().ok_or_else(|| {
+    let predicate = literal.predicate.as_ref().ok_or_else(|| {
         FieldViolation::new(field_prefix)
             .with_description("predicate variant is required")
             .with_reason(ErrorReason::FieldMissing)
     })?;
+    let key = convert_event_predicate(predicate, field_prefix)?;
+    let bitmap = if literal.negated {
+        BitmapLiteral::exclude(key)
+    } else {
+        BitmapLiteral::include(key)
+    };
+    bitmap.map_err(|e| {
+        FieldViolation::new(field_prefix)
+            .with_description(e.to_string())
+            .with_reason(ErrorReason::FieldInvalid)
+            .into()
+    })
+}
+
+fn convert_transaction_predicate(
+    predicate: &transaction_literal::Predicate,
+    field_prefix: &str,
+) -> Result<Vec<u8>, RpcError> {
     match predicate {
-        transaction_predicate::Predicate::Sender(f) => {
+        transaction_literal::Predicate::Sender(f) => {
             convert_sender(f, &format!("{field_prefix}.sender.address"))
         }
-        transaction_predicate::Predicate::AffectedAddress(f) => {
+        transaction_literal::Predicate::AffectedAddress(f) => {
             convert_affected_address(f, &format!("{field_prefix}.affected_address.address"))
         }
-        transaction_predicate::Predicate::AffectedObject(f) => {
+        transaction_literal::Predicate::AffectedObject(f) => {
             convert_affected_object(f, &format!("{field_prefix}.affected_object.object_id"))
         }
-        transaction_predicate::Predicate::MoveCall(f) => {
+        transaction_literal::Predicate::MoveCall(f) => {
             convert_move_call(f, &format!("{field_prefix}.move_call.function"))
         }
-        transaction_predicate::Predicate::EmitModule(f) => {
+        transaction_literal::Predicate::EmitModule(f) => {
             convert_emit_module(f, &format!("{field_prefix}.emit_module.module"))
         }
-        transaction_predicate::Predicate::EventType(f) => {
+        transaction_literal::Predicate::EventType(f) => {
             convert_event_type(f, &format!("{field_prefix}.event_type.event_type"))
         }
-        transaction_predicate::Predicate::EventStreamHead(f) => {
+        transaction_literal::Predicate::EventStreamHead(f) => {
             convert_event_stream_head(f, &format!("{field_prefix}.event_stream_head.stream_id"))
         }
-        transaction_predicate::Predicate::PackageWrite(f) => {
+        transaction_literal::Predicate::PackageWrite(f) => {
             convert_package_write(f, &format!("{field_prefix}.package_write"))
         }
         _ => Err(FieldViolation::new(field_prefix)
@@ -307,25 +266,20 @@ fn convert_transaction_predicate(
 }
 
 fn convert_event_predicate(
-    predicate: &EventPredicate,
+    predicate: &event_literal::Predicate,
     field_prefix: &str,
 ) -> Result<Vec<u8>, RpcError> {
-    let predicate = predicate.predicate.as_ref().ok_or_else(|| {
-        FieldViolation::new(field_prefix)
-            .with_description("predicate variant is required")
-            .with_reason(ErrorReason::FieldMissing)
-    })?;
     match predicate {
-        event_predicate::Predicate::Sender(f) => {
+        event_literal::Predicate::Sender(f) => {
             convert_sender(f, &format!("{field_prefix}.sender.address"))
         }
-        event_predicate::Predicate::EmitModule(f) => {
+        event_literal::Predicate::EmitModule(f) => {
             convert_emit_module(f, &format!("{field_prefix}.emit_module.module"))
         }
-        event_predicate::Predicate::EventType(f) => {
+        event_literal::Predicate::EventType(f) => {
             convert_event_type(f, &format!("{field_prefix}.event_type.event_type"))
         }
-        event_predicate::Predicate::EventStreamHead(f) => {
+        event_literal::Predicate::EventStreamHead(f) => {
             convert_event_stream_head(f, &format!("{field_prefix}.event_stream_head.stream_id"))
         }
         _ => Err(FieldViolation::new(field_prefix)
@@ -513,15 +467,9 @@ mod tests {
         let mut sender = SenderFilter::default();
         sender.address = Some(address);
 
-        let mut predicate = TransactionPredicate::default();
-        predicate.predicate = Some(transaction_predicate::Predicate::Sender(sender));
-
         let mut literal = TransactionLiteral::default();
-        literal.polarity = Some(if exclude {
-            transaction_literal::Polarity::Exclude(predicate)
-        } else {
-            transaction_literal::Polarity::Include(predicate)
-        });
+        literal.predicate = Some(transaction_literal::Predicate::Sender(sender));
+        literal.negated = exclude;
         literal
     }
 
@@ -579,11 +527,9 @@ mod tests {
         let mut filter = EventStreamHeadFilter::default();
         filter.stream_id = Some(stream_id);
 
-        let key = convert_event_stream_head(
-            &filter,
-            "filter.terms.literals.include.event_stream_head.stream_id",
-        )
-        .expect("valid stream id");
+        let key =
+            convert_event_stream_head(&filter, "filter.terms.literals.event_stream_head.stream_id")
+                .expect("valid stream id");
 
         assert_eq!(
             key,
@@ -593,16 +539,10 @@ mod tests {
 
     #[test]
     fn package_write_filter_encodes_dimension_key() {
-        let mut predicate = TransactionPredicate::default();
-        predicate.predicate = Some(transaction_predicate::Predicate::PackageWrite(
-            PackageWriteFilter::default(),
-        ));
+        let predicate = transaction_literal::Predicate::PackageWrite(PackageWriteFilter::default());
 
-        let key = convert_transaction_predicate(
-            &predicate,
-            "filter.terms.literals.include.package_write",
-        )
-        .expect("package write predicate converts");
+        let key = convert_transaction_predicate(&predicate, "filter.terms.literals.package_write")
+            .expect("package write predicate converts");
 
         assert_eq!(
             key,
@@ -617,15 +557,9 @@ mod tests {
         let mut sender = SenderFilter::default();
         sender.address = Some(address);
 
-        let mut predicate = EventPredicate::default();
-        predicate.predicate = Some(event_predicate::Predicate::Sender(sender));
-
         let mut literal = EventLiteral::default();
-        literal.polarity = Some(if exclude {
-            event_literal::Polarity::Exclude(predicate)
-        } else {
-            event_literal::Polarity::Include(predicate)
-        });
+        literal.predicate = Some(event_literal::Predicate::Sender(sender));
+        literal.negated = exclude;
         literal
     }
 


### PR DESCRIPTION
Update the `sui-rust-sdk` git pointers to
`c34e7a65b5983600937f965553fa373593c149d4` and adapt to the single v2alpha filter proto change that came with them (SDK #275).

The `TransactionPredicate` and `EventPredicate` messages were removed and their `predicate` oneof was merged directly into `TransactionLiteral` and `EventLiteral`. The old `include`/`exclude` polarity oneof was replaced by a `negated` boolean flag: an un-negated literal is an include, and a negated literal is an exclude.

The ledger-history converter in `sui-rpc-api` now derives `has_include` from `!literal.negated`, reads the predicate directly off the literal, and chooses `BitmapLiteral::include`/`exclude` on the `negated` flag. Since the proto no longer wraps predicates in an `include`/`exclude` message, the `.include`/`.exclude` segments were dropped from the error field paths. The light client and authenticated-events filter builders drop the predicate wrapper and construct the literal directly, and the e2e and kv-rpc test helpers were updated to set `predicate` and `negated` in place of the old polarity oneof.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
