### PR TITLE
[cli] adds move lint --explain

### DIFF
--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -50,6 +50,8 @@ pub async fn execute_move_command(
     wallet: &WalletContext,
 ) -> anyhow::Result<()> {
     let flavor = SuiFlavor::with_client(wallet);
+    // Enable the per-lint `--explain` hint on rendered lint diagnostics, naming the Sui CLI.
+    move_compiler::diagnostics::set_explain_command("sui move lint");
     match command {
         Command::Build(c) => c.execute(package_path, build_config, wallet).await,
         Command::CachePackage(c) => c.execute(flavor).await,

--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -44,5 +44,9 @@ async fn main() {
 
     let _guard = builder.init();
     debug!("Sui CLI version: {VERSION}");
+    // Lint diagnostics are rendered by every compile path (`sui client publish`/`upgrade`,
+    // `sui move build`, ...), not just `sui move lint` — set the `--explain` hint command for the
+    // whole binary so no path falls back to the default `move lint`.
+    move_compiler::diagnostics::set_explain_command("sui move lint");
     exit_main!(args.command.execute().await);
 }

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint.snap
@@ -31,3 +31,4 @@ warning[Lint W99001]: non-composable transfer to sender
    │     Transfer of an object to transaction sender address
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `sui move lint --explain self_transfer` for more information

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.sh
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.sh
@@ -1,0 +1,8 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `sui move lint --explain <CODE>` prints a lint's documentation and exits without building a
+# package. It accepts a lint name...
+sui move --client.config $CONFIG lint --explain share_owned
+# ...and the same lint by its diagnostic code.
+sui move --client.config $CONFIG lint --explain W99000

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.snap
@@ -18,10 +18,10 @@ exit_code: 0
 share_owned
 ===========
 
-group:   Security
-origin:  Sui
-level:   on by default
-code:    W99000
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99000
 
 possible owned object share
 
@@ -48,10 +48,10 @@ Suppress a specific case with `#[allow(lint(share_owned))]`.
 share_owned
 ===========
 
-group:   Security
-origin:  Sui
-level:   on by default
-code:    W99000
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99000
 
 possible owned object share
 

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.snap
@@ -1,0 +1,79 @@
+---
+source: crates/sui/tests/shell_tests.rs
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `sui move lint --explain <CODE>` prints a lint's documentation and exits without building a
+# package. It accepts a lint name...
+sui move --client.config $CONFIG lint --explain share_owned
+# ...and the same lint by its diagnostic code.
+sui move --client.config $CONFIG lint --explain W99000
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+share_owned
+===========
+
+group:   Security
+origin:  Sui
+level:   on by default
+code:    W99000
+
+possible owned object share
+
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an object that is not freshly created in this function (it arrives as a parameter or from an unpack) can silently hand every account write access to something a user believed was theirs. It fires only when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` elsewhere; a `key`-only type that is never transferred is not flagged.
+
+When it's OK:
+  The shared object really is fresh, but was produced through a helper call the local analysis can't see through — a conservative false positive.
+
+Example:
+
+  // flagged
+  // `o` is a parameter — the checker can't prove it is fresh
+  public fun share(o: Obj) {
+      transfer::public_share_object(o)
+  }
+
+  // suggested
+  // packed here, so provably a fresh object
+  public fun share(ctx: &mut TxContext) {
+      transfer::share_object(Obj { id: object::new(ctx) })
+  }
+
+Suppress a specific case with `#[allow(lint(share_owned))]`.
+share_owned
+===========
+
+group:   Security
+origin:  Sui
+level:   on by default
+code:    W99000
+
+possible owned object share
+
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an object that is not freshly created in this function (it arrives as a parameter or from an unpack) can silently hand every account write access to something a user believed was theirs. It fires only when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` elsewhere; a `key`-only type that is never transferred is not flagged.
+
+When it's OK:
+  The shared object really is fresh, but was produced through a helper call the local analysis can't see through — a conservative false positive.
+
+Example:
+
+  // flagged
+  // `o` is a parameter — the checker can't prove it is fresh
+  public fun share(o: Obj) {
+      transfer::public_share_object(o)
+  }
+
+  // suggested
+  // packed here, so provably a fresh object
+  public fun share(ctx: &mut TxContext) {
+      transfer::share_object(Obj { id: object::new(ctx) })
+  }
+
+Suppress a specific case with `#[allow(lint(share_owned))]`.
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_explain.snap
@@ -15,64 +15,76 @@ sui move --client.config $CONFIG lint --explain W99000
 success: true
 exit_code: 0
 ----- stdout -----
-share_owned
-===========
+share_owned (W99000): possible owned object share
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99000
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an
+object that is not freshly created in this function (it arrives as a parameter or from an unpack)
+can silently hand every account write access to something a user believed was theirs. It fires only
+when the type is also transferable — it has `store`, or is transferred with `transfer::transfer`
+elsewhere; a `key`-only type that is never transferred is not flagged.
 
-possible owned object share
+This lint is on by default.
 
-Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an object that is not freshly created in this function (it arrives as a parameter or from an unpack) can silently hand every account write access to something a user believed was theirs. It fires only when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` elsewhere; a `key`-only type that is never transferred is not flagged.
+## When it's OK
 
-When it's OK:
-  The shared object really is fresh, but was produced through a helper call the local analysis can't see through — a conservative false positive.
+The shared object really is fresh, but was produced through a helper call the local analysis can't
+see through — a conservative false positive.
 
-Example:
+## Example
 
-  // flagged
-  // `o` is a parameter — the checker can't prove it is fresh
-  public fun share(o: Obj) {
-      transfer::public_share_object(o)
-  }
+Flagged:
 
-  // suggested
-  // packed here, so provably a fresh object
-  public fun share(ctx: &mut TxContext) {
-      transfer::share_object(Obj { id: object::new(ctx) })
-  }
+```move
+// `o` is a parameter — the checker can't prove it is fresh
+public fun share(o: Obj) {
+    transfer::public_share_object(o)
+}
+```
+
+Suggested:
+
+```move
+// packed here, so provably a fresh object
+public fun share(ctx: &mut TxContext) {
+    transfer::share_object(Obj { id: object::new(ctx) })
+}
+```
 
 Suppress a specific case with `#[allow(lint(share_owned))]`.
-share_owned
-===========
+share_owned (W99000): possible owned object share
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99000
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an
+object that is not freshly created in this function (it arrives as a parameter or from an unpack)
+can silently hand every account write access to something a user believed was theirs. It fires only
+when the type is also transferable — it has `store`, or is transferred with `transfer::transfer`
+elsewhere; a `key`-only type that is never transferred is not flagged.
 
-possible owned object share
+This lint is on by default.
 
-Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an object that is not freshly created in this function (it arrives as a parameter or from an unpack) can silently hand every account write access to something a user believed was theirs. It fires only when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` elsewhere; a `key`-only type that is never transferred is not flagged.
+## When it's OK
 
-When it's OK:
-  The shared object really is fresh, but was produced through a helper call the local analysis can't see through — a conservative false positive.
+The shared object really is fresh, but was produced through a helper call the local analysis can't
+see through — a conservative false positive.
 
-Example:
+## Example
 
-  // flagged
-  // `o` is a parameter — the checker can't prove it is fresh
-  public fun share(o: Obj) {
-      transfer::public_share_object(o)
-  }
+Flagged:
 
-  // suggested
-  // packed here, so provably a fresh object
-  public fun share(ctx: &mut TxContext) {
-      transfer::share_object(Obj { id: object::new(ctx) })
-  }
+```move
+// `o` is a parameter — the checker can't prove it is fresh
+public fun share(o: Obj) {
+    transfer::public_share_object(o)
+}
+```
+
+Suggested:
+
+```move
+// packed here, so provably a fresh object
+public fun share(ctx: &mut TxContext) {
+    transfer::share_object(Obj { id: object::new(ctx) })
+}
+```
 
 Suppress a specific case with `#[allow(lint(share_owned))]`.
 

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_explain_unknown.sh
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_explain_unknown.sh
@@ -1,0 +1,5 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# An unrecognized lint is an error that points the user at `--list`.
+sui move --client.config $CONFIG lint --explain not_a_real_lint

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_explain_unknown.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_explain_unknown.snap
@@ -1,0 +1,17 @@
+---
+source: crates/sui/tests/shell_tests.rs
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# An unrecognized lint is an error that points the user at `--list`.
+sui move --client.config $CONFIG lint --explain not_a_real_lint
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+unknown lint `not_a_real_lint`; run `lint --list` to see every lint
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_explain_unknown.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_explain_unknown.snap
@@ -12,6 +12,6 @@ sui move --client.config $CONFIG lint --explain not_a_real_lint
 success: false
 exit_code: 1
 ----- stdout -----
-unknown lint `not_a_real_lint`; run `lint --list` to see every lint
+unknown lint `not_a_real_lint`; run `sui move lint --list` to see every lint
 
 ----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_list.sh
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_list.sh
@@ -1,0 +1,5 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `sui move lint --list` prints the full lint index, grouped by category.
+sui move --client.config $CONFIG lint --list

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
@@ -1,7 +1,17 @@
 ---
-source: crates/move-compiler/src/linters/docs.rs
-expression: render_index()
+source: crates/sui/tests/shell_tests.rs
 ---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `sui move lint --list` prints the full lint index, grouped by category.
+sui move --client.config $CONFIG lint --list
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
 Move lint index. Run `move lint --explain <name>` for details on any lint.
 
 Security
@@ -41,3 +51,6 @@ Style
     while_true                 unnecessary 'while (true)', replace with 'loop'
     unneeded_return            unneeded return
     unnecessary_unit           unit `()` expression can be removed or simplified
+
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
@@ -28,25 +28,25 @@ Suspicious
 
 Style
     constant_naming            constant should follow naming convention
-    abort_without_constant     'abort' or 'assert' without named constant
     while_true                 unnecessary 'while (true)', replace with 'loop'
     unneeded_return            unneeded return
+    abort_without_constant     'abort' or 'assert' without named constant
     unnecessary_unit           unit `()` expression can be removed or simplified
 
 Sui
     share_owned                possible owned object share
+    self_transfer              non-composable transfer to sender
     custom_state_change        potentially unenforceable custom transfer/share/freeze policy
+    coin_field                 sub-optimal 'sui::coin::Coin' field type
     freeze_wrapped             attempting to freeze wrapped objects
-    public_random              Risky use of 'sui::random'
-    freezing_capability        freezing potential capability
-    missing_key                struct with id but missing key ability
     collection_equality        possibly useless collections compare
+    public_random              Risky use of 'sui::random'
+    missing_key                struct with id but missing key ability
+    freezing_capability        freezing potential capability
+    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
+    public_entry               unnecessary `entry` on a `public` function
     uncallable_function        it will not be possible to call this function
     unused_object_with_fields  unused object with fields
-    self_transfer              non-composable transfer to sender
-    coin_field                 sub-optimal 'sui::coin::Coin' field type
-    public_entry               unnecessary `entry` on a `public` function
-    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
 
 
 ----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
@@ -12,7 +12,7 @@ sui move --client.config $CONFIG lint --list
 success: true
 exit_code: 0
 ----- stdout -----
-Move lint index. Run `move lint --explain <name>` for details on any lint.
+Move lint index. Run `sui move lint --explain <name>` for details on any lint.
 
 Complexity
     unnecessary_math           math operator can be simplified

--- a/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
+++ b/crates/sui/tests/shell_tests/sui_move_lint/lint_list.snap
@@ -14,43 +14,39 @@ exit_code: 0
 ----- stdout -----
 Move lint index. Run `move lint --explain <name>` for details on any lint.
 
-Security
-    share_owned                possible owned object share
-    custom_state_change        potentially unenforceable custom transfer/share/freeze policy
-    freeze_wrapped             attempting to freeze wrapped objects
-    public_random              Risky use of 'sui::random'
-    freezing_capability        freezing potential capability
-
-Correctness
-    missing_key                struct with id but missing key ability
-
-Suspicious
-    collection_equality        possibly useless collections compare
-    uncallable_function        it will not be possible to call this function
-    unused_object_with_fields  unused object with fields
-    loop_without_exit          'loop' without 'break' or 'return'
-    self_assignment            assignment preserves the same value
-    always_equal_operands      redundant, always-equal operands for binary operation
-    unused_return_value        return value of a non-mutating call is discarded
-
-Conventions
-    self_transfer              non-composable transfer to sender
-    coin_field                 sub-optimal 'sui::coin::Coin' field type
-    public_entry               unnecessary `entry` on a `public` function
-    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
-    constant_naming            constant should follow naming convention
-    abort_without_constant     'abort' or 'assert' without named constant
-
 Complexity
     unnecessary_math           math operator can be simplified
     unnecessary_conditional    'if' expression can be removed
     redundant_ref_deref        redundant reference/dereference
     combinable_comparisons     comparison operations condition can be simplified
 
+Suspicious
+    loop_without_exit          'loop' without 'break' or 'return'
+    self_assignment            assignment preserves the same value
+    always_equal_operands      redundant, always-equal operands for binary operation
+    unused_return_value        return value of a non-mutating call is discarded
+
 Style
+    constant_naming            constant should follow naming convention
+    abort_without_constant     'abort' or 'assert' without named constant
     while_true                 unnecessary 'while (true)', replace with 'loop'
     unneeded_return            unneeded return
     unnecessary_unit           unit `()` expression can be removed or simplified
+
+Sui
+    share_owned                possible owned object share
+    custom_state_change        potentially unenforceable custom transfer/share/freeze policy
+    freeze_wrapped             attempting to freeze wrapped objects
+    public_random              Risky use of 'sui::random'
+    freezing_capability        freezing potential capability
+    missing_key                struct with id but missing key ability
+    collection_equality        possibly useless collections compare
+    uncallable_function        it will not be possible to call this function
+    unused_object_with_fields  unused object with fields
+    self_transfer              non-composable transfer to sender
+    coin_field                 sub-optimal 'sui::coin::Coin' field type
+    public_entry               unnecessary `entry` on a `public` function
+    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
 
 
 ----- stderr -----

--- a/external-crates/move/crates/move-cli/src/base/lint.rs
+++ b/external-crates/move/crates/move-cli/src/base/lint.rs
@@ -11,7 +11,16 @@ use std::path::Path;
 /// Run Move linters on the package at `path`. If no path is provided defaults to current directory.
 #[derive(Parser)]
 #[clap(name = "lint")]
-pub struct Lint;
+pub struct Lint {
+    /// Print an explanation for a lint and exit, without building the package. Accepts a lint name
+    /// (e.g. `share_owned`) or its code (e.g. `W99000`).
+    #[clap(long, value_name = "CODE")]
+    pub explain: Option<String>,
+
+    /// List every lint with its group and summary, and exit.
+    #[clap(long)]
+    pub list: bool,
+}
 
 impl Lint {
     pub async fn execute<F: MoveFlavor>(
@@ -20,6 +29,21 @@ impl Lint {
         mut config: BuildConfig,
         flavor: F,
     ) -> anyhow::Result<()> {
+        if self.list {
+            print!("{}", move_compiler::linters::docs::LintIndex);
+            return Ok(());
+        }
+
+        if let Some(query) = self.explain.as_deref() {
+            match move_compiler::linters::docs::find_lint_doc(query) {
+                Some(doc) => print!("{doc}"),
+                None => {
+                    anyhow::bail!("unknown lint `{query}`; run `lint --list` to see every lint")
+                }
+            }
+            return Ok(());
+        }
+
         let rerooted_path = reroot_path(path)?;
         let env = find_env(&rerooted_path, &config, &flavor)?;
 

--- a/external-crates/move/crates/move-cli/src/base/lint.rs
+++ b/external-crates/move/crates/move-cli/src/base/lint.rs
@@ -30,7 +30,8 @@ impl Lint {
         flavor: F,
     ) -> anyhow::Result<()> {
         if self.list {
-            print!("{}", move_compiler::linters::docs::LintIndex);
+            let command = move_compiler::diagnostics::explain_command();
+            print!("{}", move_compiler::linters::docs::LintIndex { command });
             return Ok(());
         }
 
@@ -38,7 +39,10 @@ impl Lint {
             match move_compiler::linters::docs::find_lint_doc(query) {
                 Some(doc) => print!("{doc}"),
                 None => {
-                    anyhow::bail!("unknown lint `{query}`; run `lint --list` to see every lint")
+                    anyhow::bail!(
+                        "unknown lint `{query}`; run `{} --list` to see every lint",
+                        move_compiler::diagnostics::explain_command()
+                    )
                 }
             }
             return Ok(());

--- a/external-crates/move/crates/move-cli/src/base/lint.rs
+++ b/external-crates/move/crates/move-cli/src/base/lint.rs
@@ -36,8 +36,8 @@ impl Lint {
         }
 
         if let Some(query) = self.explain.as_deref() {
-            match move_compiler::linters::docs::find_lint_doc(query) {
-                Some(doc) => print!("{doc}"),
+            match move_compiler::linters::docs::find_lint(query) {
+                Some(explanation) => print!("{explanation}"),
                 None => {
                     anyhow::bail!(
                         "unknown lint `{query}`; run `{} --list` to see every lint",

--- a/external-crates/move/crates/move-cli/tests/build_tests/lint_command/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/lint_command/args.exp
@@ -7,6 +7,7 @@ warning[Lint W04004]: unneeded return
   │                        ^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
   │
   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unneeded_return` for more information
 
 Command `lint --mode custom`:
 BUILDING LintTest
@@ -17,6 +18,7 @@ warning[Lint W04004]: unneeded return
   │                        ^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
   │
   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ ./sources/example.move:17:24
@@ -25,6 +27,7 @@ warning[Lint W04004]: unneeded return
    │                        ^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 External Command `LC_ALL=C ls -A1`:
 Move.toml

--- a/external-crates/move/crates/move-compiler/build.rs
+++ b/external-crates/move/crates/move-compiler/build.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // `optional_include_str!` expands to `None` when an explanation file is absent, in which case
+    // rustc records no dependency on it -- watch the whole directory so adding a new explanation
+    // file triggers a rebuild.
+    println!("cargo::rerun-if-changed=src/diagnostics/explanations");
+}

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -66,6 +66,7 @@ pub struct DiagnosticInfo {
     code: u8,
     external_prefix: ExternalPrefix,
     message: &'static str,
+    explanation: Option<&'static str>,
 }
 
 pub(crate) trait DiagnosticCode: Copy {
@@ -75,16 +76,20 @@ pub(crate) trait DiagnosticCode: Copy {
 
     fn code_and_message(&self) -> (u8, &'static str);
 
+    fn explanation(&self) -> Option<&'static str>;
+
     fn into_info(self) -> DiagnosticInfo {
         let severity = self.severity();
         let category = Self::CATEGORY as u8;
         let (code, message) = self.code_and_message();
+        let explanation = self.explanation();
         DiagnosticInfo {
             severity,
             category,
             code,
             external_prefix: None,
             message,
+            explanation,
         }
     }
 }
@@ -111,6 +116,7 @@ pub const fn custom(
         code,
         external_prefix: Some(external_prefix),
         message,
+        explanation: None,
     }
 }
 
@@ -165,6 +171,20 @@ macro_rules! codes {
                         Self::DontStartAtZeroPlaceholder =>
                             panic!("ICE do not use placeholder error code"),
                         $(Self::$code => (code, $code_msg),)*
+                    }
+                }
+
+                // A code has an explanation iff `diagnostics/explanations/<Category>_<CodeName>.md`
+                // exists -- keyed by the category and code identifiers rather than the rendered
+                // code (e.g. "E04006") since the numeric portions are positional and would drift
+                // if a code were added mid-category.
+                fn explanation(&self) -> Option<&'static str> {
+                    match self {
+                        Self::DontStartAtZeroPlaceholder =>
+                            panic!("ICE do not use placeholder error code"),
+                        $(Self::$code => move_proc_macros::optional_include_str!(
+                            "src/diagnostics/explanations/", $cat, "_", $code, ".md"
+                        ),)*
                     }
                 }
             }
@@ -420,6 +440,7 @@ impl DiagnosticInfo {
             code,
             external_prefix,
             message,
+            explanation: _,
         } = self;
         let sev_prefix = match severity {
             Severity::BlockingError | Severity::NonblockingError => "E",
@@ -463,6 +484,17 @@ impl DiagnosticInfo {
 
     pub fn message(&self) -> &'static str {
         self.message
+    }
+
+    pub fn explanation(&self) -> Option<&'static str> {
+        self.explanation
+    }
+
+    /// Attach an explanation to a `custom` info. `const` so lint definitions can pair
+    /// `custom(...)` with an `optional_include_str!` explanation in a `const` context.
+    pub(crate) const fn with_explanation(mut self, explanation: Option<&'static str>) -> Self {
+        self.explanation = explanation;
+        self
     }
 
     pub fn is_external(&self) -> bool {

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_CombinableComparisons.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_CombinableComparisons.md
@@ -1,0 +1,22 @@
+Two comparisons over the same operand pair joined by `&&`/`||` often collapse to a single comparison
+(`x == y && x >= y` is just `x == y`), or to a constant `true`/`false` (`x >= y || x <= y`).
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+Negated comparisons are not handled and won't fire.
+
+## Example
+
+Flagged:
+
+```move
+let b = x == y && x >= y;
+```
+
+Suggested:
+
+```move
+let b = x == y;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_MeaninglessMath.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_MeaninglessMath.md
@@ -1,0 +1,19 @@
+An operation with an identity operand (`* 1`, `/ 1`, `+ 0`, `- 0`, `<< 0`, `>> 0`) does nothing; one
+with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x` is `1`. Only
+literal `0`/`1` operands are detected.
+
+This lint is off by default; enable it with `--lint`.
+
+## Example
+
+Flagged:
+
+```move
+let y = x * 1;
+```
+
+Suggested:
+
+```move
+let y = x;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_RedundantRefDeref.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_RedundantRefDeref.md
@@ -1,0 +1,23 @@
+Taking a reference and immediately dereferencing it (`&*(&x)`), or dereferencing a fresh field
+borrow (`*(&s.f)`), is a no-op the compiler already performs for you.
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+Dereferencing an existing reference (`*r`) is fine — only dereferencing a fresh borrow (`*(&x)` or
+`&*(&x)`) is redundant.
+
+## Example
+
+Flagged:
+
+```move
+let _ref = &*(&resource);
+```
+
+Suggested:
+
+```move
+let _ref = &resource;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_UnnecessaryConditional.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Complexity_UnnecessaryConditional.md
@@ -1,0 +1,19 @@
+An `if` with one branch `true` and the other `false` collapses to the condition itself (or its
+negation), and one whose branches are the same literal value collapses to that value. The
+conditional only adds noise.
+
+This lint is off by default; enable it with `--lint`.
+
+## Example
+
+Flagged:
+
+```move
+let b = if (!condition) true else false;
+```
+
+Suggested:
+
+```move
+let b = !condition;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_AbortWithoutConstant.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_AbortWithoutConstant.md
@@ -1,0 +1,25 @@
+A bare numeric abort code carries no meaning at the call site or in error output. A named constant
+documents the failure and keeps codes consistent across the module.
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+The whole argument must be a single named constant — `abort A + B` still fires. `assert!(cond,
+ECode)` is the idiomatic form.
+
+## Example
+
+Flagged:
+
+```move
+abort 100
+```
+
+Suggested:
+
+```move
+const ERR_INVALID_ARGUMENT: u64 = 1;
+// ...
+abort ERR_INVALID_ARGUMENT
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_ConstantNaming.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_ConstantNaming.md
@@ -1,0 +1,25 @@
+Constants are expected to be `UPPER_SNAKE_CASE` or PascalCase (either is accepted for any constant).
+A lowercase or mixed name (`max_supply`, `JSON_Max_Size`) reads like a variable and breaks module
+consistency.
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+PascalCase is deliberately allowed — including the `E`-prefixed PascalCase used for error constants,
+such as `ENotAuthorized`.
+
+## Example
+
+Flagged:
+
+```move
+const Another_BadName: u64 = 42;
+```
+
+Suggested:
+
+```move
+const MAX_LIMIT: u64 = 1000;
+const ENotAuthorized: u64 = 0;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_UnnecessaryUnit.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_UnnecessaryUnit.md
@@ -1,0 +1,18 @@
+A `()` unit expression as a non-final statement, or as a branch of an `if`, adds nothing. Remove it,
+or invert the condition to drop the empty branch.
+
+This lint is off by default; enable it with `--lint`.
+
+## Example
+
+Flagged:
+
+```move
+if (b) () else { x = 1 };
+```
+
+Suggested:
+
+```move
+if (!b) { x = 1 };
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_UnneededReturn.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_UnneededReturn.md
@@ -1,0 +1,28 @@
+In tail position the `return` keyword is redundant — the trailing expression is already the
+function's value.
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+Only a tail-position `return` is flagged — of any value-yielding expression (a call, `S { .. }`,
+arithmetic, a cast, `loop`, even `()`). A `return` used as an early exit, or whose operand doesn't
+yield a value (e.g. `return abort E`), is left alone.
+
+## Example
+
+Flagged:
+
+```move
+fun price(): u64 {
+    return 5
+}
+```
+
+Suggested:
+
+```move
+fun price(): u64 {
+    5
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_WhileTrueToLoop.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Style_WhileTrueToLoop.md
@@ -1,0 +1,22 @@
+`while (true)` is an infinite loop written the long way. `loop` states the intent directly and can
+`break` with a value. Only the literal `true` condition is detected.
+
+This lint is off by default; enable it with `--lint`.
+
+## Example
+
+Flagged:
+
+```move
+while (true) {
+    // ...
+}
+```
+
+Suggested:
+
+```move
+loop {
+    // ...
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_CoinField.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_CoinField.md
@@ -1,0 +1,30 @@
+`Coin<T>` is itself a full object (it has an `id: UID`) meant for transfers between accounts. Held
+as a field it adds needless object plumbing; `Balance<T>` is the storage-oriented type for keeping
+value inside another object.
+
+This lint is on by default.
+
+## When it's OK
+
+Keep `Coin` only if the field genuinely needs to be an independent object. An alias does not avoid
+the lint — the resolved type is what's matched.
+
+## Example
+
+Flagged:
+
+```move
+public struct S2 has key, store {
+    id: UID,
+    c: Coin<S1>,
+}
+```
+
+Suggested:
+
+```move
+public struct S2 has key, store {
+    id: UID,
+    c: Balance<S1>,
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_CollectionEquality.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_CollectionEquality.md
@@ -1,0 +1,25 @@
+Sui collections — `Bag`, `ObjectBag`, `Table`, `ObjectTable`, `LinkedTable`, `TableVec`, `VecMap`,
+and `VecSet` — have no meaningful `==`. The UID-backed ones (`Bag`, `Table`, …) compare by their
+internal handle, not contents; `VecMap`/`VecSet` compare their backing vector, so equal contents in
+a different insertion order compare unequal. Either way `==`/`!=` rarely means what it looks like.
+
+This lint is on by default.
+
+## Example
+
+Flagged:
+
+```move
+public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+    bag1 == bag2
+}
+```
+
+Suggested:
+
+```move
+// compare the state you care about, not the collection handle
+public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+    bag1.length() == bag2.length()
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_CustomStateChange.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_CustomStateChange.md
@@ -1,0 +1,30 @@
+A by-value struct defined in this module that has the `store` ability can already be transferred,
+shared, or frozen by anyone through the `public_*` API. Routing it through the private
+`transfer`/`share_object`/`freeze_object` therefore cannot enforce any custom policy — callers just
+bypass it.
+
+This lint is on by default.
+
+## When it's OK
+
+If the type keeps `store`, call the honest `public_*` variant. If the policy must actually hold,
+remove `store` so the private variant is the only path.
+
+## Example
+
+Flagged:
+
+```move
+// `S1` has `key` + `store`, so callers can already freeze it via `public_freeze_object`
+public fun custom_freeze(o: S1) {
+    transfer::freeze_object(o)
+}
+```
+
+Suggested:
+
+```move
+public fun custom_freeze(o: S1) {
+    transfer::public_freeze_object(o)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_FreezeWrapped.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_FreezeWrapped.md
@@ -1,0 +1,28 @@
+Freezing makes an object immutable forever. If the frozen object wraps another object — a field
+whose type has `key`, directly or transitively — that inner object is frozen and made unrecoverable
+too, which is almost never intended.
+
+This lint is on by default.
+
+## Example
+
+Flagged:
+
+```move
+public struct Inner has key, store { id: UID }
+public struct Wrapper has key, store { id: UID, inner: Inner }
+
+public fun freeze_wrapper(w: Wrapper) {
+    transfer::public_freeze_object(w)
+}
+```
+
+Suggested:
+
+```move
+public struct Config has key, store { id: UID, fee: u64 }
+
+public fun freeze_config(c: Config) {
+    transfer::public_freeze_object(c)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_FreezingCapability.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_FreezingCapability.md
@@ -1,0 +1,32 @@
+Capabilities gate privileged actions. Freezing one turns it into a permanent immutable object that
+anyone can reference and that can never be revoked — usually the opposite of the intended access
+control. The lint matches by struct name (a capitalized `Cap`).
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+The match is by name — a `Cap` at the end of the name, or followed by an uppercase letter, digit, or
+`_`. So a non-capability like `NoCap` is a false positive, while a real capability with an
+off-pattern name (`AdminRights`, `Capv0`) is missed.
+
+## Example
+
+Flagged:
+
+```move
+public struct AdminCap has key { id: UID }
+
+public fun freeze_cap(cap: AdminCap) {
+    transfer::public_freeze_object(cap)
+}
+```
+
+Suggested:
+
+```move
+// keep the capability owned instead of freezing it
+public fun keep_cap(cap: AdminCap, owner: address) {
+    transfer::transfer(cap, owner)
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_MissingKey.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_MissingKey.md
@@ -1,0 +1,22 @@
+A struct whose first field is `id: UID` looks like a Sui object, but without the `key` ability it
+can never be stored, transferred, or shared as one. This is almost always a forgotten `has key`.
+
+This lint is on by default.
+
+## Example
+
+Flagged:
+
+```move
+public struct MissingKeyAbility {
+    id: UID,
+}
+```
+
+Suggested:
+
+```move
+public struct HasKeyAbility has key {
+    id: UID,
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_PreferMutableTxContext.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_PreferMutableTxContext.md
@@ -1,0 +1,24 @@
+A public function that takes `&TxContext` cannot later create objects — which needs `&mut TxContext`
+— without a breaking signature change. Taking `&mut TxContext` up front keeps the API
+upgrade-compatible.
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+Only `public` functions are checked; any non-`public` visibility (private, `public(package)`,
+`public(friend)`) is exempt, since those signatures can change freely.
+
+## Example
+
+Flagged:
+
+```move
+public fun incorrect_mint(_ctx: &TxContext) {}
+```
+
+Suggested:
+
+```move
+public fun correct_mint(_ctx: &mut TxContext) {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_PublicRandom.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_PublicRandom.md
@@ -1,0 +1,25 @@
+A `public` function that takes `Random` or `RandomGenerator` can be called by other Move code,
+letting an attacker draw randomness and react to the outcome within the same transaction. Randomness
+should only be reachable from a transaction, not composed by another contract.
+
+This lint is on by default.
+
+## When it's OK
+
+Reduce the visibility below `public` — a non-public `entry` function, `public(package)`, or a
+private function — so it can't be composed by another contract. Adding `entry` to a function that
+stays `public` does not help.
+
+## Example
+
+Flagged:
+
+```move
+public fun not_allowed(_r: &Random) {}
+```
+
+Suggested:
+
+```move
+entry fun basic_random(_r: &Random) {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_SelfTransfer.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_SelfTransfer.md
@@ -1,0 +1,29 @@
+Transferring an object (one with `key` + `store`) to `ctx.sender()` inside the function makes it
+non-composable: a caller (or a programmable transaction block) cannot use the object because the
+function gives it away internally. Returning the object lets the caller decide what to do with it.
+
+This lint is on by default.
+
+## When it's OK
+
+Rare — the composable pattern is to return the object and let the caller place it. `entry` functions
+and `init` are already exempt.
+
+## Example
+
+Flagged:
+
+```move
+// `S1` has `key` + `store`
+public fun mint(ctx: &mut TxContext) {
+    transfer::public_transfer(S1 { id: object::new(ctx) }, ctx.sender())
+}
+```
+
+Suggested:
+
+```move
+public fun mint(ctx: &mut TxContext): S1 {
+    S1 { id: object::new(ctx) }
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_ShareOwned.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_ShareOwned.md
@@ -1,0 +1,32 @@
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an
+object that is not freshly created in this function (it arrives as a parameter or from an unpack)
+can silently hand every account write access to something a user believed was theirs. It fires only
+when the type is also transferable — it has `store`, or is transferred with `transfer::transfer`
+elsewhere; a `key`-only type that is never transferred is not flagged.
+
+This lint is on by default.
+
+## When it's OK
+
+The shared object really is fresh, but was produced through a helper call the local analysis can't
+see through — a conservative false positive.
+
+## Example
+
+Flagged:
+
+```move
+// `o` is a parameter — the checker can't prove it is fresh
+public fun share(o: Obj) {
+    transfer::public_share_object(o)
+}
+```
+
+Suggested:
+
+```move
+// packed here, so provably a fresh object
+public fun share(ctx: &mut TxContext) {
+    transfer::share_object(Obj { id: object::new(ctx) })
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_UncallableFunction.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_UncallableFunction.md
@@ -1,0 +1,24 @@
+The transaction runtime can only supply certain argument shapes. Taking `TxContext` by value, a
+`&mut TxContext` alongside any other `TxContext` parameter (it must be the only one), or a `&mut` to
+`Clock`/`Random` makes the function impossible to call from a transaction.
+
+This lint is on by default.
+
+## When it's OK
+
+A single `&mut TxContext` is fine. Use `&Clock` and `&Random` rather than `&mut`.
+
+## Example
+
+Flagged:
+
+```move
+// `Clock` must be passed by immutable reference
+fun uses_clock(_c: &mut Clock) {}
+```
+
+Suggested:
+
+```move
+fun uses_clock(_c: &Clock) {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_UnnecessaryPublicEntry.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_UnnecessaryPublicEntry.md
@@ -1,0 +1,19 @@
+`entry` on a `public` function is redundant: a `public` function is already callable from a
+programmable transaction block. `entry` is only meaningful on a non-`public` function, where it is
+what makes the function callable as a transaction command.
+
+This lint is on by default.
+
+## Example
+
+Flagged:
+
+```move
+public entry fun mint() {}
+```
+
+Suggested:
+
+```move
+public fun mint() {}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_UnusedObjWithFields.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Sui_UnusedObjWithFields.md
@@ -1,0 +1,28 @@
+A reference to an object that carries data beyond its `id`, but whose fields are never read, is a
+likely mistake: the function takes the object yet never looks at the values it holds.
+
+This lint is on by default.
+
+## When it's OK
+
+Objects with no field beyond `id` (pure marker capabilities), by-value params, and generic object
+types are out of scope. Otherwise the function should assert on or otherwise read a field — or drop
+the parameter if it truly isn't needed.
+
+## Example
+
+Flagged:
+
+```move
+public struct OwnerCap has key { id: UID, owns: address }
+
+public fun unused(_c: &OwnerCap) {}
+```
+
+Suggested:
+
+```move
+public fun owner(c: &OwnerCap): address {
+    c.owns
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_EqualOperands.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_EqualOperands.md
@@ -1,0 +1,19 @@
+A binary operation whose two operands are the same expression has an already-known result: `x == x`
+is always `true`, `x - x` is `0`, `x / x` is `1`, `x & x` is just `x`. The operation is dead weight
+and often a copy-paste bug where one side should differ.
+
+This lint is off by default; enable it with `--lint`.
+
+## Example
+
+Flagged:
+
+```move
+let b = x == x;
+```
+
+Suggested:
+
+```move
+let b = true;
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_LoopWithoutExit.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_LoopWithoutExit.md
@@ -1,0 +1,31 @@
+A `loop` whose body contains neither `break` nor `return` has no normal exit — it runs until it
+aborts, if ever. This is almost always a missing exit condition. (`while` is covered separately by
+`while_true`.)
+
+This lint is off by default; enable it with `--lint`.
+
+## When it's OK
+
+An `abort` inside the loop is not treated as an exit, so a deliberately divergent loop is a false
+positive.
+
+## Example
+
+Flagged:
+
+```move
+let i = 0;
+loop {
+    i = i + 1;
+}
+```
+
+Suggested:
+
+```move
+let i = 0;
+loop {
+    if (i >= 10) break;
+    i = i + 1;
+}
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_SelfAssignment.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_SelfAssignment.md
@@ -1,0 +1,18 @@
+Assigning a location to itself (`x = x`, `*r = *r`, `s.f = s.f`) has no effect. It usually signals a
+typo or an unfinished edit.
+
+This lint is off by default; enable it with `--lint`.
+
+## Example
+
+Flagged:
+
+```move
+p = p;
+```
+
+Suggested:
+
+```move
+// remove the redundant statement
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_UnusedReturnValue.md
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/explanations/Suspicious_UnusedReturnValue.md
@@ -1,0 +1,26 @@
+Discarding the result of a call that has no `&mut` arguments means the call did nothing observable.
+Either use the value or make the intent explicit with `let _ = ...`. In Sui mode `&mut TxContext` is
+treated as non-mutating, so such calls are still flagged.
+
+This lint is on by default in Sui mode; a plain `move` build needs `--lint`.
+
+## When it's OK
+
+Calls that take a `&mut` argument (a real side effect) are not flagged. Bind to `let _` to
+acknowledge an intentionally discarded value.
+
+## Example
+
+Flagged:
+
+```move
+fun price(x: u64): u64 { x + 1 }
+// ...
+price(10);
+```
+
+Suggested:
+
+```move
+let _ = price(10);
+```

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -112,6 +112,23 @@ pub struct Migration {
 // Diagnostic Reporting
 //**************************************************************************************************
 
+/// Command shown in the per-lint `run `<cmd> --explain <name>`` hint. Defaults to `move lint`; a
+/// driver that wraps the CLI under another name overrides it (the Sui CLI sets `sui move lint`).
+const DEFAULT_EXPLAIN_COMMAND: &str = "move lint";
+static EXPLAIN_COMMAND: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Override the command named in the `--explain` hint. Idempotent; the first call wins.
+pub fn set_explain_command(command: impl Into<String>) {
+    let _ = EXPLAIN_COMMAND.set(command.into());
+}
+
+fn explain_command() -> &'static str {
+    EXPLAIN_COMMAND
+        .get()
+        .map(String::as_str)
+        .unwrap_or(DEFAULT_EXPLAIN_COMMAND)
+}
+
 pub fn report_diagnostics(files: &MappedFiles, diags: Diagnostics) -> ! {
     let should_exit = true;
     report_diagnostics_impl(files, diags, should_exit);
@@ -284,6 +301,17 @@ fn render_diagnostic_text(
         mut notes,
     } = diag;
     let mut diag = csr::diagnostic::Diagnostic::new(info.severity().into_codespan_severity());
+    // Attach an `--explain` hint to every lint diagnostic that has a doc. `info.render()` below
+    // consumes `info`, so read its id first.
+    if info.external_prefix() == Some(crate::linters::LINT_WARNING_PREFIX)
+        && let Some(doc) = crate::linters::docs::lint_doc_by_id(info.category(), info.code())
+    {
+        notes.push(format!(
+            "run `{} --explain {}` for more information",
+            explain_command(),
+            doc.name
+        ));
+    }
     let (code, message) = info.render();
     diag = diag.with_code(code);
     diag = diag.with_message(message.to_string());

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -122,7 +122,10 @@ pub fn set_explain_command(command: impl Into<String>) {
     let _ = EXPLAIN_COMMAND.set(command.into());
 }
 
-fn explain_command() -> &'static str {
+/// The command a driver exposes for lints (`move lint` by default, or whatever a driver registered
+/// via [`set_explain_command`], e.g. `sui move lint`). Used to phrase `--explain`/`--list` hints
+/// consistently with how the tool is actually invoked.
+pub fn explain_command() -> &'static str {
     EXPLAIN_COMMAND
         .get()
         .map(String::as_str)

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -304,15 +304,14 @@ fn render_diagnostic_text(
         mut notes,
     } = diag;
     let mut diag = csr::diagnostic::Diagnostic::new(info.severity().into_codespan_severity());
-    // Attach an `--explain` hint to every lint diagnostic that has a doc. `info.render()` below
-    // consumes `info`, so read its id first.
+    // Attach an `--explain` hint to every lint diagnostic that has an explanation.
+    // `info.render()` below consumes `info`, so read its id first.
     if info.external_prefix() == Some(crate::linters::LINT_WARNING_PREFIX)
-        && let Some(doc) = crate::linters::docs::lint_doc_by_id(info.category(), info.code())
+        && let Some(name) = crate::linters::docs::explained_lint_name(info.category(), info.code())
     {
         notes.push(format!(
-            "run `{} --explain {}` for more information",
+            "run `{} --explain {name}` for more information",
             explain_command(),
-            doc.name
         ));
     }
     let (code, message) = info.render();

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -66,8 +66,12 @@ impl LintDoc {
 static DOCS_BY_NAME: LazyLock<BTreeMap<&'static str, &'static LintDoc>> =
     LazyLock::new(|| LINT_DOCS.iter().map(|d| (d.name, d)).collect());
 
-static DOCS_BY_ID: LazyLock<BTreeMap<(u8, u8), &'static LintDoc>> =
-    LazyLock::new(|| LINT_DOCS.iter().map(|d| ((d.category, d.code), d)).collect());
+static DOCS_BY_ID: LazyLock<BTreeMap<(u8, u8), &'static LintDoc>> = LazyLock::new(|| {
+    LINT_DOCS
+        .iter()
+        .map(|d| ((d.category, d.code), d))
+        .collect()
+});
 
 /// Look up a lint doc from raw `--explain <query>` user input: either a filter name
 /// (`share_owned`) or a rendered diagnostic code (`W99000`).
@@ -120,8 +124,8 @@ impl fmt::Display for LintDoc {
         writeln!(f, "{}", self.name)?;
         writeln!(f, "{}", "=".repeat(self.name.len()))?;
         writeln!(f)?;
-        let category = LinterDiagnosticCategory::try_from_u8(self.category)
-            .map_or("Unknown", |c| c.name());
+        let category =
+            LinterDiagnosticCategory::try_from_u8(self.category).map_or("Unknown", |c| c.name());
         writeln!(f, "category: {category}")?;
         writeln!(f, "origin:   {}", self.origin.label())?;
         writeln!(f, "level:    {level}")?;

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -1,0 +1,819 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Human-facing documentation for each lint, surfaced via `move lint --explain <CODE>` and
+//! referenced by a per-diagnostic hint. This module is the single source of truth for lint prose;
+//! the numeric `(category, code)` ids are only used to render the `Wxxyyy` code and to match
+//! emitted diagnostics so the hint can name the right lint.
+
+use std::fmt;
+
+/// Where a lint originates.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LintOrigin {
+    /// Generic Move linter (`move_compiler::linters`).
+    Core,
+    /// Sui-specific linter (`move_compiler::sui_mode::linters`).
+    Sui,
+}
+
+impl LintOrigin {
+    fn label(self) -> &'static str {
+        match self {
+            LintOrigin::Core => "Core",
+            LintOrigin::Sui => "Sui",
+        }
+    }
+}
+
+/// A worked bad/good pair illustrating a lint.
+pub struct LintExample {
+    /// A snippet that triggers the lint.
+    pub bad: &'static str,
+    /// The corrected snippet that does not.
+    pub good: &'static str,
+}
+
+/// Human-facing documentation for a single lint.
+pub struct LintDoc {
+    /// Filter name: the canonical `--explain` key and the `#[allow(lint(<name>))]` key.
+    pub name: &'static str,
+    /// Semantic group shown to users (e.g. "Security", "Complexity").
+    pub group: &'static str,
+    pub origin: LintOrigin,
+    /// `true` if the lint runs at the default level; `false` if it requires `--lint`.
+    pub default: bool,
+    /// Diagnostic category and code. Used to render the `Wxxyyy` code and to match emitted
+    /// diagnostics for the `--explain` hint. These follow the current (origin-based) numbering.
+    pub category: u8,
+    pub code: u8,
+    /// One-line description of what the lint flags (matches the diagnostic message).
+    pub summary: &'static str,
+    /// Why the flagged pattern matters.
+    pub rationale: &'static str,
+    /// When firing is acceptable, or how to knowingly opt out. `None` omits the section.
+    pub when_ok: Option<&'static str>,
+    pub example: LintExample,
+}
+
+impl LintDoc {
+    /// The rendered diagnostic code, e.g. `W99000`. Lints are always warnings, so the severity
+    /// prefix is always `W`.
+    pub fn rendered_code(&self) -> String {
+        format!("W{:02}{:03}", self.category, self.code)
+    }
+}
+
+/// Look up a lint doc by its filter name (`share_owned`) or by its rendered code, accepting
+/// `W99000`, `w99000`, `99000`, or a `Lint `-prefixed form.
+pub fn find_lint_doc(query: &str) -> Option<&'static LintDoc> {
+    let q = query.trim();
+    if let Some(doc) = LINT_DOCS.iter().find(|d| d.name == q) {
+        return Some(doc);
+    }
+    let norm = q
+        .strip_prefix("Lint ")
+        .unwrap_or(q)
+        .trim()
+        .trim_start_matches(['W', 'w']);
+    LINT_DOCS
+        .iter()
+        .find(|d| d.rendered_code().trim_start_matches('W') == norm)
+}
+
+/// Look up a lint doc by its diagnostic `(category, code)`. Used to attach the `--explain` hint to
+/// emitted lint diagnostics.
+pub fn lint_doc_by_id(category: u8, code: u8) -> Option<&'static LintDoc> {
+    LINT_DOCS
+        .iter()
+        .find(|d| d.category == category && d.code == code)
+}
+
+fn indent(s: &str, pad: &str) -> String {
+    s.lines()
+        .map(|l| {
+            if l.is_empty() {
+                String::new()
+            } else {
+                format!("{pad}{l}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The `--explain <name>` output for a single lint.
+impl fmt::Display for LintDoc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let level = if self.default {
+            "on by default"
+        } else {
+            "requires `--lint`"
+        };
+        writeln!(f, "{}", self.name)?;
+        writeln!(f, "{}", "=".repeat(self.name.len()))?;
+        writeln!(f)?;
+        writeln!(f, "group:   {}", self.group)?;
+        writeln!(f, "origin:  {}", self.origin.label())?;
+        writeln!(f, "level:   {level}")?;
+        writeln!(f, "code:    {}", self.rendered_code())?;
+        writeln!(f)?;
+        writeln!(f, "{}", self.summary)?;
+        writeln!(f)?;
+        writeln!(f, "{}", self.rationale)?;
+        if let Some(when_ok) = self.when_ok {
+            writeln!(f)?;
+            writeln!(f, "When it's OK:")?;
+            writeln!(f, "{}", indent(when_ok, "  "))?;
+        }
+        writeln!(f)?;
+        writeln!(f, "Example:")?;
+        writeln!(f)?;
+        writeln!(f, "  // flagged")?;
+        writeln!(f, "{}", indent(self.example.bad, "  "))?;
+        writeln!(f)?;
+        writeln!(f, "  // suggested")?;
+        writeln!(f, "{}", indent(self.example.good, "  "))?;
+        writeln!(f)?;
+        writeln!(
+            f,
+            "Suppress a specific case with `#[allow(lint({}))]`.",
+            self.name
+        )
+    }
+}
+
+/// The catalog listing printed by `move lint --list`.
+pub struct LintIndex;
+
+impl fmt::Display for LintIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Move lint index. Run `move lint --explain <name>` for details on any lint.\n"
+        )?;
+        let width = LINT_DOCS.iter().map(|d| d.name.len()).max().unwrap_or(0);
+        // Stable, curated group order.
+        const GROUPS: &[&str] = &[
+            "Security",
+            "Correctness",
+            "Suspicious",
+            "Conventions",
+            "Complexity",
+            "Style",
+        ];
+        for group in GROUPS {
+            let mut any = false;
+            for doc in LINT_DOCS.iter().filter(|d| &d.group == group) {
+                if !any {
+                    writeln!(f, "{group}")?;
+                    any = true;
+                }
+                writeln!(f, "    {:width$}  {}", doc.name, doc.summary, width = width)?;
+            }
+            if any {
+                writeln!(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+//**************************************************************************************************
+// Registry
+//**************************************************************************************************
+
+// Ordered by group for readability; `render_index` re-groups explicitly. The `category`/`code`
+// pairs follow the current (origin-based) numbering used to render `Wxxyyy` and match diagnostics.
+pub const LINT_DOCS: &[LintDoc] = &[
+    // -- Security ---------------------------------------------------------------------------------
+    LintDoc {
+        name: "share_owned",
+        group: "Security",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 0,
+        summary: "possible owned object share",
+        rationale: "\
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an \
+object that is not freshly created in this function (it arrives as a parameter or from an unpack) \
+can silently hand every account write access to something a user believed was theirs. It fires only \
+when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` \
+elsewhere; a `key`-only type that is never transferred is not flagged.",
+        when_ok: Some(
+            "The shared object really is fresh, but was produced through a helper call the local \
+analysis can't see through — a conservative false positive.",
+        ),
+        example: LintExample {
+            bad: "// `o` is a parameter — the checker can't prove it is fresh\npublic fun share(o: Obj) {\n    transfer::public_share_object(o)\n}",
+            good: "// packed here, so provably a fresh object\npublic fun share(ctx: &mut TxContext) {\n    transfer::share_object(Obj { id: object::new(ctx) })\n}",
+        },
+    },
+    LintDoc {
+        name: "custom_state_change",
+        group: "Security",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 2,
+        summary: "potentially unenforceable custom transfer/share/freeze policy",
+        rationale: "\
+A by-value struct defined in this module that has the `store` ability can already be transferred, \
+shared, or frozen by anyone through the `public_*` API. Routing it through the private \
+`transfer`/`share_object`/`freeze_object` therefore cannot enforce any custom policy — callers just \
+bypass it.",
+        when_ok: Some(
+            "If the type keeps `store`, call the honest `public_*` variant. If the policy must \
+actually hold, remove `store` so the private variant is the only path.",
+        ),
+        example: LintExample {
+            bad: "// `S1` has `key` + `store`, so callers can already freeze it via `public_freeze_object`\npublic fun custom_freeze(o: S1) {\n    transfer::freeze_object(o)\n}",
+            good: "public fun custom_freeze(o: S1) {\n    transfer::public_freeze_object(o)\n}",
+        },
+    },
+    LintDoc {
+        name: "freeze_wrapped",
+        group: "Security",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 4,
+        summary: "attempting to freeze wrapped objects",
+        rationale: "\
+Freezing makes an object immutable forever. If the frozen object wraps another object — a field \
+whose type has `key`, directly or transitively — that inner object is frozen and made unrecoverable \
+too, which is almost never intended.",
+        when_ok: None,
+        example: LintExample {
+            bad: "public struct Inner has key, store { id: UID }\npublic struct Wrapper has key, store { id: UID, inner: Inner }\n\npublic fun freeze_wrapper(w: Wrapper) {\n    transfer::public_freeze_object(w)\n}",
+            good: "public struct Config has key, store { id: UID, fee: u64 }\n\npublic fun freeze_config(c: Config) {\n    transfer::public_freeze_object(c)\n}",
+        },
+    },
+    LintDoc {
+        name: "public_random",
+        group: "Security",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 6,
+        summary: "Risky use of 'sui::random'",
+        rationale: "\
+A `public` function that takes `Random` or `RandomGenerator` can be called by other Move code, \
+letting an attacker draw randomness and react to the outcome within the same transaction. Randomness \
+should only be reachable from a transaction, not composed by another contract.",
+        when_ok: Some(
+            "Reduce the visibility below `public` — a non-public `entry` function, `public(package)`, \
+or a private function — so it can't be composed by another contract. Adding `entry` to a function \
+that stays `public` does not help.",
+        ),
+        example: LintExample {
+            bad: "public fun not_allowed(_r: &Random) {}",
+            good: "entry fun basic_random(_r: &Random) {}",
+        },
+    },
+    LintDoc {
+        name: "freezing_capability",
+        group: "Security",
+        origin: LintOrigin::Sui,
+        default: false,
+        category: 99,
+        code: 8,
+        summary: "freezing potential capability",
+        rationale: "\
+Capabilities gate privileged actions. Freezing one turns it into a permanent immutable object that \
+anyone can reference and that can never be revoked — usually the opposite of the intended access \
+control. The lint matches by struct name (a capitalized `Cap`).",
+        when_ok: Some(
+            "The match is by name — a `Cap` at the end of the name, or followed by an uppercase \
+letter, digit, or `_`. So a non-capability like `NoCap` is a false positive, while a real \
+capability with an off-pattern name (`AdminRights`, `Capv0`) is missed.",
+        ),
+        example: LintExample {
+            bad: "public struct AdminCap has key { id: UID }\n\npublic fun freeze_cap(cap: AdminCap) {\n    transfer::public_freeze_object(cap)\n}",
+            good: "// keep the capability owned instead of freezing it\npublic fun keep_cap(cap: AdminCap, owner: address) {\n    transfer::transfer(cap, owner)\n}",
+        },
+    },
+    // -- Correctness ------------------------------------------------------------------------------
+    LintDoc {
+        name: "missing_key",
+        group: "Correctness",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 7,
+        summary: "struct with id but missing key ability",
+        rationale: "\
+A struct whose first field is `id: UID` looks like a Sui object, but without the `key` ability it \
+can never be stored, transferred, or shared as one. This is almost always a forgotten `has key`.",
+        when_ok: None,
+        example: LintExample {
+            bad: "public struct MissingKeyAbility {\n    id: UID,\n}",
+            good: "public struct HasKeyAbility has key {\n    id: UID,\n}",
+        },
+    },
+    // -- Suspicious -------------------------------------------------------------------------------
+    LintDoc {
+        name: "collection_equality",
+        group: "Suspicious",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 5,
+        summary: "possibly useless collections compare",
+        rationale: "\
+Sui collections — `Bag`, `ObjectBag`, `Table`, `ObjectTable`, `LinkedTable`, `TableVec`, `VecMap`, \
+and `VecSet` — have no meaningful `==`. The UID-backed ones (`Bag`, `Table`, …) compare by their \
+internal handle, not contents; `VecMap`/`VecSet` compare their backing vector, so equal contents in \
+a different insertion order compare unequal. Either way `==`/`!=` rarely means what it looks like.",
+        when_ok: None,
+        example: LintExample {
+            bad: "public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {\n    bag1 == bag2\n}",
+            good: "// compare the state you care about, not the collection handle\npublic fun bag_eq(bag1: &Bag, bag2: &Bag): bool {\n    bag1.length() == bag2.length()\n}",
+        },
+    },
+    LintDoc {
+        name: "uncallable_function",
+        group: "Suspicious",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 11,
+        summary: "it will not be possible to call this function",
+        rationale: "\
+The transaction runtime can only supply certain argument shapes. Taking `TxContext` by value, a \
+`&mut TxContext` alongside any other `TxContext` parameter (it must be the only one), or a `&mut` to \
+`Clock`/`Random` makes the function impossible to call from a transaction.",
+        when_ok: Some(
+            "A single `&mut TxContext` is fine. Use `&Clock` and `&Random` rather than `&mut`.",
+        ),
+        example: LintExample {
+            bad: "// `Clock` must be passed by immutable reference\nfun uses_clock(_c: &mut Clock) {}",
+            good: "fun uses_clock(_c: &Clock) {}",
+        },
+    },
+    LintDoc {
+        name: "unused_object_with_fields",
+        group: "Suspicious",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 12,
+        summary: "unused object with fields",
+        rationale: "\
+A reference to an object that carries data beyond its `id`, but whose fields are never read, is a \
+likely mistake: the function takes the object yet never looks at the values it holds.",
+        when_ok: Some(
+            "Objects with no field beyond `id` (pure marker capabilities), by-value params, and \
+generic object types are out of scope. Otherwise the function should assert on or otherwise read a \
+field — or drop the parameter if it truly isn't needed.",
+        ),
+        example: LintExample {
+            bad: "public struct OwnerCap has key { id: UID, owns: address }\n\npublic fun unused(_c: &OwnerCap) {}",
+            good: "public fun owner(c: &OwnerCap): address {\n    c.owns\n}",
+        },
+    },
+    LintDoc {
+        name: "loop_without_exit",
+        group: "Suspicious",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 2,
+        code: 6,
+        summary: "'loop' without 'break' or 'return'",
+        rationale: "\
+A `loop` whose body contains neither `break` nor `return` has no normal exit — it runs until it \
+aborts, if ever. This is almost always a missing exit condition. (`while` is covered separately by \
+`while_true`.)",
+        when_ok: Some(
+            "An `abort` inside the loop is not treated as an exit, so a deliberately divergent loop \
+is a false positive.",
+        ),
+        example: LintExample {
+            bad: "let i = 0;\nloop {\n    i = i + 1;\n}",
+            good: "let i = 0;\nloop {\n    if (i >= 10) break;\n    i = i + 1;\n}",
+        },
+    },
+    LintDoc {
+        name: "self_assignment",
+        group: "Suspicious",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 2,
+        code: 8,
+        summary: "assignment preserves the same value",
+        rationale: "\
+Assigning a location to itself (`x = x`, `*r = *r`, `s.f = s.f`) has no effect. It usually signals a \
+typo or an unfinished edit.",
+        when_ok: None,
+        example: LintExample {
+            bad: "p = p;",
+            good: "// remove the redundant statement",
+        },
+    },
+    LintDoc {
+        name: "always_equal_operands",
+        group: "Suspicious",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 2,
+        code: 11,
+        summary: "redundant, always-equal operands for binary operation",
+        rationale: "\
+A binary operation whose two operands are the same expression has an already-known result: `x == x` \
+is always `true`, `x - x` is `0`, `x / x` is `1`, `x & x` is just `x`. The operation is dead weight \
+and often a copy-paste bug where one side should differ.",
+        when_ok: None,
+        example: LintExample {
+            bad: "let b = x == x;",
+            good: "let b = true;",
+        },
+    },
+    LintDoc {
+        name: "unused_return_value",
+        group: "Suspicious",
+        origin: LintOrigin::Core,
+        default: true,
+        category: 2,
+        code: 13,
+        summary: "return value of a non-mutating call is discarded",
+        rationale: "\
+Discarding the result of a call that has no `&mut` arguments means the call did nothing observable. \
+Either use the value or make the intent explicit with `let _ = ...`. In Sui mode `&mut TxContext` is \
+treated as non-mutating, so such calls are still flagged.",
+        when_ok: Some(
+            "Calls that take a `&mut` argument (a real side effect) are not flagged. Bind to `let _` \
+to acknowledge an intentionally discarded value.",
+        ),
+        example: LintExample {
+            bad: "fun price(x: u64): u64 { x + 1 }\n// ...\nprice(10);",
+            good: "let _ = price(10);",
+        },
+    },
+    // -- Conventions ------------------------------------------------------------------------------
+    LintDoc {
+        name: "self_transfer",
+        group: "Conventions",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 1,
+        summary: "non-composable transfer to sender",
+        rationale: "\
+Transferring an object (one with `key` + `store`) to `ctx.sender()` inside the function makes it \
+non-composable: a caller (or a programmable transaction block) cannot use the object because the \
+function gives it away internally. Returning the object lets the caller decide what to do with it.",
+        when_ok: Some(
+            "Rare — the composable pattern is to return the object and let the caller place it. \
+`entry` functions and `init` are already exempt.",
+        ),
+        example: LintExample {
+            bad: "// `S1` has `key` + `store`\npublic fun mint(ctx: &mut TxContext) {\n    transfer::public_transfer(S1 { id: object::new(ctx) }, ctx.sender())\n}",
+            good: "public fun mint(ctx: &mut TxContext): S1 {\n    S1 { id: object::new(ctx) }\n}",
+        },
+    },
+    LintDoc {
+        name: "coin_field",
+        group: "Conventions",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 3,
+        summary: "sub-optimal 'sui::coin::Coin' field type",
+        rationale: "\
+`Coin<T>` is itself a full object (it has an `id: UID`) meant for transfers between accounts. Held \
+as a field it adds needless object plumbing; `Balance<T>` is the storage-oriented type for keeping \
+value inside another object.",
+        when_ok: Some(
+            "Keep `Coin` only if the field genuinely needs to be an independent object. An alias does \
+not avoid the lint — the resolved type is what's matched.",
+        ),
+        example: LintExample {
+            bad: "public struct S2 has key, store {\n    id: UID,\n    c: Coin<S1>,\n}",
+            good: "public struct S2 has key, store {\n    id: UID,\n    c: Balance<S1>,\n}",
+        },
+    },
+    LintDoc {
+        name: "public_entry",
+        group: "Conventions",
+        origin: LintOrigin::Sui,
+        default: true,
+        category: 99,
+        code: 10,
+        summary: "unnecessary `entry` on a `public` function",
+        rationale: "\
+`entry` on a `public` function is redundant: a `public` function is already callable from a \
+programmable transaction block. `entry` is only meaningful on a non-`public` function, where it is \
+what makes the function callable as a transaction command.",
+        when_ok: None,
+        example: LintExample {
+            bad: "public entry fun mint() {}",
+            good: "public fun mint() {}",
+        },
+    },
+    LintDoc {
+        name: "prefer_mut_tx_context",
+        group: "Conventions",
+        origin: LintOrigin::Sui,
+        default: false,
+        category: 99,
+        code: 9,
+        summary: "prefer '&mut TxContext' over '&TxContext'",
+        rationale: "\
+A public function that takes `&TxContext` cannot later create objects — which needs \
+`&mut TxContext` — without a breaking signature change. Taking `&mut TxContext` up front keeps the \
+API upgrade-compatible.",
+        when_ok: Some(
+            "Only `public` functions are checked; any non-`public` visibility (private, \
+`public(package)`, `public(friend)`) is exempt, since those signatures can change freely.",
+        ),
+        example: LintExample {
+            bad: "public fun incorrect_mint(_ctx: &TxContext) {}",
+            good: "public fun correct_mint(_ctx: &mut TxContext) {}",
+        },
+    },
+    LintDoc {
+        name: "constant_naming",
+        group: "Conventions",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 4,
+        code: 1,
+        summary: "constant should follow naming convention",
+        rationale: "\
+Constants are expected to be `UPPER_SNAKE_CASE` or PascalCase (either is accepted for any constant). \
+A lowercase or mixed name (`max_supply`, `JSON_Max_Size`) reads like a variable and breaks module \
+consistency.",
+        when_ok: Some(
+            "PascalCase is deliberately allowed — including the `E`-prefixed PascalCase used for \
+error constants, such as `ENotAuthorized`.",
+        ),
+        example: LintExample {
+            bad: "const Another_BadName: u64 = 42;",
+            good: "const MAX_LIMIT: u64 = 1000;\nconst ENotAuthorized: u64 = 0;",
+        },
+    },
+    LintDoc {
+        name: "abort_without_constant",
+        group: "Conventions",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 4,
+        code: 5,
+        summary: "'abort' or 'assert' without named constant",
+        rationale: "\
+A bare numeric abort code carries no meaning at the call site or in error output. A named constant \
+documents the failure and keeps codes consistent across the module.",
+        when_ok: Some(
+            "The whole argument must be a single named constant — `abort A + B` still fires. \
+`assert!(cond, ECode)` is the idiomatic form.",
+        ),
+        example: LintExample {
+            bad: "abort 100",
+            good: "const ERR_INVALID_ARGUMENT: u64 = 1;\n// ...\nabort ERR_INVALID_ARGUMENT",
+        },
+    },
+    // -- Complexity -------------------------------------------------------------------------------
+    LintDoc {
+        name: "unnecessary_math",
+        group: "Complexity",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 1,
+        code: 3,
+        summary: "math operator can be simplified",
+        rationale: "\
+An operation with an identity operand (`* 1`, `/ 1`, `+ 0`, `- 0`, `<< 0`, `>> 0`) does nothing; one \
+with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x` is `1`. Only literal \
+`0`/`1` operands are detected.",
+        when_ok: None,
+        example: LintExample {
+            bad: "let y = x * 1;",
+            good: "let y = x;",
+        },
+    },
+    LintDoc {
+        name: "unnecessary_conditional",
+        group: "Complexity",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 1,
+        code: 7,
+        summary: "'if' expression can be removed",
+        rationale: "\
+An `if` with one branch `true` and the other `false` collapses to the condition itself (or its \
+negation), and one whose branches are the same literal value collapses to that value. The \
+conditional only adds noise.",
+        when_ok: None,
+        example: LintExample {
+            bad: "let b = if (!condition) true else false;",
+            good: "let b = !condition;",
+        },
+    },
+    LintDoc {
+        name: "redundant_ref_deref",
+        group: "Complexity",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 1,
+        code: 9,
+        summary: "redundant reference/dereference",
+        rationale: "\
+Taking a reference and immediately dereferencing it (`&*(&x)`), or dereferencing a fresh field \
+borrow (`*(&s.f)`), is a no-op the compiler already performs for you.",
+        when_ok: Some(
+            "Dereferencing an existing reference (`*r`) is fine — only dereferencing a fresh borrow \
+(`*(&x)` or `&*(&x)`) is redundant.",
+        ),
+        example: LintExample {
+            bad: "let _ref = &*(&resource);",
+            good: "let _ref = &resource;",
+        },
+    },
+    LintDoc {
+        name: "combinable_comparisons",
+        group: "Complexity",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 1,
+        code: 12,
+        summary: "comparison operations condition can be simplified",
+        rationale: "\
+Two comparisons over the same operand pair joined by `&&`/`||` often collapse to a single comparison \
+(`x == y && x >= y` is just `x == y`), or to a constant `true`/`false` (`x >= y || x <= y`).",
+        when_ok: Some("Negated comparisons are not handled and won't fire."),
+        example: LintExample {
+            bad: "let b = x == y && x >= y;",
+            good: "let b = x == y;",
+        },
+    },
+    // -- Style ------------------------------------------------------------------------------------
+    LintDoc {
+        name: "while_true",
+        group: "Style",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 4,
+        code: 2,
+        summary: "unnecessary 'while (true)', replace with 'loop'",
+        rationale: "\
+`while (true)` is an infinite loop written the long way. `loop` states the intent directly and can \
+`break` with a value. Only the literal `true` condition is detected.",
+        when_ok: None,
+        example: LintExample {
+            bad: "while (true) {\n    // ...\n}",
+            good: "loop {\n    // ...\n}",
+        },
+    },
+    LintDoc {
+        name: "unneeded_return",
+        group: "Style",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 4,
+        code: 4,
+        summary: "unneeded return",
+        rationale: "\
+In tail position the `return` keyword is redundant — the trailing expression is already the \
+function's value.",
+        when_ok: Some(
+            "Only a tail-position `return` is flagged — of any value-yielding expression (a call, \
+`S { .. }`, arithmetic, a cast, `loop`, even `()`). A `return` used as an early exit, or whose \
+operand doesn't yield a value (e.g. `return abort E`), is left alone.",
+        ),
+        example: LintExample {
+            bad: "fun price(): u64 {\n    return 5\n}",
+            good: "fun price(): u64 {\n    5\n}",
+        },
+    },
+    LintDoc {
+        name: "unnecessary_unit",
+        group: "Style",
+        origin: LintOrigin::Core,
+        default: false,
+        category: 4,
+        code: 10,
+        summary: "unit `()` expression can be removed or simplified",
+        rationale: "\
+A `()` unit expression as a non-final statement, or as a branch of an `if`, adds nothing. Remove it, \
+or invert the condition to drop the empty branch.",
+        when_ok: None,
+        example: LintExample {
+            bad: "if (b) () else { x = 1 };",
+            good: "if (!b) { x = 1 };",
+        },
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    // Route `--explain` snapshots into their own folder so they don't mix with the `.move`/`.snap`
+    // linter fixtures under `tests/`.
+    fn explain_settings() -> insta::Settings {
+        let mut settings = insta::Settings::clone_current();
+        settings.set_snapshot_path("snapshots/explain");
+        settings.set_prepend_module_to_snapshot(false);
+        settings
+    }
+
+    #[test]
+    fn explain_output_per_lint() {
+        explain_settings().bind(|| {
+            for doc in LINT_DOCS {
+                insta::assert_snapshot!(doc.name, doc.to_string());
+            }
+        });
+    }
+
+    #[test]
+    fn explain_index() {
+        explain_settings().bind(|| {
+            insta::assert_snapshot!("_index", LintIndex.to_string());
+        });
+    }
+
+    #[test]
+    fn ids_and_names_are_unique() {
+        let mut names = HashSet::new();
+        let mut ids = HashSet::new();
+        for doc in LINT_DOCS {
+            assert!(names.insert(doc.name), "duplicate lint name {}", doc.name);
+            assert!(
+                ids.insert((doc.category, doc.code)),
+                "duplicate lint id for {}",
+                doc.name
+            );
+        }
+    }
+
+    #[test]
+    fn every_registered_lint_has_a_doc() {
+        use crate::diagnostics::filter::FILTER_ALL;
+        let documented: HashSet<&str> = LINT_DOCS.iter().map(|d| d.name).collect();
+        let mut registered: HashSet<String> = HashSet::new();
+        for (_prefix, filters) in [
+            crate::linters::known_filters(),
+            crate::sui_mode::linters::known_filters(),
+        ] {
+            for (name, _ids) in filters {
+                if name.as_str() != FILTER_ALL {
+                    registered.insert(name.to_string());
+                }
+            }
+        }
+        let missing: Vec<_> = registered
+            .iter()
+            .filter(|n| !documented.contains(n.as_str()))
+            .collect();
+        assert!(missing.is_empty(), "lints missing an --explain doc: {missing:?}");
+        // Every doc must correspond to a real registered lint (no stale entries).
+        let extra: Vec<_> = documented
+            .iter()
+            .filter(|n| !registered.contains(**n))
+            .collect();
+        assert!(extra.is_empty(), "docs for unregistered lints: {extra:?}");
+    }
+
+    #[test]
+    fn explain_hint_injected_when_command_set() {
+        use crate::diagnostics::codes::{Severity, custom};
+        use crate::diagnostics::{
+            Diagnostic, Diagnostics, report_diagnostics_to_buffer, set_explain_command,
+        };
+        use crate::linters::LINT_WARNING_PREFIX;
+        use crate::shared::files::MappedFiles;
+        use move_ir_types::location::Loc;
+
+        // Runs in its own process under nextest, so the process-global command name is isolated.
+        set_explain_command("test move lint");
+        let info = custom(LINT_WARNING_PREFIX, Severity::Warning, 99, 0, "possible owned object share");
+        let diag = Diagnostic::new(
+            info,
+            (Loc::invalid(), "here"),
+            Vec::<(Loc, String)>::new(),
+            Vec::<String>::new(),
+        );
+        let mut diags = Diagnostics::new();
+        diags.add(diag);
+        let rendered =
+            String::from_utf8(report_diagnostics_to_buffer(&MappedFiles::empty(), diags, false))
+                .unwrap();
+        assert!(
+            rendered.contains("test move lint --explain share_owned"),
+            "expected `--explain` hint in output:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn find_by_name_and_code() {
+        let doc = find_lint_doc("share_owned").expect("by name");
+        assert_eq!(doc.name, "share_owned");
+        assert_eq!(find_lint_doc("W99000").unwrap().name, "share_owned");
+        assert_eq!(find_lint_doc("Lint W99000").unwrap().name, "share_owned");
+        assert_eq!(find_lint_doc("99000").unwrap().name, "share_owned");
+        assert!(find_lint_doc("nonsense").is_none());
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -85,10 +85,12 @@ pub fn find_lint_doc(query: &str) -> Option<&'static LintDoc> {
 }
 
 /// Parse a rendered `Wxxyyy` code back into its `(category, code)` id. Accepts the forms a user is
-/// likely to paste from diagnostic output: `W99000`, `w99000`, bare `99000`, or `Lint W99000`.
+/// likely to paste from diagnostic output: `W99000`, `w99000`, bare `99000`, or `Lint W99000` —
+/// and the `E`-prefixed equivalents, since `#[deny(lint(...))]` and `--warnings-are-errors`
+/// escalate lints to `error[Lint Exxyyy]`.
 fn parse_rendered_code(s: &str) -> Option<(u8, u8)> {
     let s = s.strip_prefix("Lint ").unwrap_or(s).trim();
-    let digits = s.strip_prefix(['W', 'w']).unwrap_or(s);
+    let digits = s.strip_prefix(['W', 'w', 'E', 'e']).unwrap_or(s);
     if digits.len() != 5 || !digits.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
@@ -427,6 +429,8 @@ and often a copy-paste bug where one side should differ.",
     LintDoc {
         name: "unused_return_value",
         origin: LintOrigin::Move,
+        // Only the Sui-mode visitor set runs this by default (vanilla `move` needs `--lint`), but
+        // in practice every consumer of these docs is Sui-flavored, so claim the Sui default.
         default: true,
         category: 2,
         code: 13,
@@ -846,6 +850,9 @@ mod tests {
         assert_eq!(find_lint_doc("W99000").unwrap().name, "share_owned");
         assert_eq!(find_lint_doc("Lint W99000").unwrap().name, "share_owned");
         assert_eq!(find_lint_doc("99000").unwrap().name, "share_owned");
+        // Escalated rendering (`#[deny(lint(...))]`, `--warnings-are-errors`) prints an `E` code.
+        assert_eq!(find_lint_doc("E99000").unwrap().name, "share_owned");
+        assert_eq!(find_lint_doc("Lint E99000").unwrap().name, "share_owned");
         assert!(find_lint_doc("nonsense").is_none());
     }
 }

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -7,29 +7,13 @@
 //! emitted diagnostics so the hint can name the right lint.
 
 use crate::linters::LinterDiagnosticCategory;
-use std::fmt;
-
-/// The category name for a diagnostic `category` byte, exactly as defined by
-/// [`LinterDiagnosticCategory`]. Referencing the enum discriminants keeps this in lockstep with the
-/// linter — the docs never invent categories of their own.
-fn category_label(category: u8) -> &'static str {
-    use LinterDiagnosticCategory::*;
-    match category {
-        c if c == Correctness as u8 => "Correctness",
-        c if c == Complexity as u8 => "Complexity",
-        c if c == Suspicious as u8 => "Suspicious",
-        c if c == Deprecated as u8 => "Deprecated",
-        c if c == Style as u8 => "Style",
-        c if c == Sui as u8 => "Sui",
-        _ => "Unknown",
-    }
-}
+use std::{collections::BTreeMap, fmt, sync::LazyLock};
 
 /// Where a lint originates.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LintOrigin {
     /// Generic Move linter (`move_compiler::linters`).
-    Core,
+    Move,
     /// Sui-specific linter (`move_compiler::sui_mode::linters`).
     Sui,
 }
@@ -37,7 +21,7 @@ pub enum LintOrigin {
 impl LintOrigin {
     fn label(self) -> &'static str {
         match self {
-            LintOrigin::Core => "Core",
+            LintOrigin::Move => "Move",
             LintOrigin::Sui => "Sui",
         }
     }
@@ -79,42 +63,50 @@ impl LintDoc {
     }
 }
 
-/// Look up a lint doc by its filter name (`share_owned`) or by its rendered code, accepting
-/// `W99000`, `w99000`, `99000`, or a `Lint `-prefixed form.
+static DOCS_BY_NAME: LazyLock<BTreeMap<&'static str, &'static LintDoc>> =
+    LazyLock::new(|| LINT_DOCS.iter().map(|d| (d.name, d)).collect());
+
+static DOCS_BY_ID: LazyLock<BTreeMap<(u8, u8), &'static LintDoc>> =
+    LazyLock::new(|| LINT_DOCS.iter().map(|d| ((d.category, d.code), d)).collect());
+
+/// Look up a lint doc from raw `--explain <query>` user input: either a filter name
+/// (`share_owned`) or a rendered diagnostic code (`W99000`).
 pub fn find_lint_doc(query: &str) -> Option<&'static LintDoc> {
     let q = query.trim();
-    if let Some(doc) = LINT_DOCS.iter().find(|d| d.name == q) {
+    if let Some(doc) = DOCS_BY_NAME.get(q) {
         return Some(doc);
     }
-    let norm = q
-        .strip_prefix("Lint ")
-        .unwrap_or(q)
-        .trim()
-        .trim_start_matches(['W', 'w']);
-    LINT_DOCS
-        .iter()
-        .find(|d| d.rendered_code().trim_start_matches('W') == norm)
+    let (category, code) = parse_rendered_code(q)?;
+    lint_doc_by_id(category, code)
+}
+
+/// Parse a rendered `Wxxyyy` code back into its `(category, code)` id. Accepts the forms a user is
+/// likely to paste from diagnostic output: `W99000`, `w99000`, bare `99000`, or `Lint W99000`.
+fn parse_rendered_code(s: &str) -> Option<(u8, u8)> {
+    let s = s.strip_prefix("Lint ").unwrap_or(s).trim();
+    let digits = s.strip_prefix(['W', 'w']).unwrap_or(s);
+    if digits.len() != 5 || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some((digits[..2].parse().ok()?, digits[2..].parse().ok()?))
 }
 
 /// Look up a lint doc by its diagnostic `(category, code)`. Used to attach the `--explain` hint to
 /// emitted lint diagnostics.
 pub fn lint_doc_by_id(category: u8, code: u8) -> Option<&'static LintDoc> {
-    LINT_DOCS
-        .iter()
-        .find(|d| d.category == category && d.code == code)
+    DOCS_BY_ID.get(&(category, code)).copied()
 }
 
-fn indent(s: &str, pad: &str) -> String {
-    s.lines()
-        .map(|l| {
-            if l.is_empty() {
-                String::new()
-            } else {
-                format!("{pad}{l}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+/// Write `s` indented by two spaces, preserving blank lines, with a trailing newline.
+fn write_indented(f: &mut fmt::Formatter<'_>, s: &str) -> fmt::Result {
+    for line in s.lines() {
+        if line.is_empty() {
+            writeln!(f)?;
+        } else {
+            writeln!(f, "  {line}")?;
+        }
+    }
+    Ok(())
 }
 
 /// The `--explain <name>` output for a single lint.
@@ -128,7 +120,9 @@ impl fmt::Display for LintDoc {
         writeln!(f, "{}", self.name)?;
         writeln!(f, "{}", "=".repeat(self.name.len()))?;
         writeln!(f)?;
-        writeln!(f, "category: {}", category_label(self.category))?;
+        let category = LinterDiagnosticCategory::try_from_u8(self.category)
+            .map_or("Unknown", |c| c.name());
+        writeln!(f, "category: {category}")?;
         writeln!(f, "origin:   {}", self.origin.label())?;
         writeln!(f, "level:    {level}")?;
         writeln!(f, "code:     {}", self.rendered_code())?;
@@ -139,16 +133,16 @@ impl fmt::Display for LintDoc {
         if let Some(when_ok) = self.when_ok {
             writeln!(f)?;
             writeln!(f, "When it's OK:")?;
-            writeln!(f, "{}", indent(when_ok, "  "))?;
+            write_indented(f, when_ok)?;
         }
         writeln!(f)?;
         writeln!(f, "Example:")?;
         writeln!(f)?;
         writeln!(f, "  // flagged")?;
-        writeln!(f, "{}", indent(self.example.bad, "  "))?;
+        write_indented(f, self.example.bad)?;
         writeln!(f)?;
         writeln!(f, "  // suggested")?;
-        writeln!(f, "{}", indent(self.example.good, "  "))?;
+        write_indented(f, self.example.good)?;
         writeln!(f)?;
         writeln!(
             f,
@@ -173,22 +167,11 @@ impl fmt::Display for LintIndex<'_> {
         )?;
         let width = LINT_DOCS.iter().map(|d| d.name.len()).max().unwrap_or(0);
         // Categories in `LinterDiagnosticCategory` order; empty ones are skipped.
-        const CATEGORIES: &[&str] = &[
-            "Correctness",
-            "Complexity",
-            "Suspicious",
-            "Deprecated",
-            "Style",
-            "Sui",
-        ];
-        for category in CATEGORIES {
+        for category in LinterDiagnosticCategory::ALL {
             let mut any = false;
-            for doc in LINT_DOCS
-                .iter()
-                .filter(|d| &category_label(d.category) == category)
-            {
+            for doc in LINT_DOCS.iter().filter(|d| d.category == *category as u8) {
                 if !any {
-                    writeln!(f, "{category}")?;
+                    writeln!(f, "{}", category.name())?;
                     any = true;
                 }
                 writeln!(f, "    {:width$}  {}", doc.name, doc.summary, width = width)?;
@@ -205,7 +188,7 @@ impl fmt::Display for LintIndex<'_> {
 // Registry
 //**************************************************************************************************
 
-// A flat registry; `render_index` groups by category. The `(category, code)` pairs are the lints'
+// A flat registry; `LintIndex` groups by category. The `(category, code)` pairs are the lints'
 // actual diagnostic ids (see `LinterDiagnosticCategory`), used to render `Wxxyyy` and match
 // emitted diagnostics.
 pub const LINT_DOCS: &[LintDoc] = &[
@@ -386,7 +369,7 @@ field — or drop the parameter if it truly isn't needed.",
     },
     LintDoc {
         name: "loop_without_exit",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 2,
         code: 6,
@@ -406,7 +389,7 @@ is a false positive.",
     },
     LintDoc {
         name: "self_assignment",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 2,
         code: 8,
@@ -422,7 +405,7 @@ typo or an unfinished edit.",
     },
     LintDoc {
         name: "always_equal_operands",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 2,
         code: 11,
@@ -439,7 +422,7 @@ and often a copy-paste bug where one side should differ.",
     },
     LintDoc {
         name: "unused_return_value",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: true,
         category: 2,
         code: 13,
@@ -536,7 +519,7 @@ API upgrade-compatible.",
     },
     LintDoc {
         name: "constant_naming",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 4,
         code: 1,
@@ -556,7 +539,7 @@ error constants, such as `ENotAuthorized`.",
     },
     LintDoc {
         name: "abort_without_constant",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 4,
         code: 5,
@@ -575,7 +558,7 @@ documents the failure and keeps codes consistent across the module.",
     },
     LintDoc {
         name: "unnecessary_math",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 1,
         code: 3,
@@ -592,7 +575,7 @@ with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x`
     },
     LintDoc {
         name: "unnecessary_conditional",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 1,
         code: 7,
@@ -609,7 +592,7 @@ conditional only adds noise.",
     },
     LintDoc {
         name: "redundant_ref_deref",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 1,
         code: 9,
@@ -628,7 +611,7 @@ borrow (`*(&s.f)`), is a no-op the compiler already performs for you.",
     },
     LintDoc {
         name: "combinable_comparisons",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 1,
         code: 12,
@@ -644,7 +627,7 @@ Two comparisons over the same operand pair joined by `&&`/`||` often collapse to
     },
     LintDoc {
         name: "while_true",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 4,
         code: 2,
@@ -660,7 +643,7 @@ Two comparisons over the same operand pair joined by `&&`/`||` often collapse to
     },
     LintDoc {
         name: "unneeded_return",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 4,
         code: 4,
@@ -680,7 +663,7 @@ operand doesn't yield a value (e.g. `return abort E`), is left alone.",
     },
     LintDoc {
         name: "unnecessary_unit",
-        origin: LintOrigin::Core,
+        origin: LintOrigin::Move,
         default: false,
         category: 4,
         code: 10,

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -158,14 +158,18 @@ impl fmt::Display for LintDoc {
     }
 }
 
-/// The catalog listing printed by `move lint --list`.
-pub struct LintIndex;
+/// The catalog listing printed by `<command> --list`. `command` is the tool name referenced in the
+/// header (e.g. `move lint` or `sui move lint`), so it matches how the tool was actually invoked.
+pub struct LintIndex<'a> {
+    pub command: &'a str,
+}
 
-impl fmt::Display for LintIndex {
+impl fmt::Display for LintIndex<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "Move lint index. Run `move lint --explain <name>` for details on any lint.\n"
+            "Move lint index. Run `{} --explain <name>` for details on any lint.\n",
+            self.command
         )?;
         let width = LINT_DOCS.iter().map(|d| d.name.len()).max().unwrap_or(0);
         // Categories in `LinterDiagnosticCategory` order; empty ones are skipped.
@@ -718,7 +722,13 @@ mod tests {
     #[test]
     fn explain_index() {
         explain_settings().bind(|| {
-            insta::assert_snapshot!("index", LintIndex.to_string());
+            insta::assert_snapshot!(
+                "index",
+                LintIndex {
+                    command: "move lint"
+                }
+                .to_string()
+            );
         });
     }
 
@@ -755,7 +765,10 @@ mod tests {
             .iter()
             .filter(|n| !documented.contains(n.as_str()))
             .collect();
-        assert!(missing.is_empty(), "lints missing an --explain doc: {missing:?}");
+        assert!(
+            missing.is_empty(),
+            "lints missing an --explain doc: {missing:?}"
+        );
         // Every doc must correspond to a real registered lint (no stale entries).
         let extra: Vec<_> = documented
             .iter()
@@ -812,7 +825,13 @@ mod tests {
 
         // Runs in its own process under nextest, so the process-global command name is isolated.
         set_explain_command("test move lint");
-        let info = custom(LINT_WARNING_PREFIX, Severity::Warning, 99, 0, "possible owned object share");
+        let info = custom(
+            LINT_WARNING_PREFIX,
+            Severity::Warning,
+            99,
+            0,
+            "possible owned object share",
+        );
         let diag = Diagnostic::new(
             info,
             (Loc::invalid(), "here"),
@@ -821,9 +840,12 @@ mod tests {
         );
         let mut diags = Diagnostics::new();
         diags.add(diag);
-        let rendered =
-            String::from_utf8(report_diagnostics_to_buffer(&MappedFiles::empty(), diags, false))
-                .unwrap();
+        let rendered = String::from_utf8(report_diagnostics_to_buffer(
+            &MappedFiles::empty(),
+            diags,
+            false,
+        ))
+        .unwrap();
         assert!(
             rendered.contains("test move lint --explain share_owned"),
             "expected `--explain` hint in output:\n{rendered}"

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -1,87 +1,60 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Human-facing documentation for each lint, surfaced via `move lint --explain <CODE>` and
-//! referenced by a per-diagnostic hint. This module is the single source of truth for lint prose;
-//! the numeric `(category, code)` ids are only used to render the `Wxxyyy` code and to match
-//! emitted diagnostics so the hint can name the right lint.
+//! Lookups and rendering for `move lint --explain <CODE>` and `--list`. The per-lint prose lives
+//! in `diagnostics/explanations/<Category>_<CodeName>.md` files, attached to each lint's
+//! [`DiagnosticInfo`] at compile time (see the `lints!`/`sui_lints!` macros); this module only
+//! resolves user queries against the lint tables and wraps the file contents with the few lines
+//! that would drift if hand-written -- the positional `Wxxyyy` code and the suppression
+//! attribute.
 
-use crate::linters::LinterDiagnosticCategory;
+use crate::{
+    diagnostics::codes::DiagnosticInfo,
+    linters::{LinterDiagnosticCategory, MOVE_LINTS},
+    sui_mode::linters::SUI_LINTS,
+};
 use std::{collections::BTreeMap, fmt, sync::LazyLock};
 
-/// Where a lint originates.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum LintOrigin {
-    /// Generic Move linter (`move_compiler::linters`).
-    Move,
-    /// Sui-specific linter (`move_compiler::sui_mode::linters`).
-    Sui,
+type Lint = (&'static str, DiagnosticInfo);
+
+/// Every lint as `(filter name, info)`, Move lints followed by Sui lints, in code order.
+fn all_lints() -> impl Iterator<Item = &'static Lint> {
+    MOVE_LINTS.iter().chain(SUI_LINTS.iter())
 }
 
-impl LintOrigin {
-    fn label(self) -> &'static str {
-        match self {
-            LintOrigin::Move => "Move",
-            LintOrigin::Sui => "Sui",
-        }
-    }
-}
+static LINTS_BY_NAME: LazyLock<BTreeMap<&'static str, &'static Lint>> =
+    LazyLock::new(|| all_lints().map(|lint| (lint.0, lint)).collect());
 
-/// A worked bad/good pair illustrating a lint.
-pub struct LintExample {
-    /// A snippet that triggers the lint.
-    pub bad: &'static str,
-    /// The corrected snippet that does not.
-    pub good: &'static str,
-}
-
-/// Human-facing documentation for a single lint.
-pub struct LintDoc {
-    /// Filter name: the canonical `--explain` key and the `#[allow(lint(<name>))]` key.
-    pub name: &'static str,
-    pub origin: LintOrigin,
-    /// `true` if the lint runs at the default level; `false` if it requires `--lint`.
-    pub default: bool,
-    /// Diagnostic category and code. Used to render the `Wxxyyy` code and to match emitted
-    /// diagnostics for the `--explain` hint. These follow the current (origin-based) numbering.
-    pub category: u8,
-    pub code: u8,
-    /// One-line description of what the lint flags (matches the diagnostic message).
-    pub summary: &'static str,
-    /// Why the flagged pattern matters.
-    pub rationale: &'static str,
-    /// When firing is acceptable, or how to knowingly opt out. `None` omits the section.
-    pub when_ok: Option<&'static str>,
-    pub example: LintExample,
-}
-
-impl LintDoc {
-    /// The rendered diagnostic code, e.g. `W99000`. Lints are always warnings, so the severity
-    /// prefix is always `W`.
-    pub fn rendered_code(&self) -> String {
-        format!("W{:02}{:03}", self.category, self.code)
-    }
-}
-
-static DOCS_BY_NAME: LazyLock<BTreeMap<&'static str, &'static LintDoc>> =
-    LazyLock::new(|| LINT_DOCS.iter().map(|d| (d.name, d)).collect());
-
-static DOCS_BY_ID: LazyLock<BTreeMap<(u8, u8), &'static LintDoc>> = LazyLock::new(|| {
-    LINT_DOCS
-        .iter()
-        .map(|d| ((d.category, d.code), d))
+static LINTS_BY_ID: LazyLock<BTreeMap<(u8, u8), &'static Lint>> = LazyLock::new(|| {
+    all_lints()
+        .map(|lint| ((lint.1.category(), lint.1.code()), lint))
         .collect()
 });
 
-/// Look up a lint doc from raw `--explain <query>` user input: either a filter name
-/// (`share_owned`) or a rendered diagnostic code (`W99000`).
-pub fn find_lint_doc(query: &str) -> Option<&'static LintDoc> {
+/// The `--explain` output for a single lint: the explanation file printed verbatim, between a
+/// generated `name (Wxxyyy): message` header and a generated suppression footer.
+pub struct LintExplanation {
+    name: &'static str,
+    info: &'static DiagnosticInfo,
+}
+
+/// The rendered diagnostic code without the `Lint ` prefix, e.g. `W99000`. Lints are always
+/// warnings, so the severity prefix is always `W`.
+fn rendered_code(info: &DiagnosticInfo) -> String {
+    format!("W{:02}{:03}", info.category(), info.code())
+}
+
+/// Look up a lint from raw `--explain <query>` user input: either a filter name (`share_owned`)
+/// or a rendered diagnostic code (`W99000`). A lint without an explanation file is treated as
+/// undocumented.
+pub fn find_lint(query: &str) -> Option<LintExplanation> {
     let q = query.trim();
-    if let Some(doc) = DOCS_BY_NAME.get(q) {
-        return Some(doc);
-    }
-    let (category, code) = parse_rendered_code(q)?;
-    lint_doc_by_id(category, code)
+    let (name, info) = LINTS_BY_NAME.get(q).copied().or_else(|| {
+        let (category, code) = parse_rendered_code(q)?;
+        LINTS_BY_ID.get(&(category, code)).copied()
+    })?;
+    info.explanation()?;
+    Some(LintExplanation { name, info })
 }
 
 /// Parse a rendered `Wxxyyy` code back into its `(category, code)` id. Accepts the forms a user is
@@ -97,64 +70,25 @@ fn parse_rendered_code(s: &str) -> Option<(u8, u8)> {
     Some((digits[..2].parse().ok()?, digits[2..].parse().ok()?))
 }
 
-/// Look up a lint doc by its diagnostic `(category, code)`. Used to attach the `--explain` hint to
-/// emitted lint diagnostics.
-pub fn lint_doc_by_id(category: u8, code: u8) -> Option<&'static LintDoc> {
-    DOCS_BY_ID.get(&(category, code)).copied()
+/// The filter name of the lint with the given diagnostic `(category, code)`, if it has an
+/// explanation to point at. Used to attach the `--explain` hint to emitted lint diagnostics.
+pub fn explained_lint_name(category: u8, code: u8) -> Option<&'static str> {
+    let (name, info) = LINTS_BY_ID.get(&(category, code))?;
+    info.explanation()?;
+    Some(name)
 }
 
-/// Write `s` indented by two spaces, preserving blank lines, with a trailing newline.
-fn write_indented(f: &mut fmt::Formatter<'_>, s: &str) -> fmt::Result {
-    for line in s.lines() {
-        if line.is_empty() {
-            writeln!(f)?;
-        } else {
-            writeln!(f, "  {line}")?;
-        }
-    }
-    Ok(())
-}
-
-/// The `--explain <name>` output for a single lint.
-impl fmt::Display for LintDoc {
+impl fmt::Display for LintExplanation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let level = if self.default {
-            "on by default"
-        } else {
-            "requires `--lint`"
-        };
-        writeln!(f, "{}", self.name)?;
-        writeln!(f, "{}", "=".repeat(self.name.len()))?;
+        let Self { name, info } = self;
+        // `find_lint` only constructs documented lints.
+        let explanation = info.explanation().expect("documented lint");
+        writeln!(f, "{name} ({}): {}", rendered_code(info), info.message())?;
         writeln!(f)?;
-        let category =
-            LinterDiagnosticCategory::try_from_u8(self.category).map_or("Unknown", |c| c.name());
-        writeln!(f, "category: {category}")?;
-        writeln!(f, "origin:   {}", self.origin.label())?;
-        writeln!(f, "level:    {level}")?;
-        writeln!(f, "code:     {}", self.rendered_code())?;
+        // The explanation file is printed verbatim; it ends with a newline.
+        write!(f, "{explanation}")?;
         writeln!(f)?;
-        writeln!(f, "{}", self.summary)?;
-        writeln!(f)?;
-        writeln!(f, "{}", self.rationale)?;
-        if let Some(when_ok) = self.when_ok {
-            writeln!(f)?;
-            writeln!(f, "When it's OK:")?;
-            write_indented(f, when_ok)?;
-        }
-        writeln!(f)?;
-        writeln!(f, "Example:")?;
-        writeln!(f)?;
-        writeln!(f, "  // flagged")?;
-        write_indented(f, self.example.bad)?;
-        writeln!(f)?;
-        writeln!(f, "  // suggested")?;
-        write_indented(f, self.example.good)?;
-        writeln!(f)?;
-        writeln!(
-            f,
-            "Suppress a specific case with `#[allow(lint({}))]`.",
-            self.name
-        )
+        writeln!(f, "Suppress a specific case with `#[allow(lint({name}))]`.")
     }
 }
 
@@ -171,16 +105,16 @@ impl fmt::Display for LintIndex<'_> {
             "Move lint index. Run `{} --explain <name>` for details on any lint.\n",
             self.command
         )?;
-        let width = LINT_DOCS.iter().map(|d| d.name.len()).max().unwrap_or(0);
+        let width = all_lints().map(|(name, _)| name.len()).max().unwrap_or(0);
         // Categories in `LinterDiagnosticCategory` order; empty ones are skipped.
         for category in LinterDiagnosticCategory::ALL {
             let mut any = false;
-            for doc in LINT_DOCS.iter().filter(|d| d.category == *category as u8) {
+            for (name, info) in all_lints().filter(|(_, info)| info.category() == *category as u8) {
                 if !any {
                     writeln!(f, "{}", category.name())?;
                     any = true;
                 }
-                writeln!(f, "    {:width$}  {}", doc.name, doc.summary, width = width)?;
+                writeln!(f, "    {name:width$}  {}", info.message())?;
             }
             if any {
                 writeln!(f)?;
@@ -189,503 +123,6 @@ impl fmt::Display for LintIndex<'_> {
         Ok(())
     }
 }
-
-//**************************************************************************************************
-// Registry
-//**************************************************************************************************
-
-// A flat registry; `LintIndex` groups by category. The `(category, code)` pairs are the lints'
-// actual diagnostic ids (see `LinterDiagnosticCategory`), used to render `Wxxyyy` and match
-// emitted diagnostics.
-pub const LINT_DOCS: &[LintDoc] = &[
-    LintDoc {
-        name: "share_owned",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 0,
-        summary: "possible owned object share",
-        rationale: "\
-Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an \
-object that is not freshly created in this function (it arrives as a parameter or from an unpack) \
-can silently hand every account write access to something a user believed was theirs. It fires only \
-when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` \
-elsewhere; a `key`-only type that is never transferred is not flagged.",
-        when_ok: Some(
-            "The shared object really is fresh, but was produced through a helper call the local \
-analysis can't see through — a conservative false positive.",
-        ),
-        example: LintExample {
-            bad: "// `o` is a parameter — the checker can't prove it is fresh\npublic fun share(o: Obj) {\n    transfer::public_share_object(o)\n}",
-            good: "// packed here, so provably a fresh object\npublic fun share(ctx: &mut TxContext) {\n    transfer::share_object(Obj { id: object::new(ctx) })\n}",
-        },
-    },
-    LintDoc {
-        name: "custom_state_change",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 2,
-        summary: "potentially unenforceable custom transfer/share/freeze policy",
-        rationale: "\
-A by-value struct defined in this module that has the `store` ability can already be transferred, \
-shared, or frozen by anyone through the `public_*` API. Routing it through the private \
-`transfer`/`share_object`/`freeze_object` therefore cannot enforce any custom policy — callers just \
-bypass it.",
-        when_ok: Some(
-            "If the type keeps `store`, call the honest `public_*` variant. If the policy must \
-actually hold, remove `store` so the private variant is the only path.",
-        ),
-        example: LintExample {
-            bad: "// `S1` has `key` + `store`, so callers can already freeze it via `public_freeze_object`\npublic fun custom_freeze(o: S1) {\n    transfer::freeze_object(o)\n}",
-            good: "public fun custom_freeze(o: S1) {\n    transfer::public_freeze_object(o)\n}",
-        },
-    },
-    LintDoc {
-        name: "freeze_wrapped",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 4,
-        summary: "attempting to freeze wrapped objects",
-        rationale: "\
-Freezing makes an object immutable forever. If the frozen object wraps another object — a field \
-whose type has `key`, directly or transitively — that inner object is frozen and made unrecoverable \
-too, which is almost never intended.",
-        when_ok: None,
-        example: LintExample {
-            bad: "public struct Inner has key, store { id: UID }\npublic struct Wrapper has key, store { id: UID, inner: Inner }\n\npublic fun freeze_wrapper(w: Wrapper) {\n    transfer::public_freeze_object(w)\n}",
-            good: "public struct Config has key, store { id: UID, fee: u64 }\n\npublic fun freeze_config(c: Config) {\n    transfer::public_freeze_object(c)\n}",
-        },
-    },
-    LintDoc {
-        name: "public_random",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 6,
-        summary: "Risky use of 'sui::random'",
-        rationale: "\
-A `public` function that takes `Random` or `RandomGenerator` can be called by other Move code, \
-letting an attacker draw randomness and react to the outcome within the same transaction. Randomness \
-should only be reachable from a transaction, not composed by another contract.",
-        when_ok: Some(
-            "Reduce the visibility below `public` — a non-public `entry` function, `public(package)`, \
-or a private function — so it can't be composed by another contract. Adding `entry` to a function \
-that stays `public` does not help.",
-        ),
-        example: LintExample {
-            bad: "public fun not_allowed(_r: &Random) {}",
-            good: "entry fun basic_random(_r: &Random) {}",
-        },
-    },
-    LintDoc {
-        name: "freezing_capability",
-        origin: LintOrigin::Sui,
-        default: false,
-        category: 99,
-        code: 8,
-        summary: "freezing potential capability",
-        rationale: "\
-Capabilities gate privileged actions. Freezing one turns it into a permanent immutable object that \
-anyone can reference and that can never be revoked — usually the opposite of the intended access \
-control. The lint matches by struct name (a capitalized `Cap`).",
-        when_ok: Some(
-            "The match is by name — a `Cap` at the end of the name, or followed by an uppercase \
-letter, digit, or `_`. So a non-capability like `NoCap` is a false positive, while a real \
-capability with an off-pattern name (`AdminRights`, `Capv0`) is missed.",
-        ),
-        example: LintExample {
-            bad: "public struct AdminCap has key { id: UID }\n\npublic fun freeze_cap(cap: AdminCap) {\n    transfer::public_freeze_object(cap)\n}",
-            good: "// keep the capability owned instead of freezing it\npublic fun keep_cap(cap: AdminCap, owner: address) {\n    transfer::transfer(cap, owner)\n}",
-        },
-    },
-    LintDoc {
-        name: "missing_key",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 7,
-        summary: "struct with id but missing key ability",
-        rationale: "\
-A struct whose first field is `id: UID` looks like a Sui object, but without the `key` ability it \
-can never be stored, transferred, or shared as one. This is almost always a forgotten `has key`.",
-        when_ok: None,
-        example: LintExample {
-            bad: "public struct MissingKeyAbility {\n    id: UID,\n}",
-            good: "public struct HasKeyAbility has key {\n    id: UID,\n}",
-        },
-    },
-    LintDoc {
-        name: "collection_equality",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 5,
-        summary: "possibly useless collections compare",
-        rationale: "\
-Sui collections — `Bag`, `ObjectBag`, `Table`, `ObjectTable`, `LinkedTable`, `TableVec`, `VecMap`, \
-and `VecSet` — have no meaningful `==`. The UID-backed ones (`Bag`, `Table`, …) compare by their \
-internal handle, not contents; `VecMap`/`VecSet` compare their backing vector, so equal contents in \
-a different insertion order compare unequal. Either way `==`/`!=` rarely means what it looks like.",
-        when_ok: None,
-        example: LintExample {
-            bad: "public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {\n    bag1 == bag2\n}",
-            good: "// compare the state you care about, not the collection handle\npublic fun bag_eq(bag1: &Bag, bag2: &Bag): bool {\n    bag1.length() == bag2.length()\n}",
-        },
-    },
-    LintDoc {
-        name: "uncallable_function",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 11,
-        summary: "it will not be possible to call this function",
-        rationale: "\
-The transaction runtime can only supply certain argument shapes. Taking `TxContext` by value, a \
-`&mut TxContext` alongside any other `TxContext` parameter (it must be the only one), or a `&mut` to \
-`Clock`/`Random` makes the function impossible to call from a transaction.",
-        when_ok: Some(
-            "A single `&mut TxContext` is fine. Use `&Clock` and `&Random` rather than `&mut`.",
-        ),
-        example: LintExample {
-            bad: "// `Clock` must be passed by immutable reference\nfun uses_clock(_c: &mut Clock) {}",
-            good: "fun uses_clock(_c: &Clock) {}",
-        },
-    },
-    LintDoc {
-        name: "unused_object_with_fields",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 12,
-        summary: "unused object with fields",
-        rationale: "\
-A reference to an object that carries data beyond its `id`, but whose fields are never read, is a \
-likely mistake: the function takes the object yet never looks at the values it holds.",
-        when_ok: Some(
-            "Objects with no field beyond `id` (pure marker capabilities), by-value params, and \
-generic object types are out of scope. Otherwise the function should assert on or otherwise read a \
-field — or drop the parameter if it truly isn't needed.",
-        ),
-        example: LintExample {
-            bad: "public struct OwnerCap has key { id: UID, owns: address }\n\npublic fun unused(_c: &OwnerCap) {}",
-            good: "public fun owner(c: &OwnerCap): address {\n    c.owns\n}",
-        },
-    },
-    LintDoc {
-        name: "loop_without_exit",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 2,
-        code: 6,
-        summary: "'loop' without 'break' or 'return'",
-        rationale: "\
-A `loop` whose body contains neither `break` nor `return` has no normal exit — it runs until it \
-aborts, if ever. This is almost always a missing exit condition. (`while` is covered separately by \
-`while_true`.)",
-        when_ok: Some(
-            "An `abort` inside the loop is not treated as an exit, so a deliberately divergent loop \
-is a false positive.",
-        ),
-        example: LintExample {
-            bad: "let i = 0;\nloop {\n    i = i + 1;\n}",
-            good: "let i = 0;\nloop {\n    if (i >= 10) break;\n    i = i + 1;\n}",
-        },
-    },
-    LintDoc {
-        name: "self_assignment",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 2,
-        code: 8,
-        summary: "assignment preserves the same value",
-        rationale: "\
-Assigning a location to itself (`x = x`, `*r = *r`, `s.f = s.f`) has no effect. It usually signals a \
-typo or an unfinished edit.",
-        when_ok: None,
-        example: LintExample {
-            bad: "p = p;",
-            good: "// remove the redundant statement",
-        },
-    },
-    LintDoc {
-        name: "always_equal_operands",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 2,
-        code: 11,
-        summary: "redundant, always-equal operands for binary operation",
-        rationale: "\
-A binary operation whose two operands are the same expression has an already-known result: `x == x` \
-is always `true`, `x - x` is `0`, `x / x` is `1`, `x & x` is just `x`. The operation is dead weight \
-and often a copy-paste bug where one side should differ.",
-        when_ok: None,
-        example: LintExample {
-            bad: "let b = x == x;",
-            good: "let b = true;",
-        },
-    },
-    LintDoc {
-        name: "unused_return_value",
-        origin: LintOrigin::Move,
-        // Only the Sui-mode visitor set runs this by default (vanilla `move` needs `--lint`), but
-        // in practice every consumer of these docs is Sui-flavored, so claim the Sui default.
-        default: true,
-        category: 2,
-        code: 13,
-        summary: "return value of a non-mutating call is discarded",
-        rationale: "\
-Discarding the result of a call that has no `&mut` arguments means the call did nothing observable. \
-Either use the value or make the intent explicit with `let _ = ...`. In Sui mode `&mut TxContext` is \
-treated as non-mutating, so such calls are still flagged.",
-        when_ok: Some(
-            "Calls that take a `&mut` argument (a real side effect) are not flagged. Bind to `let _` \
-to acknowledge an intentionally discarded value.",
-        ),
-        example: LintExample {
-            bad: "fun price(x: u64): u64 { x + 1 }\n// ...\nprice(10);",
-            good: "let _ = price(10);",
-        },
-    },
-    LintDoc {
-        name: "self_transfer",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 1,
-        summary: "non-composable transfer to sender",
-        rationale: "\
-Transferring an object (one with `key` + `store`) to `ctx.sender()` inside the function makes it \
-non-composable: a caller (or a programmable transaction block) cannot use the object because the \
-function gives it away internally. Returning the object lets the caller decide what to do with it.",
-        when_ok: Some(
-            "Rare — the composable pattern is to return the object and let the caller place it. \
-`entry` functions and `init` are already exempt.",
-        ),
-        example: LintExample {
-            bad: "// `S1` has `key` + `store`\npublic fun mint(ctx: &mut TxContext) {\n    transfer::public_transfer(S1 { id: object::new(ctx) }, ctx.sender())\n}",
-            good: "public fun mint(ctx: &mut TxContext): S1 {\n    S1 { id: object::new(ctx) }\n}",
-        },
-    },
-    LintDoc {
-        name: "coin_field",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 3,
-        summary: "sub-optimal 'sui::coin::Coin' field type",
-        rationale: "\
-`Coin<T>` is itself a full object (it has an `id: UID`) meant for transfers between accounts. Held \
-as a field it adds needless object plumbing; `Balance<T>` is the storage-oriented type for keeping \
-value inside another object.",
-        when_ok: Some(
-            "Keep `Coin` only if the field genuinely needs to be an independent object. An alias does \
-not avoid the lint — the resolved type is what's matched.",
-        ),
-        example: LintExample {
-            bad: "public struct S2 has key, store {\n    id: UID,\n    c: Coin<S1>,\n}",
-            good: "public struct S2 has key, store {\n    id: UID,\n    c: Balance<S1>,\n}",
-        },
-    },
-    LintDoc {
-        name: "public_entry",
-        origin: LintOrigin::Sui,
-        default: true,
-        category: 99,
-        code: 10,
-        summary: "unnecessary `entry` on a `public` function",
-        rationale: "\
-`entry` on a `public` function is redundant: a `public` function is already callable from a \
-programmable transaction block. `entry` is only meaningful on a non-`public` function, where it is \
-what makes the function callable as a transaction command.",
-        when_ok: None,
-        example: LintExample {
-            bad: "public entry fun mint() {}",
-            good: "public fun mint() {}",
-        },
-    },
-    LintDoc {
-        name: "prefer_mut_tx_context",
-        origin: LintOrigin::Sui,
-        default: false,
-        category: 99,
-        code: 9,
-        summary: "prefer '&mut TxContext' over '&TxContext'",
-        rationale: "\
-A public function that takes `&TxContext` cannot later create objects — which needs \
-`&mut TxContext` — without a breaking signature change. Taking `&mut TxContext` up front keeps the \
-API upgrade-compatible.",
-        when_ok: Some(
-            "Only `public` functions are checked; any non-`public` visibility (private, \
-`public(package)`, `public(friend)`) is exempt, since those signatures can change freely.",
-        ),
-        example: LintExample {
-            bad: "public fun incorrect_mint(_ctx: &TxContext) {}",
-            good: "public fun correct_mint(_ctx: &mut TxContext) {}",
-        },
-    },
-    LintDoc {
-        name: "constant_naming",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 4,
-        code: 1,
-        summary: "constant should follow naming convention",
-        rationale: "\
-Constants are expected to be `UPPER_SNAKE_CASE` or PascalCase (either is accepted for any constant). \
-A lowercase or mixed name (`max_supply`, `JSON_Max_Size`) reads like a variable and breaks module \
-consistency.",
-        when_ok: Some(
-            "PascalCase is deliberately allowed — including the `E`-prefixed PascalCase used for \
-error constants, such as `ENotAuthorized`.",
-        ),
-        example: LintExample {
-            bad: "const Another_BadName: u64 = 42;",
-            good: "const MAX_LIMIT: u64 = 1000;\nconst ENotAuthorized: u64 = 0;",
-        },
-    },
-    LintDoc {
-        name: "abort_without_constant",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 4,
-        code: 5,
-        summary: "'abort' or 'assert' without named constant",
-        rationale: "\
-A bare numeric abort code carries no meaning at the call site or in error output. A named constant \
-documents the failure and keeps codes consistent across the module.",
-        when_ok: Some(
-            "The whole argument must be a single named constant — `abort A + B` still fires. \
-`assert!(cond, ECode)` is the idiomatic form.",
-        ),
-        example: LintExample {
-            bad: "abort 100",
-            good: "const ERR_INVALID_ARGUMENT: u64 = 1;\n// ...\nabort ERR_INVALID_ARGUMENT",
-        },
-    },
-    LintDoc {
-        name: "unnecessary_math",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 1,
-        code: 3,
-        summary: "math operator can be simplified",
-        rationale: "\
-An operation with an identity operand (`* 1`, `/ 1`, `+ 0`, `- 0`, `<< 0`, `>> 0`) does nothing; one \
-with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x` is `1`. Only literal \
-`0`/`1` operands are detected.",
-        when_ok: None,
-        example: LintExample {
-            bad: "let y = x * 1;",
-            good: "let y = x;",
-        },
-    },
-    LintDoc {
-        name: "unnecessary_conditional",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 1,
-        code: 7,
-        summary: "'if' expression can be removed",
-        rationale: "\
-An `if` with one branch `true` and the other `false` collapses to the condition itself (or its \
-negation), and one whose branches are the same literal value collapses to that value. The \
-conditional only adds noise.",
-        when_ok: None,
-        example: LintExample {
-            bad: "let b = if (!condition) true else false;",
-            good: "let b = !condition;",
-        },
-    },
-    LintDoc {
-        name: "redundant_ref_deref",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 1,
-        code: 9,
-        summary: "redundant reference/dereference",
-        rationale: "\
-Taking a reference and immediately dereferencing it (`&*(&x)`), or dereferencing a fresh field \
-borrow (`*(&s.f)`), is a no-op the compiler already performs for you.",
-        when_ok: Some(
-            "Dereferencing an existing reference (`*r`) is fine — only dereferencing a fresh borrow \
-(`*(&x)` or `&*(&x)`) is redundant.",
-        ),
-        example: LintExample {
-            bad: "let _ref = &*(&resource);",
-            good: "let _ref = &resource;",
-        },
-    },
-    LintDoc {
-        name: "combinable_comparisons",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 1,
-        code: 12,
-        summary: "comparison operations condition can be simplified",
-        rationale: "\
-Two comparisons over the same operand pair joined by `&&`/`||` often collapse to a single comparison \
-(`x == y && x >= y` is just `x == y`), or to a constant `true`/`false` (`x >= y || x <= y`).",
-        when_ok: Some("Negated comparisons are not handled and won't fire."),
-        example: LintExample {
-            bad: "let b = x == y && x >= y;",
-            good: "let b = x == y;",
-        },
-    },
-    LintDoc {
-        name: "while_true",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 4,
-        code: 2,
-        summary: "unnecessary 'while (true)', replace with 'loop'",
-        rationale: "\
-`while (true)` is an infinite loop written the long way. `loop` states the intent directly and can \
-`break` with a value. Only the literal `true` condition is detected.",
-        when_ok: None,
-        example: LintExample {
-            bad: "while (true) {\n    // ...\n}",
-            good: "loop {\n    // ...\n}",
-        },
-    },
-    LintDoc {
-        name: "unneeded_return",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 4,
-        code: 4,
-        summary: "unneeded return",
-        rationale: "\
-In tail position the `return` keyword is redundant — the trailing expression is already the \
-function's value.",
-        when_ok: Some(
-            "Only a tail-position `return` is flagged — of any value-yielding expression (a call, \
-`S { .. }`, arithmetic, a cast, `loop`, even `()`). A `return` used as an early exit, or whose \
-operand doesn't yield a value (e.g. `return abort E`), is left alone.",
-        ),
-        example: LintExample {
-            bad: "fun price(): u64 {\n    return 5\n}",
-            good: "fun price(): u64 {\n    5\n}",
-        },
-    },
-    LintDoc {
-        name: "unnecessary_unit",
-        origin: LintOrigin::Move,
-        default: false,
-        category: 4,
-        code: 10,
-        summary: "unit `()` expression can be removed or simplified",
-        rationale: "\
-A `()` unit expression as a non-final statement, or as a branch of an `if`, adds nothing. Remove it, \
-or invert the condition to drop the empty branch.",
-        when_ok: None,
-        example: LintExample {
-            bad: "if (b) () else { x = 1 };",
-            good: "if (!b) { x = 1 };",
-        },
-    },
-];
 
 #[cfg(test)]
 mod tests {
@@ -702,10 +139,24 @@ mod tests {
     }
 
     #[test]
+    fn every_lint_has_an_explanation() {
+        let missing: Vec<_> = all_lints()
+            .filter(|(_, info)| info.explanation().is_none())
+            .map(|(name, info)| format!("{name} ({})", rendered_code(info)))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "lints without an explanation file under \
+             src/diagnostics/explanations/<Category>_<CodeName>.md: {missing:?}"
+        );
+    }
+
+    #[test]
     fn explain_output_per_lint() {
         explain_settings().bind(|| {
-            for doc in LINT_DOCS {
-                insta::assert_snapshot!(doc.name, doc.to_string());
+            for (name, _) in all_lints() {
+                let explanation = find_lint(name).expect("documented lint");
+                insta::assert_snapshot!(*name, explanation.to_string());
             }
         });
     }
@@ -727,79 +178,11 @@ mod tests {
     fn ids_and_names_are_unique() {
         let mut names = HashSet::new();
         let mut ids = HashSet::new();
-        for doc in LINT_DOCS {
-            assert!(names.insert(doc.name), "duplicate lint name {}", doc.name);
+        for (name, info) in all_lints() {
+            assert!(names.insert(*name), "duplicate lint name {name}");
             assert!(
-                ids.insert((doc.category, doc.code)),
-                "duplicate lint id for {}",
-                doc.name
-            );
-        }
-    }
-
-    #[test]
-    fn every_registered_lint_has_a_doc() {
-        use crate::diagnostics::filter::FILTER_ALL;
-        let documented: HashSet<&str> = LINT_DOCS.iter().map(|d| d.name).collect();
-        let mut registered: HashSet<String> = HashSet::new();
-        for (_prefix, filters) in [
-            crate::linters::known_filters(),
-            crate::sui_mode::linters::known_filters(),
-        ] {
-            for (name, _ids) in filters {
-                if name.as_str() != FILTER_ALL {
-                    registered.insert(name.to_string());
-                }
-            }
-        }
-        let missing: Vec<_> = registered
-            .iter()
-            .filter(|n| !documented.contains(n.as_str()))
-            .collect();
-        assert!(
-            missing.is_empty(),
-            "lints missing an --explain doc: {missing:?}"
-        );
-        // Every doc must correspond to a real registered lint (no stale entries).
-        let extra: Vec<_> = documented
-            .iter()
-            .filter(|n| !registered.contains(**n))
-            .collect();
-        assert!(extra.is_empty(), "docs for unregistered lints: {extra:?}");
-    }
-
-    #[test]
-    fn doc_ids_match_registered_filters() {
-        use crate::diagnostics::filter::FILTER_ALL;
-        // name -> (category, code) as the linter actually registers it.
-        let mut registered: std::collections::HashMap<String, (u8, u8)> =
-            std::collections::HashMap::new();
-        for (_prefix, filters) in [
-            crate::linters::known_filters(),
-            crate::sui_mode::linters::known_filters(),
-        ] {
-            for (name, ids) in filters {
-                if name.as_str() == FILTER_ALL {
-                    continue;
-                }
-                let id = ids.first().expect("lint filter has an id");
-                registered.insert(name.to_string(), (id.category, id.code));
-            }
-        }
-        for doc in LINT_DOCS {
-            let (category, code) = registered
-                .get(doc.name)
-                .unwrap_or_else(|| panic!("{} is not a registered lint", doc.name));
-            assert_eq!(
-                (doc.category, doc.code),
-                (*category, *code),
-                "doc for `{}` claims id ({}, {}) but the lint registers ({}, {}) — \
-                 category/code must match the linter, not be hand-set",
-                doc.name,
-                doc.category,
-                doc.code,
-                category,
-                code
+                ids.insert((info.category(), info.code())),
+                "duplicate lint id for {name}"
             );
         }
     }
@@ -845,14 +228,14 @@ mod tests {
 
     #[test]
     fn find_by_name_and_code() {
-        let doc = find_lint_doc("share_owned").expect("by name");
-        assert_eq!(doc.name, "share_owned");
-        assert_eq!(find_lint_doc("W99000").unwrap().name, "share_owned");
-        assert_eq!(find_lint_doc("Lint W99000").unwrap().name, "share_owned");
-        assert_eq!(find_lint_doc("99000").unwrap().name, "share_owned");
+        let explanation = find_lint("share_owned").expect("by name");
+        assert_eq!(explanation.name, "share_owned");
+        assert_eq!(find_lint("W99000").unwrap().name, "share_owned");
+        assert_eq!(find_lint("Lint W99000").unwrap().name, "share_owned");
+        assert_eq!(find_lint("99000").unwrap().name, "share_owned");
         // Escalated rendering (`#[deny(lint(...))]`, `--warnings-are-errors`) prints an `E` code.
-        assert_eq!(find_lint_doc("E99000").unwrap().name, "share_owned");
-        assert_eq!(find_lint_doc("Lint E99000").unwrap().name, "share_owned");
-        assert!(find_lint_doc("nonsense").is_none());
+        assert_eq!(find_lint("E99000").unwrap().name, "share_owned");
+        assert_eq!(find_lint("Lint E99000").unwrap().name, "share_owned");
+        assert!(find_lint("nonsense").is_none());
     }
 }

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -731,7 +731,7 @@ mod tests {
     #[test]
     fn explain_index() {
         explain_settings().bind(|| {
-            insta::assert_snapshot!("_index", LintIndex.to_string());
+            insta::assert_snapshot!("index", LintIndex.to_string());
         });
     }
 

--- a/external-crates/move/crates/move-compiler/src/linters/docs.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/docs.rs
@@ -6,7 +6,24 @@
 //! the numeric `(category, code)` ids are only used to render the `Wxxyyy` code and to match
 //! emitted diagnostics so the hint can name the right lint.
 
+use crate::linters::LinterDiagnosticCategory;
 use std::fmt;
+
+/// The category name for a diagnostic `category` byte, exactly as defined by
+/// [`LinterDiagnosticCategory`]. Referencing the enum discriminants keeps this in lockstep with the
+/// linter — the docs never invent categories of their own.
+fn category_label(category: u8) -> &'static str {
+    use LinterDiagnosticCategory::*;
+    match category {
+        c if c == Correctness as u8 => "Correctness",
+        c if c == Complexity as u8 => "Complexity",
+        c if c == Suspicious as u8 => "Suspicious",
+        c if c == Deprecated as u8 => "Deprecated",
+        c if c == Style as u8 => "Style",
+        c if c == Sui as u8 => "Sui",
+        _ => "Unknown",
+    }
+}
 
 /// Where a lint originates.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -38,8 +55,6 @@ pub struct LintExample {
 pub struct LintDoc {
     /// Filter name: the canonical `--explain` key and the `#[allow(lint(<name>))]` key.
     pub name: &'static str,
-    /// Semantic group shown to users (e.g. "Security", "Complexity").
-    pub group: &'static str,
     pub origin: LintOrigin,
     /// `true` if the lint runs at the default level; `false` if it requires `--lint`.
     pub default: bool,
@@ -113,10 +128,10 @@ impl fmt::Display for LintDoc {
         writeln!(f, "{}", self.name)?;
         writeln!(f, "{}", "=".repeat(self.name.len()))?;
         writeln!(f)?;
-        writeln!(f, "group:   {}", self.group)?;
-        writeln!(f, "origin:  {}", self.origin.label())?;
-        writeln!(f, "level:   {level}")?;
-        writeln!(f, "code:    {}", self.rendered_code())?;
+        writeln!(f, "category: {}", category_label(self.category))?;
+        writeln!(f, "origin:   {}", self.origin.label())?;
+        writeln!(f, "level:    {level}")?;
+        writeln!(f, "code:     {}", self.rendered_code())?;
         writeln!(f)?;
         writeln!(f, "{}", self.summary)?;
         writeln!(f)?;
@@ -153,20 +168,23 @@ impl fmt::Display for LintIndex {
             "Move lint index. Run `move lint --explain <name>` for details on any lint.\n"
         )?;
         let width = LINT_DOCS.iter().map(|d| d.name.len()).max().unwrap_or(0);
-        // Stable, curated group order.
-        const GROUPS: &[&str] = &[
-            "Security",
+        // Categories in `LinterDiagnosticCategory` order; empty ones are skipped.
+        const CATEGORIES: &[&str] = &[
             "Correctness",
-            "Suspicious",
-            "Conventions",
             "Complexity",
+            "Suspicious",
+            "Deprecated",
             "Style",
+            "Sui",
         ];
-        for group in GROUPS {
+        for category in CATEGORIES {
             let mut any = false;
-            for doc in LINT_DOCS.iter().filter(|d| &d.group == group) {
+            for doc in LINT_DOCS
+                .iter()
+                .filter(|d| &category_label(d.category) == category)
+            {
                 if !any {
-                    writeln!(f, "{group}")?;
+                    writeln!(f, "{category}")?;
                     any = true;
                 }
                 writeln!(f, "    {:width$}  {}", doc.name, doc.summary, width = width)?;
@@ -183,13 +201,12 @@ impl fmt::Display for LintIndex {
 // Registry
 //**************************************************************************************************
 
-// Ordered by group for readability; `render_index` re-groups explicitly. The `category`/`code`
-// pairs follow the current (origin-based) numbering used to render `Wxxyyy` and match diagnostics.
+// A flat registry; `render_index` groups by category. The `(category, code)` pairs are the lints'
+// actual diagnostic ids (see `LinterDiagnosticCategory`), used to render `Wxxyyy` and match
+// emitted diagnostics.
 pub const LINT_DOCS: &[LintDoc] = &[
-    // -- Security ---------------------------------------------------------------------------------
     LintDoc {
         name: "share_owned",
-        group: "Security",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -212,7 +229,6 @@ analysis can't see through — a conservative false positive.",
     },
     LintDoc {
         name: "custom_state_change",
-        group: "Security",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -234,7 +250,6 @@ actually hold, remove `store` so the private variant is the only path.",
     },
     LintDoc {
         name: "freeze_wrapped",
-        group: "Security",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -252,7 +267,6 @@ too, which is almost never intended.",
     },
     LintDoc {
         name: "public_random",
-        group: "Security",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -274,7 +288,6 @@ that stays `public` does not help.",
     },
     LintDoc {
         name: "freezing_capability",
-        group: "Security",
         origin: LintOrigin::Sui,
         default: false,
         category: 99,
@@ -294,10 +307,8 @@ capability with an off-pattern name (`AdminRights`, `Capv0`) is missed.",
             good: "// keep the capability owned instead of freezing it\npublic fun keep_cap(cap: AdminCap, owner: address) {\n    transfer::transfer(cap, owner)\n}",
         },
     },
-    // -- Correctness ------------------------------------------------------------------------------
     LintDoc {
         name: "missing_key",
-        group: "Correctness",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -312,10 +323,8 @@ can never be stored, transferred, or shared as one. This is almost always a forg
             good: "public struct HasKeyAbility has key {\n    id: UID,\n}",
         },
     },
-    // -- Suspicious -------------------------------------------------------------------------------
     LintDoc {
         name: "collection_equality",
-        group: "Suspicious",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -334,7 +343,6 @@ a different insertion order compare unequal. Either way `==`/`!=` rarely means w
     },
     LintDoc {
         name: "uncallable_function",
-        group: "Suspicious",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -354,7 +362,6 @@ The transaction runtime can only supply certain argument shapes. Taking `TxConte
     },
     LintDoc {
         name: "unused_object_with_fields",
-        group: "Suspicious",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -375,7 +382,6 @@ field — or drop the parameter if it truly isn't needed.",
     },
     LintDoc {
         name: "loop_without_exit",
-        group: "Suspicious",
         origin: LintOrigin::Core,
         default: false,
         category: 2,
@@ -396,7 +402,6 @@ is a false positive.",
     },
     LintDoc {
         name: "self_assignment",
-        group: "Suspicious",
         origin: LintOrigin::Core,
         default: false,
         category: 2,
@@ -413,7 +418,6 @@ typo or an unfinished edit.",
     },
     LintDoc {
         name: "always_equal_operands",
-        group: "Suspicious",
         origin: LintOrigin::Core,
         default: false,
         category: 2,
@@ -431,7 +435,6 @@ and often a copy-paste bug where one side should differ.",
     },
     LintDoc {
         name: "unused_return_value",
-        group: "Suspicious",
         origin: LintOrigin::Core,
         default: true,
         category: 2,
@@ -450,10 +453,8 @@ to acknowledge an intentionally discarded value.",
             good: "let _ = price(10);",
         },
     },
-    // -- Conventions ------------------------------------------------------------------------------
     LintDoc {
         name: "self_transfer",
-        group: "Conventions",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -474,7 +475,6 @@ function gives it away internally. Returning the object lets the caller decide w
     },
     LintDoc {
         name: "coin_field",
-        group: "Conventions",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -495,7 +495,6 @@ not avoid the lint — the resolved type is what's matched.",
     },
     LintDoc {
         name: "public_entry",
-        group: "Conventions",
         origin: LintOrigin::Sui,
         default: true,
         category: 99,
@@ -513,7 +512,6 @@ what makes the function callable as a transaction command.",
     },
     LintDoc {
         name: "prefer_mut_tx_context",
-        group: "Conventions",
         origin: LintOrigin::Sui,
         default: false,
         category: 99,
@@ -534,7 +532,6 @@ API upgrade-compatible.",
     },
     LintDoc {
         name: "constant_naming",
-        group: "Conventions",
         origin: LintOrigin::Core,
         default: false,
         category: 4,
@@ -555,7 +552,6 @@ error constants, such as `ENotAuthorized`.",
     },
     LintDoc {
         name: "abort_without_constant",
-        group: "Conventions",
         origin: LintOrigin::Core,
         default: false,
         category: 4,
@@ -573,10 +569,8 @@ documents the failure and keeps codes consistent across the module.",
             good: "const ERR_INVALID_ARGUMENT: u64 = 1;\n// ...\nabort ERR_INVALID_ARGUMENT",
         },
     },
-    // -- Complexity -------------------------------------------------------------------------------
     LintDoc {
         name: "unnecessary_math",
-        group: "Complexity",
         origin: LintOrigin::Core,
         default: false,
         category: 1,
@@ -594,7 +588,6 @@ with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x`
     },
     LintDoc {
         name: "unnecessary_conditional",
-        group: "Complexity",
         origin: LintOrigin::Core,
         default: false,
         category: 1,
@@ -612,7 +605,6 @@ conditional only adds noise.",
     },
     LintDoc {
         name: "redundant_ref_deref",
-        group: "Complexity",
         origin: LintOrigin::Core,
         default: false,
         category: 1,
@@ -632,7 +624,6 @@ borrow (`*(&s.f)`), is a no-op the compiler already performs for you.",
     },
     LintDoc {
         name: "combinable_comparisons",
-        group: "Complexity",
         origin: LintOrigin::Core,
         default: false,
         category: 1,
@@ -647,10 +638,8 @@ Two comparisons over the same operand pair joined by `&&`/`||` often collapse to
             good: "let b = x == y;",
         },
     },
-    // -- Style ------------------------------------------------------------------------------------
     LintDoc {
         name: "while_true",
-        group: "Style",
         origin: LintOrigin::Core,
         default: false,
         category: 4,
@@ -667,7 +656,6 @@ Two comparisons over the same operand pair joined by `&&`/`||` often collapse to
     },
     LintDoc {
         name: "unneeded_return",
-        group: "Style",
         origin: LintOrigin::Core,
         default: false,
         category: 4,
@@ -688,7 +676,6 @@ operand doesn't yield a value (e.g. `return abort E`), is left alone.",
     },
     LintDoc {
         name: "unnecessary_unit",
-        group: "Style",
         origin: LintOrigin::Core,
         default: false,
         category: 4,
@@ -775,6 +762,42 @@ mod tests {
             .filter(|n| !registered.contains(**n))
             .collect();
         assert!(extra.is_empty(), "docs for unregistered lints: {extra:?}");
+    }
+
+    #[test]
+    fn doc_ids_match_registered_filters() {
+        use crate::diagnostics::filter::FILTER_ALL;
+        // name -> (category, code) as the linter actually registers it.
+        let mut registered: std::collections::HashMap<String, (u8, u8)> =
+            std::collections::HashMap::new();
+        for (_prefix, filters) in [
+            crate::linters::known_filters(),
+            crate::sui_mode::linters::known_filters(),
+        ] {
+            for (name, ids) in filters {
+                if name.as_str() == FILTER_ALL {
+                    continue;
+                }
+                let id = ids.first().expect("lint filter has an id");
+                registered.insert(name.to_string(), (id.category, id.code));
+            }
+        }
+        for doc in LINT_DOCS {
+            let (category, code) = registered
+                .get(doc.name)
+                .unwrap_or_else(|| panic!("{} is not a registered lint", doc.name));
+            assert_eq!(
+                (doc.category, doc.code),
+                (*category, *code),
+                "doc for `{}` claims id ({}, {}) but the lint registers ({}, {}) — \
+                 category/code must match the linter, not be hand-set",
+                doc.name,
+                doc.category,
+                doc.code,
+                category,
+                code
+            );
+        }
     }
 
     #[test]

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -49,6 +49,33 @@ pub enum LinterDiagnosticCategory {
     Sui = 99,
 }
 
+impl LinterDiagnosticCategory {
+    /// All categories, in the order they should be displayed.
+    pub const ALL: &'static [Self] = &[
+        Self::Correctness,
+        Self::Complexity,
+        Self::Suspicious,
+        Self::Deprecated,
+        Self::Style,
+        Self::Sui,
+    ];
+
+    pub fn try_from_u8(value: u8) -> Option<Self> {
+        Self::ALL.iter().copied().find(|c| *c as u8 == value)
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Correctness => "Correctness",
+            Self::Complexity => "Complexity",
+            Self::Suspicious => "Suspicious",
+            Self::Deprecated => "Deprecated",
+            Self::Style => "Style",
+            Self::Sui => "Sui",
+        }
+    }
+}
+
 macro_rules! lints {
     (
         $(

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 pub mod abort_constant;
 pub mod combinable_comparisons;
 pub mod constant_naming;
+pub mod docs;
 pub mod equal_operands;
 pub mod loop_without_exit;
 pub mod meaningless_math_operation;

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -79,7 +79,7 @@ impl LinterDiagnosticCategory {
 macro_rules! lints {
     (
         $(
-            ($enum_name:ident, $category:expr, $filter_name:expr, $code_msg:expr)
+            ($enum_name:ident, $category:ident, $filter_name:expr, $code_msg:expr)
         ),* $(,)?
     ) => {
         #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
@@ -92,42 +92,32 @@ macro_rules! lints {
         }
 
         impl StyleCodes {
-            const fn category_code_and_message(&self) -> (u8, u8, &'static str) {
+            pub(crate) const fn diag_info(&self) -> DiagnosticInfo {
                 let code = *self as u8;
                 debug_assert!(code > 0);
                 match self {
                     Self::DontStartAtZeroPlaceholder =>
                         panic!("ICE do not use placeholder error code"),
-                    $(Self::$enum_name => ($category as u8, code, $code_msg),)*
+                    // A lint has an explanation iff
+                    // `diagnostics/explanations/<Category>_<CodeName>.md` exists -- keyed by
+                    // identifiers rather than the rendered code since the numeric portions are
+                    // positional (see `codes!` in diagnostics/codes.rs).
+                    $(Self::$enum_name => custom(
+                        LINT_WARNING_PREFIX,
+                        Severity::Warning,
+                        LinterDiagnosticCategory::$category as u8,
+                        code,
+                        $code_msg,
+                    ).with_explanation(move_proc_macros::optional_include_str!(
+                        "src/diagnostics/explanations/", $category, "_", $enum_name, ".md"
+                    )),)*
                 }
-            }
-
-            const fn category_code_and_filter_name(&self) -> (u8, u8, &'static str) {
-                let code = *self as u8;
-                debug_assert!(code > 0);
-                match self {
-                    Self::DontStartAtZeroPlaceholder =>
-                        panic!("ICE do not use placeholder error code"),
-                    $(Self::$enum_name => ($category as u8, code, $filter_name),)*
-                }
-            }
-
-            const fn diag_info(&self) -> DiagnosticInfo {
-                let (category, code, msg) = self.category_code_and_message();
-                custom(
-                    LINT_WARNING_PREFIX,
-                    Severity::Warning,
-                    category,
-                    code,
-                    msg,
-                )
             }
         }
 
-        const STYLE_WARNING_FILTERS: &[(u8, u8, &str)] = &[
-            $(
-                StyleCodes::$enum_name.category_code_and_filter_name(),
-            )*
+        /// Every Move lint as `(filter name, diagnostic info)`, in code order.
+        pub(crate) const MOVE_LINTS: &[(&str, DiagnosticInfo)] = &[
+            $(($filter_name, StyleCodes::$enum_name.diag_info()),)*
         ];
     }
 }
@@ -135,79 +125,74 @@ macro_rules! lints {
 lints!(
     (
         ConstantNaming,
-        LinterDiagnosticCategory::Style,
+        Style,
         "constant_naming",
         "constant should follow naming convention"
     ),
     (
         WhileTrueToLoop,
-        LinterDiagnosticCategory::Style,
+        Style,
         "while_true",
         "unnecessary 'while (true)', replace with 'loop'"
     ),
     (
         MeaninglessMath,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "unnecessary_math",
         "math operator can be simplified"
     ),
-    (
-        UnneededReturn,
-        LinterDiagnosticCategory::Style,
-        "unneeded_return",
-        "unneeded return"
-    ),
+    (UnneededReturn, Style, "unneeded_return", "unneeded return"),
     (
         AbortWithoutConstant,
-        LinterDiagnosticCategory::Style,
+        Style,
         "abort_without_constant",
         "'abort' or 'assert' without named constant"
     ),
     (
         LoopWithoutExit,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "loop_without_exit",
         "'loop' without 'break' or 'return'"
     ),
     (
         UnnecessaryConditional,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "unnecessary_conditional",
         "'if' expression can be removed"
     ),
     (
         SelfAssignment,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "self_assignment",
         "assignment preserves the same value"
     ),
     (
         RedundantRefDeref,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "redundant_ref_deref",
         "redundant reference/dereference"
     ),
     (
         UnnecessaryUnit,
-        LinterDiagnosticCategory::Style,
+        Style,
         "unnecessary_unit",
         "unit `()` expression can be removed or simplified"
     ),
     (
         EqualOperands,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "always_equal_operands",
         "redundant, always-equal operands for binary operation"
     ),
     (
         CombinableComparisons,
-        LinterDiagnosticCategory::Complexity,
+        Complexity,
         "combinable_comparisons",
         "comparison operations condition can be simplified"
     ),
     (
         UnusedReturnValue,
-        LinterDiagnosticCategory::Suspicious,
+        Suspicious,
         "unused_return_value",
         "return value of a non-mutating call is discarded"
     ),
@@ -222,18 +207,9 @@ pub fn known_filters() -> (Option<Symbol>, Vec<(FilterName, Vec<DiagnosticsID>)>
         vec![DiagnosticsID::all(Some(LINT_WARNING_PREFIX))],
     )];
     filters.extend(
-        STYLE_WARNING_FILTERS
+        MOVE_LINTS
             .iter()
-            .map(|(category, code, filter_name)| {
-                (
-                    Symbol::from(*filter_name),
-                    vec![DiagnosticsID::exact(
-                        Some(LINT_WARNING_PREFIX),
-                        *category,
-                        *code,
-                    )],
-                )
-            }),
+            .map(|(filter_name, info)| (Symbol::from(*filter_name), vec![info.id()])),
     );
     (Some(ALLOW_ATTR_CATEGORY.into()), filters)
 }

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/_index.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/_index.snap
@@ -1,0 +1,43 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_index()
+---
+Move lint index. Run `move lint --explain <name>` for details on any lint.
+
+Security
+    share_owned                possible owned object share
+    custom_state_change        potentially unenforceable custom transfer/share/freeze policy
+    freeze_wrapped             attempting to freeze wrapped objects
+    public_random              Risky use of 'sui::random'
+    freezing_capability        freezing potential capability
+
+Correctness
+    missing_key                struct with id but missing key ability
+
+Suspicious
+    collection_equality        possibly useless collections compare
+    uncallable_function        it will not be possible to call this function
+    unused_object_with_fields  unused object with fields
+    loop_without_exit          'loop' without 'break' or 'return'
+    self_assignment            assignment preserves the same value
+    always_equal_operands      redundant, always-equal operands for binary operation
+    unused_return_value        return value of a non-mutating call is discarded
+
+Conventions
+    self_transfer              non-composable transfer to sender
+    coin_field                 sub-optimal 'sui::coin::Coin' field type
+    public_entry               unnecessary `entry` on a `public` function
+    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
+    constant_naming            constant should follow naming convention
+    abort_without_constant     'abort' or 'assert' without named constant
+
+Complexity
+    unnecessary_math           math operator can be simplified
+    unnecessary_conditional    'if' expression can be removed
+    redundant_ref_deref        redundant reference/dereference
+    combinable_comparisons     comparison operations condition can be simplified
+
+Style
+    while_true                 unnecessary 'while (true)', replace with 'loop'
+    unneeded_return            unneeded return
+    unnecessary_unit           unit `()` expression can be removed or simplified

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 abort_without_constant
 ======================
 
-group:   Conventions
-origin:  Core
-level:   requires `--lint`
-code:    W04005
+category: Style
+origin:   Core
+level:    requires `--lint`
+code:     W04005
 
 'abort' or 'assert' without named constant
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
@@ -1,0 +1,30 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+abort_without_constant
+======================
+
+group:   Conventions
+origin:  Core
+level:   requires `--lint`
+code:    W04005
+
+'abort' or 'assert' without named constant
+
+A bare numeric abort code carries no meaning at the call site or in error output. A named constant documents the failure and keeps codes consistent across the module.
+
+When it's OK:
+  The whole argument must be a single named constant — `abort A + B` still fires. `assert!(cond, ECode)` is the idiomatic form.
+
+Example:
+
+  // flagged
+  abort 100
+
+  // suggested
+  const ERR_INVALID_ARGUMENT: u64 = 1;
+  // ...
+  abort ERR_INVALID_ARGUMENT
+
+Suppress a specific case with `#[allow(lint(abort_without_constant))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
@@ -6,7 +6,7 @@ abort_without_constant
 ======================
 
 category: Style
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W04005
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/abort_without_constant.snap
@@ -1,30 +1,33 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-abort_without_constant
-======================
+abort_without_constant (W04005): 'abort' or 'assert' without named constant
 
-category: Style
-origin:   Move
-level:    requires `--lint`
-code:     W04005
+A bare numeric abort code carries no meaning at the call site or in error output. A named constant
+documents the failure and keeps codes consistent across the module.
 
-'abort' or 'assert' without named constant
+This lint is off by default; enable it with `--lint`.
 
-A bare numeric abort code carries no meaning at the call site or in error output. A named constant documents the failure and keeps codes consistent across the module.
+## When it's OK
 
-When it's OK:
-  The whole argument must be a single named constant — `abort A + B` still fires. `assert!(cond, ECode)` is the idiomatic form.
+The whole argument must be a single named constant — `abort A + B` still fires. `assert!(cond,
+ECode)` is the idiomatic form.
 
-Example:
+## Example
 
-  // flagged
-  abort 100
+Flagged:
 
-  // suggested
-  const ERR_INVALID_ARGUMENT: u64 = 1;
-  // ...
-  abort ERR_INVALID_ARGUMENT
+```move
+abort 100
+```
+
+Suggested:
+
+```move
+const ERR_INVALID_ARGUMENT: u64 = 1;
+// ...
+abort ERR_INVALID_ARGUMENT
+```
 
 Suppress a specific case with `#[allow(lint(abort_without_constant))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
@@ -6,7 +6,7 @@ always_equal_operands
 =====================
 
 category: Suspicious
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W02011
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
@@ -1,25 +1,27 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-always_equal_operands
-=====================
+always_equal_operands (W02011): redundant, always-equal operands for binary operation
 
-category: Suspicious
-origin:   Move
-level:    requires `--lint`
-code:     W02011
+A binary operation whose two operands are the same expression has an already-known result: `x == x`
+is always `true`, `x - x` is `0`, `x / x` is `1`, `x & x` is just `x`. The operation is dead weight
+and often a copy-paste bug where one side should differ.
 
-redundant, always-equal operands for binary operation
+This lint is off by default; enable it with `--lint`.
 
-A binary operation whose two operands are the same expression has an already-known result: `x == x` is always `true`, `x - x` is `0`, `x / x` is `1`, `x & x` is just `x`. The operation is dead weight and often a copy-paste bug where one side should differ.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  let b = x == x;
+```move
+let b = x == x;
+```
 
-  // suggested
-  let b = true;
+Suggested:
+
+```move
+let b = true;
+```
 
 Suppress a specific case with `#[allow(lint(always_equal_operands))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 always_equal_operands
 =====================
 
-group:   Suspicious
-origin:  Core
-level:   requires `--lint`
-code:    W02011
+category: Suspicious
+origin:   Core
+level:    requires `--lint`
+code:     W02011
 
 redundant, always-equal operands for binary operation
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/always_equal_operands.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+always_equal_operands
+=====================
+
+group:   Suspicious
+origin:  Core
+level:   requires `--lint`
+code:    W02011
+
+redundant, always-equal operands for binary operation
+
+A binary operation whose two operands are the same expression has an already-known result: `x == x` is always `true`, `x - x` is `0`, `x / x` is `1`, `x & x` is just `x`. The operation is dead weight and often a copy-paste bug where one side should differ.
+
+Example:
+
+  // flagged
+  let b = x == x;
+
+  // suggested
+  let b = true;
+
+Suppress a specific case with `#[allow(lint(always_equal_operands))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/coin_field.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/coin_field.snap
@@ -1,34 +1,38 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-coin_field
-==========
+coin_field (W99003): sub-optimal 'sui::coin::Coin' field type
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99003
+`Coin<T>` is itself a full object (it has an `id: UID`) meant for transfers between accounts. Held
+as a field it adds needless object plumbing; `Balance<T>` is the storage-oriented type for keeping
+value inside another object.
 
-sub-optimal 'sui::coin::Coin' field type
+This lint is on by default.
 
-`Coin<T>` is itself a full object (it has an `id: UID`) meant for transfers between accounts. Held as a field it adds needless object plumbing; `Balance<T>` is the storage-oriented type for keeping value inside another object.
+## When it's OK
 
-When it's OK:
-  Keep `Coin` only if the field genuinely needs to be an independent object. An alias does not avoid the lint — the resolved type is what's matched.
+Keep `Coin` only if the field genuinely needs to be an independent object. An alias does not avoid
+the lint — the resolved type is what's matched.
 
-Example:
+## Example
 
-  // flagged
-  public struct S2 has key, store {
-      id: UID,
-      c: Coin<S1>,
-  }
+Flagged:
 
-  // suggested
-  public struct S2 has key, store {
-      id: UID,
-      c: Balance<S1>,
-  }
+```move
+public struct S2 has key, store {
+    id: UID,
+    c: Coin<S1>,
+}
+```
+
+Suggested:
+
+```move
+public struct S2 has key, store {
+    id: UID,
+    c: Balance<S1>,
+}
+```
 
 Suppress a specific case with `#[allow(lint(coin_field))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/coin_field.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/coin_field.snap
@@ -1,0 +1,34 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+coin_field
+==========
+
+group:   Conventions
+origin:  Sui
+level:   on by default
+code:    W99003
+
+sub-optimal 'sui::coin::Coin' field type
+
+`Coin<T>` is itself a full object (it has an `id: UID`) meant for transfers between accounts. Held as a field it adds needless object plumbing; `Balance<T>` is the storage-oriented type for keeping value inside another object.
+
+When it's OK:
+  Keep `Coin` only if the field genuinely needs to be an independent object. An alias does not avoid the lint — the resolved type is what's matched.
+
+Example:
+
+  // flagged
+  public struct S2 has key, store {
+      id: UID,
+      c: Coin<S1>,
+  }
+
+  // suggested
+  public struct S2 has key, store {
+      id: UID,
+      c: Balance<S1>,
+  }
+
+Suppress a specific case with `#[allow(lint(coin_field))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/coin_field.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/coin_field.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 coin_field
 ==========
 
-group:   Conventions
-origin:  Sui
-level:   on by default
-code:    W99003
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99003
 
 sub-optimal 'sui::coin::Coin' field type
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/collection_equality.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/collection_equality.snap
@@ -1,30 +1,33 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-collection_equality
-===================
+collection_equality (W99005): possibly useless collections compare
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99005
+Sui collections — `Bag`, `ObjectBag`, `Table`, `ObjectTable`, `LinkedTable`, `TableVec`, `VecMap`,
+and `VecSet` — have no meaningful `==`. The UID-backed ones (`Bag`, `Table`, …) compare by their
+internal handle, not contents; `VecMap`/`VecSet` compare their backing vector, so equal contents in
+a different insertion order compare unequal. Either way `==`/`!=` rarely means what it looks like.
 
-possibly useless collections compare
+This lint is on by default.
 
-Sui collections — `Bag`, `ObjectBag`, `Table`, `ObjectTable`, `LinkedTable`, `TableVec`, `VecMap`, and `VecSet` — have no meaningful `==`. The UID-backed ones (`Bag`, `Table`, …) compare by their internal handle, not contents; `VecMap`/`VecSet` compare their backing vector, so equal contents in a different insertion order compare unequal. Either way `==`/`!=` rarely means what it looks like.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
-      bag1 == bag2
-  }
+```move
+public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+    bag1 == bag2
+}
+```
 
-  // suggested
-  // compare the state you care about, not the collection handle
-  public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
-      bag1.length() == bag2.length()
-  }
+Suggested:
+
+```move
+// compare the state you care about, not the collection handle
+public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+    bag1.length() == bag2.length()
+}
+```
 
 Suppress a specific case with `#[allow(lint(collection_equality))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/collection_equality.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/collection_equality.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 collection_equality
 ===================
 
-group:   Suspicious
-origin:  Sui
-level:   on by default
-code:    W99005
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99005
 
 possibly useless collections compare
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/collection_equality.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/collection_equality.snap
@@ -1,0 +1,30 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+collection_equality
+===================
+
+group:   Suspicious
+origin:  Sui
+level:   on by default
+code:    W99005
+
+possibly useless collections compare
+
+Sui collections — `Bag`, `ObjectBag`, `Table`, `ObjectTable`, `LinkedTable`, `TableVec`, `VecMap`, and `VecSet` — have no meaningful `==`. The UID-backed ones (`Bag`, `Table`, …) compare by their internal handle, not contents; `VecMap`/`VecSet` compare their backing vector, so equal contents in a different insertion order compare unequal. Either way `==`/`!=` rarely means what it looks like.
+
+Example:
+
+  // flagged
+  public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+      bag1 == bag2
+  }
+
+  // suggested
+  // compare the state you care about, not the collection handle
+  public fun bag_eq(bag1: &Bag, bag2: &Bag): bool {
+      bag1.length() == bag2.length()
+  }
+
+Suppress a specific case with `#[allow(lint(collection_equality))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
@@ -1,0 +1,28 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+combinable_comparisons
+======================
+
+group:   Complexity
+origin:  Core
+level:   requires `--lint`
+code:    W01012
+
+comparison operations condition can be simplified
+
+Two comparisons over the same operand pair joined by `&&`/`||` often collapse to a single comparison (`x == y && x >= y` is just `x == y`), or to a constant `true`/`false` (`x >= y || x <= y`).
+
+When it's OK:
+  Negated comparisons are not handled and won't fire.
+
+Example:
+
+  // flagged
+  let b = x == y && x >= y;
+
+  // suggested
+  let b = x == y;
+
+Suppress a specific case with `#[allow(lint(combinable_comparisons))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
@@ -1,28 +1,30 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-combinable_comparisons
-======================
+combinable_comparisons (W01012): comparison operations condition can be simplified
 
-category: Complexity
-origin:   Move
-level:    requires `--lint`
-code:     W01012
+Two comparisons over the same operand pair joined by `&&`/`||` often collapse to a single comparison
+(`x == y && x >= y` is just `x == y`), or to a constant `true`/`false` (`x >= y || x <= y`).
 
-comparison operations condition can be simplified
+This lint is off by default; enable it with `--lint`.
 
-Two comparisons over the same operand pair joined by `&&`/`||` often collapse to a single comparison (`x == y && x >= y` is just `x == y`), or to a constant `true`/`false` (`x >= y || x <= y`).
+## When it's OK
 
-When it's OK:
-  Negated comparisons are not handled and won't fire.
+Negated comparisons are not handled and won't fire.
 
-Example:
+## Example
 
-  // flagged
-  let b = x == y && x >= y;
+Flagged:
 
-  // suggested
-  let b = x == y;
+```move
+let b = x == y && x >= y;
+```
+
+Suggested:
+
+```move
+let b = x == y;
+```
 
 Suppress a specific case with `#[allow(lint(combinable_comparisons))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
@@ -6,7 +6,7 @@ combinable_comparisons
 ======================
 
 category: Complexity
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W01012
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/combinable_comparisons.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 combinable_comparisons
 ======================
 
-group:   Complexity
-origin:  Core
-level:   requires `--lint`
-code:    W01012
+category: Complexity
+origin:   Core
+level:    requires `--lint`
+code:     W01012
 
 comparison operations condition can be simplified
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 constant_naming
 ===============
 
-group:   Conventions
-origin:  Core
-level:   requires `--lint`
-code:    W04001
+category: Style
+origin:   Core
+level:    requires `--lint`
+code:     W04001
 
 constant should follow naming convention
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
@@ -1,29 +1,33 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-constant_naming
-===============
+constant_naming (W04001): constant should follow naming convention
 
-category: Style
-origin:   Move
-level:    requires `--lint`
-code:     W04001
+Constants are expected to be `UPPER_SNAKE_CASE` or PascalCase (either is accepted for any constant).
+A lowercase or mixed name (`max_supply`, `JSON_Max_Size`) reads like a variable and breaks module
+consistency.
 
-constant should follow naming convention
+This lint is off by default; enable it with `--lint`.
 
-Constants are expected to be `UPPER_SNAKE_CASE` or PascalCase (either is accepted for any constant). A lowercase or mixed name (`max_supply`, `JSON_Max_Size`) reads like a variable and breaks module consistency.
+## When it's OK
 
-When it's OK:
-  PascalCase is deliberately allowed — including the `E`-prefixed PascalCase used for error constants, such as `ENotAuthorized`.
+PascalCase is deliberately allowed — including the `E`-prefixed PascalCase used for error constants,
+such as `ENotAuthorized`.
 
-Example:
+## Example
 
-  // flagged
-  const Another_BadName: u64 = 42;
+Flagged:
 
-  // suggested
-  const MAX_LIMIT: u64 = 1000;
-  const ENotAuthorized: u64 = 0;
+```move
+const Another_BadName: u64 = 42;
+```
+
+Suggested:
+
+```move
+const MAX_LIMIT: u64 = 1000;
+const ENotAuthorized: u64 = 0;
+```
 
 Suppress a specific case with `#[allow(lint(constant_naming))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
@@ -1,0 +1,29 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+constant_naming
+===============
+
+group:   Conventions
+origin:  Core
+level:   requires `--lint`
+code:    W04001
+
+constant should follow naming convention
+
+Constants are expected to be `UPPER_SNAKE_CASE` or PascalCase (either is accepted for any constant). A lowercase or mixed name (`max_supply`, `JSON_Max_Size`) reads like a variable and breaks module consistency.
+
+When it's OK:
+  PascalCase is deliberately allowed — including the `E`-prefixed PascalCase used for error constants, such as `ENotAuthorized`.
+
+Example:
+
+  // flagged
+  const Another_BadName: u64 = 42;
+
+  // suggested
+  const MAX_LIMIT: u64 = 1000;
+  const ENotAuthorized: u64 = 0;
+
+Suppress a specific case with `#[allow(lint(constant_naming))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/constant_naming.snap
@@ -6,7 +6,7 @@ constant_naming
 ===============
 
 category: Style
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W04001
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/custom_state_change.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/custom_state_change.snap
@@ -1,33 +1,38 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-custom_state_change
-===================
+custom_state_change (W99002): potentially unenforceable custom transfer/share/freeze policy
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99002
+A by-value struct defined in this module that has the `store` ability can already be transferred,
+shared, or frozen by anyone through the `public_*` API. Routing it through the private
+`transfer`/`share_object`/`freeze_object` therefore cannot enforce any custom policy — callers just
+bypass it.
 
-potentially unenforceable custom transfer/share/freeze policy
+This lint is on by default.
 
-A by-value struct defined in this module that has the `store` ability can already be transferred, shared, or frozen by anyone through the `public_*` API. Routing it through the private `transfer`/`share_object`/`freeze_object` therefore cannot enforce any custom policy — callers just bypass it.
+## When it's OK
 
-When it's OK:
-  If the type keeps `store`, call the honest `public_*` variant. If the policy must actually hold, remove `store` so the private variant is the only path.
+If the type keeps `store`, call the honest `public_*` variant. If the policy must actually hold,
+remove `store` so the private variant is the only path.
 
-Example:
+## Example
 
-  // flagged
-  // `S1` has `key` + `store`, so callers can already freeze it via `public_freeze_object`
-  public fun custom_freeze(o: S1) {
-      transfer::freeze_object(o)
-  }
+Flagged:
 
-  // suggested
-  public fun custom_freeze(o: S1) {
-      transfer::public_freeze_object(o)
-  }
+```move
+// `S1` has `key` + `store`, so callers can already freeze it via `public_freeze_object`
+public fun custom_freeze(o: S1) {
+    transfer::freeze_object(o)
+}
+```
+
+Suggested:
+
+```move
+public fun custom_freeze(o: S1) {
+    transfer::public_freeze_object(o)
+}
+```
 
 Suppress a specific case with `#[allow(lint(custom_state_change))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/custom_state_change.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/custom_state_change.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 custom_state_change
 ===================
 
-group:   Security
-origin:  Sui
-level:   on by default
-code:    W99002
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99002
 
 potentially unenforceable custom transfer/share/freeze policy
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/custom_state_change.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/custom_state_change.snap
@@ -1,0 +1,33 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+custom_state_change
+===================
+
+group:   Security
+origin:  Sui
+level:   on by default
+code:    W99002
+
+potentially unenforceable custom transfer/share/freeze policy
+
+A by-value struct defined in this module that has the `store` ability can already be transferred, shared, or frozen by anyone through the `public_*` API. Routing it through the private `transfer`/`share_object`/`freeze_object` therefore cannot enforce any custom policy — callers just bypass it.
+
+When it's OK:
+  If the type keeps `store`, call the honest `public_*` variant. If the policy must actually hold, remove `store` so the private variant is the only path.
+
+Example:
+
+  // flagged
+  // `S1` has `key` + `store`, so callers can already freeze it via `public_freeze_object`
+  public fun custom_freeze(o: S1) {
+      transfer::freeze_object(o)
+  }
+
+  // suggested
+  public fun custom_freeze(o: S1) {
+      transfer::public_freeze_object(o)
+  }
+
+Suppress a specific case with `#[allow(lint(custom_state_change))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freeze_wrapped.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freeze_wrapped.snap
@@ -1,0 +1,34 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+freeze_wrapped
+==============
+
+group:   Security
+origin:  Sui
+level:   on by default
+code:    W99004
+
+attempting to freeze wrapped objects
+
+Freezing makes an object immutable forever. If the frozen object wraps another object — a field whose type has `key`, directly or transitively — that inner object is frozen and made unrecoverable too, which is almost never intended.
+
+Example:
+
+  // flagged
+  public struct Inner has key, store { id: UID }
+  public struct Wrapper has key, store { id: UID, inner: Inner }
+
+  public fun freeze_wrapper(w: Wrapper) {
+      transfer::public_freeze_object(w)
+  }
+
+  // suggested
+  public struct Config has key, store { id: UID, fee: u64 }
+
+  public fun freeze_config(c: Config) {
+      transfer::public_freeze_object(c)
+  }
+
+Suppress a specific case with `#[allow(lint(freeze_wrapped))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freeze_wrapped.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freeze_wrapped.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 freeze_wrapped
 ==============
 
-group:   Security
-origin:  Sui
-level:   on by default
-code:    W99004
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99004
 
 attempting to freeze wrapped objects
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freeze_wrapped.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freeze_wrapped.snap
@@ -1,34 +1,36 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-freeze_wrapped
-==============
+freeze_wrapped (W99004): attempting to freeze wrapped objects
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99004
+Freezing makes an object immutable forever. If the frozen object wraps another object — a field
+whose type has `key`, directly or transitively — that inner object is frozen and made unrecoverable
+too, which is almost never intended.
 
-attempting to freeze wrapped objects
+This lint is on by default.
 
-Freezing makes an object immutable forever. If the frozen object wraps another object — a field whose type has `key`, directly or transitively — that inner object is frozen and made unrecoverable too, which is almost never intended.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  public struct Inner has key, store { id: UID }
-  public struct Wrapper has key, store { id: UID, inner: Inner }
+```move
+public struct Inner has key, store { id: UID }
+public struct Wrapper has key, store { id: UID, inner: Inner }
 
-  public fun freeze_wrapper(w: Wrapper) {
-      transfer::public_freeze_object(w)
-  }
+public fun freeze_wrapper(w: Wrapper) {
+    transfer::public_freeze_object(w)
+}
+```
 
-  // suggested
-  public struct Config has key, store { id: UID, fee: u64 }
+Suggested:
 
-  public fun freeze_config(c: Config) {
-      transfer::public_freeze_object(c)
-  }
+```move
+public struct Config has key, store { id: UID, fee: u64 }
+
+public fun freeze_config(c: Config) {
+    transfer::public_freeze_object(c)
+}
+```
 
 Suppress a specific case with `#[allow(lint(freeze_wrapped))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freezing_capability.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freezing_capability.snap
@@ -1,35 +1,40 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-freezing_capability
-===================
+freezing_capability (W99008): freezing potential capability
 
-category: Sui
-origin:   Sui
-level:    requires `--lint`
-code:     W99008
+Capabilities gate privileged actions. Freezing one turns it into a permanent immutable object that
+anyone can reference and that can never be revoked — usually the opposite of the intended access
+control. The lint matches by struct name (a capitalized `Cap`).
 
-freezing potential capability
+This lint is off by default; enable it with `--lint`.
 
-Capabilities gate privileged actions. Freezing one turns it into a permanent immutable object that anyone can reference and that can never be revoked — usually the opposite of the intended access control. The lint matches by struct name (a capitalized `Cap`).
+## When it's OK
 
-When it's OK:
-  The match is by name — a `Cap` at the end of the name, or followed by an uppercase letter, digit, or `_`. So a non-capability like `NoCap` is a false positive, while a real capability with an off-pattern name (`AdminRights`, `Capv0`) is missed.
+The match is by name — a `Cap` at the end of the name, or followed by an uppercase letter, digit, or
+`_`. So a non-capability like `NoCap` is a false positive, while a real capability with an
+off-pattern name (`AdminRights`, `Capv0`) is missed.
 
-Example:
+## Example
 
-  // flagged
-  public struct AdminCap has key { id: UID }
+Flagged:
 
-  public fun freeze_cap(cap: AdminCap) {
-      transfer::public_freeze_object(cap)
-  }
+```move
+public struct AdminCap has key { id: UID }
 
-  // suggested
-  // keep the capability owned instead of freezing it
-  public fun keep_cap(cap: AdminCap, owner: address) {
-      transfer::transfer(cap, owner)
-  }
+public fun freeze_cap(cap: AdminCap) {
+    transfer::public_freeze_object(cap)
+}
+```
+
+Suggested:
+
+```move
+// keep the capability owned instead of freezing it
+public fun keep_cap(cap: AdminCap, owner: address) {
+    transfer::transfer(cap, owner)
+}
+```
 
 Suppress a specific case with `#[allow(lint(freezing_capability))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freezing_capability.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freezing_capability.snap
@@ -1,0 +1,35 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+freezing_capability
+===================
+
+group:   Security
+origin:  Sui
+level:   requires `--lint`
+code:    W99008
+
+freezing potential capability
+
+Capabilities gate privileged actions. Freezing one turns it into a permanent immutable object that anyone can reference and that can never be revoked — usually the opposite of the intended access control. The lint matches by struct name (a capitalized `Cap`).
+
+When it's OK:
+  The match is by name — a `Cap` at the end of the name, or followed by an uppercase letter, digit, or `_`. So a non-capability like `NoCap` is a false positive, while a real capability with an off-pattern name (`AdminRights`, `Capv0`) is missed.
+
+Example:
+
+  // flagged
+  public struct AdminCap has key { id: UID }
+
+  public fun freeze_cap(cap: AdminCap) {
+      transfer::public_freeze_object(cap)
+  }
+
+  // suggested
+  // keep the capability owned instead of freezing it
+  public fun keep_cap(cap: AdminCap, owner: address) {
+      transfer::transfer(cap, owner)
+  }
+
+Suppress a specific case with `#[allow(lint(freezing_capability))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freezing_capability.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/freezing_capability.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 freezing_capability
 ===================
 
-group:   Security
-origin:  Sui
-level:   requires `--lint`
-code:    W99008
+category: Sui
+origin:   Sui
+level:    requires `--lint`
+code:     W99008
 
 freezing potential capability
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/index.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/index.snap
@@ -4,40 +4,36 @@ expression: LintIndex.to_string()
 ---
 Move lint index. Run `move lint --explain <name>` for details on any lint.
 
-Security
-    share_owned                possible owned object share
-    custom_state_change        potentially unenforceable custom transfer/share/freeze policy
-    freeze_wrapped             attempting to freeze wrapped objects
-    public_random              Risky use of 'sui::random'
-    freezing_capability        freezing potential capability
-
-Correctness
-    missing_key                struct with id but missing key ability
-
-Suspicious
-    collection_equality        possibly useless collections compare
-    uncallable_function        it will not be possible to call this function
-    unused_object_with_fields  unused object with fields
-    loop_without_exit          'loop' without 'break' or 'return'
-    self_assignment            assignment preserves the same value
-    always_equal_operands      redundant, always-equal operands for binary operation
-    unused_return_value        return value of a non-mutating call is discarded
-
-Conventions
-    self_transfer              non-composable transfer to sender
-    coin_field                 sub-optimal 'sui::coin::Coin' field type
-    public_entry               unnecessary `entry` on a `public` function
-    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
-    constant_naming            constant should follow naming convention
-    abort_without_constant     'abort' or 'assert' without named constant
-
 Complexity
     unnecessary_math           math operator can be simplified
     unnecessary_conditional    'if' expression can be removed
     redundant_ref_deref        redundant reference/dereference
     combinable_comparisons     comparison operations condition can be simplified
 
+Suspicious
+    loop_without_exit          'loop' without 'break' or 'return'
+    self_assignment            assignment preserves the same value
+    always_equal_operands      redundant, always-equal operands for binary operation
+    unused_return_value        return value of a non-mutating call is discarded
+
 Style
+    constant_naming            constant should follow naming convention
+    abort_without_constant     'abort' or 'assert' without named constant
     while_true                 unnecessary 'while (true)', replace with 'loop'
     unneeded_return            unneeded return
     unnecessary_unit           unit `()` expression can be removed or simplified
+
+Sui
+    share_owned                possible owned object share
+    custom_state_change        potentially unenforceable custom transfer/share/freeze policy
+    freeze_wrapped             attempting to freeze wrapped objects
+    public_random              Risky use of 'sui::random'
+    freezing_capability        freezing potential capability
+    missing_key                struct with id but missing key ability
+    collection_equality        possibly useless collections compare
+    uncallable_function        it will not be possible to call this function
+    unused_object_with_fields  unused object with fields
+    self_transfer              non-composable transfer to sender
+    coin_field                 sub-optimal 'sui::coin::Coin' field type
+    public_entry               unnecessary `entry` on a `public` function
+    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/index.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/index.snap
@@ -1,0 +1,43 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: LintIndex.to_string()
+---
+Move lint index. Run `move lint --explain <name>` for details on any lint.
+
+Security
+    share_owned                possible owned object share
+    custom_state_change        potentially unenforceable custom transfer/share/freeze policy
+    freeze_wrapped             attempting to freeze wrapped objects
+    public_random              Risky use of 'sui::random'
+    freezing_capability        freezing potential capability
+
+Correctness
+    missing_key                struct with id but missing key ability
+
+Suspicious
+    collection_equality        possibly useless collections compare
+    uncallable_function        it will not be possible to call this function
+    unused_object_with_fields  unused object with fields
+    loop_without_exit          'loop' without 'break' or 'return'
+    self_assignment            assignment preserves the same value
+    always_equal_operands      redundant, always-equal operands for binary operation
+    unused_return_value        return value of a non-mutating call is discarded
+
+Conventions
+    self_transfer              non-composable transfer to sender
+    coin_field                 sub-optimal 'sui::coin::Coin' field type
+    public_entry               unnecessary `entry` on a `public` function
+    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
+    constant_naming            constant should follow naming convention
+    abort_without_constant     'abort' or 'assert' without named constant
+
+Complexity
+    unnecessary_math           math operator can be simplified
+    unnecessary_conditional    'if' expression can be removed
+    redundant_ref_deref        redundant reference/dereference
+    combinable_comparisons     comparison operations condition can be simplified
+
+Style
+    while_true                 unnecessary 'while (true)', replace with 'loop'
+    unneeded_return            unneeded return
+    unnecessary_unit           unit `()` expression can be removed or simplified

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/index.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/index.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: LintIndex.to_string()
+expression: "LintIndex { command: \"move lint\" }.to_string()"
 ---
 Move lint index. Run `move lint --explain <name>` for details on any lint.
 
@@ -18,22 +18,22 @@ Suspicious
 
 Style
     constant_naming            constant should follow naming convention
-    abort_without_constant     'abort' or 'assert' without named constant
     while_true                 unnecessary 'while (true)', replace with 'loop'
     unneeded_return            unneeded return
+    abort_without_constant     'abort' or 'assert' without named constant
     unnecessary_unit           unit `()` expression can be removed or simplified
 
 Sui
     share_owned                possible owned object share
+    self_transfer              non-composable transfer to sender
     custom_state_change        potentially unenforceable custom transfer/share/freeze policy
+    coin_field                 sub-optimal 'sui::coin::Coin' field type
     freeze_wrapped             attempting to freeze wrapped objects
-    public_random              Risky use of 'sui::random'
-    freezing_capability        freezing potential capability
-    missing_key                struct with id but missing key ability
     collection_equality        possibly useless collections compare
+    public_random              Risky use of 'sui::random'
+    missing_key                struct with id but missing key ability
+    freezing_capability        freezing potential capability
+    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'
+    public_entry               unnecessary `entry` on a `public` function
     uncallable_function        it will not be possible to call this function
     unused_object_with_fields  unused object with fields
-    self_transfer              non-composable transfer to sender
-    coin_field                 sub-optimal 'sui::coin::Coin' field type
-    public_entry               unnecessary `entry` on a `public` function
-    prefer_mut_tx_context      prefer '&mut TxContext' over '&TxContext'

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 loop_without_exit
 =================
 
-group:   Suspicious
-origin:  Core
-level:   requires `--lint`
-code:    W02006
+category: Suspicious
+origin:   Core
+level:    requires `--lint`
+code:     W02006
 
 'loop' without 'break' or 'return'
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
@@ -6,7 +6,7 @@ loop_without_exit
 =================
 
 category: Suspicious
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W02006
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
@@ -1,0 +1,35 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+loop_without_exit
+=================
+
+group:   Suspicious
+origin:  Core
+level:   requires `--lint`
+code:    W02006
+
+'loop' without 'break' or 'return'
+
+A `loop` whose body contains neither `break` nor `return` has no normal exit — it runs until it aborts, if ever. This is almost always a missing exit condition. (`while` is covered separately by `while_true`.)
+
+When it's OK:
+  An `abort` inside the loop is not treated as an exit, so a deliberately divergent loop is a false positive.
+
+Example:
+
+  // flagged
+  let i = 0;
+  loop {
+      i = i + 1;
+  }
+
+  // suggested
+  let i = 0;
+  loop {
+      if (i >= 10) break;
+      i = i + 1;
+  }
+
+Suppress a specific case with `#[allow(lint(loop_without_exit))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/loop_without_exit.snap
@@ -1,35 +1,39 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-loop_without_exit
-=================
+loop_without_exit (W02006): 'loop' without 'break' or 'return'
 
-category: Suspicious
-origin:   Move
-level:    requires `--lint`
-code:     W02006
+A `loop` whose body contains neither `break` nor `return` has no normal exit — it runs until it
+aborts, if ever. This is almost always a missing exit condition. (`while` is covered separately by
+`while_true`.)
 
-'loop' without 'break' or 'return'
+This lint is off by default; enable it with `--lint`.
 
-A `loop` whose body contains neither `break` nor `return` has no normal exit — it runs until it aborts, if ever. This is almost always a missing exit condition. (`while` is covered separately by `while_true`.)
+## When it's OK
 
-When it's OK:
-  An `abort` inside the loop is not treated as an exit, so a deliberately divergent loop is a false positive.
+An `abort` inside the loop is not treated as an exit, so a deliberately divergent loop is a false
+positive.
 
-Example:
+## Example
 
-  // flagged
-  let i = 0;
-  loop {
-      i = i + 1;
-  }
+Flagged:
 
-  // suggested
-  let i = 0;
-  loop {
-      if (i >= 10) break;
-      i = i + 1;
-  }
+```move
+let i = 0;
+loop {
+    i = i + 1;
+}
+```
+
+Suggested:
+
+```move
+let i = 0;
+loop {
+    if (i >= 10) break;
+    i = i + 1;
+}
+```
 
 Suppress a specific case with `#[allow(lint(loop_without_exit))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/missing_key.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/missing_key.snap
@@ -1,29 +1,30 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-missing_key
-===========
+missing_key (W99007): struct with id but missing key ability
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99007
+A struct whose first field is `id: UID` looks like a Sui object, but without the `key` ability it
+can never be stored, transferred, or shared as one. This is almost always a forgotten `has key`.
 
-struct with id but missing key ability
+This lint is on by default.
 
-A struct whose first field is `id: UID` looks like a Sui object, but without the `key` ability it can never be stored, transferred, or shared as one. This is almost always a forgotten `has key`.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  public struct MissingKeyAbility {
-      id: UID,
-  }
+```move
+public struct MissingKeyAbility {
+    id: UID,
+}
+```
 
-  // suggested
-  public struct HasKeyAbility has key {
-      id: UID,
-  }
+Suggested:
+
+```move
+public struct HasKeyAbility has key {
+    id: UID,
+}
+```
 
 Suppress a specific case with `#[allow(lint(missing_key))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/missing_key.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/missing_key.snap
@@ -1,0 +1,29 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+missing_key
+===========
+
+group:   Correctness
+origin:  Sui
+level:   on by default
+code:    W99007
+
+struct with id but missing key ability
+
+A struct whose first field is `id: UID` looks like a Sui object, but without the `key` ability it can never be stored, transferred, or shared as one. This is almost always a forgotten `has key`.
+
+Example:
+
+  // flagged
+  public struct MissingKeyAbility {
+      id: UID,
+  }
+
+  // suggested
+  public struct HasKeyAbility has key {
+      id: UID,
+  }
+
+Suppress a specific case with `#[allow(lint(missing_key))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/missing_key.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/missing_key.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 missing_key
 ===========
 
-group:   Correctness
-origin:  Sui
-level:   on by default
-code:    W99007
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99007
 
 struct with id but missing key ability
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/prefer_mut_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/prefer_mut_tx_context.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 prefer_mut_tx_context
 =====================
 
-group:   Conventions
-origin:  Sui
-level:   requires `--lint`
-code:    W99009
+category: Sui
+origin:   Sui
+level:    requires `--lint`
+code:     W99009
 
 prefer '&mut TxContext' over '&TxContext'
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/prefer_mut_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/prefer_mut_tx_context.snap
@@ -1,28 +1,32 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-prefer_mut_tx_context
-=====================
+prefer_mut_tx_context (W99009): prefer '&mut TxContext' over '&TxContext'
 
-category: Sui
-origin:   Sui
-level:    requires `--lint`
-code:     W99009
+A public function that takes `&TxContext` cannot later create objects — which needs `&mut TxContext`
+— without a breaking signature change. Taking `&mut TxContext` up front keeps the API
+upgrade-compatible.
 
-prefer '&mut TxContext' over '&TxContext'
+This lint is off by default; enable it with `--lint`.
 
-A public function that takes `&TxContext` cannot later create objects — which needs `&mut TxContext` — without a breaking signature change. Taking `&mut TxContext` up front keeps the API upgrade-compatible.
+## When it's OK
 
-When it's OK:
-  Only `public` functions are checked; any non-`public` visibility (private, `public(package)`, `public(friend)`) is exempt, since those signatures can change freely.
+Only `public` functions are checked; any non-`public` visibility (private, `public(package)`,
+`public(friend)`) is exempt, since those signatures can change freely.
 
-Example:
+## Example
 
-  // flagged
-  public fun incorrect_mint(_ctx: &TxContext) {}
+Flagged:
 
-  // suggested
-  public fun correct_mint(_ctx: &mut TxContext) {}
+```move
+public fun incorrect_mint(_ctx: &TxContext) {}
+```
+
+Suggested:
+
+```move
+public fun correct_mint(_ctx: &mut TxContext) {}
+```
 
 Suppress a specific case with `#[allow(lint(prefer_mut_tx_context))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/prefer_mut_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/prefer_mut_tx_context.snap
@@ -1,0 +1,28 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+prefer_mut_tx_context
+=====================
+
+group:   Conventions
+origin:  Sui
+level:   requires `--lint`
+code:    W99009
+
+prefer '&mut TxContext' over '&TxContext'
+
+A public function that takes `&TxContext` cannot later create objects — which needs `&mut TxContext` — without a breaking signature change. Taking `&mut TxContext` up front keeps the API upgrade-compatible.
+
+When it's OK:
+  Only `public` functions are checked; any non-`public` visibility (private, `public(package)`, `public(friend)`) is exempt, since those signatures can change freely.
+
+Example:
+
+  // flagged
+  public fun incorrect_mint(_ctx: &TxContext) {}
+
+  // suggested
+  public fun correct_mint(_ctx: &mut TxContext) {}
+
+Suppress a specific case with `#[allow(lint(prefer_mut_tx_context))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_entry.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_entry.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 public_entry
 ============
 
-group:   Conventions
-origin:  Sui
-level:   on by default
-code:    W99010
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99010
 
 unnecessary `entry` on a `public` function
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_entry.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_entry.snap
@@ -1,25 +1,27 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-public_entry
-============
+public_entry (W99010): unnecessary `entry` on a `public` function
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99010
+`entry` on a `public` function is redundant: a `public` function is already callable from a
+programmable transaction block. `entry` is only meaningful on a non-`public` function, where it is
+what makes the function callable as a transaction command.
 
-unnecessary `entry` on a `public` function
+This lint is on by default.
 
-`entry` on a `public` function is redundant: a `public` function is already callable from a programmable transaction block. `entry` is only meaningful on a non-`public` function, where it is what makes the function callable as a transaction command.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  public entry fun mint() {}
+```move
+public entry fun mint() {}
+```
 
-  // suggested
-  public fun mint() {}
+Suggested:
+
+```move
+public fun mint() {}
+```
 
 Suppress a specific case with `#[allow(lint(public_entry))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_entry.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_entry.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+public_entry
+============
+
+group:   Conventions
+origin:  Sui
+level:   on by default
+code:    W99010
+
+unnecessary `entry` on a `public` function
+
+`entry` on a `public` function is redundant: a `public` function is already callable from a programmable transaction block. `entry` is only meaningful on a non-`public` function, where it is what makes the function callable as a transaction command.
+
+Example:
+
+  // flagged
+  public entry fun mint() {}
+
+  // suggested
+  public fun mint() {}
+
+Suppress a specific case with `#[allow(lint(public_entry))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_random.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_random.snap
@@ -1,28 +1,33 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-public_random
-=============
+public_random (W99006): Risky use of 'sui::random'
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99006
+A `public` function that takes `Random` or `RandomGenerator` can be called by other Move code,
+letting an attacker draw randomness and react to the outcome within the same transaction. Randomness
+should only be reachable from a transaction, not composed by another contract.
 
-Risky use of 'sui::random'
+This lint is on by default.
 
-A `public` function that takes `Random` or `RandomGenerator` can be called by other Move code, letting an attacker draw randomness and react to the outcome within the same transaction. Randomness should only be reachable from a transaction, not composed by another contract.
+## When it's OK
 
-When it's OK:
-  Reduce the visibility below `public` — a non-public `entry` function, `public(package)`, or a private function — so it can't be composed by another contract. Adding `entry` to a function that stays `public` does not help.
+Reduce the visibility below `public` — a non-public `entry` function, `public(package)`, or a
+private function — so it can't be composed by another contract. Adding `entry` to a function that
+stays `public` does not help.
 
-Example:
+## Example
 
-  // flagged
-  public fun not_allowed(_r: &Random) {}
+Flagged:
 
-  // suggested
-  entry fun basic_random(_r: &Random) {}
+```move
+public fun not_allowed(_r: &Random) {}
+```
+
+Suggested:
+
+```move
+entry fun basic_random(_r: &Random) {}
+```
 
 Suppress a specific case with `#[allow(lint(public_random))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_random.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_random.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 public_random
 =============
 
-group:   Security
-origin:  Sui
-level:   on by default
-code:    W99006
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99006
 
 Risky use of 'sui::random'
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_random.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/public_random.snap
@@ -1,0 +1,28 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+public_random
+=============
+
+group:   Security
+origin:  Sui
+level:   on by default
+code:    W99006
+
+Risky use of 'sui::random'
+
+A `public` function that takes `Random` or `RandomGenerator` can be called by other Move code, letting an attacker draw randomness and react to the outcome within the same transaction. Randomness should only be reachable from a transaction, not composed by another contract.
+
+When it's OK:
+  Reduce the visibility below `public` — a non-public `entry` function, `public(package)`, or a private function — so it can't be composed by another contract. Adding `entry` to a function that stays `public` does not help.
+
+Example:
+
+  // flagged
+  public fun not_allowed(_r: &Random) {}
+
+  // suggested
+  entry fun basic_random(_r: &Random) {}
+
+Suppress a specific case with `#[allow(lint(public_random))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
@@ -1,0 +1,28 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+redundant_ref_deref
+===================
+
+group:   Complexity
+origin:  Core
+level:   requires `--lint`
+code:    W01009
+
+redundant reference/dereference
+
+Taking a reference and immediately dereferencing it (`&*(&x)`), or dereferencing a fresh field borrow (`*(&s.f)`), is a no-op the compiler already performs for you.
+
+When it's OK:
+  Dereferencing an existing reference (`*r`) is fine — only dereferencing a fresh borrow (`*(&x)` or `&*(&x)`) is redundant.
+
+Example:
+
+  // flagged
+  let _ref = &*(&resource);
+
+  // suggested
+  let _ref = &resource;
+
+Suppress a specific case with `#[allow(lint(redundant_ref_deref))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 redundant_ref_deref
 ===================
 
-group:   Complexity
-origin:  Core
-level:   requires `--lint`
-code:    W01009
+category: Complexity
+origin:   Core
+level:    requires `--lint`
+code:     W01009
 
 redundant reference/dereference
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
@@ -6,7 +6,7 @@ redundant_ref_deref
 ===================
 
 category: Complexity
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W01009
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/redundant_ref_deref.snap
@@ -1,28 +1,31 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-redundant_ref_deref
-===================
+redundant_ref_deref (W01009): redundant reference/dereference
 
-category: Complexity
-origin:   Move
-level:    requires `--lint`
-code:     W01009
+Taking a reference and immediately dereferencing it (`&*(&x)`), or dereferencing a fresh field
+borrow (`*(&s.f)`), is a no-op the compiler already performs for you.
 
-redundant reference/dereference
+This lint is off by default; enable it with `--lint`.
 
-Taking a reference and immediately dereferencing it (`&*(&x)`), or dereferencing a fresh field borrow (`*(&s.f)`), is a no-op the compiler already performs for you.
+## When it's OK
 
-When it's OK:
-  Dereferencing an existing reference (`*r`) is fine — only dereferencing a fresh borrow (`*(&x)` or `&*(&x)`) is redundant.
+Dereferencing an existing reference (`*r`) is fine — only dereferencing a fresh borrow (`*(&x)` or
+`&*(&x)`) is redundant.
 
-Example:
+## Example
 
-  // flagged
-  let _ref = &*(&resource);
+Flagged:
 
-  // suggested
-  let _ref = &resource;
+```move
+let _ref = &*(&resource);
+```
+
+Suggested:
+
+```move
+let _ref = &resource;
+```
 
 Suppress a specific case with `#[allow(lint(redundant_ref_deref))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+self_assignment
+===============
+
+group:   Suspicious
+origin:  Core
+level:   requires `--lint`
+code:    W02008
+
+assignment preserves the same value
+
+Assigning a location to itself (`x = x`, `*r = *r`, `s.f = s.f`) has no effect. It usually signals a typo or an unfinished edit.
+
+Example:
+
+  // flagged
+  p = p;
+
+  // suggested
+  // remove the redundant statement
+
+Suppress a specific case with `#[allow(lint(self_assignment))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
@@ -6,7 +6,7 @@ self_assignment
 ===============
 
 category: Suspicious
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W02008
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
@@ -1,25 +1,26 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-self_assignment
-===============
+self_assignment (W02008): assignment preserves the same value
 
-category: Suspicious
-origin:   Move
-level:    requires `--lint`
-code:     W02008
+Assigning a location to itself (`x = x`, `*r = *r`, `s.f = s.f`) has no effect. It usually signals a
+typo or an unfinished edit.
 
-assignment preserves the same value
+This lint is off by default; enable it with `--lint`.
 
-Assigning a location to itself (`x = x`, `*r = *r`, `s.f = s.f`) has no effect. It usually signals a typo or an unfinished edit.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  p = p;
+```move
+p = p;
+```
 
-  // suggested
-  // remove the redundant statement
+Suggested:
+
+```move
+// remove the redundant statement
+```
 
 Suppress a specific case with `#[allow(lint(self_assignment))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_assignment.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 self_assignment
 ===============
 
-group:   Suspicious
-origin:  Core
-level:   requires `--lint`
-code:    W02008
+category: Suspicious
+origin:   Core
+level:    requires `--lint`
+code:     W02008
 
 assignment preserves the same value
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_transfer.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_transfer.snap
@@ -1,0 +1,33 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+self_transfer
+=============
+
+group:   Conventions
+origin:  Sui
+level:   on by default
+code:    W99001
+
+non-composable transfer to sender
+
+Transferring an object (one with `key` + `store`) to `ctx.sender()` inside the function makes it non-composable: a caller (or a programmable transaction block) cannot use the object because the function gives it away internally. Returning the object lets the caller decide what to do with it.
+
+When it's OK:
+  Rare — the composable pattern is to return the object and let the caller place it. `entry` functions and `init` are already exempt.
+
+Example:
+
+  // flagged
+  // `S1` has `key` + `store`
+  public fun mint(ctx: &mut TxContext) {
+      transfer::public_transfer(S1 { id: object::new(ctx) }, ctx.sender())
+  }
+
+  // suggested
+  public fun mint(ctx: &mut TxContext): S1 {
+      S1 { id: object::new(ctx) }
+  }
+
+Suppress a specific case with `#[allow(lint(self_transfer))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_transfer.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_transfer.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 self_transfer
 =============
 
-group:   Conventions
-origin:  Sui
-level:   on by default
-code:    W99001
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99001
 
 non-composable transfer to sender
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_transfer.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/self_transfer.snap
@@ -1,33 +1,37 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-self_transfer
-=============
+self_transfer (W99001): non-composable transfer to sender
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99001
+Transferring an object (one with `key` + `store`) to `ctx.sender()` inside the function makes it
+non-composable: a caller (or a programmable transaction block) cannot use the object because the
+function gives it away internally. Returning the object lets the caller decide what to do with it.
 
-non-composable transfer to sender
+This lint is on by default.
 
-Transferring an object (one with `key` + `store`) to `ctx.sender()` inside the function makes it non-composable: a caller (or a programmable transaction block) cannot use the object because the function gives it away internally. Returning the object lets the caller decide what to do with it.
+## When it's OK
 
-When it's OK:
-  Rare — the composable pattern is to return the object and let the caller place it. `entry` functions and `init` are already exempt.
+Rare — the composable pattern is to return the object and let the caller place it. `entry` functions
+and `init` are already exempt.
 
-Example:
+## Example
 
-  // flagged
-  // `S1` has `key` + `store`
-  public fun mint(ctx: &mut TxContext) {
-      transfer::public_transfer(S1 { id: object::new(ctx) }, ctx.sender())
-  }
+Flagged:
 
-  // suggested
-  public fun mint(ctx: &mut TxContext): S1 {
-      S1 { id: object::new(ctx) }
-  }
+```move
+// `S1` has `key` + `store`
+public fun mint(ctx: &mut TxContext) {
+    transfer::public_transfer(S1 { id: object::new(ctx) }, ctx.sender())
+}
+```
+
+Suggested:
+
+```move
+public fun mint(ctx: &mut TxContext): S1 {
+    S1 { id: object::new(ctx) }
+}
+```
 
 Suppress a specific case with `#[allow(lint(self_transfer))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/share_owned.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/share_owned.snap
@@ -1,34 +1,40 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-share_owned
-===========
+share_owned (W99000): possible owned object share
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99000
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an
+object that is not freshly created in this function (it arrives as a parameter or from an unpack)
+can silently hand every account write access to something a user believed was theirs. It fires only
+when the type is also transferable — it has `store`, or is transferred with `transfer::transfer`
+elsewhere; a `key`-only type that is never transferred is not flagged.
 
-possible owned object share
+This lint is on by default.
 
-Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an object that is not freshly created in this function (it arrives as a parameter or from an unpack) can silently hand every account write access to something a user believed was theirs. It fires only when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` elsewhere; a `key`-only type that is never transferred is not flagged.
+## When it's OK
 
-When it's OK:
-  The shared object really is fresh, but was produced through a helper call the local analysis can't see through — a conservative false positive.
+The shared object really is fresh, but was produced through a helper call the local analysis can't
+see through — a conservative false positive.
 
-Example:
+## Example
 
-  // flagged
-  // `o` is a parameter — the checker can't prove it is fresh
-  public fun share(o: Obj) {
-      transfer::public_share_object(o)
-  }
+Flagged:
 
-  // suggested
-  // packed here, so provably a fresh object
-  public fun share(ctx: &mut TxContext) {
-      transfer::share_object(Obj { id: object::new(ctx) })
-  }
+```move
+// `o` is a parameter — the checker can't prove it is fresh
+public fun share(o: Obj) {
+    transfer::public_share_object(o)
+}
+```
+
+Suggested:
+
+```move
+// packed here, so provably a fresh object
+public fun share(ctx: &mut TxContext) {
+    transfer::share_object(Obj { id: object::new(ctx) })
+}
+```
 
 Suppress a specific case with `#[allow(lint(share_owned))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/share_owned.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/share_owned.snap
@@ -1,0 +1,34 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+share_owned
+===========
+
+group:   Security
+origin:  Sui
+level:   on by default
+code:    W99000
+
+possible owned object share
+
+Sharing is irreversible and makes an object world-writable forever. Calling `share_object` on an object that is not freshly created in this function (it arrives as a parameter or from an unpack) can silently hand every account write access to something a user believed was theirs. It fires only when the type is also transferable — it has `store`, or is transferred with `transfer::transfer` elsewhere; a `key`-only type that is never transferred is not flagged.
+
+When it's OK:
+  The shared object really is fresh, but was produced through a helper call the local analysis can't see through — a conservative false positive.
+
+Example:
+
+  // flagged
+  // `o` is a parameter — the checker can't prove it is fresh
+  public fun share(o: Obj) {
+      transfer::public_share_object(o)
+  }
+
+  // suggested
+  // packed here, so provably a fresh object
+  public fun share(ctx: &mut TxContext) {
+      transfer::share_object(Obj { id: object::new(ctx) })
+  }
+
+Suppress a specific case with `#[allow(lint(share_owned))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/share_owned.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/share_owned.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 share_owned
 ===========
 
-group:   Security
-origin:  Sui
-level:   on by default
-code:    W99000
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99000
 
 possible owned object share
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/uncallable_function.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/uncallable_function.snap
@@ -1,29 +1,32 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-uncallable_function
-===================
+uncallable_function (W99011): it will not be possible to call this function
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99011
+The transaction runtime can only supply certain argument shapes. Taking `TxContext` by value, a
+`&mut TxContext` alongside any other `TxContext` parameter (it must be the only one), or a `&mut` to
+`Clock`/`Random` makes the function impossible to call from a transaction.
 
-it will not be possible to call this function
+This lint is on by default.
 
-The transaction runtime can only supply certain argument shapes. Taking `TxContext` by value, a `&mut TxContext` alongside any other `TxContext` parameter (it must be the only one), or a `&mut` to `Clock`/`Random` makes the function impossible to call from a transaction.
+## When it's OK
 
-When it's OK:
-  A single `&mut TxContext` is fine. Use `&Clock` and `&Random` rather than `&mut`.
+A single `&mut TxContext` is fine. Use `&Clock` and `&Random` rather than `&mut`.
 
-Example:
+## Example
 
-  // flagged
-  // `Clock` must be passed by immutable reference
-  fun uses_clock(_c: &mut Clock) {}
+Flagged:
 
-  // suggested
-  fun uses_clock(_c: &Clock) {}
+```move
+// `Clock` must be passed by immutable reference
+fun uses_clock(_c: &mut Clock) {}
+```
+
+Suggested:
+
+```move
+fun uses_clock(_c: &Clock) {}
+```
 
 Suppress a specific case with `#[allow(lint(uncallable_function))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/uncallable_function.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/uncallable_function.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 uncallable_function
 ===================
 
-group:   Suspicious
-origin:  Sui
-level:   on by default
-code:    W99011
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99011
 
 it will not be possible to call this function
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/uncallable_function.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/uncallable_function.snap
@@ -1,0 +1,29 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+uncallable_function
+===================
+
+group:   Suspicious
+origin:  Sui
+level:   on by default
+code:    W99011
+
+it will not be possible to call this function
+
+The transaction runtime can only supply certain argument shapes. Taking `TxContext` by value, a `&mut TxContext` alongside any other `TxContext` parameter (it must be the only one), or a `&mut` to `Clock`/`Random` makes the function impossible to call from a transaction.
+
+When it's OK:
+  A single `&mut TxContext` is fine. Use `&Clock` and `&Random` rather than `&mut`.
+
+Example:
+
+  // flagged
+  // `Clock` must be passed by immutable reference
+  fun uses_clock(_c: &mut Clock) {}
+
+  // suggested
+  fun uses_clock(_c: &Clock) {}
+
+Suppress a specific case with `#[allow(lint(uncallable_function))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 unnecessary_conditional
 =======================
 
-group:   Complexity
-origin:  Core
-level:   requires `--lint`
-code:    W01007
+category: Complexity
+origin:   Core
+level:    requires `--lint`
+code:     W01007
 
 'if' expression can be removed
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+unnecessary_conditional
+=======================
+
+group:   Complexity
+origin:  Core
+level:   requires `--lint`
+code:    W01007
+
+'if' expression can be removed
+
+An `if` with one branch `true` and the other `false` collapses to the condition itself (or its negation), and one whose branches are the same literal value collapses to that value. The conditional only adds noise.
+
+Example:
+
+  // flagged
+  let b = if (!condition) true else false;
+
+  // suggested
+  let b = !condition;
+
+Suppress a specific case with `#[allow(lint(unnecessary_conditional))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
@@ -6,7 +6,7 @@ unnecessary_conditional
 =======================
 
 category: Complexity
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W01007
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_conditional.snap
@@ -1,25 +1,27 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-unnecessary_conditional
-=======================
+unnecessary_conditional (W01007): 'if' expression can be removed
 
-category: Complexity
-origin:   Move
-level:    requires `--lint`
-code:     W01007
+An `if` with one branch `true` and the other `false` collapses to the condition itself (or its
+negation), and one whose branches are the same literal value collapses to that value. The
+conditional only adds noise.
 
-'if' expression can be removed
+This lint is off by default; enable it with `--lint`.
 
-An `if` with one branch `true` and the other `false` collapses to the condition itself (or its negation), and one whose branches are the same literal value collapses to that value. The conditional only adds noise.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  let b = if (!condition) true else false;
+```move
+let b = if (!condition) true else false;
+```
 
-  // suggested
-  let b = !condition;
+Suggested:
+
+```move
+let b = !condition;
+```
 
 Suppress a specific case with `#[allow(lint(unnecessary_conditional))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+unnecessary_math
+================
+
+group:   Complexity
+origin:  Core
+level:   requires `--lint`
+code:    W01003
+
+math operator can be simplified
+
+An operation with an identity operand (`* 1`, `/ 1`, `+ 0`, `- 0`, `<< 0`, `>> 0`) does nothing; one with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x` is `1`. Only literal `0`/`1` operands are detected.
+
+Example:
+
+  // flagged
+  let y = x * 1;
+
+  // suggested
+  let y = x;
+
+Suppress a specific case with `#[allow(lint(unnecessary_math))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
@@ -6,7 +6,7 @@ unnecessary_math
 ================
 
 category: Complexity
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W01003
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
@@ -1,25 +1,27 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-unnecessary_math
-================
+unnecessary_math (W01003): math operator can be simplified
 
-category: Complexity
-origin:   Move
-level:    requires `--lint`
-code:     W01003
+An operation with an identity operand (`* 1`, `/ 1`, `+ 0`, `- 0`, `<< 0`, `>> 0`) does nothing; one
+with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x` is `1`. Only
+literal `0`/`1` operands are detected.
 
-math operator can be simplified
+This lint is off by default; enable it with `--lint`.
 
-An operation with an identity operand (`* 1`, `/ 1`, `+ 0`, `- 0`, `<< 0`, `>> 0`) does nothing; one with an absorbing operand (`* 0`, `0 / x`, `x % 1`, `0 % x`) is `0`; and `1 % x` is `1`. Only literal `0`/`1` operands are detected.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  let y = x * 1;
+```move
+let y = x * 1;
+```
 
-  // suggested
-  let y = x;
+Suggested:
+
+```move
+let y = x;
+```
 
 Suppress a specific case with `#[allow(lint(unnecessary_math))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_math.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 unnecessary_math
 ================
 
-group:   Complexity
-origin:  Core
-level:   requires `--lint`
-code:    W01003
+category: Complexity
+origin:   Core
+level:    requires `--lint`
+code:     W01003
 
 math operator can be simplified
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+unnecessary_unit
+================
+
+group:   Style
+origin:  Core
+level:   requires `--lint`
+code:    W04010
+
+unit `()` expression can be removed or simplified
+
+A `()` unit expression as a non-final statement, or as a branch of an `if`, adds nothing. Remove it, or invert the condition to drop the empty branch.
+
+Example:
+
+  // flagged
+  if (b) () else { x = 1 };
+
+  // suggested
+  if (!b) { x = 1 };
+
+Suppress a specific case with `#[allow(lint(unnecessary_unit))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
@@ -6,7 +6,7 @@ unnecessary_unit
 ================
 
 category: Style
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W04010
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
@@ -1,25 +1,26 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-unnecessary_unit
-================
+unnecessary_unit (W04010): unit `()` expression can be removed or simplified
 
-category: Style
-origin:   Move
-level:    requires `--lint`
-code:     W04010
+A `()` unit expression as a non-final statement, or as a branch of an `if`, adds nothing. Remove it,
+or invert the condition to drop the empty branch.
 
-unit `()` expression can be removed or simplified
+This lint is off by default; enable it with `--lint`.
 
-A `()` unit expression as a non-final statement, or as a branch of an `if`, adds nothing. Remove it, or invert the condition to drop the empty branch.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  if (b) () else { x = 1 };
+```move
+if (b) () else { x = 1 };
+```
 
-  // suggested
-  if (!b) { x = 1 };
+Suggested:
+
+```move
+if (!b) { x = 1 };
+```
 
 Suppress a specific case with `#[allow(lint(unnecessary_unit))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unnecessary_unit.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 unnecessary_unit
 ================
 
-group:   Style
-origin:  Core
-level:   requires `--lint`
-code:    W04010
+category: Style
+origin:   Core
+level:    requires `--lint`
+code:     W04010
 
 unit `()` expression can be removed or simplified
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 unneeded_return
 ===============
 
-group:   Style
-origin:  Core
-level:   requires `--lint`
-code:    W04004
+category: Style
+origin:   Core
+level:    requires `--lint`
+code:     W04004
 
 unneeded return
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
@@ -1,32 +1,36 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-unneeded_return
-===============
+unneeded_return (W04004): unneeded return
 
-category: Style
-origin:   Move
-level:    requires `--lint`
-code:     W04004
+In tail position the `return` keyword is redundant — the trailing expression is already the
+function's value.
 
-unneeded return
+This lint is off by default; enable it with `--lint`.
 
-In tail position the `return` keyword is redundant — the trailing expression is already the function's value.
+## When it's OK
 
-When it's OK:
-  Only a tail-position `return` is flagged — of any value-yielding expression (a call, `S { .. }`, arithmetic, a cast, `loop`, even `()`). A `return` used as an early exit, or whose operand doesn't yield a value (e.g. `return abort E`), is left alone.
+Only a tail-position `return` is flagged — of any value-yielding expression (a call, `S { .. }`,
+arithmetic, a cast, `loop`, even `()`). A `return` used as an early exit, or whose operand doesn't
+yield a value (e.g. `return abort E`), is left alone.
 
-Example:
+## Example
 
-  // flagged
-  fun price(): u64 {
-      return 5
-  }
+Flagged:
 
-  // suggested
-  fun price(): u64 {
-      5
-  }
+```move
+fun price(): u64 {
+    return 5
+}
+```
+
+Suggested:
+
+```move
+fun price(): u64 {
+    5
+}
+```
 
 Suppress a specific case with `#[allow(lint(unneeded_return))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
@@ -6,7 +6,7 @@ unneeded_return
 ===============
 
 category: Style
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W04004
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unneeded_return.snap
@@ -1,0 +1,32 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+unneeded_return
+===============
+
+group:   Style
+origin:  Core
+level:   requires `--lint`
+code:    W04004
+
+unneeded return
+
+In tail position the `return` keyword is redundant — the trailing expression is already the function's value.
+
+When it's OK:
+  Only a tail-position `return` is flagged — of any value-yielding expression (a call, `S { .. }`, arithmetic, a cast, `loop`, even `()`). A `return` used as an early exit, or whose operand doesn't yield a value (e.g. `return abort E`), is left alone.
+
+Example:
+
+  // flagged
+  fun price(): u64 {
+      return 5
+  }
+
+  // suggested
+  fun price(): u64 {
+      5
+  }
+
+Suppress a specific case with `#[allow(lint(unneeded_return))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_object_with_fields.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_object_with_fields.snap
@@ -1,32 +1,36 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-unused_object_with_fields
-=========================
+unused_object_with_fields (W99012): unused object with fields
 
-category: Sui
-origin:   Sui
-level:    on by default
-code:     W99012
+A reference to an object that carries data beyond its `id`, but whose fields are never read, is a
+likely mistake: the function takes the object yet never looks at the values it holds.
 
-unused object with fields
+This lint is on by default.
 
-A reference to an object that carries data beyond its `id`, but whose fields are never read, is a likely mistake: the function takes the object yet never looks at the values it holds.
+## When it's OK
 
-When it's OK:
-  Objects with no field beyond `id` (pure marker capabilities), by-value params, and generic object types are out of scope. Otherwise the function should assert on or otherwise read a field — or drop the parameter if it truly isn't needed.
+Objects with no field beyond `id` (pure marker capabilities), by-value params, and generic object
+types are out of scope. Otherwise the function should assert on or otherwise read a field — or drop
+the parameter if it truly isn't needed.
 
-Example:
+## Example
 
-  // flagged
-  public struct OwnerCap has key { id: UID, owns: address }
+Flagged:
 
-  public fun unused(_c: &OwnerCap) {}
+```move
+public struct OwnerCap has key { id: UID, owns: address }
 
-  // suggested
-  public fun owner(c: &OwnerCap): address {
-      c.owns
-  }
+public fun unused(_c: &OwnerCap) {}
+```
+
+Suggested:
+
+```move
+public fun owner(c: &OwnerCap): address {
+    c.owns
+}
+```
 
 Suppress a specific case with `#[allow(lint(unused_object_with_fields))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_object_with_fields.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_object_with_fields.snap
@@ -1,0 +1,32 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: doc.to_string()
+---
+unused_object_with_fields
+=========================
+
+group:   Suspicious
+origin:  Sui
+level:   on by default
+code:    W99012
+
+unused object with fields
+
+A reference to an object that carries data beyond its `id`, but whose fields are never read, is a likely mistake: the function takes the object yet never looks at the values it holds.
+
+When it's OK:
+  Objects with no field beyond `id` (pure marker capabilities), by-value params, and generic object types are out of scope. Otherwise the function should assert on or otherwise read a field — or drop the parameter if it truly isn't needed.
+
+Example:
+
+  // flagged
+  public struct OwnerCap has key { id: UID, owns: address }
+
+  public fun unused(_c: &OwnerCap) {}
+
+  // suggested
+  public fun owner(c: &OwnerCap): address {
+      c.owns
+  }
+
+Suppress a specific case with `#[allow(lint(unused_object_with_fields))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_object_with_fields.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_object_with_fields.snap
@@ -5,10 +5,10 @@ expression: doc.to_string()
 unused_object_with_fields
 =========================
 
-group:   Suspicious
-origin:  Sui
-level:   on by default
-code:    W99012
+category: Sui
+origin:   Sui
+level:    on by default
+code:     W99012
 
 unused object with fields
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
@@ -6,7 +6,7 @@ unused_return_value
 ===================
 
 category: Suspicious
-origin:   Core
+origin:   Move
 level:    on by default
 code:     W02013
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
@@ -1,0 +1,30 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+unused_return_value
+===================
+
+group:   Suspicious
+origin:  Core
+level:   on by default
+code:    W02013
+
+return value of a non-mutating call is discarded
+
+Discarding the result of a call that has no `&mut` arguments means the call did nothing observable. Either use the value or make the intent explicit with `let _ = ...`. In Sui mode `&mut TxContext` is treated as non-mutating, so such calls are still flagged.
+
+When it's OK:
+  Calls that take a `&mut` argument (a real side effect) are not flagged. Bind to `let _` to acknowledge an intentionally discarded value.
+
+Example:
+
+  // flagged
+  fun price(x: u64): u64 { x + 1 }
+  // ...
+  price(10);
+
+  // suggested
+  let _ = price(10);
+
+Suppress a specific case with `#[allow(lint(unused_return_value))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
@@ -1,30 +1,34 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-unused_return_value
-===================
+unused_return_value (W02013): return value of a non-mutating call is discarded
 
-category: Suspicious
-origin:   Move
-level:    on by default
-code:     W02013
+Discarding the result of a call that has no `&mut` arguments means the call did nothing observable.
+Either use the value or make the intent explicit with `let _ = ...`. In Sui mode `&mut TxContext` is
+treated as non-mutating, so such calls are still flagged.
 
-return value of a non-mutating call is discarded
+This lint is on by default in Sui mode; a plain `move` build needs `--lint`.
 
-Discarding the result of a call that has no `&mut` arguments means the call did nothing observable. Either use the value or make the intent explicit with `let _ = ...`. In Sui mode `&mut TxContext` is treated as non-mutating, so such calls are still flagged.
+## When it's OK
 
-When it's OK:
-  Calls that take a `&mut` argument (a real side effect) are not flagged. Bind to `let _` to acknowledge an intentionally discarded value.
+Calls that take a `&mut` argument (a real side effect) are not flagged. Bind to `let _` to
+acknowledge an intentionally discarded value.
 
-Example:
+## Example
 
-  // flagged
-  fun price(x: u64): u64 { x + 1 }
-  // ...
-  price(10);
+Flagged:
 
-  // suggested
-  let _ = price(10);
+```move
+fun price(x: u64): u64 { x + 1 }
+// ...
+price(10);
+```
+
+Suggested:
+
+```move
+let _ = price(10);
+```
 
 Suppress a specific case with `#[allow(lint(unused_return_value))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/unused_return_value.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 unused_return_value
 ===================
 
-group:   Suspicious
-origin:  Core
-level:   on by default
-code:    W02013
+category: Suspicious
+origin:   Core
+level:    on by default
+code:     W02013
 
 return value of a non-mutating call is discarded
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: render_explanation(doc)
+expression: doc.to_string()
 ---
 while_true
 ==========
 
-group:   Style
-origin:  Core
-level:   requires `--lint`
-code:    W04002
+category: Style
+origin:   Core
+level:    requires `--lint`
+code:     W04002
 
 unnecessary 'while (true)', replace with 'loop'
 

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
@@ -1,29 +1,30 @@
 ---
 source: crates/move-compiler/src/linters/docs.rs
-expression: doc.to_string()
+expression: explanation.to_string()
 ---
-while_true
-==========
+while_true (W04002): unnecessary 'while (true)', replace with 'loop'
 
-category: Style
-origin:   Move
-level:    requires `--lint`
-code:     W04002
+`while (true)` is an infinite loop written the long way. `loop` states the intent directly and can
+`break` with a value. Only the literal `true` condition is detected.
 
-unnecessary 'while (true)', replace with 'loop'
+This lint is off by default; enable it with `--lint`.
 
-`while (true)` is an infinite loop written the long way. `loop` states the intent directly and can `break` with a value. Only the literal `true` condition is detected.
+## Example
 
-Example:
+Flagged:
 
-  // flagged
-  while (true) {
-      // ...
-  }
+```move
+while (true) {
+    // ...
+}
+```
 
-  // suggested
-  loop {
-      // ...
-  }
+Suggested:
+
+```move
+loop {
+    // ...
+}
+```
 
 Suppress a specific case with `#[allow(lint(while_true))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
@@ -1,0 +1,29 @@
+---
+source: crates/move-compiler/src/linters/docs.rs
+expression: render_explanation(doc)
+---
+while_true
+==========
+
+group:   Style
+origin:  Core
+level:   requires `--lint`
+code:    W04002
+
+unnecessary 'while (true)', replace with 'loop'
+
+`while (true)` is an infinite loop written the long way. `loop` states the intent directly and can `break` with a value. Only the literal `true` condition is detected.
+
+Example:
+
+  // flagged
+  while (true) {
+      // ...
+  }
+
+  // suggested
+  loop {
+      // ...
+  }
+
+Suppress a specific case with `#[allow(lint(while_true))]`.

--- a/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
+++ b/external-crates/move/crates/move-compiler/src/linters/snapshots/explain/while_true.snap
@@ -6,7 +6,7 @@ while_true
 ==========
 
 category: Style
-origin:   Core
+origin:   Move
 level:    requires `--lint`
 code:     W04002
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::DiagnosticInfo,
     expansion::ast::ModuleIdent,
     naming::ast as N,
     parser::ast::DatatypeName,
@@ -14,18 +14,9 @@ use crate::{
     typing::{ast as T, visitor::simple_visitor},
 };
 
-use super::{
-    COIN_MOD_NAME, COIN_STRUCT_NAME, LINT_WARNING_PREFIX, LinterDiagnosticCategory,
-    LinterDiagnosticCode,
-};
+use super::{COIN_MOD_NAME, COIN_STRUCT_NAME, LinterDiagnosticCode};
 
-const COIN_FIELD_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::CoinField as u8,
-    "sub-optimal 'sui::coin::Coin' field type",
-);
+const COIN_FIELD_DIAG: DiagnosticInfo = LinterDiagnosticCode::CoinField.diag_info();
 
 simple_visitor!(
     CoinFieldVisitor,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
@@ -10,7 +10,7 @@ use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::DiagnosticInfo,
     parser::ast as P,
     sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE},
     typing::{ast as T, visitor::simple_visitor},
@@ -18,19 +18,14 @@ use crate::{
 
 use super::{
     BAG_MOD_NAME, BAG_STRUCT_NAME, LINKED_TABLE_MOD_NAME, LINKED_TABLE_STRUCT_NAME,
-    LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode, OBJECT_BAG_MOD_NAME,
-    OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, TABLE_MOD_NAME,
-    TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME,
-    VEC_MAP_STRUCT_NAME, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME,
+    LinterDiagnosticCode, OBJECT_BAG_MOD_NAME, OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME,
+    OBJECT_TABLE_STRUCT_NAME, TABLE_MOD_NAME, TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME,
+    TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME, VEC_MAP_STRUCT_NAME, VEC_SET_MOD_NAME,
+    VEC_SET_STRUCT_NAME,
 };
 
-const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::CollectionEquality as u8,
-    "possibly useless collections compare",
-);
+const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo =
+    LinterDiagnosticCode::CollectionEquality.diag_info();
 
 const COLLECTION_TYPES: &[(Symbol, AccountAddress, &str, &str)] = &[
     (SUI_ADDR_NAME, SUI_ADDR_VALUE, BAG_MOD_NAME, BAG_STRUCT_NAME),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -22,10 +22,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics, codes::DiagnosticInfo},
     hlir::ast::{
         BaseType_, Label, ModuleCall, SingleType, SingleType_, Type, Type_, TypeName_, Var,
     },
@@ -36,8 +33,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    FREEZE_FUN, INVALID_LOC, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-    RECEIVE_FUN, SHARE_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    FREEZE_FUN, INVALID_LOC, LinterDiagnosticCode, RECEIVE_FUN, SHARE_FUN, TRANSFER_FUN,
+    TRANSFER_MOD_NAME,
 };
 
 const PRIVATE_OBJ_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
@@ -47,13 +44,8 @@ const PRIVATE_OBJ_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, RECEIVE_FUN),
 ];
 
-const CUSTOM_STATE_CHANGE_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::CustomStateChange as u8,
-    "potentially unenforceable custom transfer/share/freeze policy",
-);
+const CUSTOM_STATE_CHANGE_DIAG: DiagnosticInfo =
+    LinterDiagnosticCode::CustomStateChange.diag_info();
 
 //**************************************************************************************************
 // types

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -8,9 +8,7 @@
 use crate::{
     diag,
     diagnostics::{
-        Diagnostic, DiagnosticReporter, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-        filter::FilterScope,
+        Diagnostic, DiagnosticReporter, Diagnostics, codes::DiagnosticInfo, filter::FilterScope,
     },
     expansion::ast as E,
     naming::ast as N,
@@ -18,10 +16,7 @@ use crate::{
     shared::{CompilationEnv, Identifier, program_info::TypingProgramInfo},
     sui_mode::{
         SUI_ADDR_VALUE,
-        linters::{
-            FREEZE_FUN, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-            PUBLIC_FREEZE_FUN, TRANSFER_MOD_NAME,
-        },
+        linters::{FREEZE_FUN, LinterDiagnosticCode, PUBLIC_FREEZE_FUN, TRANSFER_MOD_NAME},
     },
     typing::{
         ast as T,
@@ -33,13 +28,7 @@ use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{collections::BTreeMap, sync::Arc};
 
-const FREEZE_WRAPPING_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::FreezeWrapped as u8,
-    "attempting to freeze wrapped objects",
-);
+const FREEZE_WRAPPING_DIAG: DiagnosticInfo = LinterDiagnosticCode::FreezeWrapped.diag_info();
 
 const FREEZE_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, PUBLIC_FREEZE_FUN),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freezing_capability.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freezing_capability.rs
@@ -6,15 +6,12 @@
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::DiagnosticInfo,
     naming::ast::TypeName_,
     shared::Identifier,
     sui_mode::{
         SUI_ADDR_VALUE,
-        linters::{
-            FREEZE_FUN, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-            PUBLIC_FREEZE_FUN, TRANSFER_MOD_NAME,
-        },
+        linters::{FREEZE_FUN, LinterDiagnosticCode, PUBLIC_FREEZE_FUN, TRANSFER_MOD_NAME},
     },
     typing::{ast as T, core, visitor::simple_visitor},
 };
@@ -25,13 +22,7 @@ use regex::Regex;
 
 use std::sync::LazyLock;
 
-const FREEZE_CAPABILITY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::FreezingCapability as u8,
-    "freezing potential capability",
-);
+const FREEZE_CAPABILITY_DIAG: DiagnosticInfo = LinterDiagnosticCode::FreezingCapability.diag_info();
 
 const FREEZE_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, PUBLIC_FREEZE_FUN),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
@@ -3,25 +3,19 @@
 
 //! This linter rule checks for structs with an `id` field of type `UID` without the `key` ability.
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::LinterDiagnosticCode;
 use crate::expansion::ast::ModuleIdent;
 use crate::parser::ast::DatatypeName;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::DiagnosticInfo,
     naming::ast::{StructDefinition, StructFields},
     parser::ast::Ability_,
     sui_mode::{ID_FIELD_NAME, OBJECT_MODULE_NAME, SUI_ADDR_VALUE, UID_TYPE_NAME},
     typing::visitor::simple_visitor,
 };
 
-const MISSING_KEY_ABILITY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::MissingKey as u8,
-    "struct with id but missing key ability",
-);
+const MISSING_KEY_ABILITY_DIAG: DiagnosticInfo = LinterDiagnosticCode::MissingKey.diag_info();
 
 simple_visitor!(
     MissingKeyVisitor,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -4,7 +4,10 @@
 use crate::{
     cfgir::visitor::AbstractInterpreterVisitor,
     command_line::compiler::Visitor,
-    diagnostics::{codes::DiagnosticsID, filter::FilterName},
+    diagnostics::{
+        codes::{DiagnosticInfo, DiagnosticsID, Severity, custom},
+        filter::FilterName,
+    },
     expansion::ast as E,
     hlir::ast::{BaseType_, SingleType, SingleType_},
     linters::{ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX, LintLevel, LinterDiagnosticCategory},
@@ -64,154 +67,123 @@ pub const VEC_MAP_STRUCT_NAME: &str = "VecMap";
 pub const VEC_SET_MOD_NAME: &str = "vec_set";
 pub const VEC_SET_STRUCT_NAME: &str = "VecSet";
 
-pub const SHARE_OWNED_FILTER_NAME: &str = "share_owned";
-pub const SELF_TRANSFER_FILTER_NAME: &str = "self_transfer";
-pub const CUSTOM_STATE_CHANGE_FILTER_NAME: &str = "custom_state_change";
-pub const COIN_FIELD_FILTER_NAME: &str = "coin_field";
-pub const FREEZE_WRAPPED_FILTER_NAME: &str = "freeze_wrapped";
-pub const COLLECTION_EQUALITY_FILTER_NAME: &str = "collection_equality";
-pub const PUBLIC_RANDOM_FILTER_NAME: &str = "public_random";
-pub const MISSING_KEY_FILTER_NAME: &str = "missing_key";
-pub const FREEZING_CAPABILITY_FILTER_NAME: &str = "freezing_capability";
-pub const PREFER_MUTABLE_TX_CONTEXT_FILTER_NAME: &str = "prefer_mut_tx_context";
-pub const UNNECESSARY_PUBLIC_ENTRY_FILTER_NAME: &str = "public_entry";
-pub const UNCALLABLE_FUNCTION_FILTER_NAME: &str = "uncallable_function";
-pub const UNUSED_OBJECT_WITH_FIELDS_FILTER_NAME: &str = "unused_object_with_fields";
-
 pub const RANDOM_MOD_NAME: &str = "random";
 pub const RANDOM_STRUCT_NAME: &str = "Random";
 pub const RANDOM_GENERATOR_STRUCT_NAME: &str = "RandomGenerator";
 
 pub const INVALID_LOC: Loc = Loc::invalid();
 
-#[repr(u8)]
-pub enum LinterDiagnosticCode {
-    ShareOwned,
-    SelfTransfer,
-    CustomStateChange,
-    CoinField,
-    FreezeWrapped,
-    CollectionEquality,
-    PublicRandom,
-    MissingKey,
-    FreezingCapability,
-    PreferMutableTxContext,
-    UnnecessaryPublicEntry,
-    UncallableFunction,
-    UnusedObjWithFields,
+macro_rules! sui_lints {
+    (
+        $(
+            ($enum_name:ident, $filter_name:expr, $code_msg:expr)
+        ),* $(,)?
+    ) => {
+        // Unlike `StyleCodes`, there is no zero placeholder -- Sui lint codes start at 0 and are
+        // positional: reordering or removing a variant changes the rendered `W99xxx` codes.
+        #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
+        #[repr(u8)]
+        pub enum LinterDiagnosticCode {
+            $(
+                $enum_name,
+            )*
+        }
+
+        impl LinterDiagnosticCode {
+            pub(crate) const fn diag_info(&self) -> DiagnosticInfo {
+                let code = *self as u8;
+                match self {
+                    // A lint has an explanation iff
+                    // `diagnostics/explanations/Sui_<CodeName>.md` exists -- keyed by
+                    // identifiers rather than the rendered code since the numeric portion is
+                    // positional (see `codes!` in diagnostics/codes.rs).
+                    $(Self::$enum_name => custom(
+                        LINT_WARNING_PREFIX,
+                        Severity::Warning,
+                        LinterDiagnosticCategory::Sui as u8,
+                        code,
+                        $code_msg,
+                    ).with_explanation(move_proc_macros::optional_include_str!(
+                        "src/diagnostics/explanations/", Sui, "_", $enum_name, ".md"
+                    )),)*
+                }
+            }
+        }
+
+        /// Every Sui lint as `(filter name, diagnostic info)`, in code order.
+        pub(crate) const SUI_LINTS: &[(&str, DiagnosticInfo)] = &[
+            $(($filter_name, LinterDiagnosticCode::$enum_name.diag_info()),)*
+        ];
+    }
 }
 
+sui_lints!(
+    (ShareOwned, "share_owned", "possible owned object share"),
+    (
+        SelfTransfer,
+        "self_transfer",
+        "non-composable transfer to sender"
+    ),
+    (
+        CustomStateChange,
+        "custom_state_change",
+        "potentially unenforceable custom transfer/share/freeze policy"
+    ),
+    (
+        CoinField,
+        "coin_field",
+        "sub-optimal 'sui::coin::Coin' field type"
+    ),
+    (
+        FreezeWrapped,
+        "freeze_wrapped",
+        "attempting to freeze wrapped objects"
+    ),
+    (
+        CollectionEquality,
+        "collection_equality",
+        "possibly useless collections compare"
+    ),
+    (PublicRandom, "public_random", "Risky use of 'sui::random'"),
+    (
+        MissingKey,
+        "missing_key",
+        "struct with id but missing key ability"
+    ),
+    (
+        FreezingCapability,
+        "freezing_capability",
+        "freezing potential capability"
+    ),
+    (
+        PreferMutableTxContext,
+        "prefer_mut_tx_context",
+        "prefer '&mut TxContext' over '&TxContext'"
+    ),
+    (
+        UnnecessaryPublicEntry,
+        "public_entry",
+        "unnecessary `entry` on a `public` function"
+    ),
+    (
+        UncallableFunction,
+        "uncallable_function",
+        "it will not be possible to call this function"
+    ),
+    (
+        UnusedObjWithFields,
+        "unused_object_with_fields",
+        "unused object with fields"
+    ),
+);
+
 pub fn known_filters() -> (Option<Symbol>, Vec<(FilterName, Vec<DiagnosticsID>)>) {
-    let sui = LinterDiagnosticCategory::Sui as u8;
     // `lint(all)` is registered by the core linter (`linters::known_filters`); don't
     // register it again here or `filter_from_str` returns duplicate ids.
-    let filters = vec![
-        (
-            Symbol::from(SHARE_OWNED_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::ShareOwned as u8,
-            )],
-        ),
-        (
-            Symbol::from(SELF_TRANSFER_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::SelfTransfer as u8,
-            )],
-        ),
-        (
-            Symbol::from(CUSTOM_STATE_CHANGE_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::CustomStateChange as u8,
-            )],
-        ),
-        (
-            Symbol::from(COIN_FIELD_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::CoinField as u8,
-            )],
-        ),
-        (
-            Symbol::from(FREEZE_WRAPPED_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::FreezeWrapped as u8,
-            )],
-        ),
-        (
-            Symbol::from(COLLECTION_EQUALITY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::CollectionEquality as u8,
-            )],
-        ),
-        (
-            Symbol::from(PUBLIC_RANDOM_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::PublicRandom as u8,
-            )],
-        ),
-        (
-            Symbol::from(MISSING_KEY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::MissingKey as u8,
-            )],
-        ),
-        (
-            Symbol::from(FREEZING_CAPABILITY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::FreezingCapability as u8,
-            )],
-        ),
-        (
-            Symbol::from(PREFER_MUTABLE_TX_CONTEXT_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::PreferMutableTxContext as u8,
-            )],
-        ),
-        (
-            Symbol::from(UNNECESSARY_PUBLIC_ENTRY_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::UnnecessaryPublicEntry as u8,
-            )],
-        ),
-        (
-            Symbol::from(UNCALLABLE_FUNCTION_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::UncallableFunction as u8,
-            )],
-        ),
-        (
-            Symbol::from(UNUSED_OBJECT_WITH_FIELDS_FILTER_NAME),
-            vec![DiagnosticsID::exact(
-                Some(LINT_WARNING_PREFIX),
-                sui,
-                LinterDiagnosticCode::UnusedObjWithFields as u8,
-            )],
-        ),
-    ];
-
+    let filters = SUI_LINTS
+        .iter()
+        .map(|(filter_name, info)| (Symbol::from(*filter_name), vec![info.id()]))
+        .collect();
     (Some(ALLOW_ATTR_CATEGORY.into()), filters)
 }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
@@ -5,10 +5,10 @@
 //! Detects and reports instances where a non-mutable reference to `TxContext` is used in public function signatures.
 //! Promotes best practices for future-proofing smart contract code by allowing mutation of the transaction context.
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::LinterDiagnosticCode;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::DiagnosticInfo,
     expansion::ast::{ModuleIdent, Visibility},
     naming::ast::TypeInner,
     parser::ast::FunctionName,
@@ -17,13 +17,8 @@ use crate::{
 };
 use move_ir_types::location::Loc;
 
-const REQUIRE_MUTABLE_TX_CONTEXT_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::PreferMutableTxContext as u8,
-    "prefer '&mut TxContext' over '&TxContext'",
-);
+const REQUIRE_MUTABLE_TX_CONTEXT_DIAG: DiagnosticInfo =
+    LinterDiagnosticCode::PreferMutableTxContext.diag_info();
 
 simple_visitor!(
     PreferMutableTxContext,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
@@ -8,25 +8,15 @@ use crate::parser::ast::FunctionName;
 use crate::sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE};
 use crate::typing::visitor::simple_visitor;
 use crate::{
-    diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
-    expansion::ast::Visibility,
-    naming::ast as N,
+    diag, diagnostics::codes::DiagnosticInfo, expansion::ast::Visibility, naming::ast as N,
     typing::ast as T,
 };
 
 use super::{
-    LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-    RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME,
+    LinterDiagnosticCode, RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME,
 };
 
-const PUBLIC_RANDOM_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::PublicRandom as u8,
-    "Risky use of 'sui::random'",
-);
+const PUBLIC_RANDOM_DIAG: DiagnosticInfo = LinterDiagnosticCode::PublicRandom.diag_info();
 
 simple_visitor!(
     PublicRandomVisitor,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -18,10 +18,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics, codes::DiagnosticInfo},
     hlir::ast::{Label, ModuleCall, Type, Type_, Var},
     parser::ast::Ability_,
     sui_mode::{SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME},
@@ -29,8 +26,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    INVALID_LOC, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-    PUBLIC_TRANSFER_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME, type_abilities,
+    INVALID_LOC, LinterDiagnosticCode, PUBLIC_TRANSFER_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    type_abilities,
 };
 
 const TRANSFER_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
@@ -38,13 +35,7 @@ const TRANSFER_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, TRANSFER_FUN),
 ];
 
-const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::SelfTransfer as u8,
-    "non-composable transfer to sender",
-);
+const SELF_TRANSFER_DIAG: DiagnosticInfo = LinterDiagnosticCode::SelfTransfer.diag_info();
 
 //**************************************************************************************************
 // types

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -17,10 +17,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics, codes::DiagnosticInfo},
     expansion::ast::ModuleIdent,
     hlir::ast::{
         BaseType, BaseType_, Exp, LValue, LValue_, Label, ModuleCall, SingleType, SingleType_,
@@ -36,8 +33,7 @@ use crate::{
         SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME,
         info::TransferKind,
         linters::{
-            LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_SHARE_FUN,
-            SHARE_FUN, TRANSFER_MOD_NAME, type_abilities,
+            LinterDiagnosticCode, PUBLIC_SHARE_FUN, SHARE_FUN, TRANSFER_MOD_NAME, type_abilities,
         },
     },
 };
@@ -51,13 +47,7 @@ const SHARE_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
     (SUI_ADDR_VALUE, TRANSFER_MOD_NAME, SHARE_FUN),
 ];
 
-const SHARE_OWNED_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::ShareOwned as u8,
-    "possible owned object share",
-);
+const SHARE_OWNED_DIAG: DiagnosticInfo = LinterDiagnosticCode::ShareOwned.diag_info();
 
 //**************************************************************************************************
 // types

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::LinterDiagnosticCode;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::DiagnosticInfo,
     expansion::ast::ModuleIdent,
     parser::ast::FunctionName,
     sui_mode::{
@@ -16,13 +16,8 @@ use crate::{
 };
 use move_ir_types::location::Loc;
 
-const UNCALLABLE_FUNCTION_SIGNATURE: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::UncallableFunction as u8,
-    "it will not be possible to call this function",
-);
+const UNCALLABLE_FUNCTION_SIGNATURE: DiagnosticInfo =
+    LinterDiagnosticCode::UncallableFunction.diag_info();
 
 simple_visitor!(
     UncallableFunction,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/unnecessary_public_entry.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/unnecessary_public_entry.rs
@@ -4,10 +4,10 @@
 // Implements lint rule for Move code to detect unnecessary `public entry` functions.
 // It identifies and reports functions that contain both `public` and `entry` modifiers.
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::LinterDiagnosticCode;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::DiagnosticInfo,
     expansion::ast::{ModuleIdent, Visibility},
     parser::ast::FunctionName,
     typing::{
@@ -16,13 +16,7 @@ use crate::{
     },
 };
 
-const PUBLIC_ENTRY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::UnnecessaryPublicEntry as u8,
-    "unnecessary `entry` on a `public` function",
-);
+const PUBLIC_ENTRY_DIAG: DiagnosticInfo = LinterDiagnosticCode::UnnecessaryPublicEntry.diag_info();
 
 simple_visitor!(
     UnnecessaryPublicEntry,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/unused_object_with_fields.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/unused_object_with_fields.rs
@@ -47,10 +47,7 @@ use crate::{
         },
     },
     diag,
-    diagnostics::{
-        Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
-    },
+    diagnostics::{Diagnostic, Diagnostics, codes::DiagnosticInfo},
     hlir::ast::{
         BaseType_, Command, Command_ as C, Exp, LValue_ as L, Label, ModuleCall, SingleType,
         SingleType_, Type, TypeName_, UnannotatedExp_, Var,
@@ -58,18 +55,13 @@ use crate::{
     naming::ast::StructFields,
     parser::ast::Ability_,
     shared::program_info::TypingProgramInfo,
-    sui_mode::linters::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode},
+    sui_mode::linters::LinterDiagnosticCode,
 };
 use move_ir_types::location::*;
 use std::collections::{BTreeMap, BTreeSet};
 
-const UNUSED_OBJ_WITH_FIELDS_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
-    Severity::Warning,
-    LinterDiagnosticCategory::Sui as u8,
-    LinterDiagnosticCode::UnusedObjWithFields as u8,
-    "unused object with fields",
-);
+const UNUSED_OBJ_WITH_FIELDS_DIAG: DiagnosticInfo =
+    LinterDiagnosticCode::UnusedObjWithFields.diag_info();
 
 //**************************************************************************************************
 // types

--- a/external-crates/move/crates/move-compiler/tests/linter/deny_lint_filter.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/deny_lint_filter.snap
@@ -12,3 +12,5 @@ error[Lint E04001]: constant should follow naming convention
   │                 --------------- the lint level is defined here
 4 │     const Another_BadName: u64 = 42;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Another_BadName' should be ALL_CAPS. Or for error constants, use PascalCase
+  │
+  = run `move lint --explain constant_naming` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/incorrect_constant_naming.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/incorrect_constant_naming.snap
@@ -12,6 +12,7 @@ warning[Lint W04001]: constant should follow naming convention
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Another_BadName' should be ALL_CAPS. Or for error constants, use PascalCase
   │
   = This warning can be suppressed with '#[allow(lint(constant_naming))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain constant_naming` for more information
 
 warning[Lint W04001]: constant should follow naming convention
   ┌─ tests/linter/incorrect_constant_naming.move:4:5
@@ -20,3 +21,4 @@ warning[Lint W04001]: constant should follow naming convention
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'JSON_Max_Size' should be ALL_CAPS. Or for error constants, use PascalCase
   │
   = This warning can be suppressed with '#[allow(lint(constant_naming))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain constant_naming` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/incorrect_redundant_ref_deref.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/incorrect_redundant_ref_deref.snap
@@ -12,6 +12,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:15:25
@@ -20,6 +21,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                         ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:20:22
@@ -28,6 +30,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                      ^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:57:21
@@ -36,6 +39,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:57:24
@@ -44,6 +48,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                        ^^^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 error[E04010]: cannot infer type
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:68:13
@@ -76,6 +81,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:80:21
@@ -84,6 +90,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:86:21
@@ -92,6 +99,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/incorrect_redundant_ref_deref.move:94:21
@@ -100,6 +108,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
     ┌─ tests/linter/incorrect_redundant_ref_deref.move:107:21
@@ -108,6 +117,7 @@ warning[Lint W01009]: redundant reference/dereference
     │                     ^^^^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
     │
     = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain redundant_ref_deref` for more information
 
 error[E04004]: expected a single non-reference type
     ┌─ tests/linter/incorrect_redundant_ref_deref.move:107:22
@@ -125,6 +135,7 @@ warning[Lint W01009]: redundant reference/dereference
     │                         ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
     │
     = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
     ┌─ tests/linter/incorrect_redundant_ref_deref.move:112:21
@@ -133,6 +144,7 @@ warning[Lint W01009]: redundant reference/dereference
     │                     ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
     │
     = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
     ┌─ tests/linter/incorrect_redundant_ref_deref.move:112:27
@@ -141,6 +153,7 @@ warning[Lint W01009]: redundant reference/dereference
     │                           ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
     │
     = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
     ┌─ tests/linter/incorrect_redundant_ref_deref.move:117:25
@@ -149,6 +162,7 @@ warning[Lint W01009]: redundant reference/dereference
     │                         ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
     │
     = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
     ┌─ tests/linter/incorrect_redundant_ref_deref.move:124:21
@@ -157,3 +171,4 @@ warning[Lint W01009]: redundant reference/dereference
     │                     ^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
     │
     = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/ref_deref_complex.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/ref_deref_complex.snap
@@ -12,6 +12,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:18:17
@@ -20,6 +21,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:27:17
@@ -28,6 +30,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:27:20
@@ -36,6 +39,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                    ^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:32:18
@@ -44,6 +48,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                  ^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:37:17
@@ -52,6 +57,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:37:23
@@ -60,6 +66,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                       ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:47:17
@@ -68,6 +75,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_complex.move:52:15
@@ -76,3 +84,4 @@ warning[Lint W01009]: redundant reference/dereference
    │               ^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/ref_deref_conditional.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/ref_deref_conditional.snap
@@ -20,6 +20,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:16:21
@@ -28,6 +29,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:22:17
@@ -36,6 +38,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 error[E04024]: invalid usage of immutable variable
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:30:5
@@ -61,6 +64,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:37:20
@@ -69,6 +73,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                    ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:50:17
@@ -77,6 +82,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:59:17
@@ -85,6 +91,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:64:17
@@ -93,6 +100,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:72:21
@@ -101,6 +109,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:83:17
@@ -109,6 +118,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_conditional.move:88:17
@@ -117,3 +127,4 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Remove this borrow-deref and use the expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/ref_deref_fields.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/ref_deref_fields.snap
@@ -12,6 +12,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:37:17
@@ -20,6 +21,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:37:20
@@ -28,6 +30,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                    ^^^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:45:21
@@ -36,6 +39,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:45:24
@@ -44,6 +48,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                        ^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:50:21
@@ -52,6 +57,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:54:21
@@ -60,6 +66,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                     ^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:59:17
@@ -68,6 +75,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:66:17
@@ -76,6 +84,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/move_2024/ref_deref_fields.move:71:17
@@ -84,3 +93,4 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/true_positive_unused_return_value.snap
@@ -13,6 +13,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:18:5
@@ -22,6 +23,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:19:12
@@ -31,6 +33,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:19:25
@@ -40,6 +43,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:21:17
@@ -49,6 +53,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:22:17
@@ -58,6 +63,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:25:22
@@ -67,6 +73,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:29:23
@@ -76,6 +83,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:31:9
@@ -85,6 +93,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:33:15
@@ -94,6 +103,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:35:29
@@ -103,6 +113,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:38:5
@@ -112,6 +123,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:44:5
@@ -121,6 +133,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:45:15
@@ -130,6 +143,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:47:29
@@ -139,6 +153,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:50:27
@@ -148,6 +163,7 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information
 
 warning[Lint W02013]: return value of a non-mutating call is discarded
    ┌─ tests/linter/move_2024/true_positive_unused_return_value.move:50:40
@@ -157,3 +173,4 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    │
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return.snap
@@ -12,6 +12,7 @@ warning[Lint W04004]: unneeded return
   │                 ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
   │
   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
   ┌─ tests/linter/move_2024/unneeded_return.move:5:17
@@ -20,6 +21,7 @@ warning[Lint W04004]: unneeded return
   │                 ^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
   │
   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
   ┌─ tests/linter/move_2024/unneeded_return.move:9:15
@@ -28,6 +30,7 @@ warning[Lint W04004]: unneeded return
   │               ^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
   │
   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:15:15
@@ -36,6 +39,7 @@ warning[Lint W04004]: unneeded return
    │               ^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:17:25
@@ -44,6 +48,7 @@ warning[Lint W04004]: unneeded return
    │                         ^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:19:12
@@ -52,6 +57,7 @@ warning[Lint W04004]: unneeded return
    │            ^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:21:28
@@ -60,6 +66,7 @@ warning[Lint W04004]: unneeded return
    │                            ^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:25:5
@@ -68,6 +75,7 @@ warning[Lint W04004]: unneeded return
    │     ^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:30:17
@@ -76,6 +84,7 @@ warning[Lint W04004]: unneeded return
    │                 ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:34:5
@@ -84,6 +93,7 @@ warning[Lint W04004]: unneeded return
    │     ^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 error[E07004]: invalid return of locally borrowed state
    ┌─ tests/linter/move_2024/unneeded_return.move:34:5
@@ -101,6 +111,7 @@ warning[Lint W04004]: unneeded return
    │                  ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:39:19
@@ -109,6 +120,7 @@ warning[Lint W04004]: unneeded return
    │                   ^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:41:25
@@ -117,6 +129,7 @@ warning[Lint W04004]: unneeded return
    │                         ^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:43:25
@@ -125,6 +138,7 @@ warning[Lint W04004]: unneeded return
    │                         ^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:45:18
@@ -133,6 +147,7 @@ warning[Lint W04004]: unneeded return
    │                  ^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return.move:47:18
@@ -141,3 +156,4 @@ warning[Lint W04004]: unneeded return
    │                  ^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.snap
@@ -20,6 +20,7 @@ warning[Lint W04004]: unneeded return
   │                 ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
   │
   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unneeded_return` for more information
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:10:5
@@ -36,6 +37,7 @@ warning[Lint W04004]: unneeded return
    │                 ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:10:35
@@ -44,6 +46,7 @@ warning[Lint W04004]: unneeded return
    │                                   ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:14:5
@@ -52,6 +55,7 @@ warning[Lint W04004]: unneeded return
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:18:5
@@ -60,6 +64,7 @@ warning[Lint W04004]: unneeded return
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:22:5
@@ -68,6 +73,7 @@ warning[Lint W04004]: unneeded return
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:31:5
@@ -79,6 +85,7 @@ warning[Lint W04004]: unneeded return
    │ ╰─────^ Remove unnecessary 'return', the expression is already in a 'return' position
    │  
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:39:18
@@ -87,6 +94,7 @@ warning[Lint W04004]: unneeded return
    │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:46:18
@@ -95,6 +103,7 @@ warning[Lint W04004]: unneeded return
    │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:47:18
@@ -103,6 +112,7 @@ warning[Lint W04004]: unneeded return
    │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:53:18
@@ -111,6 +121,7 @@ warning[Lint W04004]: unneeded return
    │                  ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
    │
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:59:5
@@ -122,6 +133,7 @@ warning[Lint W04004]: unneeded return
    │ ╰─────^ Remove unnecessary 'return', the expression is already in a 'return' position
    │  
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information
 
 warning[Lint W04004]: unneeded return
    ┌─ tests/linter/move_2024/unneeded_return_branch.move:66:5
@@ -133,3 +145,4 @@ warning[Lint W04004]: unneeded return
    │ ╰─────^ Remove unnecessary 'return', the expression is already in a 'return' position
    │  
    = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unneeded_return` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/nested_allow_lint_inner_deny_lint.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/nested_allow_lint_inner_deny_lint.snap
@@ -12,3 +12,5 @@ error[Lint E04001]: constant should follow naming convention
   │                 --------------- the lint level is defined here
 6 │     const Another_BadName: u64 = 42;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Another_BadName' should be ALL_CAPS. Or for error constants, use PascalCase
+  │
+  = run `move lint --explain constant_naming` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/nested_allow_lint_inner_warn_lint.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/nested_allow_lint_inner_warn_lint.snap
@@ -12,3 +12,5 @@ warning[Lint W04001]: constant should follow naming convention
   │                 --------------- the lint level is defined here
 6 │     const Another_BadName: u64 = 42;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Another_BadName' should be ALL_CAPS. Or for error constants, use PascalCase
+  │
+  = run `move lint --explain constant_naming` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/nested_expect_lint_inner_warn_lint.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/nested_expect_lint_inner_warn_lint.snap
@@ -20,3 +20,5 @@ warning[Lint W04001]: constant should follow naming convention
   │                 --------------- the lint level is defined here
 6 │     const Another_BadName: u64 = 42;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Another_BadName' should be ALL_CAPS. Or for error constants, use PascalCase
+  │
+  = run `move lint --explain constant_naming` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/redundant_ref_deref.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/redundant_ref_deref.snap
@@ -12,6 +12,7 @@ warning[Lint W01009]: redundant reference/dereference
   │                     ^^^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
   │
   = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/redundant_ref_deref.move:13:25
@@ -20,6 +21,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                         ^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/redundant_ref_deref.move:18:22
@@ -28,3 +30,4 @@ warning[Lint W01009]: redundant reference/dereference
    │                      ^^^^^^^^^^^^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/ref_deref_path.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/ref_deref_path.snap
@@ -12,6 +12,7 @@ warning[Lint W01009]: redundant reference/dereference
   │                   ^^^^^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
   │
   = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
   ┌─ tests/linter/ref_deref_path.move:5:21
@@ -20,3 +21,4 @@ warning[Lint W01009]: redundant reference/dereference
   │                     ^^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
   │
   = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/ref_deref_triple.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/ref_deref_triple.snap
@@ -12,6 +12,7 @@ warning[Lint W01009]: redundant reference/dereference
   │                   ^^^^^ Redundant borrow-dereference detected. Use the inner expression directly.
   │
   = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W01009]: redundant reference/dereference
   ┌─ tests/linter/ref_deref_triple.move:5:21
@@ -20,3 +21,4 @@ warning[Lint W01009]: redundant reference/dereference
   │                     ^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
   │
   = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/suppress_unnecessary_unit.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/suppress_unnecessary_unit.snap
@@ -13,3 +13,4 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
   │
   = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
   = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unused_return_value` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_abort_constant.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_abort_constant.snap
@@ -13,6 +13,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
   │
   = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
   = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:10:15
@@ -22,6 +23,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:15:15
@@ -31,6 +33,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:19:15
@@ -40,6 +43,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:23:15
@@ -49,6 +53,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:27:15
@@ -58,6 +63,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:32:15
@@ -67,6 +73,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:36:15
@@ -76,6 +83,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:40:24
@@ -85,6 +93,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:44:24
@@ -94,6 +103,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:48:24
@@ -103,6 +113,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:52:24
@@ -112,6 +123,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:56:24
@@ -121,6 +133,7 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information
 
 warning[Lint W04005]: 'abort' or 'assert' without named constant
    ┌─ tests/linter/true_positive_abort_constant.move:61:24
@@ -130,3 +143,4 @@ warning[Lint W04005]: 'abort' or 'assert' without named constant
    │
    = Consider using an error constant with the '#[error]' to allow for a more descriptive error.
    = This warning can be suppressed with '#[allow(lint(abort_without_constant))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain abort_without_constant` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_combinable_comparisons.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_combinable_comparisons.snap
@@ -12,6 +12,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
   │         ^^^^^^^^^^^^^^^^ This comparison is always 'false'
   │
   = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
   ┌─ tests/linter/true_positive_combinable_comparisons.move:5:9
@@ -20,6 +21,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
   │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
   │
   = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
   ┌─ tests/linter/true_positive_combinable_comparisons.move:6:9
@@ -28,6 +30,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
   │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
   │
   = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
   ┌─ tests/linter/true_positive_combinable_comparisons.move:7:9
@@ -36,6 +39,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
   │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
   │
   = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
   ┌─ tests/linter/true_positive_combinable_comparisons.move:8:9
@@ -44,6 +48,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
   │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
   │
   = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
   ┌─ tests/linter/true_positive_combinable_comparisons.move:9:9
@@ -52,6 +57,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
   │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
   │
   = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:10:9
@@ -60,6 +66,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:11:9
@@ -68,6 +75,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:12:9
@@ -76,6 +84,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:13:9
@@ -84,6 +93,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:14:9
@@ -92,6 +102,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:15:9
@@ -100,6 +111,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:16:9
@@ -108,6 +120,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:17:9
@@ -116,6 +129,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:18:9
@@ -124,6 +138,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:19:9
@@ -132,6 +147,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:20:9
@@ -140,6 +156,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:21:9
@@ -148,6 +165,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:22:9
@@ -156,6 +174,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:23:9
@@ -164,6 +183,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:24:9
@@ -172,6 +192,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:25:9
@@ -180,6 +201,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:26:9
@@ -188,6 +210,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:27:9
@@ -196,6 +219,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:28:9
@@ -204,6 +228,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:29:9
@@ -212,6 +237,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:30:9
@@ -220,6 +246,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:31:9
@@ -228,6 +255,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:32:9
@@ -236,6 +264,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:33:9
@@ -244,6 +273,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:34:9
@@ -252,6 +282,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:35:9
@@ -260,6 +291,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:36:9
@@ -268,6 +300,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:37:9
@@ -276,6 +309,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:38:9
@@ -284,6 +318,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:39:9
@@ -292,6 +327,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:40:9
@@ -300,6 +336,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:41:9
@@ -308,6 +345,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:42:9
@@ -316,6 +354,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:43:9
@@ -324,6 +363,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:44:9
@@ -332,6 +372,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:45:9
@@ -340,6 +381,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:46:9
@@ -348,6 +390,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:47:9
@@ -356,6 +399,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:48:9
@@ -364,6 +408,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:49:9
@@ -372,6 +417,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:50:9
@@ -380,6 +426,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:51:9
@@ -388,6 +435,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:52:9
@@ -396,6 +444,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:53:9
@@ -404,6 +453,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:54:9
@@ -412,6 +462,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:55:9
@@ -420,6 +471,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:56:9
@@ -428,6 +480,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:57:9
@@ -436,6 +489,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:58:9
@@ -444,6 +498,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:59:9
@@ -452,6 +507,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:60:9
@@ -460,6 +516,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:61:9
@@ -468,6 +525,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:62:9
@@ -476,6 +534,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:63:9
@@ -484,6 +543,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:67:9
@@ -492,6 +552,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:68:9
@@ -500,6 +561,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:69:9
@@ -508,6 +570,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:70:9
@@ -516,6 +579,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:71:9
@@ -524,6 +588,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:72:9
@@ -532,6 +597,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:73:9
@@ -540,6 +606,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:74:9
@@ -548,6 +615,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:75:9
@@ -556,6 +624,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:76:9
@@ -564,6 +633,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:77:9
@@ -572,6 +642,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:78:9
@@ -580,6 +651,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:79:9
@@ -588,6 +660,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:80:9
@@ -596,6 +669,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:81:9
@@ -604,6 +678,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:82:9
@@ -612,6 +687,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:83:9
@@ -620,6 +696,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:84:9
@@ -628,6 +705,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:85:9
@@ -636,6 +714,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:86:9
@@ -644,6 +723,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:87:9
@@ -652,6 +732,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:88:9
@@ -660,6 +741,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:89:9
@@ -668,6 +750,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:90:9
@@ -676,6 +759,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:91:9
@@ -684,6 +768,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:92:9
@@ -692,6 +777,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:93:9
@@ -700,6 +786,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:94:9
@@ -708,6 +795,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:95:9
@@ -716,6 +804,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:96:9
@@ -724,6 +813,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:97:9
@@ -732,6 +822,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:98:9
@@ -740,6 +831,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
    ┌─ tests/linter/true_positive_combinable_comparisons.move:99:9
@@ -748,6 +840,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
    │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
    │
    = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:100:9
@@ -756,6 +849,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:101:9
@@ -764,6 +858,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:102:9
@@ -772,6 +867,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:103:9
@@ -780,6 +876,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:104:9
@@ -788,6 +885,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:105:9
@@ -796,6 +894,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:106:9
@@ -804,6 +903,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison is always 'false'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:107:9
@@ -812,6 +912,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:108:9
@@ -820,6 +921,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:109:9
@@ -828,6 +930,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:110:9
@@ -836,6 +939,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison is always 'false'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:111:9
@@ -844,6 +948,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:112:9
@@ -852,6 +957,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:113:9
@@ -860,6 +966,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:114:9
@@ -868,6 +975,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:115:9
@@ -876,6 +984,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:116:9
@@ -884,6 +993,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:117:9
@@ -892,6 +1002,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:118:9
@@ -900,6 +1011,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:119:9
@@ -908,6 +1020,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:120:9
@@ -916,6 +1029,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:121:9
@@ -924,6 +1038,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:122:9
@@ -932,6 +1047,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:123:9
@@ -940,6 +1056,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:124:9
@@ -948,6 +1065,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:125:9
@@ -956,6 +1074,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^ This comparison is always 'true'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:126:9
@@ -964,6 +1083,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison is always 'true'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:130:9
@@ -972,6 +1092,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:131:9
@@ -980,6 +1101,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:132:9
@@ -988,6 +1110,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:133:9
@@ -996,6 +1119,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:134:9
@@ -1004,6 +1128,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:135:9
@@ -1012,6 +1137,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:136:9
@@ -1020,6 +1146,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:137:9
@@ -1028,6 +1155,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:138:9
@@ -1036,6 +1164,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:139:9
@@ -1044,6 +1173,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:140:9
@@ -1052,6 +1182,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:141:9
@@ -1060,6 +1191,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:142:9
@@ -1068,6 +1200,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '=='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:143:9
@@ -1076,6 +1209,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '!='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:144:9
@@ -1084,6 +1218,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:145:9
@@ -1092,6 +1227,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^ This comparison simplifies to the operation '<'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:146:9
@@ -1100,6 +1236,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:147:9
@@ -1108,6 +1245,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:150:26
@@ -1116,6 +1254,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │                          ^^^^^^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:153:9
@@ -1124,6 +1263,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>'
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:158:9
@@ -1132,6 +1272,7 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '>='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information
 
 warning[Lint W01012]: comparison operations condition can be simplified
     ┌─ tests/linter/true_positive_combinable_comparisons.move:159:9
@@ -1140,3 +1281,4 @@ warning[Lint W01012]: comparison operations condition can be simplified
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This comparison simplifies to the operation '<='
     │
     = This warning can be suppressed with '#[allow(lint(combinable_comparisons))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = run `move lint --explain combinable_comparisons` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_equal_operands.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_equal_operands.snap
@@ -16,6 +16,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
   │         This expression
   │
   = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
   ┌─ tests/linter/true_positive_equal_operands.move:7:9
@@ -28,6 +29,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
   │         This expression
   │
   = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
   ┌─ tests/linter/true_positive_equal_operands.move:8:9
@@ -40,6 +42,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
   │         This expression
   │
   = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:10:9
@@ -52,6 +55,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:11:9
@@ -64,6 +68,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:13:9
@@ -76,6 +81,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:14:9
@@ -88,6 +94,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:15:9
@@ -100,6 +107,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:17:9
@@ -112,6 +120,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:18:9
@@ -124,6 +133,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:19:9
@@ -136,6 +146,7 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information
 
 warning[Lint W02011]: redundant, always-equal operands for binary operation
    ┌─ tests/linter/true_positive_equal_operands.move:22:9
@@ -148,3 +159,4 @@ warning[Lint W02011]: redundant, always-equal operands for binary operation
    │         This expression
    │
    = This warning can be suppressed with '#[allow(lint(always_equal_operands))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain always_equal_operands` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_loop_without_exit.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_loop_without_exit.snap
@@ -12,6 +12,7 @@ warning[Lint W02006]: 'loop' without 'break' or 'return'
   │         ^^^^^^^ 'loop' without 'break' or 'return'. This code will until it errors, e.g. reaching an 'abort' or running out of gas
   │
   = This warning can be suppressed with '#[allow(lint(loop_without_exit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain loop_without_exit` for more information
 
 warning[Lint W02006]: 'loop' without 'break' or 'return'
    ┌─ tests/linter/true_positive_loop_without_exit.move:10:9
@@ -20,6 +21,7 @@ warning[Lint W02006]: 'loop' without 'break' or 'return'
    │         ^^^^^^^^^^^^^^^^^^^ 'loop' without 'break' or 'return'. This code will until it errors, e.g. reaching an 'abort' or running out of gas
    │
    = This warning can be suppressed with '#[allow(lint(loop_without_exit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain loop_without_exit` for more information
 
 warning[Lint W02006]: 'loop' without 'break' or 'return'
    ┌─ tests/linter/true_positive_loop_without_exit.move:14:9
@@ -31,3 +33,4 @@ warning[Lint W02006]: 'loop' without 'break' or 'return'
    │ ╰─────────^ 'loop' without 'break' or 'return'. This code will until it errors, e.g. reaching an 'abort' or running out of gas
    │  
    = This warning can be suppressed with '#[allow(lint(loop_without_exit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain loop_without_exit` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_meaningless_math_operation.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_meaningless_math_operation.snap
@@ -15,6 +15,7 @@ warning[Lint W01003]: math operator can be simplified
   │         This operation has no effect and can be removed
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:4:9
@@ -26,6 +27,7 @@ warning[Lint W01003]: math operator can be simplified
   │         Because of this operand
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:5:9
@@ -37,6 +39,7 @@ warning[Lint W01003]: math operator can be simplified
   │         This operation has no effect and can be removed
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:6:9
@@ -48,6 +51,7 @@ warning[Lint W01003]: math operator can be simplified
   │         This operation has no effect and can be removed
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:7:9
@@ -59,6 +63,7 @@ warning[Lint W01003]: math operator can be simplified
   │         Because of this operand
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:8:9
@@ -70,6 +75,7 @@ warning[Lint W01003]: math operator can be simplified
   │         This operation has no effect and can be removed
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
   ┌─ tests/linter/true_positive_meaningless_math_operation.move:9:9
@@ -81,6 +87,7 @@ warning[Lint W01003]: math operator can be simplified
   │         This operation has no effect and can be removed
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:10:9
@@ -92,6 +99,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:14:9
@@ -103,6 +111,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation is always zero and can be replaced with '0'
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:15:9
@@ -114,6 +123,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:16:9
@@ -125,6 +135,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:17:9
@@ -136,6 +147,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:18:9
@@ -147,6 +159,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation is always zero and can be replaced with '0'
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:22:9
@@ -158,6 +171,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:27:9
@@ -168,6 +182,7 @@ warning[Lint W01003]: math operator can be simplified
    │         ^^^^^ This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:28:9
@@ -179,6 +194,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:32:9
@@ -190,6 +206,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:33:9
@@ -201,6 +218,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation is always zero and can be replaced with '0'
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:34:9
@@ -212,6 +230,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:38:9
@@ -223,6 +242,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:39:9
@@ -234,6 +254,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation is always zero and can be replaced with '0'
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:40:9
@@ -245,6 +266,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:44:9
@@ -256,6 +278,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:45:9
@@ -267,6 +290,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation is always zero and can be replaced with '0'
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:46:9
@@ -278,6 +302,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:50:9
@@ -289,6 +314,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:51:9
@@ -300,6 +326,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation is always zero and can be replaced with '0'
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:52:9
@@ -311,6 +338,7 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:56:9
@@ -322,6 +350,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation has no effect and can be removed
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:57:9
@@ -333,6 +362,7 @@ warning[Lint W01003]: math operator can be simplified
    │         This operation is always zero and can be replaced with '0'
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information
 
 warning[Lint W01003]: math operator can be simplified
    ┌─ tests/linter/true_positive_meaningless_math_operation.move:58:9
@@ -344,3 +374,4 @@ warning[Lint W01003]: math operator can be simplified
    │         Because of this operand
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_math))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_math` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_self_assignment.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_self_assignment.snap
@@ -15,6 +15,7 @@ warning[Lint W02008]: assignment preserves the same value
   │         This location
   │
   = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:10:9
@@ -26,6 +27,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:13:9
@@ -37,6 +39,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:15:9
@@ -48,6 +51,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:18:10
@@ -59,6 +63,7 @@ warning[Lint W02008]: assignment preserves the same value
    │          This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:18:20
@@ -70,6 +75,7 @@ warning[Lint W02008]: assignment preserves the same value
    │                    This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:27:9
@@ -82,6 +88,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:28:9
@@ -94,6 +101,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:28:17
@@ -102,6 +110,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:29:9
@@ -114,6 +123,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:29:17
@@ -122,6 +132,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:30:9
@@ -134,6 +145,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:30:23
@@ -142,6 +154,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                       ^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:31:9
@@ -154,6 +167,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:31:23
@@ -162,6 +176,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                       ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:33:9
@@ -174,6 +189,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:34:9
@@ -186,6 +202,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:34:17
@@ -194,6 +211,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:35:9
@@ -206,6 +224,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:35:17
@@ -214,6 +233,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                 ^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:36:9
@@ -226,6 +246,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:36:23
@@ -234,6 +255,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                       ^^^^^^ Redundant borrow-dereference detected. Use the field access directly.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:37:9
@@ -246,6 +268,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:37:23
@@ -254,6 +277,7 @@ warning[Lint W01009]: redundant reference/dereference
    │                       ^^^^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:43:9
@@ -266,6 +290,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         This location
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:47:9
@@ -278,6 +303,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:49:9
@@ -290,6 +316,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:50:9
@@ -302,6 +329,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W02008]: assignment preserves the same value
    ┌─ tests/linter/true_positive_self_assignment.move:53:9
@@ -314,6 +342,7 @@ warning[Lint W02008]: assignment preserves the same value
    │         Unnecessary self-mutation. The mutation is redundant and will not change the value
    │
    = This warning can be suppressed with '#[allow(lint(self_assignment))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_assignment` for more information
 
 warning[Lint W01009]: redundant reference/dereference
    ┌─ tests/linter/true_positive_self_assignment.move:53:19
@@ -322,3 +351,4 @@ warning[Lint W01009]: redundant reference/dereference
    │                   ^^^^^^^ Redundant borrow-dereference detected. Replace this borrow-deref with 'copy'.
    │
    = This warning can be suppressed with '#[allow(lint(redundant_ref_deref))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain redundant_ref_deref` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_conditional.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_conditional.snap
@@ -12,6 +12,7 @@ warning[Lint W01007]: 'if' expression can be removed
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Detected an unnecessary conditional expression 'if (cond)'. Consider using the condition directly, i.e. 'cond'
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_conditional))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_conditional` for more information
 
 warning[Lint W01007]: 'if' expression can be removed
   ┌─ tests/linter/true_positive_unnecessary_conditional.move:5:9
@@ -20,6 +21,7 @@ warning[Lint W01007]: 'if' expression can be removed
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Detected an unnecessary conditional expression 'if (cond)'. Consider using the condition directly, i.e. '!cond'
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_conditional))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_conditional` for more information
 
 warning[Lint W01007]: 'if' expression can be removed
   ┌─ tests/linter/true_positive_unnecessary_conditional.move:9:9
@@ -32,6 +34,7 @@ warning[Lint W01007]: 'if' expression can be removed
   │         Detected a redundant conditional expression 'if (..) v else v', where each branch results in the same value 'v'. Consider using the value directly
   │
   = This warning can be suppressed with '#[allow(lint(unnecessary_conditional))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_conditional` for more information
 
 warning[Lint W01007]: 'if' expression can be removed
    ┌─ tests/linter/true_positive_unnecessary_conditional.move:10:9
@@ -44,6 +47,7 @@ warning[Lint W01007]: 'if' expression can be removed
    │         Detected a redundant conditional expression 'if (..) v else v', where each branch results in the same value 'v'. Consider using the value directly
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_conditional))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_conditional` for more information
 
 warning[Lint W01007]: 'if' expression can be removed
    ┌─ tests/linter/true_positive_unnecessary_conditional.move:11:9
@@ -56,3 +60,4 @@ warning[Lint W01007]: 'if' expression can be removed
    │         Detected a redundant conditional expression 'if (..) v else v', where each branch results in the same value 'v'. Consider using the value directly
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_conditional))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_conditional` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_unit.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_unit.snap
@@ -15,6 +15,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
   │
   = For example 'if (cond) () else e' can be simplified to 'if (!cond) e'
   = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
   ┌─ tests/linter/true_positive_unnecessary_unit.move:8:16
@@ -26,6 +27,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
   │
   = For example 'if (cond) () else e' can be simplified to 'if (!cond) e'
   = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:10:16
@@ -37,6 +39,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │
    = For example 'if (cond) () else e' can be simplified to 'if (!cond) e'
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:12:16
@@ -50,6 +53,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │  
    = For example 'if (cond) () else e' can be simplified to 'if (!cond) e'
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:21:31
@@ -62,6 +66,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │
    = For example 'if (cond) e else ()' can be simplified to 'if (cond) e'
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:23:31
@@ -74,6 +79,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │
    = For example 'if (cond) e else ()' can be simplified to 'if (cond) e'
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:25:34
@@ -86,6 +92,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │
    = For example 'if (cond) e else ()' can be simplified to 'if (cond) e'
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:27:31
@@ -99,6 +106,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │    
    = For example 'if (cond) e else ()' can be simplified to 'if (cond) e'
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:34:9
@@ -107,6 +115,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │         ^^ Unnecessary unit in sequence '();'. Consider removing
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:37:18
@@ -115,6 +124,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │                  ^^ Unnecessary unit in sequence '();'. Consider removing
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:39:33
@@ -123,6 +133,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │                                 ^^ Unnecessary unit in sequence '();'. Consider removing
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:39:37
@@ -131,6 +142,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │                                     ^^ Unnecessary unit in sequence '();'. Consider removing
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:41:9
@@ -139,6 +151,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │         ^^ Unnecessary unit in sequence '();'. Consider removing
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:42:9
@@ -147,6 +160,7 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │         ^^^^^^ Unnecessary unit in sequence '();'. Consider removing
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information
 
 warning[Lint W04010]: unit `()` expression can be removed or simplified
    ┌─ tests/linter/true_positive_unnecessary_unit.move:43:11
@@ -155,3 +169,4 @@ warning[Lint W04010]: unit `()` expression can be removed or simplified
    │           ^^ Unnecessary unit in sequence '();'. Consider removing
    │
    = This warning can be suppressed with '#[allow(lint(unnecessary_unit))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unnecessary_unit` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_while_loop.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/true_positive_unnecessary_while_loop.snap
@@ -13,6 +13,7 @@ warning[Lint W04002]: unnecessary 'while (true)', replace with 'loop'
   │
   = A 'loop' is more useful in these cases. Unlike 'while', 'loop' can have a 'break' with a value, e.g. 'let x = loop { break 42 };'
   = This warning can be suppressed with '#[allow(lint(while_true))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain while_true` for more information
 
 warning[Lint W04002]: unnecessary 'while (true)', replace with 'loop'
   ┌─ tests/linter/true_positive_unnecessary_while_loop.move:4:9
@@ -22,3 +23,4 @@ warning[Lint W04002]: unnecessary 'while (true)', replace with 'loop'
   │
   = A 'loop' is more useful in these cases. Unlike 'while', 'loop' can have a 'break' with a value, e.g. 'let x = loop { break 42 };'
   = This warning can be suppressed with '#[allow(lint(while_true))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain while_true` for more information

--- a/external-crates/move/crates/move-compiler/tests/linter/warn_lint_filter.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/warn_lint_filter.snap
@@ -12,3 +12,5 @@ warning[Lint W04001]: constant should follow naming convention
   │                 --------------- the lint level is defined here
 5 │     const Another_BadName: u64 = 42;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Another_BadName' should be ALL_CAPS. Or for error constants, use PascalCase
+  │
+  = run `move lint --explain constant_naming` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/coin_field.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/coin_field.snap
@@ -12,6 +12,7 @@ warning[Lint W99003]: sub-optimal 'sui::coin::Coin' field type
    │            ^^^^^^^^ Sub-optimal 'sui::coin::Coin' field type. Using 'sui::balance::Balance' instead will be more space efficient
    │
    = This warning can be suppressed with '#[allow(lint(coin_field))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain coin_field` for more information
 
 warning[Lint W99003]: sub-optimal 'sui::coin::Coin' field type
    ┌─ tests/sui_mode/linter/coin_field.move:27:12
@@ -20,3 +21,4 @@ warning[Lint W99003]: sub-optimal 'sui::coin::Coin' field type
    │            ^^^^^^^^^^^ Sub-optimal 'sui::coin::Coin' field type. Using 'sui::balance::Balance' instead will be more space efficient
    │
    = This warning can be suppressed with '#[allow(lint(coin_field))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain coin_field` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/collection_equality.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/collection_equality.snap
@@ -13,6 +13,7 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::bag::Bag' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information
 
 warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:19:14
@@ -22,6 +23,7 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::object_bag::ObjectBag' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information
 
 warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:23:16
@@ -31,6 +33,7 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::table::Table' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information
 
 warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:30:16
@@ -40,6 +43,7 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::object_table::ObjectTable' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information
 
 warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:37:16
@@ -49,6 +53,7 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::linked_table::LinkedTable' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information
 
 warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:41:16
@@ -58,6 +63,7 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::table_vec::TableVec' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information
 
 warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:45:14
@@ -67,6 +73,7 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::vec_map::VecMap' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information
 
 warning[Lint W99005]: possibly useless collections compare
    ┌─ tests/sui_mode/linter/collection_equality.move:49:14
@@ -76,3 +83,4 @@ warning[Lint W99005]: possibly useless collections compare
    │
    = Equality for collections of type 'sui::vec_set::VecSet' IS NOT a structural check based on content
    = This warning can be suppressed with '#[allow(lint(collection_equality))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain collection_equality` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/custom_state_change.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/custom_state_change.snap
@@ -17,6 +17,7 @@ warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze pol
    │
    = A custom transfer policy for a given type is implemented through calling the private 'transfer' function variant in the module defining this type
    = This warning can be suppressed with '#[allow(lint(custom_state_change))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain custom_state_change` for more information
 
 warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:20:16
@@ -30,6 +31,7 @@ warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze pol
    │
    = A custom share policy for a given type is implemented through calling the private 'share_object' function variant in the module defining this type
    = This warning can be suppressed with '#[allow(lint(custom_state_change))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain custom_state_change` for more information
 
 warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze policy
    ┌─ tests/sui_mode/linter/custom_state_change.move:24:16
@@ -43,3 +45,4 @@ warning[Lint W99002]: potentially unenforceable custom transfer/share/freeze pol
    │
    = A custom freeze policy for a given type is implemented through calling the private 'freeze_object' function variant in the module defining this type
    = This warning can be suppressed with '#[allow(lint(custom_state_change))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain custom_state_change` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/deny_lint_public_entry.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/deny_lint_public_entry.snap
@@ -14,3 +14,4 @@ error[Lint E99010]: unnecessary `entry` on a `public` function
   │            ^^^^^ `entry` on `public` is meaningless. In conjunction with `public`, `entry` adds no additional permissions or restrictions.
   │
   = `public` functions can be called from PTBs. `entry` can be used to allow non-`public` (private or `public(package)`) functions to be called from PTBs, although there will be additional restrictions on the input arguments to such functions.
+  = run `move lint --explain public_entry` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_negative_lint_missing_key.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_negative_lint_missing_key.snap
@@ -14,3 +14,4 @@ warning[Lint W99007]: struct with id but missing key ability
    │ ╰─────^ Struct's first field has an 'id' field of type 'sui::object::UID' but is missing the 'key' ability.
    │  
    = This warning can be suppressed with '#[allow(lint(missing_key))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain missing_key` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_positive_share_owned.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/false_positive_share_owned.snap
@@ -21,6 +21,7 @@ warning[Lint W99000]: possible owned object share
    │         Potential abort from a (potentially) owned object created by a different transaction.
    │
    = This warning can be suppressed with '#[allow(lint(share_owned))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain share_owned` for more information
 
 warning[Lint W99000]: possible owned object share
    ┌─ tests/sui_mode/linter/false_positive_share_owned.move:42:9
@@ -38,3 +39,4 @@ warning[Lint W99000]: possible owned object share
    │         Potential abort from a (potentially) owned object created by a different transaction.
    │
    = This warning can be suppressed with '#[allow(lint(share_owned))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain share_owned` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freeze_wrapped.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freeze_wrapped.snap
@@ -15,6 +15,7 @@ warning[Lint W99004]: attempting to freeze wrapped objects
    │                                        ^ Freezing an object of type 'Wrapper' also freezes all objects wrapped in its field 'inner'.
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freeze_wrapped` for more information
 
 warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:46:40
@@ -29,6 +30,7 @@ warning[Lint W99004]: attempting to freeze wrapped objects
    │                                        ^ Freezing an object of type 'IndirectWrapper' also freezes all objects wrapped in its field 's'.
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freeze_wrapped` for more information
 
 warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:51:40
@@ -40,6 +42,7 @@ warning[Lint W99004]: attempting to freeze wrapped objects
    │                                        ^ Freezing an object of type 'Wrapper' also freezes all objects wrapped in its field 'inner'.
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freeze_wrapped` for more information
 
 warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:55:40
@@ -51,6 +54,7 @@ warning[Lint W99004]: attempting to freeze wrapped objects
    │                                        ^ Freezing an object of type 'GenWrapper' also freezes all objects wrapped in its field 'inner'.
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freeze_wrapped` for more information
 
 warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:59:40
@@ -65,6 +69,7 @@ warning[Lint W99004]: attempting to freeze wrapped objects
    │                                        ^ Freezing an object of type 'IndirectGenWrapper' also freezes all objects wrapped in its field 'inner'.
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freeze_wrapped` for more information
 
 warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:63:40
@@ -76,6 +81,7 @@ warning[Lint W99004]: attempting to freeze wrapped objects
    │                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Freezing an object of type 'Wrapper' also freezes all objects wrapped in its field 'inner'.
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freeze_wrapped` for more information
 
 warning[Lint W99004]: attempting to freeze wrapped objects
    ┌─ tests/sui_mode/linter/freeze_wrapped.move:63:73
@@ -87,3 +93,4 @@ warning[Lint W99004]: attempting to freeze wrapped objects
    │                                                                         ^^ Freezing an object of type 'Wrapper' also freezes all objects wrapped in its field 'inner'.
    │
    = This warning can be suppressed with '#[allow(lint(freeze_wrapped))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freeze_wrapped` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_false_positives.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_false_positives.snap
@@ -13,6 +13,7 @@ warning[Lint W99008]: freezing potential capability
    │
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freezing_capability` for more information
 
 warning[Lint W99008]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_false_positives.move:29:9
@@ -22,3 +23,4 @@ warning[Lint W99008]: freezing potential capability
    │
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freezing_capability` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_true_positives.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/freezing_capability_true_positives.snap
@@ -13,6 +13,7 @@ warning[Lint W99008]: freezing potential capability
    │
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freezing_capability` for more information
 
 warning[Lint W99008]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_true_positives.move:25:9
@@ -22,6 +23,7 @@ warning[Lint W99008]: freezing potential capability
    │
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freezing_capability` for more information
 
 warning[Lint W99008]: freezing potential capability
    ┌─ tests/sui_mode/linter/freezing_capability_true_positives.move:29:9
@@ -31,3 +33,4 @@ warning[Lint W99008]: freezing potential capability
    │
    = Freezing a capability might lock out critical operations or otherwise open access to operations that otherwise should be restricted
    = This warning can be suppressed with '#[allow(lint(freezing_capability))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain freezing_capability` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/nested_allow_lint_all_inner_deny_lint_specific.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/nested_allow_lint_all_inner_deny_lint_specific.snap
@@ -14,3 +14,4 @@ error[Lint E99010]: unnecessary `entry` on a `public` function
   │            ^^^^^ `entry` on `public` is meaningless. In conjunction with `public`, `entry` adds no additional permissions or restrictions.
   │
   = `public` functions can be called from PTBs. `entry` can be used to allow non-`public` (private or `public(package)`) functions to be called from PTBs, although there will be additional restrictions on the input arguments to such functions.
+  = run `move lint --explain public_entry` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/public_random_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/public_random_invalid.snap
@@ -14,6 +14,7 @@ warning[Lint W99006]: Risky use of 'sui::random'
   = Functions that accept 'sui::random::Random' as a parameter might be abused by attackers by inspecting the results of randomness
   = Non-public functions are preferred
   = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain public_random` for more information
 
 warning[Lint W99006]: Risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:10:34
@@ -24,6 +25,7 @@ warning[Lint W99006]: Risky use of 'sui::random'
    = Functions that accept 'sui::random::RandomGenerator' as a parameter might be abused by attackers by inspecting the results of randomness
    = Non-public functions are preferred
    = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain public_random` for more information
 
 warning[Lint W99006]: Risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:12:33
@@ -34,6 +36,7 @@ warning[Lint W99006]: Risky use of 'sui::random'
    = Functions that accept 'sui::random::Random' as a parameter might be abused by attackers by inspecting the results of randomness
    = Non-public functions are preferred
    = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain public_random` for more information
 
 warning[Lint W99006]: Risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:12:47
@@ -44,6 +47,7 @@ warning[Lint W99006]: Risky use of 'sui::random'
    = Functions that accept 'sui::random::RandomGenerator' as a parameter might be abused by attackers by inspecting the results of randomness
    = Non-public functions are preferred
    = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain public_random` for more information
 
 warning[Lint W99006]: Risky use of 'sui::random'
    ┌─ tests/sui_mode/linter/public_random_invalid.move:14:48
@@ -54,3 +58,4 @@ warning[Lint W99006]: Risky use of 'sui::random'
    = Functions that accept 'sui::random::Random' as a parameter might be abused by attackers by inspecting the results of randomness
    = Non-public functions are preferred
    = This warning can be suppressed with '#[allow(lint(public_random))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain public_random` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/self_transfer.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/self_transfer.snap
@@ -17,6 +17,7 @@ warning[Lint W99001]: non-composable transfer to sender
    │         Transfer of an object to transaction sender address
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_transfer` for more information
 
 warning[Lint W99001]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:27:9
@@ -30,6 +31,7 @@ warning[Lint W99001]: non-composable transfer to sender
    │         Transfer of an object to transaction sender address
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_transfer` for more information
 
 warning[Lint W99001]: non-composable transfer to sender
    ┌─ tests/sui_mode/linter/self_transfer.move:39:9
@@ -43,3 +45,4 @@ warning[Lint W99001]: non-composable transfer to sender
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Transfer of an object to transaction sender address
    │
    = This warning can be suppressed with '#[allow(lint(self_transfer))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain self_transfer` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/suppress_public_mut_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/suppress_public_mut_tx_context.snap
@@ -15,3 +15,4 @@ warning[Lint W99011]: it will not be possible to call this function
    │
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/trigger_lint_missing_key.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/trigger_lint_missing_key.snap
@@ -14,3 +14,4 @@ warning[Lint W99007]: struct with id but missing key ability
   │ ╰─────^ Struct's first field has an 'id' field of type 'sui::object::UID' but is missing the 'key' ability.
   │  
   = This warning can be suppressed with '#[allow(lint(missing_key))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain missing_key` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_public_mut_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_public_mut_tx_context.snap
@@ -13,6 +13,7 @@ warning[Lint W99009]: prefer '&mut TxContext' over '&TxContext'
   │
   = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
   = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain prefer_mut_tx_context` for more information
 
 warning[Lint W99009]: prefer '&mut TxContext' over '&TxContext'
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:10:47
@@ -22,6 +23,7 @@ warning[Lint W99009]: prefer '&mut TxContext' over '&TxContext'
    │
    = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
    = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain prefer_mut_tx_context` for more information
 
 warning[Lint W99009]: prefer '&mut TxContext' over '&TxContext'
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:12:54
@@ -31,6 +33,7 @@ warning[Lint W99009]: prefer '&mut TxContext' over '&TxContext'
    │
    = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
    = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain prefer_mut_tx_context` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:12:70
@@ -42,6 +45,7 @@ warning[Lint W99011]: it will not be possible to call this function
    │
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information
 
 warning[Lint W99009]: prefer '&mut TxContext' over '&TxContext'
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:18:13
@@ -51,6 +55,7 @@ warning[Lint W99009]: prefer '&mut TxContext' over '&TxContext'
    │
    = When upgrading, the public function cannot be modified to take '&mut TxContext' instead of '&TxContext'. As such, it is recommended to consider using '&mut TxContext' to future-proof the function.
    = This warning can be suppressed with '#[allow(lint(prefer_mut_tx_context))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain prefer_mut_tx_context` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_public_mut_tx_context.move:19:13
@@ -62,3 +67,4 @@ warning[Lint W99011]: it will not be possible to call this function
    │
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_share_owned.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_share_owned.snap
@@ -21,6 +21,7 @@ warning[Lint W99000]: possible owned object share
    │         Potential abort from a (potentially) owned object created by a different transaction.
    │
    = This warning can be suppressed with '#[allow(lint(share_owned))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain share_owned` for more information
 
 warning[Lint W99000]: possible owned object share
    ┌─ tests/sui_mode/linter/true_positive_share_owned.move:42:9
@@ -38,3 +39,4 @@ warning[Lint W99000]: possible owned object share
    │         Potential abort from a (potentially) owned object created by a different transaction.
    │
    = This warning can be suppressed with '#[allow(lint(share_owned))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain share_owned` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_positive_uncallable_functions.snap
@@ -13,6 +13,7 @@ warning[Lint W99011]: it will not be possible to call this function
   │
   = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain uncallable_function` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
   ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:9:25
@@ -22,6 +23,7 @@ warning[Lint W99011]: it will not be possible to call this function
   │
   = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
   = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain uncallable_function` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:12:26
@@ -31,6 +33,7 @@ warning[Lint W99011]: it will not be possible to call this function
    │
    = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:15:26
@@ -40,6 +43,7 @@ warning[Lint W99011]: it will not be possible to call this function
    │
    = This object has extra restrictions checked when submitting transactions to Sui. As such, this function will not be callable.
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:20:43
@@ -51,6 +55,7 @@ warning[Lint W99011]: it will not be possible to call this function
    │
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:23:47
@@ -62,6 +67,7 @@ warning[Lint W99011]: it will not be possible to call this function
    │
    = Due to restrictions in PTB execution if there is a mutable reference to a TxContext, it must be unique. This means that there cannot be another usage of the transaction context (either '&TxContext' or '&mut TxContext') in the function parameters. This function will not be callable on Sui
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information
 
 warning[Lint W99011]: it will not be possible to call this function
    ┌─ tests/sui_mode/linter/true_positive_uncallable_functions.move:26:22
@@ -70,3 +76,4 @@ warning[Lint W99011]: it will not be possible to call this function
    │                      ^^^^^^^^^ Invalid TxContext usage. 'TxContext' must be taken by reference, e.g. '&TxContext' or '&mut TxContext'
    │
    = This warning can be suppressed with '#[allow(lint(uncallable_function))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain uncallable_function` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_unnecessary_public_entry.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/true_unnecessary_public_entry.snap
@@ -13,3 +13,4 @@ warning[Lint W99010]: unnecessary `entry` on a `public` function
   │
   = `public` functions can be called from PTBs. `entry` can be used to allow non-`public` (private or `public(package)`) functions to be called from PTBs, although there will be additional restrictions on the input arguments to such functions.
   = This warning can be suppressed with '#[allow(lint(public_entry))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = run `move lint --explain public_entry` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_object_with_fields_true_positives.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_object_with_fields_true_positives.snap
@@ -12,6 +12,7 @@ warning[Lint W99012]: unused object with fields
    │                       ^^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:16:31
@@ -20,6 +21,7 @@ warning[Lint W99012]: unused object with fields
    │                               ^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:19:33
@@ -28,6 +30,7 @@ warning[Lint W99012]: unused object with fields
    │                                 ^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:22:35
@@ -36,6 +39,7 @@ warning[Lint W99012]: unused object with fields
    │                                   ^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:27:36
@@ -44,6 +48,7 @@ warning[Lint W99012]: unused object with fields
    │                                    ^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:34:33
@@ -52,6 +57,7 @@ warning[Lint W99012]: unused object with fields
    │                                 ^^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:34:48
@@ -60,6 +66,7 @@ warning[Lint W99012]: unused object with fields
    │                                                ^^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:42:9
@@ -68,6 +75,7 @@ warning[Lint W99012]: unused object with fields
    │         ^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:52:36
@@ -76,6 +84,7 @@ warning[Lint W99012]: unused object with fields
    │                                    ^^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:52:51
@@ -84,6 +93,7 @@ warning[Lint W99012]: unused object with fields
    │                                                   ^^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information
 
 warning[Lint W99012]: unused object with fields
    ┌─ tests/sui_mode/linter/unused_object_with_fields_true_positives.move:63:35
@@ -92,3 +102,4 @@ warning[Lint W99012]: unused object with fields
    │                                   ^ Unused object with fields. Consider reading or writing the object's fields, or passing it to another function.
    │
    = This warning can be suppressed with '#[allow(lint(unused_object_with_fields))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_object_with_fields` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/unused_return_value_tx_context.snap
@@ -14,3 +14,4 @@ warning[Lint W02013]: return value of a non-mutating call is discarded
    = 'TxContext' is not considered a mutable reference input for the purposes of this lint.
    = Bind the result with 'let', or use 'let _ = ...' to discard it explicitly.
    = This warning can be suppressed with '#[allow(lint(unused_return_value))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = run `move lint --explain unused_return_value` for more information

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/linter/warn_lint_public_entry.snap
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/linter/warn_lint_public_entry.snap
@@ -14,3 +14,4 @@ warning[Lint W99010]: unnecessary `entry` on a `public` function
   │            ^^^^^ `entry` on `public` is meaningless. In conjunction with `public`, `entry` adds no additional permissions or restrictions.
   │
   = `public` functions can be called from PTBs. `entry` can be used to allow non-`public` (private or `public(package)`) functions to be called from PTBs, although there will be additional restrictions on the input arguments to such functions.
+  = run `move lint --explain public_entry` for more information

--- a/external-crates/move/crates/move-proc-macros/src/lib.rs
+++ b/external-crates/move/crates/move-proc-macros/src/lib.rs
@@ -3,7 +3,12 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DeriveInput, Ident, ItemFn, parse_macro_input};
+use syn::{
+    Data, DataEnum, DeriveInput, Ident, ItemFn, LitStr, Token,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+};
 
 /// This macro generates a function `order_to_variant_map` which returns a map
 /// of the position of each variant to the name of the variant.
@@ -109,6 +114,60 @@ pub fn growing_stack(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    output.into()
+}
+
+/// A segment of the path given to `optional_include_str!`: either a string literal or an
+/// identifier (so `macro_rules!` callers can splice in captured idents).
+enum PathPart {
+    Lit(LitStr),
+    Ident(Ident),
+}
+
+impl Parse for PathPart {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(LitStr) {
+            Ok(Self::Lit(input.parse()?))
+        } else {
+            Ok(Self::Ident(input.parse()?))
+        }
+    }
+}
+
+/// Like `include_str!`, but expands to `Some(include_str!(...))` if the file exists and `None`
+/// if it does not. The path is the concatenation of the comma-separated arguments (string
+/// literals and identifiers), resolved relative to the `CARGO_MANIFEST_DIR` of the crate
+/// invoking the macro.
+///
+/// ```rust,ignore
+/// // Some(...) if `<crate root>/docs/Foo_Bar.md` exists, None otherwise
+/// let doc: Option<&'static str> = optional_include_str!("docs/", Foo, "_", Bar, ".md");
+/// ```
+///
+/// Note: rustc only records a dependency on the file when it is actually included, so a crate
+/// using this macro should also have a build script with `cargo::rerun-if-changed` on the
+/// relevant directory to pick up newly added files.
+#[proc_macro]
+pub fn optional_include_str(input: TokenStream) -> TokenStream {
+    let parts = parse_macro_input!(input with Punctuated::<PathPart, Token![,]>::parse_terminated);
+    let relative_path: String = parts
+        .iter()
+        .map(|part| match part {
+            PathPart::Lit(lit) => lit.value(),
+            PathPart::Ident(ident) => ident.to_string(),
+        })
+        .collect();
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR not set when expanding optional_include_str!");
+    let full_path = std::path::Path::new(&manifest_dir).join(&relative_path);
+    let output = if full_path.is_file() {
+        let full_path = full_path
+            .to_str()
+            .expect("non-UTF-8 path in optional_include_str!");
+        quote! { Some(include_str!(#full_path)) }
+    } else {
+        quote! { None }
+    };
     output.into()
 }
 


### PR DESCRIPTION
## Description 

- adds `sui move lint --explain <name>` with a hint on lint firing
- adds `sui move lint --list` to list all available lints

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
