### PR TITLE
Fix homebrew-bump concurrency self-deadlock when called from release.yml

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -30,7 +30,7 @@ on:
         description: "PAT with public_repo,workflow scopes — opens the homebrew-core PR"
         required: true
 
-concurrency: ${{ github.workflow }}-${{ inputs.sui_tag }}
+concurrency: homebrew-bump-${{ inputs.sui_tag }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Every **testnet** release run of `release.yml` since the homebrew-bump workflow gained a concurrency group has ended in `failure` with all visible jobs green (e.g. [testnet-v1.75.1 run](https://github.com/MystenLabs/sui/actions/runs/28889586824), also Jun 23 / Jun 30 testnet releases). The hidden run-level error:

> Canceling since a deadlock was detected for concurrency group: 'Attach Sui binaries to a release-testnet-v1.75.1' between a top level workflow and 'Bump sui formula on Homebrew/homebrew-core'

Root cause: in a `workflow_call` context, `github.workflow` resolves to the **caller's** workflow name, so `homebrew-bump.yml`'s `concurrency: ${{ github.workflow }}-${{ inputs.sui_tag }}` claimed the exact group `release.yml` already holds → parent/child deadlock → GitHub cancels the call before the job materializes, and the Homebrew formula bump silently never runs.

Fix: use a literal `homebrew-bump-` prefix so the callee's group can never collapse onto the caller's. `workflow_dispatch` behavior is unchanged (still serialized per tag).

## Test plan

- Manual dispatch for testnet-v1.75.1 (the documented fallback) run: https://github.com/MystenLabs/sui/actions/runs/28894070184
- Next testnet release exercises the workflow_call path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)