### PR TITLE
Load-shed system execution overload via admission queue drain throttle

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1446,12 +1446,6 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_admission_queue_capacity_fraction")]
     pub admission_queue_capacity_fraction: f64,
 
-    // Fraction of max_pending_transactions below which the admission queue is
-    // bypassed (transactions are submitted directly to consensus). Above this
-    // threshold, transactions go through the priority queue.
-    #[serde(default = "default_admission_queue_bypass_fraction")]
-    pub admission_queue_bypass_fraction: f64,
-
     // Enables use of a gas-price-based priority queue for load shedding of
     // transactions at admission time. If false, when consensus is saturated, transactions
     // are rejected with TooManyTransactionsPendingConsensus.
@@ -1510,16 +1504,12 @@ fn default_admission_queue_capacity_fraction() -> f64 {
     0.5
 }
 
-fn default_admission_queue_bypass_fraction() -> f64 {
-    0.9
-}
-
 fn default_admission_queue_enabled() -> bool {
     true
 }
 
 fn default_admission_queue_failover_timeout() -> Duration {
-    Duration::from_secs(30)
+    Duration::from_secs(10)
 }
 
 impl Default for AuthorityOverloadConfig {
@@ -1538,7 +1528,6 @@ impl Default for AuthorityOverloadConfig {
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
             admission_queue_capacity_fraction: default_admission_queue_capacity_fraction(),
-            admission_queue_bypass_fraction: default_admission_queue_bypass_fraction(),
             admission_queue_enabled: default_admission_queue_enabled(),
             admission_queue_failover_timeout: default_admission_queue_failover_timeout(),
         }

--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -324,7 +324,6 @@ impl AdmissionQueueHandle {
 /// with the new epoch store to create a fresh actor and handle.
 pub struct AdmissionQueueManager {
     capacity: usize,
-    bypass_threshold: usize,
     failover_timeout: Duration,
     metrics: Arc<AdmissionQueueMetrics>,
     consensus_adapter: Arc<ConsensusAdapter>,
@@ -336,7 +335,6 @@ impl AdmissionQueueManager {
         consensus_adapter: Arc<ConsensusAdapter>,
         metrics: Arc<AdmissionQueueMetrics>,
         capacity_fraction: f64,
-        bypass_fraction: f64,
         failover_timeout: Duration,
         slot_freed_notify: Arc<tokio::sync::Notify>,
     ) -> Self {
@@ -348,7 +346,6 @@ impl AdmissionQueueManager {
         );
         Self {
             capacity,
-            bypass_threshold: (max_pending as f64 * bypass_fraction) as usize,
             failover_timeout,
             metrics,
             consensus_adapter,
@@ -362,7 +359,6 @@ impl AdmissionQueueManager {
     ) -> Self {
         Self {
             capacity: 10_000,
-            bypass_threshold: usize::MAX,
             failover_timeout: Duration::from_secs(30),
             metrics: Arc::new(AdmissionQueueMetrics::new_for_tests()),
             consensus_adapter,
@@ -372,10 +368,6 @@ impl AdmissionQueueManager {
 
     pub fn metrics(&self) -> &Arc<AdmissionQueueMetrics> {
         &self.metrics
-    }
-
-    pub(crate) fn bypass_threshold(&self) -> usize {
-        self.bypass_threshold
     }
 
     /// Spawns a new per-epoch admission queue actor and returns a handle.
@@ -432,10 +424,6 @@ impl AdmissionQueueContext {
     /// The old actor shuts down when its handle is dropped.
     pub fn rotate_for_epoch(&self, epoch_store: Arc<AuthorityPerEpochStore>) {
         self.swap.store(Arc::new(self.manager.spawn(epoch_store)));
-    }
-
-    pub(crate) fn bypass_threshold(&self) -> usize {
-        self.manager.bypass_threshold()
     }
 
     pub(crate) fn load(&self) -> arc_swap::Guard<Arc<AdmissionQueueHandle>> {
@@ -908,7 +896,6 @@ mod tests {
             adapter,
             Arc::new(AdmissionQueueMetrics::new_for_tests()),
             0.5,
-            0.9,
             Duration::from_millis(10),
             notify,
         );

--- a/crates/sui-core/src/admission_queue.rs
+++ b/crates/sui-core/src/admission_queue.rs
@@ -3,6 +3,7 @@
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::consensus_adapter::ConsensusAdapter;
+use crate::overload_monitor::AuthorityOverloadInfo;
 use arc_swap::ArcSwap;
 use mysten_common::debug_fatal;
 use mysten_metrics::spawn_monitored_task;
@@ -56,6 +57,9 @@ pub struct AdmissionQueueMetrics {
     pub evictions: IntCounter,
     pub rejections: IntCounter,
     pub duplicate_inserts: IntCounter,
+    /// 1 while the drain is throttled below real consensus capacity by execution
+    /// overload (priority load shedding is active), 0 otherwise.
+    pub drain_throttled: IntGauge,
 }
 
 impl AdmissionQueueMetrics {
@@ -89,6 +93,12 @@ impl AdmissionQueueMetrics {
             duplicate_inserts: register_int_counter_with_registry!(
                 "admission_queue_duplicate_inserts",
                 "Transactions admitted to the queue whose ConsensusTransactionKey duplicated an entry already present. Tallied as spam for DoS protection.",
+                registry,
+            )
+            .unwrap(),
+            drain_throttled: register_int_gauge_with_registry!(
+                "admission_queue_drain_throttled",
+                "1 while the queue drain is throttled below real consensus capacity by execution overload (priority load shedding active), 0 otherwise",
                 registry,
             )
             .unwrap(),
@@ -258,6 +268,35 @@ struct InsertCommand {
     response: oneshot::Sender<SuiResult<bool>>,
 }
 
+/// Consensus inflight budget reduced by the current execution-overload shed
+/// percentage. At 0% shed this is the full `max_pending_transactions`; at 100%
+/// it is 0 and the drain stops entirely. The bounded priority queue fills
+/// against this reduced budget and sheds the lowest-gas-price transactions by
+/// eviction.
+fn effective_max_pending(
+    consensus_adapter: &ConsensusAdapter,
+    overload_info: &AuthorityOverloadInfo,
+) -> u64 {
+    let max_pending = u64::try_from(consensus_adapter.max_pending_transactions()).unwrap();
+    let shed = u64::from(
+        overload_info
+            .load_shedding_percentage
+            .load(Ordering::Relaxed)
+            .min(100),
+    );
+    max_pending * (100 - shed) / 100
+}
+
+/// Whether the drain may submit more to consensus under the current (possibly
+/// shed-reduced) budget.
+fn has_consensus_capacity(
+    consensus_adapter: &ConsensusAdapter,
+    overload_info: &AuthorityOverloadInfo,
+) -> bool {
+    consensus_adapter.num_inflight_transactions()
+        < effective_max_pending(consensus_adapter, overload_info)
+}
+
 /// Cloneable handle for submitting transactions to the admission queue actor.
 /// Held by RPC handlers; the actor runs in a separate spawned task.
 #[derive(Clone)]
@@ -266,15 +305,22 @@ pub struct AdmissionQueueHandle {
     /// The moment the queue last submitted an entry to consensus.
     last_drain: Arc<Mutex<Instant>>,
     queue_depth: Arc<AtomicUsize>,
+    consensus_adapter: Arc<ConsensusAdapter>,
+    overload_info: Arc<AuthorityOverloadInfo>,
     failover_timeout: Duration,
 }
 
 impl AdmissionQueueHandle {
-    /// Returns true if the queue has been non-empty for longer than
-    /// `failover_timeout` without any drain to consensus. Callers should
-    /// bypass the queue entirely when this is true.
+    /// The queue is stuck: it has entries and the drain has capacity to submit
+    /// them (under the current, possibly shed-reduced, budget), yet nothing has
+    /// drained for `failover_timeout`. Callers submit directly to consensus when
+    /// this is true. A queue that is not draining because it is deliberately
+    /// throttled by shedding, or because consensus is saturated, has no capacity
+    /// and so is never a failover.
     pub fn failover_tripped(&self) -> bool {
-        if self.queue_depth.load(Ordering::Relaxed) == 0 {
+        if self.queue_depth.load(Ordering::Relaxed) == 0
+            || !has_consensus_capacity(&self.consensus_adapter, &self.overload_info)
+        {
             return false;
         }
         self.last_drain.lock().unwrap().elapsed() > self.failover_timeout
@@ -328,6 +374,7 @@ pub struct AdmissionQueueManager {
     metrics: Arc<AdmissionQueueMetrics>,
     consensus_adapter: Arc<ConsensusAdapter>,
     slot_freed_notify: Arc<tokio::sync::Notify>,
+    overload_info: Arc<AuthorityOverloadInfo>,
 }
 
 impl AdmissionQueueManager {
@@ -337,6 +384,7 @@ impl AdmissionQueueManager {
         capacity_fraction: f64,
         failover_timeout: Duration,
         slot_freed_notify: Arc<tokio::sync::Notify>,
+        overload_info: Arc<AuthorityOverloadInfo>,
     ) -> Self {
         let max_pending = consensus_adapter.max_pending_transactions();
         let capacity = (max_pending as f64 * capacity_fraction) as usize;
@@ -350,6 +398,7 @@ impl AdmissionQueueManager {
             metrics,
             consensus_adapter,
             slot_freed_notify,
+            overload_info,
         }
     }
 
@@ -363,6 +412,7 @@ impl AdmissionQueueManager {
             metrics: Arc::new(AdmissionQueueMetrics::new_for_tests()),
             consensus_adapter,
             slot_freed_notify,
+            overload_info: Arc::new(AuthorityOverloadInfo::default()),
         }
     }
 
@@ -387,6 +437,7 @@ impl AdmissionQueueManager {
             last_drain: last_drain.clone(),
             queue_depth: queue_depth.clone(),
             last_published_depth: 0,
+            overload_info: self.overload_info.clone(),
         };
         spawn_monitored_task!(event_loop.run());
 
@@ -394,16 +445,17 @@ impl AdmissionQueueManager {
             sender,
             last_drain,
             queue_depth,
+            consensus_adapter: self.consensus_adapter.clone(),
+            overload_info: self.overload_info.clone(),
             failover_timeout: self.failover_timeout,
         }
     }
 }
 
 /// Shared handle to a live admission queue. Holds the manager (for spawning a
-/// fresh per-epoch actor on reconfig), the per-epoch `ArcSwap` handle, and the
-/// cached (config-derived) bypass threshold. Cloned cheaply by `Arc`; passed
-/// both to `ValidatorService` (for hot-path routing) and through
-/// `ValidatorComponents` (for epoch rotation).
+/// fresh per-epoch actor on reconfig) and the per-epoch `ArcSwap` handle. Cloned
+/// cheaply by `Arc`; passed both to `ValidatorService` (for hot-path routing)
+/// and through `ValidatorComponents` (for epoch rotation).
 #[derive(Clone)]
 pub struct AdmissionQueueContext {
     manager: Arc<AdmissionQueueManager>,
@@ -442,6 +494,7 @@ struct AdmissionQueueEventLoop {
     last_drain: Arc<Mutex<Instant>>,
     queue_depth: Arc<AtomicUsize>,
     last_published_depth: usize,
+    overload_info: Arc<AuthorityOverloadInfo>,
 }
 
 impl AdmissionQueueEventLoop {
@@ -449,6 +502,7 @@ impl AdmissionQueueEventLoop {
         loop {
             self.process_pending_inserts();
             self.publish_queue_depth();
+            self.note_throttle();
 
             if !handle_fail_point_if("admission_queue_disable_drain")
                 && !self.queue.is_empty()
@@ -471,13 +525,18 @@ impl AdmissionQueueEventLoop {
                 continue;
             }
 
-            // Queue has entries but consensus is at capacity. Wait for either
-            // a new insert or a freed inflight slot.
-            // Register the notified future BEFORE re-checking capacity to avoid
-            // missing notifications.
+            // Queue has entries but the drain is at capacity — either real
+            // consensus saturation or a deliberate execution-overload throttle.
+            // Wait for a new insert, a freed inflight slot, or a change in the
+            // shed level (which moves the effective cap and so can lift the
+            // throttle). Register both notified futures BEFORE re-checking
+            // capacity to avoid missing notifications.
             let notify = self.slot_freed_notify.clone();
             let slot_freed = notify.notified();
             tokio::pin!(slot_freed);
+            let overload_info = self.overload_info.clone();
+            let shed_changed = overload_info.shed_changed.notified();
+            tokio::pin!(shed_changed);
 
             self.process_pending_inserts();
             if !handle_fail_point_if("admission_queue_disable_drain")
@@ -501,6 +560,8 @@ impl AdmissionQueueEventLoop {
                 }
 
                 _ = &mut slot_freed => {}
+
+                _ = &mut shed_changed => {}
             }
         }
     }
@@ -519,15 +580,31 @@ impl AdmissionQueueEventLoop {
         }
     }
 
+    fn effective_max_pending(&self) -> u64 {
+        effective_max_pending(&self.consensus_adapter, &self.overload_info)
+    }
+
     fn has_consensus_capacity(&self) -> bool {
-        self.consensus_adapter.num_inflight_transactions()
-            < u64::try_from(self.consensus_adapter.max_pending_transactions()).unwrap()
+        has_consensus_capacity(&self.consensus_adapter, &self.overload_info)
+    }
+
+    /// Publish the load-shedding metric: 1 while shedding is actively holding a
+    /// non-empty queue back from draining (the drain has no capacity under the
+    /// shed-reduced budget).
+    fn note_throttle(&self) {
+        let shedding = self
+            .overload_info
+            .load_shedding_percentage
+            .load(Ordering::Relaxed)
+            > 0;
+        let throttled = shedding && !self.queue.is_empty() && !self.has_consensus_capacity();
+        self.queue.metrics.drain_throttled.set(throttled as i64);
     }
 
     fn drain_batch(&mut self) {
-        let max_pending = u64::try_from(self.consensus_adapter.max_pending_transactions()).unwrap();
-        let available =
-            max_pending.saturating_sub(self.consensus_adapter.num_inflight_transactions());
+        let available = self
+            .effective_max_pending()
+            .saturating_sub(self.consensus_adapter.num_inflight_transactions());
         let entries = self.queue.pop_batch(usize::try_from(available).unwrap());
         if entries.is_empty() {
             return;
@@ -826,6 +903,7 @@ mod tests {
             last_drain: Arc::new(Mutex::new(Instant::now())),
             queue_depth: Arc::new(AtomicUsize::new(0)),
             last_published_depth: 0,
+            overload_info: Arc::new(AuthorityOverloadInfo::default()),
         };
 
         let handle = tokio::spawn(event_loop.run());
@@ -868,16 +946,33 @@ mod tests {
         (adapter, epoch_store, slot_freed_notify)
     }
 
-    #[tokio::test]
-    async fn test_failover_tripped_when_actor_stalls() {
-        // Construct a handle with a tiny failover window and no running actor.
-        // Failover requires queue_depth > 0, so simulate a non-empty queue.
-        let handle = AdmissionQueueHandle {
+    fn test_handle(
+        consensus_adapter: Arc<ConsensusAdapter>,
+        overload_info: Arc<AuthorityOverloadInfo>,
+        queue_depth: usize,
+        failover_timeout: Duration,
+    ) -> AdmissionQueueHandle {
+        AdmissionQueueHandle {
             sender: mpsc::channel(1).0,
             last_drain: Arc::new(Mutex::new(Instant::now())),
-            queue_depth: Arc::new(AtomicUsize::new(1)),
-            failover_timeout: Duration::from_millis(10),
-        };
+            queue_depth: Arc::new(AtomicUsize::new(queue_depth)),
+            consensus_adapter,
+            overload_info,
+            failover_timeout,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_failover_tripped_when_actor_stalls() {
+        // Real consensus capacity (max_pending 100, inflight 0) + a non-empty
+        // queue + no drain past the window = a stuck actor.
+        let (adapter, _epoch, _notify) = build_consensus_adapter(100).await;
+        let handle = test_handle(
+            adapter,
+            Arc::new(AuthorityOverloadInfo::default()),
+            1,
+            Duration::from_millis(10),
+        );
         assert!(!handle.failover_tripped());
         tokio::time::sleep(Duration::from_millis(30)).await;
         assert!(handle.failover_tripped());
@@ -885,6 +980,53 @@ mod tests {
         // An empty queue is never a failover, even if last_drain is stale.
         handle.queue_depth.store(0, Ordering::Relaxed);
         assert!(!handle.failover_tripped());
+    }
+
+    /// A stuck actor must be caught even during shedding: capacity exists under
+    /// the shed-reduced budget (40% shed => cap 600, inflight 0) but nothing
+    /// drains for the window, so this is a stall, not a deliberate throttle.
+    #[tokio::test]
+    async fn test_stuck_actor_trips_failover_even_while_shedding() {
+        let (adapter, _epoch, _notify) = build_consensus_adapter(1000).await;
+        let overload_info = Arc::new(AuthorityOverloadInfo::default());
+        overload_info.set_overload(40);
+        let handle = test_handle(adapter, overload_info, 1, Duration::from_millis(10));
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            handle.failover_tripped(),
+            "capacity exists under the shed cap but nothing drained => stuck actor"
+        );
+    }
+
+    /// When the drain has no capacity — full shed or genuine consensus
+    /// saturation — a non-draining queue is expected, not a stall, so failover
+    /// never trips regardless of how stale `last_drain` is.
+    #[tokio::test]
+    async fn test_no_capacity_suppresses_failover() {
+        // 100% shed => effective cap 0 => no capacity.
+        let (adapter, _epoch, _notify) = build_consensus_adapter(1000).await;
+        let overload_info = Arc::new(AuthorityOverloadInfo::default());
+        overload_info.set_overload(100);
+        let handle = test_handle(adapter, overload_info, 1, Duration::from_millis(10));
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            !handle.failover_tripped(),
+            "100% shed: no capacity, deliberate throttle, not a stall"
+        );
+
+        // Genuine saturation (max_pending 0, inflight 0) also means no capacity.
+        let (adapter, _epoch, _notify) = build_consensus_adapter(0).await;
+        let handle = test_handle(
+            adapter,
+            Arc::new(AuthorityOverloadInfo::default()),
+            1,
+            Duration::from_millis(10),
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            !handle.failover_tripped(),
+            "saturation: no capacity, not a stall"
+        );
     }
 
     #[tokio::test]
@@ -898,6 +1040,7 @@ mod tests {
             0.5,
             Duration::from_millis(10),
             notify,
+            Arc::new(AuthorityOverloadInfo::default()),
         );
         let handle = manager.spawn(epoch_store);
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -935,6 +1078,7 @@ mod tests {
             last_drain: last_drain.clone(),
             queue_depth: Arc::new(AtomicUsize::new(0)),
             last_published_depth: 0,
+            overload_info: Arc::new(AuthorityOverloadInfo::default()),
         };
 
         // Sleep so that if drain_batch erroneously stamps Instant::now() the
@@ -948,6 +1092,152 @@ mod tests {
             *last_drain.lock().unwrap(),
             before,
             "last_drain must not advance when drain_batch drained nothing"
+        );
+    }
+
+    fn event_loop_with_overload(
+        adapter: Arc<ConsensusAdapter>,
+        epoch_store: Arc<AuthorityPerEpochStore>,
+        notify: Arc<tokio::sync::Notify>,
+        overload_info: Arc<AuthorityOverloadInfo>,
+    ) -> (AdmissionQueueEventLoop, Arc<Mutex<Instant>>) {
+        let metrics = Arc::new(AdmissionQueueMetrics::new_for_tests());
+        let last_drain = Arc::new(Mutex::new(Instant::now()));
+        let event_loop = AdmissionQueueEventLoop {
+            receiver: mpsc::channel(10).1,
+            queue: PriorityAdmissionQueue::new(10, metrics),
+            consensus_adapter: adapter,
+            slot_freed_notify: notify,
+            epoch_store,
+            last_drain: last_drain.clone(),
+            queue_depth: Arc::new(AtomicUsize::new(0)),
+            last_published_depth: 0,
+            overload_info,
+        };
+        (event_loop, last_drain)
+    }
+
+    #[tokio::test]
+    async fn test_effective_max_pending_scales_with_shed() {
+        let (adapter, epoch_store, notify) = build_consensus_adapter(1000).await;
+        let overload_info = Arc::new(AuthorityOverloadInfo::default());
+        let (el, _) = event_loop_with_overload(adapter, epoch_store, notify, overload_info.clone());
+
+        // No overload: full capacity, drain allowed while inflight is below it.
+        assert_eq!(el.effective_max_pending(), 1000);
+        assert!(el.has_consensus_capacity());
+
+        // 40% shed: cap drops to 600.
+        overload_info.set_overload(40);
+        assert_eq!(el.effective_max_pending(), 600);
+
+        // 100% shed: cap is 0, so the drain stops entirely.
+        overload_info.set_overload(100);
+        assert_eq!(el.effective_max_pending(), 0);
+        assert!(!el.has_consensus_capacity());
+    }
+
+    /// The `drain_throttled` metric is 1 only while shedding actively holds a
+    /// non-empty queue back (no capacity under the shed-reduced budget), and 0
+    /// once the shed clears and capacity returns.
+    #[tokio::test]
+    async fn test_drain_throttled_metric() {
+        // 100% shed, queued work, no capacity => metric 1.
+        let (adapter, epoch_store, notify) = build_consensus_adapter(1000).await;
+        let overload_info = Arc::new(AuthorityOverloadInfo::default());
+        overload_info.set_overload(100);
+        let (mut el, _) =
+            event_loop_with_overload(adapter, epoch_store, notify, overload_info.clone());
+        let (entry, _rx) = make_test_entry(100);
+        el.queue.insert(entry).unwrap();
+        el.note_throttle();
+        assert_eq!(el.queue.metrics.drain_throttled.get(), 1);
+
+        // Shed cleared => capacity returns => metric 0.
+        overload_info.clear_overload();
+        el.note_throttle();
+        assert_eq!(el.queue.metrics.drain_throttled.get(), 0);
+    }
+
+    /// Under shed the drain is capped at `effective_max_pending` and submits the
+    /// highest-gas entries first, so the throttle holds back the cheapest work.
+    #[tokio::test]
+    async fn test_drain_capped_by_shed_submits_highest_gas() {
+        // max_pending 10, 40% shed => effective cap 6.
+        let (adapter, epoch_store, notify) = build_consensus_adapter(10).await;
+        let overload_info = Arc::new(AuthorityOverloadInfo::default());
+        overload_info.set_overload(40);
+        let (mut el, _) = event_loop_with_overload(adapter, epoch_store, notify, overload_info);
+
+        for gp in 1..=10u64 {
+            let (entry, _rx) = make_test_entry(gp);
+            el.queue.insert(entry).unwrap();
+        }
+        assert_eq!(el.queue.len(), 10);
+
+        // One drain: capped at 6 (effective cap), popping the 6 highest prices.
+        el.drain_batch();
+        assert_eq!(
+            el.queue.len(),
+            4,
+            "drain capped at effective_max_pending (6 of 10)"
+        );
+        // The 4 held back are the lowest-priced; the drain took prices 5..=10.
+        let held: Vec<u64> = el.queue.pop_batch(10).iter().map(|e| e.gas_price).collect();
+        assert_eq!(held, vec![4, 3, 2, 1]);
+    }
+
+    /// A drainer parked by full shedding must resume promptly when the shed
+    /// clears. No insert and no freed slot occurs, so only the `shed_changed`
+    /// wakeup can restart draining — if it were missing, the actor would park
+    /// forever and this test would time out.
+    #[tokio::test]
+    async fn test_drain_resumes_when_shed_clears() {
+        let (adapter, epoch_store, notify) = build_consensus_adapter(1000).await;
+        let overload_info = Arc::new(AuthorityOverloadInfo::default());
+        overload_info.set_overload(100); // effective cap 0 => the actor parks.
+
+        let metrics = Arc::new(AdmissionQueueMetrics::new_for_tests());
+        let mut queue = PriorityAdmissionQueue::new(10, metrics);
+        let (entry, _rx) = make_test_entry(100);
+        queue.insert(entry).unwrap();
+
+        let queue_depth = Arc::new(AtomicUsize::new(0));
+        // Keep the sender alive so the parked actor does not see the channel
+        // close and shut down.
+        let (_sender, receiver) = mpsc::channel(10);
+        let event_loop = AdmissionQueueEventLoop {
+            receiver,
+            queue,
+            consensus_adapter: adapter,
+            slot_freed_notify: notify,
+            epoch_store,
+            last_drain: Arc::new(Mutex::new(Instant::now())),
+            queue_depth: queue_depth.clone(),
+            last_published_depth: 0,
+            overload_info: overload_info.clone(),
+        };
+        tokio::spawn(event_loop.run());
+
+        // While fully shed, the entry must stay parked (never drained).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            queue_depth.load(Ordering::Relaxed),
+            1,
+            "fully shed: entry stays queued, not drained"
+        );
+
+        // Clearing shed wakes the drainer via `shed_changed`; it then drains.
+        overload_info.clear_overload();
+        let drained = tokio::time::timeout(Duration::from_secs(2), async {
+            while queue_depth.load(Ordering::Relaxed) != 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        assert!(
+            drained.is_ok(),
+            "shed_changed must wake the parked drainer so it resumes draining"
         );
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -935,7 +935,7 @@ pub struct AuthorityState {
     pub config: NodeConfig,
 
     /// Current overload status in this authority. Updated periodically.
-    pub overload_info: AuthorityOverloadInfo,
+    pub overload_info: Arc<AuthorityOverloadInfo>,
 
     /// The chain identifier is derived from the digest of the genesis checkpoint.
     chain_identifier: ChainIdentifier,
@@ -1317,6 +1317,13 @@ impl AuthorityState {
     }
 
     fn check_authority_overload(&self, tx_data: &SenderSignedData) -> SuiResult {
+        // When the admission queue is enabled, execution-overload load shedding is
+        // done by throttling the queue drain (which sheds the lowest-gas-price
+        // transactions by priority), not probabilistically here.
+        if self.overload_config().admission_queue_enabled {
+            return Ok(());
+        }
+
         if !self.overload_info.is_overload.load(Ordering::Relaxed) {
             return Ok(());
         }
@@ -3605,7 +3612,7 @@ impl AuthorityState {
             _authority_per_epoch_pruner,
             db_checkpoint_config: db_checkpoint_config.clone(),
             config,
-            overload_info: AuthorityOverloadInfo::default(),
+            overload_info: Arc::new(AuthorityOverloadInfo::default()),
             chain_identifier,
             congestion_tracker: Arc::new(CongestionTracker::new()),
             consensus_gasless_counter: Arc::new(ConsensusGaslessCounter::default()),

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -215,6 +215,8 @@ pub struct ValidatorServiceMetrics {
     x_forwarded_for_num_hops: Gauge,
     pub gasless_rate_limited_count: IntCounter,
     pub gasless_submission_outcomes: IntCounterVec,
+    admission_queue_direct: IntCounterVec,
+    admission_queue_failover_active: IntGauge,
 }
 
 impl ValidatorServiceMetrics {
@@ -393,6 +395,19 @@ impl ValidatorServiceMetrics {
                 registry,
             )
             .unwrap(),
+            admission_queue_direct: register_int_counter_vec_with_registry!(
+                "validator_service_admission_queue_direct",
+                "Number of submit requests routed directly to consensus, bypassing the queue, by reason (disabled, ping, failover)",
+                &["reason"],
+                registry,
+            )
+            .unwrap(),
+            admission_queue_failover_active: register_int_gauge_with_registry!(
+                "validator_service_admission_queue_failover_active",
+                "1 while admission queue failover is routing around a stuck queue actor, 0 otherwise",
+                registry,
+            )
+            .unwrap(),
         }
     }
 
@@ -406,11 +421,31 @@ impl ValidatorServiceMetrics {
 enum AdmissionQueueSubmitMode {
     /// Admit via the gas-price priority queue.
     Queue,
-    /// Submit directly to consensus, bypassing the queue — used when the queue
-    /// is turned off by config, temporarily disabled by failover, or for a ping
-    /// request. Individual txs are rejected when consensus is saturated
-    /// (pre-queue behavior).
-    Direct,
+    /// Submit directly to consensus, bypassing the queue. Individual txs are
+    /// rejected when consensus is saturated (pre-queue behavior).
+    Direct(DirectReason),
+}
+
+/// Why a request bypasses the queue and submits directly to consensus. Used as
+/// a metric label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirectReason {
+    /// Queue turned off by config.
+    Disabled,
+    /// Ping request — carries no transactions, must not wait behind queued work.
+    Ping,
+    /// Queue actor appears stuck; failover routes around it.
+    Failover,
+}
+
+impl DirectReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            DirectReason::Disabled => "disabled",
+            DirectReason::Ping => "ping",
+            DirectReason::Failover => "failover",
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -863,7 +898,7 @@ impl ValidatorService {
 
             // Use the pre-queue per-tx consensus overload reject on the direct
             // submission path (queue off, failover, or ping).
-            if matches!(submit_mode, AdmissionQueueSubmitMode::Direct)
+            if matches!(submit_mode, AdmissionQueueSubmitMode::Direct(_))
                 && let Err(error) = self.consensus_adapter.check_consensus_overload()
             {
                 state.update_overload_metrics("consensus");
@@ -1302,7 +1337,11 @@ impl ValidatorService {
         // any other error fails the whole request, after all groups have settled.
         // Soft bundles submit as a single group; individual transactions submit one group each.
         let group_results = match submit_mode {
-            AdmissionQueueSubmitMode::Direct => {
+            AdmissionQueueSubmitMode::Direct(reason) => {
+                self.metrics
+                    .admission_queue_direct
+                    .with_label_values(&[reason.as_str()])
+                    .inc();
                 let futures = tx_groups.into_iter().map(|txns| {
                     debug!(
                         "handle_submit_transaction: submitting consensus transactions ({}): {}",
@@ -1489,19 +1528,23 @@ impl ValidatorService {
 
     fn classify_submit_mode(&self, is_ping_request: bool) -> AdmissionQueueSubmitMode {
         let Some(aq) = &self.admission_queue else {
-            return AdmissionQueueSubmitMode::Direct;
+            return AdmissionQueueSubmitMode::Direct(DirectReason::Disabled);
         };
 
         // Ping requests carry no transactions and must not wait behind queued
         // work; submit them directly to consensus.
         if is_ping_request {
-            return AdmissionQueueSubmitMode::Direct;
+            return AdmissionQueueSubmitMode::Direct(DirectReason::Ping);
         }
 
         // If the queue actor is stuck, fall back to direct submission with the
         // pre-queue saturation reject until it resumes making progress.
-        if aq.load().failover_tripped() {
-            return AdmissionQueueSubmitMode::Direct;
+        let failover = aq.load().failover_tripped();
+        self.metrics
+            .admission_queue_failover_active
+            .set(failover as i64);
+        if failover {
+            return AdmissionQueueSubmitMode::Direct(DirectReason::Failover);
         }
 
         AdmissionQueueSubmitMode::Queue

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -215,7 +215,6 @@ pub struct ValidatorServiceMetrics {
     x_forwarded_for_num_hops: Gauge,
     pub gasless_rate_limited_count: IntCounter,
     pub gasless_submission_outcomes: IntCounterVec,
-    admission_queue_direct_bypasses: IntCounter,
 }
 
 impl ValidatorServiceMetrics {
@@ -394,12 +393,6 @@ impl ValidatorServiceMetrics {
                 registry,
             )
             .unwrap(),
-            admission_queue_direct_bypasses: register_int_counter_with_registry!(
-                "validator_service_admission_queue_direct_bypasses",
-                "Number of transactions that bypassed the queue (system not overloaded)",
-                registry,
-            )
-            .unwrap(),
         }
     }
 
@@ -411,14 +404,13 @@ impl ValidatorServiceMetrics {
 
 /// Where `handle_submit_transaction` routes a request.
 enum AdmissionQueueSubmitMode {
-    /// System has capacity: submit directly to consensus, skipping the queue.
-    Bypass,
-    /// System is overloaded: admit via the priority queue.
+    /// Admit via the gas-price priority queue.
     Queue,
-    /// Queue is not available — either turned off by config or temporarily
-    /// disabled by failover. Submit directly to consensus, but reject
-    /// individual txs when consensus is saturated (pre-queue behavior).
-    Disabled,
+    /// Submit directly to consensus, bypassing the queue — used when the queue
+    /// is turned off by config, temporarily disabled by failover, or for a ping
+    /// request. Individual txs are rejected when consensus is saturated
+    /// (pre-queue behavior).
+    Direct,
 }
 
 #[derive(Clone)]
@@ -869,9 +861,9 @@ impl ValidatorService {
                 continue;
             }
 
-            // Use the pre-queue per-tx consensus overload reject when the
-            // queue is disabled or in failover.
-            if matches!(submit_mode, AdmissionQueueSubmitMode::Disabled)
+            // Use the pre-queue per-tx consensus overload reject on the direct
+            // submission path (queue off, failover, or ping).
+            if matches!(submit_mode, AdmissionQueueSubmitMode::Direct)
                 && let Err(error) = self.consensus_adapter.check_consensus_overload()
             {
                 state.update_overload_metrics("consensus");
@@ -1310,10 +1302,7 @@ impl ValidatorService {
         // any other error fails the whole request, after all groups have settled.
         // Soft bundles submit as a single group; individual transactions submit one group each.
         let group_results = match submit_mode {
-            AdmissionQueueSubmitMode::Bypass | AdmissionQueueSubmitMode::Disabled => {
-                if matches!(submit_mode, AdmissionQueueSubmitMode::Bypass) {
-                    self.metrics.admission_queue_direct_bypasses.inc();
-                }
+            AdmissionQueueSubmitMode::Direct => {
                 let futures = tx_groups.into_iter().map(|txns| {
                     debug!(
                         "handle_submit_transaction: submitting consensus transactions ({}): {}",
@@ -1500,22 +1489,19 @@ impl ValidatorService {
 
     fn classify_submit_mode(&self, is_ping_request: bool) -> AdmissionQueueSubmitMode {
         let Some(aq) = &self.admission_queue else {
-            return AdmissionQueueSubmitMode::Disabled;
+            return AdmissionQueueSubmitMode::Direct;
         };
 
+        // Ping requests carry no transactions and must not wait behind queued
+        // work; submit them directly to consensus.
         if is_ping_request {
-            return AdmissionQueueSubmitMode::Bypass;
+            return AdmissionQueueSubmitMode::Direct;
         }
 
-        let inflight = usize::try_from(self.consensus_adapter.num_inflight_transactions()).unwrap();
-        if inflight < aq.bypass_threshold() {
-            return AdmissionQueueSubmitMode::Bypass;
-        }
-
-        // Failover is consulted only on the overloaded path so the hot path
-        // avoids the ArcSwap load.
+        // If the queue actor is stuck, fall back to direct submission with the
+        // pre-queue saturation reject until it resumes making progress.
         if aq.load().failover_tripped() {
-            return AdmissionQueueSubmitMode::Disabled;
+            return AdmissionQueueSubmitMode::Direct;
         }
 
         AdmissionQueueSubmitMode::Queue

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -14,6 +14,7 @@ use sui_types::digests::TransactionDigest;
 use sui_types::error::SuiErrorKind;
 use sui_types::error::SuiResult;
 use sui_types::fp_bail;
+use tokio::sync::Notify;
 use tokio::time::sleep;
 use tracing::{debug, info};
 use twox_hash::XxHash64;
@@ -25,18 +26,27 @@ pub struct AuthorityOverloadInfo {
 
     /// The calculated percentage of transactions to drop.
     pub load_shedding_percentage: AtomicU32,
+
+    /// Pulsed whenever `load_shedding_percentage` changes.
+    pub shed_changed: Notify,
 }
 
 impl AuthorityOverloadInfo {
     pub fn set_overload(&self, load_shedding_percentage: u32) {
         self.is_overload.store(true, Ordering::Relaxed);
-        self.load_shedding_percentage
-            .store(min(load_shedding_percentage, 100), Ordering::Relaxed);
+        let new = min(load_shedding_percentage, 100);
+        let prev = self.load_shedding_percentage.swap(new, Ordering::Relaxed);
+        if prev != new {
+            self.shed_changed.notify_waiters();
+        }
     }
 
     pub fn clear_overload(&self) {
         self.is_overload.store(false, Ordering::Relaxed);
-        self.load_shedding_percentage.store(0, Ordering::Relaxed);
+        let prev = self.load_shedding_percentage.swap(0, Ordering::Relaxed);
+        if prev != 0 {
+            self.shed_changed.notify_waiters();
+        }
     }
 }
 

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -762,10 +762,13 @@ async fn test_authority_txn_validation_pushback() {
     let gas_object2 = Object::with_owner_for_testing(sender);
 
     // Initialize an AuthorityState. Disable overload monitor by setting max_load_shedding_percentage to 0;
-    // Enable overload check at transaction validation time.
+    // Enable overload check at transaction validation time. Disable the admission
+    // queue so the probabilistic reject (its fallback) is exercised — with the
+    // queue enabled, execution-overload shedding is done by throttling the drain.
     let overload_config = AuthorityOverloadConfig {
         check_system_overload_at_signing: true,
         max_load_shedding_percentage: 0,
+        admission_queue_enabled: false,
         ..Default::default()
     };
     let authority_state = TestAuthorityBuilder::new()
@@ -826,4 +829,64 @@ async fn test_authority_txn_validation_pushback() {
     // Note: handle_vote_transaction is vote-only and doesn't acquire object locks.
     let result = validator_service.handle_transaction_for_testing_with_overload_check(tx.clone());
     assert!(result.is_ok());
+}
+
+// With the admission queue enabled, execution-overload load shedding is done by
+// throttling the queue drain, so the probabilistic per-tx reject in
+// check_authority_overload must be skipped even under 100% shed.
+#[tokio::test]
+async fn test_queue_enabled_skips_probabilistic_overload_reject() {
+    telemetry_subscribers::init_for_testing();
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let (recipient, _): (_, AccountKeyPair) = get_key_pair();
+    let gas_object1 = Object::with_owner_for_testing(sender);
+    let gas_object2 = Object::with_owner_for_testing(sender);
+
+    let overload_config = AuthorityOverloadConfig {
+        check_system_overload_at_signing: true,
+        max_load_shedding_percentage: 0,
+        admission_queue_enabled: true,
+        ..Default::default()
+    };
+    let authority_state = TestAuthorityBuilder::new()
+        .with_authority_overload_config(overload_config)
+        .build()
+        .await;
+    authority_state.insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()]);
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        100_000,
+        100_000,
+        ConsensusAdapterMetrics::new_test(),
+        Arc::new(tokio::sync::Notify::new()),
+    ));
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    // Force 100% shed. With the queue enabled this must NOT reject at signing;
+    // shedding happens via the drain throttle instead.
+    authority_state.overload_info.set_overload(100);
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let tx = make_transfer_object_transaction(
+        gas_object1.compute_object_reference(),
+        gas_object2.compute_object_reference(),
+        sender,
+        &sender_key,
+        recipient,
+        rgp,
+    );
+
+    let result = validator_service.handle_transaction_for_testing_with_overload_check(tx.clone());
+    assert!(
+        result.is_ok(),
+        "queue enabled: overload shedding is via the drain, not a signing-time reject"
+    );
 }

--- a/crates/sui-e2e-tests/tests/admission_queue_tests.rs
+++ b/crates/sui-e2e-tests/tests/admission_queue_tests.rs
@@ -48,7 +48,6 @@ async fn make_transfer_tx_with_gas(
 async fn test_admission_queue_basic() {
     let config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.001,
         ..Default::default()
     };
@@ -76,7 +75,6 @@ async fn test_admission_queue_basic() {
 async fn test_admission_queue_eviction_and_rejection() {
     let overload_config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         // capacity = 20_000 * 0.0001 = 2
         admission_queue_capacity_fraction: 0.0001,
         ..Default::default()
@@ -207,7 +205,6 @@ async fn test_admission_queue_eviction_and_rejection() {
 async fn test_admission_queue_epoch_boundary_cleanup() {
     let config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.001,
         ..Default::default()
     };
@@ -255,7 +252,6 @@ async fn test_admission_queue_epoch_boundary_cleanup() {
 async fn test_admission_queue_reconfig_with_pending_entries() {
     let overload_config = AuthorityOverloadConfig {
         admission_queue_enabled: true,
-        admission_queue_bypass_fraction: 0.0,
         admission_queue_capacity_fraction: 0.0001,
         ..Default::default()
     };

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1651,7 +1651,6 @@ impl SuiNode {
                 consensus_adapter.clone(),
                 Arc::new(AdmissionQueueMetrics::new(prometheus_registry)),
                 overload_config.admission_queue_capacity_fraction,
-                overload_config.admission_queue_bypass_fraction,
                 overload_config.admission_queue_failover_timeout,
                 inflight_slot_freed_notify,
             ));

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1653,6 +1653,7 @@ impl SuiNode {
                 overload_config.admission_queue_capacity_fraction,
                 overload_config.admission_queue_failover_timeout,
                 inflight_slot_freed_notify,
+                state.overload_info.clone(),
             ));
             AdmissionQueueContext::spawn(manager, epoch_store)
         });

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -153,10 +153,9 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
-        secs: 30
+        secs: 10
         nanos: 0
     execution-cache:
       writeback-cache:
@@ -332,10 +331,9 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
-        secs: 30
+        secs: 10
         nanos: 0
     execution-cache:
       writeback-cache:
@@ -511,10 +509,9 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
-        secs: 30
+        secs: 10
         nanos: 0
     execution-cache:
       writeback-cache:
@@ -690,10 +687,9 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
-        secs: 30
+        secs: 10
         nanos: 0
     execution-cache:
       writeback-cache:
@@ -869,10 +865,9 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
-        secs: 30
+        secs: 10
         nanos: 0
     execution-cache:
       writeback-cache:
@@ -1048,10 +1043,9 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
-        secs: 30
+        secs: 10
         nanos: 0
     execution-cache:
       writeback-cache:
@@ -1227,10 +1221,9 @@ validator_configs:
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 2000
       admission-queue-capacity-fraction: 0.5
-      admission-queue-bypass-fraction: 0.9
       admission-queue-enabled: true
       admission-queue-failover-timeout:
-        secs: 30
+        secs: 10
         nanos: 0
     execution-cache:
       writeback-cache:


### PR DESCRIPTION
## Description

CORE-197. Stacked on #27149.

Under execution overload we previously shed load by probabilistically rejecting transactions at signing, regardless of gas price. This routes that shedding through the admission queue instead: the drain is throttled in proportion to the overload monitor's shed percentage, so the bounded gas-price priority queue fills and sheds the lowest-gas-price transactions by eviction. The signing-time probabilistic reject is skipped when the queue is enabled.

The drainer wakes on shed-level changes so the throttle lifts promptly, and failover distinguishes a deliberate throttle (queue holding work with no capacity under the reduced cap) from a genuinely stuck actor by computing capacity live.

## Test plan

New unit tests in `admission_queue.rs` / `execution_driver_tests.rs` cover: the shed-scaled drain cap and price-ordered eviction, failover suppressed under a throttle/saturation but tripped by a stuck actor mid-shed, the event-driven resume when shed clears, and the signing-time reject being skipped when the queue is enabled.

## Release notes

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Under execution overload, validators now shed load by gas price via the admission queue rather than rejecting transactions at random. During congestion, low-gas-price transactions may be rejected with an outbidding error instead of a generic retry-after.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
