### PR TITLE
Tolerate non-JSON stderr noise in cargo-deny-autofix scan

### DIFF
--- a/scripts/cargo-deny-autofix.sh
+++ b/scripts/cargo-deny-autofix.sh
@@ -46,19 +46,35 @@ REMAINING_MD="$OUT_DIR/remaining.md"
 # be mistaken for a clean result.
 ADVISORIES=()
 scan() {
-  local ws="$1" diag deny_status=0
+  local ws="$1" diag json deny_status=0
   diag="$(mktemp)"
+  json="$(mktemp)"
   # cargo-deny writes JSON diagnostics to stderr and exits non-zero on errors.
   cargo deny --manifest-path "$ws/Cargo.toml" --format json check advisories 2> "$diag" || deny_status=$?
 
-  if ! jq -es '.' "$diag" > /dev/null 2>&1; then
+  # Other tooling can interleave non-JSON noise on the same stderr stream,
+  # e.g. rustup printing "info: syncing channel updates" while auto-installing
+  # the pinned toolchain on a fresh runner. cargo-deny emits one JSON object
+  # per line, so parse only lines that look like JSON and log the rest.
+  grep '^{' "$diag" > "$json" || true
+  grep -v '^{' "$diag" | sed 's/^/    [cargo-deny stderr] /' || true
+
+  if ! jq -es '.' "$json" > /dev/null 2>&1; then
     echo "::error::cargo-deny output for '$ws' is not valid JSON (exit ${deny_status}); raw output:"
     cat "$diag"
     exit 1
   fi
 
+  # cargo-deny ends every completed check with a summary diagnostic; if it is
+  # missing, the output was truncated or cargo-deny died mid-run.
+  if ! jq -es 'any(.[]; .type == "summary")' "$json" > /dev/null 2>&1; then
+    echo "::error::cargo-deny output for '$ws' has no summary diagnostic (exit ${deny_status}); raw output:"
+    cat "$diag"
+    exit 1
+  fi
+
   local other
-  other=$(jq -c 'select(.type == "diagnostic" and .fields.severity == "error" and .fields.advisory == null)' "$diag")
+  other=$(jq -c 'select(.type == "diagnostic" and .fields.severity == "error" and .fields.advisory == null)' "$json")
   if [[ -n "$other" ]]; then
     echo "::error::cargo-deny reported non-advisory errors for '$ws':"
     echo "$other"
@@ -68,14 +84,14 @@ scan() {
   mapfile -t ADVISORIES < <(jq -c '
     select(.type == "diagnostic" and .fields.severity == "error" and .fields.advisory != null)
     | {id: .fields.advisory.id} + (.fields.graphs[].Krate | {pkg: .name, ver: .version})
-  ' "$diag" | sort -u)
+  ' "$json" | sort -u)
 
   if [[ $deny_status -ne 0 && ${#ADVISORIES[@]} -eq 0 ]]; then
     echo "::error::cargo deny check advisories failed for '$ws' with no advisory diagnostics (exit ${deny_status}); raw output:"
     cat "$diag"
     exit 1
   fi
-  rm -f "$diag"
+  rm -f "$diag" "$json"
 }
 
 declare -A bumped_pkgs=()


### PR DESCRIPTION
## Description

The first `cargo-deny-autofix` run on main [failed](https://github.com/MystenLabs/sui/actions/runs/28902810650/job/85743290899): on a fresh runner, rustup auto-installs the pinned toolchain on the first cargo invocation and prints `info: syncing channel updates...` to stderr — the same stream the script captures for cargo-deny's JSON diagnostics — so the "stderr must be pure JSON" guard aborted a clean run.

Parse only `{`-prefixed lines as diagnostics and log the rest, and require cargo-deny's closing `summary` diagnostic as proof the check ran to completion (so truncated/garbage output still aborts instead of passing as "no advisories").

## Test plan

Re-ran the script test matrix with a cargo shim that injects rustup-style `info:` lines onto stderr (reproducing the failed run): clean no-op on the real workspaces, fixable advisory (crossbeam-epoch 0.9.18→0.9.20), unfixable (`time` 0.1), and mixed runs all produce correct `fixed.md`/`remaining.md`/`GITHUB_OUTPUT`; a nonexistent workspace still aborts with exit 1 via the new summary guard. shellcheck clean.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
