### PR TITLE
[sui-benchmark] Restore cancellation_count margin in test_composite_workload

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1640,7 +1640,7 @@ mod test {
             metrics: Some(metrics.clone()),
             ..Default::default()
         }
-        .with_probability(SharedCounterIncrement::NAME, 0.1)
+        .with_probability(SharedCounterIncrement::NAME, 0.2)
         .with_probability(SharedCounterRead::NAME, 0.1)
         .with_probability(RandomnessRead::NAME, 0.1)
         .with_probability(AddressBalanceDeposit::NAME, 0.1)
@@ -1719,7 +1719,11 @@ mod test {
         // `> 100` bar flake ~3% of the time. A `> 50` bar still asserts that
         // shared-object congestion control actually kicked in, with comfortable
         // margin below the observed floor.
-        assert!(metrics_sum.cancellation_count > 50);
+        assert!(
+            metrics_sum.cancellation_count > 50,
+            "cancellation_count too low: {}",
+            metrics_sum.cancellation_count
+        );
 
         if address_aliases_enabled {
             let alias_add_stats = metrics


### PR DESCRIPTION
## Description

`test_composite_workload` flakes ~1% of seeds on `assert!(cancellation_count > 50)`: the count of congestion-induced cancellations has drifted down since the bar was set in #26748 (100-seed sweep: mean ~88, min 44), so the lower tail crosses 50. Raising `SharedCounterIncrement` from 0.1 to 0.2 restores contention on the hot counters and lifts the distribution back to mean ~101 / min 65, and the assert now prints the actual count on failure.

## Test plan

100-seed `seed-search.py` sweep: all pass (0/100 ≤ 50), and the seed that previously failed at 44 now reports 88.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: