### PR TITLE
Skip zero net withdraws when recording unsettled object withdraws

### DIFF
--- a/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
@@ -104,6 +104,21 @@ impl TestEnv {
         }
     }
 
+    /// Creates another vault object account, in addition to the default one.
+    pub async fn new_vault(&self) -> ObjectID {
+        let gas = self.oref(&self.gas_obj);
+        let tx = TestTransactionBuilder::new(self.sender, gas, self.rgp())
+            .move_call(self.package_id, "object_balance", "new_owned", vec![])
+            .build();
+        let cert = VerifiedExecutableTransaction::new_for_testing(tx, &self.keypair);
+        let (effects, ..) = self
+            .authority
+            .try_execute_immediately(&cert, ExecutionEnv::new(), &self.epoch_store)
+            .unwrap();
+        assert!(effects.status().is_ok());
+        effects.created().into_iter().next().unwrap().0.0
+    }
+
     pub fn oref(&self, object_id: &ObjectID) -> ObjectRef {
         self.authority
             .get_object(object_id)
@@ -408,6 +423,42 @@ async fn test_object_net_deposit_same_transaction() {
         .settle_accumulator_for_testing(&all_effects, None)
         .await;
     assert_eq!(env.get_latest_balance(GAS::type_tag()), 3);
+}
+
+#[tokio::test]
+async fn test_object_zero_amount_withdraw() {
+    // A zero-amount object-fund withdraw emits a single Split(0) accumulator event.
+    // It survives effects folding as a Split (the fold's Merge tie-break only applies
+    // to accounts with multiple writes), but creates no running max entry. It must be
+    // skipped when recording unsettled withdraws instead of tripping the recording
+    // invariant check.
+    telemetry_subscribers::init_for_testing();
+    let env = TestEnv::new().await;
+    let vault: SuiAddress = env.vault_obj.into();
+    let zero_vault = env.new_vault().await;
+    env.fund_address(vault, 2).await;
+
+    // One transaction: withdraw 0 from zero_vault and 2 from the funded vault. The
+    // positive withdraw makes the running max map non-empty, so the zero withdraw
+    // reaches the unsettled recording path.
+    let gas = env.oref(&env.gas_obj);
+    let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
+        .transfer_sui_to_address_balance(
+            FundSource::object_fund_owned(env.package_id, env.oref(&zero_vault)),
+            vec![(0, env.sender)],
+        )
+        .transfer_sui_to_address_balance(
+            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj)),
+            vec![(2, env.sender)],
+        )
+        .build();
+    let cert = VerifiedExecutableTransaction::new_for_testing(tx, &env.keypair);
+    let effects = env.execute_ok(&cert).await;
+
+    env.authority
+        .settle_accumulator_for_testing(&[effects], None)
+        .await;
+    assert_eq!(env.get_latest_balance(GAS::type_tag()), 0);
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
@@ -146,17 +146,30 @@ impl ObjectFundsChecker {
                     event
                         .write
                         .get_fund_withdraw_amount()
+                        // A zero-amount withdraw emits a single Split(0) accumulator event,
+                        // which survives effects folding as a Split (the fold's Merge
+                        // tie-break only applies when an account has multiple writes).
+                        // It contributes nothing to the running max nor to settlement,
+                        // so recording it would be a no-op; skip it.
+                        .filter(|amount| *amount > 0)
                         .map(|amount| (event.accumulator_obj, amount))
                 })
                 .collect();
-            // A net withdraw in effects can never exceed the running max withdraw of the
-            // same account. Recording more than what the sufficiency check covered could
-            // break the funds >= unsettled_withdraw invariant in try_withdraw.
-            debug_assert!(updates.iter().all(|(obj_id, net)| {
-                object_running_max_withdraws
-                    .get(obj_id)
-                    .is_some_and(|max| net <= max)
-            }));
+            // A positive net withdraw in effects implies a positive peak, so the account
+            // must have a running max entry that the net cannot exceed. Recording more
+            // than what the sufficiency check covered could break the
+            // funds >= unsettled_withdraw invariant in try_withdraw.
+            debug_assert!(
+                updates.iter().all(|(obj_id, net)| {
+                    object_running_max_withdraws
+                        .get(obj_id)
+                        .is_some_and(|max| net <= max)
+                }),
+                "net withdraw exceeds running max: tx={:?} updates={:?} running_max={:?}",
+                certificate.digest(),
+                updates,
+                object_running_max_withdraws,
+            );
             updates
         } else {
             object_running_max_withdraws.clone()

--- a/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
@@ -7,13 +7,18 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::{
+    accumulator_event::AccumulatorEvent,
     accumulator_root::AccumulatorObjId,
     base_types::{ObjectID, SequenceNumber, random_object_ref},
     crypto::get_account_key_pair,
-    effects::TestEffectsBuilder,
+    effects::{
+        AccumulatorAddress, AccumulatorOperation, AccumulatorValue, AccumulatorWriteV1,
+        TestEffectsBuilder,
+    },
     executable_transaction::VerifiedExecutableTransaction,
     execution_params::FundsWithdrawStatus,
     execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus},
+    gas_coin::GAS,
 };
 
 use crate::{
@@ -423,6 +428,68 @@ async fn test_should_commit_early_exits() {
             &epoch_store,
         )
     );
