### PR TITLE
indexer-alt-graphql: configurable per-pipeline availability

### DIFF
--- a/crates/sui-indexer-alt-graphql/README.md
+++ b/crates/sui-indexer-alt-graphql/README.md
@@ -91,6 +91,17 @@ default and let you override it. Set `enabled = false` under
 `[pipeline.<name>]` entry (e.g. `[pipeline.tx_calls]`) to opt a specific
 pipeline out (or back in, if the default has been flipped to disabled).
 
+Separately, `[pipeline-defaults.availability]` and `[pipeline.<name>.availability]`
+sections gate an *enabled* pipeline's data by how far it lags behind the
+network tip, rather than whether it runs at all: `max-checkpoint-lag = N`
+serves a pipeline's data only while it is within `N` checkpoints of the tip,
+`enabled = false` never serves it, and `enabled = true` always serves it. A
+gated pipeline is dropped from the consistency boundary so other pipelines
+keep serving fresh reads, and queries that require it return
+`FeatureUnavailable` while it's gated. A pipeline with no availability policy
+is always served, so this is opt-in and doesn't change behaviour unless
+configured.
+
 ## Running
 
 The service can be run with the following minimal command:

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -103,6 +103,7 @@ impl AvailableRangeKey {
             let watermark = watermarks
                 .per_pipeline()
                 .get(pipeline)
+                .filter(|p| p.available())
                 .ok_or_else(|| pipeline_unavailable(pipeline))?;
             Ok(acc.max(watermark.lo().checkpoint()))
         })
