### PR TITLE
[chore] Bump to Rust 1.96.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,6 +28,7 @@ move-clippy = [
     "-Aclippy::question_mark",
     "-Aclippy::unnecessary_get_then_check",
     "-Aclippy::needless_borrows_for_generic_args",
+    "-Aclippy::collapsible_match",
 ]
 
 [build]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,27 @@
+# Setup scripts (experimental) require a recent nextest. CI installs the latest
+# via taiki-e/install-action@nextest; local runs need an upgrade from older ones.
+nextest-version = { required = "0.9.98" }
+
+# Opt in to setup scripts, used below to raise the worker-thread stack size for
+# the graphql transactional_tests (Rust 1.96 async-frame bloat overflows the
+# default 2 MiB tokio worker stack). Setup scripts run at test time only, so this
+# does not affect builds — unlike a global `.cargo/config.toml [env]`.
+experimental = ["setup-scripts"]
+
+[scripts.setup.big-worker-stack]
+command = 'scripts/nextest/big-worker-stack.sh'
+
+# Apply the 8 MiB worker stack only to the binary that overflows. Listed under
+# both `default` (local runs) and `ci` (CI uses `--profile ci`); a named setup
+# script runs once per test run regardless of how many rules reference it.
+[[profile.default.scripts]]
+filter = 'package(sui-indexer-alt-e2e-tests) and binary(transactional_tests)'
+setup = 'big-worker-stack'
+
+[[profile.ci.scripts]]
+filter = 'package(sui-indexer-alt-e2e-tests) and binary(transactional_tests)'
+setup = 'big-worker-stack'
+
 [profile.ci]
 # Print output for failing tests only when they fail.
 failure-output = "immediate"

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -83,6 +83,7 @@ impl Committee {
     /// from the nominal total stake computed above. We will scale `f` and `c`
     /// from the nominal value to the largest possible values where intersection
     /// properties still hold. Then the thresholds are computed with scaled `f` and `c`.
+    #[allow(clippy::int_plus_one)] // Avoid clippy warning about `+ 1` in threshold asserts.
     pub fn new_v3(
         epoch: Epoch,
         authorities: Vec<Authority>,
@@ -123,7 +124,7 @@ impl Committee {
 
         // Ensure intersection between committed certification and quorum thresholds.
         assert!(
-            certification_threshold + quorum_threshold > actual_total_stake + f,
+            certification_threshold + quorum_threshold >= actual_total_stake + f + 1,
             "Stake-safety invariant violated: \
                 committed_cert ({certification_threshold}) + \
                 quorum ({quorum_threshold}) < \

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -123,7 +123,7 @@ impl Committee {
 
         // Ensure intersection between committed certification and quorum thresholds.
         assert!(
-            certification_threshold + quorum_threshold >= actual_total_stake + f + 1,
+            certification_threshold + quorum_threshold > actual_total_stake + f,
             "Stake-safety invariant violated: \
                 committed_cert ({certification_threshold}) + \
                 quorum ({quorum_threshold}) < \

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -647,8 +647,8 @@ mod tests {
         // Take only the blocks of round 2 and try to accept them
         let round_2_blocks = dag_builder
             .blocks
-            .into_iter()
-            .filter_map(|(_, block)| (block.round() == 2).then_some(block))
+            .into_values()
+            .filter_map(|block| (block.round() == 2).then_some(block))
             .collect::<Vec<VerifiedBlock>>();
 
         // WHEN
@@ -1085,8 +1085,8 @@ mod tests {
         // Take only the blocks of round 2 and try to accept them
         let round_2_blocks = dag_builder
             .blocks
-            .iter()
-            .filter_map(|(_, block)| (block.round() == 2).then_some(block.clone()))
+            .values()
+            .filter_map(|block| (block.round() == 2).then_some(block.clone()))
             .collect::<Vec<VerifiedBlock>>();
 
         // All blocks should be missing
@@ -1121,8 +1121,8 @@ mod tests {
 
         let round_3_blocks = dag_builder
             .blocks
-            .iter()
-            .filter_map(|(_, block)| (block.round() == 3).then_some(block.reference()))
+            .values()
+            .filter_map(|block| (block.round() == 3).then_some(block.reference()))
             .collect::<Vec<BlockRef>>();
 
         let missing_block_refs_from_find = block_manager.try_find_blocks(

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -284,9 +284,7 @@ impl CommitObserver {
                 .observe(commit.blocks.len() as f64);
 
             for block in &commit.blocks {
-                let latency_ms = utc_now
-                    .checked_sub(block.timestamp_ms())
-                    .unwrap_or_default();
+                let latency_ms = utc_now.saturating_sub(block.timestamp_ms());
                 metrics
                     .block_commit_latency
                     .observe(Duration::from_millis(latency_ms).as_secs_f64());

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -633,8 +633,8 @@ where
                     let mut blocks = Vec::new();
                     for ((requested_block_ref, signed_block), serialized) in request_block_refs
                         .iter()
-                        .zip_debug_eq(signed_blocks.into_iter())
-                        .zip_debug_eq(serialized_blocks.into_iter())
+                        .zip_debug_eq(signed_blocks)
+                        .zip_debug_eq(serialized_blocks)
                     {
                         let signed_block_digest = VerifiedBlock::compute_digest(&serialized);
                         let received_block_ref = BlockRef::new(

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -477,7 +477,7 @@ impl DagState {
             .with_label_values(&["get_blocks"])
             .inc();
 
-        for ((index, _), result) in missing.into_iter().zip_debug_eq(store_results.into_iter()) {
+        for ((index, _), result) in missing.into_iter().zip_debug_eq(store_results) {
             blocks[index] = result;
         }
 
@@ -857,7 +857,7 @@ impl DagState {
             .with_label_values(&["contains_blocks"])
             .inc();
 
-        for ((index, _), result) in missing.into_iter().zip_debug_eq(store_results.into_iter()) {
+        for ((index, _), result) in missing.into_iter().zip_debug_eq(store_results) {
             exist[index] = result;
         }
 

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -270,7 +270,7 @@ impl LeaderSwapTable {
         assert_eq!(authorities_by_score.len(), context.committee.size());
         authorities_by_score.shuffle(&mut rng);
         // Stable sort the authorities by score descending. Order of authorities with the same score is preserved.
-        authorities_by_score.sort_by(|a1, a2| a2.1.cmp(&a1.1));
+        authorities_by_score.sort_by_key(|a2| std::cmp::Reverse(a2.1));
 
         // Calculating the good nodes
         let good_nodes = Self::retrieve_first_nodes(

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -270,7 +270,7 @@ impl LeaderSwapTable {
         assert_eq!(authorities_by_score.len(), context.committee.size());
         authorities_by_score.shuffle(&mut rng);
         // Stable sort the authorities by score descending. Order of authorities with the same score is preserved.
-        authorities_by_score.sort_by_key(|a2| std::cmp::Reverse(a2.1));
+        authorities_by_score.sort_by_key(|a| std::cmp::Reverse(a.1));
 
         // Calculating the good nodes
         let good_nodes = Self::retrieve_first_nodes(

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -218,7 +218,7 @@ impl LeaderScheduleV3 {
         by_score.shuffle(&mut rng);
 
         // Use stable sort to produce deterministic order of authorities with the same score.
-        by_score.sort_by(|a, b| b.1.cmp(&a.1));
+        by_score.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         let mut accumulated_bad_stake = 0u64;
         let cutoff = (self.context.protocol_config.bad_nodes_stake_threshold()

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -218,7 +218,7 @@ impl LeaderScheduleV3 {
         by_score.shuffle(&mut rng);
 
         // Use stable sort to produce deterministic order of authorities with the same score.
-        by_score.sort_by_key(|b| std::cmp::Reverse(b.1));
+        by_score.sort_by_key(|a| std::cmp::Reverse(a.1));
 
         let mut accumulated_bad_stake = 0u64;
         let cutoff = (self.context.protocol_config.bad_nodes_stake_threshold()

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -112,13 +112,12 @@ impl ScoringSubdag {
         for subdag in committed_subdags {
             // If the commit range is not set, then set it to the range of the first
             // committed subdag index.
-            if self.commit_range.is_none() {
+            if let Some(commit_range) = &mut self.commit_range {
+                commit_range.extend_to(subdag.commit_ref.index);
+            } else {
                 self.commit_range = Some(CommitRange::new(
                     subdag.commit_ref.index..=subdag.commit_ref.index,
                 ));
-            } else {
-                let commit_range = self.commit_range.as_mut().unwrap();
-                commit_range.extend_to(subdag.commit_ref.index);
             }
 
             // Add the committed leader to the list of leaders we will be scoring.

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -223,7 +223,7 @@ impl ValidatorProposer {
 
         // Sort scores descending so we can include the best of the pending excluded
         // ancestors first until we reach the threshold.
-        score_and_pending_excluded_ancestors.sort_by_key(|b| std::cmp::Reverse(b.0));
+        score_and_pending_excluded_ancestors.sort_by_key(|a| std::cmp::Reverse(a.0));
 
         let mut ancestors_to_propose = included_ancestors;
         let mut excluded_ancestors = Vec::new();

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -223,7 +223,7 @@ impl ValidatorProposer {
 
         // Sort scores descending so we can include the best of the pending excluded
         // ancestors first until we reach the threshold.
-        score_and_pending_excluded_ancestors.sort_by(|a, b| b.0.cmp(&a.0));
+        score_and_pending_excluded_ancestors.sort_by_key(|b| std::cmp::Reverse(b.0));
 
         let mut ancestors_to_propose = included_ancestors;
         let mut excluded_ancestors = Vec::new();

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -146,7 +146,7 @@ impl Store for MemStore {
         }
         let results = self.read_blocks(refs.as_slice())?;
         let mut blocks = vec![];
-        for (r, block) in refs.into_iter().zip_debug_eq(results.into_iter()) {
+        for (r, block) in refs.into_iter().zip_debug_eq(results) {
             if let Some(block) = block {
                 blocks.push(block);
             } else {
@@ -180,7 +180,7 @@ impl Store for MemStore {
         let refs_slice = refs.make_contiguous();
         let results = self.read_blocks(refs_slice)?;
         let mut blocks = vec![];
-        for (r, block) in refs.into_iter().zip_debug_eq(results.into_iter()) {
+        for (r, block) in refs.into_iter().zip_debug_eq(results) {
             blocks.push(
                 block.unwrap_or_else(|| panic!("Storage inconsistency: block {:?} not found!", r)),
             );

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -278,7 +278,7 @@ impl Store for RocksDBStore {
         }
         let results = self.read_blocks(refs.as_slice())?;
         let mut blocks = Vec::with_capacity(refs.len());
-        for (r, block) in refs.into_iter().zip_debug_eq(results.into_iter()) {
+        for (r, block) in refs.into_iter().zip_debug_eq(results) {
             blocks.push(
                 block.unwrap_or_else(|| panic!("Storage inconsistency: block {:?} not found!", r)),
             );
@@ -311,7 +311,7 @@ impl Store for RocksDBStore {
         let refs_slice = refs.make_contiguous();
         let results = self.read_blocks(refs_slice)?;
         let mut blocks = vec![];
-        for (r, block) in refs.into_iter().zip_debug_eq(results.into_iter()) {
+        for (r, block) in refs.into_iter().zip_debug_eq(results) {
             blocks.push(
                 block.unwrap_or_else(|| panic!("Storage inconsistency: block {:?} not found!", r)),
             );

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -852,12 +852,11 @@ impl<'a> LayerBuilder<'a> {
         round: Round,
         num_block: u32,
     ) -> BlockTimestampMs {
-        if self.specified_authorities.is_some() && !self.timestamps.is_empty() {
-            let specified_authorities = self.specified_authorities.as_ref().unwrap();
-
-            if let Some(position) = specified_authorities.iter().position(|&x| x == authority) {
-                return self.timestamps[position] + (round + num_block) as u64;
-            }
+        if let Some(specified_authorities) = self.specified_authorities.as_ref()
+            && !self.timestamps.is_empty()
+            && let Some(position) = specified_authorities.iter().position(|&x| x == authority)
+        {
+            return self.timestamps[position] + (round + num_block) as u64;
         }
         let author = authority.value() as u32;
         let base_ts = round as BlockTimestampMs * 1000;

--- a/crates/sui-bridge-indexer/src/indexer_builder.rs
+++ b/crates/sui-bridge-indexer/src/indexer_builder.rs
@@ -698,7 +698,7 @@ mod tests {
                 .filter(|task| task.task_name.starts_with(task_prefix))
                 .cloned()
                 .collect::<Vec<_>>();
-            tasks.sort_by(|t1, t2| t2.start_checkpoint.cmp(&t1.start_checkpoint));
+            tasks.sort_by_key(|t2| std::cmp::Reverse(t2.start_checkpoint));
             Ok(tasks)
         }
 

--- a/crates/sui-bridge-indexer/src/lib.rs
+++ b/crates/sui-bridge-indexer/src/lib.rs
@@ -304,7 +304,7 @@ impl Tasks {
 
     pub fn backfill_tasks_ordered_desc(&self) -> Vec<Task> {
         let mut tasks = self.backfill_tasks.clone();
-        tasks.sort_by(|t1, t2| t2.start_checkpoint.cmp(&t1.start_checkpoint));
+        tasks.sort_by_key(|t2| std::cmp::Reverse(t2.start_checkpoint));
         tasks
     }
 }

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -841,7 +841,7 @@ pub(crate) async fn start_bridge_cluster(
     for (i, ((kp, server_listen_port), approved_governance_actions)) in bridge_authority_keys
         .iter()
         .zip_debug_eq(bridge_server_ports.iter())
-        .zip_debug_eq(approved_governance_actions.into_iter())
+        .zip_debug_eq(approved_governance_actions)
         .enumerate()
     {
         // prepare node config (server + client)

--- a/crates/sui-cluster-test/src/helper.rs
+++ b/crates/sui-cluster-test/src/helper.rs
@@ -175,10 +175,8 @@ impl CheckerResultObject {
 macro_rules! assert_eq_if_present {
     ($left:expr, $right:expr, $($arg:tt)+) => {
         match (&$left, &$right) {
-            (Some(left_val), right_val) => {
-                 if !(&left_val == right_val) {
-                    panic!("{} does not match, left: {:?}, right: {:?}", $($arg)+, left_val, right_val);
-                }
+            (Some(left_val), right_val) if !(&left_val == right_val) => {
+                panic!("{} does not match, left: {:?}, right: {:?}", $($arg)+, left_val, right_val);
             }
             _ => ()
         }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5126,7 +5126,11 @@ impl AuthorityState {
                 |((_event_digest, tx_digest, event_seq, timestamp), event)| {
                     event
                         .map(|e| (e, tx_digest, event_seq, timestamp))
-                        .ok_or(SuiErrorKind::TransactionEventsNotFound { digest: tx_digest })
+                        .ok_or_else(|| {
+                            SuiError::from(SuiErrorKind::TransactionEventsNotFound {
+                                digest: tx_digest,
+                            })
+                        })
                 },
             )
             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1522,10 +1522,7 @@ impl AuthorityStore {
             }
         }
 
-        wb.delete_batch(
-            &self.perpetual_tables.objects,
-            object_keys_to_prune.into_iter(),
-        )?;
+        wb.delete_batch(&self.perpetual_tables.objects, object_keys_to_prune)?;
         wb.write()?;
         Ok(())
     }

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -503,14 +503,11 @@ impl AuthorityStorePruner {
         // directly instead of summing checkpoint content sizes.
         let mut pruned_tx_seq_exclusive = 0u64;
 
-        loop {
-            let Some(ckpt) = checkpoint_store
-                .tables
-                .certified_checkpoints
-                .get(&(checkpoint_number + 1))?
-            else {
-                break;
-            };
+        while let Some(ckpt) = checkpoint_store
+            .tables
+            .certified_checkpoints
+            .get(&(checkpoint_number + 1))?
+        {
             let checkpoint = ckpt.into_inner();
             // Skipping because  checkpoint's epoch or checkpoint number is too new.
             // We have to respect the highest executed checkpoint watermark (including the watermark itself)
@@ -853,8 +850,7 @@ impl AuthorityStorePruner {
             .checked_div(Self::pruning_tick_duration_ms(epoch_duration_ms))
             .unwrap_or(1);
         let delta = max_eligible_checkpoint
-            .checked_sub(pruned_checkpoint)
-            .unwrap_or_default()
+            .saturating_sub(pruned_checkpoint)
             .checked_div(num_intervals)
             .unwrap_or(1);
         Ok(pruned_checkpoint + delta)

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -2195,7 +2195,7 @@ mod tests {
             }
 
             let mut final_observations = estimator.get_observations();
-            final_observations.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+            final_observations.sort_by_key(|a| a.0.to_string());
 
             let test_transactions = generate_test_transactions(version);
             let mut transaction_estimates = Vec::new();

--- a/crates/sui-core/src/consensus_throughput_calculator.rs
+++ b/crates/sui-core/src/consensus_throughput_calculator.rs
@@ -417,9 +417,7 @@ impl ConsensusThroughputCalculator {
 
             let period = first_element_ts.saturating_sub(last_element_ts);
 
-            if period > 0 {
-                let current_throughput = inner.total_transactions / period;
-
+            if let Some(current_throughput) = inner.total_transactions.checked_div(period) {
                 self.metrics
                     .consensus_calculated_throughput
                     .set(current_throughput as i64);

--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -133,13 +133,14 @@ impl DBCheckpointHandler {
     }
     pub fn start(self: Arc<Self>) -> tokio::sync::broadcast::Sender<()> {
         let (kill_sender, _kill_receiver) = tokio::sync::broadcast::channel::<()>(1);
-        if self.output_object_store.is_some() {
+        if let Some(output_object_store) = self.output_object_store.as_ref() {
+            let output_object_store = output_object_store.clone();
             tokio::task::spawn(Self::run_db_checkpoint_upload_loop(
                 self.clone(),
                 kill_sender.subscribe(),
             ));
             tokio::task::spawn(run_manifest_update_loop(
-                self.output_object_store.as_ref().unwrap().clone(),
+                output_object_store,
                 kill_sender.subscribe(),
             ));
         } else {

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -286,8 +286,7 @@ pub trait ObjectCacheRead: Send + Sync {
                     .iter()
                     .map(|(_, k)| ObjectKey(k.0.id(), *k.1))
                     .collect::<Vec<_>>(),
-            )
-            .into_iter(),
+            ),
         ) {
             // If the key exists at the specified version, then the object is available.
             if has_key {
@@ -479,7 +478,7 @@ pub trait TransactionCacheRead: Send + Sync {
         }
 
         let effects = self.multi_get_effects(&fetch_digests);
-        for (i, effects) in fetch_indices.into_iter().zip_debug_eq(effects.into_iter()) {
+        for (i, effects) in fetch_indices.into_iter().zip_debug_eq(effects) {
             results[i] = effects;
         }
 

--- a/crates/sui-core/src/fallback_fetch.rs
+++ b/crates/sui-core/src/fallback_fetch.rs
@@ -55,7 +55,7 @@ pub fn do_fallback_lookup_fallible<K: Clone, V: Default + Clone>(
 
     for (i, result) in fallback_indices
         .into_iter()
-        .zip_debug_eq(fallback_results.into_iter())
+        .zip_debug_eq(fallback_results)
     {
         results[i] = result;
     }

--- a/crates/sui-core/src/fallback_fetch.rs
+++ b/crates/sui-core/src/fallback_fetch.rs
@@ -53,10 +53,7 @@ pub fn do_fallback_lookup_fallible<K: Clone, V: Default + Clone>(
     assert_eq!(fallback_results.len(), fallback_indices.len());
     assert_eq!(fallback_results.len(), fallback_keys.len());
 
-    for (i, result) in fallback_indices
-        .into_iter()
-        .zip_debug_eq(fallback_results)
-    {
+    for (i, result) in fallback_indices.into_iter().zip_debug_eq(fallback_results) {
         results[i] = result;
     }
     Ok(results)

--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -2001,10 +2001,7 @@ impl IndexStore {
 
     pub fn insert_genesis_objects(&self, object_index_changes: ObjectIndexChanges) -> SuiResult {
         let mut batch = self.tables.owner_index.batch();
-        batch.insert_batch(
-            &self.tables.owner_index,
-            object_index_changes.new_owners,
-        )?;
+        batch.insert_batch(&self.tables.owner_index, object_index_changes.new_owners)?;
         batch.insert_batch(
             &self.tables.dynamic_field_index,
             object_index_changes.new_dynamic_fields,

--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -949,9 +949,7 @@ impl IndexStore {
                 };
 
                 // only process coin types
-                let (coin_type, coin) = object
-                    .coin_type_maybe()
-                    .and_then(|coin_type| object.as_coin_maybe().map(|coin| (coin_type, coin)))?;
+                let (coin_type, coin) = object.coin_type_maybe().zip(object.as_coin_maybe())?;
 
                 let key = CoinIndexKey2::new(
                     *owner,
@@ -989,9 +987,7 @@ impl IndexStore {
                 };
 
                 // only process coin types
-                let (coin_type, coin) = object
-                    .coin_type_maybe()
-                    .and_then(|coin_type| object.as_coin_maybe().map(|coin| (coin_type, coin)))?;
+                let (coin_type, coin) = object.coin_type_maybe().zip(object.as_coin_maybe())?;
 
                 let key = CoinIndexKey2::new(
                     *owner,
@@ -2007,11 +2003,11 @@ impl IndexStore {
         let mut batch = self.tables.owner_index.batch();
         batch.insert_batch(
             &self.tables.owner_index,
-            object_index_changes.new_owners.into_iter(),
+            object_index_changes.new_owners,
         )?;
         batch.insert_batch(
             &self.tables.dynamic_field_index,
-            object_index_changes.new_dynamic_fields.into_iter(),
+            object_index_changes.new_dynamic_fields,
         )?;
         batch.write()?;
         Ok(())

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -106,20 +106,18 @@ impl MockConsensusClient {
                         std::mem::discriminant(&tx.kind)
                     );
                 }
-                ConsensusTransactionKind::UserTransactionV2(tx) => {
-                    if tx.tx().is_consensus_tx() {
-                        validator.execution_scheduler().enqueue(
-                            vec![(
-                                VerifiedExecutableTransaction::new_from_consensus(
-                                    VerifiedTransaction::new_unchecked(tx.tx().clone()),
-                                    0,
-                                )
-                                .into(),
-                                env,
-                            )],
-                            &epoch_store,
-                        );
-                    }
+                ConsensusTransactionKind::UserTransactionV2(tx) if tx.tx().is_consensus_tx() => {
+                    validator.execution_scheduler().enqueue(
+                        vec![(
+                            VerifiedExecutableTransaction::new_from_consensus(
+                                VerifiedTransaction::new_unchecked(tx.tx().clone()),
+                                0,
+                            )
+                            .into(),
+                            env,
+                        )],
+                        &epoch_store,
+                    );
                 }
                 _ => {}
             }

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -1002,11 +1002,9 @@ impl TrafficSim {
             metrics.abs_time_to_first_block
         );
         // Useful for ensuring that TTL is respected
-        let avg_time_blocked = if metrics.num_blocklist_adds > 0 {
-            metrics.total_time_blocked.as_millis() as u64 / metrics.num_blocklist_adds
-        } else {
-            0
-        };
+        let avg_time_blocked = (metrics.total_time_blocked.as_millis() as u64)
+            .checked_div(metrics.num_blocklist_adds)
+            .unwrap_or(0);
         println!(
             "Average time blocked (ttl): {:?}",
             Duration::from_millis(avg_time_blocked)

--- a/crates/sui-data-store/src/stores/in_memory.rs
+++ b/crates/sui-data-store/src/stores/in_memory.rs
@@ -268,12 +268,12 @@ impl ObjectStore for InMemoryStore {
                         .get(&(key.object_id, *max_version))
                         .copied();
                     let res = actual_version.and_then(|actual_version| {
-                        inner
+                        let obj = inner
                             .object_cache
                             .get(&key.object_id)
                             .and_then(|versions_map| versions_map.get(&actual_version))
-                            .cloned()
-                            .map(|obj| (obj, actual_version))
+                            .cloned()?;
+                        Some((obj, actual_version))
                     });
                     (
                         res,
@@ -287,12 +287,12 @@ impl ObjectStore for InMemoryStore {
                         .get(&(key.object_id, *checkpoint))
                         .copied();
                     let res = actual_version.and_then(|actual_version| {
-                        inner
+                        let obj = inner
                             .object_cache
                             .get(&key.object_id)
                             .and_then(|versions_map| versions_map.get(&actual_version))
-                            .cloned()
-                            .map(|obj| (obj, actual_version))
+                            .cloned()?;
+                        Some((obj, actual_version))
                     });
                     (
                         res,

--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -1413,7 +1413,7 @@ pub(crate) mod tests {
             Atom::Bytes(Cow::Borrowed(&[4, 5, 6])),
         ];
 
-        for (value, expect) in values.into_iter().zip_eq(atoms.into_iter()) {
+        for (value, expect) in values.into_iter().zip_eq(atoms) {
             let actual = Atom::try_from(value).unwrap();
             assert_eq!(actual, expect);
         }
@@ -1509,7 +1509,7 @@ pub(crate) mod tests {
             Atom::Bytes(Cow::Borrowed(&[1, 2, 3])),
         ];
 
-        for (value, expect) in values.into_iter().zip_eq(atoms.into_iter()) {
+        for (value, expect) in values.into_iter().zip_eq(atoms) {
             let actual = Atom::try_from(value).unwrap();
             assert_eq!(actual, expect);
         }
@@ -1543,7 +1543,7 @@ pub(crate) mod tests {
             json!("AQID"),
         ];
 
-        for (value, expect) in values.into_iter().zip_eq(json.into_iter()) {
+        for (value, expect) in values.into_iter().zip_eq(json) {
             let used = AtomicUsize::new(0);
             let meter = writer::Meter::new(&used, usize::MAX, usize::MAX);
             let actual = value.format_json::<Json>(meter).unwrap();

--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -156,7 +156,7 @@ where
     for attempt in 0..MAX_RETRIES {
         match tokio::time::timeout(CONNECT_TIMEOUT, connect_fn()).await {
             Ok(Ok(client)) => return client,
-            Ok(Err(e)) if attempt + 1 < MAX_RETRIES => {
+            Ok(Err(_e)) if attempt + 1 < MAX_RETRIES => {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
             Ok(Err(e)) => panic!("failed to connect after {MAX_RETRIES} attempts: {e}"),

--- a/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
@@ -159,7 +159,7 @@ where
     for attempt in 0..MAX_RETRIES {
         match tokio::time::timeout(CONNECT_TIMEOUT, connect_fn()).await {
             Ok(Ok(client)) => return client,
-            Ok(Err(e)) if attempt + 1 < MAX_RETRIES => {
+            Ok(Err(_e)) if attempt + 1 < MAX_RETRIES => {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
             Ok(Err(e)) => panic!("failed to connect after {MAX_RETRIES} attempts: {e}"),

--- a/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
@@ -471,7 +471,7 @@ async fn fuzz_dynamic_committee() {
         .collect::<Vec<_>>();
 
     // Sorted by address.
-    initial_committee.sort_by(|a, b| a.0.cmp(&b.0));
+    initial_committee.sort_by_key(|a| a.0);
 
     // Advance epoch to see the resulting state.
     runner.change_epoch().await;
@@ -516,7 +516,7 @@ async fn fuzz_dynamic_committee() {
         .map(|v| (v.sui_address, v.voting_power))
         .collect::<Vec<_>>();
 
-    post_epoch_committee.sort_by(|a, b| a.0.cmp(&b.0));
+    post_epoch_committee.sort_by_key(|a| a.0);
     post_epoch_committee
         .iter()
         .zip_debug_eq(initial_committee.iter())

--- a/crates/sui-faucet/src/local_faucet.rs
+++ b/crates/sui-faucet/src/local_faucet.rs
@@ -184,7 +184,7 @@ async fn find_gas_coins_and_address(
         .active_address()
         .map_err(|e| FaucetError::Wallet(e.to_string()))?;
 
-    for address in std::iter::once(active_address).chain(wallet.get_addresses().into_iter()) {
+    for address in std::iter::once(active_address).chain(wallet.get_addresses()) {
         let coins: Vec<_> = wallet
             .gas_objects(address)
             .await

--- a/crates/sui-indexer-alt-e2e-tests/README.md
+++ b/crates/sui-indexer-alt-e2e-tests/README.md
@@ -6,16 +6,32 @@
 2. Run the test with the `--nocapture` (goes after `--`) command line flag (see https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options).
 3. Optionally set the `RUST_LOG` (example `RUST_LOG=debug`) environment variable (defaults to `info`).
 
+### Running tests
+
+**Prerequisites**
+
+```
+gcloud-cli (as new as possible)
+gcloud components install bigtable cbt
+```
+
+**Running transactional tests**
+
+```
+cargo nextest run -p sui-indexer-alt-e2e-tests --test transactional_tests
+```
+
 ### Debugging transactional tests in RustRover
+
 
 1. Add new `Cargo` run configuration
 2. 1. Command to run all tests 
       ```
-      test -p sui-indexer-alt-e2e-tests --test transactional_tests
+      test run -p sui-indexer-alt-e2e-tests --test transactional_tests
       ```
    2. Command to run single test (replace `graphql/epochs/query.move` with the test you want to run)
       ```
-      test -p sui-indexer-alt-e2e-tests --test transactional_tests graphql/epochs/query.move
+      test run -p sui-indexer-alt-e2e-tests --test transactional_tests graphql/epochs/query.move
       ```
    3. Note: debugging is not supported for nextest (https://youtrack.jetbrains.com/issue/RUST-12459)
 3. To prevent `error: invalid value 'json' for '--format <pretty|terse|json>'` or `error: unexpected argument '-Z' found`, uncheck 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
@@ -175,11 +175,7 @@ pub(super) fn collector<H: Handler>(
                 let mut watermark = Vec::new();
                 let mut batch_len = 0;
 
-                loop {
-                    let Some(mut entry) = pending.first_entry() else {
-                        break;
-                    };
-
+                while let Some(mut entry) = pending.first_entry() {
                     if watermark.len() >= max_watermark_updates {
                         break;
                     }

--- a/crates/sui-indexer-alt-framework/src/postgres/handler.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres/handler.rs
@@ -71,10 +71,9 @@ pub trait Handler: Processor<Value: FieldCount> {
 /// Calculate the maximum number of rows that can be inserted in a single batch,
 /// given the number of fields per row.
 const fn max_chunk_rows<T: FieldCount>() -> usize {
-    if T::FIELD_COUNT == 0 {
-        i16::MAX as usize
-    } else {
-        i16::MAX as usize / T::FIELD_COUNT
+    match (i16::MAX as usize).checked_div(T::FIELD_COUNT) {
+        Some(rows) => rows,
+        None => i16::MAX as usize,
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -657,7 +657,7 @@ impl Default for Limits {
             max_query_nodes: 300,
             max_output_nodes: 1_000_000,
             // Add a 30% buffer to the protocol limit, rounded up to account Base64 overhead.
-            max_tx_payload_size: (max_tx_size_bytes * 4).div_ceil(3) as u32,
+            max_tx_payload_size: (max_tx_size_bytes * 4).div_ceil(3),
             max_query_payload_size: 5_000,
             default_page_size: 20,
             max_page_size: 50,

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -412,10 +412,9 @@ impl ReadApi {
 
         // fill cache with the timestamp
         for (_, cache_entry) in temp_response.iter_mut() {
-            if cache_entry.checkpoint_seq.is_some() {
-                // safe to unwrap because is_some is checked
+            if let Some(checkpoint_seq) = cache_entry.checkpoint_seq.as_ref() {
                 cache_entry.timestamp = *checkpoint_to_timestamp
-                    .get(cache_entry.checkpoint_seq.as_ref().unwrap())
+                    .get(checkpoint_seq)
                     // Safe to unwrap because checkpoint_seq is guaranteed to exist in checkpoint_to_timestamp
                     .unwrap();
             }

--- a/crates/sui-kvstore/src/store/bitmap_committer/mod.rs
+++ b/crates/sui-kvstore/src/store/bitmap_committer/mod.rs
@@ -192,7 +192,7 @@ impl Handle {
         let sends = self
             .shard_merge_senders
             .iter()
-            .zip_debug_eq(batch.into_iter())
+            .zip_debug_eq(batch)
             .enumerate()
             .map(|(shard_id, (tx, values))| async move {
                 let merge = shard::Merge { checkpoint, values };

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -1390,7 +1390,7 @@ impl<'l> ResolutionContext<'l> {
 
                     let params_count = params.len();
                     let data_count = self.datatypes.len();
-                    frontier.extend(params.into_iter());
+                    frontier.extend(params);
 
                     let type_params = if let Some(def) = self.datatypes.get(&key) {
                         &def.type_params
@@ -1734,7 +1734,7 @@ impl<'l> ResolutionContext<'l> {
                 AbilitySet::polymorphic_abilities(
                     def.abilities,
                     def.type_params.iter().map(|p| p.is_phantom),
-                    param_abilities?.into_iter(),
+                    param_abilities?,
                 )
                 // This error is unexpected because the only reason it would fail is because of a
                 // type parameter arity mismatch, which we check for above.

--- a/crates/sui-replay/src/data_fetcher.rs
+++ b/crates/sui-replay/src/data_fetcher.rs
@@ -524,7 +524,7 @@ impl DataFetcher for RemoteFetcher {
             u64::from_str(&w["reference_gas_price"].to_string().replace('\"', "")).unwrap()
         } else {
             return Err(ReplayEngineError::UnexpectedEventFormat {
-                event: event.clone(),
+                event: Box::new(event.clone()),
             });
         };
 
@@ -655,7 +655,9 @@ pub fn extract_epoch_and_version(ev: SuiEvent) -> Result<(u64, u64), ReplayEngin
         return Ok((epoch, version));
     }
 
-    Err(ReplayEngineError::UnexpectedEventFormat { event: ev })
+    Err(ReplayEngineError::UnexpectedEventFormat {
+        event: Box::new(ev),
+    })
 }
 
 #[derive(Clone)]

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -502,7 +502,7 @@ impl LocalExec {
             .multi_download_latest(&non_system_package_objs)
             .await?
             .into_iter()
-            .chain(syst_packages_objs.into_iter());
+            .chain(syst_packages_objs);
 
         for obj in objs.clone() {
             let o_ref = obj.compute_object_reference();

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -164,7 +164,7 @@ pub enum ReplayEngineError {
     InvalidEpochChangeTx { epoch: u64 },
 
     #[error("Unexpected event format {:#?}", event)]
-    UnexpectedEventFormat { event: SuiEvent },
+    UnexpectedEventFormat { event: Box<SuiEvent> },
 
     #[error("Unable to find event for epoch {epoch}")]
     EventNotFound { epoch: u64 },

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -3348,18 +3348,16 @@ async fn test_merge_and_redeem_fungible_staked_sui() {
     if let Some(Err(e)) = &flow_result.combine {
         panic!("Redeem combine step failed: {:?}", e);
     }
-    let response: TransactionIdentifierResponse = flow_result
-        .submit
-        .unwrap_or_else(|| {
-            panic!(
-                "Submit was None. preprocess: {:?}, metadata: {:?}, payloads: {:?}, combine: {:?}",
-                flow_result.preprocess,
-                flow_result.metadata,
-                flow_result.payloads,
-                flow_result.combine
-            )
-        })
-        .expect("Submit should succeed");
+    let Some(submit) = flow_result.submit else {
+        panic!(
+            "Submit was None. preprocess: {:?}, metadata: {:?}, payloads: {:?}, combine: {:?}",
+            flow_result.preprocess,
+            flow_result.metadata,
+            flow_result.payloads,
+            flow_result.combine
+        );
+    };
+    let response: TransactionIdentifierResponse = submit.expect("Submit should succeed");
 
     wait_for_transaction(
         &mut client,
@@ -3560,18 +3558,16 @@ async fn run_redeem_flow(
     if let Some(Err(e)) = &flow_result.combine {
         panic!("Redeem combine failed: {:?}", e);
     }
-    let response: TransactionIdentifierResponse = flow_result
-        .submit
-        .unwrap_or_else(|| {
-            panic!(
-                "Submit was None. preprocess: {:?}, metadata: {:?}, payloads: {:?}, combine: {:?}",
-                flow_result.preprocess,
-                flow_result.metadata,
-                flow_result.payloads,
-                flow_result.combine
-            )
-        })
-        .expect("Submit should succeed");
+    let Some(submit) = flow_result.submit else {
+        panic!(
+            "Submit was None. preprocess: {:?}, metadata: {:?}, payloads: {:?}, combine: {:?}",
+            flow_result.preprocess,
+            flow_result.metadata,
+            flow_result.payloads,
+            flow_result.combine
+        );
+    };
+    let response: TransactionIdentifierResponse = submit.expect("Submit should succeed");
 
     wait_for_transaction(client, &response.transaction_identifier.hash.to_string())
         .await

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -3351,10 +3351,7 @@ async fn test_merge_and_redeem_fungible_staked_sui() {
     let Some(submit) = flow_result.submit else {
         panic!(
             "Submit was None. preprocess: {:?}, metadata: {:?}, payloads: {:?}, combine: {:?}",
-            flow_result.preprocess,
-            flow_result.metadata,
-            flow_result.payloads,
-            flow_result.combine
+            flow_result.preprocess, flow_result.metadata, flow_result.payloads, flow_result.combine
         );
     };
     let response: TransactionIdentifierResponse = submit.expect("Submit should succeed");
@@ -3561,10 +3558,7 @@ async fn run_redeem_flow(
     let Some(submit) = flow_result.submit else {
         panic!(
             "Submit was None. preprocess: {:?}, metadata: {:?}, payloads: {:?}, combine: {:?}",
-            flow_result.preprocess,
-            flow_result.metadata,
-            flow_result.payloads,
-            flow_result.combine
+            flow_result.preprocess, flow_result.metadata, flow_result.payloads, flow_result.combine
         );
     };
     let response: TransactionIdentifierResponse = submit.expect("Submit should succeed");

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
@@ -217,7 +217,7 @@ pub(crate) fn render_executed_transaction(
             .inner()
             .multi_get_objects_by_key(&object_keys)
             .into_iter()
-            .zip_debug_eq(object_keys.into_iter())
+            .zip_debug_eq(object_keys)
         {
             if let Some(o) = o {
                 objects.insert(o);

--- a/crates/sui-rpc-benchmark/src/direct/metrics.rs
+++ b/crates/sui-rpc-benchmark/src/direct/metrics.rs
@@ -91,7 +91,7 @@ impl MetricsCollector {
             total_successful += successful;
         }
 
-        table_stats.sort_by(|a, b| b.queries.cmp(&a.queries));
+        table_stats.sort_by_key(|b| std::cmp::Reverse(b.queries));
 
         BenchmarkResult {
             total_queries,

--- a/crates/sui-rpc-benchmark/src/json_rpc/runner.rs
+++ b/crates/sui-rpc-benchmark/src/json_rpc/runner.rs
@@ -229,7 +229,7 @@ pub async fn run_queries(
             }
         }
 
-        let result = futures::stream::iter(requests.into_iter())
+        let result = futures::stream::iter(requests)
             .try_for_each_spawned(concurrency, |mut request_line| {
                 let client = client.clone();
                 let endpoint = endpoint.clone();

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -309,11 +309,11 @@ impl Processor for RpcCommandProcessor {
                 .with_repeat_n_times(*repeat_n_times)
         });
 
-        let coins_and_keys = if config.signer_info.is_some() {
+        let coins_and_keys = if let Some(signer_info) = &config.signer_info {
             Some(
                 prepare_new_signer_and_coins(
                     clients.first().unwrap(),
-                    config.signer_info.as_ref().unwrap(),
+                    signer_info,
                     config.num_threads * config.num_chunks_per_thread,
                     config.max_repeat as u64 + 1,
                 )

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -182,8 +182,7 @@ impl WalletContext {
         force_recache: bool,
     ) -> Result<String, anyhow::Error> {
         let env = self.get_active_env()?;
-        if !force_recache && env.chain_id.is_some() {
-            let chain_id = env.chain_id.as_ref().unwrap();
+        if !force_recache && let Some(chain_id) = env.chain_id.as_ref() {
             info!("Found cached chain ID for env {}: {}", env.alias, chain_id);
             return Ok(chain_id.clone());
         }

--- a/crates/sui-sql-macro/src/lib.rs
+++ b/crates/sui-sql-macro/src/lib.rs
@@ -128,7 +128,7 @@ pub fn sql(input: TokenStream) -> TokenStream {
 
     // Intentional zip: proc-macro crate, zip_debug_eq not applicable at compile time
     #[allow(clippy::disallowed_methods)]
-    for (expr, (ty, suffix)) in binds.iter().zip(tail.into_iter()) {
+    for (expr, (ty, suffix)) in binds.iter().zip(tail) {
         tokens.extend(if let Some(ty) = ty {
             quote! {
                 .bind::<::diesel::sql_types::#ty, _>(#expr)
@@ -188,7 +188,7 @@ pub fn query(input: TokenStream) -> TokenStream {
 
     // Intentional zip: proc-macro crate, zip_debug_eq not applicable at compile time
     #[allow(clippy::disallowed_methods)]
-    for (expr, (ty, suffix)) in binds.iter().zip(tail.into_iter()) {
+    for (expr, (ty, suffix)) in binds.iter().zip(tail) {
         tokens.extend(if let Some(ty) = ty {
             // If there is a type, this interpolation is for a bind.
             quote! {

--- a/crates/sui-types/src/full_checkpoint_content.rs
+++ b/crates/sui-types/src/full_checkpoint_content.rs
@@ -301,8 +301,8 @@ impl Checkpoint {
                 .effects
                 .deleted()
                 .into_iter()
-                .chain(tx.effects.wrapped().into_iter())
-                .chain(tx.effects.unwrapped_then_deleted().into_iter())
+                .chain(tx.effects.wrapped())
+                .chain(tx.effects.unwrapped_then_deleted())
             {
                 latest_live_output_objects.remove(&obj_ref.0);
             }
@@ -317,8 +317,8 @@ impl Checkpoint {
                 .effects
                 .deleted()
                 .into_iter()
-                .chain(tx.effects.wrapped().into_iter())
-                .chain(tx.effects.unwrapped_then_deleted().into_iter())
+                .chain(tx.effects.wrapped())
+                .chain(tx.effects.unwrapped_then_deleted())
             {
                 eventually_removed_object_refs.insert(obj_ref.0, obj_ref);
             }
@@ -455,11 +455,7 @@ impl From<CheckpointData> for Checkpoint {
             .transactions
             .into_iter()
             .map(|tx| {
-                for o in tx
-                    .input_objects
-                    .into_iter()
-                    .chain(tx.output_objects.into_iter())
-                {
+                for o in tx.input_objects.into_iter().chain(tx.output_objects) {
                     object_set.insert(o);
                 }
 

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -371,19 +371,15 @@ mod checked {
 
         fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
             let gas_used = self.gas_status.gas_used_pre_gas_price();
-            let effective_gas_price = if self
-                .cost_table
-                .max_gas_price_rgp_factor_for_aborted_transactions
-                .is_some()
+            let effective_gas_price = if let Some(max_gas_price_rgp_factor_for_aborted_transactions) =
+                self.cost_table
+                    .max_gas_price_rgp_factor_for_aborted_transactions
                 && aborted.unwrap_or(false)
             {
                 // For aborts, cap at max but don't exceed user's price
                 // This minimizes the risk of competing for priority execution in the case that the txn may be aborted.
-                let max_gas_price_for_aborted_txns = self
-                    .cost_table
-                    .max_gas_price_rgp_factor_for_aborted_transactions
-                    .unwrap()
-                    * self.reference_gas_price;
+                let max_gas_price_for_aborted_txns =
+                    max_gas_price_rgp_factor_for_aborted_transactions * self.reference_gas_price;
                 self.gas_price.min(max_gas_price_for_aborted_txns)
             } else {
                 // For all other cases, use the user's gas price

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -586,7 +586,7 @@ impl<'a> PTBBuilder<'a> {
         }
 
         let mut call_args = vec![];
-        for (param, arg) in parameters.iter().zip_debug_eq(args.into_iter()) {
+        for (param, arg) in parameters.iter().zip_debug_eq(args) {
             let call_arg = self
                 .resolve_move_call_arg(&module, ty_args, arg, param)
                 .await?;

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -770,7 +770,7 @@ impl KeyToolCommand {
                     multisig: vec![],
                 };
 
-                for (pk, w) in pks.into_iter().zip_debug_eq(weights.into_iter()) {
+                for (pk, w) in pks.into_iter().zip_debug_eq(weights) {
                     output.multisig.push(MultiSigOutput {
                         address: Into::<SuiAddress>::into(&pk),
                         public_base64_key: pk.encode_base64(),

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -734,10 +734,7 @@ impl TestCluster {
             .collect();
 
         let wait_responses = join_all(wait_futures).await;
-        for ((index, _), response) in submitted_positions
-            .into_iter()
-            .zip_debug_eq(wait_responses)
-        {
+        for ((index, _), response) in submitted_positions.into_iter().zip_debug_eq(wait_responses) {
             match response? {
                 WaitForEffectsResponse::Executed { details, .. } => {
                     let data = details.ok_or_else(|| SuiErrorKind::GenericAuthorityError {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -736,7 +736,7 @@ impl TestCluster {
         let wait_responses = join_all(wait_futures).await;
         for ((index, _), response) in submitted_positions
             .into_iter()
-            .zip_debug_eq(wait_responses.into_iter())
+            .zip_debug_eq(wait_responses)
         {
             match response? {
                 WaitForEffectsResponse::Executed { details, .. } => {
@@ -856,7 +856,7 @@ impl TestCluster {
 
         let results: SuiResult<Vec<_>> = digests
             .into_iter()
-            .zip_debug_eq(responses.into_iter())
+            .zip_debug_eq(responses)
             .map(|(digest, response)| Ok((digest, response?)))
             .collect();
 

--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-analytics-indexer/Dockerfile
+++ b/docker/sui-analytics-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-bridge-indexer-alt/Dockerfile
+++ b/docker/sui-bridge-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang ca-certificates postgresql \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-bridge-indexer/Dockerfile
+++ b/docker/sui-bridge-indexer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev postgresql ca-certificates \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-checkpoint-blob-indexer/Dockerfile
+++ b/docker/sui-checkpoint-blob-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-indexer-alt-consistent-store/Dockerfile
+++ b/docker/sui-indexer-alt-consistent-store/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 ARG PROFILE
 WORKDIR "$WORKDIR/sui"
 

--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -2,9 +2,9 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# rust:1.92-bullseye
+# rust:1.96.1-bullseye
 ARG PROFILE=release-unwind
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 ARG PROFILE
 ARG FEATURES=""
 WORKDIR "$WORKDIR/sui"

--- a/docker/sui-indexer-alt-jsonrpc/Dockerfile
+++ b/docker/sui-indexer-alt-jsonrpc/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 ARG PROFILE
 WORKDIR "$WORKDIR/sui"
 

--- a/docker/sui-indexer-alt/Dockerfile
+++ b/docker/sui-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 ARG PROFILE=release
 WORKDIR "$WORKDIR/sui"
 

--- a/docker/sui-kv-rpc/Dockerfile
+++ b/docker/sui-kv-rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS build
+FROM rust:1.96.1-bullseye AS build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-kvstore/Dockerfile
+++ b/docker/sui-kvstore/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-proxy/Dockerfile
+++ b/docker/sui-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-rpc-benchmark/Dockerfile
+++ b/docker/sui-rpc-benchmark/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang ca-certificates \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -3,7 +3,7 @@
 # Single-stage builder + minimal runtime. Layer cache short-circuits when the
 # COPY inputs are byte-identical to a previous build.
 #
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.96.1-bullseye AS builder
 RUN apt-get update \
  && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev \
  && rm -rf /var/lib/apt/lists/*

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -95,7 +95,7 @@ pretty_simple = "0.1.1"
 pretty_assertions = "1.4.1"
 primitive-types = { version = "0.10.1", features = ["impl-serde"] }
 proptest = "1.6.0"
-proptest-derive = "0.5"
+proptest-derive = { version = "0.5", features = ["boxed_union"] }
 quick_cache = { version = "0.6.18", features = ["stats"] }
 quote = "1.0.9"
 rand = "0.8.0"

--- a/external-crates/move/crates/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/deserializer.rs
@@ -415,7 +415,7 @@ fn read_table(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Table> {
 /// Tables cannot have duplicates, must cover the entire blob and must be disjoint.
 fn check_tables(tables: &mut Vec<Table>, binary_len: usize) -> BinaryLoaderResult<u32> {
     // there is no real reason to pass a mutable reference but we are sorting next line
-    tables.sort_by(|t1, t2| t1.offset.cmp(&t2.offset));
+    tables.sort_by_key(|t1| t1.offset);
 
     let mut current_offset: u32 = 0;
     let mut table_types = HashSet::new();
@@ -1681,15 +1681,15 @@ fn load_code(cursor: &mut VersionedCursor, code: &mut Vec<Bytecode>) -> BinaryLo
             | Opcodes::VEC_PUSH_BACK
             | Opcodes::VEC_POP_BACK
             | Opcodes::VEC_UNPACK
-            | Opcodes::VEC_SWAP => {
-                if cursor.version() < VERSION_4 {
-                    return Err(
-                        PartialVMError::new(StatusCode::MALFORMED).with_message(format!(
-                            "Vector operations not available before bytecode version {}",
-                            VERSION_4
-                        )),
-                    );
-                }
+            | Opcodes::VEC_SWAP
+                if cursor.version() < VERSION_4 =>
+            {
+                return Err(
+                    PartialVMError::new(StatusCode::MALFORMED).with_message(format!(
+                        "Vector operations not available before bytecode version {}",
+                        VERSION_4
+                    )),
+                );
             }
             _ => {}
         };

--- a/external-crates/move/crates/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/deserializer.rs
@@ -1681,15 +1681,15 @@ fn load_code(cursor: &mut VersionedCursor, code: &mut Vec<Bytecode>) -> BinaryLo
             | Opcodes::VEC_PUSH_BACK
             | Opcodes::VEC_POP_BACK
             | Opcodes::VEC_UNPACK
-            | Opcodes::VEC_SWAP
-                if cursor.version() < VERSION_4 =>
-            {
-                return Err(
-                    PartialVMError::new(StatusCode::MALFORMED).with_message(format!(
-                        "Vector operations not available before bytecode version {}",
-                        VERSION_4
-                    )),
-                );
+            | Opcodes::VEC_SWAP => {
+                if cursor.version() < VERSION_4 {
+                    return Err(
+                        PartialVMError::new(StatusCode::MALFORMED).with_message(format!(
+                            "Vector operations not available before bytecode version {}",
+                            VERSION_4
+                        )),
+                    );
+                }
             }
             _ => {}
         };

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -411,7 +411,7 @@ impl OnDiskStateView {
                     continue;
                 }
                 let new_dependencies = self.transitive_dependencies(dep)?;
-                all_dependencies.extend(new_dependencies.into_iter());
+                all_dependencies.extend(new_dependencies);
             }
         }
         // Consider making tehse into VM errors on failure instead.

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -596,7 +596,7 @@ fn struct_fields(context: &mut Context, tfields: N::StructFields) -> H::StructFi
         .into_iter()
         .map(|(f, (idx, (_doc, t)))| (idx, (f, base_type(&context.reporter, &t))))
         .collect::<Vec<_>>();
-    indexed_fields.sort_by(|(idx1, _), (idx2, _)| idx1.cmp(idx2));
+    indexed_fields.sort_by_key(|(idx1, _)| *idx1);
     H::StructFields::Defined(indexed_fields.into_iter().map(|(_, f_ty)| f_ty).collect())
 }
 
@@ -645,7 +645,7 @@ fn variant_fields(context: &mut Context, tfields: N::VariantFields) -> Vec<(Fiel
         .into_iter()
         .map(|(f, (idx, (_doc, t)))| (idx, (f, base_type(&context.reporter, &t))))
         .collect::<Vec<_>>();
-    indexed_fields.sort_by(|(idx1, _), (idx2, _)| idx1.cmp(idx2));
+    indexed_fields.sort_by_key(|(idx1, _)| *idx1);
     indexed_fields.into_iter().map(|(_, f_ty)| f_ty).collect()
 }
 
@@ -1560,7 +1560,7 @@ fn value_fields(
                 .map(|(ndx, (f, (exp_idx, (bt, tf))))| (ndx, f, exp_idx, bt, tf))
                 .collect()
         };
-    texp_fields.sort_by(|(_, _, eidx1, _, _), (_, _, eidx2, _, _)| eidx1.cmp(eidx2));
+    texp_fields.sort_by_key(|(_, _, eidx1, _, _)| *eidx1);
 
     let reorder_fields = texp_fields
         .iter()

--- a/external-crates/move/crates/move-compiler/src/shared/program_info.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/program_info.rs
@@ -504,7 +504,7 @@ impl<const AFTER_TYPING: bool> ProgramInfo<AFTER_TYPING> {
             .clone()
             .into_iter()
             .collect::<Vec<_>>();
-        names.sort_by(|(_, ndx0), (_, ndx1)| ndx0.cmp(ndx1));
+        names.sort_by_key(|(_, ndx0)| *ndx0);
         names.into_iter().map(|(name, _ndx)| name).collect()
     }
 

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -715,19 +715,20 @@ fn exp(context: &mut Context, e: &T::Exp) {
                 check_internal_permit(context, e.exp.loc, mcall)
             }
         }
-        T::UnannotatedExp_::Pack(m, s, _, _)
+        T::UnannotatedExp_::Pack(m, s, _, _) => {
             if !context.in_test
                 && !otw_special_cases(context)
                 && context.one_time_witness.as_ref().is_some_and(|otw| {
                     otw.as_ref()
                         .is_ok_and(|o| m == context.current_module() && o == s)
-                }) =>
-        {
-            let msg = "Invalid one-time witness construction. One-time witness types \
-                cannot be created manually, but are passed as an argument 'init'";
-            let mut diag = diag!(OTW_USAGE_DIAG, (e.exp.loc, msg));
-            diag.add_note(OTW_NOTE);
-            context.add_diag(diag)
+                })
+            {
+                let msg = "Invalid one-time witness construction. One-time witness types \
+                    cannot be created manually, but are passed as an argument 'init'";
+                let mut diag = diag!(OTW_USAGE_DIAG, (e.exp.loc, msg));
+                diag.add_note(OTW_NOTE);
+                context.add_diag(diag)
+            }
         }
         _ => (),
     }

--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -715,20 +715,19 @@ fn exp(context: &mut Context, e: &T::Exp) {
                 check_internal_permit(context, e.exp.loc, mcall)
             }
         }
-        T::UnannotatedExp_::Pack(m, s, _, _) => {
+        T::UnannotatedExp_::Pack(m, s, _, _)
             if !context.in_test
                 && !otw_special_cases(context)
                 && context.one_time_witness.as_ref().is_some_and(|otw| {
                     otw.as_ref()
                         .is_ok_and(|o| m == context.current_module() && o == s)
-                })
-            {
-                let msg = "Invalid one-time witness construction. One-time witness types \
-                    cannot be created manually, but are passed as an argument 'init'";
-                let mut diag = diag!(OTW_USAGE_DIAG, (e.exp.loc, msg));
-                diag.add_note(OTW_NOTE);
-                context.add_diag(diag)
-            }
+                }) =>
+        {
+            let msg = "Invalid one-time witness construction. One-time witness types \
+                cannot be created manually, but are passed as an argument 'init'";
+            let mut diag = diag!(OTW_USAGE_DIAG, (e.exp.loc, msg));
+            diag.add_note(OTW_NOTE);
+            context.add_diag(diag)
         }
         _ => (),
     }

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -611,7 +611,7 @@ fn enum_variants(
     gvariants: UniqueMap<VariantName, H::VariantDefinition>,
 ) -> IR::VariantDefinitions {
     let mut variants = gvariants.into_iter().collect::<Vec<_>>();
-    variants.sort_by(|(_, v0), (_, v1)| v0.index.cmp(&v1.index));
+    variants.sort_by_key(|(_, v0)| v0.index);
     variants
         .into_iter()
         .map(|(name, v)| {

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1265,7 +1265,7 @@ impl<'env, 'outer> Context<'env, 'outer> {
         }
 
         different.append(&mut same_filtered);
-        different.sort_by(|a1, a2| a1.method_name.cmp(&a2.method_name));
+        different.sort_by_key(|a1| a1.method_name);
         different
     }
 

--- a/external-crates/move/crates/move-coverage/src/coverage_map.rs
+++ b/external-crates/move/crates/move-coverage/src/coverage_map.rs
@@ -323,8 +323,8 @@ impl ExecCoverageMap {
             .collect();
 
         let compiled_modules = modules
-            .into_iter()
-            .flat_map(|(_, module_map)| {
+            .into_values()
+            .flat_map(|module_map| {
                 module_map
                     .into_iter()
                     .map(|(_, (module_path, compiled_module))| (module_path, compiled_module))

--- a/external-crates/move/crates/move-decompiler/src/structuring/hoist_declarations.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/hoist_declarations.rs
@@ -235,7 +235,7 @@ fn exp(e: Exp, summary: Summary, already_bound: &HashSet<String>) -> Exp {
             }
 
             let mut out: Vec<Exp> = Vec::with_capacity(items.len() + decl.len());
-            for (i, (item, sub)) in items.into_iter().zip(subs.into_iter()).enumerate() {
+            for (i, (item, sub)) in items.into_iter().zip(subs).enumerate() {
                 if let Some(mut names) = by_first_touch.remove(&i) {
                     names.sort();
                     out.push(Exp::Declare(names));

--- a/external-crates/move/crates/move-decompiler/src/structuring/loops.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/loops.rs
@@ -368,7 +368,7 @@ fn try_structure_loop_without_dispatch(
     let succ_set: HashSet<NodeIndex> = succ_nodes.iter().copied().collect();
     let succ_rpo = reverse_post_order_within(&graph.cfg, primary, &succ_set);
     let mut placed: HashSet<NodeIndex> = HashSet::new();
-    for n in std::iter::once(primary).chain(succ_rpo.into_iter()) {
+    for n in std::iter::once(primary).chain(succ_rpo) {
         if !owned_succs.contains(&n) || !placed.insert(n) {
             continue;
         }

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -272,10 +272,10 @@ fn verify_move_function_body(code: &[Block]) -> Result<()> {
             match &statement.value {
                 Statement_::Jump(label)
                 | Statement_::JumpIf(_, label)
-                | Statement_::JumpIfFalse(_, label)
-                    if !labels.contains(&label.value) =>
-                {
-                    undeclared.push(&label.value);
+                | Statement_::JumpIfFalse(_, label) => {
+                    if !labels.contains(&label.value) {
+                        undeclared.push(&label.value);
+                    }
                 }
                 _ => {}
             }
@@ -307,10 +307,10 @@ fn verify_bytecode_function_body(code: &[(BlockLabel_, BytecodeBlock)]) -> Resul
             match &statement.value {
                 IRBytecode_::Branch(label)
                 | IRBytecode_::BrTrue(label)
-                | IRBytecode_::BrFalse(label)
-                    if !labels.contains(&label) =>
-                {
-                    undeclared.push(label);
+                | IRBytecode_::BrFalse(label) => {
+                    if !labels.contains(&label) {
+                        undeclared.push(label);
+                    }
                 }
                 _ => {}
             }

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -272,10 +272,10 @@ fn verify_move_function_body(code: &[Block]) -> Result<()> {
             match &statement.value {
                 Statement_::Jump(label)
                 | Statement_::JumpIf(_, label)
-                | Statement_::JumpIfFalse(_, label) => {
-                    if !labels.contains(&label.value) {
-                        undeclared.push(&label.value);
-                    }
+                | Statement_::JumpIfFalse(_, label)
+                    if !labels.contains(&label.value) =>
+                {
+                    undeclared.push(&label.value);
                 }
                 _ => {}
             }
@@ -307,10 +307,10 @@ fn verify_bytecode_function_body(code: &[(BlockLabel_, BytecodeBlock)]) -> Resul
             match &statement.value {
                 IRBytecode_::Branch(label)
                 | IRBytecode_::BrTrue(label)
-                | IRBytecode_::BrFalse(label) => {
-                    if !labels.contains(&label) {
-                        undeclared.push(label);
-                    }
+                | IRBytecode_::BrFalse(label)
+                    if !labels.contains(&label) =>
+                {
+                    undeclared.push(label);
                 }
                 _ => {}
             }

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -117,8 +117,8 @@ impl Model {
             .map(|(ident, _)| (ident.module_id(), ident))
             .collect::<BTreeMap<_, _>>();
         let compiled_modules = compiled_units
-            .iter()
-            .flat_map(|(_addr, units)| units.values().map(|unit| &unit.module));
+            .values()
+            .flat_map(|units| units.values().map(|unit| &unit.module));
         let compiled = normalized::Packages::new(compiled_modules);
         let packages = compiled
             .packages

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -324,8 +324,8 @@ impl ResolvedGraph {
 
     pub fn file_sources(&self) -> BTreeMap<FileHash, (FileName, String)> {
         self.package_table
-            .iter()
-            .flat_map(|(_, rpkg)| {
+            .values()
+            .flat_map(|rpkg| {
                 rpkg.get_sources(&self.build_options)
                     .unwrap()
                     .iter()

--- a/external-crates/move/crates/move-stackless-bytecode/src/memory_instrumentation.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/memory_instrumentation.rs
@@ -317,18 +317,18 @@ impl<'a> Instrumenter<'a> {
 
                     // add a trace for written back value if it's a user variable.
                     match action.dst {
-                        BorrowNode::LocalRoot(temp) | BorrowNode::Reference(temp)
-                            if temp < self.builder.fun_env.get_local_count() =>
-                        {
-                            self.builder.emit_with(|id| {
-                                Bytecode::Call(
-                                    id,
-                                    vec![],
-                                    Operation::TraceLocal(temp),
-                                    vec![temp],
-                                    None,
-                                )
-                            });
+                        BorrowNode::LocalRoot(temp) | BorrowNode::Reference(temp) => {
+                            if temp < self.builder.fun_env.get_local_count() {
+                                self.builder.emit_with(|id| {
+                                    Bytecode::Call(
+                                        id,
+                                        vec![],
+                                        Operation::TraceLocal(temp),
+                                        vec![temp],
+                                        None,
+                                    )
+                                });
+                            }
                         }
                         _ => {}
                     }

--- a/external-crates/move/crates/move-stackless-bytecode/src/memory_instrumentation.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/memory_instrumentation.rs
@@ -317,18 +317,18 @@ impl<'a> Instrumenter<'a> {
 
                     // add a trace for written back value if it's a user variable.
                     match action.dst {
-                        BorrowNode::LocalRoot(temp) | BorrowNode::Reference(temp) => {
-                            if temp < self.builder.fun_env.get_local_count() {
-                                self.builder.emit_with(|id| {
-                                    Bytecode::Call(
-                                        id,
-                                        vec![],
-                                        Operation::TraceLocal(temp),
-                                        vec![temp],
-                                        None,
-                                    )
-                                });
-                            }
+                        BorrowNode::LocalRoot(temp) | BorrowNode::Reference(temp)
+                            if temp < self.builder.fun_env.get_local_count() =>
+                        {
+                            self.builder.emit_with(|id| {
+                                Bytecode::Call(
+                                    id,
+                                    vec![],
+                                    Operation::TraceLocal(temp),
+                                    vec![temp],
+                                    None,
+                                )
+                            });
                         }
                         _ => {}
                     }

--- a/external-crates/move/crates/move-unit-test/src/test_reporter.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_reporter.rs
@@ -408,7 +408,7 @@ impl TestStatistics {
         }
         for (module_id, test_result) in other.failed {
             let entry = self.failed.entry(module_id).or_default();
-            entry.extend(test_result.into_iter());
+            entry.extend(test_result);
         }
         self
     }

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
@@ -199,7 +199,7 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
                     continue;
                 }
                 let new_dependencies = self.transitive_dependencies(dep)?;
-                all_dependencies.extend(new_dependencies.into_iter());
+                all_dependencies.extend(new_dependencies);
             }
         }
         // Consider making tehse into VM errors on failure instead.

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -743,7 +743,7 @@ impl VMTracer<'_> {
         let current_frame_return_tys = self.current_frame()?.return_types.clone();
         let return_values: Vec<_> = return_values
             .iter()
-            .zip(current_frame_return_tys.into_iter())
+            .zip(current_frame_return_tys)
             .map(|(value, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 let layout = layout?;

--- a/external-crates/move/crates/test-generation/src/transitions.rs
+++ b/external-crates/move/crates/test-generation/src/transitions.rs
@@ -67,7 +67,7 @@ impl Subst {
                     return false;
                 }
                 assert!(params1.len() == params2.len());
-                for (s1, s2) in params1.into_iter().zip(params2.into_iter()) {
+                for (s1, s2) in params1.into_iter().zip(params2) {
                     if !self.check_and_add(s1, s2) {
                         return false;
                     }
@@ -81,7 +81,7 @@ impl Subst {
     /// Return the instantiation from the substitution that has been built.
     pub fn instantiation(self) -> Vec<SignatureToken> {
         let mut vec = self.subst.into_iter().collect::<Vec<_>>();
-        vec.sort_by(|a, b| a.0.cmp(&b.0));
+        vec.sort_by_key(|a| a.0);
         vec.into_iter().map(|x| x.1).collect()
     }
 }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
@@ -1603,23 +1603,24 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si)
-                            if !single_signature_token_map.contains_key(si) =>
-                        {
-                            let ty = match module.signature_at(*si).0.first() {
-                                None => {
-                                    return Err(PartialVMError::new(
-                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                    )
-                                    .with_message(
-                                        "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si) => {
+                            if !single_signature_token_map.contains_key(si) {
+                                let ty = match module.signature_at(*si).0.first() {
+                                    None => {
+                                        return Err(PartialVMError::new(
+                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                        )
+                                        .with_message(
+                                            "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                            .to_owned(),
-                                    ));
-                                }
-                                Some(sig_token) => sig_token,
-                            };
-                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
+                                                .to_owned(),
+                                        ));
+                                    }
+                                    Some(sig_token) => sig_token,
+                                };
+                                single_signature_token_map
+                                    .insert(*si, cache.make_type(module, ty)?);
+                            }
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/loader.rs
@@ -1603,24 +1603,23 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si) => {
-                            if !single_signature_token_map.contains_key(si) {
-                                let ty = match module.signature_at(*si).0.first() {
-                                    None => {
-                                        return Err(PartialVMError::new(
-                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                        )
-                                        .with_message(
-                                            "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si)
+                            if !single_signature_token_map.contains_key(si) =>
+                        {
+                            let ty = match module.signature_at(*si).0.first() {
+                                None => {
+                                    return Err(PartialVMError::new(
+                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                    )
+                                    .with_message(
+                                        "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                                .to_owned(),
-                                        ));
-                                    }
-                                    Some(sig_token) => sig_token,
-                                };
-                                single_signature_token_map
-                                    .insert(*si, cache.make_type(module, ty)?);
-                            }
+                                            .to_owned(),
+                                    ));
+                                }
+                                Some(sig_token) => sig_token,
+                            };
+                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/runtime.rs
@@ -182,7 +182,7 @@ impl VMRuntime {
         // each individual module in the bundle in order. But if every module in the bundle pass
         // all the checks, then the whole bundle can be published/upgraded together. Otherwise,
         // none of the module can be published/updated.
-        for (module, blob) in compiled_modules.into_iter().zip(modules.into_iter()) {
+        for (module, blob) in compiled_modules.into_iter().zip(modules) {
             let runtime_id = module.self_id();
             let storage_id = data_store
                 .relocate(&runtime_id)

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
@@ -1604,24 +1604,23 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si) => {
-                            if !single_signature_token_map.contains_key(si) {
-                                let ty = match module.signature_at(*si).0.first() {
-                                    None => {
-                                        return Err(PartialVMError::new(
-                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                        )
-                                        .with_message(
-                                            "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si)
+                            if !single_signature_token_map.contains_key(si) =>
+                        {
+                            let ty = match module.signature_at(*si).0.first() {
+                                None => {
+                                    return Err(PartialVMError::new(
+                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                    )
+                                    .with_message(
+                                        "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                                .to_owned(),
-                                        ));
-                                    }
-                                    Some(sig_token) => sig_token,
-                                };
-                                single_signature_token_map
-                                    .insert(*si, cache.make_type(module, ty)?);
-                            }
+                                            .to_owned(),
+                                    ));
+                                }
+                                Some(sig_token) => sig_token,
+                            };
+                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/loader.rs
@@ -1604,23 +1604,24 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si)
-                            if !single_signature_token_map.contains_key(si) =>
-                        {
-                            let ty = match module.signature_at(*si).0.first() {
-                                None => {
-                                    return Err(PartialVMError::new(
-                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                    )
-                                    .with_message(
-                                        "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si) => {
+                            if !single_signature_token_map.contains_key(si) {
+                                let ty = match module.signature_at(*si).0.first() {
+                                    None => {
+                                        return Err(PartialVMError::new(
+                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                        )
+                                        .with_message(
+                                            "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                            .to_owned(),
-                                    ));
-                                }
-                                Some(sig_token) => sig_token,
-                            };
-                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
+                                                .to_owned(),
+                                        ));
+                                    }
+                                    Some(sig_token) => sig_token,
+                                };
+                                single_signature_token_map
+                                    .insert(*si, cache.make_type(module, ty)?);
+                            }
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
@@ -183,7 +183,7 @@ impl VMRuntime {
         // each individual module in the bundle in order. But if every module in the bundle pass
         // all the checks, then the whole bundle can be published/upgraded together. Otherwise,
         // none of the module can be published/updated.
-        for (module, blob) in compiled_modules.into_iter().zip(modules.into_iter()) {
+        for (module, blob) in compiled_modules.into_iter().zip(modules) {
             let runtime_id = module.self_id();
             let storage_id = data_store
                 .relocate(&runtime_id)

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/loader.rs
@@ -1580,23 +1580,24 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si)
-                            if !single_signature_token_map.contains_key(si) =>
-                        {
-                            let ty = match module.signature_at(*si).0.first() {
-                                None => {
-                                    return Err(PartialVMError::new(
-                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                    )
-                                    .with_message(
-                                        "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si) => {
+                            if !single_signature_token_map.contains_key(si) {
+                                let ty = match module.signature_at(*si).0.first() {
+                                    None => {
+                                        return Err(PartialVMError::new(
+                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                        )
+                                        .with_message(
+                                            "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                            .to_owned(),
-                                    ));
-                                }
-                                Some(sig_token) => sig_token,
-                            };
-                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
+                                                .to_owned(),
+                                        ));
+                                    }
+                                    Some(sig_token) => sig_token,
+                                };
+                                single_signature_token_map
+                                    .insert(*si, cache.make_type(module, ty)?);
+                            }
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/loader.rs
@@ -1580,24 +1580,23 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si) => {
-                            if !single_signature_token_map.contains_key(si) {
-                                let ty = match module.signature_at(*si).0.first() {
-                                    None => {
-                                        return Err(PartialVMError::new(
-                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                        )
-                                        .with_message(
-                                            "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si)
+                            if !single_signature_token_map.contains_key(si) =>
+                        {
+                            let ty = match module.signature_at(*si).0.first() {
+                                None => {
+                                    return Err(PartialVMError::new(
+                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                    )
+                                    .with_message(
+                                        "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                                .to_owned(),
-                                        ));
-                                    }
-                                    Some(sig_token) => sig_token,
-                                };
-                                single_signature_token_map
-                                    .insert(*si, cache.make_type(module, ty)?);
-                            }
+                                            .to_owned(),
+                                    ));
+                                }
+                                Some(sig_token) => sig_token,
+                            };
+                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/runtime.rs
@@ -170,7 +170,7 @@ impl VMRuntime {
         // each individual module in the bundle in order. But if every module in the bundle pass
         // all the checks, then the whole bundle can be published/upgraded together. Otherwise,
         // none of the module can be published/updated.
-        for (module, blob) in compiled_modules.into_iter().zip(modules.into_iter()) {
+        for (module, blob) in compiled_modules.into_iter().zip(modules) {
             let runtime_id = module.self_id();
             let storage_id = data_store
                 .relocate(&runtime_id)

--- a/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/loader.rs
@@ -2018,23 +2018,24 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si)
-                            if !single_signature_token_map.contains_key(si) =>
-                        {
-                            let ty = match module.signature_at(*si).0.first() {
-                                None => {
-                                    return Err(PartialVMError::new(
-                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                    )
-                                    .with_message(
-                                        "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si) => {
+                            if !single_signature_token_map.contains_key(si) {
+                                let ty = match module.signature_at(*si).0.first() {
+                                    None => {
+                                        return Err(PartialVMError::new(
+                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                        )
+                                        .with_message(
+                                            "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                            .to_owned(),
-                                    ));
-                                }
-                                Some(sig_token) => sig_token,
-                            };
-                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
+                                                .to_owned(),
+                                        ));
+                                    }
+                                    Some(sig_token) => sig_token,
+                                };
+                                single_signature_token_map
+                                    .insert(*si, cache.make_type(module, ty)?);
+                            }
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/loader.rs
@@ -2018,24 +2018,23 @@ impl LoadedModule {
                         | Bytecode::VecPushBack(si)
                         | Bytecode::VecPopBack(si)
                         | Bytecode::VecUnpack(si, _)
-                        | Bytecode::VecSwap(si) => {
-                            if !single_signature_token_map.contains_key(si) {
-                                let ty = match module.signature_at(*si).0.first() {
-                                    None => {
-                                        return Err(PartialVMError::new(
-                                            StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                        )
-                                        .with_message(
-                                            "the type argument for vector-related bytecode \
+                        | Bytecode::VecSwap(si)
+                            if !single_signature_token_map.contains_key(si) =>
+                        {
+                            let ty = match module.signature_at(*si).0.first() {
+                                None => {
+                                    return Err(PartialVMError::new(
+                                        StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                    )
+                                    .with_message(
+                                        "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
-                                                .to_owned(),
-                                        ));
-                                    }
-                                    Some(sig_token) => sig_token,
-                                };
-                                single_signature_token_map
-                                    .insert(*si, cache.make_type(module, ty)?);
-                            }
+                                            .to_owned(),
+                                    ));
+                                }
+                                Some(sig_token) => sig_token,
+                            };
+                            single_signature_token_map.insert(*si, cache.make_type(module, ty)?);
                         }
                         _ => {}
                     }

--- a/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/runtime.rs
@@ -172,7 +172,7 @@ impl VMRuntime {
         // each individual module in the bundle in order. But if every module in the bundle pass
         // all the checks, then the whole bundle can be published/upgraded together. Otherwise,
         // none of the module can be published/updated.
-        for (module, blob) in compiled_modules.into_iter().zip(modules.into_iter()) {
+        for (module, blob) in compiled_modules.into_iter().zip(modules) {
             let runtime_id = module.self_id();
             let storage_id = data_store
                 .relocate(&runtime_id)

--- a/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/move-execution/v3/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -731,7 +731,7 @@ impl VMTracer<'_> {
         let current_frame_return_tys = self.current_frame()?.return_types.clone();
         let return_values: Vec<_> = return_values
             .iter()
-            .zip(current_frame_return_tys.into_iter())
+            .zip(current_frame_return_tys)
             .map(|(value, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 let layout = layout?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.92"
+channel = "1.96.1"

--- a/scripts/nextest/big-worker-stack.sh
+++ b/scripts/nextest/big-worker-stack.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# cargo-nextest setup script (see .config/nextest.toml).
+#
+# Gives the matched tests' spawned threads — including tokio runtime workers — an
+# 8 MiB stack instead of the std/tokio default of 2 MiB. Rust 1.96 enlarged
+# unoptimized async state-machine frames by ~45%, which overflows the 2 MiB tokio
+# worker stack while resolving deeply-nested async-graphql queries in
+# sui-indexer-alt-e2e-tests' `transactional_tests`.
+#
+# Setup scripts run at test-execution time only, so this does NOT affect the
+# build. tokio worker threads honor RUST_MIN_STACK (value is in bytes: 8*1024*1024).
+set -euo pipefail
+
+echo "RUST_MIN_STACK=8388608" >> "$NEXTEST_ENV"


### PR DESCRIPTION
## Description 

Upgrade the Rust toolchain from 1.92 to 1.96.1.

- Bump rust-toolchain.toml channel 1.92 → 1.96.1.
- Bump the builder base image rust:1.92-bullseye → rust:1.96.1-bullseye across all 16 docker/*/Dockerfiles.
- Fix all new Clippy lints introduced/tightened by the newer toolchain so both cargo xclippy -Dwarnings (in crates/) and cargo move-clippy -D warnings (in external-crates/move/) pass clean. No #[allow(...)] suppressions were added — every finding is fixed at the source.

The Clippy fixes are mechanical and behavior-preserving. By lint:

- useless_conversion — drop redundant .into_iter() in IntoIterator-accepting calls (zip, zip_eq, zip_debug_eq, chain, extend, batch insert/delete). Largest group.
- unnecessary_sort_by → sort_by_key (using std::cmp::Reverse where the comparator was reversed).
- iter_kv_map → .values() / .into_values() instead of .iter()/.into_iter() + key-discarding map.
- unnecessary_unwrap — replace x.is_some() + x.unwrap() with if let Some(..) / let-chains.
- collapsible_if / collapsible_match — fold nested ifs into match guards / let-chains (excluded from external crates move code)
- manual_checked_ops / manual_saturating_arithmetic → checked_div / saturating_sub.
- manual_option_zip → Option::zip.
- result_large_err — shrink oversized error enums by boxing the largest variant (ReplayEngineError::UnexpectedEventFormat) and returning the boxed SuiError wrapper instead of the large SuiErrorKind.
- while_let_loop, unnecessary_cast, unused_variables — one-off fixes.

## Test plan 

Existing CI tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
