### PR TITLE
Improve address balance withdrawal error messages

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/address_balances/insufficient_gas_payment.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/insufficient_gas_payment.snap
@@ -1,6 +1,5 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
-assertion_line: 908
 ---
 processed 12 tasks
 
@@ -84,10 +83,10 @@ task 10, lines 59-64:
 //> TransferObjects([Result(0)], Input(1))
 // Case 7: empty gas payment (pure address balance) with insufficient balance
 // B has no address balance, needs 5 SUI
-Error: Error checking transaction input objects: Invalid withdraw reservation: Available amount in account for object id object(1,0) is less than requested: 200000000 < 1000000000000
+Error: Error checking transaction input objects: Invalid withdraw reservation: Insufficient address balance of coin type 0x2::sui::SUI: the transaction requires 1000000000000 but only 200000000 is available. Note that the address balance does not include funds held in Coin objects owned by the address; to spend those funds, use the Coin objects directly as transaction inputs.
 
 task 11, lines 65-67:
 //# programmable --sender B --address-balance-gas --inputs 1000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
-Error: Error checking transaction input objects: Invalid withdraw reservation: Available amount in account for object id 0xdcf0f9a42cd89c92e9c18323982089d90141a58a8bd04ba8334eaa06fbfc692f is less than requested: 0 < 5000000000
+Error: Error checking transaction input objects: Invalid withdraw reservation: Insufficient address balance of coin type 0x2::sui::SUI: the transaction requires 5000000000 but only 0 is available. Note that the address balance does not include funds held in Coin objects owned by the address; to spend those funds, use the Coin objects directly as transaction inputs.

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/insufficient_gas_payment.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/insufficient_gas_payment.snap
@@ -83,10 +83,10 @@ task 10, lines 59-64:
 //> TransferObjects([Result(0)], Input(1))
 // Case 7: empty gas payment (pure address balance) with insufficient balance
 // B has no address balance, needs 5 SUI
-Error: Error checking transaction input objects: Invalid withdraw reservation: Insufficient address balance of coin type 0x2::sui::SUI: the transaction requires 1000000000000 but only 200000000 is available. Note that the address balance does not include funds held in Coin objects owned by the address; to spend those funds, use the Coin objects directly as transaction inputs.
+Error: Error checking transaction input objects: Invalid withdraw reservation: Insufficient address balance of coin type 0x2::sui::SUI for address @A: the transaction requires 1000000000000 but only 200000000 is available. Note that the address balance does not include funds held in Coin objects owned by the address; to spend those funds, use the Coin objects directly as transaction inputs.
 
 task 11, lines 65-67:
 //# programmable --sender B --address-balance-gas --inputs 1000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
-Error: Error checking transaction input objects: Invalid withdraw reservation: Insufficient address balance of coin type 0x2::sui::SUI: the transaction requires 5000000000 but only 0 is available. Note that the address balance does not include funds held in Coin objects owned by the address; to spend those funds, use the Coin objects directly as transaction inputs.
+Error: Error checking transaction input objects: Invalid withdraw reservation: Insufficient address balance of coin type 0x2::sui::SUI for address @B: the transaction requires 5000000000 but only 0 is available. Note that the address balance does not include funds held in Coin objects owned by the address; to spend those funds, use the Coin objects directly as transaction inputs.

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_reject.snap
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_reject.snap
@@ -1,6 +1,5 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
-assertion_line: 920
 ---
 processed 9 tasks
 
@@ -36,7 +35,7 @@ task 6, lines 36-39:
 // Reject: withdraw 9500 from 10000, leaving 500 (below min 1000) - fails at voting time
 //> 0: sui::balance::redeem_funds<test::usdc::USDC>(Input(0));
 //> 1: sui::balance::send_funds<test::usdc::USDC>(Result(0), Input(1));
