### PR TITLE
Add pull-based transaction pool for consensus submission

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -41,7 +41,10 @@ use crate::{
     storage::rocksdb_store::RocksDBStore,
     subscriber::Subscriber,
     synchronizer::{Synchronizer, SynchronizerHandle},
-    transaction::{TransactionClient, TransactionConsumer, TransactionVerifier},
+    transaction::{
+        TransactionClient, TransactionConsumer, TransactionConsumerPool, TransactionPool,
+        TransactionVerifier,
+    },
     transaction_vote_tracker::TransactionVoteTracker,
 };
 
@@ -64,6 +67,9 @@ impl ConsensusAuthority {
         network_keypair: NetworkKeyPair,
         clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
+        // When provided, the proposer takes transactions from this pool and the
+        // `TransactionClient` submission path is unused. Only relevant for validator nodes.
+        transaction_pool: Option<Arc<dyn TransactionPool>>,
         commit_consumer: CommitConsumerArgs,
         registry: Registry,
         // A counter that keeps track of how many times the consensus authority has been booted while the process
@@ -83,6 +89,7 @@ impl ConsensusAuthority {
                     network_keypair,
                     clock,
                     transaction_verifier,
+                    transaction_pool,
                     commit_consumer,
                     registry,
                     boot_counter,
@@ -182,6 +189,7 @@ where
         network_keypair: NetworkKeyPair,
         clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
+        transaction_pool: Option<Arc<dyn TransactionPool>>,
         commit_consumer: CommitConsumerArgs,
         registry: Registry,
         boot_counter: u64,
@@ -254,7 +262,19 @@ where
             .set(context.protocol_config.protocol_version() as i64);
 
         let (tx_client, tx_receiver) = TransactionClient::new(context.clone());
-        let tx_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let transaction_pool: Arc<dyn TransactionPool> = match transaction_pool {
+            // With an external pool, the TransactionClient path is unused. The channel
+            // receiver is dropped so accidental client submissions fail fast instead of
+            // hanging.
+            Some(pool) => {
+                drop(tx_receiver);
+                pool
+            }
+            None => Arc::new(TransactionConsumerPool::new(TransactionConsumer::new(
+                tx_receiver,
+                context.clone(),
+            ))),
+        };
 
         let (core_signals, signals_receivers) = CoreSignals::new(context.clone());
 
@@ -338,7 +358,7 @@ where
             Core::new_validator(
                 context.clone(),
                 leader_schedule,
-                tx_consumer,
+                transaction_pool,
                 transaction_vote_tracker.clone(),
                 block_manager,
                 commit_observer,
@@ -677,6 +697,7 @@ mod tests {
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
+            None,
             commit_consumer,
             registry,
             0,
@@ -719,6 +740,7 @@ mod tests {
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
+            None,
             commit_consumer,
             registry,
             0,
@@ -835,6 +857,7 @@ mod tests {
             observer_network_keypair,
             Arc::new(Clock::default()),
             Arc::new(NoopTransactionVerifier {}),
+            None,
             observer_commit_consumer,
             Registry::new(),
             0,
@@ -1271,6 +1294,7 @@ mod tests {
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
+            None,
             commit_consumer,
             registry,
             boot_counter,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -25,6 +25,7 @@ use crate::{
     CommitConsumerArgs, TransactionClient,
     block_verifier::NoopBlockVerifier,
     storage::{Store, WriteBatch, mem_store::MemStore},
+    transaction::{TransactionConsumer, TransactionConsumerPool},
 };
 use crate::{
     ancestor::AncestorStateManager,
@@ -42,7 +43,7 @@ use crate::{
     leader_scoring::ReputationScores,
     proposer::{ProposalLeaderWaiter, Proposer, ValidatorProposer},
     round_tracker::RoundTracker,
-    transaction::TransactionConsumer,
+    transaction::TransactionPool,
     transaction_vote_tracker::TransactionVoteTracker,
     universal_committer::{
         UniversalCommitter, universal_committer_builder::UniversalCommitterBuilder,
@@ -85,7 +86,7 @@ impl Core {
     pub(crate) fn new_validator(
         context: Arc<Context>,
         leader_schedule: Arc<LeaderSchedule>,
-        transaction_consumer: TransactionConsumer,
+        transaction_pool: Arc<dyn TransactionPool>,
         transaction_vote_tracker: TransactionVoteTracker,
         block_manager: BlockManager,
         commit_observer: CommitObserver,
@@ -163,7 +164,7 @@ impl Core {
         let proposer = Some(Box::new(ValidatorProposer::new(
             dag_state.clone(),
             context.clone(),
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker.clone(),
             block_signer,
             last_known_proposed_round,
@@ -1045,7 +1046,9 @@ impl CoreTestFixture {
                 .with_num_commits_per_schedule(10),
         );
         let (transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let transaction_consumer = Arc::new(TransactionConsumerPool::new(
+            TransactionConsumer::new(tx_receiver, context.clone()),
+        ));
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),
@@ -1133,7 +1136,9 @@ mod test {
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let transaction_consumer = Arc::new(TransactionConsumerPool::new(
+            TransactionConsumer::new(tx_receiver, context.clone()),
+        ));
         let mut block_status_subscriptions = FuturesUnordered::new();
 
         // Create test blocks for all the authorities for 4 rounds and populate them in store
@@ -1512,7 +1517,9 @@ mod test {
 
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let transaction_consumer = Arc::new(TransactionConsumerPool::new(
+            TransactionConsumer::new(tx_receiver, context.clone()),
+        ));
         let mut block_status_subscriptions = FuturesUnordered::new();
 
         let dag_str = "DAG {
@@ -2827,7 +2834,9 @@ mod test {
         );
 
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let transaction_consumer = Arc::new(TransactionConsumerPool::new(
+            TransactionConsumer::new(tx_receiver, context.clone()),
+        ));
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -392,7 +392,7 @@ mod test {
         leader_schedule::LeaderSchedule,
         round_tracker::RoundTracker,
         storage::{Store, WriteBatch, mem_store::MemStore},
-        transaction::{TransactionClient, TransactionConsumer},
+        transaction::{TransactionClient, TransactionConsumer, TransactionConsumerPool},
         transaction_vote_tracker::TransactionVoteTracker,
     };
 
@@ -405,7 +405,9 @@ mod test {
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let transaction_consumer = Arc::new(TransactionConsumerPool::new(
+            TransactionConsumer::new(tx_receiver, context.clone()),
+        ));
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),
@@ -494,7 +496,9 @@ mod test {
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
-        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let transaction_consumer = Arc::new(TransactionConsumerPool::new(
+            TransactionConsumer::new(tx_receiver, context.clone()),
+        ));
         let transaction_vote_tracker = TransactionVoteTracker::new(
             context.clone(),
             Arc::new(NoopBlockVerifier {}),

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -72,7 +72,8 @@ pub use context::Clock;
 pub use metrics::Metrics;
 pub use network::RandomnessSignatureHandler;
 pub use transaction::{
-    BlockStatus, ClientError, TransactionClient, TransactionVerifier, ValidationError,
+    BlockStatus, ClientError, LimitReached, TransactionClient, TransactionPool,
+    TransactionVerifier, ValidationError,
 };
 
 // Exported API for benchmarking

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -20,7 +20,7 @@ use crate::{
     leader_schedule_v3::NextCommitLeaderSchedule,
     round_tracker::RoundTracker,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    transaction::TransactionConsumer,
+    transaction::TransactionPool,
     transaction_vote_tracker::TransactionVoteTracker,
     universal_committer::UniversalCommitter,
 };
@@ -70,7 +70,7 @@ pub(crate) trait Proposer: Send + Sync {
 /// Validator proposal engine - full block proposal implementation
 pub(crate) struct ValidatorProposer {
     context: Arc<Context>,
-    transaction_consumer: TransactionConsumer,
+    transaction_pool: Arc<dyn TransactionPool>,
     transaction_vote_tracker: TransactionVoteTracker,
     propagation_delay: Round,
     last_included_ancestors: Vec<Option<BlockRef>>,
@@ -86,7 +86,7 @@ impl ValidatorProposer {
     pub(crate) fn new(
         dag_state: Arc<RwLock<DagState>>,
         context: Arc<Context>,
-        transaction_consumer: TransactionConsumer,
+        transaction_pool: Arc<dyn TransactionPool>,
         transaction_vote_tracker: TransactionVoteTracker,
         block_signer: ProtocolKeyPair,
         last_known_proposed_round: Option<Round>,
@@ -97,7 +97,7 @@ impl ValidatorProposer {
         let last_included_ancestors = vec![None; context.committee.size()];
         Self {
             context,
-            transaction_consumer,
+            transaction_pool,
             transaction_vote_tracker,
             propagation_delay: 0,
             last_included_ancestors,
@@ -510,9 +510,12 @@ impl Proposer for ValidatorProposer {
             }
         });
 
-        // Consume the next transactions to be included. Do not drop the guards yet as this would acknowledge
-        // the inclusion of transactions. Just let this be done in the end of the method.
-        let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
+        // Consume the next transactions to be included. Do not drop the ack yet as this would
+        // return the transactions to the pool. Just let this be done in the end of the method.
+        let (transactions, ack_transactions, _limit_reached) = self.transaction_pool.take(
+            self.context.protocol_config.max_num_transactions_in_block() as usize,
+            self.context.protocol_config.max_transactions_in_block_bytes() as usize,
+        );
         self.context
             .metrics
             .node_metrics
@@ -716,8 +719,7 @@ impl Proposer for ValidatorProposer {
     }
 
     fn notify_own_blocks_committed(&self, block_refs: Vec<BlockRef>, gc_round: Round) {
-        self.transaction_consumer
-            .notify_own_blocks_status(block_refs, gc_round);
+        self.transaction_pool.notify_committed(block_refs, gc_round);
     }
 
     #[cfg(test)]

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -514,7 +514,9 @@ impl Proposer for ValidatorProposer {
         // return the transactions to the pool. Just let this be done in the end of the method.
         let (transactions, ack_transactions, _limit_reached) = self.transaction_pool.take(
             self.context.protocol_config.max_num_transactions_in_block() as usize,
-            self.context.protocol_config.max_transactions_in_block_bytes() as usize,
+            self.context
+                .protocol_config
+                .max_transactions_in_block_bytes() as usize,
         );
         self.context
             .metrics

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -102,7 +102,13 @@ impl TransactionConsumer {
     // and `max_num_transactions_in_block` parameters specified via protocol config.
     // This returns one or more transactions to be included in the block and a callback to acknowledge the inclusion of those transactions.
     // Also returns a `LimitReached` enum to indicate which limit type has been reached.
-    pub(crate) fn next(&mut self) -> (Vec<Transaction>, Box<dyn FnOnce(BlockRef)>, LimitReached) {
+    pub(crate) fn next(
+        &mut self,
+    ) -> (
+        Vec<Transaction>,
+        Box<dyn FnOnce(BlockRef) + Send>,
+        LimitReached,
+    ) {
         let mut transactions = Vec::new();
         let mut acks = Vec::new();
         let mut total_bytes = 0;
@@ -382,6 +388,77 @@ impl TransactionClient {
             .tap_err(|e| error!("Submit transactions failed with {:?}", e))
             .map_err(|e| ClientError::ConsensusShuttingDown(e.to_string()))?;
         Ok(included_in_block_ack_receive)
+    }
+}
+
+/// `TransactionPool` supplies transactions for block proposals, as an alternative to
+/// submitting transactions through `TransactionClient`. Like `TransactionVerifier`, the
+/// implementation can be provided by Sui and passed into `ConsensusAuthority::start()`.
+pub trait TransactionPool: Send + Sync + 'static {
+    /// Called by the proposer while building a block. Takes transactions to include, up to
+    /// `max_count` transactions and `max_bytes` total serialized bytes. Returns the
+    /// transactions in block order, an ack callback the proposer invokes with the created
+    /// block's reference after the block is durably created, and which limit stopped the
+    /// take. Dropping the callback without invoking it means the transactions have not been
+    /// included in a block, and the implementation may make them available to take again.
+    fn take(
+        &self,
+        max_count: usize,
+        max_bytes: usize,
+    ) -> (
+        Vec<Transaction>,
+        Box<dyn FnOnce(BlockRef) + Send>,
+        LimitReached,
+    );
+
+    /// Called from the commit path with this authority's own committed block refs and the
+    /// current GC round. Own blocks at rounds <= `gc_round` that are not committed will
+    /// never commit.
+    fn notify_committed(&self, own_committed_blocks: Vec<BlockRef>, gc_round: Round);
+}
+
+/// Adapts the channel-based `TransactionConsumer` to the `TransactionPool` interface, for
+/// transactions submitted through `TransactionClient`.
+pub(crate) struct TransactionConsumerPool {
+    consumer: Mutex<TransactionConsumer>,
+}
+
+impl TransactionConsumerPool {
+    pub(crate) fn new(consumer: TransactionConsumer) -> Self {
+        Self {
+            consumer: Mutex::new(consumer),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn subscribe_for_block_status_testing(
+        &self,
+        block_ref: BlockRef,
+    ) -> oneshot::Receiver<BlockStatus> {
+        self.consumer
+            .lock()
+            .subscribe_for_block_status_testing(block_ref)
+    }
+}
+
+impl TransactionPool for TransactionConsumerPool {
+    fn take(
+        &self,
+        _max_count: usize,
+        _max_bytes: usize,
+    ) -> (
+        Vec<Transaction>,
+        Box<dyn FnOnce(BlockRef) + Send>,
+        LimitReached,
+    ) {
+        // The consumer enforces the same protocol-config limits internally.
+        self.consumer.lock().next()
+    }
+
+    fn notify_committed(&self, own_committed_blocks: Vec<BlockRef>, gc_round: Round) {
+        self.consumer
+            .lock()
+            .notify_own_blocks_status(own_committed_blocks, gc_round);
     }
 }
 

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -337,6 +337,7 @@ pub(crate) async fn make_authority(
         network_keypair,
         Arc::new(Clock::new_for_test(clock_drift)),
         transaction_verifier,
+        None,
         commit_consumer,
         registry,
         boot_counter,

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1464,6 +1464,12 @@ pub struct AuthorityOverloadConfig {
     // reject behavior as when the queue is disabled) until progress resumes.
     #[serde(default = "default_admission_queue_failover_timeout")]
     pub admission_queue_failover_timeout: Duration,
+
+    // Enables the pull-based transaction pool for consensus submission, replacing the
+    // admission queue + consensus adapter submission pipeline. See
+    // sui-core/src/transaction_pool.md.
+    #[serde(default = "default_transaction_pool_enabled")]
+    pub transaction_pool_enabled: bool,
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
@@ -1522,6 +1528,12 @@ fn default_admission_queue_failover_timeout() -> Duration {
     Duration::from_secs(30)
 }
 
+fn default_transaction_pool_enabled() -> bool {
+    // The env var allows enabling the pool wholesale in test runs (e.g. simtest
+    // suites) without editing per-test configs.
+    std::env::var("SUI_TRANSACTION_POOL_ENABLED").is_ok()
+}
+
 impl Default for AuthorityOverloadConfig {
     fn default() -> Self {
         Self {
@@ -1541,6 +1553,7 @@ impl Default for AuthorityOverloadConfig {
             admission_queue_bypass_fraction: default_admission_queue_bypass_fraction(),
             admission_queue_enabled: default_admission_queue_enabled(),
             admission_queue_failover_timeout: default_admission_queue_failover_timeout(),
+            transaction_pool_enabled: default_transaction_pool_enabled(),
         }
     }
 }

--- a/crates/sui-core/CLAUDE.md
+++ b/crates/sui-core/CLAUDE.md
@@ -1,0 +1,11 @@
+# sui-core
+
+## Design docs
+
+- Before modifying `src/consensus_adapter.rs`, `src/admission_queue.rs`, or the
+  transaction submission path in `src/authority_server.rs`, read
+  `src/consensus_submission_pipeline.md` for the end-to-end dataflow and behaviors.
+  Update that doc in the same change when submission behavior changes.
+- When touching `src/accumulators/` or
+  `src/execution_scheduler/funds_withdraw_scheduler/`, start with
+  `src/accumulators/design_docs/README.md`.

--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -1,6 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Gas-price priority queue admitting user transactions to consensus under load.
+//!
+//! See `consensus_submission_pipeline.md` (same directory) for the end-to-end
+//! submission dataflow and behaviors; keep it in sync with behavior changes here.
+
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::consensus_adapter::ConsensusAdapter;
 use arc_swap::ArcSwap;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -416,6 +416,10 @@ pub struct AuthorityPerEpochStore {
     /// A cache which tracks recently finalized transactions.
     pub(crate) finalized_transactions_cache: FinalizedTransactionsCache,
 
+    /// Settle-callback hook for the pull-based transaction pool, when enabled. Weak so
+    /// the epoch store doesn't keep the pool (which holds this store) alive.
+    transaction_pool: OnceCell<std::sync::Weak<crate::transaction_pool::SuiTransactionPool>>,
+
     /// The node's role for this epoch, derived from committee membership and
     /// the configured sync mode. Computed once at construction.
     node_role: NodeRole,
@@ -1007,7 +1011,10 @@ impl AuthorityPerEpochStore {
         let finalized_transactions_cache =
             FinalizedTransactionsCache::new(randomize_cache_capacity_in_tests(100_000));
 
+        let transaction_pool = OnceCell::new();
+
         let s = Arc::new(Self {
+            transaction_pool,
             name,
             committee: committee.clone(),
             protocol_config,
@@ -2024,6 +2031,9 @@ impl AuthorityPerEpochStore {
         for digest in digests {
             self.executed_transactions_to_checkpoint_notify_read
                 .notify(digest, &sequence);
+        }
+        if let Some(pool) = self.transaction_pool() {
+            pool.note_executed_in_checkpoint(digests);
         }
 
         Ok(())
@@ -3049,8 +3059,16 @@ impl AuthorityPerEpochStore {
         &'a self,
         notifications: impl Iterator<Item = &'a SequencedConsensusTransactionKey>,
     ) {
-        for key in notifications {
-            self.consensus_notify_read.notify(key, &());
+        if let Some(pool) = self.transaction_pool() {
+            let keys: Vec<_> = notifications.collect();
+            for key in &keys {
+                self.consensus_notify_read.notify(key, &());
+            }
+            pool.note_processed(keys.into_iter());
+        } else {
+            for key in notifications {
+                self.consensus_notify_read.notify(key, &());
+            }
         }
     }
 
@@ -3319,8 +3337,31 @@ impl AuthorityPerEpochStore {
         &self,
         updates: Vec<(ConsensusPosition, ConsensusTxStatus)>,
     ) {
+        if let Some(pool) = self.transaction_pool() {
+            pool.note_statuses(&updates);
+        }
         self.consensus_tx_status_cache
             .set_transaction_statuses(updates);
+    }
+
+    /// Registers the pull-based transaction pool for settle callbacks (processed keys,
+    /// per-position statuses, checkpoint-executed digests). Called once at epoch start
+    /// when the transaction pool is enabled.
+    pub fn set_transaction_pool(
+        &self,
+        pool: &Arc<crate::transaction_pool::SuiTransactionPool>,
+    ) {
+        if self
+            .transaction_pool
+            .set(Arc::downgrade(pool))
+            .is_err()
+        {
+            mysten_common::debug_fatal!("transaction pool already registered for this epoch");
+        }
+    }
+
+    fn transaction_pool(&self) -> Option<Arc<crate::transaction_pool::SuiTransactionPool>> {
+        self.transaction_pool.get().and_then(|weak| weak.upgrade())
     }
 
     pub(crate) fn set_rejection_vote_reason(&self, position: ConsensusPosition, reason: &SuiError) {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3347,15 +3347,8 @@ impl AuthorityPerEpochStore {
     /// Registers the pull-based transaction pool for settle callbacks (processed keys,
     /// per-position statuses, checkpoint-executed digests). Called once at epoch start
     /// when the transaction pool is enabled.
-    pub fn set_transaction_pool(
-        &self,
-        pool: &Arc<crate::transaction_pool::SuiTransactionPool>,
-    ) {
-        if self
-            .transaction_pool
-            .set(Arc::downgrade(pool))
-            .is_err()
-        {
+    pub fn set_transaction_pool(&self, pool: &Arc<crate::transaction_pool::SuiTransactionPool>) {
+        if self.transaction_pool.set(Arc::downgrade(pool)).is_err() {
             mysten_common::debug_fatal!("transaction pool already registered for this epoch");
         }
     }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -67,6 +67,7 @@ use tracing::{debug, error, info, instrument};
 
 use crate::admission_queue::{AdmissionQueueContext, AdmissionQueueManager};
 use crate::gasless_rate_limiter::GaslessRateLimiter;
+use crate::transaction_pool::TransactionPoolContext;
 use crate::{
     authority::{AuthorityState, consensus_tx_status_cache::ConsensusTxStatus},
     consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, ConsensusOverloadChecker},
@@ -411,6 +412,8 @@ impl ValidatorServiceMetrics {
 
 /// Where `handle_submit_transaction` routes a request.
 enum AdmissionQueueSubmitMode {
+    /// The pull-based transaction pool is enabled: every submission goes through it.
+    Pool,
     /// System has capacity: submit directly to consensus, skipping the queue.
     Bypass,
     /// System is overloaded: admit via the priority queue.
@@ -430,6 +433,7 @@ pub struct ValidatorService {
     client_id_source: Option<ClientIdSource>,
     gasless_limiter: GaslessRateLimiter,
     admission_queue: Option<AdmissionQueueContext>,
+    transaction_pool: Option<TransactionPoolContext>,
     /// Digests submitted within the last `recent_submission_window` (value: when recorded), to
     /// drop duplicate resubmissions before they reach consensus.
     recently_submitted: Cache<TransactionDigest, Instant>,
@@ -450,6 +454,7 @@ impl ValidatorService {
         validator_metrics: Arc<ValidatorServiceMetrics>,
         client_id_source: Option<ClientIdSource>,
         admission_queue: Option<AdmissionQueueContext>,
+        transaction_pool: Option<TransactionPoolContext>,
     ) -> Self {
         let traffic_controller = state.traffic_controller.clone();
         let gasless_limiter = GaslessRateLimiter::new(state.consensus_gasless_counter.clone());
@@ -462,6 +467,7 @@ impl ValidatorService {
             client_id_source,
             gasless_limiter,
             admission_queue,
+            transaction_pool,
             recently_submitted: Self::new_recently_submitted_cache(recent_submission_window),
             recent_submission_window,
             inflight_transactions: Arc::new(Mutex::new(HashSet::new())),
@@ -500,6 +506,7 @@ impl ValidatorService {
             client_id_source: None,
             gasless_limiter,
             admission_queue,
+            transaction_pool: None,
             recently_submitted: Self::new_recently_submitted_cache(recent_submission_window),
             recent_submission_window,
             inflight_transactions: Arc::new(Mutex::new(HashSet::new())),
@@ -625,6 +632,7 @@ impl ValidatorService {
             client_id_source,
             gasless_limiter: _,
             admission_queue: _,
+            transaction_pool: _,
             recently_submitted: _,
             recent_submission_window: _,
             inflight_transactions: _,
@@ -1328,6 +1336,47 @@ impl ValidatorService {
                 });
                 future::join_all(futures).await
             }
+            AdmissionQueueSubmitMode::Pool => {
+                let pool = self
+                    .transaction_pool
+                    .as_ref()
+                    .expect("Pool mode implies transaction_pool is Some");
+                let mut receivers = Vec::with_capacity(tx_groups.len());
+                for txns in tx_groups {
+                    let gas_price = Self::extract_gas_price(&txns);
+                    let result = pool.submit_for_positions(
+                        gas_price,
+                        txns,
+                        &epoch_store,
+                        submitter_client_addr,
+                    );
+                    match result {
+                        Ok((rx, newly_inserted)) => {
+                            if !newly_inserted {
+                                // Duplicate of an in-flight submission; flag the request as
+                                // spam. The per-tx result is still Submitted, so this is
+                                // tracked separately.
+                                duplicate_at_admission = true;
+                            }
+                            receivers.push(Ok(rx));
+                        }
+                        // Delivered as the group result: TransactionProcessing is handled
+                        // per-tx below, any other error fails the whole request.
+                        Err(err) => receivers.push(Err(err)),
+                    }
+                }
+                future::join_all(receivers.into_iter().map(|r| async move {
+                    match r {
+                        Ok(rx) => rx.await.unwrap_or_else(|_| {
+                            Err(SuiError::from(SuiErrorKind::FailedToSubmitToConsensus(
+                                "position channel dropped".to_string(),
+                            )))
+                        }),
+                        Err(err) => Err(err),
+                    }
+                }))
+                .await
+            }
             AdmissionQueueSubmitMode::Queue => {
                 let aq = self
                     .admission_queue
@@ -1499,6 +1548,10 @@ impl ValidatorService {
     }
 
     fn classify_submit_mode(&self, is_ping_request: bool) -> AdmissionQueueSubmitMode {
+        if self.transaction_pool.is_some() {
+            return AdmissionQueueSubmitMode::Pool;
+        }
+
         let Some(aq) = &self.admission_queue else {
             return AdmissionQueueSubmitMode::Disabled;
         };

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -214,6 +214,28 @@ pub trait SubmitToConsensus: Sync + Send + 'static {
     ) -> SuiResult;
 }
 
+// Allows an `Arc<dyn SubmitToConsensus>` to be used where `T: SubmitToConsensus` is
+// required (e.g. `SubmitCheckpointToConsensus<T>` and `Box<dyn SubmitToConsensus>`
+// construction), so callers can select the submitter implementation at runtime.
+impl SubmitToConsensus for Arc<dyn SubmitToConsensus> {
+    fn submit_to_consensus(
+        &self,
+        transactions: &[ConsensusTransaction],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        (**self).submit_to_consensus(transactions, epoch_store)
+    }
+
+    fn submit_best_effort(
+        &self,
+        transaction: &ConsensusTransaction,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        timeout: Duration,
+    ) -> SuiResult {
+        (**self).submit_best_effort(transaction, epoch_store, timeout)
+    }
+}
+
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait ConsensusClient: Sync + Send + 'static {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Submits transactions to consensus and tracks each submission until its
+//! positions reach a terminal status or it is observed processed via another path.
+//!
+//! See `consensus_submission_pipeline.md` (same directory) for the end-to-end
+//! submission dataflow and behaviors; keep it in sync with behavior changes here.
+
 use std::net::IpAddr;
 use std::ops::Deref;
 use std::sync::Arc;

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -79,7 +79,7 @@ use crate::{
         CheckpointHeight, CheckpointRoots, CheckpointService, CheckpointServiceNotify,
         PendingCheckpoint, PendingCheckpointInfo,
     },
-    consensus_adapter::ConsensusAdapter,
+    consensus_adapter::SubmitToConsensus,
     consensus_throughput_calculator::ConsensusThroughputCalculator,
     consensus_types::consensus_output_api::{ConsensusCommitAPI, ParsedTransaction},
     epoch::{
@@ -105,7 +105,7 @@ pub struct ConsensusHandlerInitializer {
     state: Arc<AuthorityState>,
     checkpoint_service: Arc<CheckpointService>,
     epoch_store: Arc<AuthorityPerEpochStore>,
-    consensus_adapter: Arc<ConsensusAdapter>,
+    consensus_adapter: Arc<dyn SubmitToConsensus>,
     throughput_calculator: Arc<ConsensusThroughputCalculator>,
     backpressure_manager: Arc<BackpressureManager>,
     congestion_logger: Option<Arc<Mutex<CongestionCommitLogger>>>,
@@ -117,7 +117,7 @@ impl ConsensusHandlerInitializer {
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
         epoch_store: Arc<AuthorityPerEpochStore>,
-        consensus_adapter: Arc<ConsensusAdapter>,
+        consensus_adapter: Arc<dyn SubmitToConsensus>,
         throughput_calculator: Arc<ConsensusThroughputCalculator>,
         backpressure_manager: Arc<BackpressureManager>,
         congestion_log_config: Option<CongestionLogConfig>,
@@ -159,7 +159,7 @@ impl ConsensusHandlerInitializer {
             state: state.clone(),
             checkpoint_service,
             epoch_store: state.epoch_store_for_testing().clone(),
-            consensus_adapter,
+            consensus_adapter: Arc::new(consensus_adapter),
             throughput_calculator: Arc::new(ConsensusThroughputCalculator::new(
                 None,
                 state.metrics.clone(),
@@ -803,8 +803,8 @@ pub struct ConsensusHandler<C> {
     metrics: Arc<AuthorityMetrics>,
     /// Lru cache to quickly discard transactions processed by consensus
     processed_cache: LruCache<SequencedConsensusTransactionKey, ()>,
-    /// Consensus adapter for submitting transactions to consensus
-    consensus_adapter: Arc<ConsensusAdapter>,
+    /// For submitting transactions (e.g. EndOfPublish) to consensus
+    consensus_adapter: Arc<dyn SubmitToConsensus>,
 
     /// Using the throughput calculator to record the current consensus throughput
     throughput_calculator: Arc<ConsensusThroughputCalculator>,
@@ -829,7 +829,7 @@ impl<C> ConsensusHandler<C> {
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<C>,
         settlement_scheduler: SettlementScheduler,
-        consensus_adapter: Arc<ConsensusAdapter>,
+        consensus_adapter: Arc<dyn SubmitToConsensus>,
         cache_reader: Arc<dyn ObjectCacheRead>,
         committee: ConsensusCommittee,
         metrics: Arc<AuthorityMetrics>,
@@ -919,7 +919,7 @@ impl<C> ConsensusHandler<C> {
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<C>,
         execution_scheduler_sender: ExecutionSchedulerSender,
-        consensus_adapter: Arc<ConsensusAdapter>,
+        consensus_adapter: Arc<dyn SubmitToConsensus>,
         cache_reader: Arc<dyn ObjectCacheRead>,
         committee: ConsensusCommittee,
         metrics: Arc<AuthorityMetrics>,
@@ -3027,9 +3027,9 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         }
 
         let end_of_publish = ConsensusTransaction::new_end_of_publish(self.epoch_store.name);
-        if let Err(err) =
-            self.consensus_adapter
-                .submit(end_of_publish, None, &self.epoch_store, None, None)
+        if let Err(err) = self
+            .consensus_adapter
+            .submit_to_consensus(&[end_of_publish], &self.epoch_store)
         {
             warn!(
                 "Error when sending EndOfPublish message from ConsensusHandler: {:?}",
@@ -3599,7 +3599,7 @@ mod tests {
             epoch_store,
             Arc::new(CheckpointServiceNoop {}),
             settlement_scheduler,
-            consensus_adapter,
+            Arc::new(consensus_adapter),
             state.get_object_cache_reader().clone(),
             consensus_committee.clone(),
             metrics,
@@ -4185,7 +4185,7 @@ mod tests {
             epoch_store.clone(),
             Arc::new(CheckpointServiceNoop {}),
             settlement_scheduler,
-            consensus_adapter,
+            Arc::new(consensus_adapter),
             state.get_object_cache_reader().clone(),
             consensus_committee.clone(),
             metrics,
@@ -4311,7 +4311,7 @@ mod tests {
             epoch_store.clone(),
             Arc::new(CheckpointServiceNoop {}),
             settlement_scheduler,
-            consensus_adapter,
+            Arc::new(consensus_adapter),
             state.get_object_cache_reader().clone(),
             consensus_committee.clone(),
             metrics,

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -255,6 +255,9 @@ impl ConsensusManager {
         epoch_store: Arc<AuthorityPerEpochStore>,
         consensus_handler_initializer: ConsensusHandlerInitializer,
         tx_validator: SuiTxValidator,
+        // When provided, the consensus proposer takes transactions from this pool and
+        // the TransactionClient submission path is unused.
+        transaction_pool: Option<Arc<dyn consensus_core::TransactionPool>>,
         randomness_signature_handler: Option<Arc<dyn RandomnessSignatureHandler>>,
     ) {
         let epoch = epoch_store.epoch();
@@ -353,7 +356,7 @@ impl ConsensusManager {
             self.network_keypair.clone(),
             Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),
-            None,
+            transaction_pool,
             commit_consumer,
             registry.clone(),
             *boot_counter,

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -353,6 +353,7 @@ impl ConsensusManager {
             self.network_keypair.clone(),
             Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),
+            None,
             commit_consumer,
             registry.clone(),
             *boot_counter,

--- a/crates/sui-core/src/consensus_submission_pipeline.md
+++ b/crates/sui-core/src/consensus_submission_pipeline.md
@@ -1,0 +1,422 @@
+# Transaction Submission Pipeline: Admission Queue and Consensus Adapter
+
+This documents the dataflow from a `SubmitTransaction` RPC arriving at a validator,
+through the gas-price admission queue (`admission_queue.rs`) and the consensus adapter
+(`consensus_adapter.rs`), to the point where the RPC request completes and the
+background submission task settles.
+
+**Keep this doc in sync**: when changing behavior in `admission_queue.rs`,
+`consensus_adapter.rs`, or the submit path in `authority_server.rs`, update this file.
+
+## Overview
+
+```
+gRPC SubmitTx
+     │
+ValidatorService::handle_submit_transaction        (authority_server.rs)
+     │  per-tx validation, dedup, voting
+     │
+classify_submit_mode()
+     │
+     ├─ Bypass ───────────────────────────────┐
+     ├─ Disabled (per-tx overload reject) ────┤
+     │                                        │
+     └─ Queue                                 │
+         │ AdmissionQueueHandle::try_insert   │
+         ▼                                    │
+   AdmissionQueueEventLoop (per-epoch actor)  │
+         │ drain_batch (highest gas price)    │
+         ▼                                    ▼
+   ConsensusAdapter::submit_and_get_positions
+         │ spawn submit_and_wait task
+         ├──► RPC caller gets Vec<ConsensusPosition>  ← request "finishes" here
+         │
+   background task continues:
+         │ block status → per-position terminal status
+         ▼
+   InflightDropGuard::drop → inflight_slot_freed_notify → queue drains more
+```
+
+## Design principles
+
+The pipeline assumes a well-behaved client submits a transaction **once** and then
+waits on its status. Occasionally the same transaction is submitted again — 
+typically when the client lost its connection to this validator and chose to retry
+here. Submitting many copies of the same transaction in a short interval is outside
+this contract: the dedup and spam-accounting layers exist to defend against that
+pattern, not to optimize for it.
+
+1. **Inflight accounting is leak-free; admission is deliberately weak.**
+   `num_inflight_transactions` is the single signal behind every backpressure
+   decision — the bypass threshold, the queue's drain capacity, and the
+   Disabled-mode reject — so it must stay accurate under high load. It is
+   maintained exclusively by RAII (`InflightDropGuard`): every exit path —
+   settled, skipped as already-processed, cancelled at epoch end, dropped
+   mid-race — releases its slots. The asymmetry is intentional: admission checks
+   are weak (checked, not atomically reserved; a transient overshoot
+   self-corrects as tasks settle), but a leaked slot is permanent capacity loss
+   for the epoch, so release correctness is the hard invariant.
+
+2. **Answer early when the outcome is already known elsewhere.** A transaction
+   observed as processed — via another validator's submission appearing in
+   consensus output, or via checkpoint execution/sync — is answered without
+   being (re)submitted, with a retriable `TransactionProcessing` or a concrete
+   terminal error. This applies both before submission (the RPC handler's
+   `is_consensus_message_processed` suppression, the adapter's
+   `check_processed_via_consensus_or_checkpoint`) and during it
+   (`processed_notify` racing the submit loop). No transaction is forced through
+   this validator's own submission to get its answer.
+
+3. **Deduplicate at every layer, with checks local to that layer.** Repeated
+   digests within a request, concurrent in-flight submissions
+   (`InflightTransactionsGuard`), recent submissions (TTL cache), already-queued
+   keys (`queued_keys`), and already-processed keys are each caught where the
+   information is cheaply available. Duplicates that slip through are still
+   *accounted* — tallied as spam weight for traffic control — even when they are
+   admitted.
+
+4. **Dedup and early-response are optimizations, not correctness requirements.**
+   Both may be imperfect where precision would cost real complexity: the
+   admission queue flags duplicates but admits them rather than coalescing
+   waiters across entries; the recently-submitted cache is a TTL approximation;
+   an expired status-cache entry ends the task instead of reconstructing the
+   outcome. This is safe because downstream consensus handling is idempotent and
+   clients own transaction-level retries — a missed dedup costs load, never
+   correctness.
+
+5. **Only system transactions are owed retries.** System transactions
+   (checkpoint signatures, `EndOfPublish`, DKG, capability notifications) have
+   no client behind them and the protocol depends on them landing, so the
+   adapter retries them until they are sequenced, observed processed, or the
+   epoch ends — the deliberate exception being self-superseding messages on the
+   `submit_best_effort` path, where the next periodic submission replaces a
+   missed one. User transactions have a client that owns retries: the adapter
+   still retries internally where it is cheap and unambiguous (resubmission
+   after garbage collection, backoff on submission errors), but only as best
+   effort — ambiguous or terminal conditions (expired status, processed
+   elsewhere, epoch end) end the task rather than retry it, and the client is
+   expected to resubmit.
+
+6. **Every submission ends in exactly one explicit, actionable outcome.** No
+   silent drops: an evicted queue entry receives a distinct outbid error (not a
+   bare channel error), a processed-elsewhere transaction a retriable error, an
+   owned-object conflict loser a terminal error. Errors are chosen to tell the
+   client what to do next — retry, outbid, or stop.
+
+7. **Prefer higher gas priced user transactions for submission.** When consensus
+   capacity is scarce, it goes to the transactions bidding the most for it —
+   admission, eviction, and drain order are all driven by gas price.
+
+8. **System messages and reconfiguration are never blocked behind user
+   traffic.** Checkpoint signatures, `EndOfPublish`, DKG, and capability
+   notifications skip both the admission queue and the submit semaphore;
+   `within_alive_epoch` cancels all pending submissions at epoch termination so
+   reconfiguration cannot be held up by a stuck submission.
+
+## 1. Entry and routing (`authority_server.rs`)
+
+`handle_submit_transaction` runs a long per-transaction validation gauntlet before
+anything touches the queue or adapter: deserialize + validity check,
+duplicate-digest-in-request check, soft-bundle gas-price equality, system overload
+check, gasless rate limiting, signature verification, already-executed
+short-circuits, an `is_consensus_message_processed` suppression path (with
+owned-lock conflict probing so conflict losers get a terminal error instead of a
+retriable one), the `InflightTransactionsGuard` dedup, and `handle_vote_transaction`.
+Survivors become `ConsensusTransaction::UserTransactionV2` messages.
+
+**Dedup guard** (`InflightTransactionsGuard`): digests are atomically acquired into
+an in-flight set for the duration of the handler; concurrent duplicates get
+`TransactionSubmitted`. On drop, digests demote into a TTL `recently_submitted`
+cache (window from node config) so immediate resubmissions are still suppressed.
+
+**Grouping**: a soft bundle is one submission group; a batch request becomes one
+group per transaction. Groups map back to `(result index, digest)` so per-group
+outcomes land on individual per-tx results.
+
+**Routing** — `classify_submit_mode`, evaluated once per request:
+
+| Condition | Mode |
+|---|---|
+| Queue not configured (`admission_queue_enabled: false`, default true) | Disabled |
+| Ping request | Bypass |
+| `num_inflight_transactions < bypass_threshold` (default 0.9 × `max_pending_transactions`) | Bypass |
+| Overloaded and `failover_tripped()` | Disabled |
+| Otherwise (overloaded, queue healthy) | Queue |
+
+Two behavioral notes:
+
+- The per-tx `check_consensus_overload()` reject (`TooManyTransactionsPendingConsensus`)
+  only runs in **Disabled** mode. Bypass mode skips it — inflight is below threshold
+  by definition. Queue mode replaces rejection with queuing/eviction.
+- The failover check is only consulted on the overloaded path, so the hot path never
+  pays the `ArcSwap` load.
+
+## 2. The queue path (`admission_queue.rs`)
+
+**Handle → actor**: `AdmissionQueueHandle::try_insert` creates a `oneshot` for the
+eventual consensus positions, packages a
+`QueueEntry { gas_price, transactions, position_sender, client_addr, enqueue_time }`,
+and sends an `InsertCommand` over a bounded mpsc to the per-epoch actor.
+`send().await` applies backpressure when the command channel
+(capacity = max(queue capacity, 1024)) is full; a closed channel or dropped ack maps
+to `TooManyTransactionsPendingConsensus`. Gas price for an entry is the *minimum*
+across the bundle, 0 for gasless — so gasless entries are always first to be evicted.
+
+**Priority queue** (`PriorityAdmissionQueue`): `BTreeMap<gas_price, VecDeque<QueueEntry>>`,
+FIFO within a price level. Capacity defaults to 0.5 × `max_pending_transactions`.
+Insert semantics when full:
+
+- New price **strictly greater** than the current minimum → evict the lowest-priced
+  (oldest at that price) entry. The evicted caller's `position_sender` gets
+  `TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: evicter's price }`,
+  so its `rx.await` returns a distinct outbid error rather than a `RecvError`.
+- Otherwise → the *incoming* insert is rejected with the same error carrying the
+  queue's current min price (equal price does not evict).
+
+**Duplicates are admitted, not rejected**: a `queued_keys` refcount detects entries
+whose `ConsensusTransactionKey` is already queued; the insert returns
+`newly_inserted = false`, which the RPC layer records as `duplicate_at_admission`
+and converts to spam weight 1 for traffic control (`request_spam_weight`). The
+duplicate still flows to consensus, where downstream dedup handles it.
+
+**Event loop** (`AdmissionQueueEventLoop::run`): a single actor per epoch, spawned by
+`AdmissionQueueManager::spawn` and rotated at reconfig. Each iteration:
+
+1. Drain all pending inserts non-blockingly; publish queue depth to an atomic
+   (read by `failover_tripped`).
+2. If the queue is non-empty and consensus has capacity
+   (`num_inflight_transactions < max_pending_transactions`), `drain_batch` and loop.
+3. Empty queue → block on `recv()` (channel closed = actor shutdown).
+4. Non-empty but consensus saturated → register the `slot_freed_notify.notified()`
+   future **before** re-checking capacity (missed-wakeup avoidance), then
+   `select! { biased; recv, slot_freed }` — new inserts win ties so eviction
+   ordering stays current.
+
+**Drain** (`drain_batch`): pops up to `max_pending − inflight` entries, highest gas
+price first, observes `queue_wait_latency`, and spawns one `submit_queue_entry` task
+per entry, which calls `consensus_adapter.submit_and_get_positions(...)` and
+forwards the result (positions or error) into the entry's `position_sender`.
+`last_drain` is stamped only when entries were actually popped, so a stuck drainer
+isn't hidden from failover. Note the slot accounting is per-*entry* at drain time,
+while the adapter's inflight count is per-*transaction* — a soft bundle occupies one
+drain slot but N inflight slots, so drains can transiently overshoot `max_pending`
+slightly.
+
+**Failover** (`AdmissionQueueHandle::failover_tripped`): if the queue is non-empty
+and no drain has happened for `admission_queue_failover_timeout` (default 30s),
+`classify_submit_mode` treats the queue as stuck and routes around it in Disabled
+mode (direct submit with per-tx saturation rejects) until the actor makes progress
+again. An empty queue never trips failover.
+
+**Epoch rotation** (`AdmissionQueueContext::rotate_for_epoch`, wired in
+`sui-node/src/lib.rs`): `AdmissionQueueContext` holds an
+`ArcSwap<AdmissionQueueHandle>`; reconfig spawns a fresh actor bound to the new
+epoch store and swaps handles. The old actor keeps draining while consensus has
+capacity (its drains reject inside the adapter with `ValidatorHaltedAtEpochEnd` once
+user certs close), and shuts down when its closed channel is observed; any entries
+still queued at that point are dropped, and their callers see `RecvError` →
+`TooManyTransactionsPendingConsensus`.
+
+**Waiting on the result**: back in `authority_server.rs`, the handler awaits all
+groups' `position_rx` receivers *without short-circuiting*. Per-group outcomes:
+
+- `Ok(positions)` → each tx gets `SubmitTxResult::Submitted { consensus_position }`.
+- `Err(TransactionProcessing)` → retriable per-tx `Rejected` (the tx is already
+  being processed elsewhere), not a request failure.
+- Any other error (outbid, halted-at-epoch-end, etc.) fails the whole request;
+  `ValidatorHaltedAtEpochEnd` is retried once by the outer loop after waiting
+  (≤15s) for the next epoch.
+
+## 3. Inside the consensus adapter (`consensus_adapter.rs`)
+
+`submit_and_get_positions` is the entry for both Bypass/Disabled and drained queue
+entries:
+
+1. Under the **reconfig read lock**: if user certs are no longer accepted →
+   `ValidatorHaltedAtEpochEnd`. Otherwise `submit_batch` → `submit_unchecked` spawns
+   the long-lived `submit_and_wait` task and the lock is released.
+2. The caller then awaits a `oneshot` carrying `SuiResult<Vec<ConsensusPosition>>`.
+   A dropped sender (e.g. the task was cancelled at epoch end) surfaces as
+   `FailedToSubmitToConsensus`.
+
+The spawned task is wrapped in `epoch_store.within_alive_epoch(...)` — every pending
+submission is cancelled at epoch termination, which is also what guarantees
+reconfiguration can proceed and that an ex-validator stops submitting.
+
+**`submit_and_wait_inner`** — the core lifecycle:
+
+- **Ping** (empty tx list): one `submit_inner` call to get a position; returned
+  immediately, block status ignored.
+- **DoS accounting**: each user tx is recorded in `submitted_transaction_cache` with
+  an amplification factor of `gas_price / reference_gas_price` before submission.
+- **Inflight accounting**: `InflightDropGuard::acquire` bumps
+  `num_inflight_transactions` by the bundle size. This is the number the queue's
+  capacity checks and the bypass threshold read. It covers the *entire* task
+  lifetime — until terminal status or cancellation, not just until the position is
+  returned.
+- **Already-processed short-circuit**
+  (`check_processed_via_consensus_or_checkpoint`): a synchronous check against
+  consensus-processed keys, checkpoint-executed digests, and (for checkpoint
+  signatures) already-synced checkpoint sequence numbers. If everything is
+  processed, submission is skipped and the position-waiting caller gets a retriable
+  `TransactionProcessing` error instead of a meaningless position.
+- **Submission concurrency**: non-system transactions must acquire
+  `submit_semaphore` (`max_pending_local_submissions` permits); system messages
+  (checkpoint sigs, EndOfPublish, DKG, capabilities) bypass it so they're never
+  buffered behind user traffic.
+- **Submit loop** raced against **`processed_notify`** via `select`:
+  - `submit_inner` calls `consensus_client.submit` with unbounded retries and
+    100ms→10s exponential backoff (errors here are expected during reconfig). On
+    success it returns `(positions, block-status waiter)`.
+  - The positions from the **first successful attempt** are sent to the caller
+    immediately (`tx_consensus_positions.take()`); the RPC request is effectively
+    done at this point. Internal retries never send a second position — clients
+    handle retries themselves if their position doesn't produce results.
+  - Block status outcomes:
+    - **`Sequenced`** → for system messages, done; for user transactions,
+      `wait_for_position_statuses` waits for every position to reach a terminal
+      `ConsensusTxStatus` (Finalized / Rejected / Dropped) via the status cache,
+      which settles the submission (`SequencingOutcome::Sequenced`). A status that
+      expired from the cache before being read means the outcome existed and was
+      missed — the task ends (`StatusExpired`) rather than resubmitting.
+    - **`GarbageCollected`** → the block never committed; sleep 1s and resubmit.
+    - **Waiter error** → sleep 1s and retry.
+  - `processed_notify` wins the race when the tx becomes visible through another
+    path first — consensus output from another validator's submission, execution in
+    a checkpoint, or (for signature messages) a synced checkpoint. The submit future
+    (including its retry loop) is dropped, and if the position was never sent, the
+    caller gets the retriable `TransactionProcessing` error.
+- **Epilogue**: after a user-transaction settle, if the epoch is closing (and not
+  timestamp-based close), an `EndOfPublish` is submitted.
+
+**How "processed" is observed**: the synchronous short-circuit and the
+`processed_notify` race are backed by the same three notification paths, each a
+sync table check paired with a notify-read:
+
+| Path | Sync check | Async notification | Populated by |
+|---|---|---|---|
+| Consensus output | `is_consensus_message_processed` | `consensus_messages_processed_notify` | The consensus handler, when a commit containing the key is processed: the key is recorded in the commit output (in-memory quarantine, later flushed to the `consensus_message_processed` table) and `process_notifications` wakes waiters. Fires for commits originating from *any* validator's submission, and for system messages. |
+| Checkpoint execution | `is_transaction_executed_in_checkpoint` | `transactions_executed_in_checkpoint_notify` | The checkpoint executor's `insert_finalized_transactions`, writing `executed_transactions_to_checkpoint` when a certified checkpoint — locally built or state-synced — is executed. Applies to cert-shaped keys (user transaction digests). |
+| Synced checkpoint | `get_highest_synced_checkpoint_seq_number() >= seq` | `notify_read_synced_checkpoint` | State sync advancing the highest synced checkpoint in `CheckpointStore`. Applies only to checkpoint-signature keys: a synced checkpoint at or above the signature's sequence number makes the signature redundant. |
+
+For soft bundles, each key is waited on individually (`FuturesUnordered`), so a
+bundle completes even when its transactions are observed through different paths;
+if any key resolves via a checkpoint path, `CheckpointExecuted` is reported as the
+processed method.
+
+**Completion and the feedback loop**: when the task ends by any path — settled
+statuses, processed notification, status expiry, or epoch-end cancellation —
+`InflightDropGuard::drop` decrements `num_inflight_transactions` and fires
+`inflight_slot_freed_notify.notify_one()`. That single `Notify` (created in
+`sui-node/src/lib.rs`, shared between `ConsensusAdapter` and
+`AdmissionQueueManager`) is exactly what the admission queue actor selects on,
+closing the loop: consensus capacity frees → the actor wakes → drains the next
+highest-gas-price entries.
+
+## 4. What "finished" means at each layer
+
+| Actor | Finishes when |
+|---|---|
+| RPC caller | All groups return consensus positions or errors → `SubmitTxResult` per tx (Submitted / Executed / Rejected). Finality is *not* awaited here; clients follow up via wait-for-effects. |
+| Queue entry | Popped and handed to the adapter (positions flow back through its oneshot), evicted (outbid error), or dropped at actor shutdown (`TooManyTransactionsPendingConsensus`). |
+| Adapter task | All positions reach a terminal consensus status, or the tx is observed processed via another path, or the status expired, or the epoch ends. Only then does the inflight slot free. |
+
+## 5. Per-transaction outcomes: errors and effects
+
+### SubmitTx results
+
+Each transaction in the request resolves to one `SubmitTxResult`:
+
+| Result | Meaning |
+|---|---|
+| `Submitted { consensus_position }` | Accepted (directly or via the queue) and acknowledged by consensus; the position identifies the block/index. A queue-admitted duplicate still gets its own position — duplication only affects spam weight. |
+| `Executed { effects_digest, details }` | The transaction already executed; effects are returned directly in the submit response. |
+| `Rejected { error }` | Not submitted (or suppressed); the error tells the client what to do next. |
+
+### Rejection errors, by provenance
+
+**Generated internally** — from this validator's own admission state, nothing
+consensus-derived consulted:
+
+| Error | Trigger | Client action |
+|---|---|---|
+| `RepeatedTransactions` | Duplicate digest within one request (fails the whole request for soft bundles) | Fix the request |
+| Overload errors (e.g. `ValidatorOverloadedRetryAfter`) | `check_system_overload` at signing; gasless rate limiting | Retry after backoff |
+| `TooManyTransactionsPendingConsensus` | Per-tx consensus saturation check (Disabled mode only); also whole-request when the queue actor is gone | Retry after backoff |
+| `TransactionSubmitted` | Concurrent in-flight duplicate or recently-submitted duplicate (dedup guard / TTL cache) | Wait; the earlier submission is in flight |
+| `TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price }` | Queue full and gas price too low (immediate reject), or entry later evicted by a higher bid (delivered through the position channel); fails the whole request | Resubmit with gas price above `min_gas_price` |
+| `ValidatorHaltedAtEpochEnd` | Reconfig closed user certs; the handler internally retries once after waiting (≤15s) for the new epoch before surfacing it | Retry (possibly on another validator) |
+| `FailedToSubmitToConsensus` | Position channel dropped (e.g. submission task cancelled at epoch end) | Retry |
+
+**Read from consensus-derived state** — caches and tables populated by consensus
+output or checkpoints, so they fire even if this validator never submitted the
+transaction itself:
+
+| Error | Read from | Client action |
+|---|---|---|
+| `TransactionAlreadyExecuted` | Transaction cache: digest executed in a previous epoch | Stop; terminal |
+| Owned-object lock conflict | Epoch owned-lock table (populated post-consensus): the digest lost a conflict to another transaction holding its input locks | Stop; terminal |
+| Revalidation errors (stale/unavailable input versions, etc.) | Live object state via `handle_vote_transaction`, surfacing terminal errors once a conflict winner executed | Stop; terminal |
+| `TransactionProcessing { digest, status }` | Consensus-processed key table: the digest is known-processed but may still execute (e.g. deferred). Returned upfront by the RPC handler, or by the adapter when the already-processed check or the `processed_notify` race fires before a position was sent | Retriable: poll WaitForEffects or resubmit later |
+
+Note: per-position consensus statuses (`Finalized` / `Rejected` / `Dropped`) never
+surface through SubmitTx — the submit response completes at position
+acknowledgment. They surface through WaitForEffects.
+
+### Effects in responses
+
+- **SubmitTx**: when the digest already has executed effects,
+  `complete_executed_data` packages the effects together with events and
+  input/output objects into `SubmitTxResult::Executed`. If that data can no longer
+  be reconstructed (e.g. objects pruned), the handler falls through to the
+  processed-suppression path and returns a retriable error instead.
+- **WaitForEffects** (the expected follow-up to `Submitted`, keyed by digest plus
+  optional consensus position):
+  - `Executed { effects_digest, details? }` — resolves when executed effects appear
+    in the transaction cache, whether execution came via this validator's
+    submission, another validator's, or checkpoint sync. Details (events,
+    input/output objects) only when requested.
+  - `Rejected { error: Option<_> }` — the status cache reported `Rejected` or
+    `Dropped` for the position. The error is **read from the
+    `TransactionRejectReasonCache`**, populated when reject votes are cast or
+    observed (`consensus_validator.rs`, `consensus_handler.rs`); it is `None` when
+    no reason was recorded locally or it already expired.
+  - `Expired { epoch, round }` — the position aged out of the status-cache
+    retention window with no recorded status; the client should resubmit.
+  - Request-level: a guard rejects positions too far ahead of the last committed
+    round; the handler times out after 20s; `EpochEnded` if the epoch terminates
+    mid-wait.
+
+## 6. Backpressure and limits
+
+Config lives in `AuthorityOverloadConfig` (`sui-config/src/node.rs`).
+
+- `max_pending_transactions` — global inflight budget; caps queue drains and defines
+  the two derived thresholds. Enforced weakly (checked, not atomically reserved).
+- `admission_queue_bypass_fraction` (default 0.9) — below this inflight level the
+  queue is skipped entirely.
+- `admission_queue_capacity_fraction` (default 0.5) — queue size; overflow resolves
+  by gas-price eviction/rejection.
+- `admission_queue_failover_timeout` (default 30s) — stuck-queue detection window.
+- `max_pending_local_submissions` — semaphore on concurrent
+  `consensus_client.submit` calls for user txs.
+- Actor mpsc channel — `max(queue capacity, 1024)`; senders await rather than fail
+  when it's full.
+
+A design consequence worth stating: in Queue mode, saturation no longer rejects
+transactions outright — it converts consensus capacity into a gas-price auction,
+with FIFO fairness within a price level and gasless transactions as designated first
+victims. Rejection only reappears when the queue itself is full (outbid) or presumed
+dead (failover → Disabled semantics).
+
+## 7. Non-queue producers into the adapter
+
+System messages never pass through the admission queue — they enter the adapter
+directly and skip the submit semaphore:
+
+- Checkpoint signatures via `SubmitToConsensus::submit_to_consensus`.
+- `EndOfPublish` via `ReconfigurationInitiator::close_epoch` and
+  `recover_end_of_publish` (crash recovery).
+- Timeout-bounded `submit_best_effort` for self-superseding messages (e.g.
+  execution-time observations): one `submit_inner` attempt bounded by a timeout, no
+  status wait, no retry on GC. User transactions are rejected on this path.

--- a/crates/sui-core/src/consensus_submission_pipeline.md
+++ b/crates/sui-core/src/consensus_submission_pipeline.md
@@ -47,9 +47,10 @@ this contract: the dedup and spam-accounting layers exist to defend against that
 pattern, not to optimize for it.
 
 1. **Inflight accounting is leak-free; admission is deliberately weak.**
-   `num_inflight_transactions` is the single signal behind every backpressure
-   decision — the bypass threshold, the queue's drain capacity, and the
-   Disabled-mode reject — so it must stay accurate under high load. It is
+   `num_inflight_transactions` is the signal behind the pipeline's backpressure
+   decisions — the bypass threshold, the queue's drain capacity, and (together
+   with submit-semaphore availability) the Disabled-mode reject — so it must
+   stay accurate under high load. It is
    maintained exclusively by RAII (`InflightDropGuard`): every exit path —
    settled, skipped as already-processed, cancelled at epoch end, dropped
    mid-race — releases its slots. The asymmetry is intentional: admission checks
@@ -58,8 +59,8 @@ pattern, not to optimize for it.
    for the epoch, so release correctness is the hard invariant.
 
 2. **Answer early when the outcome is already known elsewhere.** A transaction
-   observed as processed — via another validator's submission appearing in
-   consensus output, or via checkpoint execution/sync — is answered without
+   observed as processed — via consensus output, or via checkpoint
+   execution/sync — is answered without
    being (re)submitted, with a retriable `TransactionProcessing` or a concrete
    terminal error. This applies both before submission (the RPC handler's
    `is_consensus_message_processed` suppression, the adapter's
@@ -155,7 +156,7 @@ Two behavioral notes:
 
 **Handle → actor**: `AdmissionQueueHandle::try_insert` creates a `oneshot` for the
 eventual consensus positions, packages a
-`QueueEntry { gas_price, transactions, position_sender, client_addr, enqueue_time }`,
+`QueueEntry { gas_price, transactions, position_sender, submitter_client_addr, enqueue_time }`,
 and sends an `InsertCommand` over a bounded mpsc to the per-epoch actor.
 `send().await` applies backpressure when the command channel
 (capacity = max(queue capacity, 1024)) is full; a closed channel or dropped ack maps
@@ -249,7 +250,8 @@ reconfiguration can proceed and that an ex-validator stops submitting.
 - **Ping** (empty tx list): one `submit_inner` call to get a position; returned
   immediately, block status ignored.
 - **DoS accounting**: each user tx is recorded in `submitted_transaction_cache` with
-  an amplification factor of `gas_price / reference_gas_price` before submission.
+  an amplification factor of `gas_price / reference_gas_price` (floored at 1, so
+  gasless and below-RGP transactions record 1) before submission.
 - **Inflight accounting**: `InflightDropGuard::acquire` bumps
   `num_inflight_transactions` by the bundle size. This is the number the queue's
   capacity checks and the bypass threshold read. It covers the *entire* task
@@ -262,9 +264,10 @@ reconfiguration can proceed and that an ex-validator stops submitting.
   processed, submission is skipped and the position-waiting caller gets a retriable
   `TransactionProcessing` error instead of a meaningless position.
 - **Submission concurrency**: non-system transactions must acquire
-  `submit_semaphore` (`max_pending_local_submissions` permits); system messages
-  (checkpoint sigs, EndOfPublish, DKG, capabilities) bypass it so they're never
-  buffered behind user traffic.
+  `submit_semaphore` (`max_pending_local_submissions` permits); the permit is
+  held until the submission settles, not just for the duration of the submit
+  call. System messages (checkpoint sigs, EndOfPublish, DKG, capabilities)
+  bypass it so they're never buffered behind user traffic.
 - **Submit loop** raced against **`processed_notify`** via `select`:
   - `submit_inner` calls `consensus_client.submit` with unbounded retries and
     100ms→10s exponential backoff (errors here are expected during reconfig). On
@@ -274,19 +277,25 @@ reconfiguration can proceed and that an ex-validator stops submitting.
     done at this point. Internal retries never send a second position — clients
     handle retries themselves if their position doesn't produce results.
   - Block status outcomes:
-    - **`Sequenced`** → for system messages, done; for user transactions,
-      `wait_for_position_statuses` waits for every position to reach a terminal
-      `ConsensusTxStatus` (Finalized / Rejected / Dropped) via the status cache,
-      which settles the submission (`SequencingOutcome::Sequenced`). A status that
-      expired from the cache before being read means the outcome existed and was
-      missed — the task ends (`StatusExpired`) rather than resubmitting.
+    - **`Sequenced`** → for user transactions, `wait_for_position_statuses`
+      waits for every position to reach a terminal `ConsensusTxStatus`
+      (Finalized / Rejected / Dropped) via the status cache, which settles the
+      submission (`SequencingOutcome::Sequenced`). A status that expired from
+      the cache before being read means the outcome existed and was missed —
+      the task ends (`StatusExpired`) rather than resubmitting. For system
+      messages the submit loop ends here, but the task does not settle yet: the
+      commit handler assigns per-position statuses only to user transactions,
+      so a system message settles by awaiting `processed_notify`.
     - **`GarbageCollected`** → the block never committed; sleep 1s and resubmit.
     - **Waiter error** → sleep 1s and retry.
-  - `processed_notify` wins the race when the tx becomes visible through another
-    path first — consensus output from another validator's submission, execution in
-    a checkpoint, or (for signature messages) a synced checkpoint. The submit future
-    (including its retry loop) is dropped, and if the position was never sent, the
-    caller gets the retriable `TransactionProcessing` error.
+  - `processed_notify` wins the race when a processed notification fires before
+    the submit loop settles — from consensus output (the notification has no
+    submitter filter, so this validator's *own* committed submission counts, and
+    since the `select` polls the processed waiter first this is a common settle
+    path), execution in a checkpoint, or (for signature messages) a synced
+    checkpoint. The submit future (including its retry loop) is dropped, and if
+    the position was never sent, the caller gets the retriable
+    `TransactionProcessing` error.
 - **Epilogue**: after a user-transaction settle, if the epoch is closing (and not
   timestamp-based close), an `EndOfPublish` is submitted.
 
@@ -320,7 +329,7 @@ highest-gas-price entries.
 |---|---|
 | RPC caller | All groups return consensus positions or errors → `SubmitTxResult` per tx (Submitted / Executed / Rejected). Finality is *not* awaited here; clients follow up via wait-for-effects. |
 | Queue entry | Popped and handed to the adapter (positions flow back through its oneshot), evicted (outbid error), or dropped at actor shutdown (`TooManyTransactionsPendingConsensus`). |
-| Adapter task | All positions reach a terminal consensus status, or the tx is observed processed via another path, or the status expired, or the epoch ends. Only then does the inflight slot free. |
+| Adapter task | All positions reach a terminal consensus status (user transactions), or the tx is observed processed via consensus output or a checkpoint (the only settle path for system messages), or the status expired, or the epoch ends. Only then does the inflight slot free. |
 
 ## 5. Per-transaction outcomes: errors and effects
 
@@ -355,10 +364,10 @@ transaction itself:
 
 | Error | Read from | Client action |
 |---|---|---|
-| `TransactionAlreadyExecuted` | Transaction cache: digest executed in a previous epoch | Stop; terminal |
+| `TransactionAlreadyExecuted` | Transaction cache: digest executed in the immediately preceding epoch | Stop; terminal |
 | Owned-object lock conflict | Epoch owned-lock table (populated post-consensus): the digest lost a conflict to another transaction holding its input locks | Stop; terminal |
 | Revalidation errors (stale/unavailable input versions, etc.) | Live object state via `handle_vote_transaction`, surfacing terminal errors once a conflict winner executed | Stop; terminal |
-| `TransactionProcessing { digest, status }` | Consensus-processed key table: the digest is known-processed but may still execute (e.g. deferred). Returned upfront by the RPC handler, or by the adapter when the already-processed check or the `processed_notify` race fires before a position was sent | Retriable: poll WaitForEffects or resubmit later |
+| `TransactionProcessing { digest, status }` | Consensus-processed key table, or checkpoint state (executed-in-checkpoint digests, synced checkpoint sequence): the digest is known-processed — it may have already executed, or may still execute (e.g. deferred). Returned upfront by the RPC handler, or by the adapter when the already-processed check or the `processed_notify` race fires before a position was sent | Retriable: poll WaitForEffects or resubmit later |
 
 Note: per-position consensus statuses (`Finalized` / `Rejected` / `Dropped`) never
 surface through SubmitTx — the submit response completes at position
@@ -369,8 +378,9 @@ acknowledgment. They surface through WaitForEffects.
 - **SubmitTx**: when the digest already has executed effects,
   `complete_executed_data` packages the effects together with events and
   input/output objects into `SubmitTxResult::Executed`. If that data can no longer
-  be reconstructed (e.g. objects pruned), the handler falls through to the
-  processed-suppression path and returns a retriable error instead.
+  be reconstructed (e.g. objects pruned), the handler falls through to the normal
+  validation and suppression paths, which end in a terminal or retriable error for
+  that transaction.
 - **WaitForEffects** (the expected follow-up to `Submitted`, keyed by digest plus
   optional consensus position):
   - `Executed { effects_digest, details? }` — resolves when executed effects appear
@@ -390,17 +400,21 @@ acknowledgment. They surface through WaitForEffects.
 
 ## 6. Backpressure and limits
 
-Config lives in `AuthorityOverloadConfig` (`sui-config/src/node.rs`).
+The admission-queue knobs live in `AuthorityOverloadConfig`
+(`sui-config/src/node.rs`); the consensus capacity limit comes from
+`ConsensusConfig`.
 
-- `max_pending_transactions` — global inflight budget; caps queue drains and defines
-  the two derived thresholds. Enforced weakly (checked, not atomically reserved).
+- `max_pending_transactions` (`ConsensusConfig`, default 20,000) — global inflight
+  budget; caps queue drains and defines the two derived thresholds. Enforced
+  weakly (checked, not atomically reserved).
 - `admission_queue_bypass_fraction` (default 0.9) — below this inflight level the
   queue is skipped entirely.
 - `admission_queue_capacity_fraction` (default 0.5) — queue size; overflow resolves
   by gas-price eviction/rejection.
 - `admission_queue_failover_timeout` (default 30s) — stuck-queue detection window.
-- `max_pending_local_submissions` — semaphore on concurrent
-  `consensus_client.submit` calls for user txs.
+- `max_pending_local_submissions` — submit-semaphore size, bounding user-tx
+  submissions between permit acquisition and settle. Not a config field: derived at
+  node startup from `max_pending_transactions` and the committee size.
 - Actor mpsc channel — `max(queue capacity, 1024)`; senders await rather than fail
   when it's full.
 

--- a/crates/sui-core/src/consensus_submission_pipeline.md
+++ b/crates/sui-core/src/consensus_submission_pipeline.md
@@ -40,7 +40,7 @@ classify_submit_mode()
 ## Design principles
 
 The pipeline assumes a well-behaved client submits a transaction **once** and then
-waits on its status. Occasionally the same transaction is submitted again — 
+waits on its status. Occasionally the same transaction is submitted again —
 typically when the client lost its connection to this validator and chose to retry
 here. Submitting many copies of the same transaction in a short interval is outside
 this contract: the dedup and spam-accounting layers exist to defend against that
@@ -176,8 +176,9 @@ Insert semantics when full:
 **Duplicates are admitted, not rejected**: a `queued_keys` refcount detects entries
 whose `ConsensusTransactionKey` is already queued; the insert returns
 `newly_inserted = false`, which the RPC layer records as `duplicate_at_admission`
-and converts to spam weight 1 for traffic control (`request_spam_weight`). The
-duplicate still flows to consensus, where downstream dedup handles it.
+and converts to spam weight 1 for traffic control (`request_spam_weight`). If the
+adapter does not suppress the entry as already processed, the duplicate can still
+flow to consensus; admission duplicate detection itself only affects spam weight.
 
 **Event loop** (`AdmissionQueueEventLoop::run`): a single actor per epoch, spawned by
 `AdmissionQueueManager::spawn` and rotated at reconfig. Each iteration:
@@ -329,7 +330,7 @@ Each transaction in the request resolves to one `SubmitTxResult`:
 
 | Result | Meaning |
 |---|---|
-| `Submitted { consensus_position }` | Accepted (directly or via the queue) and acknowledged by consensus; the position identifies the block/index. A queue-admitted duplicate still gets its own position — duplication only affects spam weight. |
+| `Submitted { consensus_position }` | Accepted (directly or via the queue) and acknowledged by consensus; the position identifies the block/index. A queue-admitted duplicate can still get its own position if it is not suppressed by already-processed checks; admission duplicate detection only affects spam weight. |
 | `Executed { effects_digest, details }` | The transaction already executed; effects are returned directly in the submit response. |
 | `Rejected { error }` | Not submitted (or suppressed); the error tells the client what to do next. |
 

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -56,6 +56,7 @@ pub mod transaction_driver;
 mod transaction_input_loader;
 pub mod transaction_orchestrator;
 mod transaction_outputs;
+pub mod transaction_pool;
 mod transaction_signing_filter;
 pub mod validator_client_monitor;
 

--- a/crates/sui-core/src/transaction_pool.md
+++ b/crates/sui-core/src/transaction_pool.md
@@ -1,0 +1,574 @@
+# TransactionPool: Pull-Based Consensus Submission
+
+`transaction_pool.rs` is an alternative to the current submission pipeline
+(`admission_queue.rs` + the submission half of `consensus_adapter.rs`), selected by
+node config (`transaction_pool_enabled`, default off; the
+`SUI_TRANSACTION_POOL_ENABLED` env var flips the default for test runs). It keeps
+the same entry points, external contracts, and design principles as
+`consensus_submission_pipeline.md`, while deleting most of the moving parts. Read
+that doc first for the current pipeline and the principles referenced here. Keep
+this doc in sync with behavior changes in `transaction_pool.rs`.
+
+## The core inversion
+
+Today's pipeline is **push-based**: the admission queue actor drains entries into
+`ConsensusAdapter::submit_and_get_positions`, which spawns a long-lived task per
+submission; the task pushes bytes into consensus's `TransactionClient` channel,
+races a `processed_notify`, waits on block status and per-position statuses, and
+frees an inflight slot on drop, which wakes the queue actor to drain more.
+
+The pool is **pull-based**: transactions sit in one prioritized in-memory pool, and
+consensus *takes* from it when proposing a block — the same moment today's
+`TransactionConsumer::next()` drains its channel (`proposer.rs` `try_new_block`).
+Settlement is **push-based callbacks** from the components that already learn the
+outcomes (the commit handler, the checkpoint executor), instead of per-transaction
+tasks awaiting notifications.
+
+Everything between "validated transaction" and "bytes in a proposed block" becomes
+a state machine over three maps behind one mutex. Deleted outright:
+
+- The per-submission `submit_and_wait` task, its `within_alive_epoch` wrapper, the
+  `select!` race against `processed_notify`, and the status-expiry settle path.
+- `InflightDropGuard`, the `num_inflight_transactions` atomic, and the shared
+  `inflight_slot_freed_notify` feedback `Notify`. Accounting becomes structural:
+  an entry occupies capacity exactly while it is in the maps.
+- The admission queue actor, its command mpsc, insert-ack oneshots, the drain loop,
+  and the missed-wakeup registration dance.
+- The `Bypass` / `Queue` / `Disabled` routing trichotomy and failover detection.
+  There is no actor that can get stuck independently of consensus, so there is
+  nothing to fail over from; every submission takes the same path.
+- `submit_semaphore` / `max_pending_local_submissions`. The pull model self-limits:
+  consensus takes exactly what fits in blocks, bounded by the inflight budget.
+- The `submit_inner` retry loop with exponential backoff. There is no submission
+  RPC to fail; reconfig-window submissions simply wait in the pool (see
+  [Epoch rotation](#epoch-rotation)).
+- On the consensus side (once the pool is the only path):
+  `TransactionClient`, `TransactionConsumer`, `TransactionsGuard`, the 2,000-entry
+  submission channel, and the `block_status_subscribers` oneshot registry.
+
+## Overview
+
+```
+gRPC SubmitTx                          system messages (checkpoint sigs, EoP, DKG, …)
+     │                                                    │
+ValidatorService::handle_submit_transaction               │
+     │  per-tx validation, dedup, voting (unchanged)      │
+     ▼                                                    ▼
+SuiTransactionPool::submit ◄──────────────────────────────┘
+     │  insert into pending (priority: system > gas price desc, FIFO within price)
+     │  full → gas auction: evict lowest or reject with outbid error
+     │
+     │            consensus proposer (core thread)
+     │                 │ take(max_count, max_bytes)   ── pull, replaces consumer.next()
+     ├────────────────►│
+     │                 │ block created & flushed
+     │                 │ ack(block_ref)
+     │◄────────────────┘
+     │  entries → inflight[round]; positions → waiters   ← RPC finishes here
+     │
+     │            commit handler / checkpoint executor (push callbacks)
+     │◄── note_statuses(position, Finalized|Rejected|Dropped)
+     │◄── note_processed(consensus tx keys)               ── any validator's block
+     │◄── note_executed_in_checkpoint(digests)
+     │◄── notify_committed(own blocks, gc_round)          ── GC → requeue system entries
+     ▼
+   entry removed from maps (capacity freed structurally)
+```
+
+## Data structures
+
+One `Mutex<PoolInner>`; every transition is a short synchronous critical section.
+The lock is never held across an await and no callback under the lock calls back
+out of the pool.
+
+```rust
+struct PoolInner {
+    /// Transactions waiting to be proposed, in take order.
+    pending: BTreeMap<PoolKey, Arc<PoolEntry>>,
+    /// Transactions in our own proposed blocks, awaiting terminal outcome.
+    /// BlockRef orders round-first, so GC is a front-pop while
+    /// `key.round <= gc_round` — the same pattern as today's
+    /// TransactionConsumer::block_status_subscribers. Each bucket records
+    /// whether the block was sequenced and each entry's first block index,
+    /// for matching position-keyed status updates.
+    inflight: BTreeMap<BlockRef, ProposedBlock>, // { sequenced, Vec<(first_index, Arc<PoolEntry>)> }
+    /// Ack/dedup index over both maps, mapping each key to its entry and the
+    /// transaction's index within the entry. For user transactions the key is
+    /// ConsensusTransactionKey::Certificate(digest), so this is the
+    /// digest-keyed acknowledgment map; keying by ConsensusTransactionKey
+    /// additionally covers system messages (which have no digest).
+    /// First-writer-wins: an entry admitted while its key is already mapped
+    /// (partial bundle overlap) settles via its own position statuses instead.
+    by_key: HashMap<ConsensusTransactionKey, (Arc<PoolEntry>, usize)>,
+    next_seq: u64,
+    /// Per-transaction occupancy counters (an entry contributes its bundle
+    /// size): `pending` for the capacity/auction bound, staged+proposed for
+    /// the inflight take budget.
+    pending_user_txs: usize,
+    inflight_user_txs: usize,
+    shutdown: bool,
+}
+```
+
+**`PoolKey`** ranks entries; `BTreeMap` ascending order *is* take order:
+
+```rust
+struct PoolKey {
+    class: PriorityClass, // System < User — system messages always first
+    price: Reverse<u64>,  // user gas price, descending; system entries use 0
+    seq: u64,             // insertion counter: FIFO within a price, unique keys
+}
+```
+
+Extensible by construction: future criteria (fee-per-byte, age boost, client
+class) slot in as comparison fields. The eviction victim is the *oldest entry at
+the lowest price* — the last price band's smallest `seq`, one range query —
+matching today's queue. System entries are never evicted and don't count against
+capacity (small, bounded population).
+
+**`PoolEntry`** is one submission group — a single transaction, or a
+soft bundle that must land in one block (atomicity is preserved because `take`
+moves whole entries, exactly like today's all-or-nothing `TransactionsGuard`):
+
+```rust
+struct PoolEntry {
+    transactions: Vec<ConsensusTransaction>,
+    serialized: Vec<Vec<u8>>,    // BCS cached at insert; take() never serializes
+    keys: Vec<ConsensusTransactionKey>,
+    gas_price: u64,              // min across the bundle; 0 for gasless
+    kind: EntryKind,             // User | System | BestEffort{deadline} | Ping
+    tx_type: &'static str,       // metrics label
+    pool_key: PoolKey,           // fixed at insert; retained across GC requeue
+    submit_time: Instant,
+    mutable: Mutex<EntryMut>,    // locked only under the pool mutex
+}
+
+struct EntryMut {
+    state: EntryState,
+    /// All coalesced waiters receive the same positions (or error).
+    waiters: Vec<oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>>,
+    /// Per-transaction terminal-signal flags + countdown.
+    unsettled: Vec<bool>,
+    unsettled_count: usize,
+    /// One element per (coalesced) submission, drained for DoS accounting at
+    /// take time.
+    unrecorded_addrs: Vec<Option<IpAddr>>,
+    dos_recorded: bool,
+}
+
+enum EntryState {
+    Pending,
+    Staged,                       // taken, awaiting ack(block_ref)
+    Proposed { block_ref: BlockRef, first_index: TransactionIndex },
+    Settled,
+}
+
+// Settle reasons (waiter errors, metric labels, logs): Processed | Status(_)
+// | CheckpointExecuted | GarbageCollected | Evicted | Shutdown
+// | BestEffortExpired | Sweep.
+```
+
+Entries are `Arc`-shared across the maps; their mutable state sits behind a
+per-entry mutex locked only while holding the pool mutex (a fixed lock order, so
+no inversion is possible). State transitions are idempotent (first terminal
+transition wins), so signals arriving in any order — status before GC
+notification, processed-key before ack — are safe.
+
+## Consensus integration
+
+The `TransactionPool` trait lives in `consensus-core`, mirroring
+`TransactionVerifier` exactly: defined next to it in `transaction.rs`,
+`Arc<dyn _>` through `ConsensusAuthority::start` → `AuthorityNode::start`, with
+sui-core's `SuiTransactionPool` implementing it the way `SuiTxValidator`
+implements `TransactionVerifier`. It deals only in consensus types — bytes, `BlockRef`,
+`Round` — keeping consensus-core Sui-agnostic:
+
+```rust
+pub trait TransactionPool: Send + Sync + 'static {
+    /// Called by the proposer while building a block. Returns serialized
+    /// transactions in block order, an ack invoked with the created block's
+    /// ref after the block is durably created, and which limit stopped the
+    /// take — the same contract as today's consumer `next()`. Dropping the ack
+    /// without calling it returns the staged entries to the pool — any
+    /// proposer error path is safe by construction.
+    fn take(
+        &self,
+        max_count: usize,       // protocol max_num_transactions_in_block
+        max_bytes: usize,       // protocol max_transactions_in_block_bytes
+    ) -> (Vec<Transaction>, Box<dyn FnOnce(BlockRef) + Send>, LimitReached);
+
+    /// Called from Core::try_commit with own committed block refs and the
+    /// current GC round — the same signal that today feeds
+    /// TransactionConsumer::notify_own_blocks_status.
+    fn notify_committed(&self, own_committed: Vec<BlockRef>, gc_round: Round);
+}
+```
+
+Proposer changes are minimal: `try_new_block` calls `take` where it called
+`transaction_consumer.next()` and invokes the ack in the same place; `try_commit`
+routes its existing own-blocks/GC notification to `notify_committed`. During
+migration a shim implements the trait on top of the existing
+`TransactionConsumer`, so the proposer code is unconditional and the legacy
+pipeline keeps working unmodified.
+
+No proposal wake-up is needed: block proposal is driven by round advance and
+leader timeouts, never by transaction arrival — a newly inserted entry is picked
+up at the next `try_new_block`, exactly like a transaction sitting in today's
+consumer channel.
+
+### Lifetimes and wiring
+
+Two layers, mirroring `AdmissionQueueContext` over per-epoch actors:
+
+- **`SuiTransactionPool`** is per-epoch. Created in
+  `start_epoch_specific_validator_components` alongside `SuiTxValidator` and
+  passed into `ConsensusManager::start` → `ConsensusAuthority::start` as the
+  `Arc<dyn TransactionPool>` trait object. The per-epoch `ConsensusCommitHandler` (via
+  `ConsensusHandlerInitializer`) and the checkpoint executor hold an `Arc` for the
+  settle callbacks.
+- **`TransactionPoolContext`** is long-lived (like `ConsensusAdapter` /
+  `AdmissionQueueContext`): an `ArcSwap<Arc<SuiTransactionPool>>` rotated at
+  reconfig. It carries the sui-core-facing entry points, including the
+  `SubmitToConsensus` impl held by `RandomnessManager`,
+  `SubmitCheckpointToConsensus`, etc. Calls verify the caller's epoch against the
+  current pool's epoch and reject mismatches with `ValidatorHaltedAtEpochEnd`.
+
+Why per-epoch instances rather than one pool with an internal `clear()`: a fresh
+instance makes "no state survives the epoch" structural instead of a `clear()`
+that must stay exhaustive, and it makes boundary races benign: late callbacks
+from the old core thread or commit handler land on the old, inert pool object —
+whose `inflight` keys and `gc_round` arithmetic are only coherent within one
+consensus instance — rather than mutating new-epoch state. It also lets the pool
+hold its `Arc<AuthorityPerEpochStore>` as a plain field (released when the pool
+drops), with a single epoch check at the context boundary — versus the
+cross-epoch `ConsensusAdapter`, which pays with an `epoch_store` parameter on
+every call and `within_alive_epoch` on every task. The admission queue's
+per-epoch actor exists for the same reason. Carrying pending user entries across
+the boundary would be possible (ranking by absolute gas price stays valid under
+an RGP change) but is deliberately not done: dropping everything keeps rotation
+trivial, and clients already own retries.
+
+## Lifecycle
+
+### Insert
+
+`TransactionPoolContext::submit_and_get_positions(transactions, gas_price,
+epoch_store, submitter_client_addr)` — same contract and callers as the adapter's
+method (the RPC layer passes the group's minimum gas price, as it did for the
+queue); the queue's `try_insert` collapses into it.
+
+1. **Already-processed short-circuit** (unchanged semantics, RPC thread): the
+   adapter's `check_processed_via_consensus_or_checkpoint` — consensus-processed
+   keys, checkpoint-executed digests, synced-checkpoint sequence for signature
+   messages. Everything processed → retriable `TransactionProcessing`, nothing
+   inserted. The same check guards **system** submissions
+   (`submit_to_consensus` / `submit_best_effort`), where it is a correctness
+   requirement, not just an optimization: system messages get no per-position
+   statuses and a processed key is only recorded once, so an already-processed
+   system message admitted to the pool would never settle.
+2. **Dedup by coalescing**: when the submission's key set exactly matches an
+   existing entry's, the caller's waiter (and client addr) attaches to that entry
+   instead of admitting a copy — both waiters get the same positions, and if the
+   entry is already `Proposed` the known positions are returned immediately. A
+   *partial* key overlap (a bundle sharing only some keys with a resident entry)
+   is admitted as a separate entry, like today's queue duplicates. Either way the
+   insert reports `newly_inserted = false`, which the RPC layer converts to spam
+   weight exactly as `duplicate_at_admission` does today. Coalescing is
+   *stronger* than the queue (which flags duplicates but still admits them
+   toward consensus) while preserving the accounting.
+3. **Capacity / gas auction** (user entries only, unchanged semantics): while the
+   pool is full, evict the oldest entry at the lowest price if that price is
+   strictly below the newcomer's, failing its waiters with
+   `TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price }`;
+   if eviction cannot free enough capacity, reject the newcomer with the same
+   error carrying the current min. Gas price is the minimum across the bundle, 0
+   for gasless — gasless remain the designated first victims.
+4. Insert into `pending` + `by_key`; BCS bytes cached now so `take` does no
+   serialization on the core thread. The caller awaits its oneshot.
+5. `shutdown` set → `ValidatorHaltedAtEpochEnd` (the RPC handler's existing outer
+   retry waits for the next epoch).
+
+System entries skip 3 (never evicted, never counted against capacity) and attach
+no waiter. Pings insert a payload-less `Ping` entry at system priority.
+
+### Take and ack
+
+`take(max_count, max_bytes)` runs on the consensus core thread; it must stay
+allocation-light and do **no DB reads or serialization**:
+
+1. Effective count budget = `min(max_count, max_pending_transactions −
+   inflight_transaction_count)`, where the inflight count is per *transaction*
+   (an entry contributes its bundle size; staged and proposed entries both
+   count), maintained as a counter under the pool lock. This is the same
+   backpressure the queue's drain applies today: when settlement lags, blocks
+   stop filling with user transactions. System entries are exempt from the
+   budget.
+2. Walk `pending` in `PoolKey` order, moving whole entries (bundle atomicity)
+   until the next entry would exceed either budget — stop rather than skip ahead,
+   preserving strict price order, exactly like today's consumer parking a
+   non-fitting guard.
+   - `BestEffort` entries past their deadline are settled (`BestEffortExpired`)
+     and skipped. (Checkpoint-signature redundancy against synced checkpoints is
+     handled at insert time — see Insert step 1 — keeping `take` free of store
+     reads.)
+3. Taken entries → `Staged`; DoS amplification is recorded per user transaction
+   (`submitted_transaction_cache.record_submitted_tx`, in-memory LRU) at this
+   point — the same "just before actual submission" point as today, so evicted
+   entries never consume DoS allowance.
+4. The ack closure captures the staged entries. On `ack(block_ref)`: entries →
+   `inflight[block_ref]` as `Proposed`, indices assigned by block order,
+   and every waiter receives its `Vec<ConsensusPosition>` — the RPC request is
+   done here, as today. Pings get `ConsensusPosition::ping(epoch, block_ref)`. If
+   the ack is dropped un-called (proposer error path, shutdown), a drop guard
+   returns staged entries to `pending`.
+
+### Settlement
+
+Settlement callbacks are synchronous batched pushes from the code that already
+computes the outcomes. Signal coverage (see `consensus_handler.rs::
+filter_consensus_txns`) dictates that **no single signal suffices** — in
+particular, vote-rejected transactions are *never* marked
+consensus-message-processed, and system messages never get per-position statuses:
+
+| Signal | Callback (called from) | Keyed by | Settles |
+|---|---|---|---|
+| Per-position status `Finalized` / `Rejected` / `Dropped` | `note_statuses` — commit handler, same site as `set_consensus_tx_statuses` | `ConsensusPosition`: direct lookup `inflight[position.block]` + index | User entries in our own blocks. **Sole signal for vote-rejected and for certs-closed / post-EoP drops.** |
+| Consensus key processed | `note_processed` — commit handler, same site as `record_consensus_message_processed` / `process_notifications` | `ConsensusTransactionKey` → `by_key` | Accepted user txs from **any validator's block** (settles even `Pending` entries — answer early), and **the sole signal for system messages**. |
+| Executed in checkpoint | `note_executed_in_checkpoint` — checkpoint executor's `insert_finalized_transactions` | digest → `Certificate` key → `by_key` | Entries whose transaction executed via a locally built or state-synced checkpoint. |
+| Own block committed / GC round advanced | `notify_committed` — `Core::try_commit` (the trait method) | `BlockRef` keys (round-first order) | GC: for un-sequenced blocks with `round <= gc_round`, system entries requeue to `pending`; user entries settle (below). |
+| Epoch end | `shutdown()` — reconfig | everything | All waiters fail with `ValidatorHaltedAtEpochEnd`; maps drained. |
+
+Rules on settle:
+
+- A bundle entry settles when **all** its keys/positions have a terminal signal
+  (`unsettled` countdown) — mirrors today's per-key `FuturesUnordered` wait.
+- A `Pending`/`Staged` entry settled by `note_processed` or checkpoint execution
+  whose waiters never got positions receives the retriable
+  `TransactionProcessing` error — identical to today's `processed_notify` win.
+- A status for a *different* position of the same digest (someone else's block)
+  does **not** settle our entry: our copy may still be voted differently. Only the
+  digest-level "processed" signal (which only fires for accepted transactions) or
+  our own position's status settles.
+- Settle removes the entry from all maps — capacity frees structurally; there is
+  no counter to leak (principle 1 satisfied by construction, with the release
+  paths reduced from "every exit of a spawned task" to "one `settle` function").
+
+Because outcomes are pushed at commit-processing time rather than pulled from the
+status cache, the **status-expiry settle path disappears**: the 400-round
+`ConsensusTxStatusCache` retention still serves `WaitForEffects` clients, but the
+pool cannot "miss" a status. A defensive sweep (`debug_fatal!` + settle) reaps any
+entry still unsettled under a *sequenced* block far below the GC round, so a
+coverage bug degrades to a metric, not a capacity leak.
+
+### Garbage collection and resubmission
+
+`notify_committed(own_committed, gc_round)`:
+
+- Committed own blocks are marked sequenced (direct `inflight` lookup); their
+  entries settle via the commit handler's status/processed pushes for that same
+  commit (either ordering of the two signals is fine — settle is idempotent).
+- Un-sequenced blocks with `round <= gc_round` (a front-pop, since `BlockRef`
+  orders round-first) will never commit. **System entries requeue to `pending`**
+  with their original `seq` — the protocol depends on them landing; this
+  replaces the adapter's "GC → sleep 1s → resubmit" loop. **User and
+  `BestEffort` entries settle** (`GarbageCollected`): their positions were
+  already delivered, and a GC'd position never receives a status, so the client
+  observes `Expired` via `WaitForEffects` (or hits its own deadline) and
+  resubmits.
+- Delta vs today: the adapter internally resubmits GC'd *user* transactions
+  until they land; the pool does not — principle 5 taken at face value (clients
+  own user-transaction retries), which also keeps the user-entry lifecycle
+  linear (`Pending → Staged → Proposed → Settled`, never backwards). Own-block
+  GC is rare — the proposer's block must miss the DAG past the GC horizon — so
+  the cost is an occasional client-driven resubmit.
+
+### Epoch rotation
+
+Consensus is torn down and rebuilt per epoch; the pool follows:
+
+1. Reconfig calls `TransactionPoolContext::rotate_for_epoch(new_epoch_store)`:
+   the old pool's `shutdown()` drains all maps and fails every waiter with
+   `ValidatorHaltedAtEpochEnd` (explicit, actionable — an upgrade over today's
+   dropped-oneshot → `TooManyTransactionsPendingConsensus` mapping), and the
+   context swaps in a fresh pool bound to the new epoch.
+2. The new pool is handed to `ConsensusManager::start`. Submissions arriving
+   before the new consensus instance begins taking simply wait in `pending` —
+   replacing today's reconfig-window backoff-retry loop inside `submit_inner`.
+3. Old consensus's core thread stops before rotation, so no stale `take`/
+   `notify_committed` can reach the new pool. Un-settled system messages are
+   regenerated by their existing recovery paths (`recover_end_of_publish`,
+   checkpoint-signature resubmission), as with today's cancelled tasks.
+
+## Entry-point parity
+
+| Today | Pool |
+|---|---|
+| `ConsensusAdapter::submit_and_get_positions(txns, epoch_store, addr)` | `TransactionPoolContext::submit_and_get_positions` — same contract and callers, with the group's min gas price passed explicitly |
+| `AdmissionQueueHandle::try_insert(gas_price, txns, addr)` → `(rx, newly_inserted)` | Folded into the same submit path; gas price computed internally; `newly_inserted` preserved for spam weight |
+| `classify_submit_mode` → Bypass / Queue / Disabled | Deleted — one path. Node config selects pool vs. legacy pipeline during rollout |
+| `SubmitToConsensus::submit_to_consensus` (checkpoint sigs, DKG) | Implemented by `TransactionPoolContext`: insert system entry; retained until processed (GC-requeue) — same "retried until sequenced or epoch end" guarantee |
+| `SubmitToConsensus::submit_best_effort` (execution-time observations) | Insert `BestEffort{deadline}` entry: no GC-requeue, lazily dropped past deadline; returns immediately as today |
+| `ConsensusAdapter::submit` (EndOfPublish, capabilities, JWK) | Same messages via context system-submit |
+| `recover_end_of_publish` | Unchanged, routed to the pool |
+| `check_consensus_overload` (`TooManyTransactionsPendingConsensus`) | `TransactionPoolContext::check_overload()` over structural counts |
+| Ping requests | `Ping` entry; position `ConsensusPosition::ping` at next ack |
+
+`authority_server.rs` upstream is unchanged: the validation gauntlet,
+`InflightTransactionsGuard` + TTL dedup, grouping, `SubmitTxResult` mapping, and
+the `ValidatorHaltedAtEpochEnd` outer retry all stay. (TODO: revisit the RPC
+layer's `InflightTransactionsGuard` + TTL cache after rollout — the pool's
+`by_key` coalescing likely subsumes them for the submit path.) `WaitForEffects`
+is untouched — the status cache and reject-reason cache continue to be populated
+by the commit handler for clients regardless of the submission pipeline.
+
+## Design principles, restated for the pool
+
+1. **Leak-free accounting** — structural instead of RAII: capacity *is* map
+   membership under one lock; a single `settle` function is the only release
+   path. Admission remains deliberately weak (drain-budget overshoot for bundles
+   self-corrects, as today).
+2. **Answer early** — insert-time processed check, plus push-settlement that
+   reaches even `Pending` entries the moment another validator's commit or a
+   checkpoint covers them; they are never pointlessly proposed.
+3. **Dedup at every layer** — upstream layers unchanged; the pool layer upgrades
+   flag-and-admit to coalescing, with the duplicate still tallied as spam weight.
+4. **Dedup as optimization, not correctness** — unchanged; downstream consensus
+   handling stays idempotent and clients own transaction-level retries.
+5. **Only system transactions are owed retries** — system entries are never
+   evicted and are GC-requeued until processed; user entries get no internal
+   retries at all: every outcome, including GC, settles the entry and the
+   client resubmits.
+6. **Every submission ends in one explicit outcome** — same error taxonomy;
+   eviction keeps its outbid error; epoch-end becomes an explicit
+   `ValidatorHaltedAtEpochEnd` instead of a mapped channel error.
+7. **Prefer higher gas price** — one ordering (`PoolKey`) now drives admission,
+   eviction, *and* block inclusion, instead of a queue order plus a drain order.
+8. **System messages never blocked behind user traffic** — top priority class,
+   capacity-exempt, budget-exempt; and with no semaphore there is no permit to
+   wait on at all.
+
+## Backpressure and limits
+
+- `max_pending_transactions` (default 20,000) keeps both roles, as two
+  **independent** bounds: pool `pending` capacity (the auction bound) and the
+  inflight take budget. Both are counted per *transaction* — an entry
+  contributes its bundle size — via counters maintained under the pool lock
+  (today's analogues split this: the queue counts per entry, the inflight guard
+  per transaction). They are deliberately not one joint bound: settle lag
+  filling `inflight` must not shrink the auction space — holding the overflow
+  *is* `pending`'s job — it just stops `take` from moving entries onward. With
+  Bypass gone the pending capacity absorbs the full stream, so the default is
+  the full value rather than the queue's 0.5×; total resident transactions are
+  bounded by 2× the knob, comparable to today's queue + inflight.
+- Deleted knobs: `admission_queue_bypass_fraction`,
+  `admission_queue_capacity_fraction`, `admission_queue_failover_timeout`,
+  `max_pending_local_submissions`, and the actor channel size. New knob:
+  `transaction_pool_enabled` (mutually exclusive with `admission_queue_enabled`).
+- Saturation semantics are unchanged from Queue mode: capacity converts to a
+  gas-price auction; outright rejection only when outbid.
+
+## Observability
+
+### Metrics
+
+The pool **reuses `ConsensusAdapterMetrics`** (the same registered instance, shared
+with the adapter) wherever the semantics carry over, so existing dashboards and
+alerts keep working across the migration:
+
+| Reused adapter metric | Pool semantics |
+|---|---|
+| `sequencing_certificate_attempt{tx_type}` | incremented at insert |
+| `sequencing_certificate_inflight{tx_type}` | entries resident between insert and settle |
+| `sequencing_certificate_success` / `_failures{tx_type}` | settle outcome: done vs. evicted/shutdown/expired |
+| `sequencing_certificate_status{tx_type, status}` | own-block `Sequenced` / `GarbageCollected` from `notify_committed` |
+| `sequencing_certificate_settled_status{tx_type, status}` | terminal `Finalized` / `Rejected` / `Dropped` from `note_statuses` |
+| `sequencing_certificate_latency{submitted, tx_type, processed_method}` | insert → settle; `processed_method` = settle reason |
+| `sequencing_acknowledge_latency{retry, tx_type}` | insert → position ack (block inclusion); `retry` always `"false"` |
+| `sequencing_certificate_processed{source}` | settle via consensus vs. checkpoint, as today |
+| `sequencing_best_effort_timeout{tx_type}` | best-effort entry expired before being taken |
+| `consensus_latency` | `submit_and_get_positions` → position return, as today |
+
+Metrics with no pool analogue are left to the adapter and retire with it:
+`sequencing_in_flight_submissions`, `sequencing_in_flight_semaphore_wait`, and the
+`admission_queue_*` family. Pool-specific state gets new metrics:
+`transaction_pool_pending` / `transaction_pool_inflight` (per-transaction gauges),
+`transaction_pool_wait_latency` (insert → take), `transaction_pool_evictions` /
+`_rejections` / `_coalesced_inserts` (auction and dedup outcomes), and
+`transaction_pool_gc_requeues` (system entries re-queued after own-block GC).
+
+### Logging
+
+Every major lifecycle event is logged with the entry's transaction keys so one
+transaction can be traced through the pool. Per-transaction events on the hot path
+log at `debug!`; client-visible or abnormal events at `info!`/`warn!`:
+
+- **Entrance**: `debug!` per insert — keys, kind, gas price, and whether it
+  coalesced onto an existing entry.
+- **Eviction / outbid rejection**: `info!` — the evicted (or rejected) keys and
+  both gas prices; these are client-visible auction outcomes.
+- **Submitted to consensus**: `debug!` at ack, one line per proposed block — block
+  ref, entry count, and index range (`take`/ack run on the core thread, so no
+  per-entry lines there).
+- **Exit**: `debug!` per settle — keys, settle reason (processed / status /
+  checkpoint-executed / GC-drop), and pool residence time. `warn!` when the
+  defensive sweep settles an entry the status callbacks missed.
+- **Epoch rotation / shutdown**: `info!` summary with counts of entries drained.
+
+## Behavior deltas (intentional)
+
+- **Duplicates coalesce** instead of being admitted alongside the original:
+  strictly less consensus load; a duplicate of a `Proposed` entry now gets the
+  real position instead of a second submission or an error.
+- **GC'd user transactions are dropped, not resubmitted.** The adapter retries
+  them internally after garbage collection; the pool settles them and the
+  client resubmits (the position surfaces as `Expired` through
+  `WaitForEffects`). Only system entries requeue.
+- **No status-expiry outcome for the pool** (push vs. pull); `Expired` remains a
+  client-visible `WaitForEffects` outcome only.
+- **Reconfig-window submissions wait in the pool** rather than erroring or
+  backoff-retrying against a cleared client.
+- **The adapter's per-settle `EndOfPublish` epilogue is not carried over.**
+  Timestamp-based epoch close is now the default, so the pool submits no
+  `EndOfPublish` of its own. The remaining triggers (`close_epoch`,
+  `recover_end_of_publish`, the consensus handler's
+  `send_end_of_publish_if_needed`) are unchanged and route through the pool as
+  ordinary system entries.
+- **Bypass mode's zero-queue hop is gone**: every transaction pays one mutex'd
+  map insert. This replaces a bounded-channel send + actor hop; below-threshold
+  latency is expected to be equal or better (one fewer task handoff), to be
+  confirmed by benchmark.
+
+## Risks
+
+- **Core-thread coupling**: `take` and `ack` run on the consensus core thread.
+  Mitigations: cached serialization, no DB access in `take`, short critical
+  sections. Watch proposer latency metrics; the mutex can be split (pending vs.
+  settle-index) if insert contention shows up.
+- **Settle-coverage completeness** is the correctness crux: every user
+  transaction in a committed block receives exactly one terminal status in
+  `filter_consensus_txns`, and every surviving or explicitly-dropped key is
+  recorded processed — the callback sites piggyback on those exact points, and
+  the sequenced-bucket sweep catches any future gap. New drop paths added to the
+  commit handler must keep the pool callbacks in sync (extend the
+  keep-in-sync mandate of `consensus_submission_pipeline.md` to this file).
+- **Lock discipline**: commit handler and checkpoint executor call into the pool;
+  the pool must never synchronously call back into them (it doesn't — its only
+  outbound effects are oneshot sends and metric bumps, performed after the lock
+  is released where practical).
+- **Crash/amnesia**: after restart the pool is empty; pre-crash proposed blocks
+  may still commit — harmless (no waiters; commit-handler processing is
+  idempotent), identical to today.
+
+## Rollout
+
+1. Land the `TransactionPool` trait in consensus-core with a shim impl over the
+   existing `TransactionConsumer`; proposer/core call sites switch to the trait
+   unconditionally. No behavior change.
+2. Land `transaction_pool.rs` + `TransactionPoolContext` behind
+   `transaction_pool_enabled` (default off). `ValidatorService` and the system
+   submitters route by config to pool or legacy queue+adapter.
+3. Parity validation: e2e + simtests for both configurations; benchmark
+   submission latency (p50/p99 position latency below and above saturation) and
+   congestion behavior (auction fairness, eviction rates).
+4. Default on; delete the admission queue, the adapter's submission half,
+   `TransactionClient`/`TransactionConsumer`, and the legacy knobs.

--- a/crates/sui-core/src/transaction_pool.rs
+++ b/crates/sui-core/src/transaction_pool.rs
@@ -180,6 +180,10 @@ enum PriorityClass {
     User,
 }
 
+/// Ping entries have no transaction bytes and consume neither block nor user-pool
+/// capacity. Bound them separately so RPC pings cannot create unbounded proposer work.
+pub(crate) const MAX_PENDING_PINGS: usize = 128;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum EntryKind {
     User,
@@ -386,6 +390,8 @@ struct PoolInner {
     /// User transactions staged or proposed and not yet settled, counted per
     /// transaction.
     inflight_user_txs: usize,
+    /// Ping entries resident in the pool, including entries staged for a proposal.
+    pending_pings: usize,
     shutdown: bool,
 }
 
@@ -438,6 +444,9 @@ impl PoolInner {
                 }
             }
             EntryState::Settled => unreachable!(),
+        }
+        if matches!(entry.kind, EntryKind::Ping) {
+            self.pending_pings -= 1;
         }
         for key in &entry.keys {
             if let std::collections::hash_map::Entry::Occupied(slot) =
@@ -576,6 +585,7 @@ impl SuiTransactionPool {
                 next_seq: 0,
                 pending_user_txs: 0,
                 inflight_user_txs: 0,
+                pending_pings: 0,
                 shutdown: false,
             })),
             metrics,
@@ -709,6 +719,9 @@ impl SuiTransactionPool {
             if inner.shutdown {
                 return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
             }
+            if matches!(kind, EntryKind::Ping) && inner.pending_pings >= MAX_PENDING_PINGS {
+                return Err(SuiErrorKind::TooManyTransactionsPendingConsensus.into());
+            }
 
             // Coalesce onto an existing entry when the key sets match exactly: the new
             // waiter shares the existing entry's positions. A partial overlap is
@@ -834,6 +847,9 @@ impl SuiTransactionPool {
             }
             if kind.is_user() {
                 inner.pending_user_txs += num_txs;
+            }
+            if matches!(kind, EntryKind::Ping) {
+                inner.pending_pings += 1;
             }
             inner.pending.insert(pool_key, entry);
 
@@ -1281,6 +1297,7 @@ impl StagedBatch {
                 match m.state {
                     EntryState::Staged if matches!(entry.kind, EntryKind::Ping) => {
                         m.state = EntryState::Settled;
+                        inner.pending_pings -= 1;
                         let waiters = std::mem::take(&mut m.waiters);
                         drop(m);
                         for waiter in waiters {

--- a/crates/sui-core/src/transaction_pool.rs
+++ b/crates/sui-core/src/transaction_pool.rs
@@ -1,0 +1,1581 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pull-based transaction pool feeding consensus block proposals.
+//!
+//! Transactions wait in a prioritized pool (system entries first, then user entries by
+//! gas price descending) until the consensus proposer takes them into a block, and are
+//! settled by push callbacks from the commit handler and checkpoint executor. This is an
+//! alternative to the admission queue + consensus adapter submission pipeline.
+//!
+//! See `transaction_pool.md` (same directory) for the design; keep it in sync with
+//! behavior changes here.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, HashMap};
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arc_swap::ArcSwap;
+use consensus_core::{LimitReached, TransactionPool};
+use consensus_types::block::{BlockRef, Round, TransactionIndex};
+use mysten_common::debug_fatal;
+use parking_lot::Mutex;
+use prometheus::{
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    register_histogram_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry,
+};
+use sui_types::base_types::{AuthorityName, TransactionDigest};
+use sui_types::committee::EpochId;
+use sui_types::error::{SuiError, SuiErrorKind, SuiResult};
+use sui_types::messages_consensus::{
+    ConsensusPosition, ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
+};
+use sui_types::transaction::TransactionDataAPI;
+use tokio::sync::oneshot;
+use tracing::{debug, info, warn};
+
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::consensus_tx_status_cache::ConsensusTxStatus;
+use crate::checkpoints::CheckpointStore;
+use crate::consensus_adapter::{ConsensusAdapterMetrics, SubmitToConsensus};
+use crate::consensus_handler::{SequencedConsensusTransactionKey, classify};
+
+/// A sequenced own block whose entries have not fully settled after this many rounds
+/// past its round indicates missed settle coverage; the defensive sweep reaps it.
+const SWEEP_GRACE_ROUNDS: Round = 100;
+
+/// Metrics for the transaction pool. Reuses the already-registered
+/// `ConsensusAdapterMetrics` series (prometheus handles are cheap clones sharing the
+/// registered state) where the semantics carry over, so dashboards keep working across
+/// the migration, and registers pool-specific metrics for pool state.
+pub struct TransactionPoolMetrics {
+    // Reused ConsensusAdapterMetrics series.
+    sequencing_certificate_attempt: IntCounterVec,
+    sequencing_certificate_success: IntCounterVec,
+    sequencing_certificate_failures: IntCounterVec,
+    sequencing_certificate_status: IntCounterVec,
+    sequencing_certificate_settled_status: IntCounterVec,
+    sequencing_certificate_inflight: IntGaugeVec,
+    sequencing_acknowledge_latency: HistogramVec,
+    sequencing_certificate_latency: HistogramVec,
+    sequencing_certificate_processed: IntCounterVec,
+    sequencing_best_effort_timeout: IntCounterVec,
+    consensus_latency: Histogram,
+    num_rejected_cert_in_epoch_boundary: IntCounter,
+    // Pool-specific metrics.
+    pool_pending: IntGauge,
+    pool_inflight: IntGauge,
+    pool_wait_latency: Histogram,
+    pool_evictions: IntCounter,
+    pool_rejections: IntCounter,
+    pool_coalesced_inserts: IntCounter,
+    pool_gc_requeues: IntCounter,
+}
+
+impl TransactionPoolMetrics {
+    pub fn new(registry: &Registry, adapter_metrics: &ConsensusAdapterMetrics) -> Self {
+        Self {
+            sequencing_certificate_attempt: adapter_metrics.sequencing_certificate_attempt.clone(),
+            sequencing_certificate_success: adapter_metrics.sequencing_certificate_success.clone(),
+            sequencing_certificate_failures: adapter_metrics
+                .sequencing_certificate_failures
+                .clone(),
+            sequencing_certificate_status: adapter_metrics.sequencing_certificate_status.clone(),
+            sequencing_certificate_settled_status: adapter_metrics
+                .sequencing_certificate_settled_status
+                .clone(),
+            sequencing_certificate_inflight: adapter_metrics
+                .sequencing_certificate_inflight
+                .clone(),
+            sequencing_acknowledge_latency: adapter_metrics.sequencing_acknowledge_latency.clone(),
+            sequencing_certificate_latency: adapter_metrics.sequencing_certificate_latency.clone(),
+            sequencing_certificate_processed: adapter_metrics
+                .sequencing_certificate_processed
+                .clone(),
+            sequencing_best_effort_timeout: adapter_metrics.sequencing_best_effort_timeout.clone(),
+            consensus_latency: adapter_metrics.consensus_latency.clone(),
+            num_rejected_cert_in_epoch_boundary: adapter_metrics
+                .num_rejected_cert_in_epoch_boundary
+                .clone(),
+            pool_pending: register_int_gauge_with_registry!(
+                "transaction_pool_pending",
+                "Number of user transactions pending in the pool, waiting to be taken into a block",
+                registry,
+            )
+            .unwrap(),
+            pool_inflight: register_int_gauge_with_registry!(
+                "transaction_pool_inflight",
+                "Number of user transactions taken into proposed blocks and not yet settled",
+                registry,
+            )
+            .unwrap(),
+            pool_wait_latency: register_histogram_with_registry!(
+                "transaction_pool_wait_latency",
+                "Time a transaction spends pending in the pool before being taken into a block",
+                mysten_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            pool_evictions: register_int_counter_with_registry!(
+                "transaction_pool_evictions",
+                "Number of entries evicted from the pool by higher gas price transactions",
+                registry,
+            )
+            .unwrap(),
+            pool_rejections: register_int_counter_with_registry!(
+                "transaction_pool_rejections",
+                "Number of transactions rejected because the pool was full and their gas price was too low",
+                registry,
+            )
+            .unwrap(),
+            pool_coalesced_inserts: register_int_counter_with_registry!(
+                "transaction_pool_coalesced_inserts",
+                "Duplicate submissions coalesced onto (or admitted alongside) an existing pool entry. Tallied as spam for DoS protection.",
+                registry,
+            )
+            .unwrap(),
+            pool_gc_requeues: register_int_counter_with_registry!(
+                "transaction_pool_gc_requeues",
+                "System entries returned to pending after their block was garbage collected",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+
+    pub fn new_for_tests() -> Arc<Self> {
+        let registry = Registry::new();
+        let adapter_metrics = ConsensusAdapterMetrics::new(&registry);
+        Arc::new(Self::new(&registry, &adapter_metrics))
+    }
+}
+
+/// Ranks pool entries for take order: system entries first, then user entries by gas
+/// price descending; FIFO within a price level via the insertion sequence. `BTreeMap`
+/// ascending iteration order is take order. Extensible: future ranking criteria slot in
+/// as comparison fields.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct PoolKey {
+    class: PriorityClass,
+    price: Reverse<u64>,
+    seq: u64,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum PriorityClass {
+    System,
+    User,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum EntryKind {
+    User,
+    System,
+    /// One-shot system submission: dropped instead of taken past the deadline, and
+    /// dropped instead of re-queued on garbage collection.
+    BestEffort { deadline: Instant },
+    /// Payload-less entry acknowledged with a ping position at the next proposed block.
+    Ping,
+}
+
+impl EntryKind {
+    fn priority_class(&self) -> PriorityClass {
+        match self {
+            EntryKind::User => PriorityClass::User,
+            EntryKind::System | EntryKind::BestEffort { .. } | EntryKind::Ping => {
+                PriorityClass::System
+            }
+        }
+    }
+
+    fn is_user(&self) -> bool {
+        matches!(self, EntryKind::User)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum EntryState {
+    /// Waiting in the pending map to be taken into a block.
+    Pending,
+    /// Taken by the proposer, awaiting the block ack.
+    Staged,
+    /// In a proposed block, awaiting a terminal outcome.
+    Proposed {
+        block_ref: BlockRef,
+        first_index: TransactionIndex,
+    },
+    Settled,
+}
+
+/// Why an entry left the pool. Used for waiter errors, metrics labels and logs.
+#[derive(Clone, Copy, Debug)]
+enum SettleReason {
+    /// Consensus key observed processed, from any validator's committed block.
+    Processed,
+    /// Terminal per-position status for our own proposed block.
+    Status(ConsensusTxStatus),
+    /// Transaction executed via a (locally built or state-synced) checkpoint.
+    CheckpointExecuted,
+    /// Own block garbage collected; user and best-effort entries are dropped
+    /// (system entries requeue instead of settling).
+    GarbageCollected,
+    /// Evicted from a full pool by a higher-priced submission carrying this price.
+    Evicted { min_gas_price: u64 },
+    /// Pool shut down at epoch end.
+    Shutdown,
+    /// Best-effort entry passed its deadline before being taken.
+    BestEffortExpired,
+    /// Defensive sweep of a sequenced block whose statuses never fully arrived.
+    Sweep,
+}
+
+impl SettleReason {
+    fn as_label(&self) -> &'static str {
+        match self {
+            SettleReason::Processed => "processed",
+            SettleReason::Status(ConsensusTxStatus::Finalized) => "status_finalized",
+            SettleReason::Status(ConsensusTxStatus::Rejected) => "status_rejected",
+            SettleReason::Status(ConsensusTxStatus::Dropped) => "status_dropped",
+            SettleReason::CheckpointExecuted => "checkpoint_executed",
+            SettleReason::GarbageCollected => "garbage_collected",
+            SettleReason::Evicted { .. } => "evicted",
+            SettleReason::Shutdown => "shutdown",
+            SettleReason::BestEffortExpired => "best_effort_expired",
+            SettleReason::Sweep => "sweep",
+        }
+    }
+
+    fn is_success(&self) -> bool {
+        matches!(
+            self,
+            SettleReason::Processed | SettleReason::Status(_) | SettleReason::CheckpointExecuted
+        )
+    }
+
+    /// The error delivered to waiters that have not received positions yet.
+    fn waiter_error(&self, digest: TransactionDigest) -> SuiError {
+        match self {
+            SettleReason::Processed | SettleReason::Status(_) => {
+                SuiErrorKind::TransactionProcessing {
+                    digest,
+                    status: "processed via consensus".to_string(),
+                }
+                .into()
+            }
+            SettleReason::CheckpointExecuted => SuiErrorKind::TransactionProcessing {
+                digest,
+                status: "processed via checkpoint".to_string(),
+            }
+            .into(),
+            SettleReason::Evicted { min_gas_price } => {
+                SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion {
+                    min_gas_price: *min_gas_price,
+                }
+                .into()
+            }
+            SettleReason::Shutdown => SuiErrorKind::ValidatorHaltedAtEpochEnd.into(),
+            SettleReason::GarbageCollected
+            | SettleReason::BestEffortExpired
+            | SettleReason::Sweep => SuiErrorKind::FailedToSubmitToConsensus(format!(
+                "submission ended: {}",
+                self.as_label()
+            ))
+            .into(),
+        }
+    }
+}
+
+fn status_label(status: &ConsensusTxStatus) -> &'static str {
+    match status {
+        ConsensusTxStatus::Finalized => "finalized",
+        ConsensusTxStatus::Rejected => "rejected",
+        ConsensusTxStatus::Dropped => "dropped",
+    }
+}
+
+type PositionWaiter = oneshot::Sender<SuiResult<Vec<ConsensusPosition>>>;
+type Notifications = Vec<(PositionWaiter, SuiResult<Vec<ConsensusPosition>>)>;
+
+fn deliver(notifications: Notifications) {
+    for (waiter, result) in notifications {
+        let _ = waiter.send(result);
+    }
+}
+
+/// Mutable entry state; guarded by its own mutex, only locked while holding the pool
+/// mutex (lock order: pool mutex, then entry mutex).
+struct EntryMut {
+    state: EntryState,
+    waiters: Vec<PositionWaiter>,
+    /// Per-transaction flags: true while the transaction lacks a terminal signal.
+    unsettled: Vec<bool>,
+    unsettled_count: usize,
+    /// One element per (coalesced) submission not yet accounted for DoS, drained when
+    /// the entry is taken.
+    unrecorded_addrs: Vec<Option<IpAddr>>,
+    /// Whether the entry has been taken at least once (DoS accounting ran).
+    dos_recorded: bool,
+}
+
+/// One submission group (a single transaction, or a soft bundle that must land in one
+/// block) resident in the pool.
+pub struct PoolEntry {
+    transactions: Vec<ConsensusTransaction>,
+    /// BCS bytes cached at insert so `take()` never serializes on the core thread.
+    serialized: Vec<Vec<u8>>,
+    keys: Vec<ConsensusTransactionKey>,
+    gas_price: u64,
+    kind: EntryKind,
+    tx_type: &'static str,
+    pool_key: PoolKey,
+    submit_time: Instant,
+    mutable: Mutex<EntryMut>,
+}
+
+impl PoolEntry {
+    fn total_bytes(&self) -> usize {
+        self.serialized.iter().map(|t| t.len()).sum()
+    }
+
+    fn num_transactions(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn first_user_digest(&self) -> TransactionDigest {
+        self.transactions
+            .iter()
+            .find_map(|t| t.kind.as_user_transaction().map(|tx| *tx.digest()))
+            .unwrap_or_default()
+    }
+}
+
+struct ProposedBlock {
+    sequenced: bool,
+    /// Entries in block order with the block index of their first transaction.
+    entries: Vec<(TransactionIndex, Arc<PoolEntry>)>,
+}
+
+struct PoolInner {
+    /// Transactions waiting to be proposed, in take order.
+    pending: BTreeMap<PoolKey, Arc<PoolEntry>>,
+    /// Transactions in our own proposed blocks, awaiting terminal outcome. BlockRef
+    /// orders round-first, so GC processes a prefix.
+    inflight: BTreeMap<BlockRef, ProposedBlock>,
+    /// Settle/dedup index over both maps, first-writer-wins: an entry admitted while
+    /// its key is already mapped (partial bundle overlap) settles via its own position
+    /// statuses instead.
+    by_key: HashMap<ConsensusTransactionKey, (Arc<PoolEntry>, usize)>,
+    next_seq: u64,
+    /// User transactions resident in `pending`, counted per transaction.
+    pending_user_txs: usize,
+    /// User transactions staged or proposed and not yet settled, counted per
+    /// transaction.
+    inflight_user_txs: usize,
+    shutdown: bool,
+}
+
+impl PoolInner {
+    /// Marks transaction `tx_idx` of `entry` settled. Returns true when this was the
+    /// entry's last unsettled transaction; the caller must then `finish_entry`.
+    fn mark_tx_settled(&self, entry: &PoolEntry, tx_idx: usize) -> bool {
+        let mut m = entry.mutable.lock();
+        if matches!(m.state, EntryState::Settled) || !m.unsettled[tx_idx] {
+            return false;
+        }
+        m.unsettled[tx_idx] = false;
+        m.unsettled_count -= 1;
+        m.unsettled_count == 0
+    }
+
+    /// Removes the entry from all maps and bookkeeping, transitions it to `Settled`,
+    /// and collects its waiters (paired with the error to deliver, when positions were
+    /// never sent) into `notifications` for delivery after the pool lock is released.
+    fn finish_entry(
+        &mut self,
+        entry: &Arc<PoolEntry>,
+        reason: SettleReason,
+        metrics: &TransactionPoolMetrics,
+        notifications: &mut Notifications,
+    ) {
+        let mut m = entry.mutable.lock();
+        if matches!(m.state, EntryState::Settled) {
+            return;
+        }
+        let prev_state = m.state;
+        m.state = EntryState::Settled;
+        m.unsettled_count = 0;
+        m.unsettled.fill(false);
+        let waiters = std::mem::take(&mut m.waiters);
+        drop(m);
+
+        match prev_state {
+            EntryState::Pending => {
+                self.pending.remove(&entry.pool_key);
+                if entry.kind.is_user() {
+                    self.pending_user_txs -= entry.num_transactions();
+                }
+            }
+            EntryState::Staged | EntryState::Proposed { .. } => {
+                // Staged entries are owned by the in-flight take; proposed entries sit
+                // in their `inflight` bucket, cleaned up in `notify_committed`.
+                if entry.kind.is_user() {
+                    self.inflight_user_txs -= entry.num_transactions();
+                }
+            }
+            EntryState::Settled => unreachable!(),
+        }
+        for key in &entry.keys {
+            if let std::collections::hash_map::Entry::Occupied(slot) =
+                self.by_key.entry(key.clone())
+                && Arc::ptr_eq(&slot.get().0, entry)
+            {
+                slot.remove();
+            }
+        }
+
+        let error = reason.waiter_error(entry.first_user_digest());
+        for waiter in waiters {
+            notifications.push((waiter, Err(error.clone())));
+        }
+
+        let submitted = if matches!(prev_state, EntryState::Proposed { .. }) {
+            "true"
+        } else {
+            "false"
+        };
+        metrics
+            .sequencing_certificate_latency
+            .with_label_values(&[submitted, entry.tx_type, reason.as_label()])
+            .observe(entry.submit_time.elapsed().as_secs_f64());
+        if reason.is_success() {
+            metrics
+                .sequencing_certificate_success
+                .with_label_values(&[entry.tx_type])
+                .inc();
+        } else {
+            metrics
+                .sequencing_certificate_failures
+                .with_label_values(&[entry.tx_type])
+                .inc();
+        }
+        metrics
+            .sequencing_certificate_inflight
+            .with_label_values(&[entry.tx_type])
+            .sub(entry.num_transactions().max(1) as i64);
+        self.publish_gauges(metrics);
+
+        debug!(
+            keys = ?entry.keys,
+            reason = reason.as_label(),
+            residence = ?entry.submit_time.elapsed(),
+            "Transaction pool entry settled",
+        );
+    }
+
+    /// Returns a staged or proposed entry to `pending` (GC requeue and dropped-ack
+    /// paths), retaining its original pool key and thus its seniority.
+    fn requeue_entry(&mut self, entry: Arc<PoolEntry>) {
+        let mut m = entry.mutable.lock();
+        debug_assert!(matches!(
+            m.state,
+            EntryState::Staged | EntryState::Proposed { .. }
+        ));
+        m.state = EntryState::Pending;
+        drop(m);
+        if entry.kind.is_user() {
+            self.inflight_user_txs -= entry.num_transactions();
+            self.pending_user_txs += entry.num_transactions();
+        }
+        let key = entry.pool_key;
+        self.pending.insert(key, entry);
+    }
+
+    /// The oldest pending user entry at the lowest gas price: the eviction victim.
+    fn eviction_victim(&self) -> Option<Arc<PoolEntry>> {
+        let (last_key, last_entry) = self.pending.last_key_value()?;
+        if !last_entry.kind.is_user() {
+            return None;
+        }
+        let band_start = PoolKey {
+            class: PriorityClass::User,
+            price: last_key.price,
+            seq: 0,
+        };
+        self.pending
+            .range(band_start..)
+            .next()
+            .map(|(_, e)| e.clone())
+    }
+
+    fn publish_gauges(&self, metrics: &TransactionPoolMetrics) {
+        metrics.pool_pending.set(self.pending_user_txs as i64);
+        metrics.pool_inflight.set(self.inflight_user_txs as i64);
+    }
+}
+
+/// Per-epoch pull-based transaction pool. Implements the consensus-core
+/// `TransactionPool` trait for the proposer, and receives settle callbacks from the
+/// commit handler and checkpoint executor via the epoch store.
+pub struct SuiTransactionPool {
+    epoch: EpochId,
+    epoch_store: Arc<AuthorityPerEpochStore>,
+    /// `pending` user-transaction capacity: the gas auction bound.
+    capacity: usize,
+    /// Inflight user-transaction budget: `take` stops filling blocks with user
+    /// transactions when this many are staged/proposed and unsettled.
+    max_pending_transactions: usize,
+    inner: Arc<Mutex<PoolInner>>,
+    metrics: Arc<TransactionPoolMetrics>,
+}
+
+impl SuiTransactionPool {
+    pub fn new(
+        epoch_store: Arc<AuthorityPerEpochStore>,
+        capacity: usize,
+        max_pending_transactions: usize,
+        metrics: Arc<TransactionPoolMetrics>,
+    ) -> Arc<Self> {
+        assert!(capacity > 0);
+        Arc::new(Self {
+            epoch: epoch_store.epoch(),
+            epoch_store,
+            capacity,
+            max_pending_transactions,
+            inner: Arc::new(Mutex::new(PoolInner {
+                pending: BTreeMap::new(),
+                inflight: BTreeMap::new(),
+                by_key: HashMap::new(),
+                next_seq: 0,
+                pending_user_txs: 0,
+                inflight_user_txs: 0,
+                shutdown: false,
+            })),
+            metrics,
+        })
+    }
+
+    pub fn epoch(&self) -> EpochId {
+        self.epoch
+    }
+
+    /// Number of user transactions pending in the pool.
+    pub fn pending_user_transactions(&self) -> usize {
+        self.inner.lock().pending_user_txs
+    }
+
+    /// Number of user transactions staged or in proposed blocks, not yet settled.
+    pub fn inflight_user_transactions(&self) -> usize {
+        self.inner.lock().inflight_user_txs
+    }
+
+    /// Submits user transactions (or a ping, when `transactions` is empty) and returns
+    /// a receiver for their consensus positions plus whether this was a new entry
+    /// (false = duplicate submission; tallied as spam by the RPC layer).
+    ///
+    /// `gas_price` is the minimum across the group, 0 for gasless.
+    pub fn submit_user_transactions(
+        &self,
+        gas_price: u64,
+        transactions: Vec<ConsensusTransaction>,
+        submitter_client_addr: Option<IpAddr>,
+    ) -> SuiResult<(oneshot::Receiver<SuiResult<Vec<ConsensusPosition>>>, bool)> {
+        let kind = if transactions.is_empty() {
+            EntryKind::Ping
+        } else {
+            EntryKind::User
+        };
+        let (tx, rx) = oneshot::channel();
+        let newly_inserted = self.submit_entry(
+            kind,
+            gas_price,
+            transactions,
+            submitter_client_addr,
+            Some(tx),
+        )?;
+        Ok((rx, newly_inserted))
+    }
+
+    /// Submits a system transaction. System entries are never evicted, don't count
+    /// against pool capacity, and are retained (re-queued on garbage collection) until
+    /// observed processed or the epoch ends — unless `best_effort_deadline` is set, in
+    /// which case the entry is dropped at the deadline or on garbage collection.
+    pub fn submit_system_transaction(
+        &self,
+        transaction: ConsensusTransaction,
+        best_effort_deadline: Option<Instant>,
+    ) -> SuiResult {
+        assert!(
+            !transaction.is_user_transaction(),
+            "user transactions must go through submit_user_transactions"
+        );
+        let kind = match best_effort_deadline {
+            Some(deadline) => EntryKind::BestEffort { deadline },
+            None => EntryKind::System,
+        };
+        if matches!(transaction.kind, ConsensusTransactionKind::EndOfPublish(..)) {
+            info!(epoch = ?self.epoch, "Submitting EndOfPublish message to consensus");
+            self.epoch_store
+                .record_epoch_pending_certs_process_time_metric();
+        }
+        self.submit_entry(kind, 0, vec![transaction], None, None)?;
+        Ok(())
+    }
+
+    /// Inserts an entry into the pool. Returns whether it was newly inserted (false =
+    /// duplicate of an existing entry, coalesced or admitted alongside).
+    fn submit_entry(
+        &self,
+        kind: EntryKind,
+        gas_price: u64,
+        transactions: Vec<ConsensusTransaction>,
+        submitter_client_addr: Option<IpAddr>,
+        waiter: Option<PositionWaiter>,
+    ) -> SuiResult<bool> {
+        let keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
+        let serialized: Vec<_> = transactions
+            .iter()
+            .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
+            .collect();
+        let tx_type = match kind {
+            EntryKind::Ping => "ping",
+            _ if transactions.len() > 1 => "soft_bundle",
+            _ => classify(&transactions[0]),
+        };
+        let num_txs = transactions.len();
+
+        let mut notifications = Notifications::new();
+        let mut record_dos_for_coalesced: Option<Arc<PoolEntry>> = None;
+        let result = 'inserted: {
+            let mut inner = self.inner.lock();
+            if inner.shutdown {
+                return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
+            }
+
+            // Coalesce onto an existing entry when the key sets match exactly: the new
+            // waiter shares the existing entry's positions. A partial overlap is
+            // admitted as a separate entry (flagged not-new), like today's queue
+            // duplicates; such an entry settles via its own position statuses.
+            if !keys.is_empty()
+                && let Some((existing, _)) = inner.by_key.get(&keys[0]).cloned()
+                && existing.keys == keys
+            {
+                let mut m = existing.mutable.lock();
+                if let EntryState::Proposed {
+                    block_ref,
+                    first_index,
+                } = m.state
+                {
+                    // Positions are already known: answer immediately.
+                    if let Some(waiter) = waiter {
+                        let positions = (0..num_txs as TransactionIndex)
+                            .map(|i| ConsensusPosition {
+                                epoch: self.epoch,
+                                block: block_ref,
+                                index: first_index + i,
+                            })
+                            .collect();
+                        notifications.push((waiter, Ok(positions)));
+                    }
+                } else if let Some(waiter) = waiter {
+                    m.waiters.push(waiter);
+                }
+                if m.dos_recorded {
+                    record_dos_for_coalesced = Some(existing.clone());
+                } else {
+                    m.unrecorded_addrs.push(submitter_client_addr);
+                }
+                drop(m);
+                self.metrics.pool_coalesced_inserts.inc();
+                debug!(?keys, "Coalesced duplicate submission onto pool entry");
+                break 'inserted Ok(false);
+            }
+
+            let newly_inserted = !keys.iter().any(|k| inner.by_key.contains_key(k));
+            if !newly_inserted {
+                self.metrics.pool_coalesced_inserts.inc();
+            }
+
+            // Gas auction: evict strictly lower-priced user entries (oldest at the
+            // lowest price first) until the newcomer fits; reject the newcomer if
+            // that cannot free enough capacity.
+            if kind.is_user() {
+                while inner.pending_user_txs + num_txs > self.capacity {
+                    let victim = inner.eviction_victim();
+                    match victim {
+                        Some(victim) if victim.gas_price < gas_price => {
+                            inner.finish_entry(
+                                &victim,
+                                SettleReason::Evicted {
+                                    min_gas_price: gas_price,
+                                },
+                                &self.metrics,
+                                &mut notifications,
+                            );
+                            self.metrics.pool_evictions.inc();
+                            info!(
+                                evicted_keys = ?victim.keys,
+                                evicted_gas_price = victim.gas_price,
+                                evicting_gas_price = gas_price,
+                                "Evicted pool entry outbid by higher gas price",
+                            );
+                        }
+                        _ => {
+                            self.metrics.pool_rejections.inc();
+                            let min_gas_price =
+                                victim.map(|v| v.gas_price).unwrap_or(gas_price);
+                            info!(
+                                ?keys,
+                                gas_price,
+                                min_gas_price,
+                                "Rejected submission: pool full and gas price too low",
+                            );
+                            drop(inner);
+                            deliver(notifications);
+                            return Err(
+                                SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion {
+                                    min_gas_price,
+                                }
+                                .into(),
+                            );
+                        }
+                    }
+                }
+            }
+
+            let pool_key = PoolKey {
+                class: kind.priority_class(),
+                price: Reverse(gas_price),
+                seq: inner.next_seq,
+            };
+            inner.next_seq += 1;
+
+            let entry = Arc::new(PoolEntry {
+                serialized,
+                keys: keys.clone(),
+                gas_price,
+                kind,
+                tx_type,
+                pool_key,
+                submit_time: Instant::now(),
+                mutable: Mutex::new(EntryMut {
+                    state: EntryState::Pending,
+                    waiters: waiter.into_iter().collect(),
+                    unsettled: vec![true; num_txs],
+                    unsettled_count: num_txs,
+                    unrecorded_addrs: vec![submitter_client_addr],
+                    dos_recorded: false,
+                }),
+                transactions,
+            });
+
+            for (i, key) in keys.iter().enumerate() {
+                inner
+                    .by_key
+                    .entry(key.clone())
+                    .or_insert((entry.clone(), i));
+            }
+            if kind.is_user() {
+                inner.pending_user_txs += num_txs;
+            }
+            inner.pending.insert(pool_key, entry);
+
+            self.metrics
+                .sequencing_certificate_attempt
+                .with_label_values(&[tx_type])
+                .inc();
+            self.metrics
+                .sequencing_certificate_inflight
+                .with_label_values(&[tx_type])
+                .add(num_txs.max(1) as i64);
+            inner.publish_gauges(&self.metrics);
+            debug!(?keys, gas_price, ?kind, "Transaction entered pool");
+            Ok(newly_inserted)
+        };
+        deliver(notifications);
+        if let Some(entry) = record_dos_for_coalesced {
+            self.record_dos_accounting(&entry, &[submitter_client_addr]);
+        }
+        result
+    }
+
+    /// DoS/spam accounting, at the point transactions are actually submitted to
+    /// consensus: caps how many times a digest may be observed in consensus output
+    /// across validators before further appearances are tallied as spam.
+    fn record_dos_accounting(&self, entry: &PoolEntry, addrs: &[Option<IpAddr>]) {
+        if !entry.kind.is_user() {
+            return;
+        }
+        let rgp = self.epoch_store.reference_gas_price().max(1);
+        for tx in &entry.transactions {
+            let Some(user_tx) = tx.kind.as_user_transaction() else {
+                continue;
+            };
+            let amplification_factor = (user_tx.transaction_data().gas_price() / rgp).max(1);
+            for addr in addrs {
+                self.epoch_store
+                    .submitted_transaction_cache
+                    .record_submitted_tx(user_tx.digest(), amplification_factor as u32, *addr);
+            }
+        }
+    }
+
+    /// Settles entries whose consensus key was recorded processed by the commit
+    /// handler, for commits from any validator's blocks. This is the sole settle
+    /// signal for system messages, and reaches entries in any state — a pending entry
+    /// covered by another validator's commit is answered without being proposed.
+    pub fn note_processed<'a>(
+        &self,
+        keys: impl Iterator<Item = &'a SequencedConsensusTransactionKey>,
+    ) {
+        let mut notifications = Notifications::new();
+        {
+            let mut inner = self.inner.lock();
+            if inner.shutdown {
+                return;
+            }
+            for key in keys {
+                let SequencedConsensusTransactionKey::External(key) = key else {
+                    continue;
+                };
+                let Some((entry, idx)) = inner.by_key.get(key).cloned() else {
+                    continue;
+                };
+                if inner.mark_tx_settled(&entry, idx) {
+                    inner.finish_entry(
+                        &entry,
+                        SettleReason::Processed,
+                        &self.metrics,
+                        &mut notifications,
+                    );
+                    self.metrics
+                        .sequencing_certificate_processed
+                        .with_label_values(&["consensus"])
+                        .inc();
+                }
+            }
+        }
+        deliver(notifications);
+    }
+
+    /// Settles user transactions in our own proposed blocks by their terminal
+    /// per-position status. This is the sole settle signal for vote-rejected
+    /// transactions and for certs-closed / post-EndOfPublish drops, which are never
+    /// marked consensus-message-processed.
+    pub fn note_statuses(&self, updates: &[(ConsensusPosition, ConsensusTxStatus)]) {
+        let mut notifications = Notifications::new();
+        {
+            let mut inner = self.inner.lock();
+            if inner.shutdown {
+                return;
+            }
+            for (position, status) in updates {
+                let Some(block) = inner.inflight.get(&position.block) else {
+                    // Not our block (or already cleaned up).
+                    continue;
+                };
+                // The entry covering this index: the last entry whose
+                // first_index <= position.index.
+                let i = match block
+                    .entries
+                    .binary_search_by_key(&position.index, |(first, _)| *first)
+                {
+                    Ok(i) => i,
+                    Err(0) => continue,
+                    Err(i) => i - 1,
+                };
+                let (first_index, entry) = &block.entries[i];
+                let tx_idx = (position.index - first_index) as usize;
+                if tx_idx >= entry.num_transactions() {
+                    // Covers the block-level ping position as well.
+                    continue;
+                }
+                let entry = entry.clone();
+                self.metrics
+                    .sequencing_certificate_settled_status
+                    .with_label_values(&[entry.tx_type, status_label(status)])
+                    .inc();
+                if inner.mark_tx_settled(&entry, tx_idx) {
+                    inner.finish_entry(
+                        &entry,
+                        SettleReason::Status(*status),
+                        &self.metrics,
+                        &mut notifications,
+                    );
+                }
+            }
+        }
+        deliver(notifications);
+    }
+
+    /// Settles entries whose transaction was executed via a certified checkpoint
+    /// (locally built or state-synced).
+    pub fn note_executed_in_checkpoint(&self, digests: &[TransactionDigest]) {
+        let mut notifications = Notifications::new();
+        {
+            let mut inner = self.inner.lock();
+            if inner.shutdown {
+                return;
+            }
+            for digest in digests {
+                let key = ConsensusTransactionKey::Certificate(*digest);
+                let Some((entry, idx)) = inner.by_key.get(&key).cloned() else {
+                    continue;
+                };
+                if inner.mark_tx_settled(&entry, idx) {
+                    inner.finish_entry(
+                        &entry,
+                        SettleReason::CheckpointExecuted,
+                        &self.metrics,
+                        &mut notifications,
+                    );
+                    self.metrics
+                        .sequencing_certificate_processed
+                        .with_label_values(&["checkpoint"])
+                        .inc();
+                }
+            }
+        }
+        deliver(notifications);
+    }
+
+    /// Shuts the pool down at epoch end: fails every waiter with
+    /// `ValidatorHaltedAtEpochEnd` and drains all maps. Subsequent submissions are
+    /// rejected and callbacks become no-ops.
+    pub fn shutdown(&self) {
+        let mut notifications = Notifications::new();
+        {
+            let mut inner = self.inner.lock();
+            if inner.shutdown {
+                return;
+            }
+            inner.shutdown = true;
+            let pending: Vec<_> = inner.pending.values().cloned().collect();
+            let proposed: Vec<_> = inner
+                .inflight
+                .values()
+                .flat_map(|b| b.entries.iter().map(|(_, e)| e.clone()))
+                .collect();
+            let (num_pending, num_proposed) = (pending.len(), proposed.len());
+            for entry in pending.into_iter().chain(proposed) {
+                inner.finish_entry(
+                    &entry,
+                    SettleReason::Shutdown,
+                    &self.metrics,
+                    &mut notifications,
+                );
+                self.metrics.num_rejected_cert_in_epoch_boundary.inc();
+            }
+            inner.pending.clear();
+            inner.inflight.clear();
+            inner.by_key.clear();
+            inner.pending_user_txs = 0;
+            inner.inflight_user_txs = 0;
+            inner.publish_gauges(&self.metrics);
+            info!(
+                epoch = self.epoch,
+                num_pending, num_proposed, "Transaction pool shut down",
+            );
+        }
+        deliver(notifications);
+    }
+}
+
+impl TransactionPool for SuiTransactionPool {
+    fn take(
+        &self,
+        max_count: usize,
+        max_bytes: usize,
+    ) -> (
+        Vec<consensus_core::Transaction>,
+        Box<dyn FnOnce(BlockRef) + Send>,
+        LimitReached,
+    ) {
+        let mut taken: Vec<Arc<PoolEntry>> = Vec::new();
+        let mut transactions = Vec::new();
+        let mut limit = LimitReached::AllTransactionsIncluded;
+        let mut notifications = Notifications::new();
+        {
+            let mut inner = self.inner.lock();
+            if !inner.shutdown {
+                let user_budget = self
+                    .max_pending_transactions
+                    .saturating_sub(inner.inflight_user_txs);
+                let now = Instant::now();
+                let mut count = 0usize;
+                let mut bytes = 0usize;
+                let mut user_count = 0usize;
+                let mut expired = Vec::new();
+                for entry in inner.pending.values() {
+                    if let EntryKind::BestEffort { deadline } = entry.kind
+                        && deadline < now
+                    {
+                        expired.push(entry.clone());
+                        continue;
+                    }
+                    let n = entry.num_transactions();
+                    let entry_bytes = entry.total_bytes();
+                    if bytes + entry_bytes > max_bytes {
+                        limit = LimitReached::MaxBytes;
+                        break;
+                    }
+                    if count + n > max_count {
+                        limit = LimitReached::MaxNumOfTransactions;
+                        break;
+                    }
+                    if entry.kind.is_user() && user_count + n > user_budget {
+                        // Pool-side inflight throttle, not a block limit: stop filling
+                        // blocks with user transactions until in-flight ones settle.
+                        // All remaining entries are user entries (system sorts first).
+                        limit = LimitReached::MaxNumOfTransactions;
+                        break;
+                    }
+                    count += n;
+                    bytes += entry_bytes;
+                    if entry.kind.is_user() {
+                        user_count += n;
+                    }
+                    taken.push(entry.clone());
+                }
+                for entry in expired {
+                    inner.finish_entry(
+                        &entry,
+                        SettleReason::BestEffortExpired,
+                        &self.metrics,
+                        &mut notifications,
+                    );
+                    self.metrics
+                        .sequencing_best_effort_timeout
+                        .with_label_values(&[entry.tx_type])
+                        .inc();
+                }
+                for entry in &taken {
+                    inner.pending.remove(&entry.pool_key);
+                    entry.mutable.lock().state = EntryState::Staged;
+                    if entry.kind.is_user() {
+                        inner.pending_user_txs -= entry.num_transactions();
+                        inner.inflight_user_txs += entry.num_transactions();
+                    }
+                    self.metrics
+                        .pool_wait_latency
+                        .observe(entry.submit_time.elapsed().as_secs_f64());
+                    for bytes in &entry.serialized {
+                        transactions.push(consensus_core::Transaction::new(bytes.clone()));
+                    }
+                }
+                inner.publish_gauges(&self.metrics);
+            }
+        }
+        deliver(notifications);
+
+        // DoS accounting for every (coalesced) submission of each taken user
+        // transaction, at the point of actual submission to consensus.
+        for entry in &taken {
+            let addrs = {
+                let mut m = entry.mutable.lock();
+                m.dos_recorded = true;
+                std::mem::take(&mut m.unrecorded_addrs)
+            };
+            self.record_dos_accounting(entry, &addrs);
+        }
+
+        let batch = StagedBatch {
+            inner: self.inner.clone(),
+            metrics: self.metrics.clone(),
+            epoch: self.epoch,
+            entries: Some(taken),
+        };
+        (
+            transactions,
+            Box::new(move |block_ref| batch.ack(block_ref)),
+            limit,
+        )
+    }
+
+    fn notify_committed(&self, own_committed_blocks: Vec<BlockRef>, gc_round: Round) {
+        let mut notifications = Notifications::new();
+        {
+            let mut inner = self.inner.lock();
+            if inner.shutdown {
+                return;
+            }
+            for block_ref in own_committed_blocks {
+                if let Some(block) = inner.inflight.get_mut(&block_ref) {
+                    block.sequenced = true;
+                    for (_, entry) in &block.entries {
+                        self.metrics
+                            .sequencing_certificate_status
+                            .with_label_values(&[entry.tx_type, "sequenced"])
+                            .inc();
+                    }
+                }
+            }
+
+            let expired_refs: Vec<BlockRef> = inner
+                .inflight
+                .keys()
+                .take_while(|b| b.round <= gc_round)
+                .copied()
+                .collect();
+            for block_ref in expired_refs {
+                let block = inner.inflight.remove(&block_ref).unwrap();
+                let unsettled: Vec<_> = block
+                    .entries
+                    .iter()
+                    .filter(|(_, e)| !matches!(e.mutable.lock().state, EntryState::Settled))
+                    .map(|(_, e)| e.clone())
+                    .collect();
+                if block.sequenced {
+                    if unsettled.is_empty() {
+                        continue;
+                    }
+                    if block_ref.round + SWEEP_GRACE_ROUNDS > gc_round {
+                        // Statuses from the sequencing commit may still be in flight;
+                        // keep the bucket for now.
+                        inner.inflight.insert(block_ref, block);
+                        continue;
+                    }
+                    // A sequenced block's transactions must all have received status
+                    // or processed signals by now; a leftover indicates missed settle
+                    // coverage. Degrade to a metric and a warning instead of leaking.
+                    debug_fatal!(
+                        "Unsettled entries in sequenced block {} far below gc round {}",
+                        block_ref,
+                        gc_round
+                    );
+                    for entry in unsettled {
+                        warn!(
+                            keys = ?entry.keys,
+                            %block_ref,
+                            "Sweeping unsettled entry in sequenced block",
+                        );
+                        inner.finish_entry(
+                            &entry,
+                            SettleReason::Sweep,
+                            &self.metrics,
+                            &mut notifications,
+                        );
+                    }
+                    continue;
+                }
+                // The block was garbage collected and will never commit. System
+                // entries requeue (the protocol depends on them landing); user and
+                // best-effort entries settle — the client observes position expiry
+                // via WaitForEffects and resubmits.
+                for entry in unsettled {
+                    self.metrics
+                        .sequencing_certificate_status
+                        .with_label_values(&[entry.tx_type, "garbage_collected"])
+                        .inc();
+                    if matches!(entry.kind, EntryKind::System) {
+                        self.metrics.pool_gc_requeues.inc();
+                        debug!(
+                            keys = ?entry.keys,
+                            %block_ref,
+                            "Requeuing system entry from garbage collected block",
+                        );
+                        inner.requeue_entry(entry);
+                    } else {
+                        inner.finish_entry(
+                            &entry,
+                            SettleReason::GarbageCollected,
+                            &self.metrics,
+                            &mut notifications,
+                        );
+                    }
+                }
+            }
+            inner.publish_gauges(&self.metrics);
+        }
+        deliver(notifications);
+    }
+}
+
+/// Entries taken by the proposer, awaiting the block ack. Dropping the batch without
+/// acking (proposer error path, consensus shutdown) returns the entries to the pool.
+struct StagedBatch {
+    inner: Arc<Mutex<PoolInner>>,
+    metrics: Arc<TransactionPoolMetrics>,
+    epoch: EpochId,
+    entries: Option<Vec<Arc<PoolEntry>>>,
+}
+
+impl StagedBatch {
+    fn ack(mut self, block_ref: BlockRef) {
+        let entries = self.entries.take().unwrap();
+        let mut notifications = Notifications::new();
+        {
+            let mut inner = self.inner.lock();
+            let mut offset: TransactionIndex = 0;
+            let mut proposed = Vec::new();
+            let mut num_txs = 0usize;
+            for entry in entries {
+                let first_index = offset;
+                // The block contains the entry's transactions regardless of entry
+                // state, so the offset always advances.
+                offset += entry.num_transactions() as TransactionIndex;
+                num_txs += entry.num_transactions();
+
+                let mut m = entry.mutable.lock();
+                match m.state {
+                    EntryState::Staged if matches!(entry.kind, EntryKind::Ping) => {
+                        m.state = EntryState::Settled;
+                        let waiters = std::mem::take(&mut m.waiters);
+                        drop(m);
+                        for waiter in waiters {
+                            notifications.push((
+                                waiter,
+                                Ok(vec![ConsensusPosition::ping(self.epoch, block_ref)]),
+                            ));
+                        }
+                        self.metrics
+                            .sequencing_certificate_inflight
+                            .with_label_values(&[entry.tx_type])
+                            .sub(1);
+                    }
+                    EntryState::Staged => {
+                        m.state = EntryState::Proposed {
+                            block_ref,
+                            first_index,
+                        };
+                        let waiters = std::mem::take(&mut m.waiters);
+                        drop(m);
+                        let positions: Vec<_> = (0..entry.num_transactions()
+                            as TransactionIndex)
+                            .map(|i| ConsensusPosition {
+                                epoch: self.epoch,
+                                block: block_ref,
+                                index: first_index + i,
+                            })
+                            .collect();
+                        for waiter in waiters {
+                            notifications.push((waiter, Ok(positions.clone())));
+                        }
+                        self.metrics
+                            .sequencing_acknowledge_latency
+                            .with_label_values(&["false", entry.tx_type])
+                            .observe(entry.submit_time.elapsed().as_secs_f64());
+                        proposed.push((first_index, entry.clone()));
+                    }
+                    // Settled while staged (e.g. observed processed from another
+                    // validator's commit, or pool shutdown): its bytes are in the
+                    // block, but there is nothing left to track.
+                    EntryState::Settled => {}
+                    state => {
+                        debug_fatal!("Unexpected entry state at block ack: {:?}", state);
+                    }
+                }
+            }
+            if num_txs > 0 || !proposed.is_empty() {
+                debug!(
+                    %block_ref,
+                    entries = proposed.len(),
+                    transactions = num_txs,
+                    "Transactions submitted to consensus in proposed block",
+                );
+            }
+            if !proposed.is_empty() {
+                inner.inflight.insert(
+                    block_ref,
+                    ProposedBlock {
+                        sequenced: false,
+                        entries: proposed,
+                    },
+                );
+            }
+        }
+        deliver(notifications);
+    }
+}
+
+impl Drop for StagedBatch {
+    fn drop(&mut self) {
+        let Some(entries) = self.entries.take() else {
+            return;
+        };
+        let mut inner = self.inner.lock();
+        for entry in entries {
+            if matches!(entry.mutable.lock().state, EntryState::Staged) {
+                inner.requeue_entry(entry);
+            }
+        }
+        inner.publish_gauges(&self.metrics);
+    }
+}
+
+/// Long-lived handle to the current epoch's pool. Carries the sui-core-facing entry
+/// points; rotated at reconfiguration.
+#[derive(Clone)]
+pub struct TransactionPoolContext {
+    inner: Arc<TransactionPoolContextInner>,
+}
+
+struct TransactionPoolContextInner {
+    checkpoint_store: Arc<CheckpointStore>,
+    capacity: usize,
+    max_pending_transactions: usize,
+    metrics: Arc<TransactionPoolMetrics>,
+    current: ArcSwap<SuiTransactionPool>,
+}
+
+impl TransactionPoolContext {
+    pub fn new(
+        checkpoint_store: Arc<CheckpointStore>,
+        max_pending_transactions: usize,
+        metrics: Arc<TransactionPoolMetrics>,
+        epoch_store: Arc<AuthorityPerEpochStore>,
+    ) -> Self {
+        // Pending capacity absorbs the full stream (there is no bypass), so it
+        // defaults to the full inflight budget; total resident transactions are
+        // bounded by 2x max_pending_transactions.
+        let capacity = max_pending_transactions;
+        let pool = SuiTransactionPool::new(
+            epoch_store,
+            capacity,
+            max_pending_transactions,
+            metrics.clone(),
+        );
+        Self {
+            inner: Arc::new(TransactionPoolContextInner {
+                checkpoint_store,
+                capacity,
+                max_pending_transactions,
+                metrics,
+                current: ArcSwap::new(pool),
+            }),
+        }
+    }
+
+    /// The current epoch's pool; handed to consensus at epoch start and registered on
+    /// the epoch store for settle callbacks.
+    pub fn current_pool(&self) -> Arc<SuiTransactionPool> {
+        self.inner.current.load_full()
+    }
+
+    /// Shuts down the old epoch's pool (failing all waiters with
+    /// `ValidatorHaltedAtEpochEnd`) and swaps in a fresh pool bound to the new epoch.
+    /// Returns the new pool for handing to consensus.
+    pub fn rotate_for_epoch(
+        &self,
+        epoch_store: Arc<AuthorityPerEpochStore>,
+    ) -> Arc<SuiTransactionPool> {
+        let new_pool = SuiTransactionPool::new(
+            epoch_store,
+            self.inner.capacity,
+            self.inner.max_pending_transactions,
+            self.inner.metrics.clone(),
+        );
+        let old_pool = self.inner.current.swap(new_pool.clone());
+        if !Arc::ptr_eq(&old_pool, &new_pool) {
+            old_pool.shutdown();
+        }
+        new_pool
+    }
+
+    /// Submits user transactions (or a ping when `transactions` is empty) and returns
+    /// a receiver for their consensus positions, plus whether the submission created a
+    /// new pool entry (false is tallied as spam weight by the RPC layer).
+    ///
+    /// A `TransactionProcessing` error means the outcome is already known via
+    /// consensus output or checkpoint state; it is retriable per transaction.
+    pub fn submit_for_positions(
+        &self,
+        gas_price: u64,
+        transactions: Vec<ConsensusTransaction>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        submitter_client_addr: Option<IpAddr>,
+    ) -> SuiResult<(oneshot::Receiver<SuiResult<Vec<ConsensusPosition>>>, bool)> {
+        let pool = self.current_pool();
+        if pool.epoch() != epoch_store.epoch() {
+            return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
+        }
+
+        // Hold the reconfiguration read lock across the insert so no user transaction
+        // enters the pool after user certs close.
+        let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
+        if !reconfiguration_lock.should_accept_user_certs() {
+            self.inner
+                .metrics
+                .num_rejected_cert_in_epoch_boundary
+                .inc();
+            return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
+        }
+
+        // Answer early when the outcome is already known via consensus output or
+        // checkpoint state, instead of (re)submitting.
+        if !transactions.is_empty()
+            && let Some(status) = check_already_processed(
+                &transactions,
+                epoch_store,
+                &self.inner.checkpoint_store,
+                &self.inner.metrics,
+            )
+        {
+            let digest = transactions
+                .iter()
+                .find_map(|t| t.kind.as_user_transaction().map(|tx| *tx.digest()))
+                .unwrap_or_default();
+            return Err(SuiErrorKind::TransactionProcessing {
+                digest,
+                status: status.to_string(),
+            }
+            .into());
+        }
+
+        pool.submit_user_transactions(gas_price, transactions, submitter_client_addr)
+    }
+
+    /// Submits user transactions and awaits their consensus positions. Same contract
+    /// as `ConsensusAdapter::submit_and_get_positions`.
+    pub async fn submit_and_get_positions(
+        &self,
+        transactions: Vec<ConsensusTransaction>,
+        gas_price: u64,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        submitter_client_addr: Option<IpAddr>,
+    ) -> SuiResult<Vec<ConsensusPosition>> {
+        let _timer = self.inner.metrics.consensus_latency.start_timer();
+        let (rx, _newly_inserted) =
+            self.submit_for_positions(gas_price, transactions, epoch_store, submitter_client_addr)?;
+        rx.await.map_err(|e| {
+            SuiError::from(SuiErrorKind::FailedToSubmitToConsensus(format!(
+                "Failed to get consensus position: {e}"
+            )))
+        })?
+    }
+
+    /// Crash recovery: resubmit EndOfPublish if the node restarted after closing user
+    /// certs but before the message landed.
+    pub fn recover_end_of_publish(
+        &self,
+        authority: AuthorityName,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) {
+        if epoch_store.should_send_end_of_publish() {
+            let transaction = ConsensusTransaction::new_end_of_publish(authority);
+            if let Err(e) = self.submit_to_consensus(&[transaction], epoch_store) {
+                warn!("Failed to recover EndOfPublish submission: {e}");
+            }
+        }
+    }
+}
+
+impl SubmitToConsensus for TransactionPoolContext {
+    fn submit_to_consensus(
+        &self,
+        transactions: &[ConsensusTransaction],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        let pool = self.current_pool();
+        if pool.epoch() != epoch_store.epoch() {
+            return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
+        }
+        for transaction in transactions {
+            // Answer early: system messages get no per-position statuses and their
+            // processed key is only recorded once, so an already-processed message
+            // must not enter the pool (it would never settle).
+            if check_already_processed(
+                std::slice::from_ref(transaction),
+                epoch_store,
+                &self.inner.checkpoint_store,
+                &self.inner.metrics,
+            )
+            .is_some()
+            {
+                continue;
+            }
+            pool.submit_system_transaction(transaction.clone(), None)?;
+        }
+        Ok(())
+    }
+
+    fn submit_best_effort(
+        &self,
+        transaction: &ConsensusTransaction,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        timeout: Duration,
+    ) -> SuiResult {
+        if transaction.is_user_transaction() {
+            return Err(SuiErrorKind::UnsupportedFeatureError {
+                error: "submit_best_effort does not accept user transactions".to_string(),
+            }
+            .into());
+        }
+        let pool = self.current_pool();
+        if pool.epoch() != epoch_store.epoch() {
+            return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
+        }
+        if check_already_processed(
+            std::slice::from_ref(transaction),
+            epoch_store,
+            &self.inner.checkpoint_store,
+            &self.inner.metrics,
+        )
+        .is_some()
+        {
+            return Ok(());
+        }
+        pool.submit_system_transaction(transaction.clone(), Some(Instant::now() + timeout))
+    }
+}
+
+/// Synchronous already-processed check against consensus-processed keys,
+/// checkpoint-executed digests and synced checkpoint sequence numbers. Returns the
+/// processed method when every transaction of the group is covered.
+fn check_already_processed(
+    transactions: &[ConsensusTransaction],
+    epoch_store: &Arc<AuthorityPerEpochStore>,
+    checkpoint_store: &Arc<CheckpointStore>,
+    metrics: &TransactionPoolMetrics,
+) -> Option<&'static str> {
+    let mut seen_checkpoint = false;
+    for transaction in transactions {
+        let key = transaction.key();
+        if epoch_store
+            .is_consensus_message_processed(&SequencedConsensusTransactionKey::External(
+                key.clone(),
+            ))
+            .expect("Storage error when checking consensus message processed")
+        {
+            metrics
+                .sequencing_certificate_processed
+                .with_label_values(&["consensus"])
+                .inc();
+            continue;
+        }
+        if let ConsensusTransactionKey::Certificate(digest) = &key
+            && epoch_store
+                .is_transaction_executed_in_checkpoint(digest)
+                .expect("Storage error when checking transaction executed in checkpoint")
+        {
+            metrics
+                .sequencing_certificate_processed
+                .with_label_values(&["checkpoint"])
+                .inc();
+            seen_checkpoint = true;
+            continue;
+        }
+        if let ConsensusTransactionKey::CheckpointSignature(_, seq)
+        | ConsensusTransactionKey::CheckpointSignatureV2(_, seq, _) = &key
+            && let Some(synced_seq) = checkpoint_store
+                .get_highest_synced_checkpoint_seq_number()
+                .expect("Storage error when reading highest synced checkpoint")
+            && synced_seq >= *seq
+        {
+            metrics
+                .sequencing_certificate_processed
+                .with_label_values(&["synced_checkpoint"])
+                .inc();
+            seen_checkpoint = true;
+            continue;
+        }
+        return None;
+    }
+    if seen_checkpoint {
+        Some("processed via checkpoint")
+    } else {
+        Some("processed via consensus")
+    }
+}

--- a/crates/sui-core/src/transaction_pool.rs
+++ b/crates/sui-core/src/transaction_pool.rs
@@ -47,6 +47,10 @@ use crate::consensus_adapter::{ConsensusAdapterMetrics, SubmitToConsensus};
 use crate::consensus_handler::{SequencedConsensusTransactionKey, classify};
 use crate::epoch::reconfiguration::ReconfigurationInitiator;
 
+#[cfg(test)]
+#[path = "unit_tests/transaction_pool_tests.rs"]
+mod transaction_pool_tests;
+
 /// A sequenced own block whose entries have not fully settled after this many rounds
 /// past its round indicates missed settle coverage; the defensive sweep reaps it.
 const SWEEP_GRACE_ROUNDS: Round = 100;
@@ -868,7 +872,7 @@ impl SuiTransactionPool {
     /// per-position status. This is the sole settle signal for vote-rejected
     /// transactions and for certs-closed / post-EndOfPublish drops, which are never
     /// marked consensus-message-processed.
-    pub fn note_statuses(&self, updates: &[(ConsensusPosition, ConsensusTxStatus)]) {
+    pub(crate) fn note_statuses(&self, updates: &[(ConsensusPosition, ConsensusTxStatus)]) {
         let mut notifications = Notifications::new();
         {
             let mut inner = self.inner.lock();

--- a/crates/sui-core/src/transaction_pool.rs
+++ b/crates/sui-core/src/transaction_pool.rs
@@ -52,8 +52,10 @@ use crate::epoch::reconfiguration::ReconfigurationInitiator;
 mod transaction_pool_tests;
 
 /// A sequenced own block whose entries have not fully settled after this many rounds
-/// past its round indicates missed settle coverage; the defensive sweep reaps it.
-const SWEEP_GRACE_ROUNDS: Round = 100;
+/// past its round is reaped by the defensive sweep. Kept below the status cache's
+/// 400-round retention, but generous enough for legitimately slow terminal signals
+/// (e.g. congestion-deferred transactions).
+const SWEEP_GRACE_ROUNDS: Round = 300;
 
 /// Metrics for the transaction pool. Reuses the already-registered
 /// `ConsensusAdapterMetrics` series (prometheus handles are cheap clones sharing the
@@ -531,7 +533,15 @@ impl PoolInner {
 /// commit handler and checkpoint executor via the epoch store.
 pub struct SuiTransactionPool {
     epoch: EpochId,
-    epoch_store: Arc<AuthorityPerEpochStore>,
+    /// Weak: the epoch store (indirectly, via the randomness manager it owns) holds
+    /// the pool context, which holds this pool. A strong reference here would create
+    /// a cycle that keeps the epoch store — and everything it pins — alive forever.
+    epoch_store: std::sync::Weak<AuthorityPerEpochStore>,
+    /// Cached per-epoch constants, so the hot paths don't need the epoch store.
+    reference_gas_price: u64,
+    max_transaction_size_bytes: u64,
+    max_transactions_in_block_bytes: u64,
+    max_num_transactions_in_block: u64,
     /// `pending` user-transaction capacity: the gas auction bound.
     capacity: usize,
     /// Inflight user-transaction budget: `take` stops filling blocks with user
@@ -549,9 +559,14 @@ impl SuiTransactionPool {
         metrics: Arc<TransactionPoolMetrics>,
     ) -> Arc<Self> {
         assert!(capacity > 0);
+        let protocol_config = epoch_store.protocol_config();
         Arc::new(Self {
             epoch: epoch_store.epoch(),
-            epoch_store,
+            reference_gas_price: epoch_store.reference_gas_price(),
+            max_transaction_size_bytes: protocol_config.max_transaction_size_bytes(),
+            max_transactions_in_block_bytes: protocol_config.max_transactions_in_block_bytes(),
+            max_num_transactions_in_block: protocol_config.max_num_transactions_in_block(),
+            epoch_store: Arc::downgrade(&epoch_store),
             capacity,
             max_pending_transactions,
             inner: Arc::new(Mutex::new(PoolInner {
@@ -627,8 +642,9 @@ impl SuiTransactionPool {
         };
         if matches!(transaction.kind, ConsensusTransactionKind::EndOfPublish(..)) {
             info!(epoch = ?self.epoch, "Submitting EndOfPublish message to consensus");
-            self.epoch_store
-                .record_epoch_pending_certs_process_time_metric();
+            if let Some(epoch_store) = self.epoch_store.upgrade() {
+                epoch_store.record_epoch_pending_certs_process_time_metric();
+            }
         }
         self.submit_entry(kind, 0, vec![transaction], None, None)?;
         Ok(())
@@ -655,6 +671,36 @@ impl SuiTransactionPool {
             _ => classify(&transactions[0]),
         };
         let num_txs = transactions.len();
+
+        // Enforce consensus size limits at admission (as TransactionClient::submit does
+        // today): an entry that cannot fit in a block would otherwise wedge the head of
+        // the take order forever.
+        if num_txs as u64 > self.max_num_transactions_in_block {
+            return Err(SuiErrorKind::FailedToSubmitToConsensus(format!(
+                "transaction bundle count {} exceeds block limit {}",
+                num_txs, self.max_num_transactions_in_block
+            ))
+            .into());
+        }
+        let mut bundle_bytes = 0u64;
+        for bytes in &serialized {
+            if bytes.len() as u64 > self.max_transaction_size_bytes {
+                return Err(SuiErrorKind::FailedToSubmitToConsensus(format!(
+                    "transaction size {}B exceeds limit {}B",
+                    bytes.len(),
+                    self.max_transaction_size_bytes
+                ))
+                .into());
+            }
+            bundle_bytes += bytes.len() as u64;
+        }
+        if bundle_bytes > self.max_transactions_in_block_bytes {
+            return Err(SuiErrorKind::FailedToSubmitToConsensus(format!(
+                "transaction bundle size {}B exceeds block limit {}B",
+                bundle_bytes, self.max_transactions_in_block_bytes
+            ))
+            .into());
+        }
 
         let mut notifications = Notifications::new();
         let mut record_dos_for_coalesced: Option<Arc<PoolEntry>> = None;
@@ -817,16 +863,21 @@ impl SuiTransactionPool {
         if !entry.kind.is_user() {
             return;
         }
-        let rgp = self.epoch_store.reference_gas_price().max(1);
+        let Some(epoch_store) = self.epoch_store.upgrade() else {
+            return;
+        };
+        let rgp = self.reference_gas_price.max(1);
         for tx in &entry.transactions {
             let Some(user_tx) = tx.kind.as_user_transaction() else {
                 continue;
             };
             let amplification_factor = (user_tx.transaction_data().gas_price() / rgp).max(1);
             for addr in addrs {
-                self.epoch_store
-                    .submitted_transaction_cache
-                    .record_submitted_tx(user_tx.digest(), amplification_factor as u32, *addr);
+                epoch_store.submitted_transaction_cache.record_submitted_tx(
+                    user_tx.digest(),
+                    amplification_factor as u32,
+                    *addr,
+                );
             }
         }
     }
@@ -1146,18 +1197,17 @@ impl TransactionPool for SuiTransactionPool {
                         inner.inflight.insert(block_ref, block);
                         continue;
                     }
-                    // A sequenced block's transactions must all have received status
-                    // or processed signals by now; a leftover indicates missed settle
-                    // coverage. Degrade to a metric and a warning instead of leaking.
-                    debug_fatal!(
-                        "Unsettled entries in sequenced block {} far below gc round {}",
-                        block_ref,
-                        gc_round
-                    );
+                    // A sequenced block's transactions should have received status or
+                    // processed signals by now. Legitimate stragglers exist (e.g.
+                    // congestion-deferred transactions whose terminal status arrives
+                    // commits later), so sweep with a warning rather than treating this
+                    // as fatal — an early settle costs only accounting, never
+                    // correctness.
                     for entry in unsettled {
                         warn!(
                             keys = ?entry.keys,
                             %block_ref,
+                            gc_round,
                             "Sweeping unsettled entry in sequenced block",
                         );
                         inner.finish_entry(

--- a/crates/sui-core/src/transaction_pool.rs
+++ b/crates/sui-core/src/transaction_pool.rs
@@ -18,7 +18,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
-use consensus_core::{LimitReached, TransactionPool};
+use consensus_core::LimitReached;
+// Re-exported so downstream crates (e.g. sui-node) can name the consensus-facing trait
+// without a direct consensus-core dependency.
+pub use consensus_core::TransactionPool;
 use consensus_types::block::{BlockRef, Round, TransactionIndex};
 use mysten_common::debug_fatal;
 use parking_lot::Mutex;
@@ -42,6 +45,7 @@ use crate::authority::consensus_tx_status_cache::ConsensusTxStatus;
 use crate::checkpoints::CheckpointStore;
 use crate::consensus_adapter::{ConsensusAdapterMetrics, SubmitToConsensus};
 use crate::consensus_handler::{SequencedConsensusTransactionKey, classify};
+use crate::epoch::reconfiguration::ReconfigurationInitiator;
 
 /// A sequenced own block whose entries have not fully settled after this many rounds
 /// past its round indicates missed settle coverage; the defensive sweep reaps it.
@@ -1314,6 +1318,7 @@ pub struct TransactionPoolContext {
 
 struct TransactionPoolContextInner {
     checkpoint_store: Arc<CheckpointStore>,
+    authority: AuthorityName,
     capacity: usize,
     max_pending_transactions: usize,
     metrics: Arc<TransactionPoolMetrics>,
@@ -1323,6 +1328,7 @@ struct TransactionPoolContextInner {
 impl TransactionPoolContext {
     pub fn new(
         checkpoint_store: Arc<CheckpointStore>,
+        authority: AuthorityName,
         max_pending_transactions: usize,
         metrics: Arc<TransactionPoolMetrics>,
         epoch_store: Arc<AuthorityPerEpochStore>,
@@ -1340,6 +1346,7 @@ impl TransactionPoolContext {
         Self {
             inner: Arc::new(TransactionPoolContextInner {
                 checkpoint_store,
+                authority,
                 capacity,
                 max_pending_transactions,
                 metrics,
@@ -1448,15 +1455,32 @@ impl TransactionPoolContext {
 
     /// Crash recovery: resubmit EndOfPublish if the node restarted after closing user
     /// certs but before the message landed.
-    pub fn recover_end_of_publish(
-        &self,
-        authority: AuthorityName,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) {
+    pub fn recover_end_of_publish(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         if epoch_store.should_send_end_of_publish() {
-            let transaction = ConsensusTransaction::new_end_of_publish(authority);
+            let transaction = ConsensusTransaction::new_end_of_publish(self.inner.authority);
             if let Err(e) = self.submit_to_consensus(&[transaction], epoch_store) {
                 warn!("Failed to recover EndOfPublish submission: {e}");
+            }
+        }
+    }
+}
+
+impl ReconfigurationInitiator for TransactionPoolContext {
+    /// Begins reconfiguration: sets reconfig state to reject new user transactions,
+    /// then submits EndOfPublish.
+    fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
+        {
+            let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
+            if !reconfig_guard.should_accept_user_certs() {
+                // Allow caller to call this method multiple times
+                return;
+            }
+            epoch_store.close_user_certs(reconfig_guard);
+        }
+        if epoch_store.should_send_end_of_publish() {
+            let transaction = ConsensusTransaction::new_end_of_publish(self.inner.authority);
+            if let Err(err) = self.submit_to_consensus(&[transaction], epoch_store) {
+                warn!("Error when sending end of publish message: {:?}", err);
             }
         }
     }

--- a/crates/sui-core/src/transaction_pool.rs
+++ b/crates/sui-core/src/transaction_pool.rs
@@ -184,7 +184,9 @@ enum EntryKind {
     System,
     /// One-shot system submission: dropped instead of taken past the deadline, and
     /// dropped instead of re-queued on garbage collection.
-    BestEffort { deadline: Instant },
+    BestEffort {
+        deadline: Instant,
+    },
     /// Payload-less entry acknowledged with a ping position at the next proposed block.
     Ping,
 }
@@ -732,8 +734,7 @@ impl SuiTransactionPool {
                         }
                         _ => {
                             self.metrics.pool_rejections.inc();
-                            let min_gas_price =
-                                victim.map(|v| v.gas_price).unwrap_or(gas_price);
+                            let min_gas_price = victim.map(|v| v.gas_price).unwrap_or(gas_price);
                             info!(
                                 ?keys,
                                 gas_price,
@@ -1250,8 +1251,7 @@ impl StagedBatch {
                         };
                         let waiters = std::mem::take(&mut m.waiters);
                         drop(m);
-                        let positions: Vec<_> = (0..entry.num_transactions()
-                            as TransactionIndex)
+                        let positions: Vec<_> = (0..entry.num_transactions() as TransactionIndex)
                             .map(|i| ConsensusPosition {
                                 epoch: self.epoch,
                                 block: block_ref,
@@ -1407,10 +1407,7 @@ impl TransactionPoolContext {
         // enters the pool after user certs close.
         let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
         if !reconfiguration_lock.should_accept_user_certs() {
-            self.inner
-                .metrics
-                .num_rejected_cert_in_epoch_boundary
-                .inc();
+            self.inner.metrics.num_rejected_cert_in_epoch_boundary.inc();
             return Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into());
         }
 

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -103,6 +103,7 @@ async fn test_consensus_manager() {
                     SuiTxValidatorMetrics::new(&Registry::new()),
                 ),
                 None,
+                None,
             )
             .await;
 
@@ -184,6 +185,7 @@ async fn test_consensus_manager_address_update() {
                 SuiTxValidatorMetrics::new(&Registry::new()),
             ),
             None,
+            None,
         )
         .await;
 
@@ -248,6 +250,7 @@ async fn test_consensus_manager_address_update() {
                 Arc::new(CheckpointServiceNoop {}),
                 SuiTxValidatorMetrics::new(&Registry::new()),
             ),
+            None,
             None,
         )
         .await;

--- a/crates/sui-core/src/unit_tests/consensus_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/consensus_test_utils.rs
@@ -358,7 +358,7 @@ where
         epoch_store.clone(),
         checkpoint_service,
         execution_scheduler_sender,
-        consensus_adapter,
+        Arc::new(consensus_adapter),
         authority.get_object_cache_reader().clone(),
         consensus_committee,
         metrics,

--- a/crates/sui-core/src/unit_tests/transaction_pool_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_pool_tests.rs
@@ -1,0 +1,683 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::authority::AuthorityState;
+use crate::authority::authority_tests::init_state_with_objects;
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::consensus_adapter::consensus_tests::{test_gas_objects, test_user_transactions};
+use consensus_types::block::PING_TRANSACTION_INDEX;
+use fastcrypto::traits::KeyPair;
+use sui_types::crypto::{AuthorityKeyPair, get_key_pair};
+use sui_types::object::Object;
+
+async fn make_pool(
+    capacity: usize,
+    max_pending: usize,
+) -> (Arc<SuiTransactionPool>, Arc<AuthorityState>) {
+    let state = TestAuthorityBuilder::new().build().await;
+    let epoch_store = state.epoch_store_for_testing().clone();
+    let pool = SuiTransactionPool::new(
+        epoch_store,
+        capacity,
+        max_pending,
+        TransactionPoolMetrics::new_for_tests(),
+    );
+    (pool, state)
+}
+
+/// A distinct consensus transaction per call (EndOfPublish keyed by a fresh authority
+/// name). Used as a stand-in payload for both user- and system-classed entries; entry
+/// class comes from the submission API, not the payload.
+fn make_tx() -> ConsensusTransaction {
+    let (_, key_pair): (_, AuthorityKeyPair) = get_key_pair();
+    ConsensusTransaction::new_end_of_publish(key_pair.public().into())
+}
+
+fn tx_bytes(tx: &ConsensusTransaction) -> Vec<u8> {
+    bcs::to_bytes(tx).unwrap()
+}
+
+fn block_ref(round: Round) -> BlockRef {
+    BlockRef {
+        author: consensus_config::AuthorityIndex::ZERO,
+        round,
+        digest: Default::default(),
+    }
+}
+
+fn position(round: Round, index: TransactionIndex) -> ConsensusPosition {
+    ConsensusPosition {
+        epoch: 0,
+        block: block_ref(round),
+        index,
+    }
+}
+
+fn processed_key(tx: &ConsensusTransaction) -> SequencedConsensusTransactionKey {
+    SequencedConsensusTransactionKey::External(tx.key())
+}
+
+#[test]
+fn test_pool_key_ordering() {
+    let key = |class, price, seq| PoolKey {
+        class,
+        price: Reverse(price),
+        seq,
+    };
+    // System entries sort before any user entry, regardless of price or age.
+    assert!(key(PriorityClass::System, 0, 100) < key(PriorityClass::User, u64::MAX, 0));
+    // Higher gas price first.
+    assert!(key(PriorityClass::User, 300, 7) < key(PriorityClass::User, 200, 1));
+    // FIFO within a price level.
+    assert!(key(PriorityClass::User, 300, 1) < key(PriorityClass::User, 300, 2));
+}
+
+#[tokio::test]
+async fn test_take_order_system_first_then_gas_price_fifo() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let (u100, u300a, u200, u300b, sys) = (make_tx(), make_tx(), make_tx(), make_tx(), make_tx());
+    pool.submit_user_transactions(100, vec![u100.clone()], None)
+        .unwrap();
+    pool.submit_user_transactions(300, vec![u300a.clone()], None)
+        .unwrap();
+    pool.submit_user_transactions(200, vec![u200.clone()], None)
+        .unwrap();
+    pool.submit_user_transactions(300, vec![u300b.clone()], None)
+        .unwrap();
+    pool.submit_system_transaction(sys.clone(), None).unwrap();
+
+    let (transactions, _ack, limit) = pool.take(100, usize::MAX);
+    assert_eq!(limit, LimitReached::AllTransactionsIncluded);
+    let taken: Vec<_> = transactions.iter().map(|t| t.data().to_vec()).collect();
+    let expected: Vec<_> = [&sys, &u300a, &u300b, &u200, &u100]
+        .iter()
+        .map(|t| tx_bytes(t))
+        .collect();
+    assert_eq!(taken, expected);
+}
+
+#[tokio::test]
+async fn test_take_respects_max_count_and_bundle_atomicity() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let bundle: Vec<_> = (0..3).map(|_| make_tx()).collect();
+    pool.submit_user_transactions(200, bundle, None).unwrap();
+    pool.submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+
+    // The 3-tx bundle doesn't fit in 2 slots; take stops rather than splitting the
+    // bundle or skipping ahead past it.
+    let (transactions, _ack, limit) = pool.take(2, usize::MAX);
+    assert!(transactions.is_empty());
+    assert_eq!(limit, LimitReached::MaxNumOfTransactions);
+
+    let (transactions, _ack, limit) = pool.take(4, usize::MAX);
+    assert_eq!(transactions.len(), 4);
+    assert_eq!(limit, LimitReached::AllTransactionsIncluded);
+}
+
+#[tokio::test]
+async fn test_take_respects_max_bytes() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let (a, b) = (make_tx(), make_tx());
+    let a_size = tx_bytes(&a).len();
+    pool.submit_user_transactions(200, vec![a], None).unwrap();
+    pool.submit_user_transactions(100, vec![b], None).unwrap();
+
+    let (transactions, _ack, limit) = pool.take(100, a_size);
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(limit, LimitReached::MaxBytes);
+}
+
+#[tokio::test]
+async fn test_take_user_inflight_budget_and_system_exemption() {
+    // Inflight budget of 2 user transactions.
+    let (pool, _state) = make_pool(100, 2).await;
+    for price in [300, 200, 100] {
+        pool.submit_user_transactions(price, vec![make_tx()], None)
+            .unwrap();
+    }
+
+    let (transactions, ack, limit) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 2);
+    assert_eq!(limit, LimitReached::MaxNumOfTransactions);
+    ack(block_ref(1));
+    assert_eq!(pool.inflight_user_transactions(), 2);
+
+    // Budget exhausted: no user transactions are taken, but system entries are exempt.
+    pool.submit_system_transaction(make_tx(), None).unwrap();
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 1);
+
+    // Settling the proposed transactions frees the budget.
+    pool.note_statuses(&[
+        (position(1, 0), ConsensusTxStatus::Finalized),
+        (position(1, 1), ConsensusTxStatus::Finalized),
+    ]);
+    assert_eq!(pool.inflight_user_transactions(), 0);
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 1);
+}
+
+#[tokio::test]
+async fn test_ack_assigns_positions_and_notifies_waiters() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let (rx_single, _) = pool
+        .submit_user_transactions(300, vec![make_tx()], None)
+        .unwrap();
+    let (rx_bundle, _) = pool
+        .submit_user_transactions(200, vec![make_tx(), make_tx()], None)
+        .unwrap();
+
+    let (_transactions, ack, _) = pool.take(100, usize::MAX);
+    ack(block_ref(5));
+
+    assert_eq!(rx_single.await.unwrap().unwrap(), vec![position(5, 0)]);
+    assert_eq!(
+        rx_bundle.await.unwrap().unwrap(),
+        vec![position(5, 1), position(5, 2)]
+    );
+}
+
+#[tokio::test]
+async fn test_dropped_ack_returns_entries_to_pending() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let (mut rx, _) = pool
+        .submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+
+    let (transactions, ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(pool.pending_user_transactions(), 0);
+    drop(ack);
+
+    // The entry is back in pending with its waiter intact, and can be taken again.
+    assert_eq!(pool.pending_user_transactions(), 1);
+    assert!(rx.try_recv().is_err());
+    let (transactions, ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 1);
+    ack(block_ref(1));
+    assert_eq!(rx.await.unwrap().unwrap(), vec![position(1, 0)]);
+}
+
+#[tokio::test]
+async fn test_eviction_when_full() {
+    let (pool, _state) = make_pool(2, 100).await;
+    let (rx_low, _) = pool
+        .submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+    pool.submit_user_transactions(200, vec![make_tx()], None)
+        .unwrap();
+
+    // Evicts the lowest-priced entry; its waiter gets an explicit outbid error
+    // carrying the evicting price.
+    pool.submit_user_transactions(300, vec![make_tx()], None)
+        .unwrap();
+    assert_eq!(pool.pending_user_transactions(), 2);
+    let err = rx_low.await.unwrap().unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: 300 }
+    ));
+}
+
+#[tokio::test]
+async fn test_rejection_when_full_and_price_too_low() {
+    let (pool, _state) = make_pool(2, 100).await;
+    pool.submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+    pool.submit_user_transactions(200, vec![make_tx()], None)
+        .unwrap();
+
+    // Strictly lower price: rejected with the current minimum.
+    let err = pool
+        .submit_user_transactions(50, vec![make_tx()], None)
+        .unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: 100 }
+    ));
+
+    // Equal price does not evict.
+    let err = pool
+        .submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: 100 }
+    ));
+    assert_eq!(pool.pending_user_transactions(), 2);
+}
+
+#[tokio::test]
+async fn test_gasless_evicted_first() {
+    let (pool, _state) = make_pool(2, 100).await;
+    let (rx_gasless, _) = pool
+        .submit_user_transactions(0, vec![make_tx()], None)
+        .unwrap();
+    pool.submit_user_transactions(1000, vec![make_tx()], None)
+        .unwrap();
+
+    pool.submit_user_transactions(2000, vec![make_tx()], None)
+        .unwrap();
+    let err = rx_gasless.await.unwrap().unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TransactionRejectedDueToOutbiddingDuringCongestion { .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_system_entries_never_evicted_and_capacity_exempt() {
+    let (pool, _state) = make_pool(1, 100).await;
+    pool.submit_system_transaction(make_tx(), None).unwrap();
+    pool.submit_system_transaction(make_tx(), None).unwrap();
+    // Capacity 1 counts user transactions only.
+    pool.submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+    assert_eq!(pool.pending_user_transactions(), 1);
+
+    // A higher-priced user transaction can only evict the user entry, never the
+    // system entries.
+    pool.submit_user_transactions(200, vec![make_tx()], None)
+        .unwrap();
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 3);
+}
+
+#[tokio::test]
+async fn test_duplicate_coalesces_onto_entry() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let tx = make_tx();
+    let (rx1, newly1) = pool
+        .submit_user_transactions(100, vec![tx.clone()], None)
+        .unwrap();
+    let (rx2, newly2) = pool
+        .submit_user_transactions(100, vec![tx.clone()], None)
+        .unwrap();
+    assert!(newly1);
+    assert!(!newly2);
+    // One entry, not two.
+    assert_eq!(pool.pending_user_transactions(), 1);
+
+    let (transactions, ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 1);
+    ack(block_ref(2));
+
+    // Both waiters share the same position.
+    assert_eq!(rx1.await.unwrap().unwrap(), vec![position(2, 0)]);
+    assert_eq!(rx2.await.unwrap().unwrap(), vec![position(2, 0)]);
+}
+
+#[tokio::test]
+async fn test_duplicate_of_proposed_entry_gets_position_immediately() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let tx = make_tx();
+    pool.submit_user_transactions(100, vec![tx.clone()], None)
+        .unwrap();
+    let (_transactions, ack, _) = pool.take(100, usize::MAX);
+    ack(block_ref(3));
+
+    let (rx, newly) = pool
+        .submit_user_transactions(100, vec![tx.clone()], None)
+        .unwrap();
+    assert!(!newly);
+    assert_eq!(rx.await.unwrap().unwrap(), vec![position(3, 0)]);
+}
+
+#[tokio::test]
+async fn test_partial_bundle_overlap_admitted_as_separate_entry() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let (a, b) = (make_tx(), make_tx());
+    let (_rx1, newly1) = pool
+        .submit_user_transactions(100, vec![a.clone()], None)
+        .unwrap();
+    assert!(newly1);
+    // A bundle sharing a key with an existing entry cannot coalesce (key sets don't
+    // match exactly); it is admitted alongside, flagged as a duplicate.
+    let (_rx2, newly2) = pool
+        .submit_user_transactions(100, vec![a.clone(), b.clone()], None)
+        .unwrap();
+    assert!(!newly2);
+    assert_eq!(pool.pending_user_transactions(), 3);
+}
+
+#[tokio::test]
+async fn test_note_processed_settles_pending_with_retriable_error() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let tx = make_tx();
+    let (rx, _) = pool
+        .submit_user_transactions(100, vec![tx.clone()], None)
+        .unwrap();
+
+    // The transaction was observed processed (e.g. committed from another validator's
+    // block) before ever being proposed here: the waiter is answered early and the
+    // entry never reaches consensus.
+    pool.note_processed(std::iter::once(&processed_key(&tx)));
+    let err = rx.await.unwrap().unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TransactionProcessing { .. }
+    ));
+    assert_eq!(pool.pending_user_transactions(), 0);
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert!(transactions.is_empty());
+}
+
+#[tokio::test]
+async fn test_note_processed_settles_proposed_entry() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let tx = make_tx();
+    let (rx, _) = pool
+        .submit_user_transactions(100, vec![tx.clone()], None)
+        .unwrap();
+    let (_transactions, ack, _) = pool.take(100, usize::MAX);
+    ack(block_ref(1));
+    assert_eq!(rx.await.unwrap().unwrap(), vec![position(1, 0)]);
+    assert_eq!(pool.inflight_user_transactions(), 1);
+
+    pool.note_processed(std::iter::once(&processed_key(&tx)));
+    assert_eq!(pool.inflight_user_transactions(), 0);
+}
+
+#[tokio::test]
+async fn test_note_statuses_settles_only_matching_position() {
+    let (pool, _state) = make_pool(100, 100).await;
+    pool.submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+    let (_transactions, ack, _) = pool.take(100, usize::MAX);
+    ack(block_ref(7));
+
+    // A status for the same index in a different block (e.g. the same digest
+    // submitted by another validator) must not settle this entry.
+    pool.note_statuses(&[(position(8, 0), ConsensusTxStatus::Finalized)]);
+    assert_eq!(pool.inflight_user_transactions(), 1);
+
+    // Vote-rejected transactions settle solely via their position status.
+    pool.note_statuses(&[(position(7, 0), ConsensusTxStatus::Rejected)]);
+    assert_eq!(pool.inflight_user_transactions(), 0);
+}
+
+#[tokio::test]
+async fn test_bundle_settles_when_all_transactions_settle() {
+    let (pool, _state) = make_pool(100, 100).await;
+    pool.submit_user_transactions(100, vec![make_tx(), make_tx()], None)
+        .unwrap();
+    let (_transactions, ack, _) = pool.take(100, usize::MAX);
+    ack(block_ref(1));
+
+    // Partial settlement keeps the entry (and its inflight accounting) alive.
+    pool.note_statuses(&[(position(1, 0), ConsensusTxStatus::Finalized)]);
+    assert_eq!(pool.inflight_user_transactions(), 2);
+    pool.note_statuses(&[(position(1, 1), ConsensusTxStatus::Dropped)]);
+    assert_eq!(pool.inflight_user_transactions(), 0);
+}
+
+#[tokio::test]
+async fn test_gc_requeues_system_and_drops_user_entries() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let sys = make_tx();
+    pool.submit_system_transaction(sys.clone(), None).unwrap();
+    pool.submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+    let (transactions, ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 2);
+    ack(block_ref(3));
+
+    // The block was garbage collected: the system entry requeues, the user entry is
+    // dropped (its client resolves via WaitForEffects position expiry and resubmits).
+    pool.notify_committed(vec![], 3);
+    assert_eq!(pool.inflight_user_transactions(), 0);
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    let taken: Vec<_> = transactions.iter().map(|t| t.data().to_vec()).collect();
+    assert_eq!(taken, vec![tx_bytes(&sys)]);
+}
+
+#[tokio::test]
+async fn test_sequenced_block_is_not_garbage_collected() {
+    let (pool, _state) = make_pool(100, 100).await;
+    pool.submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+    let (_transactions, ack, _) = pool.take(100, usize::MAX);
+    ack(block_ref(3));
+
+    // The block committed: entries are retained awaiting their status callbacks even
+    // though the GC round has passed the block's round.
+    pool.notify_committed(vec![block_ref(3)], 3);
+    assert_eq!(pool.inflight_user_transactions(), 1);
+
+    pool.note_statuses(&[(position(3, 0), ConsensusTxStatus::Finalized)]);
+    assert_eq!(pool.inflight_user_transactions(), 0);
+}
+
+#[tokio::test]
+async fn test_best_effort_expires_instead_of_being_taken() {
+    let (pool, _state) = make_pool(100, 100).await;
+    pool.submit_system_transaction(make_tx(), Some(Instant::now() - Duration::from_millis(1)))
+        .unwrap();
+
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert!(transactions.is_empty());
+    // The expired entry was settled, not retained.
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert!(transactions.is_empty());
+}
+
+#[tokio::test]
+async fn test_best_effort_dropped_on_garbage_collection() {
+    let (pool, _state) = make_pool(100, 100).await;
+    pool.submit_system_transaction(make_tx(), Some(Instant::now() + Duration::from_secs(60)))
+        .unwrap();
+    let (transactions, ack, _) = pool.take(100, usize::MAX);
+    assert_eq!(transactions.len(), 1);
+    ack(block_ref(3));
+
+    // Unlike a regular system entry, a best-effort entry does not requeue after GC.
+    pool.notify_committed(vec![], 3);
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert!(transactions.is_empty());
+}
+
+#[tokio::test]
+async fn test_shutdown_fails_waiters_and_rejects_submissions() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let (rx_pending, _) = pool
+        .submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+    let (rx_proposed, _) = pool
+        .submit_user_transactions(200, vec![make_tx()], None)
+        .unwrap();
+    let tx3 = make_tx();
+    let (_transactions, ack, _) = pool.take(1, usize::MAX);
+    ack(block_ref(1));
+    // The proposed waiter already has its position.
+    assert!(rx_proposed.await.unwrap().is_ok());
+
+    pool.shutdown();
+    let err = rx_pending.await.unwrap().unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::ValidatorHaltedAtEpochEnd
+    ));
+    assert_eq!(pool.pending_user_transactions(), 0);
+    assert_eq!(pool.inflight_user_transactions(), 0);
+
+    let err = pool
+        .submit_user_transactions(100, vec![tx3], None)
+        .unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::ValidatorHaltedAtEpochEnd
+    ));
+    let (transactions, _ack, _) = pool.take(100, usize::MAX);
+    assert!(transactions.is_empty());
+}
+
+#[tokio::test]
+async fn test_ping_gets_position_at_next_block() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let (rx, _) = pool.submit_user_transactions(0, vec![], None).unwrap();
+
+    let (transactions, ack, _) = pool.take(100, usize::MAX);
+    // Pings contribute no transactions to the block.
+    assert!(transactions.is_empty());
+    ack(block_ref(2));
+
+    let positions = rx.await.unwrap().unwrap();
+    assert_eq!(positions, vec![ConsensusPosition::ping(0, block_ref(2))]);
+    assert_eq!(positions[0].index, PING_TRANSACTION_INDEX);
+}
+
+#[tokio::test]
+async fn test_context_rotate_shuts_down_old_pool() {
+    let state = TestAuthorityBuilder::new().build().await;
+    let epoch_store = state.epoch_store_for_testing().clone();
+    let context = TransactionPoolContext::new(
+        CheckpointStore::new_for_tests(),
+        state.name,
+        100,
+        TransactionPoolMetrics::new_for_tests(),
+        epoch_store.clone(),
+    );
+    let old_pool = context.current_pool();
+    let (rx, _) = old_pool
+        .submit_user_transactions(100, vec![make_tx()], None)
+        .unwrap();
+
+    let new_pool = context.rotate_for_epoch(epoch_store);
+    assert!(Arc::ptr_eq(&context.current_pool(), &new_pool));
+    assert!(!Arc::ptr_eq(&old_pool, &new_pool));
+    let err = rx.await.unwrap().unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::ValidatorHaltedAtEpochEnd
+    ));
+}
+
+#[tokio::test]
+async fn test_note_executed_in_checkpoint_settles_user_transaction() {
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let transaction = test_user_transactions(&state, shared_object)
+        .await
+        .pop()
+        .unwrap();
+    let digest = *transaction.tx().digest();
+    let consensus_tx =
+        ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+
+    let epoch_store = state.epoch_store_for_testing().clone();
+    let pool = SuiTransactionPool::new(
+        epoch_store,
+        100,
+        100,
+        TransactionPoolMetrics::new_for_tests(),
+    );
+    let (rx, _) = pool
+        .submit_user_transactions(1000, vec![consensus_tx], None)
+        .unwrap();
+
+    // The transaction executed via a certified checkpoint (e.g. state sync) — the
+    // waiter is answered with a retriable processing error carrying the digest.
+    pool.note_executed_in_checkpoint(&[digest]);
+    let err = rx.await.unwrap().unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TransactionProcessing { digest: d, .. } if *d == digest
+    ));
+    assert_eq!(pool.pending_user_transactions(), 0);
+}
+
+#[tokio::test]
+async fn test_context_suppresses_already_processed_submission() {
+    let mut objects = test_gas_objects();
+    let shared_object = Object::shared_for_testing();
+    objects.push(shared_object.clone());
+    let state = init_state_with_objects(objects).await;
+    let transaction = test_user_transactions(&state, shared_object)
+        .await
+        .pop()
+        .unwrap();
+    let digest = *transaction.tx().digest();
+    let consensus_tx =
+        ConsensusTransaction::new_user_transaction_v2_message(&state.name, transaction.into());
+
+    let epoch_store = state.epoch_store_for_testing().clone();
+    // Simulate the transaction already appearing in consensus output before this
+    // submission.
+    epoch_store.test_insert_user_signature(digest, vec![]);
+
+    let context = TransactionPoolContext::new(
+        CheckpointStore::new_for_tests(),
+        state.name,
+        100,
+        TransactionPoolMetrics::new_for_tests(),
+        epoch_store.clone(),
+    );
+    let err = context
+        .submit_for_positions(1000, vec![consensus_tx], &epoch_store, None)
+        .unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TransactionProcessing { digest: d, .. } if *d == digest
+    ));
+    // Nothing entered the pool.
+    assert_eq!(context.current_pool().pending_user_transactions(), 0);
+}
+
+#[tokio::test]
+async fn test_context_end_to_end_submit_and_get_positions() {
+    let state = TestAuthorityBuilder::new().build().await;
+    let epoch_store = state.epoch_store_for_testing().clone();
+    let context = TransactionPoolContext::new(
+        CheckpointStore::new_for_tests(),
+        state.name,
+        100,
+        TransactionPoolMetrics::new_for_tests(),
+        epoch_store.clone(),
+    );
+
+    // Drive the consensus side: propose a block as soon as the pool has content.
+    let pool = context.current_pool();
+    let driver = tokio::spawn(async move {
+        loop {
+            let (transactions, ack, _) = pool.take(100, usize::MAX);
+            if !transactions.is_empty() {
+                ack(block_ref(9));
+                return;
+            }
+            drop(ack);
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    });
+
+    let positions = context
+        .submit_and_get_positions(vec![make_tx()], 100, &epoch_store, None)
+        .await
+        .unwrap();
+    assert_eq!(positions, vec![position(9, 0)]);
+    driver.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_submit_to_consensus_dedups_system_message() {
+    let (pool, state) = make_pool(100, 100).await;
+    let epoch_store = state.epoch_store_for_testing().clone();
+    let context = TransactionPoolContext::new(
+        CheckpointStore::new_for_tests(),
+        state.name,
+        100,
+        TransactionPoolMetrics::new_for_tests(),
+        epoch_store.clone(),
+    );
+    drop(pool);
+
+    let tx = make_tx();
+    context.submit_to_consensus(&[tx.clone()], &epoch_store).unwrap();
+    // Same key coalesces instead of adding a second entry.
+    context.submit_to_consensus(&[tx], &epoch_store).unwrap();
+    let (transactions, _ack, _) = context.current_pool().take(100, usize::MAX);
+    assert_eq!(transactions.len(), 1);
+}

--- a/crates/sui-core/src/unit_tests/transaction_pool_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_pool_tests.rs
@@ -675,7 +675,9 @@ async fn test_submit_to_consensus_dedups_system_message() {
     drop(pool);
 
     let tx = make_tx();
-    context.submit_to_consensus(&[tx.clone()], &epoch_store).unwrap();
+    context
+        .submit_to_consensus(std::slice::from_ref(&tx), &epoch_store)
+        .unwrap();
     // Same key coalesces instead of adding a second entry.
     context.submit_to_consensus(&[tx], &epoch_store).unwrap();
     let (transactions, _ack, _) = context.current_pool().take(100, usize::MAX);

--- a/crates/sui-core/src/unit_tests/transaction_pool_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_pool_tests.rs
@@ -529,6 +529,36 @@ async fn test_ping_gets_position_at_next_block() {
 }
 
 #[tokio::test]
+async fn test_pending_pings_are_bounded() {
+    let (pool, _state) = make_pool(100, 100).await;
+    let mut receivers = Vec::with_capacity(MAX_PENDING_PINGS);
+    for _ in 0..MAX_PENDING_PINGS {
+        let (rx, newly_inserted) = pool.submit_user_transactions(0, vec![], None).unwrap();
+        assert!(newly_inserted);
+        receivers.push(rx);
+    }
+
+    let err = pool.submit_user_transactions(0, vec![], None).unwrap_err();
+    assert!(matches!(
+        err.as_inner(),
+        SuiErrorKind::TooManyTransactionsPendingConsensus
+    ));
+
+    let (transactions, ack, _) = pool.take(1, usize::MAX);
+    assert!(transactions.is_empty());
+    ack(block_ref(3));
+    for rx in receivers {
+        assert_eq!(
+            rx.await.unwrap().unwrap(),
+            vec![ConsensusPosition::ping(0, block_ref(3))]
+        );
+    }
+
+    // Acknowledging the pings releases their capacity.
+    pool.submit_user_transactions(0, vec![], None).unwrap();
+}
+
+#[tokio::test]
 async fn test_context_rotate_shuts_down_old_pool() {
     let state = TestAuthorityBuilder::new().build().await;
     let epoch_store = state.epoch_store_for_testing().clone();

--- a/crates/sui-e2e-tests/tests/admission_queue_tests.rs
+++ b/crates/sui-e2e-tests/tests/admission_queue_tests.rs
@@ -48,6 +48,9 @@ async fn make_transfer_tx_with_gas(
 async fn test_admission_queue_basic() {
     let config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
+        // These tests exercise admission queue behavior; pin the queue pipeline even
+        // when SUI_TRANSACTION_POOL_ENABLED selects the transaction pool by default.
+        transaction_pool_enabled: false,
         admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.001,
         ..Default::default()
@@ -76,6 +79,9 @@ async fn test_admission_queue_basic() {
 async fn test_admission_queue_eviction_and_rejection() {
     let overload_config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
+        // These tests exercise admission queue behavior; pin the queue pipeline even
+        // when SUI_TRANSACTION_POOL_ENABLED selects the transaction pool by default.
+        transaction_pool_enabled: false,
         admission_queue_bypass_fraction: 0.0,
         // capacity = 20_000 * 0.0001 = 2
         admission_queue_capacity_fraction: 0.0001,
@@ -207,6 +213,9 @@ async fn test_admission_queue_eviction_and_rejection() {
 async fn test_admission_queue_epoch_boundary_cleanup() {
     let config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
+        // These tests exercise admission queue behavior; pin the queue pipeline even
+        // when SUI_TRANSACTION_POOL_ENABLED selects the transaction pool by default.
+        transaction_pool_enabled: false,
         admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.001,
         ..Default::default()
@@ -255,6 +264,9 @@ async fn test_admission_queue_epoch_boundary_cleanup() {
 async fn test_admission_queue_reconfig_with_pending_entries() {
     let overload_config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
+        // These tests exercise admission queue behavior; pin the queue pipeline even
+        // when SUI_TRANSACTION_POOL_ENABLED selects the transaction pool by default.
+        transaction_pool_enabled: false,
         admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.0001,
         ..Default::default()

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -101,7 +101,8 @@ use sui_core::checkpoints::{
     CheckpointMetrics, CheckpointOutput, CheckpointService, CheckpointStore, LogCheckpointOutput,
     SendCheckpointToStateSync, SubmitCheckpointToConsensus,
 };
-use sui_core::consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics};
+use sui_core::consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, SubmitToConsensus};
+use sui_core::transaction_pool::{TransactionPool, TransactionPoolContext, TransactionPoolMetrics};
 use sui_core::consensus_manager::ConsensusManager;
 use sui_core::consensus_throughput_calculator::ConsensusThroughputCalculator;
 use sui_core::consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics};
@@ -174,6 +175,7 @@ pub struct ValidatorComponents {
     checkpoint_metrics: Arc<CheckpointMetrics>,
     sui_tx_validator_metrics: Arc<SuiTxValidatorMetrics>,
     admission_queue: Option<AdmissionQueueContext>,
+    transaction_pool: Option<TransactionPoolContext>,
 }
 pub struct P2pComponents {
     p2p_network: Network,
@@ -333,7 +335,7 @@ impl SuiNode {
         metrics: Arc<SuiNodeMetrics>,
         authority: AuthorityName,
         epoch_store: Arc<AuthorityPerEpochStore>,
-        consensus_adapter: Arc<ConsensusAdapter>,
+        consensus_adapter: Arc<dyn SubmitToConsensus>,
     ) {
         let epoch = epoch_store.epoch();
 
@@ -449,7 +451,7 @@ impl SuiNode {
                                     jwk_log!("Submitting JWK to consensus: {:?}", id);
 
                                     let txn = ConsensusTransaction::new_jwk_fetched(authority, id, jwk);
-                                    consensus_adapter.submit(txn, None, &epoch_store, None, None)
+                                    consensus_adapter.submit_to_consensus(&[txn], &epoch_store)
                                         .tap_err(|e| warn!("Error when submitting JWKs to consensus {:?}", e))
                                         .ok();
                                 }
@@ -925,9 +927,13 @@ impl SuiNode {
             .await?;
 
             if node_role.is_validator() {
-                components
-                    .consensus_adapter
-                    .recover_end_of_publish(&epoch_store);
+                if let Some(pool) = &components.transaction_pool {
+                    pool.recover_end_of_publish(&epoch_store);
+                } else {
+                    components
+                        .consensus_adapter
+                        .recover_end_of_publish(&epoch_store);
+                }
 
                 // Start the gRPC server
                 components.validator_server_handle = Some(
@@ -1020,13 +1026,15 @@ impl SuiNode {
     // Init reconfig process by starting to reject user certs
     pub async fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) -> SuiResult {
         info!("close_epoch (current epoch = {})", epoch_store.epoch());
-        self.validator_components
-            .lock()
-            .await
+        let components_guard = self.validator_components.lock().await;
+        let components = components_guard
             .as_ref()
-            .ok_or_else(|| SuiError::from("Node is not a validator"))?
-            .consensus_adapter
-            .close_epoch(epoch_store);
+            .ok_or_else(|| SuiError::from("Node is not a validator"))?;
+        if let Some(pool) = &components.transaction_pool {
+            pool.close_epoch(epoch_store);
+        } else {
+            components.consensus_adapter.close_epoch(epoch_store);
+        }
         Ok(())
     }
 
@@ -1332,14 +1340,33 @@ impl SuiNode {
 
         let client = Arc::new(UpdatableConsensusClient::new());
         let inflight_slot_freed_notify = Arc::new(tokio::sync::Notify::new());
+        let ca_metrics = ConsensusAdapterMetrics::new(&registry_service.default_registry());
+        // The pull-based transaction pool replaces the admission queue and the
+        // adapter's submission path when enabled.
+        let transaction_pool = config
+            .authority_overload_config
+            .transaction_pool_enabled
+            .then(|| {
+                let pool_metrics = Arc::new(TransactionPoolMetrics::new(
+                    &registry_service.default_registry(),
+                    &ca_metrics,
+                ));
+                TransactionPoolContext::new(
+                    checkpoint_store.clone(),
+                    state.name,
+                    consensus_config.max_pending_transactions(),
+                    pool_metrics,
+                    epoch_store.clone(),
+                )
+            });
         let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
             &committee,
             consensus_config,
             state.name,
-            &registry_service.default_registry(),
             client.clone(),
             checkpoint_store.clone(),
             inflight_slot_freed_notify.clone(),
+            ca_metrics,
         ));
 
         let consensus_manager = Arc::new(ConsensusManager::new(
@@ -1369,6 +1396,7 @@ impl SuiNode {
                 epoch_store.clone(),
                 &registry_service.default_registry(),
                 inflight_slot_freed_notify,
+                transaction_pool.clone(),
             )
             .await?;
             (Some(handle), queue)
@@ -1414,6 +1442,7 @@ impl SuiNode {
             sui_node_metrics,
             sui_tx_validator_metrics,
             admission_queue,
+            transaction_pool,
             node_role,
         )
         .await
@@ -1438,11 +1467,20 @@ impl SuiNode {
         sui_node_metrics: Arc<SuiNodeMetrics>,
         sui_tx_validator_metrics: Arc<SuiTxValidatorMetrics>,
         admission_queue: Option<AdmissionQueueContext>,
+        transaction_pool: Option<TransactionPoolContext>,
         node_role: NodeRole,
     ) -> Result<ValidatorComponents> {
+        // System messages are submitted through the transaction pool when enabled,
+        // otherwise through the consensus adapter.
+        let consensus_submitter: Arc<dyn SubmitToConsensus> = match &transaction_pool {
+            Some(pool) => Arc::new(pool.clone()),
+            None => Arc::new(consensus_adapter.clone()),
+        };
+
         let checkpoint_service = Self::build_checkpoint_service(
             config,
             consensus_adapter.clone(),
+            transaction_pool.clone(),
             checkpoint_store.clone(),
             epoch_store.clone(),
             state.clone(),
@@ -1464,7 +1502,7 @@ impl SuiNode {
             };
             let randomness_manager = RandomnessManager::try_new(
                 Arc::downgrade(&epoch_store),
-                Box::new(consensus_adapter.clone()),
+                Box::new(consensus_submitter.clone()),
                 randomness_handle,
                 authority_key_pair,
                 randomness_receiver_handle.clone(),
@@ -1480,7 +1518,7 @@ impl SuiNode {
         if node_role.is_validator() {
             ExecutionTimeObserver::spawn(
                 epoch_store.clone(),
-                Box::new(consensus_adapter.clone()),
+                Box::new(consensus_submitter.clone()),
                 config
                     .execution_time_observer_config
                     .clone()
@@ -1497,11 +1535,19 @@ impl SuiNode {
             state.clone(),
             checkpoint_service.clone(),
             epoch_store.clone(),
-            consensus_adapter.clone(),
+            consensus_submitter.clone(),
             throughput_calculator,
             backpressure_manager,
             config.congestion_log.clone(),
         );
+
+        // Rotate the transaction pool for the new epoch and register it on the epoch
+        // store for settle callbacks, before consensus starts taking from it.
+        let consensus_transaction_pool = transaction_pool.as_ref().map(|ctx| {
+            let pool = ctx.rotate_for_epoch(epoch_store.clone());
+            epoch_store.set_transaction_pool(&pool);
+            pool as Arc<dyn TransactionPool>
+        });
 
         info!("Starting consensus manager asynchronously");
 
@@ -1523,6 +1569,7 @@ impl SuiNode {
                         epoch_store,
                         consensus_handler_initializer,
                         sui_tx_validator,
+                        consensus_transaction_pool,
                         Some(randomness_receiver_handle),
                     )
                     .await;
@@ -1546,7 +1593,7 @@ impl SuiNode {
                 sui_node_metrics,
                 state.name,
                 epoch_store.clone(),
-                consensus_adapter.clone(),
+                consensus_submitter.clone(),
             );
         }
 
@@ -1563,12 +1610,14 @@ impl SuiNode {
             checkpoint_metrics,
             sui_tx_validator_metrics,
             admission_queue,
+            transaction_pool,
         })
     }
 
     fn build_checkpoint_service(
         config: &NodeConfig,
         consensus_adapter: Arc<ConsensusAdapter>,
+        transaction_pool: Option<TransactionPoolContext>,
         checkpoint_store: Arc<CheckpointStore>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         state: Arc<AuthorityState>,
@@ -1586,7 +1635,21 @@ impl SuiNode {
             epoch_start_timestamp_ms, epoch_duration_ms
         );
 
-        let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.is_validator() {
+        // The checkpoint output needs both submission and epoch-close (timestamp-based
+        // close) capabilities, so it is built with the concrete submitter type.
+        let checkpoint_output: Box<dyn CheckpointOutput> = if !node_role.is_validator() {
+            Box::new(LogCheckpointOutput::new(checkpoint_metrics.clone()))
+        } else if let Some(pool) = transaction_pool {
+            Box::new(SubmitCheckpointToConsensus::new(
+                pool,
+                state.secret.clone(),
+                config.protocol_public_key(),
+                epoch_start_timestamp_ms
+                    .checked_add(epoch_duration_ms)
+                    .expect("Overflow calculating next_reconfiguration_timestamp_ms"),
+                checkpoint_metrics.clone(),
+            ))
+        } else {
             Box::new(SubmitCheckpointToConsensus::new(
                 consensus_adapter,
                 state.secret.clone(),
@@ -1596,8 +1659,6 @@ impl SuiNode {
                     .expect("Overflow calculating next_reconfiguration_timestamp_ms"),
                 checkpoint_metrics.clone(),
             ))
-        } else {
-            Box::new(LogCheckpointOutput::new(checkpoint_metrics.clone()))
         };
 
         let certified_checkpoint_output = SendCheckpointToStateSync::new(state_sync_handle);
@@ -1618,12 +1679,11 @@ impl SuiNode {
         committee: &Committee,
         consensus_config: &ConsensusConfig,
         authority: AuthorityName,
-        prometheus_registry: &Registry,
         consensus_client: Arc<dyn ConsensusClient>,
         checkpoint_store: Arc<CheckpointStore>,
         inflight_slot_freed_notify: Arc<tokio::sync::Notify>,
+        ca_metrics: ConsensusAdapterMetrics,
     ) -> ConsensusAdapter {
-        let ca_metrics = ConsensusAdapterMetrics::new(prometheus_registry);
         // The consensus adapter allows the authority to send user certificates through consensus.
 
         ConsensusAdapter::new(
@@ -1644,9 +1704,13 @@ impl SuiNode {
         epoch_store: Arc<AuthorityPerEpochStore>,
         prometheus_registry: &Registry,
         inflight_slot_freed_notify: Arc<tokio::sync::Notify>,
+        transaction_pool: Option<TransactionPoolContext>,
     ) -> Result<(SpawnOnce, Option<AdmissionQueueContext>)> {
         let overload_config = &config.authority_overload_config;
-        let admission_queue = overload_config.admission_queue_enabled.then(|| {
+        // The transaction pool replaces the admission queue when enabled.
+        let admission_queue = (overload_config.admission_queue_enabled
+            && transaction_pool.is_none())
+        .then(|| {
             let manager = Arc::new(AdmissionQueueManager::new(
                 consensus_adapter.clone(),
                 Arc::new(AdmissionQueueMetrics::new(prometheus_registry)),
@@ -1663,6 +1727,7 @@ impl SuiNode {
             Arc::new(ValidatorServiceMetrics::new(prometheus_registry)),
             config.policy_config.clone().map(|p| p.client_id_source),
             admission_queue.clone(),
+            transaction_pool,
         );
 
         let mut server_conf = mysten_network::config::Config::new();
@@ -1854,13 +1919,17 @@ impl SuiNode {
                     ),
                 );
                 info!(?transaction, "submitting capabilities to consensus");
-                components.consensus_adapter.submit(
-                    transaction,
-                    None,
-                    &cur_epoch_store,
-                    None,
-                    None,
-                )?;
+                if let Some(pool) = &components.transaction_pool {
+                    pool.submit_to_consensus(&[transaction], &cur_epoch_store)?;
+                } else {
+                    components.consensus_adapter.submit(
+                        transaction,
+                        None,
+                        &cur_epoch_store,
+                        None,
+                        None,
+                    )?;
+                }
             }
 
             let stop_condition = checkpoint_executor.run_epoch(run_with_range).await;
@@ -1956,6 +2025,7 @@ impl SuiNode {
                 checkpoint_metrics,
                 sui_tx_validator_metrics,
                 admission_queue,
+                transaction_pool,
             }) = validator_components_lock_guard.take()
             {
                 info!("Reconfiguring node (was running consensus).");
@@ -2001,6 +2071,7 @@ impl SuiNode {
                             self.metrics.clone(),
                             sui_tx_validator_metrics,
                             admission_queue,
+                            transaction_pool,
                             new_role,
                         )
                         .await?,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -102,7 +102,6 @@ use sui_core::checkpoints::{
     SendCheckpointToStateSync, SubmitCheckpointToConsensus,
 };
 use sui_core::consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, SubmitToConsensus};
-use sui_core::transaction_pool::{TransactionPool, TransactionPoolContext, TransactionPoolMetrics};
 use sui_core::consensus_manager::ConsensusManager;
 use sui_core::consensus_throughput_calculator::ConsensusThroughputCalculator;
 use sui_core::consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics};
@@ -120,6 +119,7 @@ use sui_core::signature_verifier::SignatureVerifierMetrics;
 use sui_core::storage::RocksDbStore;
 use sui_core::storage::RpcStoreReadStore;
 use sui_core::transaction_orchestrator::TransactionOrchestrator;
+use sui_core::transaction_pool::{TransactionPool, TransactionPoolContext, TransactionPoolMetrics};
 use sui_core::{
     authority::{AuthorityState, AuthorityStore},
     authority_client::NetworkAuthorityClient,
@@ -1708,19 +1708,18 @@ impl SuiNode {
     ) -> Result<(SpawnOnce, Option<AdmissionQueueContext>)> {
         let overload_config = &config.authority_overload_config;
         // The transaction pool replaces the admission queue when enabled.
-        let admission_queue = (overload_config.admission_queue_enabled
-            && transaction_pool.is_none())
-        .then(|| {
-            let manager = Arc::new(AdmissionQueueManager::new(
-                consensus_adapter.clone(),
-                Arc::new(AdmissionQueueMetrics::new(prometheus_registry)),
-                overload_config.admission_queue_capacity_fraction,
-                overload_config.admission_queue_bypass_fraction,
-                overload_config.admission_queue_failover_timeout,
-                inflight_slot_freed_notify,
-            ));
-            AdmissionQueueContext::spawn(manager, epoch_store)
-        });
+        let admission_queue =
+            (overload_config.admission_queue_enabled && transaction_pool.is_none()).then(|| {
+                let manager = Arc::new(AdmissionQueueManager::new(
+                    consensus_adapter.clone(),
+                    Arc::new(AdmissionQueueMetrics::new(prometheus_registry)),
+                    overload_config.admission_queue_capacity_fraction,
+                    overload_config.admission_queue_bypass_fraction,
+                    overload_config.admission_queue_failover_timeout,
+                    inflight_slot_freed_notify,
+                ));
+                AdmissionQueueContext::spawn(manager, epoch_store)
+            });
         let validator_service = ValidatorService::new(
             state.clone(),
             consensus_adapter,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1470,6 +1470,16 @@ impl SuiNode {
         transaction_pool: Option<TransactionPoolContext>,
         node_role: NodeRole,
     ) -> Result<ValidatorComponents> {
+        // Rotate the transaction pool for the new epoch and register it on the epoch
+        // store for settle callbacks, before any per-epoch component (randomness DKG,
+        // checkpoint service) submits system messages: submissions park in the pool
+        // until consensus starts taking from it.
+        let consensus_transaction_pool = transaction_pool.as_ref().map(|ctx| {
+            let pool = ctx.rotate_for_epoch(epoch_store.clone());
+            epoch_store.set_transaction_pool(&pool);
+            pool as Arc<dyn TransactionPool>
+        });
+
         // System messages are submitted through the transaction pool when enabled,
         // otherwise through the consensus adapter.
         let consensus_submitter: Arc<dyn SubmitToConsensus> = match &transaction_pool {
@@ -1540,14 +1550,6 @@ impl SuiNode {
             backpressure_manager,
             config.congestion_log.clone(),
         );
-
-        // Rotate the transaction pool for the new epoch and register it on the epoch
-        // store for settle callbacks, before consensus starts taking from it.
-        let consensus_transaction_pool = transaction_pool.as_ref().map(|ctx| {
-            let pool = ctx.rotate_for_epoch(epoch_store.clone());
-            epoch_store.set_transaction_pool(&pool);
-            pool as Arc<dyn TransactionPool>
-        });
 
         info!("Starting consensus manager asynchronously");
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -158,6 +158,7 @@ validator_configs:
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
+      transaction-pool-enabled: false
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -337,6 +338,7 @@ validator_configs:
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
+      transaction-pool-enabled: false
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -516,6 +518,7 @@ validator_configs:
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
+      transaction-pool-enabled: false
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -695,6 +698,7 @@ validator_configs:
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
+      transaction-pool-enabled: false
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -874,6 +878,7 @@ validator_configs:
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
+      transaction-pool-enabled: false
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -1053,6 +1058,7 @@ validator_configs:
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
+      transaction-pool-enabled: false
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -1232,6 +1238,7 @@ validator_configs:
       admission-queue-failover-timeout:
         secs: 30
         nanos: 0
+      transaction-pool-enabled: false
     execution-cache:
       writeback-cache:
         max_cache_size: ~


### PR DESCRIPTION
## Description

Add a pull-based transaction pool as an opt-in alternative to the admission queue + consensus adapter submission pipeline, to simplify the logic without sacrificing performance or behavior. Design doc: `crates/sui-core/src/transaction_pool.md` (first two commits); stacked on #27184.

Instead of pushing submissions through per-transaction tasks into a consensus channel, transactions wait in a prioritized pool (system entries first, then gas price descending) that the consensus proposer takes from when building a block, via a new `TransactionPool` trait mirroring `TransactionVerifier`. Settlement is pushed from the commit handler and checkpoint executor at the sites that already compute the outcomes. This deletes the per-submission task + `processed_notify` race, the inflight RAII accounting and its feedback `Notify`, the admission queue actor, the Bypass/Queue/Disabled routing with failover, the submit semaphore, and the submission retry/backoff loop.

Enabled by `authority-overload-config.transaction-pool-enabled` (default off; the `SUI_TRANSACTION_POOL_ENABLED` env var flips the default for whole test runs). Default-off behavior is unchanged: the proposer consumes the existing `TransactionConsumer` through a shim.

## Test plan

- New unit tests in `transaction_pool.rs` cover take ordering and block limits (incl. bundle atomicity and the inflight budget), the gas auction (eviction/outbid/gasless-first, system exemption), duplicate coalescing, all settle paths (processed keys, per-position statuses, checkpoint execution), GC requeue of system entries vs dropping user entries, best-effort expiry, shutdown/rotation, and ping positions.
- With the pool enabled (`SUI_TRANSACTION_POOL_ENABLED=1 cargo simtest`): `sui-benchmark` 37/37 and `sui-e2e-tests` 434/434 pass (admission-queue-specific e2e tests pin `transaction_pool_enabled: false` since they assert queue-full rejection).
- Simtests caught and this PR fixes: pool rotation must precede per-epoch component startup (a DKG submission error otherwise aborts reconfiguration), and the pool must hold the epoch store weakly (the epoch store → randomness manager → pool context → pool cycle pinned RocksDB across node restarts).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Adds an experimental, default-off `transaction-pool-enabled` option under `authority-overload-config` that routes validator consensus submissions through a pull-based transaction pool instead of the admission queue and consensus adapter. No action required; behavior is unchanged unless enabled.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
