### PR TITLE
nickv/pipelined key batches

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -3639,15 +3639,18 @@ async fn test_list_checkpoints_with_transactions_read_mask() {
     let mut cluster = FullCluster::new().await.unwrap();
     let (sender, kp, mut gas) = cluster.funded_account(20 * DEFAULT_GAS_BUDGET).unwrap();
 
-    // Two checkpoints, each containing one transfer tx. Capture the digests
-    // so we can confirm the populated `transactions[].digest` matches.
+    // One checkpoint with three self-transfers. The transfers chain the same
+    // gas object, so they are causally ordered and appear in the checkpoint
+    // contents in build order — capture that order to assert exact per-cp
+    // `transactions[].digest` order (not just set membership).
     let mut expected_digests: Vec<sui_types::digests::TransactionDigest> = Vec::new();
-    for _ in 0..2 {
+    for _ in 0..3 {
         let (digest, new_gas) = transfer_self(&mut cluster, sender, &kp, gas).await;
-        cluster.create_checkpoint().await;
         expected_digests.push(digest);
         gas = new_gas;
     }
+    let checkpoint = cluster.create_checkpoint().await;
+    let seq = checkpoint.sequence_number;
 
     let mut client = KvLedgerServiceClient::connect(cluster.kv_rpc_url().to_string())
         .await
@@ -3662,24 +3665,30 @@ async fn test_list_checkpoints_with_transactions_read_mask() {
 
     let resp = list_checkpoints_result(&mut client, req).await;
 
-    let returned_digests: std::collections::HashSet<String> = resp
+    let proto_cp = resp
         .checkpoints
         .iter()
-        .flat_map(|cp| {
-            let proto_cp = cp.checkpoint.as_ref().expect("checkpoint populated");
-            proto_cp
-                .transactions
-                .iter()
-                .filter_map(|tx| tx.digest.clone())
-        })
-        .collect();
+        .filter_map(|cp| cp.checkpoint.as_ref())
+        .find(|cp| cp.sequence_number == Some(seq))
+        .expect("checkpoint with our sequence number returned");
 
-    for expected in &expected_digests {
-        assert!(
-            returned_digests.contains(&expected.to_string()),
-            "expected digest {expected} to appear in transactions[].digest, got {returned_digests:?}"
-        );
-    }
+    // The checkpoint also contains system transactions (e.g. a
+    // consensus-commit prologue) around our transfers, so filter the returned
+    // digests down to the ones we created and assert their relative order is
+    // preserved end-to-end — that is what the Stage C reconstruction must get
+    // right regardless of BigTable row arrival order.
+    let expected: Vec<String> = expected_digests.iter().map(|d| d.to_string()).collect();
+    let expected_set: std::collections::HashSet<&String> = expected.iter().collect();
+    let returned_ours: Vec<String> = proto_cp
+        .transactions
+        .iter()
+        .filter_map(|tx| tx.digest.clone())
+        .filter(|d| expected_set.contains(d))
+        .collect();
+    assert_eq!(
+        returned_ours, expected,
+        "our transactions must appear in transactions[].digest in checkpoint contents order"
+    );
 }
 
 #[tokio::test]

--- a/crates/sui-kv-rpc/Cargo.toml
+++ b/crates/sui-kv-rpc/Cargo.toml
@@ -51,3 +51,5 @@ tracing.workspace = true
 [dev-dependencies]
 # `test-util` powers `#[tokio::test(start_paused = true)]` in the limiter tests.
 tokio = { workspace = true, features = ["test-util"] }
+# Enables the in-memory mock BigTable server for the real-stage resolver tests.
+sui-kvstore = { workspace = true, features = ["testing"] }

--- a/crates/sui-kv-rpc/src/render.rs
+++ b/crates/sui-kv-rpc/src/render.rs
@@ -8,6 +8,7 @@
 //! them.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use move_core_types::language_storage::StructTag;
 use mysten_common::ZipDebugEqIteratorExt;
@@ -32,6 +33,7 @@ use sui_types::storage::ObjectKey;
 use tracing::warn;
 
 use crate::PackageResolver;
+use crate::object_cache::ObjectMap;
 
 /// Maximum size in bytes for JSON-rendered Move values (1 MiB).
 const MAX_JSON_MOVE_VALUE_SIZE: usize = 1024 * 1024;
@@ -86,11 +88,13 @@ pub(crate) fn checkpoint_to_response(
 /// Build the full proto `Checkpoint` (summary + signatures + contents +
 /// transactions + objects) from resolved BigTable data. `objects` must contain
 /// exactly the objects referenced by this checkpoint's transactions — the whole
-/// map is folded into the rendered `ObjectSet`.
+/// map is folded into the rendered `ObjectSet`. Takes the `ObjectMap` by value
+/// so objects can be moved into the `ObjectSet` when the map is uniquely owned
+/// (the common case: one map per checkpoint); a shared map falls back to a clone.
 pub(crate) fn render_full_checkpoint(
     checkpoint: CheckpointData,
     txs: Vec<TransactionData>,
-    objects: &HashMap<ObjectKey, Object>,
+    objects: ObjectMap,
     read_mask: &FieldMaskTree,
 ) -> Result<Checkpoint, RpcError> {
     let summary = checkpoint
@@ -136,8 +140,12 @@ pub(crate) fn render_full_checkpoint(
         .collect::<Result<Vec<_>, _>>()?;
 
     let mut object_set = ObjectSet::default();
-    for (_, obj) in objects.iter() {
-        object_set.insert(obj.clone());
+    // The map is uniquely owned per checkpoint, so move each `Object` into the
+    // set rather than deep-cloning it; a shared map (refcount > 1) falls back
+    // to a one-time clone.
+    let objects = Arc::try_unwrap(objects).unwrap_or_else(|arc| (*arc).clone());
+    for (_, obj) in objects {
+        object_set.insert(obj);
     }
 
     let full_checkpoint = FullCheckpoint {
@@ -169,19 +177,19 @@ pub(crate) async fn transaction_to_response(
     }
 
     if let Some(submask) = mask.subtree(ExecutedTransaction::TRANSACTION_FIELD.name)
-        && let Some(tx_data) = &source.transaction_data
+        && let Some(tx_data) = source.transaction_data
     {
-        let transaction = sui_sdk_types::Transaction::try_from(tx_data.clone())?;
+        let transaction = sui_sdk_types::Transaction::try_from(tx_data)?;
         message.transaction = Some(Transaction::merge_from(transaction, &submask));
     }
 
     if let Some(submask) = mask.subtree(ExecutedTransaction::SIGNATURES_FIELD.name)
-        && let Some(sigs) = &source.signatures
+        && let Some(sigs) = source.signatures
     {
         message.signatures = sigs
-            .iter()
+            .into_iter()
             .map(|s| {
-                sui_sdk_types::UserSignature::try_from(s.clone())
+                sui_sdk_types::UserSignature::try_from(s)
                     .map(|s| UserSignature::merge_from(s, &submask))
             })
             .collect::<Result<_, _>>()?;

--- a/crates/sui-kv-rpc/src/resolve.rs
+++ b/crates/sui-kv-rpc/src/resolve.rs
@@ -26,10 +26,16 @@ use sui_types::storage::ObjectKey;
 use crate::bigtable_client::BigTableClient;
 use crate::config::ResolvedStageConfig;
 use crate::object_cache::{BigTableObjectFetcher, ObjectCache, ObjectMap};
-use crate::pipeline::{InputOrderEmitter, Watermarked, pipelined_chunks, pipelined_keyed_batches};
+use crate::pipeline::{Watermarked, pipelined_chunks, pipelined_keyed_batches};
 
 pub(crate) type CpWithTxs = (u64, CheckpointData, Vec<TransactionData>);
 pub(crate) type ResolvedCp = (u64, CheckpointData, Vec<TransactionData>, ObjectMap);
+/// Stage-C keyed-batch output: a checkpoint paired with a map of just its own
+/// transaction rows (the `pipelined_keyed_batches` per-item map).
+type CpTxMap = (
+    (u64, CheckpointData),
+    Arc<HashMap<TransactionDigest, TransactionData>>,
+);
 
 /// Attach a per-item `ObjectMap` to each item in `upstream`. When
 /// `needs_objects` is false every item is paired with an empty map (no
@@ -102,29 +108,107 @@ where
     let tx_columns: Arc<[&'static str]> = list_transactions_columns(read_mask).into();
     let needs_objects = read_mask.contains(Checkpoint::OBJECTS_FIELD);
 
-    // Stage C: (cp_seq, CheckpointData) -> + Vec<TransactionData>. Batched
-    // across the chunk: gather ALL tx_digests across all cps in the chunk into
-    // one multi_get, route results back per-cp, then emit in input cp_seq order
-    // after the chunk drains.
-    let cp_with_txs_stream = pipelined_chunks(
-        cp_data_stream,
+    // Stage C: (cp_seq, CheckpointData) -> + Vec<TransactionData>. Derive each
+    // checkpoint's transaction digests and fetch them through
+    // `pipelined_keyed_batches` — chunk-bounded and concurrent, batching at
+    // `chunk_size` keys per BigTable request just like the objects stage
+    // (`with_object_maps`). `sui-kvstore` additionally re-clamps each request
+    // to `MAX_TX_DIGESTS_PER_REQUEST` as a backend safety net, so a misconfigured
+    // `chunk_size` still can't exceed the request-size limit. Each checkpoint's
+    // transaction vector is then reconstructed in checkpoint-contents order;
+    // input order is preserved by `pipelined_keyed_batches`, so no
+    // `InputOrderEmitter`.
+    let with_keys = cp_data_stream
+        .map(|res: Result<Watermarked<(u64, CheckpointData)>, E>| {
+            let m = res?;
+            Ok::<_, E>(match m {
+                Watermarked::Item((cp_seq, cp_data)) => {
+                    let keys = cp_data
+                        .contents
+                        .as_ref()
+                        .ok_or_else(|| {
+                            E::from(anyhow::anyhow!(
+                                "checkpoint {cp_seq} contents column missing"
+                            ))
+                        })?
+                        .iter()
+                        .map(|d| d.transaction)
+                        .collect::<Vec<TransactionDigest>>();
+                    Watermarked::Item(((cp_seq, cp_data), keys))
+                }
+                Watermarked::Watermark(p) => Watermarked::Watermark(p),
+            })
+        })
+        .boxed();
+
+    let cp_with_map_stream = pipelined_keyed_batches(
+        with_keys,
+        transactions_stage.chunk_size,
         transactions_stage.chunk_size,
         transactions_stage.concurrency,
         {
             let client = client.clone();
             let columns = tx_columns.clone();
-            move |items| {
+            move |keys| {
                 let client = client.clone();
                 let columns = columns.clone();
                 async move {
-                    fetch_transactions_for_cps(client, columns, items)
+                    let requested = keys.len();
+                    let stream = fetch_transaction_rows(client, columns, keys)
                         .await
-                        .map(|s| s.map_err(E::from).boxed())
-                        .map_err(E::from)
+                        .map_err(E::from)?;
+                    futures::pin_mut!(stream);
+                    let mut map: HashMap<TransactionDigest, TransactionData> = HashMap::new();
+                    while let Some(row) = stream.next().await {
+                        let (digest, tx) = row.map_err(E::from)?;
+                        map.insert(digest, tx);
+                    }
+                    // `keys` is de-duplicated by `pipelined_keyed_batches`, so a
+                    // shortfall means BigTable is missing a requested row. Fail
+                    // with a domain-specific message (the reassembler's own
+                    // missing-key check would otherwise fire first with a
+                    // generic one).
+                    if map.len() != requested {
+                        return Err(E::from(anyhow::anyhow!(
+                            "resolve_checkpoints: BigTable returned fewer transactions than \
+                             requested ({} of {} rows)",
+                            map.len(),
+                            requested
+                        )));
+                    }
+                    Ok(map)
                 }
             }
         },
     );
+
+    let cp_with_txs_stream = cp_with_map_stream
+        .map(|res: Result<Watermarked<CpTxMap>, E>| {
+            let m = res?;
+            Ok::<_, E>(match m {
+                Watermarked::Item(((cp_seq, cp_data), tx_map)) => {
+                    let contents = cp_data.contents.as_ref().ok_or_else(|| {
+                        E::from(anyhow::anyhow!(
+                            "checkpoint {cp_seq} contents column missing"
+                        ))
+                    })?;
+                    let mut txs: Vec<TransactionData> = Vec::new();
+                    for d in contents.iter() {
+                        let digest = d.transaction;
+                        let tx = tx_map.get(&digest).cloned().ok_or_else(|| {
+                            E::from(anyhow::anyhow!(
+                                "resolve_checkpoints: BigTable returned fewer transactions \
+                                 than requested (checkpoint {cp_seq} missing transaction {digest})"
+                            ))
+                        })?;
+                        txs.push(tx);
+                    }
+                    Watermarked::Item((cp_seq, cp_data, txs))
+                }
+                Watermarked::Watermark(p) => Watermarked::Watermark(p),
+            })
+        })
+        .boxed();
 
     // Stage D: each cp must see only its own object keys, since
     // `render_full_checkpoint` folds the whole map into an `ObjectSet`.
@@ -253,134 +337,6 @@ async fn fetch_transaction_rows(
         .get_transactions_stream(digests, Some(column_filter))
         .await?
         .boxed())
-}
-
-/// Fetch the transactions for a chunk of checkpoints in a single batched
-/// multi_get, routing rows back per-cp and emitting in input cp_seq order once
-/// each cp's full set has arrived.
-async fn fetch_transactions_for_cps(
-    client: BigTableClient,
-    columns: Arc<[&'static str]>,
-    items: Vec<(u64, CheckpointData)>,
-) -> Result<BoxStream<'static, Result<CpWithTxs, anyhow::Error>>, anyhow::Error> {
-    if items.is_empty() {
-        return Ok(stream::empty().boxed());
-    }
-
-    let mut input_order: Vec<u64> = Vec::with_capacity(items.len());
-    let mut cp_data_by_seq: HashMap<u64, CheckpointData> = HashMap::with_capacity(items.len());
-    let mut expected_count: HashMap<u64, usize> = HashMap::with_capacity(items.len());
-    let mut digest_to_cp: HashMap<TransactionDigest, u64> = HashMap::new();
-    let mut txs_by_seq: HashMap<u64, Vec<TransactionData>> = HashMap::with_capacity(items.len());
-    let mut flat_digests: Vec<TransactionDigest> = Vec::new();
-
-    for (cp_seq, cp_data) in items {
-        let contents = cp_data
-            .contents
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("checkpoint {cp_seq} contents column missing"))?;
-        let cp_digests: Vec<_> = contents.iter().map(|d| d.transaction).collect();
-        expected_count.insert(cp_seq, cp_digests.len());
-        txs_by_seq.insert(cp_seq, Vec::with_capacity(cp_digests.len()));
-        for digest in &cp_digests {
-            digest_to_cp.insert(*digest, cp_seq);
-        }
-        flat_digests.extend(cp_digests);
-        input_order.push(cp_seq);
-        cp_data_by_seq.insert(cp_seq, cp_data);
-    }
-
-    // Empty checkpoints (zero transactions) generate no BigTable rows, so
-    // pre-collect them and release through the emitter before draining the
-    // tx stream — otherwise they'd never get emitted.
-    let empty_cps: Vec<u64> = input_order
-        .iter()
-        .copied()
-        .filter(|cp_seq| expected_count[cp_seq] == 0)
-        .collect();
-
-    // CRITICAL: never call `get_transactions_stream` with an empty digest list
-    // (an empty `RowSet` is read as a full transactions-table scan). When every
-    // cp in this chunk is empty, fall back to an empty stream and let the
-    // pre-emit loop alone drive emission.
-    let tx_stream: BoxStream<'static, Result<(TransactionDigest, TransactionData), anyhow::Error>> =
-        if flat_digests.is_empty() {
-            stream::empty().boxed()
-        } else {
-            let column_filter = BigTableClient::column_filter(&columns);
-            client
-                .get_transactions_stream(flat_digests, Some(column_filter))
-                .await?
-                .boxed()
-        };
-
-    Ok(async_stream::try_stream! {
-        let mut emitter: InputOrderEmitter<u64, CpWithTxs> = InputOrderEmitter::new(input_order);
-        for cp_seq in empty_cps {
-            let cp_data = cp_data_by_seq.remove(&cp_seq).expect("cp_data entry present");
-            for v in emitter.push(
-                cp_seq,
-                (cp_seq, cp_data, Vec::new()),
-                "resolve_checkpoints: checkpoint transaction lookup",
-            )? {
-                yield v;
-            }
-        }
-        futures::pin_mut!(tx_stream);
-        while let Some(row) = tx_stream.next().await {
-            let (digest, tx) = row?;
-            let cp_seq = digest_to_cp.remove(&digest).ok_or_else(|| {
-                anyhow::anyhow!("resolve_checkpoints: unexpected transaction body row {digest}")
-            })?;
-            let cp_txs = txs_by_seq
-                .get_mut(&cp_seq)
-                .expect("txs_by_seq entry present");
-            cp_txs.push(tx);
-            if cp_txs.len() == expected_count[&cp_seq] {
-                let txs = txs_by_seq.remove(&cp_seq).expect("txs_by_seq entry");
-                let cp_data = cp_data_by_seq
-                    .remove(&cp_seq)
-                    .expect("cp_data entry present");
-                for v in emitter.push(
-                    cp_seq,
-                    (cp_seq, cp_data, txs),
-                    "resolve_checkpoints: checkpoint transaction lookup",
-                )? {
-                    yield v;
-                }
-            }
-        }
-        // Defensive: if BigTable returned fewer rows than requested, surface
-        // the missing digests as an internal error rather than emit a partial
-        // checkpoint downstream.
-        if !cp_data_by_seq.is_empty() {
-            let mut incomplete: Vec<(u64, usize, usize)> = cp_data_by_seq
-                .keys()
-                .map(|cp_seq| {
-                    let got = txs_by_seq.get(cp_seq).map(|v| v.len()).unwrap_or(0);
-                    let expected = expected_count.get(cp_seq).copied().unwrap_or(0);
-                    (*cp_seq, got, expected)
-                })
-                .collect();
-            incomplete.sort_unstable();
-            tracing::warn!(
-                incomplete_count = incomplete.len(),
-                ?incomplete,
-                "resolve_checkpoints: BigTable returned fewer transactions than requested (cp_seq, got, expected)"
-            );
-            Err(RpcError::new(
-                tonic::Code::Internal,
-                format!(
-                    "resolve_checkpoints: BigTable returned fewer transactions than requested for {} checkpoint(s)",
-                    incomplete.len()
-                ),
-            ))?;
-        }
-        for v in emitter.finish("resolve_checkpoints: missing selected checkpoint transactions")? {
-            yield v;
-        }
-    }
-    .boxed())
 }
 
 // --- Read-mask -> column / fetch planning ---
@@ -512,4 +468,230 @@ pub(crate) fn list_transactions_columns(mask: &FieldMaskTree) -> Vec<&'static st
         columns.push(col::UNCHANGED_LOADED);
     }
     columns
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    use sui_kvstore::BigTableClient as InnerBigTableClient;
+    use sui_kvstore::testing::{MockBigtableServer, ReadRowsResponseOrder};
+    use sui_rpc::field::{FieldMask, FieldMaskUtil};
+    use sui_types::base_types::ExecutionDigests;
+    use sui_types::digests::TransactionEffectsDigest;
+    use sui_types::messages_checkpoint::CheckpointContents;
+
+    use crate::bigtable_client::Metrics;
+
+    /// Transactions-stage chunk size used by the resolver tests. Mirrors the
+    /// production default (`DEFAULT_STAGE_CHUNK_SIZE`) and is the per-request
+    /// batch size the pipeline hands to BigTable — deliberately far below the
+    /// backend `MAX_TX_DIGESTS_PER_REQUEST` clamp.
+    const TX_CHUNK_SIZE: usize = 100;
+
+    /// Deterministic, unique 32-byte digest: `i` big-endian in the low 8 bytes.
+    fn digest(i: u64) -> TransactionDigest {
+        let mut bytes = [0u8; 32];
+        bytes[24..32].copy_from_slice(&i.to_be_bytes());
+        TransactionDigest::new(bytes)
+    }
+
+    /// A checkpoint whose `contents` enumerate `digests` in order. `summary`
+    /// and `signatures` stay `None` — the resolver tests don't render.
+    fn checkpoint_data(digests: &[TransactionDigest]) -> CheckpointData {
+        let contents = CheckpointContents::new_with_digests_only_for_tests(
+            digests
+                .iter()
+                .map(|d| ExecutionDigests::new(*d, TransactionEffectsDigest::ZERO)),
+        );
+        CheckpointData {
+            summary: None,
+            contents: Some(contents),
+            signatures: None,
+        }
+    }
+
+    /// Insert a minimal transaction row (just the small metadata columns) so
+    /// `tables::transactions::decode` succeeds for `digest`.
+    async fn insert_tx_row(mock: &MockBigtableServer, digest: TransactionDigest) {
+        mock.insert_row(
+            tables::transactions::NAME,
+            tables::transactions::encode_key(&digest),
+            [
+                (
+                    tables::transactions::col::CHECKPOINT_NUMBER,
+                    Bytes::from(bcs::to_bytes(&0u64).unwrap()),
+                ),
+                (
+                    tables::transactions::col::TIMESTAMP,
+                    Bytes::from(bcs::to_bytes(&0u64).unwrap()),
+                ),
+            ],
+        )
+        .await;
+    }
+
+    /// Spawn a mock BigTable server and a request-scoped wrapper client wired
+    /// to it. The returned `JoinHandle` keeps the server task owned by the test.
+    async fn setup() -> (
+        MockBigtableServer,
+        BigTableClient,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let mock = MockBigtableServer::new();
+        let (addr, handle) = mock.start().await.unwrap();
+        let inner = InnerBigTableClient::new_local(addr.to_string(), "test".to_string())
+            .await
+            .unwrap();
+        let client = BigTableClient::new(
+            inner,
+            16,
+            Metrics::for_testing().0,
+            "test_resolve_checkpoints",
+        );
+        (mock, client, handle)
+    }
+
+    /// Drive the real `resolve_checkpoints` stream over `cps` and collect the
+    /// emitted checkpoint items (dropping watermarks).
+    async fn run_resolver(
+        client: BigTableClient,
+        read_mask: &FieldMaskTree,
+        cps: Vec<(u64, CheckpointData)>,
+    ) -> Result<Vec<ResolvedCp>, RpcError> {
+        let tx_stage = ResolvedStageConfig {
+            chunk_size: TX_CHUNK_SIZE,
+            concurrency: 4,
+        };
+        let obj_stage = ResolvedStageConfig {
+            chunk_size: 100,
+            concurrency: 1,
+        };
+        let input = stream::iter(
+            cps.into_iter()
+                .map(|cp| Ok::<_, RpcError>(Watermarked::Item(cp))),
+        )
+        .boxed();
+        let stream = resolve_checkpoints(client, read_mask, tx_stage, obj_stage, input);
+        futures::pin_mut!(stream);
+        let mut out = Vec::new();
+        while let Some(item) = stream.next().await {
+            if let Watermarked::Item(resolved) = item? {
+                out.push(resolved);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Recorded `ReadRows` calls scoped to the transactions table.
+    async fn tx_read_calls(mock: &MockBigtableServer) -> Vec<sui_kvstore::testing::ReadRowsCall> {
+        mock.read_rows_calls()
+            .await
+            .into_iter()
+            .filter(|c| c.table == tables::transactions::NAME)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn resolve_checkpoints_splits_fat_checkpoint_transaction_reads() {
+        let (mock, client, _handle) = setup().await;
+        // One checkpoint with more transactions than the stage `chunk_size`, so
+        // the pipeline must split its digests across multiple capped BigTable
+        // requests (the objects stage batches the same way). The backend
+        // `MAX_TX_DIGESTS_PER_REQUEST` clamp is a separate safety net covered by
+        // the `sui-kvstore` `get_transactions_stream_*` tests.
+        let n = TX_CHUNK_SIZE * 2 + 1;
+        let digests: Vec<_> = (0..n as u64).map(digest).collect();
+        for d in &digests {
+            insert_tx_row(&mock, *d).await;
+        }
+        let read_mask = FieldMaskTree::from(FieldMask::from_paths(["transactions.digest"]));
+        let out = run_resolver(client, &read_mask, vec![(0, checkpoint_data(&digests))])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1, "exactly one checkpoint item");
+        let (_, _, txs, _) = &out[0];
+        assert_eq!(txs.len(), n, "all transactions returned");
+
+        let calls = tx_read_calls(&mock).await;
+        assert!(
+            calls.len() >= 2,
+            "fat checkpoint should split into >=2 ReadRows calls, got {}",
+            calls.len()
+        );
+        for c in &calls {
+            assert!(
+                c.row_keys.len() <= TX_CHUNK_SIZE,
+                "ReadRows call exceeded chunk_size: {} keys",
+                c.row_keys.len()
+            );
+        }
+        let total: usize = calls.iter().map(|c| c.row_keys.len()).sum();
+        assert_eq!(total, n, "every digest fetched exactly once");
+    }
+
+    #[tokio::test]
+    async fn resolve_checkpoints_reconstructs_transactions_in_contents_order() {
+        let (mock, client, _handle) = setup().await;
+        let digests: Vec<_> = (0..3).map(digest).collect();
+        for d in &digests {
+            insert_tx_row(&mock, *d).await;
+        }
+        // Backend arrival order is deliberately the reverse of the request,
+        // so a caller that emits in arrival order would fail this assertion.
+        mock.set_read_rows_response_order(ReadRowsResponseOrder::ReverseRequestOrder)
+            .await;
+        let read_mask = FieldMaskTree::from(FieldMask::from_paths(["transactions.digest"]));
+        let out = run_resolver(client, &read_mask, vec![(10, checkpoint_data(&digests))])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1);
+        let (_, _, txs, _) = &out[0];
+        let got: Vec<_> = txs.iter().map(|tx| tx.digest).collect();
+        assert_eq!(
+            got, digests,
+            "transactions must follow checkpoint contents order"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_checkpoints_empty_checkpoint_skips_transaction_read() {
+        let (mock, client, _handle) = setup().await;
+        let read_mask = FieldMaskTree::from(FieldMask::from_paths(["transactions.digest"]));
+        let out = run_resolver(client, &read_mask, vec![(5, checkpoint_data(&[]))])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1, "empty checkpoint still emits one item");
+        let (_, _, txs, _) = &out[0];
+        assert!(txs.is_empty(), "empty checkpoint has no transactions");
+        assert!(
+            tx_read_calls(&mock).await.is_empty(),
+            "empty checkpoint must not issue a transactions ReadRows"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_checkpoints_missing_transaction_row_errors_internal() {
+        let (mock, client, _handle) = setup().await;
+        let digests: Vec<_> = (0..2).map(digest).collect();
+        insert_tx_row(&mock, digests[0]).await; // omit digests[1]
+        let read_mask = FieldMaskTree::from(FieldMask::from_paths(["transactions.digest"]));
+        let err = run_resolver(client, &read_mask, vec![(7, checkpoint_data(&digests))])
+            .await
+            .unwrap_err();
+
+        let status = tonic::Status::from(err);
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert!(
+            status.message().contains(
+                "resolve_checkpoints: BigTable returned fewer transactions than requested"
+            ),
+            "unexpected message: {}",
+            status.message()
+        );
+    }
 }

--- a/crates/sui-kv-rpc/src/resolve.rs
+++ b/crates/sui-kv-rpc/src/resolve.rs
@@ -111,13 +111,7 @@ where
     // Stage C: (cp_seq, CheckpointData) -> + Vec<TransactionData>. Derive each
     // checkpoint's transaction digests and fetch them through
     // `pipelined_keyed_batches` — chunk-bounded and concurrent, batching at
-    // `chunk_size` keys per BigTable request just like the objects stage
-    // (`with_object_maps`). `sui-kvstore` additionally re-clamps each request
-    // to `MAX_TX_DIGESTS_PER_REQUEST` as a backend safety net, so a misconfigured
-    // `chunk_size` still can't exceed the request-size limit. Each checkpoint's
-    // transaction vector is then reconstructed in checkpoint-contents order;
-    // input order is preserved by `pipelined_keyed_batches`, so no
-    // `InputOrderEmitter`.
+    // `chunk_size` keys per BigTable request.
     let with_keys = cp_data_stream
         .map(|res: Result<Watermarked<(u64, CheckpointData)>, E>| {
             let m = res?;
@@ -163,11 +157,6 @@ where
                         let (digest, tx) = row.map_err(E::from)?;
                         map.insert(digest, tx);
                     }
-                    // `keys` is de-duplicated by `pipelined_keyed_batches`, so a
-                    // shortfall means BigTable is missing a requested row. Fail
-                    // with a domain-specific message (the reassembler's own
-                    // missing-key check would otherwise fire first with a
-                    // generic one).
                     if map.len() != requested {
                         return Err(E::from(anyhow::anyhow!(
                             "resolve_checkpoints: BigTable returned fewer transactions than \
@@ -192,10 +181,16 @@ where
                             "checkpoint {cp_seq} contents column missing"
                         ))
                     })?;
-                    let mut txs: Vec<TransactionData> = Vec::new();
+                    // The per-item map is uniquely owned here — the reassembler
+                    // just built it and handed it over — so move each body out
+                    // in checkpoint-contents order rather than deep-cloning it.
+                    // The `unwrap_or_else` clone is a correctness fallback for
+                    // the (currently impossible) case of a shared map.
+                    let mut tx_map = Arc::try_unwrap(tx_map).unwrap_or_else(|arc| (*arc).clone());
+                    let mut txs: Vec<TransactionData> = Vec::with_capacity(contents.size());
                     for d in contents.iter() {
                         let digest = d.transaction;
-                        let tx = tx_map.get(&digest).cloned().ok_or_else(|| {
+                        let tx = tx_map.remove(&digest).ok_or_else(|| {
                             E::from(anyhow::anyhow!(
                                 "resolve_checkpoints: BigTable returned fewer transactions \
                                  than requested (checkpoint {cp_seq} missing transaction {digest})"

--- a/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
+++ b/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
@@ -109,5 +109,5 @@ async fn resolve_full_checkpoint(
     )
     .await?;
 
-    render::render_full_checkpoint(cp_data, txs, objects.as_ref(), read_mask)
+    render::render_full_checkpoint(cp_data, txs, objects, read_mask)
 }

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -314,7 +314,7 @@ pub(crate) async fn list_checkpoints(
                     checkpoint_boundary = advance_checkpoint_boundary(checkpoint_boundary, cp_seq, &options);
                     let wm = item_watermark(&options, cp_seq, cp_seq, checkpoint_boundary);
                     let message =
-                        render_full_checkpoint(cp_data, txs, objects.as_ref(), &read_mask)?;
+                        render_full_checkpoint(cp_data, txs, objects, &read_mask)?;
                     emitted += 1;
                     yield response_for(wm, message);
                 }

--- a/crates/sui-kvstore/Cargo.toml
+++ b/crates/sui-kvstore/Cargo.toml
@@ -6,6 +6,11 @@ publish = false
 edition = "2024"
 version.workspace = true
 
+[features]
+# Exposes the in-memory mock BigTable server (`testing::MockBigtableServer`)
+# for cross-crate read/write-path tests without pulling it into normal builds.
+testing = ["dep:tokio-stream"]
+
 [dependencies]
 anyhow.workspace = true
 arc-swap.workspace = true
@@ -44,6 +49,7 @@ telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, features = ["transport"] }
 tonic-prost.workspace = true
+tokio-stream = { workspace = true, optional = true }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -1251,7 +1251,7 @@ impl BigTableClient {
     /// from caller-scoped values (avoids lifetime capture in `impl Stream`).
     ///
     /// Splits `digests` into sequential sub-requests of at most
-    /// [`MAX_TX_DIGESTS_PER_REQUEST`] keys so a single call can never
+    /// `MAX_TX_DIGESTS_PER_REQUEST` keys so a single call can never
     /// exceed BigTable's `ReadRowsRequest` size limit, regardless of how many
     /// digests a caller passes. An empty `digests` yields an empty stream and
     /// issues no read.

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -78,6 +78,17 @@ const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 // TODO: Add per-method timeouts (e.g. separate write vs read) via tonic::Request::set_timeout().
 const DEFAULT_CHANNEL_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Max transaction digest row keys to send in a single `ReadRowsRequest`
+/// (see [`BigTableClient::get_transactions_stream`]).
+///
+/// BigTable rejects a serialized `ReadRowsRequest` above 512 KiB
+/// (524_288 bytes). Transaction-table row keys are 32-byte digests that encode
+/// to ~34 bytes each inside `RowSet.row_keys`; reserving ~1 KiB for the table
+/// name and filter leaves `(524_288 - 1_024) / 34 ≈ 15_390` keys, so 10_000
+/// keeps comfortable headroom. This is a backend-owned invariant, not a
+/// user-tunable knob.
+pub(crate) const MAX_TX_DIGESTS_PER_REQUEST: usize = 10_000;
+
 /// Error returned when a batch write has per-entry failures.
 /// Contains the keys and error details for each failed mutation.
 #[derive(Debug)]
@@ -1238,31 +1249,39 @@ impl BigTableClient {
     /// `(TransactionDigest, TransactionData)` per row as it arrives.
     /// Takes an owned `column_filter` so the returned stream does not borrow
     /// from caller-scoped values (avoids lifetime capture in `impl Stream`).
+    ///
+    /// Splits `digests` into sequential sub-requests of at most
+    /// [`MAX_TX_DIGESTS_PER_REQUEST`] keys so a single call can never
+    /// exceed BigTable's `ReadRowsRequest` size limit, regardless of how many
+    /// digests a caller passes. An empty `digests` yields an empty stream and
+    /// issues no read.
     pub async fn get_transactions_stream(
         &mut self,
         digests: Vec<TransactionDigest>,
         column_filter: Option<RowFilter>,
     ) -> Result<impl futures::Stream<Item = Result<(TransactionDigest, TransactionData)>> + use<>>
     {
-        let keys = digests
-            .iter()
-            .map(tables::transactions::encode_key)
-            .collect();
-        let filter = column_filter;
-        let rows = self
-            .multi_get_stream(tables::transactions::NAME, keys, filter)
-            .await?;
-
+        let mut client = self.clone();
         Ok(async_stream::try_stream! {
-            futures::pin_mut!(rows);
-            while let Some(row) = rows.next().await {
-                let (key, cells) = row?;
-                let digest = TransactionDigest::from(
-                    <[u8; 32]>::try_from(key.as_ref())
-                        .context("invalid transaction digest key length")?,
-                );
-                let tx = tables::transactions::decode(digest, &cells)?;
-                yield (digest, tx);
+            for chunk in digests.chunks(MAX_TX_DIGESTS_PER_REQUEST) {
+                let keys: Vec<Vec<u8>> = chunk
+                    .iter()
+                    .map(tables::transactions::encode_key)
+                    .collect();
+                let filter = column_filter.clone();
+                let rows = client
+                    .multi_get_stream(tables::transactions::NAME, keys, filter)
+                    .await?;
+                futures::pin_mut!(rows);
+                while let Some(row) = rows.next().await {
+                    let (key, cells) = row?;
+                    let digest = TransactionDigest::from(
+                        <[u8; 32]>::try_from(key.as_ref())
+                            .context("invalid transaction digest key length")?,
+                    );
+                    let tx = tables::transactions::decode(digest, &cells)?;
+                    yield (digest, tx);
+                }
             }
         })
     }
@@ -2095,5 +2114,100 @@ mod tests {
         .await
         .expect("rows_limit can stop before range end");
         assert_eq!(got, vec![3, 4]);
+    }
+
+    /// Build `n` deterministic, unique transaction digests.
+    fn tx_digest(i: u64) -> TransactionDigest {
+        let mut bytes = [0u8; 32];
+        bytes[24..32].copy_from_slice(&i.to_be_bytes());
+        TransactionDigest::new(bytes)
+    }
+
+    /// Insert a minimal transaction row so `tables::transactions::decode`
+    /// succeeds for `digest`.
+    async fn insert_tx_row(
+        mock: &crate::bigtable::mock_server::MockBigtableServer,
+        digest: &TransactionDigest,
+    ) {
+        mock.insert_row(
+            tables::transactions::NAME,
+            tables::transactions::encode_key(digest),
+            [
+                (
+                    tables::transactions::col::CHECKPOINT_NUMBER,
+                    Bytes::from(bcs::to_bytes(&0u64).unwrap()),
+                ),
+                (
+                    tables::transactions::col::TIMESTAMP,
+                    Bytes::from(bcs::to_bytes(&0u64).unwrap()),
+                ),
+            ],
+        )
+        .await;
+    }
+
+    /// Recorded `ReadRows` calls scoped to the transactions table.
+    async fn tx_read_calls(
+        mock: &crate::bigtable::mock_server::MockBigtableServer,
+    ) -> Vec<crate::bigtable::mock_server::ReadRowsCall> {
+        mock.read_rows_calls()
+            .await
+            .into_iter()
+            .filter(|c| c.table == tables::transactions::NAME)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn get_transactions_stream_splits_digest_batches_at_max() {
+        let mock = crate::bigtable::mock_server::MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let mut client = BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test")
+            .await
+            .unwrap();
+
+        let n = MAX_TX_DIGESTS_PER_REQUEST + 1;
+        let digests: Vec<_> = (0..n as u64).map(tx_digest).collect();
+        for d in &digests {
+            insert_tx_row(&mock, d).await;
+        }
+
+        let stream = client
+            .get_transactions_stream(digests.clone(), None)
+            .await
+            .unwrap();
+        let got: Vec<_> = stream.try_collect().await.unwrap();
+        let got_digests: std::collections::HashSet<_> = got.iter().map(|(d, _)| *d).collect();
+        assert_eq!(got_digests.len(), n, "all digests returned");
+        for d in &digests {
+            assert!(got_digests.contains(d), "missing digest {d}");
+        }
+
+        let calls = tx_read_calls(&mock).await;
+        let lens: Vec<usize> = calls.iter().map(|c| c.row_keys.len()).collect();
+        assert_eq!(
+            lens,
+            vec![MAX_TX_DIGESTS_PER_REQUEST, 1],
+            "digest batches split at the cap"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_transactions_stream_empty_digest_list_issues_no_read() {
+        let mock = crate::bigtable::mock_server::MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let mut client = BigTableClient::new_for_host(addr.to_string(), "test".to_string(), "test")
+            .await
+            .unwrap();
+
+        let stream = client
+            .get_transactions_stream(Vec::new(), None)
+            .await
+            .unwrap();
+        let got: Vec<_> = stream.try_collect().await.unwrap();
+        assert!(got.is_empty(), "empty digest list yields no rows");
+        assert!(
+            tx_read_calls(&mock).await.is_empty(),
+            "empty digest list must not issue a transactions ReadRows"
+        );
     }
 }

--- a/crates/sui-kvstore/src/bigtable/mock_server.rs
+++ b/crates/sui-kvstore/src/bigtable/mock_server.rs
@@ -7,17 +7,19 @@
 //! - `MutateRows`: optional row-key expectations, per-entry injected failures,
 //!   pause gates, and successful `SetCell` persistence with latest-timestamp
 //!   semantics.
-//! - `ReadRows`: explicit row-key lookups with an optional row limit, with no
-//!   filter or `CellsPerColumnLimitFilter(1)`. Row ranges, reverse scans, and
-//!   other filters are intentionally unsupported.
+//! - `ReadRows`: explicit row-key lookups with an optional row limit. Supports
+//!   the column filters this crate builds (`None`, `CellsPerColumnLimitFilter(1)`,
+//!   `ColumnQualifierRegexFilter`, and `Chain`s of those plus an optional
+//!   `FamilyNameRegexFilter`), records each call for assertions, and can emit
+//!   rows in reverse request order. Row ranges and reverse scans are unsupported.
 //! - `CheckAndMutateRow`: `PassAllFilter(true)` and the CAS helper shape used
 //!   by this crate (`Chain` of family regex, column qualifier regex, optional
 //!   value range, and optional cells-per-column limit).
 //!
 //! Anything outside that subset should return `UNIMPLEMENTED` so tests do not
 //! accidentally rely on BigTable behavior this mock does not model.
-
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -74,6 +76,24 @@ pub struct ExpectedCall {
     pub row_keys: Vec<&'static [u8]>,
     /// Map of entry index -> gRPC status code (non-zero = failure).
     pub failures: HashMap<usize, i32>,
+}
+
+/// A single recorded `ReadRows` call: the resolved table name (suffix after
+/// `/tables/`) and the explicit row keys requested, in request order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadRowsCall {
+    pub table: String,
+    pub row_keys: Vec<Bytes>,
+}
+
+/// Order in which `ReadRows` emits matching rows relative to the request's
+/// `row_keys`. `ReverseRequestOrder` lets tests prove callers reconstruct a
+/// stable order rather than leaning on backend arrival order.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ReadRowsResponseOrder {
+    #[default]
+    RequestOrder,
+    ReverseRequestOrder,
 }
 
 struct Cell {
@@ -179,6 +199,10 @@ struct MockState {
     /// In-memory row storage keyed by (table_name_suffix, row_key).
     /// Table name suffix is the part after the /tables/ prefix.
     rows: HashMap<(String, Bytes), Row>,
+    /// Every `ReadRows` call in arrival order, for test assertions.
+    read_rows_calls: Vec<ReadRowsCall>,
+    /// Order in which `ReadRows` emits matching rows.
+    read_rows_response_order: ReadRowsResponseOrder,
 }
 
 /// Mock BigTable server with injectable failures and call recording.
@@ -282,6 +306,51 @@ impl MockBigtableServer {
             .map(|cell| cell.value.clone())
     }
 
+    /// Insert a row into the in-memory store directly, bypassing the mutation
+    /// proto path. Cells are stored under the shared column family
+    /// [`crate::tables::FAMILY`] with each provided column name as the qualifier.
+    /// Later inserts for the same (table, row, column) overwrite the value.
+    pub async fn insert_row(
+        &self,
+        table: &str,
+        row_key: impl Into<Bytes>,
+        cells: impl IntoIterator<Item = (&'static str, Bytes)>,
+    ) {
+        let mut state = self.state.lock().await;
+        let row = state
+            .rows
+            .entry((table.to_string(), row_key.into()))
+            .or_default();
+        for (column, value) in cells {
+            row.insert(
+                (
+                    crate::tables::FAMILY.to_string(),
+                    Bytes::from_static(column.as_bytes()),
+                ),
+                Cell {
+                    value,
+                    timestamp_micros: 0,
+                },
+            );
+        }
+    }
+
+    /// Snapshot of every recorded `ReadRows` call in arrival order.
+    pub async fn read_rows_calls(&self) -> Vec<ReadRowsCall> {
+        self.state.lock().await.read_rows_calls.clone()
+    }
+
+    /// Clear the recorded `ReadRows` calls (e.g. to isolate a phase of a test).
+    pub async fn clear_read_rows_calls(&self) {
+        self.state.lock().await.read_rows_calls.clear();
+    }
+
+    /// Control the order in which `ReadRows` emits matching rows relative to
+    /// the request's `row_keys`.
+    pub async fn set_read_rows_response_order(&self, order: ReadRowsResponseOrder) {
+        self.state.lock().await.read_rows_response_order = order;
+    }
+
     /// Start the mock server on a random available port.
     /// Returns the socket address the server is listening on.
     pub async fn start(&self) -> Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
@@ -317,6 +386,70 @@ fn strip_regex_anchors(qualifier: &Bytes) -> &[u8] {
     let bytes = qualifier.as_ref();
     let stripped = bytes.strip_prefix(b"^").unwrap_or(bytes);
     stripped.strip_suffix(b"$").unwrap_or(stripped)
+}
+
+/// Extract the alternation of literal qualifiers from a column-qualifier regex
+/// of the exact shape this crate builds: `^col$` or `^(a|b|c)$`. Returns the
+/// literal qualifier bytes, or `None` if the pattern isn't in that shape.
+fn extract_qualifier_alternation(pattern: &[u8]) -> Option<Vec<Vec<u8>>> {
+    let inner = pattern.strip_prefix(b"^")?.strip_suffix(b"$")?;
+    let inner = match inner.strip_prefix(b"(") {
+        Some(rest) => rest.strip_suffix(b")")?,
+        None => inner,
+    };
+    Some(inner.split(|&b| b == b'|').map(|s| s.to_vec()).collect())
+}
+
+/// Parse a `ReadRows` row filter into the set of allowed column qualifiers.
+/// `Ok(None)` means no qualifier restriction (all cells pass); `Ok(Some(set))`
+/// restricts emitted cells to those qualifiers. Only the filter shapes this
+/// crate builds are supported: `None`, `CellsPerColumnLimitFilter(1)`,
+/// `ColumnQualifierRegexFilter`, and a `Chain` of those plus an optional
+/// `FamilyNameRegexFilter` matching [`crate::tables::FAMILY`].
+fn parse_read_filter(filter: Option<Filter>) -> Result<Option<HashSet<Vec<u8>>>, Status> {
+    fn qualifiers_from_regex(pattern: &Bytes) -> Result<HashSet<Vec<u8>>, Status> {
+        extract_qualifier_alternation(pattern.as_ref())
+            .map(|quals| quals.into_iter().collect())
+            .ok_or_else(|| {
+                Status::unimplemented(
+                    "mock ReadRows only supports `^col$` / `^(a|b|c)$` column qualifier regexes",
+                )
+            })
+    }
+    match filter {
+        None | Some(Filter::CellsPerColumnLimitFilter(1)) => Ok(None),
+        Some(Filter::ColumnQualifierRegexFilter(pattern)) => {
+            Ok(Some(qualifiers_from_regex(&pattern)?))
+        }
+        Some(Filter::Chain(chain)) => {
+            let mut allowed: Option<HashSet<Vec<u8>>> = None;
+            for f in chain.filters {
+                match f.filter {
+                    Some(Filter::CellsPerColumnLimitFilter(1)) | None => {}
+                    Some(Filter::ColumnQualifierRegexFilter(pattern)) => {
+                        allowed = Some(qualifiers_from_regex(&pattern)?);
+                    }
+                    Some(Filter::FamilyNameRegexFilter(family)) => {
+                        let family = Bytes::from(family.into_bytes());
+                        if strip_regex_anchors(&family) != crate::tables::FAMILY.as_bytes() {
+                            return Err(Status::unimplemented(
+                                "mock ReadRows only supports the `sui` column family",
+                            ));
+                        }
+                    }
+                    _ => {
+                        return Err(Status::unimplemented(
+                            "mock ReadRows Chain filter contains an unsupported sub-filter",
+                        ));
+                    }
+                }
+            }
+            Ok(allowed)
+        }
+        Some(_) => Err(Status::unimplemented(
+            "mock ReadRows only supports column-qualifier / cells-per-column / chain filters",
+        )),
+    }
 }
 
 /// Evaluate a ValueRangeFilter against a raw cell value. Unbounded sides are treated
@@ -483,7 +616,7 @@ impl Bigtable for MockBigtableServer {
     ) -> Result<Response<Self::ReadRowsStream>, Status> {
         self.request_count.fetch_add(1, Ordering::Relaxed);
         let req = request.into_inner();
-        let state = self.state.lock().await;
+        let mut state = self.state.lock().await;
 
         // Extract the table name suffix (after /tables/).
         let table = req
@@ -502,14 +635,15 @@ impl Bigtable for MockBigtableServer {
                 "mock ReadRows does not support negative rows_limit",
             ));
         }
-        match req.filter.and_then(|f| f.filter) {
-            None | Some(Filter::CellsPerColumnLimitFilter(1)) => {}
-            Some(_) => {
-                return Err(Status::unimplemented(
-                    "mock ReadRows only supports CellsPerColumnLimitFilter(1)",
-                ));
-            }
-        }
+        // Parse the column filter into an optional set of allowed qualifiers.
+        // `None` means every qualifier passes; `Some(set)` restricts emitted
+        // cells to those qualifiers. Only the filter shapes this crate builds
+        // are supported (see `BigTableClient::column_filter` /
+        // `build_multi_get_request`).
+        let allowed_qualifiers = match parse_read_filter(req.filter.and_then(|f| f.filter)) {
+            Ok(set) => set,
+            Err(status) => return Err(status),
+        };
         let Some(row_set) = req.rows else {
             return Err(Status::unimplemented(
                 "mock ReadRows requires explicit row_keys",
@@ -525,14 +659,29 @@ impl Bigtable for MockBigtableServer {
         } else {
             req.rows_limit as usize
         };
-        let requested_keys = row_set.row_keys.into_iter().take(limit);
+
+        let mut requested_keys: Vec<Bytes> = row_set.row_keys.into_iter().take(limit).collect();
+        state.read_rows_calls.push(ReadRowsCall {
+            table: table.clone(),
+            row_keys: requested_keys.clone(),
+        });
+        if state.read_rows_response_order == ReadRowsResponseOrder::ReverseRequestOrder {
+            requested_keys.reverse();
+        }
 
         let mut chunks = Vec::new();
         for row_key in requested_keys {
             let Some(row) = state.rows.get(&(table.clone(), row_key.clone())) else {
                 continue;
             };
+            let start = chunks.len();
             for ((family, qualifier), cell) in row {
+                if allowed_qualifiers
+                    .as_ref()
+                    .is_some_and(|set| !set.contains(qualifier.as_ref()))
+                {
+                    continue;
+                }
                 chunks.push(CellChunk {
                     row_key: row_key.clone(),
                     family_name: Some(family.clone()),
@@ -544,8 +693,11 @@ impl Bigtable for MockBigtableServer {
                     row_status: None,
                 });
             }
-            // Emit CommitRow on the last chunk (or a standalone marker if row is empty).
-            if let Some(last) = chunks.last_mut() {
+            // Emit CommitRow on this row's last emitted chunk. Skip rows that
+            // produced no matching cells so we don't tag a prior row's chunk.
+            if chunks.len() > start
+                && let Some(last) = chunks.last_mut()
+            {
                 last.row_status = Some(RowStatus::CommitRow(true));
             }
         }

--- a/crates/sui-kvstore/src/bigtable/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/mod.rs
@@ -3,6 +3,6 @@
 
 pub(crate) mod client;
 mod metrics;
-#[cfg(test)]
-pub(crate) mod mock_server;
+#[cfg(any(test, feature = "testing"))]
+pub mod mock_server;
 pub(crate) mod proto;

--- a/crates/sui-kvstore/src/testing.rs
+++ b/crates/sui-kvstore/src/testing.rs
@@ -157,3 +157,9 @@ pub async fn create_tables(host: &str, instance_id: &str) -> Result<()> {
     .await?;
     Ok(())
 }
+
+/// Deterministic in-memory mock BigTable server for cross-crate read/write
+/// path tests. Gated behind the `testing` feature so it never enters normal
+/// builds. See [`crate::bigtable::mock_server`].
+#[cfg(any(test, feature = "testing"))]
+pub use crate::bigtable::mock_server::{MockBigtableServer, ReadRowsCall, ReadRowsResponseOrder};


### PR DESCRIPTION
## Description

There were some requests failing in my test environment because we were chunking on checkpoint count, but then fetching all the transactions for all the checkpoints in the chunk in one multi-get. So the size of the multi-get could exceed bigtable limits.

This PR re-uses the "pipelined_keyed_batches" primitive that I previously wrote to fetch batches of objects for chunks of transactions to fix this.

Now we take the chunk of checkpoints, and fire off many multi-get batches of a configurable size N instead of one big batch.

I also noticed some minor allocation fixes while I was in there.

## Test plan

Verified the errors are gone in the test environment.