-Error: Error checking transaction input objects: Invalid withdraw reservation: Invalid gasless withdrawal from object(3,0). Gasless transactions must either use the entire balance, or leave at least 1000 for token type object(1,0)::usdc::USDC. Remaining amount is 500
+Error: Error checking transaction input objects: Invalid withdraw reservation: Invalid gasless withdrawal of coin type object(1,0)::usdc::USDC. Gasless transactions must either use the entire address balance, or leave at least 1000. Remaining amount would be 500
 
 task 7, lines 41-46:
 //# programmable --sender A --address-balance-gas --gas-price 0 --gas-budget 0 --inputs withdraw<sui::balance::Balance<test::usdc::USDC>>(3000) @B 2500 @A

--- a/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_reject.snap
+++ b/crates/sui-adapter-transactional-tests/tests/gasless/gasless_remaining_balance_reject.snap
@@ -35,7 +35,7 @@ task 6, lines 36-39:
 // Reject: withdraw 9500 from 10000, leaving 500 (below min 1000) - fails at voting time
 //> 0: sui::balance::redeem_funds<test::usdc::USDC>(Input(0));
 //> 1: sui::balance::send_funds<test::usdc::USDC>(Result(0), Input(1));
-Error: Error checking transaction input objects: Invalid withdraw reservation: Invalid gasless withdrawal of coin type object(1,0)::usdc::USDC. Gasless transactions must either use the entire address balance, or leave at least 1000. Remaining amount would be 500
+Error: Error checking transaction input objects: Invalid withdraw reservation: Invalid gasless withdrawal of coin type object(1,0)::usdc::USDC from address @A. Gasless transactions must either use the entire address balance, or leave at least 1000. Remaining amount would be 500
 
 task 7, lines 41-46:
 //# programmable --sender A --address-balance-gas --gas-price 0 --gas-budget 0 --inputs withdraw<sui::balance::Balance<test::usdc::USDC>>(3000) @B 2500 @A

--- a/crates/sui-core/src/accumulators/funds_read.rs
+++ b/crates/sui-core/src/accumulators/funds_read.rs
@@ -7,7 +7,7 @@ use move_core_types::language_storage::TypeTag;
 use sui_types::{
     accumulator_root::AccumulatorObjId,
     balance::Balance,
-    base_types::SequenceNumber,
+    base_types::{SequenceNumber, SuiAddress},
     error::{SuiErrorKind, SuiResult, UserInputError},
 };
 
