### PR TITLE
sui-proxy: use grpc for dynamic peer lookups

### DIFF
--- a/crates/sui-proxy/src/config.rs
+++ b/crates/sui-proxy/src/config.rs
@@ -40,15 +40,15 @@ pub struct RemoteWriteConfig {
 
 /// DynamicPeerValidationConfig controls what sui-node, sui-bridge, and hashi-server
 /// binaries (each functioning as a node in a Sui-anchored network) we'll accept
-/// metrics from. Peer membership is determined dynamically via json-rpc calls to a
-/// full node — sui validator set and bridge committee come from fixed RPC methods,
-/// hashi membership comes from reading the on-chain `Hashi` shared object
-/// when `hashi_object_id` is set.
+/// metrics from. Peer membership is determined dynamically via Sui gRPC calls to
+/// a full node — sui validator set and bridge committee are always resolved
+/// from on-chain state, and hashi membership is resolved when `hashi_object_id`
+/// is set.
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct DynamicPeerValidationConfig {
-    /// url is the json-rpc url we use to obtain valid peers on the blockchain
+    /// url is the Sui gRPC url we use to obtain valid peers on the blockchain.
     pub url: String,
     #[serde_as(as = "DurationSeconds<u64>")]
     pub interval: Duration,

--- a/crates/sui-proxy/src/data/config.yaml
+++ b/crates/sui-proxy/src/data/config.yaml
@@ -5,7 +5,7 @@ remote-write:
   username: foo
   password: fooman
 dynamic-peers:
-  url: http://127.0.0.1:9000
+  url: http://127.0.0.1:9443
   interval: 30
   certificate-file: /opt/joeman/fullchain.pem
   private-key: /opt/joeman/privkey.pem

--- a/crates/sui-proxy/src/peers.rs
+++ b/crates/sui-proxy/src/peers.rs
@@ -11,7 +11,6 @@ use prometheus::{CounterVec, HistogramVec, IntGaugeVec};
 use prometheus::{register_counter_vec, register_histogram_vec, register_int_gauge_vec};
 use prost_types::Value as JsonValue;
 use prost_types::value::Kind as JsonKind;
-use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::{
@@ -21,11 +20,13 @@ use std::{
 };
 use sui_rpc::Client as SuiRpcClient;
 use sui_rpc::field::{FieldMask, FieldMaskUtil};
-use sui_rpc::proto::sui::rpc::v2::{GetObjectRequest, Object};
+use sui_rpc::proto::sui::rpc::v2::{Epoch, GetEpochRequest, GetObjectRequest, Object};
 use sui_sdk_types::{Address, TypeTag};
 use sui_tls::Allower;
+use sui_types::SUI_BRIDGE_OBJECT_ID;
 use sui_types::base_types::SuiAddress;
-use sui_types::bridge::BridgeSummary;
+use sui_types::bridge::{BridgeInnerV1, BridgeSummary, BridgeTrait, BridgeWrapper};
+use sui_types::dynamic_field::Field;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use tracing::{debug, error, info, warn};
 use url::Url;
@@ -41,7 +42,7 @@ static JSON_RPC_STATE: Lazy<CounterVec> = Lazy::new(|| {
 static JSON_RPC_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "json_rpc_duration_seconds",
-        "The json-rpc latencies in seconds.",
+        "The Sui RPC latencies in seconds.",
         &["rpc_method"],
         vec![
             0.0008, 0.0016, 0.0032, 0.0064, 0.0128, 0.0256, 0.0512, 0.1024, 0.2048, 0.4096, 0.8192,
@@ -186,116 +187,96 @@ impl SuiNodeProvider {
 
     /// get_validators will retrieve known validators
     async fn get_validators(url: String) -> Result<SuiSystemStateSummary> {
-        let rpc_method = "suix_getLatestSuiSystemState";
-        let observe = || {
-            let timer = JSON_RPC_DURATION
-                .with_label_values(&[rpc_method])
-                .start_timer();
-            || {
-                timer.observe_duration();
-            }
-        }();
-        let client = reqwest::Client::builder().build().unwrap();
-        let request = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method":rpc_method,
-            "id":1,
-        });
+        let rpc_method = "sui_rpc.LedgerService.GetEpoch:SystemState";
+        let _timer = JSON_RPC_DURATION
+            .with_label_values(&[rpc_method])
+            .start_timer();
+        let mut client = SuiRpcClient::new(url.to_owned())
+            .with_context(|| format!("creating sui-rpc client for {url}"))?;
+        let request = GetEpochRequest::default().with_read_mask(FieldMask::from_paths([
+            Epoch::path_builder().epoch(),
+            Epoch::path_builder().system_state().finish(),
+        ]));
         let response = client
-            .post(url)
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(request.to_string())
-            .send()
+            .ledger_client()
+            .get_epoch(request)
             .await
             .with_context(|| {
                 JSON_RPC_STATE
                     .with_label_values(&[rpc_method, "failed_get"])
                     .inc();
-                observe();
-                "unable to perform json rpc"
+                "unable to fetch system state over gRPC"
             })?;
 
-        let raw = response.bytes().await.with_context(|| {
+        let response = response.into_inner();
+        let system_state = response
+            .epoch()
+            .system_state_opt()
+            .context("get_epoch response missing system_state")?;
+        let summary: SuiSystemStateSummary = system_state.try_into().with_context(|| {
             JSON_RPC_STATE
-                .with_label_values(&[rpc_method, "failed_body_extract"])
+                .with_label_values(&[rpc_method, "failed_decode"])
                 .inc();
-            observe();
-            "unable to extract body bytes from json rpc"
+            "unable to decode gRPC system state summary"
         })?;
-
-        #[derive(Debug, Deserialize)]
-        struct ResponseBody {
-            result: SuiSystemStateSummary,
-        }
-
-        let body: ResponseBody = match serde_json::from_slice(&raw) {
-            Ok(b) => b,
-            Err(error) => {
-                JSON_RPC_STATE
-                    .with_label_values(&[rpc_method, "failed_json_decode"])
-                    .inc();
-                observe();
-                bail!(
-                    "unable to decode json: {error} response from json rpc: {:?}",
-                    raw
-                )
-            }
-        };
         JSON_RPC_STATE
             .with_label_values(&[rpc_method, "success"])
             .inc();
-        observe();
-        Ok(body.result)
+        Ok(summary)
     }
 
     /// get_bridge_validators will retrieve known bridge validators
     async fn get_bridge_validators(url: String) -> Result<BridgeSummary> {
-        let rpc_method = "suix_getLatestBridge";
+        let rpc_method = "sui_rpc.LedgerService.GetObject:BridgeSummary";
         let _timer = JSON_RPC_DURATION
             .with_label_values(&[rpc_method])
             .start_timer();
-        let client = reqwest::Client::builder().build().unwrap();
-        let request = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method":rpc_method,
-            "id":1,
-        });
-        let response = client
-            .post(url)
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(request.to_string())
-            .send()
-            .await
-            .with_context(|| {
+        let mut client = SuiRpcClient::new(url.to_owned())
+            .with_context(|| format!("creating sui-rpc client for {url}"))?;
+        let bridge_wrapper_bcs = get_object_contents(
+            &mut client,
+            SUI_BRIDGE_OBJECT_ID.into(),
+            rpc_method,
+            "BridgeWrapper",
+        )
+        .await?;
+        let bridge_wrapper: BridgeWrapper =
+            bcs::from_bytes(&bridge_wrapper_bcs).with_context(|| {
                 JSON_RPC_STATE
-                    .with_label_values(&[rpc_method, "failed_get"])
+                    .with_label_values(&[rpc_method, "failed_decode_wrapper"])
                     .inc();
-                "unable to perform json rpc"
+                "unable to decode BridgeWrapper from gRPC object contents"
             })?;
 
-        let raw = response.bytes().await.with_context(|| {
-            JSON_RPC_STATE
-                .with_label_values(&[rpc_method, "failed_body_extract"])
-                .inc();
-            "unable to extract body bytes from json rpc"
-        })?;
-
-        #[derive(Debug, Deserialize)]
-        struct ResponseBody {
-            result: BridgeSummary,
+        let bridge_version = bridge_wrapper.version.version;
+        if bridge_version != 1 {
+            bail!("unsupported SuiBridge version: {bridge_version}");
         }
-        let summary: BridgeSummary = match serde_json::from_slice::<ResponseBody>(&raw) {
-            Ok(b) => b.result,
-            Err(error) => {
-                JSON_RPC_STATE
-                    .with_label_values(&[rpc_method, "failed_json_decode"])
-                    .inc();
-                bail!(
-                    "unable to decode json: {error} response from json rpc: {:?}",
-                    raw
-                )
-            }
-        };
+
+        let bridge_version_id: Address = bridge_wrapper.version.id.id.bytes.into();
+        let bridge_inner_id = bridge_version_id.derive_dynamic_child_id(
+            &TypeTag::U64,
+            &bcs::to_bytes(&bridge_version).expect("u64 always BCS-encodes"),
+        );
+        let field_bcs = get_object_contents(
+            &mut client,
+            bridge_inner_id,
+            rpc_method,
+            "BridgeInner dynamic field",
+        )
+        .await?;
+        let field: Field<u64, BridgeInnerV1> = bcs::from_bytes(&field_bcs).with_context(|| {
+            JSON_RPC_STATE
+                .with_label_values(&[rpc_method, "failed_decode_inner"])
+                .inc();
+            "unable to decode BridgeInner dynamic field from gRPC object contents"
+        })?;
+        let summary = field.value.try_into_bridge_summary().with_context(|| {
+            JSON_RPC_STATE
+                .with_label_values(&[rpc_method, "failed_summary"])
+                .inc();
+            "unable to build bridge summary"
+        })?;
         JSON_RPC_STATE
             .with_label_values(&[rpc_method, "success"])
             .inc();
@@ -405,7 +386,7 @@ impl SuiNodeProvider {
 
     /// poll_peer_list will act as a refresh interval for our cache
     pub fn poll_peer_list(&self) {
-        info!("Started polling for peers using rpc: {}", self.rpc_url);
+        info!("Started polling for peers using Sui gRPC: {}", self.rpc_url);
 
         let rpc_poll_interval = self.rpc_poll_interval;
         let cloned_self = self.clone();
@@ -431,6 +412,38 @@ impl SuiNodeProvider {
             }
         });
     }
+}
+
+async fn get_object_contents(
+    client: &mut SuiRpcClient,
+    object_id: Address,
+    rpc_method: &'static str,
+    object_name: &str,
+) -> Result<Vec<u8>> {
+    let response = client
+        .ledger_client()
+        .get_object(
+            GetObjectRequest::new(&object_id).with_read_mask(FieldMask::from_paths([
+                Object::path_builder().contents().finish(),
+            ])),
+        )
+        .await
+        .with_context(|| {
+            JSON_RPC_STATE
+                .with_label_values(&[rpc_method, "failed_get"])
+                .inc();
+            format!("get_object failed for {object_name} {object_id}")
+        })?;
+
+    let inner = response.into_inner();
+    let contents = inner.object().contents_opt().with_context(|| {
+        JSON_RPC_STATE
+            .with_label_values(&[rpc_method, "missing_contents"])
+            .inc();
+        format!("get_object response for {object_name} {object_id} missing contents")
+    })?;
+
+    Ok(contents.value().to_vec())
 }
 
 /// extract will get the network pubkey bytes from a SuiValidatorSummary type.  This type comes from a
@@ -1055,7 +1068,7 @@ fn sui_address_to_sdk_address(addr: SuiAddress) -> Address {
 mod tests {
     use super::*;
     use crate::admin::{CertKeyPair, generate_self_cert};
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
     use sui_types::base_types::SuiAddress;
     use sui_types::bridge::{BridgeCommitteeSummary, BridgeSummary, MoveTypeCommitteeMember};
     use sui_types::sui_system_state::sui_system_state_summary::{


### PR DESCRIPTION
## Description

- replace sui-proxy validator dynamic peer lookup with Sui gRPC `GetEpoch` system-state reads
- replace bridge committee lookup with Sui gRPC object reads for the bridge wrapper and inner dynamic field
- update sui-proxy config comments and sample dynamic peer URL to refer to Sui gRPC

## Test plan

- `cargo fmt --manifest-path /Users/johnmartin/src/github.com/MystenLabs/sui/Cargo.toml --package sui-proxy`
- `cargo check --manifest-path /Users/johnmartin/src/github.com/MystenLabs/sui/Cargo.toml -p sui-proxy`
- `cargo test --manifest-path /Users/johnmartin/src/github.com/MystenLabs/sui/Cargo.toml -p sui-proxy --lib`
- `cargo clippy --manifest-path /Users/johnmartin/src/github.com/MystenLabs/sui/Cargo.toml -p sui-proxy`