+}
+
+#[tokio::test]
+async fn test_should_commit_ignores_zero_net_withdraws() {
+    // A zero-amount withdraw emits a single Split(0) accumulator event, which survives
+    // effects folding as a Split but creates no running max entry. It must be skipped
+    // when recording unsettled withdraws instead of tripping the recording invariant
+    // check.
+    let checker = ObjectFundsChecker::new(
+        SequenceNumber::from_u64(0),
+        Arc::new(ObjectFundsCheckerMetrics::new(&prometheus::Registry::new())),
+    );
+    let state = TestAuthorityBuilder::new().build().await;
+    let epoch_store = state.epoch_store_for_testing().clone();
+
+    let (sender, keypair) = get_account_key_pair();
+    let tx = VerifiedExecutableTransaction::new_for_testing(
+        TestTransactionBuilder::new(sender, random_object_ref(), 1).build(),
+        &keypair,
+    );
+    let zero_account = ObjectID::random();
+    let withdraw_account = ObjectID::random();
+    // Only the positive withdraw has a running max entry.
+    let running_max_withdraws =
+        BTreeMap::from([(AccumulatorObjId::new_unchecked(withdraw_account), 50)]);
+    let funds_read: Arc<dyn AccountFundsRead> = Arc::new(MockFundsRead::new(
+        SequenceNumber::from_u64(0),
+        BTreeMap::from([(withdraw_account, 100)]),
+    ));
+    let effects = TestEffectsBuilder::new(tx.data())
+        .with_accumulator_events(vec![
+            AccumulatorEvent::new(
+                AccumulatorObjId::new_unchecked(zero_account),
+                AccumulatorWriteV1 {
+                    address: AccumulatorAddress::new(sender, GAS::type_tag()),
+                    operation: AccumulatorOperation::Split,
+                    value: AccumulatorValue::Integer(0),
+                },
+            ),
+            AccumulatorEvent::new(
+                AccumulatorObjId::new_unchecked(withdraw_account),
+                AccumulatorWriteV1 {
+                    address: AccumulatorAddress::new(sender, GAS::type_tag()),
+                    operation: AccumulatorOperation::Split,
+                    value: AccumulatorValue::Integer(50),
+                },
+            ),
+        ])
+        .build();
+
+    assert!(checker.should_commit_object_funds_withdraws(
+        &tx,
+        &effects,
+        &running_max_withdraws,
+        &ExecutionEnv::new().with_assigned_versions(AssignedVersions::new(
+            vec![],
+            Some(SequenceNumber::from_u64(0))
+        )),
+        &funds_read,
+        state.execution_scheduler(),
+        &epoch_store,
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

The recording invariant check added in #27157 (a recorded net object withdraw must have a running-max counterpart it cannot exceed) failed in the nightly simtests (https://github.com/MystenLabs/sui/actions/runs/28933297862).

Root cause: a zero-amount object-fund withdraw emits a single `Split(0)` accumulator event. Effects folding returns a lone write as-is — its Merge tie-break for zero nets only applies to accounts with multiple writes — so the event surfaces in effects as a net `Split` of 0, while `calculate_accumulator_running_max_withdraws` only creates entries for strictly positive peaks. The debug assert then fails on the missing running-max entry.

Recording a zero withdraw is a no-op for both the sufficiency check and settlement, so skip zero amounts when building the unsettled withdraw updates. This restores the invariant that every recorded entry has a positive running-max counterpart.

## Test plan

- New unit test drives `should_commit_object_funds_withdraws` with effects containing a lone `Split(0)` event alongside a positive withdraw on another account — the exact shape that fired the assert.
- New integration test executes a real transaction combining a zero-amount object-fund withdraw from one vault with a positive withdraw from another, then settles and verifies balances.

Both tests reproduce the nightly panic when the fix is disabled. Additionally, `test_simulated_load_conflicting_transfers` was rerun with a locally-found reproducing seed (20260717): it panics on main and passes with this fix.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 