@@ -40,9 +40,9 @@ pub trait AccountFundsRead: Send + Sync {
     /// where deterministic results are not required.
     fn check_amounts_available(
         &self,
-        requested_amounts: &BTreeMap<AccumulatorObjId, (u64, TypeTag)>,
+        requested_amounts: &BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>,
     ) -> SuiResult {
-        for (object_id, (requested_amount, type_tag)) in requested_amounts {
+        for (object_id, (requested_amount, type_tag, owner)) in requested_amounts {
             let actual_amount = self.get_latest_account_amount(object_id);
 
             if actual_amount < *requested_amount as u128 {
@@ -51,12 +51,12 @@ pub trait AccountFundsRead: Send + Sync {
                 return Err(SuiErrorKind::UserInputError {
                     error: UserInputError::InvalidWithdrawReservation {
                         error: format!(
-                            "Insufficient address balance of coin type {coin_type}: \
-                             the transaction requires {requested_amount} but only \
-                             {actual_amount} is available. Note that the address balance \
-                             does not include funds held in Coin objects owned by the \
-                             address; to spend those funds, use the Coin objects directly \
-                             as transaction inputs.",
+                            "Insufficient address balance of coin type {coin_type} \
+                             for address {owner}: the transaction requires \
+                             {requested_amount} but only {actual_amount} is available. \
+                             Note that the address balance does not include funds held \
+                             in Coin objects owned by the address; to spend those funds, \
+                             use the Coin objects directly as transaction inputs.",
                         ),
                     },
                 }
@@ -73,10 +73,10 @@ pub trait AccountFundsRead: Send + Sync {
     /// token type.
     fn check_remaining_amounts_after_withdrawal(
         &self,
-        requested_amounts: &BTreeMap<AccumulatorObjId, (u64, TypeTag)>,
+        requested_amounts: &BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>,
         min_amounts: &BTreeMap<TypeTag, u64>,
     ) -> SuiResult {
-        for (object_id, (requested_amount, type_tag)) in requested_amounts {
+        for (object_id, (requested_amount, type_tag, owner)) in requested_amounts {
             let actual_amount = self.get_latest_account_amount(object_id);
             let remaining = actual_amount.saturating_sub(*requested_amount as u128);
             if remaining == 0 {
@@ -91,7 +91,8 @@ pub trait AccountFundsRead: Send + Sync {
                 return Err(SuiErrorKind::UserInputError {
                     error: UserInputError::InvalidWithdrawReservation {
                         error: format!(
-                            "Invalid gasless withdrawal of coin type {coin_type}. \
+                            "Invalid gasless withdrawal of coin type {coin_type} \
+                             from address {owner}. \
                              Gasless transactions must either use the entire address \
                              balance, or leave at least {min_amount}. \
                              Remaining amount would be {remaining}",

--- a/crates/sui-core/src/accumulators/funds_read.rs
+++ b/crates/sui-core/src/accumulators/funds_read.rs
@@ -42,15 +42,21 @@ pub trait AccountFundsRead: Send + Sync {
         &self,
         requested_amounts: &BTreeMap<AccumulatorObjId, (u64, TypeTag)>,
     ) -> SuiResult {
-        for (object_id, (requested_amount, _type_tag)) in requested_amounts {
+        for (object_id, (requested_amount, type_tag)) in requested_amounts {
             let actual_amount = self.get_latest_account_amount(object_id);
 
             if actual_amount < *requested_amount as u128 {
+                let coin_type = Balance::maybe_get_balance_type_param(type_tag)
+                    .unwrap_or_else(|| type_tag.clone());
                 return Err(SuiErrorKind::UserInputError {
                     error: UserInputError::InvalidWithdrawReservation {
                         error: format!(
-                            "Available amount in account for object id {} is less than requested: {} < {}",
-                            object_id, actual_amount, requested_amount
+                            "Insufficient address balance of coin type {coin_type}: \
+                             the transaction requires {requested_amount} but only \
+                             {actual_amount} is available. Note that the address balance \
+                             does not include funds held in Coin objects owned by the \
+                             address; to spend those funds, use the Coin objects directly \
+                             as transaction inputs.",
                         ),
                     },
                 }
@@ -85,10 +91,10 @@ pub trait AccountFundsRead: Send + Sync {
                 return Err(SuiErrorKind::UserInputError {
                     error: UserInputError::InvalidWithdrawReservation {
                         error: format!(
-                            "Invalid gasless withdrawal from {object_id}. \
-                             Gasless transactions must either use the entire balance, \
-                             or leave at least {min_amount} for token type {coin_type}. \
-                             Remaining amount is {remaining}",
+                            "Invalid gasless withdrawal of coin type {coin_type}. \
+                             Gasless transactions must either use the entire address \
+                             balance, or leave at least {min_amount}. \
+                             Remaining amount would be {remaining}",
                         ),
                     },
                 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1015,7 +1015,7 @@ impl AuthorityState {
         input_object_kinds: &[InputObjectKind],
         receiving_objects_refs: &[ObjectRef],
         protocol_config: &ProtocolConfig,
-    ) -> SuiResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+    ) -> SuiResult<BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>> {
         // Note: the deny checks may do redundant package loads but:
         // - they only load packages when there is an active package deny map
         // - the loads are cached anyway
@@ -1110,7 +1110,7 @@ impl AuthorityState {
 
         let funds_withdraw_types = declared_withdrawals
             .values()
-            .filter_map(|(_, type_tag)| {
+            .filter_map(|(_, type_tag, _)| {
                 Balance::maybe_get_balance_type_param(type_tag)
                     .map(|ty| ty.to_canonical_string(false))
             })

--- a/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_compatibility_tests.rs
@@ -48,7 +48,7 @@ async fn test_coin_reservation_validation() {
             .transfer_from_coin_to_address_balance(sender1, coin_res, vec![(1, sender1)])
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("is less than requested"));
+        assert!(err.to_string().contains("Insufficient address balance"));
     }
 
     // Verify transaction is rejected if it uses a bogus accumulator object id.
@@ -677,7 +677,7 @@ async fn test_coin_reservation_enforced_when_not_used() {
 
     // Send tx, assert it fails due to insufficient balance.
     let err = test_env.exec_tx_directly(tx).await.unwrap_err();
-    assert!(err.to_string().contains("is less than requested"));
+    assert!(err.to_string().contains("Insufficient address balance"));
 
     test_env.cluster.trigger_reconfiguration().await;
 }

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -450,7 +450,7 @@ async fn test_withdraw_non_existent_balance() {
         .build();
     let err = test_env.exec_tx_directly(tx).await.unwrap_err();
 
-    assert!(err.to_string().contains("is less than requested"));
+    assert!(err.to_string().contains("Insufficient address balance"));
 }
 
 #[sim_test]
@@ -478,7 +478,7 @@ async fn test_withdraw_insufficient_balance() {
         )
         .build();
     let err = test_env.exec_tx_directly(tx).await.unwrap_err();
-    assert!(err.to_string().contains("is less than requested"));
+    assert!(err.to_string().contains("Insufficient address balance"));
 
     // Refresh gas1 after the failed transaction
     let (sender, gas) = test_env.get_sender_and_all_gas(0);
@@ -3486,7 +3486,7 @@ async fn address_balance_stress_test() {
                         }
                         Err(err) => {
                             let err_str = err.to_string();
-                            if err_str.contains("Available amount in account for object id") {
+                            if err_str.contains("Insufficient address balance") {
                                 signing_failure_count.fetch_add(1, Ordering::Relaxed);
                             }
                         }
@@ -4338,7 +4338,7 @@ async fn test_explicit_withdrawal_plus_implicit_gas_exceeds_balance() {
 
     let err = test_env.exec_tx_directly(tx).await.unwrap_err();
     assert!(
-        err.to_string().contains("is less than requested"),
+        err.to_string().contains("Insufficient address balance"),
         "Expected insufficient balance error, got: {}",
         err
     );

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -525,7 +525,9 @@ fn select_gas(
                 .and_then(|withdrawals| {
                     let sui_type = Balance::type_tag(GAS::type_tag());
                     let sui_account_id = AccumulatorValue::get_field_id(owner, &sui_type).ok()?;
-                    withdrawals.get(&sui_account_id).map(|(amount, _)| *amount)
+                    withdrawals
+                        .get(&sui_account_id)
+                        .map(|(amount, _, _)| *amount)
                 })
                 .unwrap_or(0);
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2882,9 +2882,9 @@ pub trait TransactionDataAPI {
     ) -> UserInputResult<(Vec<ObjectRef>, Vec<ObjectID>, Vec<ObjectRef>)>;
 
     /// Processes funds withdraws and returns a map from funds account object ID to (total
-    /// reserved amount, type tag). This method aggregates all withdraw operations for the same
-    /// account by merging their reservations. Each account object ID is derived from the type
-    /// parameter of each withdraw operation.
+    /// reserved amount, type tag, owner address). This method aggregates all withdraw operations
+    /// for the same account by merging their reservations. Each account object ID is derived from
+    /// the owner address and the type parameter of each withdraw operation.
     ///
     /// This method is used at signing time, and can reject a transaction if it contains
     /// invalid reservations.
@@ -2892,7 +2892,7 @@ pub trait TransactionDataAPI {
         &self,
         chain_identifier: ChainIdentifier,
         coin_resolver: &dyn CoinReservationResolverTrait,
-    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>>;
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>>;
 
     /// Like `process_funds_withdrawals_for_signing`, but excludes the implicit gas payment
     /// withdrawal. This is used during gas selection estimation to avoid double-counting the
@@ -2901,7 +2901,7 @@ pub trait TransactionDataAPI {
         &self,
         chain_identifier: ChainIdentifier,
         coin_resolver: &dyn CoinReservationResolverTrait,
-    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>>;
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>>;
 
     /// Like `process_funds_withdrawals_for_signing`, but must only be called on a certified
     /// transaction, i.e. one that is known to be valid.
@@ -3052,7 +3052,7 @@ impl TransactionDataAPI for TransactionDataV1 {
         &self,
         chain_identifier: ChainIdentifier,
         coin_resolver: &dyn CoinReservationResolverTrait,
-    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>> {
         self.accumulate_funds_withdrawals(chain_identifier, coin_resolver, true)
     }
 
@@ -3060,7 +3060,7 @@ impl TransactionDataAPI for TransactionDataV1 {
         &self,
         chain_identifier: ChainIdentifier,
         coin_resolver: &dyn CoinReservationResolverTrait,
-    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>> {
         self.accumulate_funds_withdrawals(chain_identifier, coin_resolver, false)
     }
 
@@ -3544,7 +3544,7 @@ impl TransactionDataV1 {
         chain_identifier: ChainIdentifier,
         coin_resolver: &dyn CoinReservationResolverTrait,
         include_gas_payment: bool,
-    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)>> {
         let mut withdraws: Vec<_> = self.get_funds_withdrawals().collect();
 
         for withdraw in self.parsed_coin_reservations(chain_identifier) {
@@ -3557,7 +3557,8 @@ impl TransactionDataV1 {
             withdraws.extend(self.get_funds_withdrawal_for_gas_payment());
         }
 
-        let mut withdraw_map: BTreeMap<AccumulatorObjId, (u64, TypeTag)> = BTreeMap::new();
+        let mut withdraw_map: BTreeMap<AccumulatorObjId, (u64, TypeTag, SuiAddress)> =
+            BTreeMap::new();
         for withdraw in withdraws {
             let reserved_amount = match &withdraw.reservation {
                 Reservation::MaxAmountU64(amount) => {
@@ -3580,9 +3581,9 @@ impl TransactionDataV1 {
                     }
                 })?;
 
-            let (current_amount, _) = withdraw_map
+            let (current_amount, _, _) = withdraw_map
                 .entry(account_id)
-                .or_insert_with(|| (0, type_tag));
+                .or_insert_with(|| (0, type_tag, account_address));
             *current_amount = current_amount.checked_add(reserved_amount).ok_or(
                 UserInputError::InvalidWithdrawReservation {
                     error: "Balance withdraw reservation overflow".to_string(),


### PR DESCRIPTION
## Description 

The insufficient-balance error at signing time leaked the accumulator object ID, which is an internal implementation detail (e.g. `Available amount in account for object id 0xdcf0f9... is less than requested: 0 < 5000000000`) and gave users no hint about what "account" refers to. The message now names the coin type and the owner address of the balance (sender or sponsor), states that the address balance is insufficient, and explains that funds held in Coin objects are not part of the address balance and should be passed as transaction inputs directly. The gasless remaining-balance error had the same object-ID leak and is reworded the same way.

To make the owner address available at the check site, the withdrawal maps returned by `process_funds_withdrawals_for_signing`/`_for_estimation` now carry the owner address alongside the amount and type tag.

## Test plan 

Covered by existing tests, updated to the new wording: the `insufficient_gas_payment` and `gasless_remaining_balance_reject` transactional-test snapshots capture the full new messages for both error paths (including that the reported owner address distinguishes different balance owners), and the e2e address-balance tests assert the message when withdrawing from a non-existent balance, withdrawing more than available, when an explicit withdrawal plus implicit gas withdrawal exceeds the balance, and when a coin reservation exceeds the reserved coin's balance.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Improved the error message returned when a transaction's address balance withdrawal exceeds the available balance: it no longer exposes internal accumulator object IDs, and now names the coin type and owner address and clarifies that Coin objects owned by the address are not part of its address balance.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
