### PR TITLE
rpc-store: scope the health check to the live cohort

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -830,6 +830,14 @@ impl RpcStateReader for RpcStoreReadStore {
         Some(self)
     }
 
+    fn get_highest_executed_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        // The raw executed tip, read straight from the checkpoint store. Unlike
+        // `get_latest_checkpoint`, this is not bounded to the live-object index
+        // frontier -- the health check measures how far that frontier trails
+        // the executed tip, so it must see the unbounded value.
+        Ok(*self.rocks.get_latest_checkpoint()?.sequence_number())
+    }
+
     fn get_struct_layout_with_overlay(
         &self,
         struct_tag: &move_core_types::language_storage::StructTag,
@@ -906,6 +914,12 @@ impl RpcIndexes for RpcStoreReadStore {
         &self,
     ) -> Result<Option<CheckpointSequenceNumber>> {
         self.reader.get_highest_indexed_checkpoint_seq_number()
+    }
+
+    fn get_highest_live_indexed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        self.reader.get_highest_live_indexed_checkpoint_seq_number()
     }
 
     fn ledger_tx_seq_digest(&self, tx_seq: u64) -> Result<Option<LedgerTxSeqDigest>> {

--- a/crates/sui-rpc-api/src/service/health.rs
+++ b/crates/sui-rpc-api/src/service/health.rs
@@ -8,14 +8,17 @@ use std::time::SystemTime;
 use crate::Result;
 use crate::RpcService;
 
-/// The largest gap, in checkpoints, between the latest checkpoint and the
-/// highest indexed checkpoint still considered healthy.
+/// The largest gap, in checkpoints, between the latest executed checkpoint and
+/// the highest checkpoint the live-object index has committed while still
+/// considered healthy.
 ///
-/// The embedded indexer follows the tip asynchronously, so the highest indexed
-/// checkpoint always trails the reported tip by a little (roughly the indexer's
-/// snapshot window). A gap larger than this means the index is still
-/// backfilling -- e.g. the ledger-history cohort after a restore -- and cannot
-/// serve complete reads even though the raw tip is readable.
+/// The embedded indexer follows the tip asynchronously, so the live-object
+/// index always trails the executed tip by a little (roughly the indexer's
+/// snapshot window). A gap larger than this means the live index has fallen
+/// behind -- e.g. the indexer has stalled -- and cannot serve current
+/// live-object reads. The ledger-history cohort backfills separately after a
+/// restore and is deliberately excluded from this gap, so a node is healthy as
+/// soon as its live-object reads are caught up.
 const MAX_HEALTHY_INDEX_LAG: u64 = 60;
 
 impl RpcService {
@@ -27,9 +30,9 @@ impl RpcService {
     /// subject to a staleness check.
     ///
     /// Independent of the threshold, when indexing is enabled the server is
-    /// only considered healthy once its indexes have caught up to within
-    /// `MAX_HEALTHY_INDEX_LAG` checkpoints of the latest checkpoint. When
-    /// indexing is disabled this check is skipped.
+    /// only considered healthy once its live-object indexes have caught up to
+    /// within `MAX_HEALTHY_INDEX_LAG` checkpoints of the latest executed
+    /// checkpoint. When indexing is disabled this check is skipped.
     pub fn health_check(&self, threshold_seconds: Option<u32>) -> Result<()> {
         let latest = self.reader.inner().get_latest_checkpoint()?;
 
@@ -48,23 +51,29 @@ impl RpcService {
             }
         }
 
-        // When indexing is enabled, the node is only healthy once its indexes
-        // have kept up with the latest checkpoint. The embedded indexer follows
-        // the tip asynchronously and its ledger-history cohort backfills
-        // independently after a restore, so a lagging index cannot serve
-        // complete reads even though the raw tip is readable. A node without an
-        // index surface (indexing disabled) skips this check.
+        // When indexing is enabled, the node is only healthy once its
+        // live-object indexes (owned objects, types, balances) have kept up
+        // with the executed tip. Those indexes are restored to the tip and
+        // follow it, so a healthy node's live frontier trails execution by at
+        // most the indexer's snapshot window. The ledger-history cohort
+        // backfills independently after a restore and is deliberately excluded:
+        // gating on it would report a node unhealthy for the whole backfill
+        // even though its live-object reads are already caught up. The executed
+        // tip is read unbounded (rather than via `get_latest_checkpoint`, which
+        // is itself bounded to the live frontier) so a stalled live indexer,
+        // whose frontier falls behind ongoing execution, is still detected. A
+        // node without an index surface (indexing disabled) skips this check.
         if let Some(indexes) = self.reader.inner().indexes() {
-            let highest_indexed = indexes.get_highest_indexed_checkpoint_seq_number()?;
+            let executed = self
+                .reader
+                .inner()
+                .get_highest_executed_checkpoint_seq_number()?;
+            let highest_live_indexed = indexes.get_highest_live_indexed_checkpoint_seq_number()?;
 
-            if !index_caught_up(
-                latest.sequence_number,
-                highest_indexed,
-                MAX_HEALTHY_INDEX_LAG,
-            ) {
+            if !index_caught_up(executed, highest_live_indexed, MAX_HEALTHY_INDEX_LAG) {
                 return Err(anyhow::anyhow!(
-                    "the rpc index is not caught up to within {MAX_HEALTHY_INDEX_LAG} \
-                     checkpoints of the latest checkpoint"
+                    "the live-object index is not caught up to within {MAX_HEALTHY_INDEX_LAG} \
+                     checkpoints of the latest executed checkpoint"
                 )
                 .into());
             }
@@ -74,15 +83,16 @@ impl RpcService {
     }
 }
 
-/// Whether the highest indexed checkpoint is close enough to the latest
-/// checkpoint to be considered healthy.
+/// Whether the highest live-indexed checkpoint is close enough to the executed
+/// tip to be considered healthy.
 ///
-/// `highest_indexed` is `None` when the index has not committed any checkpoint
-/// yet, which is never healthy. A frontier at or past the tip (which should not
-/// happen, as the tip is itself index-bounded) saturates to a zero lag.
-fn index_caught_up(latest_seq: u64, highest_indexed: Option<u64>, max_lag: u64) -> bool {
-    match highest_indexed {
-        Some(indexed) => latest_seq.saturating_sub(indexed) <= max_lag,
+/// `highest_live_indexed` is `None` when the live-object index has not committed
+/// any checkpoint yet, which is never healthy. The live frontier never runs
+/// ahead of execution (it indexes executed checkpoints), but an equal frontier
+/// saturates to a zero lag rather than underflowing.
+fn index_caught_up(executed_seq: u64, highest_live_indexed: Option<u64>, max_lag: u64) -> bool {
+    match highest_live_indexed {
+        Some(indexed) => executed_seq.saturating_sub(indexed) <= max_lag,
         None => false,
     }
 }
@@ -111,14 +121,16 @@ pub async fn health(
 mod tests {
     use super::*;
 
-    // The index has not committed any checkpoint yet: never healthy.
+    // The live-object index has not committed any checkpoint yet: never
+    // healthy.
     #[test]
     fn not_caught_up_when_unindexed() {
         assert!(!index_caught_up(100, None, MAX_HEALTHY_INDEX_LAG));
         assert!(!index_caught_up(0, None, MAX_HEALTHY_INDEX_LAG));
     }
 
-    // Within (or at) the allowed lag: healthy.
+    // The live frontier is within (or at) the allowed lag of the executed tip:
+    // healthy.
     #[test]
     fn caught_up_within_lag() {
         assert!(index_caught_up(100, Some(100), 60)); // no lag
@@ -126,17 +138,21 @@ mod tests {
         assert!(index_caught_up(100, Some(41), 60)); // inside the bound
     }
 
-    // Beyond the allowed lag (e.g. a ledger-history backfill): unhealthy.
+    // The live frontier trails the executed tip by more than the allowed lag
+    // (e.g. the live indexer stalled while execution advanced): unhealthy. A
+    // lagging ledger-history backfill does not reach this path -- it is not part
+    // of the live frontier.
     #[test]
     fn not_caught_up_beyond_lag() {
         assert!(!index_caught_up(100, Some(39), 60)); // one past the bound
-        assert!(!index_caught_up(1_000, Some(0), 60)); // backfilling from genesis
+        assert!(!index_caught_up(1_000, Some(0), 60)); // live index far behind
     }
 
-    // A frontier at or past the tip saturates to zero lag rather than
-    // underflowing.
+    // A live frontier level with the executed tip saturates to zero lag rather
+    // than underflowing.
     #[test]
-    fn caught_up_when_index_at_or_past_tip() {
+    fn caught_up_when_index_at_tip() {
+        assert!(index_caught_up(100, Some(100), 60));
         assert!(index_caught_up(100, Some(200), 60));
     }
 }

--- a/crates/sui-rpc-store/src/reader/indexes.rs
+++ b/crates/sui-rpc-store/src/reader/indexes.rs
@@ -311,6 +311,15 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         Ok(min)
     }
 
+    fn get_highest_live_indexed_checkpoint_seq_number(
+        &self,
+    ) -> StorageResult<Option<CheckpointSequenceNumber>> {
+        // Only the live cohort (owned objects, types, balances); the
+        // ledger-history cohort backfills independently and is excluded so a
+        // node is healthy as soon as its live-object reads are caught up.
+        self.highest_live_committed_checkpoint()
+    }
+
     fn ledger_tx_seq_digest(&self, tx_seq: u64) -> StorageResult<Option<LedgerTxSeqDigest>> {
         let meta = self
             .schema()

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -637,6 +637,20 @@ pub trait RpcStateReader:
     // Get a handle to an instance of the RpcIndexes
     fn indexes(&self) -> Option<&dyn RpcIndexes>;
 
+    /// The sequence number of the highest executed checkpoint, independent of
+    /// how far any embedded index has caught up.
+    ///
+    /// [`ReadStore::get_latest_checkpoint`] may bound the reported tip to the
+    /// live-object index frontier, so clients never observe a checkpoint whose
+    /// indexed state is not yet readable. The health check, by contrast, needs
+    /// the true executed tip to measure that index lag against, so it reads
+    /// this instead. Defaults to
+    /// [`ReadStore::get_latest_checkpoint_sequence_number`] for backends that
+    /// do not bound their reported tip.
+    fn get_highest_executed_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        self.get_latest_checkpoint_sequence_number()
+    }
+
     fn get_type_layout(&self, type_tag: &TypeTag) -> Result<Option<MoveTypeLayout>> {
         match type_tag {
             TypeTag::Bool => Ok(Some(MoveTypeLayout::Bool)),
@@ -729,6 +743,25 @@ pub trait RpcIndexes: Send + Sync {
 
     fn get_highest_indexed_checkpoint_seq_number(&self)
     -> Result<Option<CheckpointSequenceNumber>>;
+
+    /// The highest checkpoint the live-object cohort -- the indexes derivable
+    /// from the live object set (owned objects, types, and balances) -- has
+    /// committed, or `None` if it has not committed any checkpoint yet.
+    ///
+    /// This is the frontier the health check measures against. The live-object
+    /// indexes are restored to the tip and follow it, whereas the
+    /// ledger-history cohort backfills independently after a restore; gating
+    /// health on the latter would report a node unhealthy for the whole
+    /// backfill even though its live-object reads are already caught up.
+    ///
+    /// Defaults to [`Self::get_highest_indexed_checkpoint_seq_number`] for
+    /// backends without a live/history cohort split, where every index tracks
+    /// the tip together.
+    fn get_highest_live_indexed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        self.get_highest_indexed_checkpoint_seq_number()
+    }
 
     fn ledger_tx_seq_digest(&self, tx_seq: u64) -> Result<Option<LedgerTxSeqDigest>>;
 


### PR DESCRIPTION
Previously the health check compared the reported tip against `get_highest_indexed_checkpoint_seq_number`, the minimum watermark across every pipeline. The embedded indexer's ledger-history cohort backfills independently after a restore, so that minimum was dragged down by the backfill and the node reported unhealthy for its whole duration, even though its live-object reads were already caught up. Now that the indexing framework runs the live and history cohorts on separate ingestion streams, the live cohort tracks the tip while history backfills separately, so gating health on history is no longer warranted.

With this commit the health check instead compares the raw executed tip against the live-object cohort frontier (owned objects, types, and balances) alone. A restored node is healthy as soon as its live-object reads catch up, regardless of the history backfill.

`get_latest_checkpoint` is already bounded to the live frontier for read-after-write consistency, so comparing it against that same frontier would be vacuous and would mask a stalled live indexer. To keep a meaningful signal the check reads the unbounded executed tip through a new `RpcStateReader::get_highest_executed_checkpoint_seq_number`, so a live frontier that falls behind ongoing execution is still detected. The live-cohort frontier is exposed through a new
`RpcIndexes::get_highest_live_indexed_checkpoint_seq_number`. Both trait methods default to their prior all-tables behavior, so non-cohort backends are unaffected, and `get_highest_indexed_checkpoint_seq_number` is unchanged for the proof and ledger-read paths that need its min-across-all coherence.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
