### PR TITLE
indexer-alt: merge ingestion cohorts as they converge

### DIFF
--- a/crates/sui-analytics-indexer/src/config.rs
+++ b/crates/sui-analytics-indexer/src/config.rs
@@ -134,6 +134,7 @@ pub struct IngestionLayer {
     pub streaming_connection_timeout_ms: Option<u64>,
     pub streaming_statement_timeout_ms: Option<u64>,
     pub min_cohort_boundary: Option<u64>,
+    pub cohort_merge_threshold: Option<u64>,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber_channel_size`.
@@ -167,6 +168,9 @@ impl IngestionLayer {
                 .streaming_statement_timeout_ms
                 .unwrap_or(base.streaming_statement_timeout_ms),
             min_cohort_boundary: self.min_cohort_boundary.unwrap_or(base.min_cohort_boundary),
+            cohort_merge_threshold: self
+                .cohort_merge_threshold
+                .unwrap_or(base.cohort_merge_threshold),
         }
     }
 }

--- a/crates/sui-checkpoint-blob-indexer/src/config.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/config.rs
@@ -119,6 +119,7 @@ pub struct IngestionConfig {
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
     pub min_cohort_boundary: u64,
+    pub cohort_merge_threshold: u64,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -141,6 +142,7 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
             min_cohort_boundary: config.min_cohort_boundary,
+            cohort_merge_threshold: config.cohort_merge_threshold,
             checkpoint_buffer_size: None,
         }
     }
@@ -164,6 +166,7 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
             min_cohort_boundary: config.min_cohort_boundary,
+            cohort_merge_threshold: config.cohort_merge_threshold,
         }
     }
 }

--- a/crates/sui-futures/src/stream.rs
+++ b/crates/sui-futures/src/stream.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use futures::FutureExt;
 use futures::future::try_join_all;
 use futures::stream::Stream;
-use futures::try_join;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 
@@ -87,7 +86,7 @@ pub trait TrySpawnStreamExt: Stream {
     /// the limit never changes; for adaptive configs, the limit adjusts based on the fill fraction
     /// of the output channel.
     ///
-    /// Unlike [`try_for_each_broadcast_spawned`](TrySpawnStreamExt::try_for_each_broadcast_spawned),
+    /// Unlike [`try_for_each_broadcast_filtered_spawned`](TrySpawnStreamExt::try_for_each_broadcast_filtered_spawned),
     /// `T` does not need to be `Clone` since there is only a single receiver.
     ///
     /// The `report` callback is invoked each iteration with concurrency stats for metrics.
@@ -105,16 +104,30 @@ pub trait TrySpawnStreamExt: Stream {
         E: Send + 'static,
         R: Fn(ConcurrencyStats);
 
-    /// Process each stream item through a spawned task, broadcasting results to multiple channels.
+    /// Process each stream item through a spawned task, broadcasting results to a filtered
+    /// subset of channels.
     ///
     /// Same as [`try_for_each_send_spawned`](TrySpawnStreamExt::try_for_each_send_spawned) but
-    /// sends a clone of each result to every channel in `txs`. Fill fraction is measured as the
-    /// maximum across all channels. Requires `T: Clone` since values are cloned to each receiver.
-    fn try_for_each_broadcast_spawned<Fut, F, T, E, R>(
+    /// sends a clone of each result to every channel in `txs` for which `filter(i, &value)`
+    /// (where `i` is the channel's position in `txs`) returns `true` -- requires `T: Clone`
+    /// since values are cloned to each receiver. Broadcast to every channel with an always-true
+    /// filter. A value that no channel accepts is dropped, which counts as a successful send.
+    ///
+    /// The filter is invoked concurrently from worker tasks, once per channel index per value,
+    /// so it must be cheap and must not block. A filter that keeps state must manage its own
+    /// synchronization (e.g. through atomics), and observes values in task completion order,
+    /// not stream order.
+    ///
+    /// Channels that reject a value are not touched by that send, so a closed channel only
+    /// stops the pipeline once the filter routes a value to it. The fill fraction that drives
+    /// adaptive concurrency is the maximum across all channels, including ones the filter is
+    /// currently rejecting.
+    fn try_for_each_broadcast_filtered_spawned<Fut, F, T, E, P, R>(
         self,
         config: ConcurrencyConfig,
         f: F,
         txs: Vec<mpsc::Sender<T>>,
+        filter: P,
         report: R,
     ) -> impl Future<Output = Result<(), Break<E>>>
     where
@@ -122,6 +135,7 @@ pub trait TrySpawnStreamExt: Stream {
         F: FnMut(Self::Item) -> Fut,
         T: Clone + Send + Sync + 'static,
         E: Send + 'static,
+        P: Fn(usize, &T) -> bool + Send + Sync + 'static,
         R: Fn(ConcurrencyStats);
 }
 
@@ -144,8 +158,12 @@ trait Sender: Clone + Send + Sync + 'static {
 /// Single-channel sender.
 struct SingleSender<T>(mpsc::Sender<T>);
 
-/// Broadcast sender that clones the value to all channels.
-struct BroadcastSender<T>(Arc<Vec<mpsc::Sender<T>>>);
+/// Broadcast sender that clones the value to the subset of channels chosen by a shared filter.
+/// The unfiltered broadcast path uses this with an always-true filter.
+struct FilteredBroadcastSender<T, P> {
+    txs: Arc<Vec<mpsc::Sender<T>>>,
+    filter: Arc<P>,
+}
 
 impl ConcurrencyConfig {
     pub fn fixed(n: usize) -> Self {
@@ -296,11 +314,12 @@ impl<S: Stream + Sized + 'static> TrySpawnStreamExt for S {
         adaptive_spawn_send(self, config, f, SingleSender(tx), report).await
     }
 
-    async fn try_for_each_broadcast_spawned<Fut, F, T, E, R>(
+    async fn try_for_each_broadcast_filtered_spawned<Fut, F, T, E, P, R>(
         self,
         config: ConcurrencyConfig,
         f: F,
         txs: Vec<mpsc::Sender<T>>,
+        filter: P,
         report: R,
     ) -> Result<(), Break<E>>
     where
@@ -308,9 +327,14 @@ impl<S: Stream + Sized + 'static> TrySpawnStreamExt for S {
         F: FnMut(Self::Item) -> Fut,
         T: Clone + Send + Sync + 'static,
         E: Send + 'static,
+        P: Fn(usize, &T) -> bool + Send + Sync + 'static,
         R: Fn(ConcurrencyStats),
     {
-        adaptive_spawn_send(self, config, f, BroadcastSender(Arc::new(txs)), report).await
+        let sender = FilteredBroadcastSender {
+            txs: Arc::new(txs),
+            filter: Arc::new(filter),
+        };
+        adaptive_spawn_send(self, config, f, sender, report).await
     }
 }
 
@@ -332,36 +356,51 @@ impl<T: Send + 'static> Sender for SingleSender<T> {
     }
 }
 
-impl<T> Clone for BroadcastSender<T> {
+impl<T, P> Clone for FilteredBroadcastSender<T, P> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            txs: self.txs.clone(),
+            filter: self.filter.clone(),
+        }
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> Sender for BroadcastSender<T> {
+impl<T, P> Sender for FilteredBroadcastSender<T, P>
+where
+    T: Clone + Send + Sync + 'static,
+    P: Fn(usize, &T) -> bool + Send + Sync + 'static,
+{
     type Value = T;
 
     async fn send(&self, value: T) -> Result<(), ()> {
-        let (last, rest) = self.0.split_last().ok_or(())?;
-        let rest_fut = try_join_all(rest.iter().map(|tx| {
-            let v = value.clone();
-            async move { tx.send(v).await.map_err(|_| ()) }
-        }));
-        let last_fut = last.send(value).map(|r| r.map_err(|_| ()));
-        try_join!(rest_fut, last_fut)?;
-        Ok(())
+        // No channels at all is treated like all channels being closed.
+        if self.txs.is_empty() {
+            return Err(());
+        }
+
+        // A value that no channel accepts is dropped, which counts as a successful send.
+        let sends = self
+            .txs
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| (self.filter)(*i, &value))
+            .map(|(_, tx)| {
+                let v = value.clone();
+                async move { tx.send(v).await.map_err(|_| ()) }
+            });
+        try_join_all(sends).await.map(|_| ())
     }
 
     fn fill(&self) -> f64 {
-        self.0
+        self.txs
             .iter()
             .map(|tx| 1.0 - (tx.capacity() as f64 / tx.max_capacity() as f64))
             .fold(0.0f64, f64::max)
     }
 }
 
-/// Shared adaptive concurrency loop used by both `try_for_each_send_spawned` and
-/// `try_for_each_broadcast_spawned`.
+/// Shared adaptive concurrency loop used by the `try_for_each_send_spawned` and
+/// `try_for_each_broadcast_filtered_spawned` methods.
 ///
 /// The algorithm is a result of weeks of trial and error guided by lots of Claude Research queries.
 /// I tried to document where each of the ideas came from in the footnotes of this comment.
@@ -585,6 +624,16 @@ mod tests {
     use futures::stream;
 
     use super::*;
+
+    /// Drain everything currently in `rx` and return it sorted.
+    fn drain_sorted(rx: &mut mpsc::Receiver<u64>) -> Vec<u64> {
+        let mut values = Vec::new();
+        while let Ok(v) = rx.try_recv() {
+            values.push(v);
+        }
+        values.sort();
+        values
+    }
 
     #[tokio::test]
     async fn for_each_explicit_sequential_iteration() {
@@ -817,35 +866,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn broadcast_spawned_basic() {
+    async fn broadcast_filtered_spawned_all_channels() {
         let (tx1, mut rx1) = mpsc::channel(100);
         let (tx2, mut rx2) = mpsc::channel(100);
         let txs = vec![tx1, tx2];
 
         let result = stream::iter(0..5u64)
-            .try_for_each_broadcast_spawned(
+            .try_for_each_broadcast_filtered_spawned(
                 ConcurrencyConfig::fixed(2),
                 |i| async move { Ok::<_, Break<()>>(i * 3) },
                 txs,
+                |_, _: &u64| true,
                 |_| {},
             )
             .await;
 
         assert!(result.is_ok());
 
-        let mut v1 = Vec::new();
-        while let Ok(v) = rx1.try_recv() {
-            v1.push(v);
-        }
-        let mut v2 = Vec::new();
-        while let Ok(v) = rx2.try_recv() {
-            v2.push(v);
-        }
-        v1.sort();
-        v2.sort();
         let expected: Vec<u64> = (0..5).map(|i| i * 3).collect();
-        assert_eq!(v1, expected);
-        assert_eq!(v2, expected);
+        assert_eq!(drain_sorted(&mut rx1), expected);
+        assert_eq!(drain_sorted(&mut rx2), expected);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1103,7 +1143,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn broadcast_spawned_slow_receiver_triggers_decrease() {
+    async fn broadcast_filtered_spawned_slow_receiver_triggers_decrease() {
         let (tx_fast, mut rx_fast) = mpsc::channel(100);
         let (tx_slow, mut rx_slow) = mpsc::channel(4);
         let txs = vec![tx_fast, tx_slow];
@@ -1112,13 +1152,14 @@ mod tests {
         let limits2 = limits.clone();
         let handle = tokio::spawn(async move {
             stream::iter(0..100u64)
-                .try_for_each_broadcast_spawned(
+                .try_for_each_broadcast_filtered_spawned(
                     ConcurrencyConfig::adaptive(10, 1, 20),
                     |i| async move {
                         tokio::time::sleep(Duration::from_millis(5)).await;
                         Ok::<_, Break<()>>(i)
                     },
                     txs,
+                    |_, _: &u64| true,
                     move |stats| {
                         limits2.lock().unwrap().push(stats.limit);
                     },
@@ -1159,21 +1200,270 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn broadcast_spawned_channel_closed() {
+    async fn broadcast_filtered_spawned_routes_per_channel() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                |i, v: &u64| {
+                    if i == 0 {
+                        v.is_multiple_of(2)
+                    } else {
+                        !v.is_multiple_of(2)
+                    }
+                },
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        assert_eq!(drain_sorted(&mut rx1), vec![0, 2, 4, 6, 8]);
+        assert_eq!(drain_sorted(&mut rx2), vec![1, 3, 5, 7, 9]);
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_threshold_filter() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        // The shape the indexing framework uses: each channel has a resume point below which
+        // it does not receive values.
+        let next = [0u64, 5];
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                move |i, v: &u64| *v >= next[i],
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        assert_eq!(drain_sorted(&mut rx1), (0..10).collect::<Vec<_>>());
+        assert_eq!(drain_sorted(&mut rx2), (5..10).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_drops_unmatched() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                |_, _: &u64| false,
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert!(rx1.try_recv().is_err());
+        assert!(rx2.try_recv().is_err());
+    }
+
+    /// A filter that keeps state does so through its own interior mutability; the combinator
+    /// does not synchronize filter calls.
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_interior_mutability_filter() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        // Limit 1 makes completion order match stream order, so the stateful cutoff is
+        // deterministic.
+        let sent = AtomicUsize::new(0);
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(1),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                move |i, _: &u64| {
+                    if i == 0 {
+                        sent.fetch_add(1, Ordering::Relaxed) < 3
+                    } else {
+                        true
+                    }
+                },
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        let mut v1 = Vec::new();
+        while let Ok(v) = rx1.try_recv() {
+            v1.push(v);
+        }
+        let mut v2 = Vec::new();
+        while let Ok(v) = rx2.try_recv() {
+            v2.push(v);
+        }
+        assert_eq!(v1, vec![0, 1, 2]);
+        assert_eq!(v2, (0..10).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_ignores_closed_filtered_out_channel() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, rx2) = mpsc::channel(100);
+        drop(rx2);
+
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                |i, _: &u64| i == 0,
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        assert_eq!(drain_sorted(&mut rx1), (0..10).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_kept_channel_closed() {
         let (tx1, _rx1) = mpsc::channel(100);
         let (tx2, rx2) = mpsc::channel(100);
         drop(rx2);
 
         let result: Result<(), Break<()>> = stream::iter(0..10u64)
-            .try_for_each_broadcast_spawned(
+            .try_for_each_broadcast_filtered_spawned(
                 ConcurrencyConfig::fixed(2),
                 |i| async move { Ok(i) },
                 vec![tx1, tx2],
+                |_, _: &u64| true,
                 |_| {},
             )
             .await;
 
         assert!(matches!(result, Err(Break::Break)));
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_empty_txs_breaks() {
+        let result: Result<(), Break<()>> = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok(i) },
+                Vec::new(),
+                |_, _: &u64| true,
+                |_| {},
+            )
+            .await;
+
+        assert!(matches!(result, Err(Break::Break)));
+    }
+
+    /// A channel the filter rejects still drives the adaptive controller: fill is the max
+    /// across ALL channels, so a full rejected channel throttles concurrency to min -- but it
+    /// is never sent to, so it neither blocks the pipeline nor receives values.
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_rejected_full_channel_throttles() {
+        let (tx_active, mut rx_active) = mpsc::channel(500);
+        let (tx_rejected, mut rx_rejected) = mpsc::channel(4);
+        // Pin channel 1's fill at 1.0 forever: pre-fill it and never drain.
+        for v in 0..4u64 {
+            tx_rejected.try_send(v).unwrap();
+        }
+
+        let limits: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+        let limits2 = limits.clone();
+        let result = stream::iter(0..200u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::adaptive(10, 1, 20),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx_active, tx_rejected],
+                |i, _: &u64| i == 0,
+                move |stats| limits2.lock().unwrap().push(stats.limit),
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        // No value lost and no deadlock: the full rejected channel is never sent to.
+        assert_eq!(drain_sorted(&mut rx_active), (0..200).collect::<Vec<_>>());
+        assert_eq!(drain_sorted(&mut rx_rejected), vec![0, 1, 2, 3]);
+
+        let limits = limits.lock().unwrap();
+        assert_eq!(
+            *limits.iter().min().unwrap(),
+            1,
+            "full rejected channel must drive the limit to min"
+        );
+        assert!(
+            limits.windows(2).all(|w| w[1] <= w[0]),
+            "increase branch must never fire while any channel is full: {limits:?}"
+        );
+    }
+
+    /// A panic in a spawned item task resurfaces from the broadcast path instead of being
+    /// swallowed as a clean shutdown.
+    #[tokio::test]
+    #[should_panic(expected = "broadcast worker panicked")]
+    async fn broadcast_filtered_spawned_panic_propagation() {
+        let (tx, _rx) = mpsc::channel(100);
+        let _ = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(1),
+                |i| async move {
+                    if i == 3 {
+                        panic!("broadcast worker panicked");
+                    }
+                    Ok::<_, Break<()>>(i)
+                },
+                vec![tx],
+                |_, _: &u64| true,
+                |_| {},
+            )
+            .await;
+    }
+
+    /// The filter is invoked exactly once per channel index per value -- the contract a
+    /// stateful filter relies on.
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_filter_called_once_per_channel_per_value() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, _rx2) = mpsc::channel(100);
+        let (tx3, _rx3) = mpsc::channel(100);
+
+        let calls: Arc<Mutex<Vec<(usize, u64)>>> = Arc::new(Mutex::new(Vec::new()));
+        let calls2 = calls.clone();
+        let result = stream::iter(0..5u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(1),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2, tx3],
+                move |i, v: &u64| {
+                    calls2.lock().unwrap().push((i, *v));
+                    i == 0
+                },
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(drain_sorted(&mut rx1), (0..5).collect::<Vec<_>>());
+
+        let mut calls = calls.lock().unwrap().clone();
+        calls.sort();
+        let expected: Vec<(usize, u64)> = (0..3usize)
+            .flat_map(|i| (0..5u64).map(move |v| (i, v)))
+            .collect();
+        assert_eq!(
+            calls, expected,
+            "filter must be called exactly once per (channel, value)"
+        );
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-consistent-store/src/config.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/config.rs
@@ -47,6 +47,7 @@ pub struct IngestionConfig {
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
     pub min_cohort_boundary: u64,
+    pub cohort_merge_threshold: u64,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -156,6 +157,7 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
             min_cohort_boundary: config.min_cohort_boundary,
+            cohort_merge_threshold: config.cohort_merge_threshold,
             checkpoint_buffer_size: None,
         }
     }
@@ -179,6 +181,7 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
             min_cohort_boundary: config.min_cohort_boundary,
+            cohort_merge_threshold: config.cohort_merge_threshold,
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/cohort.rs
+++ b/crates/sui-indexer-alt-framework/src/cohort.rs
@@ -5,8 +5,31 @@
 //! pipeline's resume checkpoint is. Pipelines in the same cohort share one ingestion service, so
 //! a far-behind pipeline only applies backpressure to similarly-lagging peers, not to pipelines
 //! that are already at the tip.
+//!
+//! Cohorts also merge back together at runtime: when a trailing cohort's ingestion frontier gets
+//! within [`IngestionConfig::cohort_merge_threshold`] checkpoints of the cohort ahead of it, the
+//! trailing cohort hands its subscribers off to the ahead cohort (exactly once -- no gaps, no
+//! duplicate deliveries) and winds down. The protocol lives entirely in the cohort table, under
+//! its one mutex: alongside its frontier, each cohort advertises the exclusive end of the range
+//! its broadcaster currently has in flight ([`CohortSlot::in_flight`]) -- nothing at or above
+//! that point is broadcast before the next range is picked up. A merging cohort atomically
+//! registers its subscribers in the target's [`CohortSlot::pending`] at exactly that point, the
+//! handoff checkpoint: the target absorbs them into its subscriber list when it commits the
+//! range that starts there, while the mergee keeps delivering everything below it before winding
+//! down. The target never has to coordinate -- registration is a push into the table, so a
+//! trailing cohort can merge into a cohort whose broadcaster is parked on backpressure.
+//!
+//! [`IngestionConfig::cohort_merge_threshold`]: crate::ingestion::IngestionConfig::cohort_merge_threshold
+
+use std::ops::Range;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use tokio::sync::mpsc;
+use tracing::debug;
 
 use crate::PendingPipeline;
+use crate::ingestion::ingestion_client::CheckpointEnvelope;
 
 /// Default for [`IngestionConfig::min_cohort_boundary`]: a cohort's boundary (its maximum member
 /// distance from the tip) is at least this many checkpoints, so that pipelines that are roughly
@@ -14,6 +37,251 @@ use crate::PendingPipeline;
 ///
 /// [`IngestionConfig::min_cohort_boundary`]: crate::ingestion::IngestionConfig::min_cohort_boundary
 pub(crate) const DEFAULT_MIN_COHORT_BOUNDARY: u64 = 25_000;
+
+/// Default for [`IngestionConfig::cohort_merge_threshold`]: a trailing cohort merges into the
+/// cohort ahead of it once its ingestion frontier is within this many checkpoints of that
+/// cohort's frontier.
+///
+/// [`IngestionConfig::cohort_merge_threshold`]: crate::ingestion::IngestionConfig::cohort_merge_threshold
+pub(crate) const DEFAULT_COHORT_MERGE_THRESHOLD: u64 = 1_000;
+
+/// Upper bound on the size of the ingestion chunks a merge-enabled broadcaster splits its legs
+/// into. Chunk boundaries are where a broadcaster looks for merge opportunities and absorbs
+/// adopted subscribers, so the chunk size tracks the merge threshold (a trigger should fire
+/// before frontiers drift by more than a threshold), but is capped so a large threshold does not
+/// starve triggers.
+const MAX_MERGE_CHUNK: u64 = 1_000;
+
+/// Where a cohort is in its lifecycle, from its peers' point of view.
+#[derive(Default)]
+pub(crate) enum CohortState {
+    /// Running; may merge away or be merged into.
+    #[default]
+    Active,
+
+    /// Committed to merging into another cohort; delivering its final leg.
+    Merging,
+
+    /// Its broadcaster has finished.
+    Gone,
+}
+
+/// One cohort's entry in the table its peers consult to find merge targets and to hand their
+/// subscribers over.
+#[derive(Default)]
+pub(crate) struct CohortSlot {
+    pub(crate) state: CohortState,
+
+    /// The cohort's ingestion frontier: everything below this checkpoint has been delivered to
+    /// its subscribers. `None` until the cohort's broadcaster starts. May lag the true frontier
+    /// by up to one ingestion chunk; merge decisions only need it as a hint, because the handoff
+    /// checkpoint comes from `in_flight`, which is exact.
+    pub(crate) frontier: Option<u64>,
+
+    /// The exclusive end of the range this cohort's broadcaster is currently committed to:
+    /// nothing at or above this checkpoint is broadcast before the broadcaster commits its next
+    /// range (absorbing `pending` first), so it is the exact point at which new subscribers can
+    /// still join in full. `None` while no range is committed (before the broadcaster starts,
+    /// and through each leg's setup window), during which adoptions are refused.
+    pub(crate) in_flight: Option<u64>,
+
+    /// Subscribers handed over by merging cohorts, each with the first checkpoint it is owed;
+    /// this cohort's broadcaster absorbs them into its subscriber list at the commit of the
+    /// range their checkpoint starts.
+    pub(crate) pending: Vec<(Subscriber, u64)>,
+}
+
+/// A broadcaster's view of the cohort table, used to publish its frontier and find (or become) a
+/// merge target. Present only when the indexer runs multiple cohorts with merging enabled.
+#[derive(Clone)]
+pub(crate) struct MergeContext {
+    pub(crate) table: Arc<Mutex<Vec<CohortSlot>>>,
+
+    /// This cohort's index into the table.
+    pub(crate) cohort: usize,
+
+    /// Merge when the cohort ahead is within this many checkpoints.
+    pub(crate) threshold: u64,
+}
+
+/// Marks a cohort [`CohortState::Gone`] when dropped. Held by the cohort's broadcaster so that
+/// every exit path -- completion, error, panic, and abort alike -- retires the slot: peers stop
+/// targeting it, and dropping its unabsorbed `pending` closes those subscribers' channels, the
+/// same wind-down they would see from a running service shutting down.
+pub(crate) struct CohortGuard(MergeContext);
+
+/// A subscription to the ingestion service: the channel checkpoints are delivered on, and the
+/// first checkpoint the subscriber still needs. The broadcaster does not deliver checkpoints
+/// below `next_checkpoint` -- the subscriber has already processed them.
+#[derive(Clone)]
+pub(crate) struct Subscriber {
+    pub(crate) tx: mpsc::Sender<Arc<CheckpointEnvelope>>,
+
+    /// The subscriber's resume point.
+    pub(crate) next_checkpoint: u64,
+}
+
+impl Subscriber {
+    /// Whether this subscriber still needs `sequence_number`.
+    pub(crate) fn needs(&self, sequence_number: u64) -> bool {
+        self.next_checkpoint <= sequence_number
+    }
+}
+
+impl MergeContext {
+    /// The number of checkpoints a broadcaster should ingest between merge trigger points.
+    pub(crate) fn chunk(&self) -> u64 {
+        self.threshold.clamp(1, MAX_MERGE_CHUNK)
+    }
+
+    /// Called by this cohort's broadcaster at a clean state -- everything below `frontier`
+    /// delivered to `subscribers`, nothing in flight. Absorbs subscribers owed from `frontier`,
+    /// publishes it, and withdraws the cohort's join point (nothing is in flight, so there is no
+    /// exact point to join at until the next range is committed).
+    ///
+    /// Then, if a cohort ahead is within the merge threshold, commits this cohort to merging
+    /// into it: every subscriber (and every not-yet-absorbed adoptee) is registered with the
+    /// target at the handoff checkpoint -- the exclusive end of the target's in-flight range --
+    /// and the target's index and the handoff are returned. This cohort should truncate its own
+    /// range to end at the handoff, so between the two cohorts every subscriber sees every
+    /// checkpoint exactly once.
+    pub(crate) fn at_clean_state(
+        &self,
+        frontier: u64,
+        subscribers: &mut Vec<Subscriber>,
+    ) -> Option<(usize, u64)> {
+        let mut table = self.table.lock().unwrap();
+
+        let slot = &mut table[self.cohort];
+        absorb(&mut slot.pending, frontier, subscribers);
+        slot.frontier = Some(frontier);
+        slot.in_flight = None;
+
+        if !matches!(slot.state, CohortState::Active) {
+            return None;
+        }
+
+        let (target, handoff) = self.target_of(&table, frontier)?;
+        debug_assert!(frontier <= handoff, "handoff below the mergee's frontier");
+
+        // Register this cohort's subscribers with the target from the handoff. Adoptees still
+        // pending here (owed from beyond `frontier`) are registered as well, but also retained:
+        // this cohort's final leg still owes them everything below the handoff.
+        let handed: Vec<_> = subscribers
+            .iter()
+            .map(|s| (s.clone(), handoff))
+            .chain(
+                table[self.cohort]
+                    .pending
+                    .iter()
+                    .map(|(s, from)| (s.clone(), (*from).max(handoff))),
+            )
+            .collect();
+        table[target].pending.extend(handed);
+        table[self.cohort].state = CohortState::Merging;
+
+        Some((target, handoff))
+    }
+
+    /// Called by this cohort's broadcaster when it commits to ingesting `range`: absorbs
+    /// subscribers owed from its start into `subscribers` (before the range's snapshot is
+    /// taken), and advertises its end as the point where new adoptions can join.
+    pub(crate) fn commit_range(&self, range: Range<u64>, subscribers: &mut Vec<Subscriber>) {
+        let mut table = self.table.lock().unwrap();
+        let slot = &mut table[self.cohort];
+        absorb(&mut slot.pending, range.start, subscribers);
+        debug_assert!(
+            slot.pending.iter().all(|(_, from)| *from >= range.end),
+            "pending adoption strictly inside a committed range"
+        );
+        slot.frontier = Some(range.start);
+        slot.in_flight = Some(range.end);
+    }
+
+    /// Called by this cohort's broadcaster before streaming checkpoint `lo` to `subscribers`
+    /// (streaming is in order, so `lo` is the exact frontier): absorbs subscribers owed from
+    /// `lo`, publishes the frontier, and advertises `lo + 1` as the join point.
+    ///
+    /// Returns whether a cohort ahead has come within merge range, in which case nothing is
+    /// advertised and the caller should break out *without* sending `lo`, so the merge can be
+    /// arranged at a clean state with frontier `lo`.
+    pub(crate) fn commit_streamed(&self, lo: u64, subscribers: &mut Vec<Subscriber>) -> bool {
+        let mut table = self.table.lock().unwrap();
+        let slot = &mut table[self.cohort];
+        absorb(&mut slot.pending, lo, subscribers);
+        slot.frontier = Some(lo);
+        let active = matches!(slot.state, CohortState::Active);
+
+        if active && self.target_of(&table, lo).is_some() {
+            table[self.cohort].in_flight = None;
+            true
+        } else {
+            table[self.cohort].in_flight = Some(lo.saturating_add(1));
+            false
+        }
+    }
+
+    /// The guard this cohort's broadcaster holds so that its slot is retired however it exits.
+    pub(crate) fn guard(&self) -> CohortGuard {
+        CohortGuard(self.clone())
+    }
+
+    /// The nearest active cohort whose frontier is at or ahead of `frontier` by at most the
+    /// merge threshold and whose join point is advertised, along with that join point (the
+    /// handoff checkpoint for a merge committed now).
+    fn target_of(&self, table: &[CohortSlot], frontier: u64) -> Option<(usize, u64)> {
+        let mut best: Option<(u64, usize, u64)> = None;
+        for (index, slot) in table.iter().enumerate() {
+            if index == self.cohort || !matches!(slot.state, CohortState::Active) {
+                continue;
+            }
+
+            let (Some(ahead), Some(in_flight)) = (slot.frontier, slot.in_flight) else {
+                continue;
+            };
+
+            if ahead < frontier || ahead - frontier > self.threshold {
+                continue;
+            }
+
+            if best.is_none_or(|(f, _, _)| ahead < f) {
+                best = Some((ahead, index, in_flight));
+            }
+        }
+        best.map(|(_, index, in_flight)| (index, in_flight))
+    }
+}
+
+impl Drop for CohortGuard {
+    fn drop(&mut self) {
+        // Retire the slot even if the mutex was poisoned by a panicking peer.
+        let mut table = self
+            .0
+            .table
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let slot = &mut table[self.0.cohort];
+        slot.state = CohortState::Gone;
+        slot.in_flight = None;
+        slot.pending.clear();
+    }
+}
+
+/// Move subscribers owed from at or below `frontier` out of `pending` and into `subscribers`.
+/// Registrations always land exactly on the next commit point, so an absorbed subscriber is owed
+/// precisely the range being committed.
+fn absorb(pending: &mut Vec<(Subscriber, u64)>, frontier: u64, subscribers: &mut Vec<Subscriber>) {
+    pending.retain(|(subscriber, from)| {
+        if *from > frontier {
+            return true;
+        }
+
+        debug_assert_eq!(*from, frontier, "absorbed a subscriber past its handoff");
+        debug!(from = *from, "Absorbing adopted subscriber");
+        subscribers.push(subscriber.clone());
+        false
+    });
+}
 
 /// Group pipelines into cohorts by their distance from the network tip.
 ///
@@ -62,6 +330,45 @@ mod tests {
             next_checkpoint: u64::MAX - distance,
             build: Box::new(|_| unreachable!("cohort grouping never builds pipelines")),
         }
+    }
+
+    fn slot(state: CohortState, frontier: Option<u64>, in_flight: Option<u64>) -> CohortSlot {
+        CohortSlot {
+            state,
+            frontier,
+            in_flight,
+            pending: vec![],
+        }
+    }
+
+    fn context(slots: Vec<CohortSlot>, cohort: usize, threshold: u64) -> MergeContext {
+        MergeContext {
+            table: Arc::new(Mutex::new(slots)),
+            cohort,
+            threshold,
+        }
+    }
+
+    /// A subscriber resuming at `next_checkpoint`, with its receiver.
+    fn subscriber(next_checkpoint: u64) -> (Subscriber, mpsc::Receiver<Arc<CheckpointEnvelope>>) {
+        let (tx, rx) = mpsc::channel(16);
+        (
+            Subscriber {
+                tx,
+                next_checkpoint,
+            },
+            rx,
+        )
+    }
+
+    /// Register `subscriber` in `cohort`'s slot at its advertised join point, as a merging peer
+    /// would, and return that handoff checkpoint.
+    fn register(ctx: &MergeContext, cohort: usize, subscriber: Subscriber) -> u64 {
+        let mut table = ctx.table.lock().unwrap();
+        let slot = &mut table[cohort];
+        let handoff = slot.in_flight.expect("no join point advertised");
+        slot.pending.push((subscriber, handoff));
+        handoff
     }
 
     /// Group `pipelines` (tip at `u64::MAX`) and read each cohort back out as member distances.
@@ -183,5 +490,281 @@ mod tests {
             grouped(vec![at(0), at(100), at(101)], DEFAULT_MIN_COHORT_BOUNDARY),
             vec![vec![0, 100, 101]]
         );
+    }
+
+    /// Committing a range absorbs subscribers registered at its start into the subscriber list,
+    /// and advertises the range's end as the next join point.
+    #[test]
+    fn test_commit_range_absorbs_and_advertises() {
+        let ctx = context(vec![slot(CohortState::Active, Some(10), Some(10))], 0, 50);
+        let (sub, _rx) = subscriber(99);
+        assert_eq!(register(&ctx, 0, sub), 10);
+
+        let mut subscribers = vec![];
+        ctx.commit_range(10..20, &mut subscribers);
+
+        // Absorption preserves the subscriber's own resume point; only the pair's absorb point
+        // is protocol state.
+        assert_eq!(subscribers.len(), 1);
+        assert_eq!(subscribers[0].next_checkpoint, 99);
+        let table = ctx.table.lock().unwrap();
+        assert!(table[0].pending.is_empty());
+        assert_eq!(table[0].in_flight, Some(20));
+        assert_eq!(table[0].frontier, Some(10));
+    }
+
+    /// A subscriber registered mid-range (at the range's end) is not absorbed until the commit
+    /// of the range that starts there.
+    #[test]
+    fn test_commit_range_leaves_future_adoptions_pending() {
+        let ctx = context(vec![slot(CohortState::Active, Some(10), Some(20))], 0, 50);
+        let (sub, _rx) = subscriber(0);
+        assert_eq!(register(&ctx, 0, sub), 20);
+
+        let mut subscribers = vec![];
+        ctx.commit_range(20..30, &mut subscribers);
+        assert_eq!(subscribers.len(), 1);
+    }
+
+    /// A clean state absorbs subscribers owed from the frontier, publishes it, and withdraws the
+    /// join point.
+    #[test]
+    fn test_clean_state_absorbs_and_withdraws() {
+        let ctx = context(vec![slot(CohortState::Active, Some(10), Some(15))], 0, 50);
+        let (sub, _rx) = subscriber(999);
+        assert_eq!(register(&ctx, 0, sub), 15);
+
+        let mut subscribers = vec![];
+        assert!(ctx.at_clean_state(15, &mut subscribers).is_none());
+
+        // Absorbed at the join point, with a resume point beyond it left intact: delivery from
+        // here on is still filtered by the subscriber's own `next_checkpoint`.
+        assert_eq!(subscribers.len(), 1);
+        assert_eq!(subscribers[0].next_checkpoint, 999);
+        let table = ctx.table.lock().unwrap();
+        assert!(table[0].pending.is_empty());
+        assert_eq!(table[0].in_flight, None);
+        assert_eq!(table[0].frontier, Some(15));
+    }
+
+    /// The nearest active cohort ahead within the threshold is chosen, the handoff is its
+    /// advertised join point, and committing to the merge takes this cohort out of the running.
+    #[test]
+    fn test_merge_target_nearest_ahead() {
+        let ctx = context(
+            vec![
+                slot(CohortState::Active, Some(100), None),
+                slot(CohortState::Active, Some(150), Some(170)),
+                slot(CohortState::Active, Some(120), Some(140)),
+            ],
+            0,
+            1_000,
+        );
+
+        let (sub, _rx) = subscriber(999);
+        let mut subscribers = vec![sub];
+        assert_eq!(
+            ctx.at_clean_state(100, &mut subscribers),
+            Some((2, 140)),
+            "nearest cohort ahead wins, handing off at its join point"
+        );
+
+        {
+            let table = ctx.table.lock().unwrap();
+            assert!(matches!(table[0].state, CohortState::Merging));
+            assert_eq!(table[2].pending.len(), 1);
+            // Registration stamps the handoff on the pair, but the subscriber's own resume
+            // point (here, beyond the handoff) rides along unchanged.
+            assert_eq!(table[2].pending[0].1, 140);
+            assert_eq!(table[2].pending[0].0.next_checkpoint, 999);
+        }
+
+        // Committed: the mergee no longer looks for targets.
+        assert!(ctx.at_clean_state(100, &mut subscribers).is_none());
+    }
+
+    /// Cohorts that are behind, out of threshold, not yet started, without an advertised join
+    /// point, or no longer active are all skipped.
+    #[test]
+    fn test_merge_target_filters() {
+        let ctx = context(
+            vec![
+                slot(CohortState::Active, Some(100), Some(120)),
+                slot(CohortState::Active, Some(90), Some(120)),
+                slot(CohortState::Active, Some(151), Some(170)),
+                slot(CohortState::Active, None, None),
+                slot(CohortState::Active, Some(110), None),
+                slot(CohortState::Merging, Some(110), Some(130)),
+                slot(CohortState::Gone, Some(110), Some(130)),
+            ],
+            0,
+            50,
+        );
+        let mut subscribers = vec![];
+        assert!(ctx.at_clean_state(100, &mut subscribers).is_none());
+    }
+
+    /// The merge threshold is inclusive.
+    #[test]
+    fn test_merge_threshold_inclusive() {
+        let ctx = context(
+            vec![
+                slot(CohortState::Active, Some(0), Some(10)),
+                slot(CohortState::Active, Some(50), Some(60)),
+            ],
+            0,
+            50,
+        );
+        let mut subscribers = vec![];
+        assert_eq!(ctx.at_clean_state(0, &mut subscribers), Some((1, 60)));
+    }
+
+    /// A zero threshold does not disable merging: cohorts merge once their frontiers meet
+    /// exactly, but not a checkpoint sooner.
+    #[test]
+    fn test_merge_threshold_zero() {
+        let ctx = context(
+            vec![
+                slot(CohortState::Active, Some(100), Some(120)),
+                slot(CohortState::Active, Some(100), Some(120)),
+            ],
+            0,
+            0,
+        );
+        let mut subscribers = vec![];
+        assert!(ctx.at_clean_state(99, &mut subscribers).is_none());
+
+        // Rolling the frontier back to re-check is artificial, but exercises the boundary.
+        ctx.table.lock().unwrap()[0].frontier = None;
+        assert_eq!(ctx.at_clean_state(100, &mut subscribers), Some((1, 120)));
+    }
+
+    /// A merging cohort passes its own not-yet-absorbed adoptees along to the target (at the
+    /// handoff, or their own owed checkpoint if that is later), while retaining them: its final
+    /// leg still owes them everything below the handoff.
+    #[test]
+    fn test_merge_passes_pending_adoptees_along() {
+        let ctx = context(
+            vec![
+                slot(CohortState::Active, Some(100), Some(110)),
+                slot(CohortState::Active, Some(105), Some(120)),
+            ],
+            0,
+            50,
+        );
+        let (sub, _rx) = subscriber(115);
+        assert_eq!(register(&ctx, 0, sub), 110);
+
+        let (own, _own_rx) = subscriber(7);
+        let mut subscribers = vec![own];
+        assert_eq!(ctx.at_clean_state(100, &mut subscribers), Some((1, 120)));
+
+        let table = ctx.table.lock().unwrap();
+        // The adoptee (owed from 110 < 120) was not absorbed at frontier 100, so it is both
+        // retained locally and registered with the target at the handoff. Both handed entries
+        // keep their own resume points.
+        assert_eq!(table[0].pending.len(), 1);
+        assert_eq!(table[0].pending[0].1, 110);
+        let handed: Vec<(u64, u64)> = table[1]
+            .pending
+            .iter()
+            .map(|(s, from)| (*from, s.next_checkpoint))
+            .collect();
+        assert_eq!(handed, vec![(120, 7), (120, 115)]);
+    }
+
+    /// Committing a streamed checkpoint absorbs subscribers owed from it (before it is sent) and
+    /// advertises the next checkpoint as the join point.
+    #[test]
+    fn test_commit_streamed_absorbs_and_advertises() {
+        let ctx = context(vec![slot(CohortState::Active, Some(6), Some(7))], 0, 50);
+        let (sub, _rx) = subscriber(0);
+        assert_eq!(register(&ctx, 0, sub), 7);
+
+        let mut subscribers = vec![];
+        assert!(!ctx.commit_streamed(7, &mut subscribers));
+
+        assert_eq!(subscribers.len(), 1);
+        let table = ctx.table.lock().unwrap();
+        assert!(table[0].pending.is_empty());
+        assert_eq!(table[0].in_flight, Some(8));
+        assert_eq!(table[0].frontier, Some(7));
+    }
+
+    /// When a cohort ahead comes within merge range of the streamed frontier, the commit is
+    /// refused (nothing advertised) so the caller breaks out to arrange the merge.
+    #[test]
+    fn test_commit_streamed_breaks_for_merge() {
+        let ctx = context(
+            vec![
+                slot(CohortState::Active, Some(90), Some(91)),
+                slot(CohortState::Active, Some(105), Some(120)),
+            ],
+            0,
+            10,
+        );
+
+        let mut subscribers = vec![];
+        assert!(!ctx.commit_streamed(94, &mut subscribers));
+        assert!(ctx.commit_streamed(95, &mut subscribers));
+
+        let table = ctx.table.lock().unwrap();
+        assert_eq!(table[0].in_flight, None);
+        assert_eq!(table[0].frontier, Some(95));
+    }
+
+    /// Dropping a cohort's guard retires its slot: peers stop finding it, and pending adoptees'
+    /// channels close, winding them down like subscribers of a stopping service.
+    #[test]
+    fn test_guard_retires_slot_and_drops_pending() {
+        let ctx = context(vec![slot(CohortState::Active, Some(10), Some(20))], 0, 50);
+        let (sub, mut rx) = subscriber(0);
+        assert_eq!(register(&ctx, 0, sub), 20);
+
+        drop(ctx.guard());
+
+        {
+            let table = ctx.table.lock().unwrap();
+            assert!(matches!(table[0].state, CohortState::Gone));
+            assert_eq!(table[0].in_flight, None);
+            assert!(table[0].pending.is_empty());
+        }
+
+        // The adoptee's channel has no senders left.
+        assert!(rx.blocking_recv().is_none());
+    }
+
+    /// The guard retires the slot even when a panicking peer has poisoned the table mutex, so
+    /// pending adoptees' channels still close and peers stop targeting the cohort.
+    #[test]
+    fn test_guard_retires_slot_despite_poisoned_table() {
+        let ctx = context(vec![slot(CohortState::Active, Some(10), Some(20))], 0, 50);
+        let (sub, mut rx) = subscriber(0);
+        assert_eq!(register(&ctx, 0, sub), 20);
+
+        // Poison the table, as a peer panicking while holding the lock would.
+        let table = ctx.table.clone();
+        std::thread::spawn(move || {
+            let _lock = table.lock().unwrap();
+            panic!("peer panic");
+        })
+        .join()
+        .unwrap_err();
+
+        drop(ctx.guard());
+
+        {
+            // Poison persists after `into_inner`, so the assertions must also recover from it.
+            let table = ctx
+                .table
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            assert!(matches!(table[0].state, CohortState::Gone));
+            assert_eq!(table[0].in_flight, None);
+            assert!(table[0].pending.is_empty());
+        }
+
+        // The adoptee's channel has no senders left.
+        assert!(rx.blocking_recv().is_none());
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -34,6 +34,24 @@ use crate::metrics::CohortMetrics;
 /// path catch up first.
 const STREAMING_CATCHUP_THRESHOLD: u64 = 1_000;
 
+/// A subscription to the ingestion service: the channel checkpoints are delivered on, and the
+/// first checkpoint the subscriber still needs. The broadcaster does not deliver checkpoints
+/// below `next_checkpoint` -- the subscriber has already processed them.
+#[derive(Clone)]
+pub(super) struct Subscriber {
+    pub(super) tx: mpsc::Sender<Arc<CheckpointEnvelope>>,
+
+    /// The subscriber's resume point.
+    pub(super) next_checkpoint: u64,
+}
+
+impl Subscriber {
+    /// Whether this subscriber still needs `sequence_number`.
+    pub(super) fn needs(&self, sequence_number: u64) -> bool {
+        self.next_checkpoint <= sequence_number
+    }
+}
+
 /// Broadcaster task that manages checkpoint flow and spawns broadcast tasks for ranges
 /// via either streaming or ingesting, or both.
 ///
@@ -47,13 +65,14 @@ const STREAMING_CATCHUP_THRESHOLD: u64 = 1_000;
 /// Backpressure is **per-subscriber, channel-fill based**: each subscriber's bounded mpsc
 /// channel acts as both transport and the backpressure signal. When any subscriber's channel
 /// fills, [`TrySpawnStreamExt::try_for_each_broadcast_filtered_spawned`]'s adaptive controller
-/// cuts ingest concurrency. The task will shut down if the `checkpoints` range completes.
+/// cuts ingest concurrency. Checkpoints below a subscriber's `next_checkpoint` are not
+/// delivered to it. The task will shut down if the `checkpoints` range completes.
 pub(super) fn broadcaster<R>(
     checkpoints: R,
     streaming_client: Option<ArcStreamingClient>,
     config: IngestionConfig,
     client: IngestionClient,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
 ) -> Service
 where
     R: std::ops::RangeBounds<u64> + Send + 'static,
@@ -155,19 +174,21 @@ where
 
 /// Fetch and broadcast checkpoints from a range [start..end) to subscribers. The adaptive
 /// controller reads the max `fill` across subscribers (channel capacity for bounded,
-/// `len / soft_limit` for unbounded) and adjusts ingest concurrency to match.
+/// `len / soft_limit` for unbounded) and adjusts ingest concurrency to match. Each checkpoint
+/// is only delivered to subscribers whose `next_checkpoint` it has reached.
 fn ingest_and_broadcast_range(
     start: u64,
     end: u64,
     retry_interval: Duration,
     ingest_concurrency: ConcurrencyConfig,
     client: IngestionClient,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
     cohort_metrics: Arc<CohortMetrics>,
 ) -> TaskGuard<Result<(), Break<Error>>> {
     TaskGuard::new(tokio::spawn(async move {
         let concurrency_limit = cohort_metrics.ingestion_concurrency_limit.clone();
         let concurrency_inflight = cohort_metrics.ingestion_concurrency_inflight.clone();
+        let txs: Vec<_> = subscribers.iter().map(|s| s.tx.clone()).collect();
         futures::stream::iter(start..end)
             .try_for_each_broadcast_filtered_spawned(
                 ingest_concurrency.into(),
@@ -180,8 +201,10 @@ fn ingest_and_broadcast_range(
                         Ok(Arc::new(checkpoint_envelope))
                     }
                 },
-                subscribers,
-                |_, _: &Arc<CheckpointEnvelope>| true,
+                txs,
+                move |i, envelope: &Arc<CheckpointEnvelope>| {
+                    subscribers[i].needs(*envelope.checkpoint.summary.sequence_number())
+                },
                 move |stats| {
                     concurrency_limit.set(stats.limit as i64);
                     concurrency_inflight.set(stats.inflight as i64);
@@ -200,7 +223,7 @@ async fn setup_streaming_task(
     end_cp: u64,
     streaming_backoff_batch_size: &mut u64,
     config: &IngestionConfig,
-    subscribers: &[mpsc::Sender<Arc<CheckpointEnvelope>>],
+    subscribers: &[Subscriber],
     cohort_metrics: &Arc<CohortMetrics>,
 ) -> (TaskGuard<u64>, u64) {
     // No streaming client configured so we ingest all the way to end_cp.
@@ -292,7 +315,7 @@ async fn stream_and_broadcast_range(
     mut lo: u64,
     hi: u64,
     mut stream: impl Stream<Item = Result<CheckpointEnvelope, Error>> + Unpin,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
     cohort_metrics: Arc<CohortMetrics>,
 ) -> u64 {
     let latest_streamed = cohort_metrics.latest_streamed_checkpoint.clone();
@@ -363,14 +386,18 @@ fn noop_streaming_task(checkpoint_hi: u64) -> TaskGuard<u64> {
     TaskGuard::new(tokio::spawn(async move { checkpoint_hi }))
 }
 
-/// Send a checkpoint to all subscribers. Returns an error if any subscriber's channel is closed.
+/// Send a checkpoint to every subscriber whose `next_checkpoint` it has reached; subscribers
+/// still below their resume point have already processed it. Returns an error if any selected
+/// subscriber's channel is closed.
 async fn send_checkpoint(
     checkpoint_envelope: Arc<CheckpointEnvelope>,
-    subscribers: &[mpsc::Sender<Arc<CheckpointEnvelope>>],
+    subscribers: &[Subscriber],
 ) -> Result<Vec<()>, mpsc::error::SendError<Arc<CheckpointEnvelope>>> {
+    let sequence_number = *checkpoint_envelope.checkpoint.summary.sequence_number();
     let futures = subscribers
         .iter()
-        .map(|s| s.send(checkpoint_envelope.clone()));
+        .filter(|s| s.needs(sequence_number))
+        .map(|s| s.tx.send(checkpoint_envelope.clone()));
     try_join_all(futures).await
 }
 
@@ -382,6 +409,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
     use tokio::time::timeout;
 
     use crate::cohort::DEFAULT_MIN_COHORT_BOUNDARY;
@@ -450,16 +478,36 @@ mod tests {
         result
     }
 
-    /// Build a subscribers list with a single bounded subscriber of the given capacity. Returns
-    /// the senders vec (to pass into `broadcaster(...)`) and the subscriber's stream.
-    fn single_subscriber(
+    /// Build a single bounded subscriber with the given channel capacity and resume point.
+    /// Returns the subscriber (to pass into `broadcaster(...)`) and its stream.
+    fn subscriber(
         capacity: usize,
+        next_checkpoint: u64,
     ) -> (
-        Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+        Subscriber,
         impl Stream<Item = Arc<CheckpointEnvelope>> + Send + Unpin + 'static,
     ) {
         let (tx, rx) = mpsc::channel(capacity);
-        (vec![tx], tokio_stream::wrappers::ReceiverStream::new(rx))
+        (
+            Subscriber {
+                tx,
+                next_checkpoint,
+            },
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )
+    }
+
+    /// Build a subscribers list with a single bounded subscriber of the given capacity that
+    /// receives everything. Returns the subscribers vec (to pass into `broadcaster(...)`) and
+    /// the subscriber's stream.
+    fn single_subscriber(
+        capacity: usize,
+    ) -> (
+        Vec<Subscriber>,
+        impl Stream<Item = Arc<CheckpointEnvelope>> + Send + Unpin + 'static,
+    ) {
+        let (sub, rx) = subscriber(capacity, 0);
+        (vec![sub], rx)
     }
 
     /// Receive `count` checkpoints from the stream and return their sequence numbers as a BTreeSet.
@@ -553,11 +601,9 @@ mod tests {
 
     #[tokio::test]
     async fn multiple_physical_subscribers() {
-        let (tx1, rx1) = mpsc::channel(1);
-        let (tx2, rx2) = mpsc::channel(1);
-        let subscribers = vec![tx1, tx2];
-        let mut subscriber_rx1 = tokio_stream::wrappers::ReceiverStream::new(rx1);
-        let mut subscriber_rx2 = tokio_stream::wrappers::ReceiverStream::new(rx2);
+        let (sub1, mut subscriber_rx1) = subscriber(1, 0);
+        let (sub2, mut subscriber_rx2) = subscriber(1, 0);
+        let subscribers = vec![sub1, sub2];
 
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
@@ -583,6 +629,140 @@ mod tests {
 
         // The broadcaster should shut down gracefully
         svc.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ingest_skips_below_subscriber_next_checkpoint() {
+        let (sub1, mut rx1) = subscriber(10, 0);
+        let (sub2, mut rx2) = subscriber(10, 5);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..10,
+            None,
+            test_config(),
+            mock_client_with_range(0..10, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        assert_eq!(recv_set(&mut rx1, 10).await, BTreeSet::from_iter(0..10));
+        assert_eq!(recv_set(&mut rx2, 5).await, BTreeSet::from_iter(5..10));
+
+        svc.join().await.unwrap();
+
+        // The broadcaster is done and its senders are dropped: an empty channel here proves
+        // checkpoints below the resume point were never delivered, not merely delivered late.
+        assert!(expect_recv(&mut rx2).await.is_none());
+    }
+
+    /// A dropped subscriber that ingestion has not yet reached does not stop the broadcaster:
+    /// checkpoints below its resume point are never routed to it, so its closed channel goes
+    /// unnoticed for the whole range.
+    #[tokio::test]
+    async fn dropped_filtered_subscriber_does_not_stop_broadcaster() {
+        let (sub1, mut rx1) = subscriber(20, 0);
+        let (sub2, rx2) = subscriber(1, 100);
+        drop(rx2);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..20,
+            None,
+            test_config(),
+            mock_client_with_range(0..20, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        assert_eq!(recv_set(&mut rx1, 20).await, BTreeSet::from_iter(0..20));
+
+        svc.join().await.unwrap();
+    }
+
+    /// Once ingestion reaches a dropped subscriber's resume point, the failed send is noticed
+    /// and the broadcaster winds down without completing the range.
+    #[tokio::test]
+    async fn broadcaster_stops_when_range_reaches_dropped_subscriber() {
+        let (sub1, mut rx1) = subscriber(40, 0);
+        let (sub2, rx2) = subscriber(1, 10);
+        drop(rx2);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..40,
+            None,
+            test_config(),
+            mock_client_with_range(0..40, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        svc.join().await.unwrap();
+
+        // The live subscriber received everything below the dropped subscriber's resume point,
+        // plus at most the few checkpoints that were in flight when the send failure hit.
+        let mut received = BTreeSet::new();
+        while let Some(checkpoint_envelope) = expect_recv(&mut rx1).await {
+            received.insert(*checkpoint_envelope.checkpoint.summary.sequence_number());
+        }
+        assert!(received.is_superset(&BTreeSet::from_iter(0..10)));
+        // With fixed ingest concurrency 2, at most checkpoints 10 and 11 can be in flight when
+        // the first failed send is recorded, and no further tasks spawn after it -- so the live
+        // subscriber can receive checkpoints 0..12 at most.
+        assert!(received.len() <= 12);
+    }
+
+    /// A subscriber whose channel is full but whose resume point is above the whole range still
+    /// counts toward the adaptive controller's fill (the max spans all channels), throttling
+    /// ingest to min -- but no send is ever attempted on it, so delivery completes.
+    #[tokio::test]
+    async fn full_filtered_subscriber_throttles_ingest_without_blocking_delivery() {
+        let (sub1, mut rx1) = subscriber(256, 0);
+
+        // Resume point above the whole range: never selected by the filter. Pre-fill its
+        // capacity-1 channel so its fill is pinned at 1.0 for the whole run.
+        let (sub2, mut rx2) = subscriber(1, 1_000);
+        let parked = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(TestCheckpointBuilder::new(999).build_checkpoint()),
+            chain_id: MockIngestionClient::mock_chain_id(),
+        });
+        sub2.tx.try_send(parked).unwrap();
+
+        let config = IngestionConfig {
+            ingest_concurrency: ConcurrencyConfig::Adaptive {
+                initial: 8,
+                min: 1,
+                max: 8,
+                dead_band: None,
+            },
+            ..test_config()
+        };
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..100,
+            None,
+            config,
+            mock_client_with_range(0..100, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        // The full-but-filtered channel never has a send attempted on it, so the range
+        // completes and the live subscriber receives everything.
+        assert_eq!(recv_set(&mut rx1, 100).await, BTreeSet::from_iter(0..100));
+        svc.join().await.unwrap();
+
+        // ...but it does count toward the controller's fill, so the limit walks down to min.
+        assert_eq!(
+            metrics
+                .ingestion_concurrency_limit
+                .with_label_values(&["0"])
+                .get(),
+            1
+        );
+
+        // Only the parked checkpoint ever sat in its channel.
+        let received = expect_recv(&mut rx2).await.unwrap();
+        assert_eq!(*received.checkpoint.summary.sequence_number(), 999);
+        assert!(expect_recv(&mut rx2).await.is_none());
     }
 
     // =============== Streaming Tests ==================
@@ -629,6 +809,87 @@ mod tests {
                 .with_label_values(&["0"])
                 .get(),
             4
+        );
+
+        svc.join().await.unwrap();
+    }
+
+    /// The streaming path also skips delivering checkpoints below a subscriber's resume point.
+    #[tokio::test]
+    async fn streaming_skips_below_subscriber_next_checkpoint() {
+        let (sub1, mut rx1) = subscriber(10, 0);
+        let (sub2, mut rx2) = subscriber(10, 5);
+
+        let streaming_client = MockStreamingClient::new(0..10, None);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..10,
+            Some(Arc::new(streaming_client)),
+            test_config(),
+            mock_client_with_range(0..10, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        assert_eq!(recv_vec(&mut rx1, 10).await, Vec::from_iter(0..10));
+        assert_eq!(recv_vec(&mut rx2, 5).await, Vec::from_iter(5..10));
+
+        // Everything was delivered by streaming, so the skipped deliveries were the streaming
+        // path's doing, not the ingest path's.
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            10
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+
+        svc.join().await.unwrap();
+
+        assert!(expect_recv(&mut rx2).await.is_none());
+    }
+
+    /// The streaming path's `send_checkpoint` filters subscribers before building sends, so a
+    /// closed channel above the streamed range never produces a `SendError` and the broadcaster
+    /// completes the range instead of winding down.
+    #[tokio::test]
+    async fn streaming_ignores_closed_subscriber_below_resume_point() {
+        let (sub1, mut rx1) = subscriber(20, 0);
+        let (sub2, rx2) = subscriber(1, 100);
+        drop(rx2);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..10,
+            Some(Arc::new(MockStreamingClient::new(0..10, None))),
+            test_config(),
+            mock_client_with_range(0..10, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        // In order: everything was delivered, and by streaming -- so the closed channel was
+        // skipped by send_checkpoint, not by the ingest path.
+        assert_eq!(recv_vec(&mut rx1, 10).await, Vec::from_iter(0..10));
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            10
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
         );
 
         svc.join().await.unwrap();

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -46,8 +46,8 @@ const STREAMING_CATCHUP_THRESHOLD: u64 = 1_000;
 ///
 /// Backpressure is **per-subscriber, channel-fill based**: each subscriber's bounded mpsc
 /// channel acts as both transport and the backpressure signal. When any subscriber's channel
-/// fills, [`TrySpawnStreamExt::try_for_each_broadcast_spawned`]'s adaptive controller cuts
-/// ingest concurrency. The task will shut down if the `checkpoints` range completes.
+/// fills, [`TrySpawnStreamExt::try_for_each_broadcast_filtered_spawned`]'s adaptive controller
+/// cuts ingest concurrency. The task will shut down if the `checkpoints` range completes.
 pub(super) fn broadcaster<R>(
     checkpoints: R,
     streaming_client: Option<ArcStreamingClient>,
@@ -169,7 +169,7 @@ fn ingest_and_broadcast_range(
         let concurrency_limit = cohort_metrics.ingestion_concurrency_limit.clone();
         let concurrency_inflight = cohort_metrics.ingestion_concurrency_inflight.clone();
         futures::stream::iter(start..end)
-            .try_for_each_broadcast_spawned(
+            .try_for_each_broadcast_filtered_spawned(
                 ingest_concurrency.into(),
                 |cp| {
                     let client = client.clone();
@@ -181,6 +181,7 @@ fn ingest_and_broadcast_range(
                     }
                 },
                 subscribers,
+                |_, _: &Arc<CheckpointEnvelope>| true,
                 move |stats| {
                     concurrency_limit.set(stats.limit as i64);
                     concurrency_inflight.set(stats.inflight as i64);

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::marker::Unpin;
+use std::ops::ControlFlow;
+use std::ops::Range;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -15,11 +19,14 @@ use sui_futures::stream::Break;
 use sui_futures::stream::TrySpawnStreamExt;
 use sui_futures::task::TaskGuard;
 use tokio::sync::mpsc;
+use tokio::task::JoinError;
 use tokio_stream::StreamExt;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
 
+use crate::cohort::MergeContext;
+use crate::cohort::Subscriber;
 use crate::config::ConcurrencyConfig;
 use crate::ingestion::ArcStreamingClient;
 use crate::ingestion::IngestionConfig;
@@ -28,29 +35,12 @@ use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::ingestion::ingestion_client::IngestionClient;
 use crate::ingestion::streaming_client::CheckpointStream;
 use crate::metrics::CohortMetrics;
+use crate::metrics::IngestionMetrics;
 
 /// If the network's latest checkpoint (per the streaming client) is more than this many
 /// checkpoints ahead of where ingestion currently is, skip streaming and let the ingestion
 /// path catch up first.
 const STREAMING_CATCHUP_THRESHOLD: u64 = 1_000;
-
-/// A subscription to the ingestion service: the channel checkpoints are delivered on, and the
-/// first checkpoint the subscriber still needs. The broadcaster does not deliver checkpoints
-/// below `next_checkpoint` -- the subscriber has already processed them.
-#[derive(Clone)]
-pub(super) struct Subscriber {
-    pub(super) tx: mpsc::Sender<Arc<CheckpointEnvelope>>,
-
-    /// The subscriber's resume point.
-    pub(super) next_checkpoint: u64,
-}
-
-impl Subscriber {
-    /// Whether this subscriber still needs `sequence_number`.
-    pub(super) fn needs(&self, sequence_number: u64) -> bool {
-        self.next_checkpoint <= sequence_number
-    }
-}
 
 /// Broadcaster task that manages checkpoint flow and spawns broadcast tasks for ranges
 /// via either streaming or ingesting, or both.
@@ -67,38 +57,57 @@ impl Subscriber {
 /// fills, [`TrySpawnStreamExt::try_for_each_broadcast_filtered_spawned`]'s adaptive controller
 /// cuts ingest concurrency. Checkpoints below a subscriber's `next_checkpoint` are not
 /// delivered to it. The task will shut down if the `checkpoints` range completes.
+///
+/// With `merge` set, the task also participates in cohort merging. Whenever it commits to a
+/// range of checkpoints (an ingestion chunk, or each streamed checkpoint), it first absorbs
+/// subscribers that merging cohorts have registered at that range's start into its own
+/// subscriber list, and advertises the range's end as the point where new registrations can
+/// still join in full. Conversely, at every clean state -- everything below `checkpoint_hi`
+/// delivered, nothing in flight -- it looks for a cohort ahead of it within the merge threshold
+/// to register its own subscribers with. Ingestion legs are chunked so those commit points and
+/// clean states come around regularly, and the streaming path breaks out of an (otherwise
+/// unbounded) stream when a merge becomes available.
 pub(super) fn broadcaster<R>(
     checkpoints: R,
     streaming_client: Option<ArcStreamingClient>,
     config: IngestionConfig,
     client: IngestionClient,
-    subscribers: Vec<Subscriber>,
+    mut subscribers: Vec<Subscriber>,
+    merge: Option<MergeContext>,
 ) -> Service
 where
     R: std::ops::RangeBounds<u64> + Send + 'static,
 {
-    Service::new().spawn_aborting(async move {
+    // Extract start and end from the range bounds
+    let start_cp = match checkpoints.start_bound() {
+        std::ops::Bound::Included(&n) => n,
+        std::ops::Bound::Excluded(&n) => n + 1,
+        std::ops::Bound::Unbounded => 0,
+    };
+
+    let end_cp = match checkpoints.end_bound() {
+        // If u64::MAX is provided as an inclusive bound, the saturating_add
+        // here will prevent overflow but the broadcaster will actually
+        // only ingest up to u64::MAX - 1, since the range is [start..end).
+        // This isn't an issue in practice since we won't see that many checkpoints
+        // in our lifetime anyway.
+        std::ops::Bound::Included(&n) => n.saturating_add(1),
+        std::ops::Bound::Excluded(&n) => n,
+        std::ops::Bound::Unbounded => u64::MAX,
+    };
+
+    let service = Service::new();
+
+    service.spawn_aborting(async move {
         info!("Starting broadcaster");
 
+        // Retire this cohort's slot in the table on every exit path -- completion, error, and
+        // abort alike -- so peers stop targeting it, and adoptees never absorbed have their
+        // channels closed (the wind-down they would see from a running service shutting down).
+        let _guard = merge.as_ref().map(MergeContext::guard);
+
         let cohort_metrics = client.cohort_metrics().clone();
-
-        // Extract start and end from the range bounds
-        let start_cp = match checkpoints.start_bound() {
-            std::ops::Bound::Included(&n) => n,
-            std::ops::Bound::Excluded(&n) => n + 1,
-            std::ops::Bound::Unbounded => 0,
-        };
-
-        let end_cp = match checkpoints.end_bound() {
-            // If u64::MAX is provided as an inclusive bound, the saturating_add
-            // here will prevent overflow but the broadcaster will actually
-            // only ingest up to u64::MAX - 1, since the range is [start..end).
-            // This isn't an issue in practice since we won't see that many checkpoints
-            // in our lifetime anyway.
-            std::ops::Bound::Included(&n) => n.saturating_add(1),
-            std::ops::Bound::Excluded(&n) => n,
-            std::ops::Bound::Unbounded => u64::MAX,
-        };
+        let metrics = client.metrics().clone();
 
         // If the first attempt at streaming connection fails, we back off for an initial number
         // of checkpoints to process using ingestion. This value doubles on each subsequent failure.
@@ -109,7 +118,24 @@ where
         // This value is updated every outer loop iteration after both streaming and broadcasting complete.
         let mut checkpoint_hi = start_cp;
 
-        while checkpoint_hi < end_cp {
+        // A merge truncates the range: the cohort ahead takes over from the handoff checkpoint.
+        let mut end_cp = end_cp;
+
+        // The concurrency limit the adaptive controller reached in the previous ingestion leg;
+        // the next leg resumes from it instead of re-ramping from the configured initial value.
+        let last_limit = Arc::new(AtomicUsize::new(config.ingest_concurrency.initial()));
+
+        'ingest: while checkpoint_hi < end_cp {
+            // A clean state: everything below `checkpoint_hi` has been delivered and nothing is
+            // in flight, so adoptions owed from here can be absorbed and a merge into a cohort
+            // ahead can be arranged exactly.
+            if let Some(merge) = &merge
+                && let Some(handoff) = clean_state(merge, &mut subscribers, checkpoint_hi, &metrics)
+            {
+                end_cp = end_cp.min(handoff);
+                continue;
+            }
+
             // Set up the streaming task for the current range [checkpoint_hi, end_cp). This function
             // will return a handle to the streaming task and the end cp of the ingestion task, calculated
             // based on 1) if streaming is used, 2) streaming connection success status, and 3) the network
@@ -122,18 +148,59 @@ where
                 end_cp,
                 &mut streaming_backoff_batch_size,
                 &config,
-                &subscribers,
+                &mut subscribers,
+                merge.as_ref(),
                 &cohort_metrics,
             )
             .await;
 
+            let Some(stream_guard) = stream_guard else {
+                // No streaming for this leg: ingest [checkpoint_hi, ingestion_end) directly.
+                // With merging enabled the leg is processed in chunks: each chunk's commit
+                // absorbs newly adopted subscribers, and each chunk ends at a clean state where
+                // the frontier is exact and a merge can be arranged.
+                let chunk = merge.as_ref().map_or(u64::MAX, MergeContext::chunk);
+                while checkpoint_hi < ingestion_end.min(end_cp) {
+                    let chunk_end = ingestion_end
+                        .min(end_cp)
+                        .min(checkpoint_hi.saturating_add(chunk));
+
+                    if let Some(merge) = &merge {
+                        merge.commit_range(checkpoint_hi..chunk_end, &mut subscribers);
+                    }
+
+                    let ingest_guard = ingest_and_broadcast_range(
+                        checkpoint_hi..chunk_end,
+                        config.retry_interval(),
+                        seeded_concurrency(&config.ingest_concurrency, &last_limit),
+                        last_limit.clone(),
+                        client.clone(),
+                        subscribers.clone(),
+                        cohort_metrics.clone(),
+                    );
+
+                    if ingest_outcome(ingest_guard.await)?.is_break() {
+                        break 'ingest;
+                    }
+
+                    checkpoint_hi = chunk_end;
+                    if let Some(merge) = &merge
+                        && let Some(handoff) =
+                            clean_state(merge, &mut subscribers, checkpoint_hi, &metrics)
+                    {
+                        end_cp = end_cp.min(handoff);
+                    }
+                }
+                continue;
+            };
+
             // Spawn a broadcaster task for this range.
             // It will exit when the range is complete or if it is cancelled.
             let ingest_guard = ingest_and_broadcast_range(
-                checkpoint_hi,
-                ingestion_end,
+                checkpoint_hi..ingestion_end,
                 config.retry_interval(),
-                config.ingest_concurrency.clone(),
+                seeded_concurrency(&config.ingest_concurrency, &last_limit),
+                last_limit.clone(),
                 client.clone(),
                 subscribers.clone(),
                 cohort_metrics.clone(),
@@ -142,24 +209,20 @@ where
             let (streaming_result, ingestion_result) =
                 futures::future::join(stream_guard, ingest_guard).await;
 
-            // Check ingestion result, exit on any error.
-            match ingestion_result.context("Ingestion task panicked, stopping broadcaster")? {
-                Ok(()) => {}
-
-                // Ingestion stopped because one of its channels was closed. The
-                // overall broadcaster should also shutdown.
-                Err(Break::Break) => break,
-
-                // Ingestion failed with an error of some kind, surface this as an
-                // overall error from the broadcaster.
-                Err(Break::Err(e)) => {
-                    return Err(anyhow!(e).context("Ingestion task failed, stopping broadcaster"));
-                }
+            if ingest_outcome(ingestion_result)?.is_break() {
+                break 'ingest;
             }
 
-            // Update checkpoint_hi from streaming, or shutdown on error
-            checkpoint_hi =
-                streaming_result.context("Streaming task panicked, stopping broadcaster")?;
+            // Update checkpoint_hi (and the subscriber list, which may have absorbed adoptions
+            // during the leg) from streaming, or shutdown on error.
+            let leg = streaming_result.context("Streaming task panicked, stopping broadcaster")?;
+            checkpoint_hi = leg.lo;
+            subscribers = leg.subscribers;
+
+            // A subscriber hung up mid-stream; the overall broadcaster should also shutdown.
+            if leg.closed {
+                break 'ingest;
+            }
 
             info!(
                 checkpoint_hi,
@@ -172,15 +235,16 @@ where
     })
 }
 
-/// Fetch and broadcast checkpoints from a range [start..end) to subscribers. The adaptive
-/// controller reads the max `fill` across subscribers (channel capacity for bounded,
-/// `len / soft_limit` for unbounded) and adjusts ingest concurrency to match. Each checkpoint
-/// is only delivered to subscribers whose `next_checkpoint` it has reached.
+/// Fetch and broadcast `checkpoints` to subscribers. The adaptive controller reads the max
+/// `fill` across subscribers (channel capacity for bounded, `len / soft_limit` for unbounded)
+/// and adjusts ingest concurrency to match, recording the limit it settles on in `last_limit`
+/// so the next leg can resume from it. Each checkpoint is only delivered to subscribers whose
+/// `next_checkpoint` it has reached.
 fn ingest_and_broadcast_range(
-    start: u64,
-    end: u64,
+    checkpoints: Range<u64>,
     retry_interval: Duration,
     ingest_concurrency: ConcurrencyConfig,
+    last_limit: Arc<AtomicUsize>,
     client: IngestionClient,
     subscribers: Vec<Subscriber>,
     cohort_metrics: Arc<CohortMetrics>,
@@ -189,7 +253,7 @@ fn ingest_and_broadcast_range(
         let concurrency_limit = cohort_metrics.ingestion_concurrency_limit.clone();
         let concurrency_inflight = cohort_metrics.ingestion_concurrency_inflight.clone();
         let txs: Vec<_> = subscribers.iter().map(|s| s.tx.clone()).collect();
-        futures::stream::iter(start..end)
+        futures::stream::iter(checkpoints)
             .try_for_each_broadcast_filtered_spawned(
                 ingest_concurrency.into(),
                 |cp| {
@@ -206,6 +270,7 @@ fn ingest_and_broadcast_range(
                     subscribers[i].needs(*envelope.checkpoint.summary.sequence_number())
                 },
                 move |stats| {
+                    last_limit.store(stats.limit, Ordering::Relaxed);
                     concurrency_limit.set(stats.limit as i64);
                     concurrency_inflight.set(stats.inflight as i64);
                 },
@@ -214,21 +279,26 @@ fn ingest_and_broadcast_range(
     }))
 }
 
-/// Sets up either a noop or real streaming task based on network state and proximity to
-/// the current checkpoint_hi, and returns a streaming task handle and the `ingestion_end`
-/// telling the main task that ingestion should be used up to this point.
+/// Sets up a streaming task based on network state and proximity to the current checkpoint_hi,
+/// and returns the streaming task handle (`None` when this leg is ingestion-only) and the
+/// `ingestion_end` telling the main task that ingestion should be used up to this point.
+///
+/// When a streaming task is spawned, the leg is committed (through `merge`) just beforehand, so
+/// both the leg's ingestion snapshot (taken by the caller from `subscribers`) and the streaming
+/// task's own copy include every subscriber adopted so far.
 async fn setup_streaming_task(
     streaming_client: &Option<ArcStreamingClient>,
     checkpoint_hi: u64,
     end_cp: u64,
     streaming_backoff_batch_size: &mut u64,
     config: &IngestionConfig,
-    subscribers: &[Subscriber],
+    subscribers: &mut Vec<Subscriber>,
+    merge: Option<&MergeContext>,
     cohort_metrics: &Arc<CohortMetrics>,
-) -> (TaskGuard<u64>, u64) {
+) -> (Option<TaskGuard<StreamLeg>>, u64) {
     // No streaming client configured so we ingest all the way to end_cp.
     let Some(streaming_client) = streaming_client else {
-        return (noop_streaming_task(end_cp), end_cp);
+        return (None, end_cp);
     };
 
     let backoff_batch_size = *streaming_backoff_batch_size;
@@ -245,7 +315,7 @@ async fn setup_streaming_task(
         connection_failures.inc();
         *streaming_backoff_batch_size =
             (backoff_batch_size * 2).min(config.streaming_backoff_max_batch_size as u64);
-        (noop_streaming_task(ingestion_end), ingestion_end)
+        (None, ingestion_end)
     };
 
     let CheckpointStream {
@@ -283,7 +353,7 @@ async fn setup_streaming_task(
             threshold = STREAMING_CATCHUP_THRESHOLD,
             "Network is far ahead, delaying streaming start to let ingestion catch up"
         );
-        return (noop_streaming_task(ingestion_end), ingestion_end);
+        return (None, ingestion_end);
     }
 
     info!(
@@ -291,33 +361,58 @@ async fn setup_streaming_task(
         checkpoint_hi, "Within catchup threshold, starting streaming"
     );
 
+    // Commit the joint leg before the streaming task starts: ingestion covers
+    // [checkpoint_hi, ingestion_end) and streaming starts at `stream_lo`, so subscribers
+    // adopted up to this point join both snapshots here, and `stream_lo` (clamped to the
+    // requested range) is the join point until the stream's per-checkpoint commits take over.
+    let stream_lo = network_latest_cp.max(checkpoint_hi);
+    if let Some(merge) = merge {
+        merge.commit_range(checkpoint_hi..stream_lo.min(end_cp), subscribers);
+    }
+
     let envelope_stream = stream.map_ok(move |checkpoint| CheckpointEnvelope {
         checkpoint: Arc::new(checkpoint),
         chain_id,
     });
     let stream_guard = TaskGuard::new(tokio::spawn(stream_and_broadcast_range(
-        network_latest_cp.max(checkpoint_hi),
+        stream_lo,
         end_cp,
         envelope_stream,
-        subscribers.to_vec(),
+        subscribers.clone(),
+        merge.cloned(),
         cohort_metrics.clone(),
     )));
 
-    (stream_guard, ingestion_end)
+    (Some(stream_guard), ingestion_end)
+}
+
+/// What a streaming leg hands back to the broadcaster's main loop.
+struct StreamLeg {
+    /// The checkpoint to resume from: everything below it has been delivered.
+    lo: u64,
+
+    /// The subscriber list, including any subscribers adopted during the leg.
+    subscribers: Vec<Subscriber>,
+
+    /// A subscriber hung up; the service should wind down.
+    closed: bool,
 }
 
 /// Streams and broadcasts checkpoints from a range [start, end) to subscribers. Each
 /// `mpsc::Sender::send` honors that subscriber's channel capacity, so a slow consumer
 /// naturally stalls the streaming side. If we encounter any streaming error or out-of-order
 /// checkpoint greater than the current `lo`, we stop streaming and return `lo` so the main
-/// loop can reconnect and fill in the gap using ingestion.
+/// loop can reconnect and fill in the gap using ingestion. A merge opportunity is treated the
+/// same way: the stream (which may otherwise run unbounded) is broken so the main loop can
+/// arrange the merge at its next clean state, `lo`.
 async fn stream_and_broadcast_range(
     mut lo: u64,
     hi: u64,
     mut stream: impl Stream<Item = Result<CheckpointEnvelope, Error>> + Unpin,
-    subscribers: Vec<Subscriber>,
+    mut subscribers: Vec<Subscriber>,
+    merge: Option<MergeContext>,
     cohort_metrics: Arc<CohortMetrics>,
-) -> u64 {
+) -> StreamLeg {
     let latest_streamed = cohort_metrics.latest_streamed_checkpoint.clone();
     let latest_skipped = cohort_metrics.latest_skipped_streamed_checkpoint.clone();
     let skipped_streamed = cohort_metrics.total_skipped_streamed_checkpoints.clone();
@@ -326,6 +421,7 @@ async fn stream_and_broadcast_range(
         .clone();
     let streamed = cohort_metrics.total_streamed_checkpoints.clone();
     let stream_disconnections = cohort_metrics.total_stream_disconnections.clone();
+    let mut closed = false;
     while lo < hi {
         let Some(item) = stream.next().await else {
             warn!(lo, "Streaming ended unexpectedly");
@@ -361,10 +457,24 @@ async fn stream_and_broadcast_range(
 
         assert_eq!(sequence_number, lo);
 
+        // Streaming delivers in order, so `lo` is this cohort's exact frontier. Commit it
+        // before sending: adoptions owed from `lo` join the subscriber list, and if a cohort
+        // ahead has come within merge range, hand back to the main loop -- without sending --
+        // to arrange the merge at the clean state `lo`.
+        if let Some(merge) = &merge
+            && merge.commit_streamed(lo, &mut subscribers)
+        {
+            info!(lo, "Pausing streaming to merge with a cohort ahead");
+            break;
+        }
+
         if send_checkpoint(Arc::new(checkpoint_envelope), &subscribers)
             .await
             .is_err()
         {
+            // A subscriber hung up; report it so the main loop winds the service down instead
+            // of committing further ranges.
+            closed = true;
             break;
         }
 
@@ -377,13 +487,11 @@ async fn stream_and_broadcast_range(
     // We exit the loop either due to cancellation, error or completion of the range,
     // in all cases we disconnect the stream and return the current watermark.
     stream_disconnections.inc();
-    lo
-}
-
-// A noop streaming task that just returns the provided checkpoint_hi, used to simplify
-// join logic when streaming is not used.
-fn noop_streaming_task(checkpoint_hi: u64) -> TaskGuard<u64> {
-    TaskGuard::new(tokio::spawn(async move { checkpoint_hi }))
+    StreamLeg {
+        lo,
+        subscribers,
+        closed,
+    }
 }
 
 /// Send a checkpoint to every subscriber whose `next_checkpoint` it has reached; subscribers
@@ -401,17 +509,78 @@ async fn send_checkpoint(
     try_join_all(futures).await
 }
 
+/// Classify a joined ingestion task's result: whether the broadcaster should continue with its
+/// next leg, or wind down because one of the subscribers' channels was closed. Panics and
+/// ingestion errors are surfaced as broadcaster errors.
+fn ingest_outcome(
+    joined: Result<Result<(), Break<Error>>, JoinError>,
+) -> anyhow::Result<ControlFlow<()>> {
+    match joined.context("Ingestion task panicked, stopping broadcaster")? {
+        Ok(()) => Ok(ControlFlow::Continue(())),
+        Err(Break::Break) => Ok(ControlFlow::Break(())),
+        Err(Break::Err(e)) => {
+            Err(anyhow!(e).context("Ingestion task failed, stopping broadcaster"))
+        }
+    }
+}
+
+/// The concurrency configuration for the next ingestion leg: adaptive configurations resume
+/// from `last_limit` (what the controller settled on in the previous leg) instead of re-ramping
+/// from their configured initial value.
+fn seeded_concurrency(config: &ConcurrencyConfig, last_limit: &AtomicUsize) -> ConcurrencyConfig {
+    match config.clone() {
+        fixed @ ConcurrencyConfig::Fixed { .. } => fixed,
+        ConcurrencyConfig::Adaptive {
+            initial: _,
+            min,
+            max,
+            dead_band,
+        } => ConcurrencyConfig::Adaptive {
+            initial: last_limit.load(Ordering::Relaxed).clamp(min, max),
+            min,
+            max,
+            dead_band,
+        },
+    }
+}
+
+/// At a clean state -- everything below `frontier` delivered to `subscribers`, nothing in
+/// flight -- absorb newly adopted subscribers, and look for a cohort ahead of this one within
+/// the merge threshold to merge into. On success, every subscriber has been registered with the
+/// target from the returned handoff checkpoint `H >= frontier` (the end of the target's
+/// in-flight range, from which the target delivers to them in full); this service's range
+/// should be truncated to end at `H`, so between the two services every subscriber sees every
+/// checkpoint exactly once.
+fn clean_state(
+    merge: &MergeContext,
+    subscribers: &mut Vec<Subscriber>,
+    frontier: u64,
+    metrics: &Arc<IngestionMetrics>,
+) -> Option<u64> {
+    let (target, handoff) = merge.at_clean_state(frontier, subscribers)?;
+    info!(
+        cohort = merge.cohort,
+        target, handoff, "Merging into cohort ahead"
+    );
+    metrics.total_cohort_merges.inc();
+    Some(handoff)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
     use std::num::NonZeroUsize;
     use std::ops::Range;
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::time::Duration;
 
     use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
     use tokio::time::timeout;
 
+    use crate::cohort::CohortSlot;
+    use crate::cohort::CohortState;
+    use crate::cohort::DEFAULT_COHORT_MERGE_THRESHOLD;
     use crate::cohort::DEFAULT_MIN_COHORT_BOUNDARY;
     use crate::ingestion::IngestionConfig;
     use crate::ingestion::ingestion_client::tests::MockIngestionClient;
@@ -448,6 +617,7 @@ mod tests {
             streaming_connection_timeout_ms: 100,
             streaming_statement_timeout_ms: 100,
             min_cohort_boundary: DEFAULT_MIN_COHORT_BOUNDARY,
+            cohort_merge_threshold: DEFAULT_COHORT_MERGE_THRESHOLD,
         }
     }
 
@@ -534,6 +704,100 @@ mod tests {
         result
     }
 
+    /// Assemble a cohort table from `slots` and run `broadcaster` with merging enabled, as the
+    /// cohort at index `own` (whose slot is reset -- the broadcaster populates it as it runs).
+    /// The merge threshold is taken from `config`.
+    fn merge_broadcaster<R>(
+        checkpoints: R,
+        streaming_client: Option<ArcStreamingClient>,
+        config: IngestionConfig,
+        client: IngestionClient,
+        subscribers: Vec<Subscriber>,
+        mut slots: Vec<CohortSlot>,
+        own: usize,
+    ) -> (Service, Arc<Mutex<Vec<CohortSlot>>>)
+    where
+        R: std::ops::RangeBounds<u64> + Send + 'static,
+    {
+        slots[own] = CohortSlot::default();
+        let table = Arc::new(Mutex::new(slots));
+        let merge = MergeContext {
+            table: table.clone(),
+            cohort: own,
+            threshold: config.cohort_merge_threshold,
+        };
+        let service = broadcaster(
+            checkpoints,
+            streaming_client,
+            config,
+            client,
+            subscribers,
+            Some(merge),
+        );
+        (service, table)
+    }
+
+    /// A cohort slot pinned at `frontier`, advertising `in_flight` as its join point.
+    fn cohort_at(frontier: u64, in_flight: u64) -> CohortSlot {
+        CohortSlot {
+            state: CohortState::Active,
+            frontier: Some(frontier),
+            in_flight: Some(in_flight),
+            pending: vec![],
+        }
+    }
+
+    /// Register `subscriber` in `cohort`'s slot at its advertised join point, as a merging peer
+    /// would, waiting for a join point to be advertised first. Returns the handoff checkpoint.
+    async fn register_at_join_point(
+        table: &Arc<Mutex<Vec<CohortSlot>>>,
+        cohort: usize,
+        subscriber: Subscriber,
+    ) -> u64 {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                {
+                    let mut table = table.lock().unwrap();
+                    if let Some(handoff) = table[cohort].in_flight {
+                        table[cohort].pending.push((subscriber.clone(), handoff));
+                        return handoff;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for a join point")
+    }
+
+    /// The handoff checkpoints of the subscribers registered in `cohort`'s slot.
+    fn registered_handoffs(table: &Arc<Mutex<Vec<CohortSlot>>>, cohort: usize) -> Vec<u64> {
+        table.lock().unwrap()[cohort]
+            .pending
+            .iter()
+            .map(|(_, from)| *from)
+            .collect()
+    }
+
+    /// Adaptive configurations are re-seeded from the previous leg's limit, clamped into the
+    /// leg's own bounds; fixed configurations pass through untouched.
+    #[test]
+    fn seeded_concurrency_clamps_adaptive_and_passes_fixed_through() {
+        let adaptive = |initial| ConcurrencyConfig::Adaptive {
+            initial,
+            min: 2,
+            max: 16,
+            dead_band: None,
+        };
+        let seed = |n: usize| seeded_concurrency(&adaptive(8), &AtomicUsize::new(n));
+        assert_eq!(seed(12), adaptive(12));
+        assert_eq!(seed(100), adaptive(16));
+        assert_eq!(seed(0), adaptive(2));
+
+        let fixed = ConcurrencyConfig::Fixed { value: 3 };
+        assert_eq!(seeded_concurrency(&fixed, &AtomicUsize::new(9)), fixed);
+    }
+
     #[tokio::test]
     async fn finite_list_of_checkpoints() {
         let (subscriber_dest, mut subscriber_rx) = single_subscriber(1);
@@ -546,6 +810,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         assert_eq!(
@@ -567,6 +832,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         assert_eq!(
@@ -589,6 +855,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         assert_eq!(
@@ -612,6 +879,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscribers,
+            None,
         );
 
         // Both subscribers should receive checkpoints
@@ -643,6 +911,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..10, metrics.clone()),
             vec![sub1, sub2],
+            None,
         );
 
         assert_eq!(recv_set(&mut rx1, 10).await, BTreeSet::from_iter(0..10));
@@ -671,6 +940,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             vec![sub1, sub2],
+            None,
         );
 
         assert_eq!(recv_set(&mut rx1, 20).await, BTreeSet::from_iter(0..20));
@@ -693,6 +963,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..40, metrics.clone()),
             vec![sub1, sub2],
+            None,
         );
 
         svc.join().await.unwrap();
@@ -743,6 +1014,7 @@ mod tests {
             config,
             mock_client_with_range(0..100, metrics.clone()),
             vec![sub1, sub2],
+            None,
         );
 
         // The full-but-filtered channel never has a send attempted on it, so the range
@@ -783,6 +1055,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should receive all checkpoints from the stream in order
@@ -829,6 +1102,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..10, metrics.clone()),
             vec![sub1, sub2],
+            None,
         );
 
         assert_eq!(recv_vec(&mut rx1, 10).await, Vec::from_iter(0..10));
@@ -872,6 +1146,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..10, metrics.clone()),
             vec![sub1, sub2],
+            None,
         );
 
         // In order: everything was delivered, and by streaming -- so the closed channel was
@@ -910,6 +1185,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..60, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         assert_eq!(
@@ -962,6 +1238,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..30, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should use only ingestion since streaming is beyond end_cp
@@ -1004,6 +1281,7 @@ mod tests {
             test_config(),
             mock_client_with_range(30..100, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         assert_eq!(
@@ -1071,6 +1349,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should receive all checkpoints exactly once (no duplicates) from streaming.
@@ -1135,6 +1414,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..10, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should receive first three checkpoints from streaming in order
@@ -1197,6 +1477,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should receive first 5 checkpoints from streaming in order
@@ -1254,6 +1535,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should eventually receive all checkpoints despite errors from streaming.
@@ -1311,6 +1593,7 @@ mod tests {
             },
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should fallback to ingestion for initial batch size checkpoints
@@ -1362,6 +1645,7 @@ mod tests {
             },
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should fallback to ingestion for first 10 checkpoints
@@ -1410,6 +1694,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should fallback to ingestion for all checkpoints
@@ -1463,6 +1748,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should fallback to ingestion for first 2 + 4 + 8 + 16 = 30 checkpoints
@@ -1538,6 +1824,7 @@ mod tests {
             config,
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should fallback to ingestion for initial batch size checkpoints
@@ -1598,6 +1885,7 @@ mod tests {
             config,
             mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should fallback to ingestion for first batch
@@ -1647,6 +1935,7 @@ mod tests {
             test_config(),
             mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
+            None,
         );
 
         // Should receive first 5 checkpoints from streaming in order
@@ -1684,5 +1973,458 @@ mod tests {
         );
 
         svc.join().await.unwrap();
+    }
+
+    // =============== Cohort merge tests ==================
+
+    /// With merging enabled, a small threshold splits the range into many small ingestion
+    /// chunks (with the adaptive concurrency limit carried across them); delivery is unchanged.
+    #[tokio::test]
+    async fn chunked_ingestion_preserves_delivery() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(30);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            ingest_concurrency: ConcurrencyConfig::Adaptive {
+                initial: 1,
+                min: 1,
+                max: 4,
+                dead_band: None,
+            },
+            cohort_merge_threshold: 3,
+            ..test_config()
+        };
+
+        let (mut svc, _table) = merge_broadcaster(
+            0..25,
+            None,
+            config,
+            mock_client_with_range(0..25, metrics.clone()),
+            subscriber_dest,
+            vec![CohortSlot::default()],
+            0,
+        );
+
+        assert_eq!(
+            recv_set(&mut subscriber_rx, 25).await,
+            BTreeSet::from_iter(0..25)
+        );
+
+        svc.join().await.unwrap();
+    }
+
+    /// A subscriber registered at the broadcaster's advertised join point mid-broadcast is
+    /// absorbed there and receives exactly the checkpoints from that point onward, while the
+    /// original subscriber still sees everything.
+    #[tokio::test]
+    async fn adoption_joins_mid_broadcast() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(300);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 3,
+            ..test_config()
+        };
+
+        // Start with no checkpoints available, so the broadcaster parks in its first chunk and
+        // the registration below deterministically lands at that chunk's end.
+        let mock = Arc::new(MockIngestionClient::default());
+        let client = IngestionClient::from_trait(mock.clone(), metrics.clone()).for_cohort(0);
+
+        let (mut svc, table) = merge_broadcaster(
+            0..250,
+            None,
+            config,
+            client,
+            subscriber_dest,
+            vec![CohortSlot::default()],
+            0,
+        );
+
+        let (sub, mut adopted_rx) = subscriber(300, 0);
+        let handoff = register_at_join_point(&table, 0, sub).await;
+        assert_eq!(handoff, 3);
+
+        mock.insert_checkpoints(0..250);
+
+        assert_eq!(
+            recv_set(&mut subscriber_rx, 250).await,
+            BTreeSet::from_iter(0..250)
+        );
+        assert_eq!(
+            recv_set(&mut adopted_rx, 247).await,
+            BTreeSet::from_iter(3..250)
+        );
+
+        svc.join().await.unwrap();
+    }
+
+    /// An adoptee's own resume point rides along through adoption: registered (and absorbed) at
+    /// the join point, but resuming later, it only receives checkpoints from its resume point
+    /// onward.
+    #[tokio::test]
+    async fn adoption_preserves_adoptee_resume_point() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(300);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 3,
+            ..test_config()
+        };
+
+        // Start with no checkpoints available, so the broadcaster parks in its first chunk and
+        // the registration below deterministically lands at that chunk's end.
+        let mock = Arc::new(MockIngestionClient::default());
+        let client = IngestionClient::from_trait(mock.clone(), metrics.clone()).for_cohort(0);
+
+        let (mut svc, table) = merge_broadcaster(
+            0..250,
+            None,
+            config,
+            client,
+            subscriber_dest,
+            vec![CohortSlot::default()],
+            0,
+        );
+
+        // The adoptee joins at checkpoint 3, but has already processed everything below 50.
+        let (sub, mut adopted_rx) = subscriber(300, 50);
+        assert_eq!(register_at_join_point(&table, 0, sub).await, 3);
+
+        mock.insert_checkpoints(0..250);
+
+        assert_eq!(
+            recv_set(&mut subscriber_rx, 250).await,
+            BTreeSet::from_iter(0..250)
+        );
+        assert_eq!(
+            recv_set(&mut adopted_rx, 200).await,
+            BTreeSet::from_iter(50..250)
+        );
+
+        svc.join().await.unwrap();
+
+        // The broadcaster is done and its senders are dropped: an empty channel here proves
+        // checkpoints in [3, 50) were never delivered to the adoptee, not merely delivered
+        // late.
+        assert!(expect_recv(&mut adopted_rx).await.is_none());
+    }
+
+    /// A subscriber registered at a streamed join point is absorbed by the live streaming path
+    /// before that checkpoint is sent, receives everything from its handoff on, and is carried
+    /// into the ingestion-fallback legs after the stream ends.
+    #[tokio::test]
+    async fn adoption_joins_mid_stream() {
+        // Capacity 1: the stream parks on backpressure after a couple of sends, pinning the
+        // advertised join point low while the adoptee registers.
+        let (sub, mut own_rx) = subscriber(1, 0);
+
+        // The stream serves [0, 10); [10, 20) arrives via the ingestion fallback afterwards.
+        let streaming_client = MockStreamingClient::new(0..10, None);
+
+        let metrics = test_ingestion_metrics();
+        let (mut svc, table) = merge_broadcaster(
+            0..20,
+            Some(Arc::new(streaming_client)),
+            test_config(),
+            mock_client_with_range(0..20, metrics.clone()),
+            vec![sub],
+            vec![CohortSlot::default()],
+            0,
+        );
+
+        let (adoptee, mut adopted_rx) = subscriber(30, 0);
+        let handoff = register_at_join_point(&table, 0, adoptee).await;
+        // The own channel (capacity 1) pins the stream before its join point can pass 2.
+        assert!(
+            handoff <= 2,
+            "join point advertised too far ahead: {handoff}"
+        );
+
+        assert_eq!(recv_set(&mut own_rx, 20).await, BTreeSet::from_iter(0..20));
+        assert_eq!(
+            recv_set(&mut adopted_rx, (20 - handoff) as usize).await,
+            BTreeSet::from_iter(handoff..20)
+        );
+
+        svc.join().await.unwrap();
+
+        // Nothing below the handoff was ever delivered to the adoptee.
+        assert!(expect_recv(&mut adopted_rx).await.is_none());
+    }
+
+    /// The core handoff, from the ingestion path: the trailing broadcaster reaches a chunk
+    /// boundary within the merge threshold of the cohort ahead, registers its subscriber at
+    /// that cohort's advertised join point, finishes up to the handoff checkpoint, and winds
+    /// down on its own -- all without the target doing anything.
+    #[tokio::test]
+    async fn merges_into_cohort_ahead_mid_ingest() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(120);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 10,
+            ..test_config()
+        };
+
+        let (mut svc, table) = merge_broadcaster(
+            0..,
+            None,
+            config,
+            mock_client_with_range(0..115, metrics.clone()),
+            subscriber_dest,
+            vec![CohortSlot::default(), cohort_at(105, 115)],
+            0,
+        );
+
+        // Chunk boundary 100 is the first within threshold of the target's frontier (105); the
+        // handoff is the target's join point (115), and the mergee delivers [0, 115) -- its
+        // whole range up to the handoff -- and completes, even though its requested range was
+        // unbounded.
+        assert_eq!(
+            recv_set(&mut subscriber_rx, 115).await,
+            BTreeSet::from_iter(0..115)
+        );
+        svc.join().await.unwrap();
+
+        assert_eq!(registered_handoffs(&table, 1), vec![115]);
+        assert!(matches!(table.lock().unwrap()[0].state, CohortState::Gone));
+        assert_eq!(metrics.total_cohort_merges.get(), 1);
+    }
+
+    /// The same handoff discovered while streaming: the stream is broken at the first in-order
+    /// frontier within threshold of the target -- before that checkpoint is sent -- the
+    /// subscriber is registered at the target's join point, and the final leg is delivered
+    /// before the broadcaster completes.
+    #[tokio::test]
+    async fn merges_into_cohort_ahead_mid_stream() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(120);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 10,
+            ..test_config()
+        };
+
+        let (mut svc, table) = merge_broadcaster(
+            0..,
+            Some(Arc::new(MockStreamingClient::new(0..200, None))),
+            config,
+            mock_client_with_range(0..200, metrics.clone()),
+            subscriber_dest,
+            vec![CohortSlot::default(), cohort_at(105, 115)],
+            0,
+        );
+
+        // Streaming breaks at the first in-order frontier within threshold of the target's
+        // frontier (105 - lo <= 10 at lo = 95), without sending 95; everything below streams
+        // in order.
+        assert_eq!(
+            recv_vec(&mut subscriber_rx, 95).await,
+            Vec::from_iter(0..95)
+        );
+
+        // The final leg [95, 115) is delivered (partly by ingestion, so unordered) and the
+        // broadcaster completes at the handoff.
+        assert_eq!(
+            recv_set(&mut subscriber_rx, 20).await,
+            BTreeSet::from_iter(95..115)
+        );
+        svc.join().await.unwrap();
+
+        assert_eq!(registered_handoffs(&table, 1), vec![115]);
+        assert_eq!(metrics.total_cohort_merges.get(), 1);
+    }
+
+    /// A merging broadcaster hands subscribers it had itself adopted over to the target along
+    /// with its own, having served them up to the handoff through its final leg.
+    #[tokio::test]
+    async fn merges_with_adoptees() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(120);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 10,
+            ..test_config()
+        };
+
+        // Start with no checkpoints available, so the registration below deterministically
+        // lands at the first chunk's end.
+        let mock = Arc::new(MockIngestionClient::default());
+        let client = IngestionClient::from_trait(mock.clone(), metrics.clone()).for_cohort(0);
+
+        let (mut svc, table) = merge_broadcaster(
+            0..,
+            None,
+            config,
+            client,
+            subscriber_dest,
+            vec![CohortSlot::default(), cohort_at(103, 110)],
+            0,
+        );
+
+        let (sub, mut adopted_rx) = subscriber(120, 0);
+        assert_eq!(register_at_join_point(&table, 0, sub).await, 10);
+
+        mock.insert_checkpoints(0..110);
+
+        // The direct subscriber receives the mergee's full coverage, the adoptee everything
+        // from its join point, and both are handed to the target at the handoff (110).
+        assert_eq!(
+            recv_set(&mut subscriber_rx, 110).await,
+            BTreeSet::from_iter(0..110)
+        );
+        assert_eq!(
+            recv_set(&mut adopted_rx, 100).await,
+            BTreeSet::from_iter(10..110)
+        );
+        svc.join().await.unwrap();
+
+        assert_eq!(registered_handoffs(&table, 1), vec![110, 110]);
+        assert_eq!(metrics.total_cohort_merges.get(), 1);
+    }
+
+    /// A cohort that has not advertised a join point (e.g. its broadcaster is between legs, or
+    /// gone without cleanup) cannot be merged into; the broadcaster carries on with its own
+    /// range.
+    #[tokio::test]
+    async fn no_merge_without_join_point() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(50);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 10,
+            ..test_config()
+        };
+
+        let mut target = cohort_at(5, 15);
+        target.in_flight = None;
+
+        let (mut svc, _table) = merge_broadcaster(
+            0..30,
+            None,
+            config,
+            mock_client_with_range(0..30, metrics.clone()),
+            subscriber_dest,
+            vec![CohortSlot::default(), target],
+            0,
+        );
+
+        // The merge attempt at startup (gap 5 <= 10) finds no join point; the broadcaster
+        // completes its whole range itself.
+        assert_eq!(
+            recv_set(&mut subscriber_rx, 30).await,
+            BTreeSet::from_iter(0..30)
+        );
+        svc.join().await.unwrap();
+        assert_eq!(metrics.total_cohort_merges.get(), 0);
+    }
+
+    /// A merge whose handoff equals the mergee's frontier -- frontiers meeting exactly, at
+    /// threshold 0 -- leaves an empty final leg: the mergee winds down immediately without
+    /// fetching the handoff checkpoint.
+    #[tokio::test]
+    async fn merges_with_empty_final_leg() {
+        let (subscriber_dest, mut rx) = single_subscriber(20);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 0,
+            ..test_config()
+        };
+
+        // Checkpoint 10 is never served: an off-by-one that ingests past the handoff would
+        // retry it forever instead of completing.
+        let (mut svc, table) = merge_broadcaster(
+            0..,
+            None,
+            config,
+            mock_client_with_range(0..10, metrics.clone()),
+            subscriber_dest,
+            vec![CohortSlot::default(), cohort_at(10, 10)],
+            0,
+        );
+
+        // Frontiers meet exactly at 10: the merge fires with handoff == frontier and the final
+        // leg [10, 10) is empty.
+        assert_eq!(recv_set(&mut rx, 10).await, BTreeSet::from_iter(0..10));
+        timeout(Duration::from_secs(5), svc.join())
+            .await
+            .expect("broadcaster should wind down without fetching the handoff checkpoint")
+            .unwrap();
+
+        assert_eq!(registered_handoffs(&table, 1), vec![10]);
+        assert!(matches!(table.lock().unwrap()[0].state, CohortState::Gone));
+        assert_eq!(metrics.total_cohort_merges.get(), 1);
+
+        // The sender registered in the target's pending keeps the channel open, so assert
+        // emptiness rather than closure: the broadcaster has joined, so nothing more can
+        // arrive, and nothing at or above the handoff was delivered.
+        assert!(
+            timeout(Duration::from_millis(100), rx.next())
+                .await
+                .is_err(),
+            "delivered at or above the handoff"
+        );
+    }
+
+    /// However the broadcaster winds down -- here, a subscriber hanging up -- its cohort guard
+    /// retires the slot, and adoptees that were never absorbed have their channels closed
+    /// instead of pending forever.
+    #[tokio::test]
+    async fn winddown_closes_pending_adoptees() {
+        let (subscriber_dest, subscriber_rx) = single_subscriber(10);
+        let metrics = test_ingestion_metrics();
+        let config = IngestionConfig {
+            cohort_merge_threshold: 3,
+            ..test_config()
+        };
+
+        // Park in the first chunk so the registration deterministically lands beyond the traffic
+        // the hung-up subscriber's channel can absorb.
+        let mock = Arc::new(MockIngestionClient::default());
+        let client = IngestionClient::from_trait(mock.clone(), metrics.clone()).for_cohort(0);
+
+        let (mut svc, table) = merge_broadcaster(
+            0..,
+            None,
+            config,
+            client,
+            subscriber_dest,
+            vec![CohortSlot::default()],
+            0,
+        );
+
+        let (sub, mut rx) = subscriber(10, 0);
+        assert_eq!(register_at_join_point(&table, 0, sub).await, 3);
+
+        drop(subscriber_rx);
+        mock.insert_checkpoints(0..10);
+
+        svc.join().await.unwrap();
+        assert!(matches!(table.lock().unwrap()[0].state, CohortState::Gone));
+        assert!(rx.next().await.is_none());
+    }
+
+    /// A subscriber hanging up mid-stream winds the whole broadcaster down directly, without
+    /// falling back to ingestion first.
+    #[tokio::test]
+    async fn shutdown_on_sender_closed_mid_stream() {
+        let (subscriber_dest, mut subscriber_rx) = single_subscriber(10);
+        let streaming_client = MockStreamingClient::new(0..100, None);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..,
+            Some(Arc::new(streaming_client)),
+            test_config(),
+            mock_client_with_range(0..100, metrics.clone()),
+            subscriber_dest,
+            None,
+        );
+
+        assert_eq!(recv_vec(&mut subscriber_rx, 5).await, Vec::from_iter(0..5));
+        drop(subscriber_rx);
+
+        svc.join().await.unwrap();
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -12,9 +12,11 @@ use sui_futures::service::Service;
 use tokio::sync::mpsc;
 use tracing::warn;
 
+use crate::cohort::DEFAULT_COHORT_MERGE_THRESHOLD;
 use crate::cohort::DEFAULT_MIN_COHORT_BOUNDARY;
+use crate::cohort::MergeContext;
+use crate::cohort::Subscriber;
 pub use crate::config::ConcurrencyConfig as IngestConcurrencyConfig;
-use crate::ingestion::broadcaster::Subscriber;
 use crate::ingestion::broadcaster::broadcaster;
 use crate::ingestion::error::Error;
 use crate::ingestion::error::Result;
@@ -89,6 +91,12 @@ pub struct IngestionConfig {
     /// caught-up pipelines are not fragmented into many tiny cohorts. Defaults to 25,000
     /// checkpoints when unset.
     pub min_cohort_boundary: u64,
+
+    /// When a trailing ingestion cohort's frontier comes within this many checkpoints of the
+    /// cohort ahead of it, the trailing cohort merges into the one ahead: its pipelines are
+    /// handed off exactly-once and its ingestion service winds down. Defaults to 1,000
+    /// checkpoints when unset; at 0, cohorts merge only once their frontiers meet exactly.
+    pub cohort_merge_threshold: u64,
 }
 
 pub struct IngestionService {
@@ -96,6 +104,10 @@ pub struct IngestionService {
     ingestion_client: IngestionClient,
     streaming_client: Option<ArcStreamingClient>,
     subscribers: Vec<Subscriber>,
+
+    /// This service's view of the indexer's cohort table, when it participates in cohort
+    /// merging.
+    merge: Option<MergeContext>,
 }
 
 /// Creates the [IngestionService]s that an indexer runs -- one per cohort of pipelines with
@@ -175,6 +187,7 @@ impl IngestionService {
             ingestion_client,
             streaming_client,
             subscribers: Vec::new(),
+            merge: None,
         }
     }
 
@@ -206,6 +219,14 @@ impl IngestionService {
         rx
     }
 
+    /// Enroll this service in cohort merging: it will publish its ingestion frontier and join
+    /// point to the table in `merge`, hand its subscribers off to a cohort ahead of it once
+    /// within the merge threshold, and absorb subscribers that cohorts behind it register in
+    /// its slot.
+    pub(crate) fn set_merge_context(&mut self, merge: MergeContext) {
+        self.merge = Some(merge);
+    }
+
     /// Start the ingestion service as a background task, consuming it in the process.
     ///
     /// Checkpoints are fetched concurrently from the `checkpoints` iterator and pushed to
@@ -228,6 +249,7 @@ impl IngestionService {
             ingestion_client,
             streaming_client,
             subscribers,
+            merge,
         } = self;
 
         if subscribers.is_empty() {
@@ -240,6 +262,7 @@ impl IngestionService {
             config,
             ingestion_client,
             subscribers,
+            merge,
         ))
     }
 }
@@ -328,6 +351,7 @@ impl Default for IngestionConfig {
             streaming_connection_timeout_ms: 5000,   // 5 seconds
             streaming_statement_timeout_ms: 5000,    // 5 seconds
             min_cohort_boundary: DEFAULT_MIN_COHORT_BOUNDARY,
+            cohort_merge_threshold: DEFAULT_COHORT_MERGE_THRESHOLD,
         }
     }
 }
@@ -684,6 +708,7 @@ mod tests {
 
         let factory =
             IngestionFactory::new(args, IngestionConfig::default(), None, &registry).unwrap();
+        let families = registry.gather().len();
 
         let first = factory.create(0);
         let second = factory.create(1);
@@ -695,12 +720,7 @@ mod tests {
             second.ingestion_client.metrics(),
             factory.metrics()
         ));
-        assert!(
-            registry
-                .gather()
-                .iter()
-                .all(|family| !family.name().contains("cohort"))
-        );
+        assert_eq!(registry.gather().len(), families);
     }
 
     /// Services created by a client-driven factory all share the client's metrics handle, and

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -14,6 +14,7 @@ use tracing::warn;
 
 use crate::cohort::DEFAULT_MIN_COHORT_BOUNDARY;
 pub use crate::config::ConcurrencyConfig as IngestConcurrencyConfig;
+use crate::ingestion::broadcaster::Subscriber;
 use crate::ingestion::broadcaster::broadcaster;
 use crate::ingestion::error::Error;
 use crate::ingestion::error::Result;
@@ -94,7 +95,7 @@ pub struct IngestionService {
     config: IngestionConfig,
     ingestion_client: IngestionClient,
     streaming_client: Option<ArcStreamingClient>,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
 }
 
 /// Creates the [IngestionService]s that an indexer runs -- one per cohort of pipelines with
@@ -187,10 +188,21 @@ impl IngestionService {
     /// fills and the adaptive ingestion controller cuts fetch concurrency. Send blocks when the
     /// channel is full.
     ///
+    /// `next_checkpoint` is the first checkpoint this subscriber still needs: the broadcaster
+    /// skips delivering checkpoints below it, on the basis that the subscriber has already
+    /// processed them. Subscribers without a resume point pass `0` to receive everything.
+    ///
     /// Callers typically pass `pipeline::IngestionConfig::subscriber_channel_size()`.
-    pub fn subscribe_bounded(&mut self, size: usize) -> mpsc::Receiver<Arc<CheckpointEnvelope>> {
+    pub fn subscribe_bounded(
+        &mut self,
+        size: usize,
+        next_checkpoint: u64,
+    ) -> mpsc::Receiver<Arc<CheckpointEnvelope>> {
         let (tx, rx) = mpsc::channel(size);
-        self.subscribers.push(tx);
+        self.subscribers.push(Subscriber {
+            tx,
+            next_checkpoint,
+        });
         rx
     }
 
@@ -201,7 +213,8 @@ impl IngestionService {
     /// acts as the backpressure signal: when it fills, the adaptive ingestion controller
     /// throttles fetch concurrency. The slowest subscriber gates ingestion for everyone.
     ///
-    /// If a subscriber closes its channel, the ingestion service shuts down as well.
+    /// If a subscriber closes its channel, the ingestion service shuts down as well, once
+    /// ingestion reaches a checkpoint that subscriber would receive.
     ///
     /// If ingestion reaches the leading edge of the network, it will encounter checkpoints
     /// that do not exist yet. These are retried on a fixed `retry_interval` until they become
@@ -478,7 +491,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(usize::MAX, rx).await;
         let svc = ingestion_service.run(0..).await.unwrap();
 
@@ -500,7 +513,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(1, rx).await;
         let mut svc = ingestion_service.run(0..).await.unwrap();
 
@@ -528,7 +541,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0..).await.unwrap();
 
@@ -555,7 +568,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0..).await.unwrap();
 
@@ -582,13 +595,13 @@ mod tests {
         let size = 3;
 
         // This subscriber will take its sweet time processing checkpoints.
-        let mut laggard = ingestion_service.subscribe_bounded(size);
+        let mut laggard = ingestion_service.subscribe_bounded(size, 0);
         async fn unblock(laggard: &mut mpsc::Receiver<Arc<CheckpointEnvelope>>) -> u64 {
             let checkpoint_envelope = laggard.recv().await.unwrap();
             checkpoint_envelope.checkpoint.summary.sequence_number
         }
 
-        let rx = ingestion_service.subscribe_bounded(size);
+        let rx = ingestion_service.subscribe_bounded(size, 0);
         let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0..).await.unwrap();
 

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -517,8 +517,8 @@ impl<S: ConcurrentStore> Indexer<S> {
             name: H::NAME,
             next_checkpoint,
             build: Box::new(move |ingestion| {
-                let checkpoint_rx =
-                    ingestion.subscribe_bounded(config.ingestion.subscriber_channel_size());
+                let checkpoint_rx = ingestion
+                    .subscribe_bounded(config.ingestion.subscriber_channel_size(), next_checkpoint);
                 concurrent::pipeline::<H>(
                     handler,
                     next_checkpoint,
@@ -572,8 +572,8 @@ impl<T: SequentialStore> Indexer<T> {
             name: H::NAME,
             next_checkpoint,
             build: Box::new(move |ingestion| {
-                let checkpoint_rx =
-                    ingestion.subscribe_bounded(config.ingestion.subscriber_channel_size());
+                let checkpoint_rx = ingestion
+                    .subscribe_bounded(config.ingestion.subscriber_channel_size(), next_checkpoint);
                 sequential::pipeline::<H>(
                     handler,
                     next_checkpoint,
@@ -1316,10 +1316,12 @@ mod tests {
                 .get(),
             24
         );
+        // Pipelines never receive checkpoints below their own watermark, even though the
+        // cohort's ingestion starts at the minimum watermark across members.
         assert_out_of_order!(indexer_metrics, A::NAME, 0);
-        assert_out_of_order!(indexer_metrics, B::NAME, 5);
-        assert_out_of_order!(indexer_metrics, C::NAME, 10);
-        assert_out_of_order!(indexer_metrics, D::NAME, 15);
+        assert_out_of_order!(indexer_metrics, B::NAME, 0);
+        assert_out_of_order!(indexer_metrics, C::NAME, 0);
+        assert_out_of_order!(indexer_metrics, D::NAME, 0);
     }
 
     // test ingestion, no pipelines missing watermarks, first_checkpoint provided
@@ -1364,9 +1366,9 @@ mod tests {
             24
         );
         assert_out_of_order!(metrics, A::NAME, 0);
-        assert_out_of_order!(metrics, B::NAME, 5);
-        assert_out_of_order!(metrics, C::NAME, 10);
-        assert_out_of_order!(metrics, D::NAME, 15);
+        assert_out_of_order!(metrics, B::NAME, 0);
+        assert_out_of_order!(metrics, C::NAME, 0);
+        assert_out_of_order!(metrics, D::NAME, 0);
     }
 
     // test ingestion, some pipelines missing watermarks, no first_checkpoint provided
@@ -1409,9 +1411,9 @@ mod tests {
             30
         );
         assert_out_of_order!(metrics, A::NAME, 0);
-        assert_out_of_order!(metrics, B::NAME, 11);
-        assert_out_of_order!(metrics, C::NAME, 16);
-        assert_out_of_order!(metrics, D::NAME, 21);
+        assert_out_of_order!(metrics, B::NAME, 0);
+        assert_out_of_order!(metrics, C::NAME, 0);
+        assert_out_of_order!(metrics, D::NAME, 0);
     }
 
     // test ingestion, some pipelines missing watermarks, use first_checkpoint
@@ -1455,9 +1457,75 @@ mod tests {
             20
         );
         assert_out_of_order!(metrics, A::NAME, 0);
-        assert_out_of_order!(metrics, B::NAME, 1);
-        assert_out_of_order!(metrics, C::NAME, 6);
-        assert_out_of_order!(metrics, D::NAME, 11);
+        assert_out_of_order!(metrics, B::NAME, 0);
+        assert_out_of_order!(metrics, C::NAME, 0);
+        assert_out_of_order!(metrics, D::NAME, 0);
+    }
+
+    /// Pipelines that share a cohort don't receive checkpoints below their own watermark, even
+    /// though the cohort's ingestion range starts at the minimum watermark across its members.
+    #[tokio::test]
+    async fn test_shared_cohort_pipeline_never_reprocesses_committed_checkpoints() {
+        let registry = Registry::new();
+        let store = FallibleMockStore::default();
+
+        test_pipeline!(A, "concurrent_a");
+        test_pipeline!(B, "concurrent_b");
+
+        let mut conn = store.connect().await.unwrap();
+        set_committer_watermark(&mut conn, A::NAME, 5).await;
+        set_committer_watermark(&mut conn, B::NAME, 20).await;
+
+        let indexer_args = IndexerArgs {
+            last_checkpoint: Some(29),
+            ..Default::default()
+        };
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((30, 1))).await;
+
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+
+        let ingestion_metrics = indexer.ingestion_metrics().clone();
+        let indexer_metrics = indexer.indexer_metrics().clone();
+
+        indexer.run().await.unwrap().join().await.unwrap();
+
+        // Each checkpoint in 6..=29 is fetched exactly once for the cohort.
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            24
+        );
+
+        // B was only served the checkpoints past its own watermark (21..=29).
+        assert_eq!(
+            indexer_metrics
+                .total_handler_checkpoints_received
+                .get_metric_with_label_values(&[B::NAME])
+                .unwrap()
+                .get(),
+            9
+        );
+        assert_out_of_order!(indexer_metrics, A::NAME, 0);
+        assert_out_of_order!(indexer_metrics, B::NAME, 0);
+
+        // B never re-committed checkpoints at or below its watermark.
+        let committed = store.data.get(B::NAME).unwrap();
+        for cp in 6..21 {
+            assert!(
+                !committed.contains_key(&cp),
+                "B re-committed checkpoint {cp}"
+            );
+        }
+        for cp in 21..30 {
+            assert!(
+                committed.contains_key(&cp),
+                "B did not commit checkpoint {cp}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -4,11 +4,14 @@
 use std::collections::BTreeSet;
 use std::ops::Bound;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::bail;
 use anyhow::ensure;
+use cohort::CohortSlot;
+use cohort::MergeContext;
 use cohort::cohorts;
 use ingestion::ArcStreamingClient;
 use ingestion::ClientArgs;
@@ -368,9 +371,16 @@ impl<S: Store> Indexer<S> {
     /// held back (through channel backpressure) by pipelines that have a long backfill ahead of
     /// them.
     ///
+    /// Cohorts merge back together as they converge: once a trailing cohort's ingestion frontier
+    /// comes within `cohort_merge_threshold` checkpoints of the cohort ahead of it, its
+    /// pipelines are handed off to that cohort's ingestion service (exactly once -- no gaps, no
+    /// duplicates) and its own service winds down, so a fully caught-up indexer ends up back on
+    /// a single ingestion service.
+    ///
     /// Ingestion will stop after consuming the configured `last_checkpoint` if one is provided.
-    /// Note that a pipeline dropping its checkpoint subscription only winds down its own
-    /// cohort's ingestion service; other cohorts keep running.
+    /// Note that a pipeline dropping its checkpoint subscription winds down its own cohort's
+    /// ingestion service (including pipelines merged into that cohort); other cohorts keep
+    /// running.
     pub async fn run(self) -> anyhow::Result<Service> {
         let Self {
             ingestion_factory,
@@ -404,6 +414,17 @@ impl<S: Store> Indexer<S> {
 
         let end = last_checkpoint.map_or(Bound::Unbounded, Bound::Included);
 
+        // The table through which cohorts coordinate merges, with one slot per cohort.
+        let threshold = ingestion_factory.config().cohort_merge_threshold;
+        let table = (groups.len() > 1).then(|| {
+            Arc::new(Mutex::new(
+                groups
+                    .iter()
+                    .map(|_| CohortSlot::default())
+                    .collect::<Vec<_>>(),
+            ))
+        });
+
         let mut service = Service::new();
         for (cohort, group) in groups.into_iter().enumerate() {
             let mut ingestion = ingestion_factory.create(cohort);
@@ -418,6 +439,14 @@ impl<S: Store> Indexer<S> {
             }
 
             info!(cohort, start, end = last_checkpoint, pipelines = ?names, "Ingestion range");
+
+            if let Some(table) = &table {
+                ingestion.set_merge_context(MergeContext {
+                    table: table.clone(),
+                    cohort,
+                    threshold,
+                });
+            }
 
             let mut cohort_service = ingestion
                 .run((Bound::Included(start), end))
@@ -618,68 +647,75 @@ mod tests {
     #[derive(Clone, FieldCount)]
     struct MockValue(u64);
 
-    /// A handler that can be controlled externally to block checkpoint processing.
-    struct ControllableHandler {
-        /// Process checkpoints less than or equal to this value.
-        process_below: watch::Receiver<u64>,
-    }
-
-    impl ControllableHandler {
-        fn with_limit(limit: u64) -> (Self, watch::Sender<u64>) {
-            let (tx, rx) = watch::channel(limit);
-            (Self { process_below: rx }, tx)
-        }
-    }
-
-    #[async_trait]
-    impl Processor for ControllableHandler {
-        const NAME: &'static str = "controllable";
-        type Value = MockValue;
-
-        async fn process(
-            &self,
-            checkpoint: &Arc<sui_types::full_checkpoint_content::Checkpoint>,
-        ) -> anyhow::Result<Vec<Self::Value>> {
-            let cp_num = checkpoint.summary.sequence_number;
-
-            // Wait until the checkpoint is allowed to be processed
-            self.process_below
-                .clone()
-                .wait_for(|&limit| cp_num <= limit)
-                .await
-                .ok();
-
-            Ok(vec![MockValue(cp_num)])
-        }
-    }
-
-    #[async_trait]
-    impl concurrent::Handler for ControllableHandler {
-        type Store = FallibleMockStore;
-        type Batch = Vec<MockValue>;
-
-        fn batch(
-            &self,
-            batch: &mut Self::Batch,
-            values: &mut std::vec::IntoIter<Self::Value>,
-        ) -> concurrent::BatchStatus {
-            batch.extend(values);
-            concurrent::BatchStatus::Ready
-        }
-
-        async fn commit<'a>(
-            &self,
-            batch: &Self::Batch,
-            conn: &mut <Self::Store as Store>::Connection<'a>,
-        ) -> anyhow::Result<usize> {
-            for value in batch {
-                conn.0
-                    .commit_data(Self::NAME, value.0, vec![value.0])
-                    .await?;
+    /// A handler that can be controlled externally to block checkpoint processing: it only
+    /// processes checkpoints at or below a limit adjusted through the returned `watch` sender.
+    macro_rules! controllable_handler {
+        ($handler:ident, $name:literal) => {
+            struct $handler {
+                /// Process checkpoints less than or equal to this value.
+                process_below: watch::Receiver<u64>,
             }
-            Ok(batch.len())
-        }
+
+            impl $handler {
+                fn with_limit(limit: u64) -> (Self, watch::Sender<u64>) {
+                    let (tx, rx) = watch::channel(limit);
+                    (Self { process_below: rx }, tx)
+                }
+            }
+
+            #[async_trait]
+            impl Processor for $handler {
+                const NAME: &'static str = $name;
+                type Value = MockValue;
+
+                async fn process(
+                    &self,
+                    checkpoint: &Arc<sui_types::full_checkpoint_content::Checkpoint>,
+                ) -> anyhow::Result<Vec<Self::Value>> {
+                    let cp_num = checkpoint.summary.sequence_number;
+
+                    // Wait until the checkpoint is allowed to be processed
+                    self.process_below
+                        .clone()
+                        .wait_for(|&limit| cp_num <= limit)
+                        .await
+                        .ok();
+
+                    Ok(vec![MockValue(cp_num)])
+                }
+            }
+
+            #[async_trait]
+            impl concurrent::Handler for $handler {
+                type Store = FallibleMockStore;
+                type Batch = Vec<MockValue>;
+
+                fn batch(
+                    &self,
+                    batch: &mut Self::Batch,
+                    values: &mut std::vec::IntoIter<Self::Value>,
+                ) -> concurrent::BatchStatus {
+                    batch.extend(values);
+                    concurrent::BatchStatus::Ready
+                }
+
+                async fn commit<'a>(
+                    &self,
+                    batch: &Self::Batch,
+                    conn: &mut <Self::Store as Store>::Connection<'a>,
+                ) -> anyhow::Result<usize> {
+                    for value in batch {
+                        conn.0
+                            .commit_data(Self::NAME, value.0, vec![value.0])
+                            .await?;
+                    }
+                    Ok(batch.len())
+                }
+            }
+        };
     }
+
+    controllable_handler!(ControllableHandler, "controllable");
 
     macro_rules! test_pipeline {
         ($handler:ident, $name:literal) => {
@@ -2054,9 +2090,13 @@ mod tests {
                 ..Default::default()
             },
             // A small cohort boundary splits the near-tip and far-behind pipelines into separate
-            // cohorts without having to generate tens of thousands of checkpoints.
+            // cohorts without having to generate tens of thousands of checkpoints, and a zero
+            // merge threshold keeps them separate for the whole test (the wedged far-behind
+            // cohort's frontier never reaches the near-tip cohort's): at this scale the two
+            // cohorts start within the default merge threshold of each other.
             IngestionConfig {
                 min_cohort_boundary: 10,
+                cohort_merge_threshold: 0,
                 ..Default::default()
             },
             None,
@@ -2105,6 +2145,304 @@ mod tests {
         assert!(store.data.get(ControllableHandler::NAME).is_none());
 
         // The merged service never completes on its own while a cohort is wedged; drop aborts it.
+        drop(service);
+    }
+
+    /// End-to-end cohort merging: a far-behind pipeline backfills, and once its ingestion
+    /// frontier comes within the merge threshold of the near-tip cohort, its subscription is
+    /// handed off to that cohort's ingestion service (exactly once -- no gaps, no duplicates)
+    /// and its own service winds down; the far pipeline then follows new checkpoints through
+    /// the near cohort's service.
+    #[tokio::test]
+    async fn test_cohorts_merge_as_they_converge() {
+        const TIP: u64 = 100;
+        const END: u64 = 160;
+
+        let registry = Registry::new();
+        let store = FallibleMockStore::default();
+
+        test_pipeline!(B, "far_behind");
+
+        // The near pipeline initially blocks every checkpoint above 99, so its cohort's
+        // broadcaster backpressures to a halt mid-chunk with its published frontier pinned at
+        // 95, giving the far cohort a stationary target to converge on. Keep the release
+        // sender alive for the whole test.
+        let (near, release) = ControllableHandler::with_limit(99);
+
+        let temp_dir = init_ingestion_dir(Some(TIP));
+        let mut conn = store.connect().await.unwrap();
+        set_committer_watermark(&mut conn, ControllableHandler::NAME, 94).await; // resumes at 95
+        set_committer_watermark(&mut conn, B::NAME, 9).await; // resumes at 10
+        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+            ingestion_dir: temp_dir.path().to_owned(),
+            starting_checkpoint: 0,
+            num_checkpoints: END + 1, // checkpoints [0, END]
+            checkpoint_size: 1,
+        })
+        .await;
+
+        let mut indexer = Indexer::new(
+            store.clone(),
+            // Unbounded: the merged service keeps following the tip.
+            IndexerArgs::default(),
+            ClientArgs {
+                ingestion: IngestionClientArgs {
+                    local_ingestion_path: Some(temp_dir.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            // A small cohort boundary splits the pipelines into two cohorts (distances 5 and
+            // 90 from the advertised tip), and the far cohort merges into the near one when it
+            // gets within 20 checkpoints of it -- at its chunk boundary 90, against the near
+            // cohort's pinned frontier of 95.
+            IngestionConfig {
+                min_cohort_boundary: 10,
+                cohort_merge_threshold: 20,
+                ..Default::default()
+            },
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        // Commit promptly so watermarks advance without waiting on the default intervals, and
+        // give the near pipeline a small subscriber channel so blocking its handler parks its
+        // broadcaster after only a few buffered checkpoints.
+        let committer = || CommitterConfig {
+            collect_interval_ms: 10,
+            watermark_interval_ms: 10,
+            ..Default::default()
+        };
+        indexer
+            .concurrent_pipeline(
+                near,
+                ConcurrentConfig {
+                    committer: committer(),
+                    ingestion: crate::pipeline::IngestionConfig {
+                        subscriber_channel_size: Some(4),
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        indexer
+            .concurrent_pipeline(
+                B,
+                ConcurrentConfig {
+                    committer: committer(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let ingestion_metrics = indexer.ingestion_metrics().clone();
+        let indexer_metrics = indexer.indexer_metrics().clone();
+        let service = indexer.run().await.unwrap();
+
+        // The far cohort backfills to its chunk boundary at 90, finds the near cohort's
+        // frontier (95) within the merge threshold, and merges into it.
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while ingestion_metrics.total_cohort_merges.get() == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for the cohorts to merge");
+
+        // Unblock the near pipeline: the merged service absorbs the far pipeline's subscription
+        // at the handoff checkpoint, and deliveries to both pipelines flow through to the end
+        // of the data.
+        release.send(u64::MAX).unwrap();
+
+        store
+            .wait_for_watermark(ControllableHandler::NAME, END, Duration::from_secs(10))
+            .await;
+        store
+            .wait_for_watermark(B::NAME, END, Duration::from_secs(10))
+            .await;
+
+        // Exactly-once delivery across the handoff: each handler saw each checkpoint in its
+        // range exactly once (a gap would have stalled its watermark above; a duplicate would
+        // inflate its received count).
+        let received = |name| {
+            indexer_metrics
+                .total_handler_checkpoints_received
+                .get_metric_with_label_values(&[name])
+                .unwrap()
+                .get()
+        };
+        assert_eq!(received(ControllableHandler::NAME), END - 95 + 1);
+        assert_eq!(received(B::NAME), END - 10 + 1);
+
+        // The far cohort stopped ingesting at its handoff checkpoint -- the end of the near
+        // cohort's parked chunk [95, 115) -- instead of following the data to the end itself.
+        assert_eq!(ingestion_metrics.total_cohort_merges.get(), 1);
+        let far_ingested = ingestion_metrics
+            .total_ingested_checkpoints
+            .with_label_values(&["1"])
+            .get();
+        assert_eq!(far_ingested, 115 - 10);
+
+        // The merged service follows the tip indefinitely; drop aborts it.
+        drop(service);
+    }
+
+    /// A subscription handed off once can be handed off again: the far cohort merges into the
+    /// mid cohort, the mid cohort absorbs the handed-off subscription and later re-registers it
+    /// (alongside its own) when it merges into the near cohort -- and every pipeline sees every
+    /// checkpoint in its range exactly once across three ingestion services.
+    #[tokio::test]
+    async fn test_three_cohorts_cascade_merge() {
+        const TIP: u64 = 100;
+        const END: u64 = 160;
+
+        let registry = Registry::new();
+        let store = FallibleMockStore::default();
+
+        controllable_handler!(Near, "cascade_near");
+        controllable_handler!(Mid, "cascade_mid");
+        controllable_handler!(Far, "cascade_far");
+
+        // Every cohort parks at startup: near blocks above 99 (broadcaster parked in
+        // [95, 115)), mid and far block everything from their resume points (parked in
+        // [56, 76) and [10, 30)) until released. Keep the senders alive for the whole test.
+        let (near, release_near) = Near::with_limit(99);
+        let (mid, release_mid) = Mid::with_limit(55);
+        let (far, release_far) = Far::with_limit(9);
+
+        let temp_dir = init_ingestion_dir(Some(TIP));
+        let mut conn = store.connect().await.unwrap();
+        set_committer_watermark(&mut conn, Near::NAME, 94).await; // resumes at 95, distance 5
+        set_committer_watermark(&mut conn, Mid::NAME, 55).await; // resumes at 56, distance 44
+        set_committer_watermark(&mut conn, Far::NAME, 9).await; // resumes at 10, distance 90
+        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+            ingestion_dir: temp_dir.path().to_owned(),
+            starting_checkpoint: 0,
+            num_checkpoints: END + 1, // checkpoints [0, END]
+            checkpoint_size: 1,
+        })
+        .await;
+
+        let mut indexer = Indexer::new(
+            store.clone(),
+            // Unbounded: the surviving service keeps following the tip.
+            IndexerArgs::default(),
+            ClientArgs {
+                ingestion: IngestionClientArgs {
+                    local_ingestion_path: Some(temp_dir.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            // Distances 5 / 44 / 90 form three cohorts (mid's boundary is 2 * 44 = 88 < 90),
+            // each merging into the one ahead once within 20 checkpoints; chunk = 20.
+            IngestionConfig {
+                min_cohort_boundary: 10,
+                cohort_merge_threshold: 20,
+                ..Default::default()
+            },
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        // Commit promptly, and use small subscriber channels so a blocked handler parks its
+        // broadcaster after only a few buffered checkpoints.
+        let config = || ConcurrentConfig {
+            committer: CommitterConfig {
+                collect_interval_ms: 10,
+                watermark_interval_ms: 10,
+                ..Default::default()
+            },
+            ingestion: crate::pipeline::IngestionConfig {
+                subscriber_channel_size: Some(4),
+            },
+            ..Default::default()
+        };
+        indexer.concurrent_pipeline(near, config()).await.unwrap();
+        indexer.concurrent_pipeline(mid, config()).await.unwrap();
+        indexer.concurrent_pipeline(far, config()).await.unwrap();
+
+        let ingestion_metrics = indexer.ingestion_metrics().clone();
+        let indexer_metrics = indexer.indexer_metrics().clone();
+        let service = indexer.run().await.unwrap();
+
+        let ingested = |cohort: &str| {
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&[cohort])
+                .get()
+        };
+        async fn wait_until(what: &str, cond: impl Fn() -> bool) {
+            tokio::time::timeout(Duration::from_secs(10), async {
+                while !cond() {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
+        }
+
+        // Both cohorts ahead must have committed their first (parked) chunks -- publishing
+        // their frontiers and join points -- before the far cohort starts converging.
+        wait_until(
+            "the near and mid cohorts to publish their first chunks",
+            || ingested("0") > 0 && ingested("1") > 0,
+        )
+        .await;
+
+        // The far cohort backfills to its chunk boundary at 50, finds mid's frontier (56)
+        // within the threshold, hands its subscription off at mid's join point (76), delivers
+        // [10, 76), and winds down.
+        release_far.send(u64::MAX).unwrap();
+        wait_until("the far cohort to merge into the mid cohort", || {
+            ingestion_metrics.total_cohort_merges.get() == 1
+        })
+        .await;
+
+        // Mid completes [56, 76), absorbs far's subscription there, then finds near's frontier
+        // (95) within the threshold and re-registers both subscriptions at near's join point
+        // (115).
+        release_mid.send(u64::MAX).unwrap();
+        wait_until("the mid cohort to merge into the near cohort", || {
+            ingestion_metrics.total_cohort_merges.get() == 2
+        })
+        .await;
+
+        // Unblock near: it absorbs both subscriptions at its clean state (115) and carries all
+        // three pipelines to the end of the data.
+        release_near.send(u64::MAX).unwrap();
+        for name in [Near::NAME, Mid::NAME, Far::NAME] {
+            store
+                .wait_for_watermark(name, END, Duration::from_secs(10))
+                .await;
+        }
+
+        // Exactly-once across both handoffs: each pipeline saw each checkpoint in its range
+        // exactly once (a gap would have stalled its watermark above; a duplicate would
+        // inflate its received count).
+        let received = |name| {
+            indexer_metrics
+                .total_handler_checkpoints_received
+                .get_metric_with_label_values(&[name])
+                .unwrap()
+                .get()
+        };
+        assert_eq!(received(Near::NAME), END - 95 + 1);
+        assert_eq!(received(Mid::NAME), END - 56 + 1);
+        assert_eq!(received(Far::NAME), END - 10 + 1);
+
+        // Each mergee stopped ingesting at its handoff: far at mid's join point (76), mid at
+        // near's (115).
+        assert_eq!(ingested("2"), 76 - 10);
+        assert_eq!(ingested("1"), 115 - 56);
+
+        // The surviving service follows the tip indefinitely; drop aborts it.
         drop(service);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -57,10 +57,10 @@ const BATCH_SIZE_BUCKETS: &[f64] = &[
 /// Metrics specific to the ingestion service.
 ///
 /// Almost every metric is labeled by `cohort`: the framework mints one ingestion service per cohort,
-/// all sharing this handle, so the label keeps their series from colliding. The two exceptions are
-/// `total_ingested_bytes` (counted inside the checkpoint source, which is shared across cohorts) and
+/// all sharing this handle, so the label keeps their series from colliding. The exceptions are
+/// `total_ingested_bytes` (counted inside the checkpoint source, which is shared across cohorts),
 /// `ingested_latest_checkpoint_latency` (recorded only by the factory's one-time tip probe, before
-/// any cohort exists).
+/// any cohort exists), and `total_cohort_merges` (each merge involves two cohorts).
 #[derive(Clone)]
 pub struct IngestionMetrics {
     // Statistics related to fetching data from the remote store.
@@ -76,6 +76,7 @@ pub struct IngestionMetrics {
     pub total_out_of_order_streamed_checkpoints: IntCounterVec,
     pub total_stream_disconnections: IntCounterVec,
     pub total_streaming_connection_failures: IntCounterVec,
+    pub total_cohort_merges: IntCounter,
 
     // Checkpoint lag metrics for the ingestion pipeline.
     pub latest_ingested_checkpoint: IntGaugeVec,
@@ -303,6 +304,12 @@ impl IngestionMetrics {
                 name("total_streaming_connection_failures"),
                 "Total number of failures due to streaming service connection or peek failures",
                 &["cohort"],
+                registry,
+            )
+            .unwrap(),
+            total_cohort_merges: register_int_counter_with_registry!(
+                name("total_cohort_merges"),
+                "Total number of times an ingestion cohort has merged into the cohort ahead of it",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -58,6 +58,7 @@ pub struct IngestionLayer {
     pub streaming_connection_timeout_ms: Option<u64>,
     pub streaming_statement_timeout_ms: Option<u64>,
     pub min_cohort_boundary: Option<u64>,
+    pub cohort_merge_threshold: Option<u64>,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -213,6 +214,9 @@ impl IngestionLayer {
                 .streaming_statement_timeout_ms
                 .unwrap_or(base.streaming_statement_timeout_ms),
             min_cohort_boundary: self.min_cohort_boundary.unwrap_or(base.min_cohort_boundary),
+            cohort_merge_threshold: self
+                .cohort_merge_threshold
+                .unwrap_or(base.cohort_merge_threshold),
         })
     }
 }
@@ -365,6 +369,7 @@ impl Merge for IngestionLayer {
                 .streaming_statement_timeout_ms
                 .or(self.streaming_statement_timeout_ms),
             min_cohort_boundary: other.min_cohort_boundary.or(self.min_cohort_boundary),
+            cohort_merge_threshold: other.cohort_merge_threshold.or(self.cohort_merge_threshold),
             checkpoint_buffer_size: other.checkpoint_buffer_size.or(self.checkpoint_buffer_size),
         })
     }
@@ -491,6 +496,7 @@ impl From<IngestionConfig> for IngestionLayer {
             streaming_connection_timeout_ms: Some(config.streaming_connection_timeout_ms),
             streaming_statement_timeout_ms: Some(config.streaming_statement_timeout_ms),
             min_cohort_boundary: Some(config.min_cohort_boundary),
+            cohort_merge_threshold: Some(config.cohort_merge_threshold),
             checkpoint_buffer_size: None,
         }
     }

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -286,6 +286,7 @@ pub struct IngestionConfig {
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
     pub min_cohort_boundary: u64,
+    pub cohort_merge_threshold: u64,
 
     /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
     /// per-pipeline `ingestion.subscriber-channel-size`.
@@ -308,6 +309,7 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
             min_cohort_boundary: config.min_cohort_boundary,
+            cohort_merge_threshold: config.cohort_merge_threshold,
             checkpoint_buffer_size: None,
         }
     }
@@ -331,6 +333,7 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
             min_cohort_boundary: config.min_cohort_boundary,
+            cohort_merge_threshold: config.cohort_merge_threshold,
         }
     }
 }


### PR DESCRIPTION
## Description

Continues work started in #27209 (merged).

Cohorts are fixed at startup, so a backfilling cohort that catches up keeps running its own ingestion service — duplicate fetching and streaming subscriptions — forever. This PR merges cohorts at runtime: once a trailing cohort's frontier comes within `cohort-merge-threshold` checkpoints (default 1,000) of the cohort ahead, it hands its subscribers over exactly once and winds down, so a caught-up indexer converges back to a single ingestion service.

The handoff goes through the cohort table:

- Each service advertises its frontier and the exclusive end of its in-flight range — the exact point at which a subscriber can still join in full — and absorbs subscribers registered there when it commits its next range (ingestion legs are chunked when merging is enabled; streaming commits per checkpoint).
- A merging cohort registers its subscribers at that point in one atomic step under the table lock, delivers everything below it, and winds down.
- The target stays completely passive — a trailing cohort can merge into a service parked on backpressure — and adoptees become plain subscribers of the target: native backpressure and shutdown, no extra hops.

## Test plan

New tests cover:

- The table protocol: registration and absorption at range commits, refusal while no join point is advertised, pass-along of pending adoptees across cascaded merges, and the guard closing pending adoptees' channels on wind-down.
- Broadcaster-level merges from both the ingestion and streaming paths, and immediate wind-down when a subscriber hangs up mid-stream.
- End-to-end merges: a two-cohort merge where a backfill converges on a backpressured near-tip cohort, and a three-cohort cascade where a handed-off subscription is handed off again -- in both, every pipeline receives its exact range exactly once.
- Adoption from both broadcast paths: subscribers registered at ingestion-chunk and streamed join points, absorbed mid-run and carried across leg transitions.
- Handoffs compose with per-subscriber resume points: `next_checkpoint` rides through registration and absorption unchanged, including an adoptee whose resume point lies beyond the join point.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Ingestion cohorts now merge back together at runtime once a trailing cohort catches up to within `cohort-merge-threshold` checkpoints (default 1,000) of the cohort ahead; set the new `ingestion.cohort-merge-threshold` config to tune how eagerly they merge. Pipelines sharing an ingestion service no longer receive checkpoints below their own resume watermark.

