### PR TITLE
Update next-steps.mdx

### DIFF
--- a/docs/content/getting-started/onboarding/next-steps.mdx
+++ b/docs/content/getting-started/onboarding/next-steps.mdx
@@ -59,9 +59,9 @@ Move is the language of smart contracts on Sui. [The Move Book](https://move-boo
 ## Connect with the Sui community
 
 - Join the [Sui Discord](https://discord.gg/sui) 
-- Join **Suinami Riders** on [Telegram](https://web.telegram.org/z/?ref=blog.sui.io#-1742460518)
 - Check out the [Sui Developer Forum](https://forums.sui.io/)
-- Follow [@SuiFoundation](https://twitter.com/@SuiFoundation) on X
+- Follow [@SuiFoundation](https://x.com/SuiNetwork) on X
+- Follow [@SuiDevelopers](https://x.com/suidevelopers) on X
 
 ### Awesome Sui
 
@@ -69,11 +69,7 @@ The [Awesome Sui](/references/awesome-sui) repo is a curated list of developer t
 
 ### Upcoming hackathons 
 
-Check out [upcoming hackathon events](https://www.deepsurge.xyz/ to build applications alongside other developers. 
-
-### Developer newsletter
-
-Sign up for the [Sui Developer Newsletter](https://developers.sui.io/) to receive hyperfocused content to help you build on Sui.
+Check out [upcoming hackathon events](https://www.deepsurge.xyz/) to build applications alongside other developers. 
 
 ### Developer portal
 


### PR DESCRIPTION
## Description 

1. Removed Suinami Riders TG link as it's invite only and people can't join from that link
2. Fixed SuiFoundation X link that was still www.twitter.com (mainly for future proofing incase X ever gets rid of the redirect)
3. Added SuiDevelopers X link
4. Fixed broken inline link for "upcoming hackathon events" 
5. Removed Developer newsletter link as it goes to the same link as "developer portal" right below, and the newsletter is currently paused.


## Test plan 

N/A

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