@@ -143,6 +144,9 @@ pub(crate) fn pipeline_unavailable(pipeline: &str) -> RpcError {
         "cp_sequence_numbers" => feature_unavailable("querying checkpoints"),
         "ev_emit_mod" => feature_unavailable("querying events by emitting module"),
         "ev_struct_inst" => feature_unavailable("querying events by type"),
+        "kv_checkpoints" => feature_unavailable("fetching checkpoint contents"),
+        "kv_objects" => feature_unavailable("fetching object contents"),
+        "kv_transactions" => feature_unavailable("fetching transaction contents"),
         "obj_versions" => feature_unavailable("querying object versions"),
         "tx_affected_addresses" => {
             feature_unavailable("filtering transactions by affected address")
@@ -153,6 +157,26 @@ pub(crate) fn pipeline_unavailable(pipeline: &str) -> RpcError {
         "tx_digests" => feature_unavailable("querying transactions"),
         "tx_kinds" => feature_unavailable("filtering transactions by kind"),
         _ => anyhow!("unrecognized pipeline name: {}", pipeline).into(),
+    }
+}
+
+/// Guard a read path that consumes `pipeline` but does not go through [`AvailableRangeKey::reader_lo`].
+///
+/// Returns `FeatureUnavailable` when `pipeline` is tracked but gated off by the configured
+/// availability policy. A pipeline that is not tracked at all is a no-op: its data is either served
+/// from an external store (e.g. `kv_*` content under a Bigtable/Ledger backend) or genuinely
+/// absent, and those cases are handled by the read path itself.
+pub(crate) fn require_pipeline(ctx: &Context<'_>, pipeline: &str) -> Result<(), RpcError> {
+    let watermarks: &Arc<Watermarks> = ctx.data()?;
+    check_pipeline_available(watermarks, pipeline)
+}
+
+/// The availability decision behind [`require_pipeline`], split out so it can be unit-tested
+/// without a GraphQL context.
+fn check_pipeline_available(watermarks: &Watermarks, pipeline: &str) -> Result<(), RpcError> {
+    match watermarks.per_pipeline().get(pipeline) {
+        Some(p) if !p.available() => Err(pipeline_unavailable(pipeline)),
+        _ => Ok(()),
     }
 }
 
@@ -674,5 +698,105 @@ mod field_piplines_tests {
             return true;
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod reader_lo_tests {
+    use std::collections::BTreeMap;
+
+    use crate::config::AvailabilityConfig;
+    use crate::config::PipelineAvailability;
+    use crate::error::RpcError;
+    use crate::task::watermark::Watermarks;
+
+    use super::AvailableRangeKey;
+    use super::check_pipeline_available;
+
+    /// `Query.transactions(filter: { function })` requires the `tx_calls` pipeline.
+    fn tx_by_function_key() -> AvailableRangeKey {
+        AvailableRangeKey {
+            type_: "Query".to_string(),
+            field: Some("transactions".to_string()),
+            filters: Some(vec!["function".to_string()]),
+        }
+    }
+
+    #[test]
+    fn available_pipeline_yields_reader_lo() {
+        let watermarks = Watermarks::for_test(&[
+            ("cp_sequence_numbers", 100),
+            ("tx_digests", 100),
+            ("tx_calls", 100),
+        ]);
+        assert_eq!(tx_by_function_key().reader_lo(&watermarks).unwrap(), 0);
+    }
+
+    #[test]
+    fn gated_pipeline_is_feature_unavailable() {
+        // `tx_calls` lags the other pipelines (the tip) by 100 checkpoints, beyond its lag budget.
+        let config = AvailabilityConfig {
+            default: None,
+            pipelines: BTreeMap::from([(
+                "tx_calls".to_string(),
+                PipelineAvailability::MaxCheckpointLag(50),
+            )]),
+        };
+        let watermarks = Watermarks::for_test_with_availability(
+            &[
+                ("cp_sequence_numbers", 200),
+                ("tx_digests", 200),
+                ("tx_calls", 100),
+            ],
+            &config,
+        );
+        let err = tx_by_function_key().reader_lo(&watermarks).unwrap_err();
+        assert!(
+            matches!(err, RpcError::FeatureUnavailable { what } if what.contains("function calls")),
+            "expected a FeatureUnavailable error about function calls, got: {err:?}",
+        );
+    }
+
+    #[test]
+    fn require_pipeline_gates_present_but_unavailable() {
+        // `consistent` lags the tip by 100 checkpoints, beyond its lag budget.
+        let config = AvailabilityConfig {
+            default: None,
+            pipelines: BTreeMap::from([(
+                "consistent".to_string(),
+                PipelineAvailability::MaxCheckpointLag(50),
+            )]),
+        };
+        let watermarks =
+            Watermarks::for_test_with_availability(&[("consistent", 100), ("tip", 200)], &config);
+        assert!(check_pipeline_available(&watermarks, "consistent").is_err());
+    }
+
+    #[test]
+    fn require_pipeline_allows_available_pipeline() {
+        let watermarks = Watermarks::for_test(&[("consistent", 100)]);
+        assert!(check_pipeline_available(&watermarks, "consistent").is_ok());
+    }
+
+    #[test]
+    fn require_pipeline_is_noop_for_untracked_pipeline() {
+        // An absent pipeline (e.g. `kv_objects` when content is served from Bigtable) must not be
+        // gated: the guard only fires when the pipeline is tracked and gated off.
+        let watermarks = Watermarks::for_test(&[("other", 100)]);
+        assert!(check_pipeline_available(&watermarks, "kv_objects").is_ok());
+    }
+
+    #[test]
+    fn content_pipelines_have_feature_mappings() {
+        // Gating a content pipeline must produce a `FeatureUnavailable`, not an internal error.
+        for pipeline in ["kv_objects", "kv_transactions", "kv_checkpoints"] {
+            assert!(
+                matches!(
+                    super::pipeline_unavailable(pipeline),
+                    RpcError::FeatureUnavailable { .. }
+                ),
+                "{pipeline} should map to a FeatureUnavailable error",
+            );
+        }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
@@ -15,10 +15,12 @@ use sui_types::base_types::SuiAddress;
 
 use crate::api::scalars::big_int::BigInt;
 use crate::api::scalars::cursor;
+use crate::api::types::available_range::require_pipeline;
 use crate::api::types::move_type::MoveType;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
 use crate::error::feature_unavailable;
+use crate::error::upcast;
 use crate::extensions::query_limits;
 use crate::pagination::Page;
 use crate::scope::Scope;
@@ -92,6 +94,8 @@ impl Balance {
             return Ok(None);
         };
 
+        require_pipeline(ctx, "consistent").map_err(upcast)?;
+
         query_limits::rich::debit(ctx)?;
         let consistent_reader: &ConsistentReader = ctx.data()?;
         let balance = consistent_reader
@@ -121,6 +125,8 @@ impl Balance {
         let Some(checkpoint) = scope.root_checkpoint() else {
             return Ok(None);
         };
+
+        require_pipeline(ctx, "consistent").map_err(upcast)?;
 
         query_limits::rich::debit(ctx)?;
         let consistent_reader: &ConsistentReader = ctx.data()?;
@@ -159,6 +165,8 @@ impl Balance {
         let Some(root_checkpoint) = scope.root_checkpoint() else {
             return Ok(Connection::new(false, false));
         };
+
+        require_pipeline(ctx, "consistent").map_err(upcast)?;
 
         query_limits::rich::debit(ctx)?;
         let consistent_reader: &ConsistentReader = ctx.data()?;

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -28,6 +28,7 @@ use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::available_range::require_pipeline;
 use crate::api::types::checkpoint::filter::CheckpointFilter;
 use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::checkpoint::filter::cp_by_epoch;
@@ -303,6 +304,8 @@ impl Checkpoint {
         scope: Scope,
         digest: CheckpointDigest,
     ) -> Result<Option<Self>, RpcError> {
+        require_pipeline(ctx, "kv_checkpoints")?;
+
         let kv_loader: &KvLoader = ctx.data()?;
         let Some(sequence_number) = kv_loader
             .load_one_checkpoint_seq_by_digest(digest)
@@ -370,6 +373,8 @@ impl CheckpointContents {
         scope: Scope,
         sequence_number: u64,
     ) -> Result<Self, RpcError> {
+        require_pipeline(ctx, "kv_checkpoints")?;
+
         let kv_loader: &KvLoader = ctx.data()?;
         let contents = kv_loader
             .load_one_checkpoint(sequence_number)

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
@@ -12,6 +12,7 @@ use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionEventsContents;
 use sui_types::digests::TransactionDigest;
 
+use crate::api::types::available_range::require_pipeline;
 use crate::api::types::event::CEvent;
 use crate::api::types::event::Event;
 use crate::api::types::event::EventCursor;
@@ -37,6 +38,8 @@ pub(crate) async fn events_from_sequence_numbers(
     let kv_loader: &KvLoader = ctx.data()?;
 
     let digests = tx_digests(ctx, tx_sequence_numbers).await?;
+
+    require_pipeline(ctx, "kv_transactions")?;
 
     let digest_to_events = kv_loader
         .load_many_transaction_events(digests.iter().map(|d| d.1).collect())

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -54,6 +54,7 @@ use crate::api::scalars::type_filter::TypeInput;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::address;
 use crate::api::types::address::Address;
+use crate::api::types::available_range::require_pipeline;
 use crate::api::types::balance;
 use crate::api::types::balance::Balance;
 use crate::api::types::coin_metadata::CoinMetadata;
@@ -801,6 +802,8 @@ impl Object {
         address: SuiAddress,
         root_version: UInt53,
     ) -> Result<Option<Self>, RpcError> {
+        require_pipeline(ctx, "obj_versions")?;
+
         let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
 
         let Some(stored) = pg_loader
@@ -825,6 +828,8 @@ impl Object {
         address: SuiAddress,
         at_checkpoint: UInt53,
     ) -> Result<Option<Self>, RpcError> {
+        require_pipeline(ctx, "obj_versions")?;
+
         let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
 
         let Some(stored) = pg_loader
@@ -855,6 +860,8 @@ impl Object {
         let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
             return Ok(None);
         };
+
+        require_pipeline(ctx, "kv_objects")?;
 
         let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
         let kv_loader: &KvLoader = ctx.data()?;
@@ -961,6 +968,8 @@ impl Object {
             return Ok(Connection::new(false, false));
         };
 
+        require_pipeline(ctx, "obj_versions")?;
+
         query_limits::rich::debit(ctx)?;
         let pg_reader: &PgReader = ctx.data()?;
 
@@ -1048,6 +1057,8 @@ impl Object {
         let Some(root_checkpoint) = scope.root_checkpoint() else {
             return Ok(Connection::new(false, false));
         };
+
+        require_pipeline(ctx, "consistent").map_err(upcast)?;
 
         query_limits::rich::debit(ctx)?;
         let consistent_reader: &ConsistentReader = ctx.data()?;
@@ -1207,6 +1218,8 @@ impl Object {
                 } else if let Some(cp) = self.super_.scope.checkpoint_viewed_at() {
                     // If we don't have a version, we need to do a checkpoint-bounded lookup first
                     // to get the version, then fetch contents with that version.
+                    require_pipeline(ctx, "obj_versions")?;
+
                     let Some(stored) = pg_loader
                         .load_one(CheckpointBoundedObjectVersionKey(
                             self.super_.address.into(),
@@ -1231,6 +1244,7 @@ impl Object {
                 {
                     Ok(Some(cached_object.clone()))
                 } else {
+                    require_pipeline(ctx, "kv_objects")?;
                     Ok(kv_loader
                         .load_one_object(self.super_.address.into(), version.into())
                         .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -46,6 +46,7 @@ use crate::api::scalars::json::Json;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::types::address::Address;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::available_range::require_pipeline;
 use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::gas_input::GasInput;
@@ -510,6 +511,8 @@ impl TransactionContents {
         let Some(checkpoint_viewed_at) = self.scope.checkpoint_viewed_at() else {
             return Ok(self.clone());
         };
+
+        require_pipeline(ctx, "kv_transactions")?;
 
         let kv_loader: &KvLoader = ctx.data()?;
         let Some(transaction) = kv_loader

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -33,6 +33,7 @@ use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::digest::Digest;
 use crate::api::scalars::json::Json;
 use crate::api::scalars::uint53::UInt53;
+use crate::api::types::available_range::require_pipeline;
 use crate::api::types::balance_change::BalanceChange;
 use crate::api::types::balance_change::BalanceChangeContents;
 use crate::api::types::checkpoint::Checkpoint;
@@ -270,6 +271,8 @@ impl EffectsContents {
                 }
 
                 // Fall back to loading from database
+                require_pipeline(ctx, "tx_balance_changes")?;
+
                 let transaction_digest = content.digest()?;
                 let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
                 let key = TxBalanceChangeKey(transaction_digest);
@@ -322,6 +325,8 @@ impl EffectsContents {
                 }
 
                 // Fall back to loading from database
+                require_pipeline(ctx, "tx_balance_changes")?;
+
                 let transaction_digest = content.digest()?;
                 let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
                 let key = TxBalanceChangeKey(transaction_digest);
@@ -580,6 +585,8 @@ impl EffectsContents {
         let Some(checkpoint_viewed_at) = self.scope.checkpoint_viewed_at() else {
             return Ok(self.clone());
         };
+
+        require_pipeline(ctx, "kv_transactions")?;
 
         let kv_loader: &KvLoader = ctx.data()?;
         let Some(transaction) = kv_loader

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -46,6 +46,9 @@ pub struct RpcConfig {
 
     /// Configuration for which pipelines this service can expect to find populated.
     pub pipeline: PipelineConfig,
+
+    /// Which pipelines to serve, based on how far their data lags behind the network tip.
+    pub availability: AvailabilityConfig,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -84,25 +87,115 @@ pub struct PipelineConfig {
     pub default_availability: PipelineAvailability,
 }
 
-/// Whether a pipeline is enabled: tracked by GraphQL and expected to be populated in the database
-/// it reads from.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Availability policy for a pipeline: serve it unconditionally (`enabled = true`), never serve
+/// it (`enabled = false`), or serve it only while its high-watermark is within
+/// `max-checkpoint-lag` checkpoints of the network tip. A policy section sets exactly one of the
+/// two keys. Queries that require a pipeline that is not served return a `FeatureUnavailable`
+/// error, and such a pipeline stops pinning the server's consistency boundary.
+///
+/// The shared `[pipeline-defaults].availability` section sets a default policy for every tracked
+/// pipeline, and a `[pipeline.<name>].availability` section overrides it for a single pipeline
+/// (e.g. `enabled = true` exempts one pipeline from a configured default). A pipeline with neither
+/// is always served, so this feature is opt-in and does not change behaviour unless configured:
+///
+/// ```toml
+/// [pipeline-defaults.availability]
+/// max-checkpoint-lag = 100          # default for every tracked pipeline
+///
+/// [pipeline.kv_objects.availability]
+/// enabled = true                    # always serve, exempt from the default
+///
+/// [pipeline.tx_kinds.availability]
+/// enabled = false                   # never serve
+///
+/// [pipeline.tx_calls.availability]
+/// max-checkpoint-lag = 1000         # lag-gated override
+/// ```
+///
+/// The lag distance is measured against the network tip, approximated as the highest checkpoint
+/// high-watermark across all tracked pipelines (equal to the true network tip when a Bigtable or
+/// Ledger gRPC KV source is configured, and the fastest local pipeline otherwise). The default
+/// also covers the virtual `bigtable`/`ledger_grpc`/`consistent` pipelines tracked from those
+/// stores; the KV ones define the tip, so in practice a lag default never gates them. Gating a
+/// `kv_*` content pipeline only takes effect in a pure-Postgres deployment; when content is served
+/// from an external KV store those pipelines are not tracked, so the policy is inert.
+///
+/// Also doubles as the resolved value in [`PipelineConfig::availability`]/`default_availability`,
+/// where only the `Enabled`/`Disabled` variants are ever produced (from a pipeline's plain
+/// `enabled` setting, not an explicit availability policy).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(
+    try_from = "PipelineAvailabilityLayer",
+    into = "PipelineAvailabilityLayer"
+)]
 pub enum PipelineAvailability {
+    /// Always serve the pipeline.
     #[default]
     Enabled,
+
+    /// Never serve the pipeline.
     Disabled,
+
+    /// Serve the pipeline only while its high-watermark is within this many checkpoints of the
+    /// network tip.
+    MaxCheckpointLag(u64),
 }
 
-/// Configuration for a single pipeline's `enabled` setting -- used both for the shared default
-/// (`[pipeline-defaults]`) and for per-pipeline overrides (`[pipeline.<name>]`). Kept as its own
-/// type/section rather than flattened together with the per-pipeline map: TOML forbids redefining
-/// the same key as both a scalar and a table, so if the default lived directly in the `[pipeline]`
-/// table, a pipeline named `enabled` could never be expressed, regardless of how the Rust side
-/// deserialized it.
+/// Availability policies assembled from `[pipeline-defaults].availability` and each pipeline's own
+/// `[pipeline.<name>].availability` override. See [`PipelineAvailability`] for the policy
+/// semantics.
+#[derive(Clone, Default)]
+pub struct AvailabilityConfig {
+    /// Default policy applied to every tracked pipeline without an override.
+    pub default: Option<PipelineAvailability>,
+
+    /// Per-pipeline overrides, keyed by pipeline name.
+    pub pipelines: BTreeMap<String, PipelineAvailability>,
+}
+
+/// TOML mirror of [`PipelineAvailability`]: a policy section sets exactly one of these keys,
+/// validated when converting to the enum.
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PipelineAvailabilityLayer {
+    pub enabled: Option<bool>,
+    pub max_checkpoint_lag: Option<u64>,
+}
+
+impl PipelineAvailability {
+    /// Whether a pipeline whose high-watermark is at `checkpoint` should be served, given the
+    /// current `network_tip` (the highest checkpoint high-watermark across all tracked pipelines).
+    pub(crate) fn is_available(&self, checkpoint: u64, network_tip: u64) -> bool {
+        match self {
+            Self::Enabled => true,
+            Self::Disabled => false,
+            Self::MaxCheckpointLag(lag) => network_tip.saturating_sub(checkpoint) <= *lag,
+        }
+    }
+}
+
+impl AvailabilityConfig {
+    /// The policy gating `pipeline`, if any: its own override when configured, otherwise the
+    /// default.
+    pub(crate) fn policy_for(&self, pipeline: &str) -> Option<&PipelineAvailability> {
+        self.pipelines.get(pipeline).or(self.default.as_ref())
+    }
+}
+
+/// Configuration for a single pipeline's `enabled` and `availability` settings -- used both for
+/// the shared default (`[pipeline-defaults]`) and for per-pipeline overrides (`[pipeline.<name>]`).
+/// Kept as its own type/section rather than flattened together with the per-pipeline map: TOML
+/// forbids redefining the same key as both a scalar and a table, so if the default lived directly
+/// in the `[pipeline]` table, a pipeline named `enabled` could never be expressed, regardless of
+/// how the Rust side deserialized it.
+#[derive(Clone, Default, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PipelineLayer {
     pub enabled: Option<bool>,
+
+    /// Overrides the default availability policy for this pipeline. An override exists only to
+    /// set a policy, so its section must set `enabled` or `max-checkpoint-lag`.
+    pub availability: Option<PipelineAvailability>,
 }
 
 pub struct Limits {
@@ -376,12 +469,22 @@ impl RpcLayer {
             logging: LoggingConfig::default().into(),
             pipeline_defaults: PipelineLayer {
                 enabled: Some(true),
+                availability: None,
             },
             pipeline: BTreeMap::new(),
         }
     }
 
     pub fn finish(self) -> RpcConfig {
+        let availability = AvailabilityConfig {
+            default: self.pipeline_defaults.availability,
+            pipelines: self
+                .pipeline
+                .iter()
+                .filter_map(|(name, layer)| Some((name.clone(), layer.availability?)))
+                .collect(),
+        };
+
         RpcConfig {
             limits: self.limits.finish(Limits::default()),
             health: self.health.finish(HealthConfig::default()),
@@ -395,6 +498,7 @@ impl RpcLayer {
                 self.pipeline,
                 PipelineConfig::default(),
             ),
+            availability,
         }
     }
 }
@@ -573,6 +677,41 @@ impl From<PipelineLayer> for PipelineAvailability {
             PipelineAvailability::Enabled
         } else {
             PipelineAvailability::Disabled
+        }
+    }
+}
+
+impl TryFrom<PipelineAvailabilityLayer> for PipelineAvailability {
+    type Error = String;
+
+    fn try_from(layer: PipelineAvailabilityLayer) -> Result<Self, Self::Error> {
+        match (layer.enabled, layer.max_checkpoint_lag) {
+            (Some(_), Some(_)) => {
+                Err("'enabled' and 'max-checkpoint-lag' are mutually exclusive".to_string())
+            }
+            (Some(true), None) => Ok(Self::Enabled),
+            (Some(false), None) => Ok(Self::Disabled),
+            (None, Some(lag)) => Ok(Self::MaxCheckpointLag(lag)),
+            (None, None) => Err("expected 'enabled' or 'max-checkpoint-lag'".to_string()),
+        }
+    }
+}
+
+impl From<PipelineAvailability> for PipelineAvailabilityLayer {
+    fn from(value: PipelineAvailability) -> Self {
+        match value {
+            PipelineAvailability::Enabled => Self {
+                enabled: Some(true),
+                max_checkpoint_lag: None,
+            },
+            PipelineAvailability::Disabled => Self {
+                enabled: Some(false),
+                max_checkpoint_lag: None,
+            },
+            PipelineAvailability::MaxCheckpointLag(lag) => Self {
+                enabled: None,
+                max_checkpoint_lag: Some(lag),
+            },
         }
     }
 }
@@ -875,5 +1014,201 @@ mod tests {
             enabled_pipelines(&config.pipeline),
             BTreeSet::from(["tx_calls"]),
         );
+    }
+
+    #[test]
+    fn availability_within_tip_respects_lag() {
+        let a = PipelineAvailability::MaxCheckpointLag(100);
+        // At the tip, and exactly at the lag boundary (inclusive), are available.
+        assert!(a.is_available(1_000_000, 1_000_000));
+        assert!(a.is_available(999_900, 1_000_000));
+        // One checkpoint beyond the lag budget is unavailable.
+        assert!(!a.is_available(999_899, 1_000_000));
+        // A watermark momentarily ahead of the recorded tip saturates to zero lag.
+        assert!(a.is_available(1_000_050, 1_000_000));
+    }
+
+    #[test]
+    fn enabled_and_disabled_ignore_lag() {
+        // Force-on serves regardless of distance from the tip; force-off never serves, even at it.
+        assert!(PipelineAvailability::Enabled.is_available(0, 1_000_000));
+        assert!(!PipelineAvailability::Disabled.is_available(1_000_000, 1_000_000));
+    }
+
+    #[test]
+    fn default_and_overrides_parse_from_toml() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults.availability]
+            max-checkpoint-lag = 100
+
+            [pipeline.tx_calls.availability]
+            max-checkpoint-lag = 1000
+
+            [pipeline.tx_kinds.availability]
+            max-checkpoint-lag = 0
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish().availability;
+        assert_eq!(
+            config.policy_for("tx_calls"),
+            Some(&PipelineAvailability::MaxCheckpointLag(1000))
+        );
+        assert_eq!(
+            config.policy_for("tx_kinds"),
+            Some(&PipelineAvailability::MaxCheckpointLag(0))
+        );
+        // A pipeline with no override falls back to the default.
+        assert_eq!(
+            config.policy_for("unset"),
+            Some(&PipelineAvailability::MaxCheckpointLag(100))
+        );
+    }
+
+    #[test]
+    fn enabled_and_disabled_parse_from_toml() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline-defaults.availability]
+            max-checkpoint-lag = 100
+
+            [pipeline.kv_objects.availability]
+            enabled = true
+
+            [pipeline.tx_kinds.availability]
+            enabled = false
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish().availability;
+        assert_eq!(
+            config.policy_for("kv_objects"),
+            Some(&PipelineAvailability::Enabled)
+        );
+        assert_eq!(
+            config.policy_for("tx_kinds"),
+            Some(&PipelineAvailability::Disabled)
+        );
+    }
+
+    #[test]
+    fn enabled_and_lag_are_mutually_exclusive() {
+        let err = toml::from_str::<RpcLayer>(
+            r#"
+            [pipeline.tx_calls.availability]
+            enabled = true
+            max-checkpoint-lag = 100
+            "#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn overrides_without_a_default_gate_only_themselves() {
+        let layer: RpcLayer = toml::from_str(
+            r#"
+            [pipeline.tx_calls.availability]
+            max-checkpoint-lag = 100
+            "#,
+        )
+        .unwrap();
+
+        let config = layer.finish().availability;
+        assert_eq!(
+            config.policy_for("tx_calls"),
+            Some(&PipelineAvailability::MaxCheckpointLag(100))
+        );
+        assert_eq!(config.policy_for("unset"), None);
+    }
+
+    #[test]
+    fn empty_availability_sections_are_rejected() {
+        // A policy section exists only to set a policy, so one of its keys is mandatory.
+        for toml in [
+            "[pipeline-defaults.availability]",
+            "[pipeline.tx_calls.availability]",
+        ] {
+            let err = toml::from_str::<RpcLayer>(toml).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("expected 'enabled' or 'max-checkpoint-lag'"),
+                "unexpected error for {toml:?}: {err}",
+            );
+        }
+    }
+
+    #[test]
+    fn pipeline_section_without_availability_has_no_override() {
+        // An enablement-only pipeline section (no `.availability` sub-table) implies no
+        // availability override, regardless of whether it enables the pipeline.
+        let layer: RpcLayer = toml::from_str("[pipeline.tx_calls]").unwrap();
+        let config = layer.finish().availability;
+        assert_eq!(config.policy_for("tx_calls"), None);
+    }
+
+    #[test]
+    fn availability_sections_reject_unknown_fields() {
+        for toml in [
+            "[pipeline-defaults.availability]\nmode = \"disabled\"",
+            "[pipeline.tx_calls]\nmode = \"disabled\"",
+            "[pipeline.tx_calls.availability]\nmax-checkpoint-lag = 100\nmode = \"disabled\"",
+        ] {
+            let result: Result<RpcLayer, _> = toml::from_str(toml);
+            assert!(result.is_err(), "expected {toml:?} to be rejected");
+        }
+    }
+
+    #[test]
+    fn empty_config_has_no_availability_policies() {
+        let layer: RpcLayer = toml::from_str("").unwrap();
+        let config = layer.finish().availability;
+        assert!(config.default.is_none());
+        assert!(config.pipelines.is_empty());
+    }
+
+    #[test]
+    fn example_config_roundtrips() {
+        let example = RpcLayer::example();
+        let serialized = toml::to_string_pretty(&example).unwrap();
+        let parsed: RpcLayer = toml::from_str(&serialized).unwrap();
+        assert_eq!(parsed.pipeline_defaults, example.pipeline_defaults);
+        assert_eq!(parsed.pipeline, example.pipeline);
+    }
+
+    #[test]
+    fn availability_policies_roundtrip() {
+        for policy in [
+            PipelineAvailability::Enabled,
+            PipelineAvailability::Disabled,
+            PipelineAvailability::MaxCheckpointLag(100),
+        ] {
+            let layer = RpcLayer {
+                pipeline_defaults: PipelineLayer {
+                    availability: Some(policy),
+                    ..PipelineLayer::default()
+                },
+                ..RpcLayer::default()
+            };
+            let serialized = toml::to_string_pretty(&layer).unwrap();
+            let parsed: RpcLayer = toml::from_str(&serialized).unwrap();
+            assert_eq!(
+                parsed.pipeline_defaults.availability,
+                Some(policy),
+                "roundtrip failed for {policy:?}:\n{serialized}",
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_top_level_key_is_rejected() {
+        let result: Result<RpcLayer, _> = toml::from_str("nonexistent-key = 3");
+        assert!(result.is_err());
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -162,26 +162,6 @@ pub struct PipelineAvailabilityLayer {
     pub max_checkpoint_lag: Option<u64>,
 }
 
-impl PipelineAvailability {
-    /// Whether a pipeline whose high-watermark is at `checkpoint` should be served, given the
-    /// current `network_tip` (the highest checkpoint high-watermark across all tracked pipelines).
-    pub(crate) fn is_available(&self, checkpoint: u64, network_tip: u64) -> bool {
-        match self {
-            Self::Enabled => true,
-            Self::Disabled => false,
-            Self::MaxCheckpointLag(lag) => network_tip.saturating_sub(checkpoint) <= *lag,
-        }
-    }
-}
-
-impl AvailabilityConfig {
-    /// The policy gating `pipeline`, if any: its own override when configured, otherwise the
-    /// default.
-    pub(crate) fn policy_for(&self, pipeline: &str) -> Option<&PipelineAvailability> {
-        self.pipelines.get(pipeline).or(self.default.as_ref())
-    }
-}
-
 /// Configuration for a single pipeline's `enabled` and `availability` settings -- used both for
 /// the shared default (`[pipeline-defaults]`) and for per-pipeline overrides (`[pipeline.<name>]`).
 /// Kept as its own type/section rather than flattened together with the per-pipeline map: TOML
@@ -511,6 +491,26 @@ impl HealthLayer {
                 .map(Duration::from_millis)
                 .unwrap_or(base.max_checkpoint_lag),
         }
+    }
+}
+
+impl PipelineAvailability {
+    /// Whether a pipeline whose high-watermark is at `checkpoint` should be served, given the
+    /// current `network_tip` (the highest checkpoint high-watermark across all tracked pipelines).
+    pub(crate) fn is_available(&self, checkpoint: u64, network_tip: u64) -> bool {
+        match self {
+            Self::Enabled => true,
+            Self::Disabled => false,
+            Self::MaxCheckpointLag(lag) => network_tip.saturating_sub(checkpoint) <= *lag,
+        }
+    }
+}
+
+impl AvailabilityConfig {
+    /// The policy gating `pipeline`, if any: its own override when configured, otherwise the
+    /// default.
+    pub(crate) fn policy_for(&self, pipeline: &str) -> Option<&PipelineAvailability> {
+        self.pipelines.get(pipeline).or(self.default.as_ref())
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -368,6 +368,7 @@ pub async fn start_rpc(
     let watermark_task = WatermarkTask::new(
         config.watermark,
         config.pipeline,
+        config.availability,
         pg_reader.clone(),
         bigtable_reader,
         ledger_grpc_reader.clone(),

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -780,6 +780,7 @@ mod tests {
                 watermark_polling_interval: Duration::from_millis(20),
             },
             pipeline,
+            AvailabilityConfig::default(),
             pg_reader,
             None,
             None,

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -31,6 +31,7 @@ use tonic::metadata::AsciiMetadataValue;
 use tracing::debug;
 use tracing::warn;
 
+use crate::config::AvailabilityConfig;
 use crate::config::PipelineAvailability;
 use crate::config::PipelineConfig;
 use crate::config::WatermarkConfig;
@@ -71,6 +72,9 @@ pub(crate) struct WatermarkTask {
     /// the watermark for.
     pipeline: PipelineConfig,
 
+    /// Availability policy applied to each snapshot before it is published.
+    availability: AvailabilityConfig,
+
     /// Access to metrics to report watermark updates.
     metrics: Arc<RpcMetrics>,
 }
@@ -102,6 +106,10 @@ pub(crate) struct Pipeline {
     hi: Watermark,
     lo: Watermark,
     timestamp_ms_hi_inclusive: i64,
+
+    /// Whether this pipeline is currently served, per the configured availability policy. Set by
+    /// [`Watermarks::apply_availability`].
+    available: bool,
 }
 
 #[derive(QueryableByName, Clone)]
@@ -137,6 +145,7 @@ impl WatermarkTask {
     pub(crate) fn new(
         config: WatermarkConfig,
         pipeline: PipelineConfig,
+        availability: AvailabilityConfig,
         pg_reader: PgReader,
         bigtable_reader: Option<BigtableReader>,
         ledger_grpc_reader: Option<LedgerGrpcReader>,
@@ -157,6 +166,7 @@ impl WatermarkTask {
             consistent_reader,
             interval: watermark_polling_interval,
             pipeline,
+            availability,
             metrics,
         }
     }
@@ -184,6 +194,7 @@ impl WatermarkTask {
                 consistent_reader,
                 interval,
                 pipeline,
+                availability,
                 metrics,
             } = self;
 
@@ -233,6 +244,11 @@ impl WatermarkTask {
                         continue;
                     }
                 };
+
+                // Gate pipelines per the configured availability policy and recompute the global
+                // upperbound over only the available ones, so a gated pipeline no longer pins the
+                // consistency boundary.
+                w.apply_availability(&availability);
 
                 let previous = watermarks.read().await.clone();
                 for (pipeline, next) in &w.per_pipeline {
@@ -314,6 +330,7 @@ impl Watermarks {
                 transaction: row.tx_lo,
             },
             timestamp_ms_hi_inclusive: row.timestamp_ms_hi_inclusive,
+            available: true,
         };
 
         self.global_hi.epoch = self.global_hi.epoch.min(pipeline.hi.epoch);
@@ -324,6 +341,56 @@ impl Watermarks {
             .min(pipeline.timestamp_ms_hi_inclusive);
 
         self.per_pipeline.insert(row.pipeline, pipeline);
+    }
+
+    /// Apply the configured availability policy to this snapshot: flag each pipeline as available
+    /// or not, then recompute the global upperbound (and its timestamp) over only the available
+    /// pipelines. A gated pipeline therefore stops pinning `checkpoint_viewed_at`, while remaining
+    /// present in `per_pipeline` for health and metrics reporting.
+    fn apply_availability(&mut self, config: &AvailabilityConfig) {
+        // Approximate the network tip as the furthest-ahead pipeline. When a Bigtable or Ledger
+        // gRPC source is configured its virtual pipeline tracks the true network tip; computing the
+        // max over every pipeline (including any that end up gated) keeps the reference stable.
+        let network_tip = self
+            .per_pipeline
+            .values()
+            .map(|p| p.hi.checkpoint)
+            .max()
+            .unwrap_or(0) as u64;
+
+        for (name, pipeline) in self.per_pipeline.iter_mut() {
+            // A pipeline's own override wins, then the configured default; a pipeline with
+            // neither is always available.
+            pipeline.available = match config.policy_for(name) {
+                Some(policy) => policy.is_available(pipeline.hi.checkpoint as u64, network_tip),
+                None => true,
+            };
+        }
+
+        let mut global_hi = Watermark {
+            epoch: i64::MAX,
+            checkpoint: i64::MAX,
+            transaction: i64::MAX,
+        };
+        let mut timestamp_ms_hi_inclusive = i64::MAX;
+        let mut any_available = false;
+        for pipeline in self.per_pipeline.values().filter(|p| p.available) {
+            any_available = true;
+            global_hi.epoch = global_hi.epoch.min(pipeline.hi.epoch);
+            global_hi.checkpoint = global_hi.checkpoint.min(pipeline.hi.checkpoint);
+            global_hi.transaction = global_hi.transaction.min(pipeline.hi.transaction);
+            timestamp_ms_hi_inclusive =
+                timestamp_ms_hi_inclusive.min(pipeline.timestamp_ms_hi_inclusive);
+        }
+
+        // A lag policy can never gate the furthest-ahead pipeline (it is at zero distance from
+        // the tip), but `enabled = false` can gate every pipeline. In that case (and for an empty
+        // snapshot) keep the merge-time bounds so the snapshot stays `initialized` with a sane
+        // `checkpoint_viewed_at` rather than `i64::MAX`.
+        if any_available {
+            self.global_hi = global_hi;
+            self.timestamp_ms_hi_inclusive = timestamp_ms_hi_inclusive;
+        }
     }
 }
 
@@ -355,6 +422,10 @@ impl Pipeline {
 
     pub(crate) fn lo(&self) -> &Watermark {
         &self.lo
+    }
+
+    pub(crate) fn available(&self) -> bool {
+        self.available
     }
 }
 
@@ -439,22 +510,32 @@ impl Default for Watermarks {
 
 #[cfg(test)]
 impl Watermarks {
-    /// Build a `Watermarks` snapshot with the given pipeline high-checkpoints.
+    /// Build a `Watermarks` snapshot with the given pipeline high-checkpoints, merged the same
+    /// way production rows are.
     pub(crate) fn for_test(pipelines: &[(&str, u64)]) -> Self {
         let mut w = Self::default();
         for (name, hi_cp) in pipelines {
-            w.per_pipeline.insert(
-                name.to_string(),
-                Pipeline {
-                    hi: Watermark {
-                        checkpoint: *hi_cp as i64,
-                        ..Default::default()
-                    },
-                    lo: Watermark::default(),
-                    timestamp_ms_hi_inclusive: 0,
-                },
-            );
+            w.merge(WatermarkRow {
+                pipeline: name.to_string(),
+                epoch_hi_inclusive: 0,
+                checkpoint_hi_inclusive: *hi_cp as i64,
+                tx_hi: 0,
+                timestamp_ms_hi_inclusive: 0,
+                epoch_lo: 0,
+                checkpoint_lo: 0,
+                tx_lo: 0,
+            });
         }
+        w
+    }
+
+    /// Build a snapshot from `pipelines`, then apply `config`'s availability policy to it.
+    pub(crate) fn for_test_with_availability(
+        pipelines: &[(&str, u64)],
+        config: &AvailabilityConfig,
+    ) -> Self {
+        let mut w = Self::for_test(pipelines);
+        w.apply_availability(config);
         w
     }
 }
@@ -717,6 +798,23 @@ mod tests {
         rx.borrow_and_update().clone()
     }
 
+    fn within_tip(pipeline: &str, max_checkpoint_lag: u64) -> AvailabilityConfig {
+        AvailabilityConfig {
+            default: None,
+            pipelines: BTreeMap::from([(
+                pipeline.to_string(),
+                PipelineAvailability::MaxCheckpointLag(max_checkpoint_lag),
+            )]),
+        }
+    }
+
+    fn default_within_tip(max_checkpoint_lag: u64) -> AvailabilityConfig {
+        AvailabilityConfig {
+            default: Some(PipelineAvailability::MaxCheckpointLag(max_checkpoint_lag)),
+            pipelines: BTreeMap::new(),
+        }
+    }
+
     #[tokio::test]
     async fn explicit_enabled_and_disabled_are_respected() {
         let (_db, pg_reader, consistent_reader, metrics) = setup(&["tx_calls", "kv_objects"]).await;
@@ -765,5 +863,133 @@ mod tests {
         let w = snapshot(pipeline, pg_reader, consistent_reader, metrics).await;
 
         assert!(!w.per_pipeline().contains_key("tx_calls"));
+    }
+
+    #[test]
+    fn empty_config_keeps_all_available_and_global_hi_is_min() {
+        let mut w = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+        w.apply_availability(&AvailabilityConfig::default());
+        assert!(w.per_pipeline["a"].available);
+        assert!(w.per_pipeline["b"].available);
+        assert_eq!(w.high_watermark().checkpoint(), 100);
+    }
+
+    #[test]
+    fn lagging_pipeline_is_dropped_from_global_hi() {
+        // "a" is the min and lags "b" (the tip) by 100 checkpoints.
+        let mut w = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+        w.apply_availability(&within_tip("a", 50));
+        assert!(!w.per_pipeline["a"].available);
+        assert!(w.per_pipeline["b"].available);
+        // Gating "a" advances the boundary to "b".
+        assert_eq!(w.high_watermark().checkpoint(), 200);
+    }
+
+    #[test]
+    fn within_tip_gates_on_distance_from_the_tip() {
+        // "tip" is the furthest-ahead pipeline; "lagging" is 100 checkpoints behind it.
+        let base = Watermarks::for_test(&[("tip", 1_000_000), ("lagging", 999_900)]);
+
+        // A budget of 100 keeps the lagging pipeline available (boundary inclusive).
+        let mut within = base.clone();
+        within.apply_availability(&within_tip("lagging", 100));
+        assert!(within.per_pipeline["lagging"].available);
+        assert_eq!(within.high_watermark().checkpoint(), 999_900);
+
+        // A budget of 99 gates it out, advancing the boundary to the tip.
+        let mut beyond = base;
+        beyond.apply_availability(&within_tip("lagging", 99));
+        assert!(!beyond.per_pipeline["lagging"].available);
+        assert_eq!(beyond.high_watermark().checkpoint(), 1_000_000);
+    }
+
+    #[test]
+    fn furthest_ahead_pipeline_is_never_gated() {
+        let mut w = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+        // Gate every pipeline to zero lag: "a" is 100 behind the tip and drops, but "b" is the tip
+        // itself (zero distance) and stays available, so the boundary never resets to `i64::MAX`.
+        w.apply_availability(&default_within_tip(0));
+        assert!(!w.per_pipeline["a"].available);
+        assert!(w.per_pipeline["b"].available);
+        assert!(w.initialized());
+        assert_eq!(w.high_watermark().checkpoint(), 200);
+    }
+
+    #[test]
+    fn default_gates_pipelines_without_an_override() {
+        // "a" lags "b" (the tip) by 100 checkpoints, beyond the default budget of 50.
+        let mut w = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+        w.apply_availability(&default_within_tip(50));
+        assert!(!w.per_pipeline["a"].available);
+        assert!(w.per_pipeline["b"].available);
+        assert_eq!(w.high_watermark().checkpoint(), 200);
+    }
+
+    #[test]
+    fn override_beats_the_default() {
+        let base = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+
+        // A looser override keeps "a" available where the default would gate it.
+        let mut loosened = base.clone();
+        let mut config = default_within_tip(50);
+        config.pipelines.insert(
+            "a".to_string(),
+            PipelineAvailability::MaxCheckpointLag(1000),
+        );
+        loosened.apply_availability(&config);
+        assert!(loosened.per_pipeline["a"].available);
+        assert_eq!(loosened.high_watermark().checkpoint(), 100);
+
+        // A tighter override gates "a" where the default would allow it.
+        let mut tightened = base;
+        let mut config = default_within_tip(1000);
+        config
+            .pipelines
+            .insert("a".to_string(), PipelineAvailability::MaxCheckpointLag(50));
+        tightened.apply_availability(&config);
+        assert!(!tightened.per_pipeline["a"].available);
+        assert_eq!(tightened.high_watermark().checkpoint(), 200);
+    }
+
+    #[test]
+    fn disabled_pipeline_is_dropped_even_at_the_tip() {
+        let mut w = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+        let mut config = AvailabilityConfig::default();
+        config
+            .pipelines
+            .insert("b".to_string(), PipelineAvailability::Disabled);
+        w.apply_availability(&config);
+        assert!(w.per_pipeline["a"].available);
+        assert!(!w.per_pipeline["b"].available);
+        // With the tip gated, the boundary is the min over the remaining pipelines.
+        assert_eq!(w.high_watermark().checkpoint(), 100);
+    }
+
+    #[test]
+    fn enabled_override_exempts_from_the_default() {
+        // "a" lags beyond the default budget but is force-enabled, so it stays available and
+        // keeps pinning the boundary.
+        let mut w = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+        let mut config = default_within_tip(50);
+        config
+            .pipelines
+            .insert("a".to_string(), PipelineAvailability::Enabled);
+        w.apply_availability(&config);
+        assert!(w.per_pipeline["a"].available);
+        assert_eq!(w.high_watermark().checkpoint(), 100);
+    }
+
+    #[test]
+    fn all_disabled_snapshot_stays_initialized() {
+        let mut w = Watermarks::for_test(&[("a", 100), ("b", 200)]);
+        w.apply_availability(&AvailabilityConfig {
+            default: Some(PipelineAvailability::Disabled),
+            pipelines: BTreeMap::new(),
+        });
+        assert!(!w.per_pipeline["a"].available);
+        assert!(!w.per_pipeline["b"].available);
+        // No pipeline is available; the merge-time bounds are kept so the snapshot stays usable.
+        assert!(w.initialized());
+        assert_eq!(w.high_watermark().checkpoint(), 100);
     }
 }

--- a/examples/prod-config/graphql.toml
+++ b/examples/prod-config/graphql.toml
@@ -34,3 +34,15 @@ watermark-polling-interval-ms = 500
 [zklogin]
 env = "Prod"
 max-epoch-upper-bound-delta = 30
+
+[pipeline-defaults]
+# Enable every pipeline by default; set `enabled = false` on a specific
+# `[pipeline.<name>]` entry to opt back out despite the default.
+enabled = true
+
+# Gate served data by how far a pipeline lags behind the network tip. With no
+# [pipeline-defaults.availability] section (or per-pipeline override), every
+# enabled pipeline is always served, so this is optional and does not change
+# behaviour if omitted.
+# [pipeline-defaults.availability]
+# max-checkpoint-lag = 100


### PR DESCRIPTION
## Description

Stacked on #27341 and #27342.

Today `checkpoint_viewed_at` is the MIN high-watermark across every tracked pipeline, so a single lagging pipeline pins the whole GraphQL server to its stale checkpoint. This lets an operator gate pipelines by availability policy: `max-checkpoint-lag` serves a pipeline's data only while it is within that many checkpoints of the network tip, `enabled = false` never serves it (kill-switch), and `enabled = true` always serves it. A gated pipeline is dropped from the consistency boundary so the caught-up pipelines keep serving fresh reads. It's the read-side companion to ingestion cohorts.

Gating a pipeline excludes it from the `checkpoint_viewed_at` MIN and adds `FeatureUnavailable` guards on the read paths that bypass `reader_lo` (`consistent`, `obj_versions`, `tx_balance_changes`, and the `kv_*` content pipelines) so a gated pipeline can never silently serve stale or out-of-range data. Pipelines with no policy are always served, so behavior is unchanged unless configured. The network tip is approximated as the MAX high-watermark across tracked pipelines (the true tip when a Bigtable/Ledger-gRPC KV source is configured).

Availability policy lives in the same `[pipeline-defaults]`/`[pipeline.<name>]` config surface #27341/#27342 use for pipeline enablement, as a nested `availability` section; a policy sets exactly one of `enabled` or `max-checkpoint-lag`:

```toml
[pipeline-defaults.availability]
max-checkpoint-lag = 100          # default for every tracked pipeline

[pipeline.kv_objects.availability]
enabled = true                    # always serve, exempt from the default

[pipeline.tx_kinds.availability]
enabled = false                   # never serve

[pipeline.tx_calls.availability]
max-checkpoint-lag = 1000         # lag-gated override
```

## Test plan

New unit tests cover `is_available` (lag boundaries inclusive/exclusive, `enabled`/`disabled` ignoring lag), `apply_availability` (advancing the boundary past a lagging pipeline, the furthest-ahead pipeline never lag-gated, `disabled` gating even the tip, an `enabled` override exempting a pipeline from the default, an all-disabled snapshot staying initialized), TOML parse/round-trip of every policy form (including mutual-exclusion and empty-section rejection), the `reader_lo` gate, and `require_pipeline` (present-and-gated fires, untracked is a no-op). Covered by existing tests otherwise.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Operators can now gate pipelines in the RPC config with availability policies: `[pipeline-defaults.availability]` sets a default for every tracked pipeline and `[pipeline.<name>.availability]` overrides it per pipeline. A policy is either `max-checkpoint-lag = N` (serve only while within N checkpoints of the network tip), `enabled = false` (never serve), or `enabled = true` (always serve). A gated pipeline no longer holds back the server's consistency boundary, and queries requiring it return `FeatureUnavailable`. Pipelines with no policy are always served, so no action is needed unless you opt in.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
