### PR TITLE
[move-stackless-bytecode] Seed VariantSwitch jump-table targets into label map

### DIFF
--- a/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
@@ -77,6 +77,16 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                     label_map.insert(offs, label);
                 }
             }
+            if let MoveBytecode::VariantSwitch(jump_table_idx) = bytecode {
+                let JumpTableInner::Full(offsets) =
+                    &self.func_env.get_jump_tables()[jump_table_idx.0 as usize].jump_table;
+                for code_offset in offsets {
+                    if label_map.get(code_offset).is_none() {
+                        let label = Label::new(label_map.len());
+                        label_map.insert(*code_offset, label);
+                    }
+                }
+            }
             if let MoveBytecode::BrTrue(_) | MoveBytecode::BrFalse(_) = bytecode {
                 let next_offs = (pos + 1) as CodeOffset;
                 if label_map.get(&next_offs).is_none() {

--- a/external-crates/move/crates/move-stackless-bytecode/tests/from_move/smoke_test.move
+++ b/external-crates/move/crates/move-stackless-bytecode/tests/from_move/smoke_test.move
@@ -90,4 +90,40 @@ module 0x42::SmokeTest {
         if (b_var != 42) abort 42;
         var_a
     }
+
+    // -----------------
+    // Enums
+    // -----------------
+
+    public enum Color { Red, Green, Blue }
+
+    public enum Shape {
+        Circle { radius: u64 },
+        Rect { width: u64, height: u64 },
+    }
+
+    // Match arms are reachable only through the `VariantSwitch` jump table.
+    fun match_color(c: &Color): u64 {
+        match (c) {
+            Color::Red => 1,
+            Color::Green => 2,
+            Color::Blue => 3,
+        }
+    }
+
+    // Or-pattern: `Red | Green` lowers into separate jump-table arms.
+    fun classify_color(c: &Color): u64 {
+        match (c) {
+            Color::Red | Color::Green => 1,
+            Color::Blue => 2,
+        }
+    }
+
+    // By-value match with field bindings (VariantSwitch + UnpackVariant).
+    fun shape_size(s: Shape): u64 {
+        match (s) {
+            Shape::Circle { radius } => radius,
+            Shape::Rect { width, height } => width + height,
+        }
+    }
 }

--- a/external-crates/move/crates/move-stackless-bytecode/tests/from_move/smoke_test.snap
+++ b/external-crates/move/crates/move-stackless-bytecode/tests/from_move/smoke_test.snap
@@ -116,6 +116,47 @@ fun SmokeTest::bool_ops($t0|a: u64, $t1|b: u64): (bool, bool) {
 
 
 [variant baseline]
+fun SmokeTest::classify_color($t0|c: &SmokeTest::Color): u64 {
+     var $t1|tmp#$1: u64
+     var $t2|tmp#$2: &SmokeTest::Color
+     var $t3: &SmokeTest::Color
+     var $t4: &SmokeTest::Color
+     var $t5: &SmokeTest::Color
+     var $t6: u64
+     var $t7: &SmokeTest::Color
+     var $t8: u64
+     var $t9: &SmokeTest::Color
+     var $t10: u64
+     var $t11: u64
+  0: $t3 := move($t0)
+  1: $t2 := $t3
+  2: $t4 := copy($t2)
+  3: switch $t4 { 0 => 4 1 => 10 2 => 16}
+  4: label L0
+  5: $t5 := move($t2)
+  6: &unpack_variant<SmokeTest::Color>::Red($t5)
+  7: $t6 := 1
+  8: $t1 := $t6
+  9: goto 22
+ 10: label L1
+ 11: $t7 := move($t2)
+ 12: &unpack_variant<SmokeTest::Color>::Green($t7)
+ 13: $t8 := 1
+ 14: $t1 := $t8
+ 15: goto 22
+ 16: label L2
+ 17: $t9 := move($t2)
+ 18: &unpack_variant<SmokeTest::Color>::Blue($t9)
+ 19: $t10 := 2
+ 20: $t1 := $t10
+ 21: goto 22
+ 22: label L3
+ 23: $t11 := move($t1)
+ 24: return $t11
+}
+
+
+[variant baseline]
 fun SmokeTest::identity($t0|a: SmokeTest::A, $t1|b: SmokeTest::B, $t2|c: SmokeTest::C): (SmokeTest::A, SmokeTest::B, SmokeTest::C) {
      var $t3: SmokeTest::A
      var $t4: SmokeTest::B
@@ -124,6 +165,47 @@ fun SmokeTest::identity($t0|a: SmokeTest::A, $t1|b: SmokeTest::B, $t2|c: SmokeTe
   1: $t4 := move($t1)
   2: $t5 := move($t2)
   3: return ($t3, $t4, $t5)
+}
+
+
+[variant baseline]
+fun SmokeTest::match_color($t0|c: &SmokeTest::Color): u64 {
+     var $t1|tmp#$1: u64
+     var $t2|tmp#$2: &SmokeTest::Color
+     var $t3: &SmokeTest::Color
+     var $t4: &SmokeTest::Color
+     var $t5: &SmokeTest::Color
+     var $t6: u64
+     var $t7: &SmokeTest::Color
+     var $t8: u64
+     var $t9: &SmokeTest::Color
+     var $t10: u64
+     var $t11: u64
+  0: $t3 := move($t0)
+  1: $t2 := $t3
+  2: $t4 := copy($t2)
+  3: switch $t4 { 0 => 4 1 => 10 2 => 16}
+  4: label L0
+  5: $t5 := move($t2)
+  6: &unpack_variant<SmokeTest::Color>::Red($t5)
+  7: $t6 := 1
+  8: $t1 := $t6
+  9: goto 22
+ 10: label L1
+ 11: $t7 := move($t2)
+ 12: &unpack_variant<SmokeTest::Color>::Green($t7)
+ 13: $t8 := 2
+ 14: $t1 := $t8
+ 15: goto 22
+ 16: label L2
+ 17: $t9 := move($t2)
+ 18: &unpack_variant<SmokeTest::Color>::Blue($t9)
+ 19: $t10 := 3
+ 20: $t1 := $t10
+ 21: goto 22
+ 22: label L3
+ 23: $t11 := move($t1)
+ 24: return $t11
 }
 
 
@@ -235,6 +317,68 @@ fun SmokeTest::ref_A($t0|a: address, $t1|b: bool): SmokeTest::A {
  26: label L3
  27: $t18 := move($t3)
  28: return $t18
+}
+
+
+[variant baseline]
+fun SmokeTest::shape_size($t0|s: SmokeTest::Shape): u64 {
+     var $t1|tmp#$1: u64
+     var $t2|tmp#$2: u64
+     var $t3|tmp#$3: &SmokeTest::Shape
+     var $t4|tmp#$4: SmokeTest::Shape
+     var $t5|height#1#0: u64
+     var $t6|width#1#0: u64
+     var $t7: SmokeTest::Shape
+     var $t8: &SmokeTest::Shape
+     var $t9: &SmokeTest::Shape
+     var $t10: &SmokeTest::Shape
+     var $t11: &u64
+     var $t12: SmokeTest::Shape
+     var $t13: u64
+     var $t14: &SmokeTest::Shape
+     var $t15: &u64
+     var $t16: &u64
+     var $t17: SmokeTest::Shape
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+  0: $t7 := move($t0)
+  1: $t4 := $t7
+  2: $t8 := borrow_local($t4)
+  3: $t3 := $t8
+  4: $t9 := copy($t3)
+  5: switch $t9 { 0 => 6 1 => 14}
+  6: label L0
+  7: $t10 := move($t3)
+  8: $t11 := &unpack_variant<SmokeTest::Shape>::Circle($t10)
+  9: destroy($t11)
+ 10: $t12 := move($t4)
+ 11: $t13 := unpack_variant<SmokeTest::Shape>::Circle($t12)
+ 12: $t1 := $t13
+ 13: goto 30
+ 14: label L1
+ 15: $t14 := move($t3)
+ 16: ($t15, $t16) := &unpack_variant<SmokeTest::Shape>::Rect($t14)
+ 17: destroy($t16)
+ 18: destroy($t15)
+ 19: $t17 := move($t4)
+ 20: ($t18, $t19) := unpack_variant<SmokeTest::Shape>::Rect($t17)
+ 21: $t2 := $t19
+ 22: $t6 := $t18
+ 23: $t20 := move($t2)
+ 24: $t5 := $t20
+ 25: $t21 := move($t6)
+ 26: $t22 := move($t5)
+ 27: $t23 := +($t21, $t22)
+ 28: $t1 := $t23
+ 29: goto 30
+ 30: label L2
+ 31: $t24 := move($t1)
+ 32: return $t24
 }
 
 


### PR DESCRIPTION
## Description

`StacklessBytecodeGenerator` panics (`no entry found for key`) on any function containing a `match` on an enum: the label-collection pass seeds `label_map` only from `BrTrue`/`BrFalse`/`Branch` targets, so `VariantSwitch` jump-table targets — normally reachable only through the jump table — are missing when the lowering arm indexes them. Seed them the same way branch targets are seeded.

Fixes #27186.

## Test plan

Extended `tests/from_move/smoke_test.move` with an enums section (unit-variant match by reference, or-pattern, by-value match with field bindings); each previously panicked and now snapshots the expected `switch`/`unpack_variant` lowering.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
