### PR TITLE
docs: update epoch and clock docs for timestamp-based epoch close

### DIFF
--- a/docs/content/develop/sui-architecture/epochs.mdx
+++ b/docs/content/develop/sui-architecture/epochs.mdx
@@ -12,7 +12,7 @@ Epoch values are included in the metadata of all [transactions](/develop/transac
 
 Reconfiguration is a critical process occurring at the end of each epoch. It involves several key steps to adjust the network for the upcoming epoch:
 
-1. **Finalizing transactions and checkpoints:** The network reaches consensus on the final set of transactions and checkpoints for the current epoch. This ensures all validators have an identical state at epoch conclusion.
+1. **Closing the epoch:** When the consensus commit timestamp exceeds the target reconfiguration time (epoch start + epoch duration), validators stop accepting new user transactions and finalize the remaining transactions and checkpoints for the current epoch. This ensures all validators have an identical state at epoch conclusion.
 
     - **Synchronous moment:** This is the only fully synchronous event in the network, crucial for maintaining consistency.
 

--- a/docs/content/sui-stack/on-chain-primitives/access-time.mdx
+++ b/docs/content/sui-stack/on-chain-primitives/access-time.mdx
@@ -4,7 +4,7 @@ description: Access network-based time for your transactions. Sui provides a Clo
 keywords: [ network-based time, onchain time, onchain time, sui::clock::Clock, clock module, sui::clock::timestamp_ms, epoch timestamps, timestamps, use time in transactions, sui::tx_context ] 
 ---
 
-If you need a near real-time measurement (within a few seconds) for your application, use the immutable reference of time provided by the `Clock` module in Move. The reference value from this module updates with every network checkpoint. If you do not need the current time, use the `epoch_timestamp_ms` function to refer to the timestamp of when the current epoch started.
+If you need a near real-time measurement (within a few seconds) for your application, use the immutable reference of time provided by the `Clock` module in Move. The reference value from this module updates with every consensus commit. If you do not need the current time, use the `epoch_timestamp_ms` function to refer to the timestamp of when the current epoch started.
 
 ## The `sui::clock::Clock` module
 
@@ -26,7 +26,7 @@ Call the previous entry function with the following format, passing `0x6` as the
 $ sui client call --package <EXAMPLE> --module 'clock' --function 'access' --args '0x6' --gas-budget <GAS-AMOUNT>
 ```
 
-The `sui::clock::Clock` timestamp changes at the rate the network generates checkpoints, which is approximately every 1/4 second. Find the current network checkpoint rate on the [public dashboard](https://metrics.sui.io/public-dashboards/4ceb11cc210d4025b122294586961169).
+The `sui::clock::Clock` timestamp advances with each consensus commit, which occurs approximately every 1/4 second.
 
 Successful calls to `sui::clock::timestamp_ms` in the same transaction always produce the same result because transactions take effect instantly, but timestamps from `sui::clock::Clock` are otherwise monotonic across transactions that touch the same shared objects. Successful transactions see a greater or equal timestamp to their predecessors.
 


### PR DESCRIPTION
## Summary
- Updates Clock object description (`access-time.mdx`) to say the timestamp advances with each **consensus commit**, not "every network checkpoint"
- Updates reconfiguration section (`epochs.mdx`) to describe the **consensus-timestamp-driven epoch close** mechanism introduced at protocol version 127, replacing the previous checkpoint-based description

## Context
Mainnet switched to timestamp-based epoch closing at protocol version 127. The previous documentation described checkpoint-based epoch closing and the Clock updating per checkpoint, which is now misleading.

## Test plan
- [ ] Review wording accuracy against `consensus_handler.rs` epoch close logic
- [ ] Verify no other pages reference checkpoint-based epoch closing

🤖 Generated with [Claude Code](https://claude.com/claude-code)