### PR TITLE
rpc-store: per-pipeline availability policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16911,6 +16911,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "toml 0.7.4",
  "tracing",
  "typed-store-error",
 ]

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -24,7 +24,9 @@ pub mod validator_client_monitor_config;
 pub mod verifier_signing_config;
 
 pub use node::{ConsensusConfig, ExecutionCacheConfig, NodeConfig};
-pub use rpc_config::{RpcConfig, RpcIndexInitConfig, RpcTlsConfig};
+pub use rpc_config::{
+    PipelineAvailabilityConfig, RpcAvailabilityConfig, RpcConfig, RpcIndexInitConfig, RpcTlsConfig,
+};
 use sui_types::multiaddr::Multiaddr;
 use tracing::debug;
 

--- a/crates/sui-config/src/rpc_config.rs
+++ b/crates/sui-config/src/rpc_config.rs
@@ -65,6 +65,13 @@ pub struct RpcConfig {
     /// Configuration for rendering Objects based on the Display standard
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display: Option<DisplayConfig>,
+
+    /// Read-availability policies for the index pipelines served by the
+    /// embedded rpc-store. Only meaningful when `enable-indexing` is true.
+    /// A pipeline with no policy (neither here nor via the global default)
+    /// is always served.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub availability: Option<RpcAvailabilityConfig>,
 }
 
 impl RpcConfig {
@@ -109,10 +116,18 @@ impl RpcConfig {
             .unwrap_or(&DEFAULT_LEDGER_HISTORY_CONFIG)
     }
 
+    pub fn availability(&self) -> Option<&RpcAvailabilityConfig> {
+        self.availability.as_ref()
+    }
+
     /// Validate cross-field invariants. Call once at startup to fail fast on a
     /// misconfiguration rather than surfacing it per-request.
     pub fn validate(&self) -> anyhow::Result<()> {
-        self.ledger_history().validate()
+        self.ledger_history().validate()?;
+        if let Some(availability) = &self.availability {
+            availability.validate()?;
+        }
+        Ok(())
     }
 
     pub fn display(&self) -> &DisplayConfig {
@@ -427,5 +442,180 @@ impl LedgerHistoryConfig {
             self.max_bitmap_filter_literals(),
         );
         Ok(())
+    }
+}
+
+/// Read-availability policies for the embedded rpc-store's index pipelines,
+/// under `rpc.availability` in the node YAML. The top-level `enabled` /
+/// `max-checkpoint-lag` keys set a default policy for every pipeline;
+/// `pipelines` overrides it per pipeline:
+///
+/// ```yaml
+/// rpc:
+///   enable-indexing: true
+///   availability:
+///     max-checkpoint-lag: 100
+///     pipelines:
+///       balance:
+///         enabled: false
+/// ```
+///
+/// Policy semantics: `enabled: true` always serves the pipeline, `enabled:
+/// false` never serves it, and `max-checkpoint-lag: N` serves it only while
+/// its committed watermark is within N checkpoints of the tip. A policy sets
+/// at most one of the two keys. Gated pipelines fail their reads as
+/// unavailable and stop pinning the reported tip; indexing is unaffected.
+///
+/// Pipelines are keyed by their canonical snake_case names (e.g. `balance`,
+/// `object_by_owner`, `transaction_bitmap`) — the same names the watermark
+/// metrics use. Unknown names are rejected at startup.
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct RpcAvailabilityConfig {
+    /// Default policy: always (`true`) or never (`false`) serve pipelines
+    /// without an override. Mutually exclusive with `max-checkpoint-lag`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    /// Default policy: serve pipelines without an override only while their
+    /// committed watermark is within this many checkpoints of the tip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_checkpoint_lag: Option<u64>,
+
+    /// Per-pipeline overrides, keyed by pipeline name.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub pipelines: std::collections::BTreeMap<String, PipelineAvailabilityConfig>,
+}
+
+/// A single pipeline's availability policy override. Semantics as on
+/// [`RpcAvailabilityConfig`]; at most one key may be set.
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PipelineAvailabilityConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_checkpoint_lag: Option<u64>,
+}
+
+impl RpcAvailabilityConfig {
+    /// The global default expressed as a per-pipeline policy value.
+    pub fn default_policy(&self) -> PipelineAvailabilityConfig {
+        PipelineAvailabilityConfig {
+            enabled: self.enabled,
+            max_checkpoint_lag: self.max_checkpoint_lag,
+        }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        use anyhow::Context as _;
+        self.default_policy()
+            .validate()
+            .context("rpc.availability")?;
+        for (name, policy) in &self.pipelines {
+            policy
+                .validate()
+                .with_context(|| format!("rpc.availability.pipelines.{name}"))?;
+        }
+        Ok(())
+    }
+}
+
+impl PipelineAvailabilityConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !(self.enabled.is_some() && self.max_checkpoint_lag.is_some()),
+            "an availability policy must set at most one of `enabled` / `max-checkpoint-lag`",
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn availability_parses_from_yaml() {
+        let config: RpcConfig = serde_yaml::from_str(
+            r#"
+            enable-indexing: true
+            availability:
+              max-checkpoint-lag: 100
+              pipelines:
+                balance:
+                  enabled: false
+                object_by_owner:
+                  enabled: true
+                epochs:
+                  max-checkpoint-lag: 1000
+            "#,
+        )
+        .unwrap();
+
+        let availability = config.availability().unwrap();
+        assert_eq!(availability.max_checkpoint_lag, Some(100));
+        assert_eq!(availability.enabled, None);
+        assert_eq!(availability.pipelines["balance"].enabled, Some(false));
+        assert_eq!(
+            availability.pipelines["object_by_owner"].enabled,
+            Some(true)
+        );
+        assert_eq!(
+            availability.pipelines["epochs"].max_checkpoint_lag,
+            Some(1000)
+        );
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn availability_policy_keys_are_mutually_exclusive() {
+        for yaml in [
+            // Global default sets both keys.
+            r#"
+            availability:
+              enabled: true
+              max-checkpoint-lag: 100
+            "#,
+            // A per-pipeline override sets both keys.
+            r#"
+            availability:
+              pipelines:
+                balance:
+                  enabled: false
+                  max-checkpoint-lag: 100
+            "#,
+        ] {
+            let config: RpcConfig = serde_yaml::from_str(yaml).unwrap();
+            let err = config.validate().unwrap_err();
+            assert!(
+                format!("{err:#}").contains("at most one of"),
+                "unexpected error for {yaml:?}: {err:#}",
+            );
+        }
+    }
+
+    #[test]
+    fn availability_rejects_unknown_keys() {
+        let result: Result<RpcConfig, _> = serde_yaml::from_str(
+            r#"
+            availability:
+              max-checkpoint-lagg: 5
+            "#,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn config_without_availability_serializes_unchanged() {
+        let config = RpcConfig {
+            enable_indexing: Some(true),
+            ..RpcConfig::default()
+        };
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        assert!(!yaml.contains("availability"), "{yaml}");
+        let parsed: RpcConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert!(parsed.availability().is_none());
     }
 }

--- a/crates/sui-core/src/rpc_store_embed.rs
+++ b/crates/sui-core/src/rpc_store_embed.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use prometheus::Registry;
 use sui_config::NodeConfig;
+use sui_config::rpc_config::PipelineAvailabilityConfig;
 use sui_consistent_store::ChainId;
 use sui_consistent_store::Db;
 use sui_consistent_store::DbOptions;
@@ -50,11 +51,13 @@ use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClient;
 use sui_indexer_alt_framework::metrics::IngestionMetrics;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::service::Service;
+use sui_rpc_store::AvailabilityConfig;
 use sui_rpc_store::ConsistencyConfig;
 use sui_rpc_store::HISTORY_COHORT;
 use sui_rpc_store::Indexer;
 use sui_rpc_store::LIVE_COHORT;
 use sui_rpc_store::METRICS_PREFIX;
+use sui_rpc_store::PipelineAvailability;
 use sui_rpc_store::PipelineLayer;
 use sui_rpc_store::RestoreLayer;
 use sui_rpc_store::RpcStoreReader;
@@ -219,6 +222,50 @@ fn decide(
     Bootstrap::Resume
 }
 
+/// Build the reader's availability policies from `rpc.availability` in the
+/// node config, rejecting malformed policies and pipeline names outside the
+/// embedded cohorts. Called at the top of [`EmbeddedRpcStore::bootstrap`] so
+/// a misconfiguration fails startup in milliseconds rather than after a
+/// multi-hour restore.
+fn availability_policies(config: &NodeConfig) -> anyhow::Result<AvailabilityConfig> {
+    let Some(availability) = config.rpc().and_then(|rpc| rpc.availability()) else {
+        return Ok(AvailabilityConfig::default());
+    };
+
+    let default = to_policy(&availability.default_policy()).context("rpc.availability")?;
+    let mut pipelines = std::collections::BTreeMap::new();
+    for (name, policy) in &availability.pipelines {
+        anyhow::ensure!(
+            LIVE_COHORT.contains(&name.as_str()) || HISTORY_COHORT.contains(&name.as_str()),
+            "rpc.availability.pipelines names unknown pipeline {name:?}; valid pipelines: {:?}",
+            LIVE_COHORT.iter().chain(HISTORY_COHORT).collect::<Vec<_>>(),
+        );
+        if let Some(policy) =
+            to_policy(policy).with_context(|| format!("rpc.availability.pipelines.{name}"))?
+        {
+            pipelines.insert(name.clone(), policy);
+        }
+    }
+
+    Ok(AvailabilityConfig { default, pipelines })
+}
+
+/// Convert one `rpc.availability` policy from its node-YAML shape to the
+/// rpc-store policy value. `None` when neither key is set (an empty
+/// per-pipeline entry is a no-op rather than an error, matching the
+/// permissive node-YAML conventions).
+fn to_policy(config: &PipelineAvailabilityConfig) -> anyhow::Result<Option<PipelineAvailability>> {
+    match (config.enabled, config.max_checkpoint_lag) {
+        (Some(_), Some(_)) => {
+            anyhow::bail!("set at most one of `enabled` / `max-checkpoint-lag`")
+        }
+        (Some(true), None) => Ok(Some(PipelineAvailability::Enabled)),
+        (Some(false), None) => Ok(Some(PipelineAvailability::Disabled)),
+        (None, Some(lag)) => Ok(Some(PipelineAvailability::MaxCheckpointLag(lag))),
+        (None, None) => Ok(None),
+    }
+}
+
 /// A bootstrapped embedded rpc-store, ready to hand to the pruner and
 /// the rpc-api read path and to start tip indexing.
 pub struct EmbeddedRpcStore {
@@ -266,6 +313,11 @@ impl EmbeddedRpcStore {
         chain_identifier: ChainIdentifier,
         registry: &Registry,
     ) -> anyhow::Result<Self> {
+        // Fail fast on a malformed `rpc.availability` block — before the
+        // (potentially hours-long) restore below, and before the node-level
+        // `RpcConfig::validate()` which only runs once HTTP servers build.
+        let availability = availability_policies(config)?;
+
         let perpetual = authority_store.perpetual_tables.clone();
         let path = config.db_path().join(RPC_STORE_DIR);
         let (db, schema) = open_db(&path).await?;
@@ -374,7 +426,11 @@ impl EmbeddedRpcStore {
         }
 
         let store = sui_consistent_store::Store::new(db.clone(), schema.clone());
-        let reader = RpcStoreReader::new(db, schema);
+        // Serving policies live only on this reader: the bootstrap logic
+        // above (`decide`/`cohort_resume`), `indexed_checkpoint_fn`, and the
+        // cohort introspection helpers read watermarks straight off the `Db`
+        // and must not be availability-gated.
+        let reader = RpcStoreReader::new(db, schema).with_availability(availability);
 
         Ok(Self {
             store,
@@ -768,5 +824,95 @@ mod tests {
         );
         // History exactly at the floor resumes.
         assert_eq!(decide(Some(200), 100, Some(true), 100), Bootstrap::Resume);
+    }
+
+    fn policy(enabled: Option<bool>, lag: Option<u64>) -> PipelineAvailabilityConfig {
+        PipelineAvailabilityConfig {
+            enabled,
+            max_checkpoint_lag: lag,
+        }
+    }
+
+    #[test]
+    fn to_policy_maps_each_shape() {
+        assert_eq!(to_policy(&policy(None, None)).unwrap(), None);
+        assert_eq!(
+            to_policy(&policy(Some(true), None)).unwrap(),
+            Some(PipelineAvailability::Enabled)
+        );
+        assert_eq!(
+            to_policy(&policy(Some(false), None)).unwrap(),
+            Some(PipelineAvailability::Disabled)
+        );
+        assert_eq!(
+            to_policy(&policy(None, Some(42))).unwrap(),
+            Some(PipelineAvailability::MaxCheckpointLag(42))
+        );
+        let err = to_policy(&policy(Some(true), Some(42))).unwrap_err();
+        assert!(format!("{err:#}").contains("at most one of"), "{err:#}");
+    }
+
+    fn node_config_with_availability(
+        availability: sui_config::rpc_config::RpcAvailabilityConfig,
+    ) -> NodeConfig {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = sui_swarm_config::network_config_builder::ConfigBuilder::new(&dir)
+            .build()
+            .validator_configs()[0]
+            .clone();
+        config.rpc = Some(sui_config::RpcConfig {
+            availability: Some(availability),
+            ..Default::default()
+        });
+        config
+    }
+
+    #[test]
+    fn availability_policies_rejects_unknown_pipeline() {
+        let config = node_config_with_availability(sui_config::rpc_config::RpcAvailabilityConfig {
+            pipelines: [("balanec".to_string(), policy(Some(false), None))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        });
+        let err = availability_policies(&config).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("unknown pipeline \"balanec\""),
+            "{message}"
+        );
+        assert!(message.contains("balance"), "{message}");
+    }
+
+    #[test]
+    fn availability_policies_builds_default_and_overrides() {
+        let config = node_config_with_availability(sui_config::rpc_config::RpcAvailabilityConfig {
+            max_checkpoint_lag: Some(100),
+            pipelines: [("balance".to_string(), policy(Some(false), None))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        });
+        let policies = availability_policies(&config).unwrap();
+        assert_eq!(
+            policies.default,
+            Some(PipelineAvailability::MaxCheckpointLag(100))
+        );
+        assert_eq!(
+            policies.pipelines.get("balance"),
+            Some(&PipelineAvailability::Disabled)
+        );
+    }
+
+    #[test]
+    fn no_availability_block_is_trivial() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = sui_swarm_config::network_config_builder::ConfigBuilder::new(&dir)
+            .build()
+            .validator_configs()[0]
+            .clone();
+        let policies = availability_policies(&config).unwrap();
+        assert!(policies.default.is_none());
+        assert!(policies.pipelines.is_empty());
     }
 }

--- a/crates/sui-e2e-tests/tests/rpc/availability.rs
+++ b/crates/sui-e2e-tests/tests/rpc/availability.rs
@@ -1,0 +1,203 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-pipeline availability policies (`rpc.availability`) on the embedded
+//! `sui-rpc-store`, end to end: node YAML → rpc-store reader gating → gRPC
+//! `Unavailable`.
+//!
+//! Each test spawns a dedicated fullnode (reusing the harness from
+//! [`restore`](crate::restore)) with one pipeline disabled, and asserts that
+//! (1) reads needing the gated pipeline return `Code::Unavailable` naming
+//! it, (2) neighbouring index surfaces keep serving, and (3) indexing itself
+//! is unaffected — `wait_for_indexed` still sees both cohorts advance,
+//! because availability is a read-side policy only.
+//!
+//! Only `enabled: false` is exercised here: `max-checkpoint-lag` gating
+//! depends on transient lag, which is nondeterministic in a live cluster,
+//! and is covered by the reader's unit tests instead.
+
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+
+use prost_types::FieldMask;
+use sui_config::RpcConfig;
+use sui_config::rpc_config::PipelineAvailabilityConfig;
+use sui_config::rpc_config::RpcAvailabilityConfig;
+use sui_macros::sim_test;
+use sui_rpc::Client;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::GetBalanceRequest;
+use sui_rpc::proto::sui::rpc::v2::ListOwnedObjectsRequest;
+use sui_rpc::proto::sui::rpc::v2alpha::ListTransactionsRequest;
+use sui_rpc::proto::sui::rpc::v2alpha::QueryOptions;
+use sui_rpc::proto::sui::rpc::v2alpha::ledger_service_client::LedgerServiceClient;
+use sui_rpc::proto::sui::rpc::v2alpha::list_transactions_response;
+use sui_types::base_types::SuiAddress;
+use test_cluster::TestClusterBuilder;
+
+use crate::restore::SUI_COIN_TYPE;
+use crate::restore::chain_tip;
+use crate::restore::sender_filter;
+use crate::restore::spawn_fullnode;
+use crate::restore::transfer_to_fresh_address;
+use crate::restore::wait_for_indexed;
+
+/// An rpc config with embedded indexing on and `pipelines` disabled via
+/// `rpc.availability`.
+fn config_with_disabled_pipelines(pipelines: &[&str]) -> RpcConfig {
+    RpcConfig {
+        enable_indexing: Some(true),
+        availability: Some(RpcAvailabilityConfig {
+            pipelines: pipelines
+                .iter()
+                .map(|name| {
+                    (
+                        name.to_string(),
+                        PipelineAvailabilityConfig {
+                            enabled: Some(false),
+                            ..Default::default()
+                        },
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// `GetBalance` for `owner`'s SUI, surfacing the gRPC status.
+async fn sui_balance_response(rpc_url: &str, owner: SuiAddress) -> Result<u64, tonic::Status> {
+    let mut client = Client::new(rpc_url.to_owned()).unwrap();
+    let mut request = GetBalanceRequest::default();
+    request.owner = Some(owner.to_string());
+    request.coin_type = Some(SUI_COIN_TYPE.to_string());
+    Ok(client
+        .state_client()
+        .get_balance(request)
+        .await?
+        .into_inner()
+        .balance
+        .unwrap()
+        .balance
+        .unwrap())
+}
+
+/// `ListOwnedObjects` object ids for `owner`, surfacing the gRPC status.
+async fn owned_object_ids(rpc_url: &str, owner: SuiAddress) -> Result<Vec<String>, tonic::Status> {
+    let mut client = Client::new(rpc_url.to_owned()).unwrap();
+    let mut request = ListOwnedObjectsRequest::default();
+    request.owner = Some(owner.to_string());
+    request.read_mask = Some(FieldMask::from_paths(["object_id"]));
+    Ok(client
+        .state_client()
+        .list_owned_objects(request)
+        .await?
+        .into_inner()
+        .objects
+        .into_iter()
+        .filter_map(|object| object.object_id)
+        .collect())
+}
+
+/// `ListTransactions` digests for `sender`, surfacing the gRPC status
+/// whether it fails at the call or on the stream's first message.
+async fn transaction_digests_by_sender(
+    rpc_url: &str,
+    sender: SuiAddress,
+) -> Result<HashSet<String>, tonic::Status> {
+    let mut client = LedgerServiceClient::connect(rpc_url.to_owned())
+        .await
+        .unwrap();
+    let mut options = QueryOptions::default();
+    options.limit = Some(500);
+    let mut request = ListTransactionsRequest::default();
+    request.read_mask = Some(FieldMask::from_paths(["digest"]));
+    request.filter = Some(sender_filter(sender));
+    request.options = Some(options);
+    let mut stream = client.list_transactions(request).await?.into_inner();
+    let mut digests = HashSet::new();
+    while let Some(response) = stream.message().await? {
+        if let Some(list_transactions_response::Response::Item(item)) = response.response
+            && let Some(digest) = item.transaction.and_then(|tx| tx.digest)
+        {
+            digests.insert(digest);
+        }
+    }
+    Ok(digests)
+}
+
+fn assert_unavailable(status: &tonic::Status, pipeline: &str) {
+    assert_eq!(status.code(), tonic::Code::Unavailable, "{status:?}");
+    assert!(
+        status.message().contains(pipeline),
+        "expected the gated pipeline {pipeline:?} in the message: {status:?}",
+    );
+}
+
+/// Disabling the `balance` pipeline gates `GetBalance` as `Unavailable`
+/// while `ListOwnedObjects` (live cohort) and `ListTransactions` (history
+/// cohort) keep serving, and indexing keeps advancing.
+#[sim_test]
+async fn disabled_balance_pipeline_gates_only_balance_reads() {
+    let mut cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .disable_fullnode_pruning()
+        .build()
+        .await;
+    let (name, rpc_url) =
+        spawn_fullnode(&mut cluster, config_with_disabled_pipelines(&["balance"])).await;
+
+    let transfer = transfer_to_fresh_address(&cluster, 11_000_000).await;
+    // Both cohorts still index through the tip: gating is read-side only.
+    wait_for_indexed(&cluster, &name, chain_tip(&cluster)).await;
+
+    let status = sui_balance_response(&rpc_url, transfer.receiver)
+        .await
+        .expect_err("balance reads should be gated");
+    assert_unavailable(&status, "balance");
+
+    let owned = owned_object_ids(&rpc_url, transfer.receiver)
+        .await
+        .expect("owned-object reads are not gated");
+    assert!(
+        !owned.is_empty(),
+        "the recipient's transferred coin should be listed",
+    );
+
+    let digests = transaction_digests_by_sender(&rpc_url, transfer.sender)
+        .await
+        .expect("ledger-history reads are not gated");
+    assert!(digests.contains(&transfer.digest.to_string()));
+}
+
+/// Disabling the `transaction_bitmap` pipeline gates `ListTransactions` as
+/// `Unavailable` while `GetBalance` keeps serving.
+#[sim_test]
+async fn disabled_transaction_bitmap_gates_list_transactions() {
+    let mut cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .disable_fullnode_pruning()
+        .build()
+        .await;
+    let (name, rpc_url) = spawn_fullnode(
+        &mut cluster,
+        config_with_disabled_pipelines(&["transaction_bitmap"]),
+    )
+    .await;
+
+    let transfer = transfer_to_fresh_address(&cluster, 13_000_000).await;
+    wait_for_indexed(&cluster, &name, chain_tip(&cluster)).await;
+
+    let status = transaction_digests_by_sender(&rpc_url, transfer.sender)
+        .await
+        .expect_err("bitmap-backed list reads should be gated");
+    assert_unavailable(&status, "transaction_bitmap");
+
+    assert_eq!(
+        sui_balance_response(&rpc_url, transfer.receiver)
+            .await
+            .expect("balance reads are not gated"),
+        transfer.amount,
+    );
+}

--- a/crates/sui-e2e-tests/tests/rpc/main.rs
+++ b/crates/sui-e2e-tests/tests/rpc/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod availability;
 mod client;
 mod restore;
 mod v2;

--- a/crates/sui-e2e-tests/tests/rpc/restore.rs
+++ b/crates/sui-e2e-tests/tests/rpc/restore.rs
@@ -59,7 +59,7 @@ use sui_types::transaction::TransactionDataAPI;
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
 
-const SUI_COIN_TYPE: &str =
+pub(crate) const SUI_COIN_TYPE: &str =
     "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI";
 
 /// How long to wait for the dedicated fullnode to sync and index a target
@@ -89,7 +89,10 @@ fn no_indexing_config() -> RpcConfig {
 /// (stable) name and rpc url. The handle `spawn_new_node` returns is
 /// dropped immediately so the node keeps no external strong reference and a
 /// later [`restart_fullnode`] can release its DB locks on stop.
-async fn spawn_fullnode(cluster: &mut TestCluster, rpc: RpcConfig) -> (AuthorityName, String) {
+pub(crate) async fn spawn_fullnode(
+    cluster: &mut TestCluster,
+    rpc: RpcConfig,
+) -> (AuthorityName, String) {
     let config = cluster
         .fullnode_config_builder()
         .with_rpc_config(rpc)
@@ -172,7 +175,7 @@ async fn wait_for_executed(cluster: &TestCluster, name: &AuthorityName, target: 
 /// Block until both cohorts of the dedicated fullnode's embedded store have
 /// committed through `target`. Panics on timeout with the last-observed
 /// watermarks.
-async fn wait_for_indexed(cluster: &TestCluster, name: &AuthorityName, target: u64) {
+pub(crate) async fn wait_for_indexed(cluster: &TestCluster, name: &AuthorityName, target: u64) {
     let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
     loop {
         let live = live_committed(cluster, name);
@@ -192,20 +195,20 @@ async fn wait_for_indexed(cluster: &TestCluster, name: &AuthorityName, target: u
 
 /// A transfer executed against the cluster, with the facts a test asserts
 /// on afterward.
-struct Transfer {
+pub(crate) struct Transfer {
     /// The transaction's sender (whichever account funded the gas).
-    sender: SuiAddress,
+    pub(crate) sender: SuiAddress,
     /// A fresh address with no prior coins, so its post-transfer SUI
     /// balance is exactly `amount`.
-    receiver: SuiAddress,
-    amount: u64,
-    digest: TransactionDigest,
+    pub(crate) receiver: SuiAddress,
+    pub(crate) amount: u64,
+    pub(crate) digest: TransactionDigest,
 }
 
 /// Transfer `amount` MIST of SUI to a fresh address through the cluster's
 /// primary fullnode and wait for the transaction to land in an executed
 /// checkpoint.
-async fn transfer_to_fresh_address(cluster: &TestCluster, amount: u64) -> Transfer {
+pub(crate) async fn transfer_to_fresh_address(cluster: &TestCluster, amount: u64) -> Transfer {
     let receiver = SuiAddress::random_for_testing_only();
     let txn = make_transfer_sui_transaction(&cluster.wallet, Some(receiver), Some(amount)).await;
     let executed = cluster.execute_transaction(txn).await;
@@ -221,7 +224,7 @@ async fn transfer_to_fresh_address(cluster: &TestCluster, amount: u64) -> Transf
 
 /// The chain tip as seen by the cluster's primary fullnode -- an upper
 /// bound on the checkpoints the dedicated node must sync and index.
-fn chain_tip(cluster: &TestCluster) -> u64 {
+pub(crate) fn chain_tip(cluster: &TestCluster) -> u64 {
     cluster.fullnode_handle.sui_node.with(|node| {
         node.state()
             .get_checkpoint_store()
@@ -250,7 +253,7 @@ async fn sui_balance(rpc_url: &str, owner: SuiAddress) -> u64 {
 }
 
 /// A `ListTransactions` filter matching a single sender.
-fn sender_filter(sender: SuiAddress) -> TransactionFilter {
+pub(crate) fn sender_filter(sender: SuiAddress) -> TransactionFilter {
     let mut sender_filter = SenderFilter::default();
     sender_filter.address = Some(sender.to_string());
     let mut literal = TransactionLiteral::default();

--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -76,16 +76,29 @@ impl From<RpcError> for tonic::Status {
 
 impl From<sui_types::storage::error::Error> for RpcError {
     fn from(value: sui_types::storage::error::Error) -> Self {
+        use std::error::Error;
         use sui_types::storage::error::Kind;
 
         let code = match value.kind() {
             Kind::Missing => Code::NotFound,
+            Kind::Unavailable => Code::Unavailable,
             _ => Code::Internal,
+        };
+
+        // `storage::Error`'s `Display` is a debug dump; for the client-facing `Unavailable`
+        // message prefer the human-readable source.
+        let message = if value.kind() == Kind::Unavailable {
+            value
+                .source()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| value.to_string())
+        } else {
+            value.to_string()
         };
 
         Self {
             code,
-            message: Some(value.to_string()),
+            message: Some(message),
             details: None,
         }
     }
@@ -436,5 +449,26 @@ impl std::error::Error for EpochNotFoundError {}
 impl From<EpochNotFoundError> for crate::RpcError {
     fn from(value: EpochNotFoundError) -> Self {
         Self::new(tonic::Code::NotFound, value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_storage_error_maps_to_unavailable_status() {
+        let err = RpcError::from(sui_types::storage::error::Error::unavailable(
+            "pipeline balance is disabled by config",
+        ));
+        let status = tonic::Status::from(err);
+        assert_eq!(status.code(), Code::Unavailable);
+        assert_eq!(status.message(), "pipeline balance is disabled by config");
+    }
+
+    #[test]
+    fn missing_storage_error_still_maps_to_not_found() {
+        let err = RpcError::from(sui_types::storage::error::Error::missing("no row"));
+        assert_eq!(tonic::Status::from(err).code(), Code::NotFound);
     }
 }

--- a/crates/sui-rpc-api/src/grpc/v2/move_package_service/list_package_versions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/move_package_service/list_package_versions.rs
@@ -59,7 +59,7 @@ pub fn list_package_versions(
     let mut versions = vec![];
     let iter = indexes
         .package_versions_iter(original_package_id, page_token.map(|t| t.version))
-        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+        .map_err(RpcError::from)?;
 
     for result in iter.take(page_size + 1) {
         let (version, storage_id) =

--- a/crates/sui-rpc-api/src/grpc/v2/state_service/get_coin_info.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/state_service/get_coin_info.rs
@@ -171,10 +171,16 @@ fn get_coin_info_from_registry(
         };
 
         let coin_info = indexes.get_coin_info(core_coin_type).map_err(|e| {
-            RpcError::new(
-                tonic::Code::Internal,
-                format!("Failed to get coin info for {}: {}", core_coin_type, e),
-            )
+            // Let an unavailable-index signal reach the client as `Unavailable` instead of
+            // masking it behind `Internal`.
+            if e.kind() == sui_types::storage::error::Kind::Unavailable {
+                RpcError::from(e)
+            } else {
+                RpcError::new(
+                    tonic::Code::Internal,
+                    format!("Failed to get coin info for {}: {}", core_coin_type, e),
+                )
+            }
         })?;
 
         let regulated_id = coin_info.and_then(|info| info.regulated_coin_metadata_object_id);

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/bitmap_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/bitmap_scan.rs
@@ -314,9 +314,16 @@ where
                     BitmapScanError::Cancelled.to_string(),
                 ));
             }
-            // Genuine fault → gRPC Internal, carrying the error unchanged.
+            // Genuine fault → gRPC Internal, carrying the error unchanged — except an
+            // unavailable-index signal from the reader, which renders as `Unavailable`.
             Some(Err(BitmapScanError::Source(inner))) => {
-                return Err(RpcError::new(tonic::Code::Internal, inner.to_string()));
+                return Err(match inner.downcast::<sui_types::storage::error::Error>() {
+                    Ok(e) if e.kind() == sui_types::storage::error::Kind::Unavailable => {
+                        RpcError::from(e)
+                    }
+                    Ok(e) => RpcError::new(tonic::Code::Internal, e.to_string()),
+                    Err(inner) => RpcError::new(tonic::Code::Internal, inner.to_string()),
+                });
             }
             None => {
                 next_range = None;
@@ -453,7 +460,9 @@ impl<'a> RpcIndexesBitmapIterator<'a> {
                         descending,
                     ),
                 };
-                iter.map_err(|e| anyhow::anyhow!(e.to_string()))
+                // Keep the typed error so the drain loop can distinguish an
+                // unavailable-index signal from a genuine fault.
+                iter.map_err(anyhow::Error::new)
             });
 
         let (iter, initial_error) = match iter {

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/ledger_read.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/ledger_read.rs
@@ -40,7 +40,7 @@ pub(super) fn checkpoint_hi_exclusive(service: &RpcService) -> Result<u64, RpcEr
         .ok_or_else(|| RpcError::new(tonic::Code::Unavailable, "rpc indexes are disabled"))?;
     let checkpoint = indexes
         .get_highest_indexed_checkpoint_seq_number()
-        .map_err(storage_error)?
+        .map_err(RpcError::from)?
         .ok_or_else(|| RpcError::new(tonic::Code::Unavailable, "rpc index is empty"))?;
     checkpoint
         .checked_add(1)
@@ -135,7 +135,7 @@ pub(super) fn get_tx_seq_digest_multi(
         .ok_or_else(|| RpcError::new(tonic::Code::Unavailable, "rpc indexes are disabled"))?;
     indexes
         .ledger_tx_seq_digest_multi_get(tx_seqs)
-        .map_err(storage_error)?
+        .map_err(RpcError::from)?
         .into_iter()
         .zip_debug_eq(tx_seqs.iter().copied())
         .map(|(row, tx_seq)| row.ok_or_else(|| missing_row_error(service, tx_seq)))
@@ -159,7 +159,7 @@ pub(super) fn get_tx_seq_digest_rows(
         .ok_or_else(|| RpcError::new(tonic::Code::Unavailable, "rpc indexes are disabled"))?;
     let mut iter = indexes
         .ledger_tx_seq_digest_iter(range.start, range.end, descending)
-        .map_err(storage_error)?;
+        .map_err(RpcError::from)?;
     let mut rows = Vec::with_capacity(row_limit);
     let mut expected = if descending {
         range.end - 1

--- a/crates/sui-rpc-api/src/grpc/v2alpha/proof_service/get_checkpoint_object_proof.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/proof_service/get_checkpoint_object_proof.rs
@@ -78,7 +78,7 @@ fn validate_checkpoint_bounds(service: &RpcService, checkpoint_seq: u64) -> Resu
     let indexes = reader.indexes().ok_or_else(RpcError::not_found)?;
     let highest_indexed = indexes
         .get_highest_indexed_checkpoint_seq_number()
-        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?
+        .map_err(RpcError::from)?
         .unwrap_or(0);
     let lowest_available = reader
         .get_lowest_available_checkpoint_objects()

--- a/crates/sui-rpc-store/Cargo.toml
+++ b/crates/sui-rpc-store/Cargo.toml
@@ -36,3 +36,4 @@ typed-store-error.workspace = true
 futures.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+toml.workspace = true

--- a/crates/sui-rpc-store/src/config.rs
+++ b/crates/sui-rpc-store/src/config.rs
@@ -9,14 +9,16 @@
 //!
 //! Per-pipeline enable/disable is expressed through
 //! [`PipelineLayer`]: every pipeline maps to an
-//! `Option<CommitterLayer>` field; `Some(_)` means the pipeline is
-//! registered (with the supplied committer overrides), `None` means
-//! it is skipped. The standalone binary populates the layer from
-//! its TOML config; the embedded-fullnode caller builds it
-//! programmatically via [`PipelineLayer::embedded`] so the raw
-//! chain CFs (served by the fullnode's perpetual store) are not
-//! double-written by this indexer.
+//! `Option<PipelineConfig>` field; `Some(_)` means the pipeline is
+//! registered (with the supplied committer overrides and optional
+//! availability policy), `None` means it is skipped. The standalone
+//! binary populates the layer from its TOML config; the
+//! embedded-fullnode caller builds it programmatically via
+//! [`PipelineLayer::embedded`] so the raw chain CFs (served by the
+//! fullnode's perpetual store) are not double-written by this
+//! indexer.
 
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -39,8 +41,14 @@ pub struct ServiceConfig {
     /// individual fields.
     pub committer: CommitterLayer,
 
+    /// Default availability policy applied to every pipeline
+    /// without a `[pipeline.<name>.availability]` override. Absent
+    /// (the default) means every pipeline is always served. See
+    /// [`PipelineAvailability`].
+    pub availability: Option<PipelineAvailability>,
+
     /// Per-pipeline enable/disable plus optional committer
-    /// overrides.
+    /// overrides and availability policies.
     pub pipeline: PipelineLayer,
 
     /// Pruning policy for the historical CFs. Absent (the default)
@@ -150,11 +158,78 @@ impl PrunerConfig {
     }
 }
 
+/// Read-availability policy for a pipeline: serve it
+/// unconditionally (`enabled = true`), never serve it
+/// (`enabled = false`), or serve it only while its committed
+/// watermark is within `max-checkpoint-lag` checkpoints of the tip
+/// (the highest committed watermark across all pipelines). A policy
+/// section sets exactly one of the two keys. Reads that need a
+/// pipeline that is not served fail as unavailable, and such a
+/// pipeline is excluded from the reader's cross-pipeline watermark
+/// bounds so it stops pinning the reported tip.
+///
+/// The top-level `[availability]` key sets a default policy for
+/// every pipeline, and `[pipeline.<name>.availability]` overrides
+/// it for a single pipeline (e.g. `enabled = true` exempts one
+/// pipeline from a configured default). A pipeline with neither is
+/// always served, so this feature is opt-in:
+///
+/// ```toml
+/// [availability]
+/// max-checkpoint-lag = 100          # default for every pipeline
+///
+/// [pipeline.balance.availability]
+/// enabled = false                   # never serve
+///
+/// [pipeline.object-by-owner.availability]
+/// enabled = true                    # always serve, exempt from the default
+/// ```
+///
+/// The policy is read-side only: it never affects whether a
+/// pipeline indexes. Registration (`Some`/`None` in
+/// [`PipelineLayer`]) remains the write-side switch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(try_from = "AvailabilityLayer", into = "AvailabilityLayer")]
+pub enum PipelineAvailability {
+    /// Always serve the pipeline.
+    Enabled,
+
+    /// Never serve the pipeline.
+    Disabled,
+
+    /// Serve the pipeline only while its committed watermark is
+    /// within this many checkpoints of the tip.
+    MaxCheckpointLag(u64),
+}
+
+/// TOML mirror of [`PipelineAvailability`]: a policy section sets
+/// exactly one of these keys, validated when converting to the
+/// enum.
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct AvailabilityLayer {
+    pub enabled: Option<bool>,
+    pub max_checkpoint_lag: Option<u64>,
+}
+
+/// Resolved availability policies: the top-level `[availability]`
+/// default plus the `[pipeline.<name>.availability]` overrides.
+/// Handed to the reader; see
+/// [`RpcStoreReader::with_availability`](crate::RpcStoreReader::with_availability).
+#[derive(Clone, Debug, Default)]
+pub struct AvailabilityConfig {
+    /// Default policy applied to every pipeline without an override.
+    pub default: Option<PipelineAvailability>,
+
+    /// Per-pipeline overrides, keyed by pipeline name.
+    pub pipelines: BTreeMap<String, PipelineAvailability>,
+}
+
 /// Per-pipeline registration + override map. Every pipeline that
 /// writes to a CF in [`RpcStoreSchema`] has a corresponding
-/// `Option<CommitterLayer>` field here.
+/// `Option<PipelineConfig>` field here.
 ///
-/// `Some(layer)` registers the pipeline with the supplied committer
+/// `Some(entry)` registers the pipeline with the supplied committer
 /// overrides folded onto the shared [`CommitterLayer`] default;
 /// `None` skips the pipeline entirely (e.g. the raw chain CFs in
 /// the embedded-fullnode case, where the fullnode populates them
@@ -165,28 +240,43 @@ impl PrunerConfig {
 ///
 /// [`RpcStoreSchema`]: crate::RpcStoreSchema
 #[derive(Default, Deserialize, Serialize)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PipelineLayer {
     // --- Raw chain data ---
-    pub epochs: Option<CommitterLayer>,
-    pub checkpoint_summary: Option<CommitterLayer>,
-    pub checkpoint_contents: Option<CommitterLayer>,
-    pub checkpoint_seq_by_digest: Option<CommitterLayer>,
-    pub transactions: Option<CommitterLayer>,
-    pub tx_seq_by_digest: Option<CommitterLayer>,
-    pub tx_metadata_by_seq: Option<CommitterLayer>,
-    pub effects: Option<CommitterLayer>,
-    pub events: Option<CommitterLayer>,
-    pub objects: Option<CommitterLayer>,
-    pub object_version_by_checkpoint: Option<CommitterLayer>,
+    pub epochs: Option<PipelineConfig>,
+    pub checkpoint_summary: Option<PipelineConfig>,
+    pub checkpoint_contents: Option<PipelineConfig>,
+    pub checkpoint_seq_by_digest: Option<PipelineConfig>,
+    pub transactions: Option<PipelineConfig>,
+    pub tx_seq_by_digest: Option<PipelineConfig>,
+    pub tx_metadata_by_seq: Option<PipelineConfig>,
+    pub effects: Option<PipelineConfig>,
+    pub events: Option<PipelineConfig>,
+    pub objects: Option<PipelineConfig>,
+    pub object_version_by_checkpoint: Option<PipelineConfig>,
 
     // --- Indexes ---
-    pub object_by_owner: Option<CommitterLayer>,
-    pub object_by_type: Option<CommitterLayer>,
-    pub balance: Option<CommitterLayer>,
-    pub package_versions: Option<CommitterLayer>,
-    pub transaction_bitmap: Option<CommitterLayer>,
-    pub event_bitmap: Option<CommitterLayer>,
+    pub object_by_owner: Option<PipelineConfig>,
+    pub object_by_type: Option<PipelineConfig>,
+    pub balance: Option<PipelineConfig>,
+    pub package_versions: Option<PipelineConfig>,
+    pub transaction_bitmap: Option<PipelineConfig>,
+    pub event_bitmap: Option<PipelineConfig>,
+}
+
+/// Per-pipeline registration entry, under `[pipeline.<name>]`. An
+/// empty entry registers the pipeline with all-default settings.
+#[derive(Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PipelineConfig {
+    /// Committer overrides folded onto the shared `[committer]`
+    /// default.
+    pub committer: CommitterLayer,
+
+    /// Overrides the top-level `[availability]` default for this
+    /// pipeline. Read-side only: it does not affect whether the
+    /// pipeline indexes.
+    pub availability: Option<PipelineAvailability>,
 }
 
 /// Per-pipeline committer overrides. Every field is optional; an
@@ -210,36 +300,124 @@ impl ServiceConfig {
         Self {
             consistency: ConsistencyConfig::default(),
             committer: CommitterConfig::default().into(),
+            availability: None,
             pipeline: PipelineLayer::all(),
             pruner: Some(PrunerConfig::default()),
         }
     }
+
+    /// The resolved per-pipeline availability policies, for handing
+    /// to [`RpcStoreReader::with_availability`](crate::RpcStoreReader::with_availability).
+    pub fn availability_config(&self) -> AvailabilityConfig {
+        AvailabilityConfig {
+            default: self.availability,
+            pipelines: self.pipeline.availability_overrides(),
+        }
+    }
+}
+
+impl PipelineAvailability {
+    /// Whether a pipeline whose committed watermark is at
+    /// `committed` (`None` = no watermark yet) should be served,
+    /// given the current `tip` (the highest committed watermark
+    /// across all pipelines).
+    pub fn is_available(&self, committed: Option<u64>, tip: u64) -> bool {
+        match self {
+            Self::Enabled => true,
+            Self::Disabled => false,
+            Self::MaxCheckpointLag(lag) => committed.is_some_and(|c| tip.saturating_sub(c) <= *lag),
+        }
+    }
+}
+
+impl AvailabilityConfig {
+    /// The policy gating `pipeline`, if any: its own override when
+    /// configured, otherwise the default.
+    pub fn policy_for(&self, pipeline: &str) -> Option<PipelineAvailability> {
+        self.pipelines.get(pipeline).copied().or(self.default)
+    }
+
+    /// No policy configured anywhere — the reader's zero-cost fast
+    /// path.
+    pub fn is_trivial(&self) -> bool {
+        self.default.is_none() && self.pipelines.is_empty()
+    }
 }
 
 impl PipelineLayer {
-    /// Every pipeline enabled with default committer overrides
-    /// (`Some(CommitterLayer::default())`). The standalone-binary
+    /// Every pipeline enabled with default settings
+    /// (`Some(PipelineConfig::default())`). The standalone-binary
     /// default.
     pub fn all() -> Self {
         Self {
-            epochs: Some(CommitterLayer::default()),
-            checkpoint_summary: Some(CommitterLayer::default()),
-            checkpoint_contents: Some(CommitterLayer::default()),
-            checkpoint_seq_by_digest: Some(CommitterLayer::default()),
-            transactions: Some(CommitterLayer::default()),
-            tx_seq_by_digest: Some(CommitterLayer::default()),
-            tx_metadata_by_seq: Some(CommitterLayer::default()),
-            effects: Some(CommitterLayer::default()),
-            events: Some(CommitterLayer::default()),
-            objects: Some(CommitterLayer::default()),
-            object_version_by_checkpoint: Some(CommitterLayer::default()),
-            object_by_owner: Some(CommitterLayer::default()),
-            object_by_type: Some(CommitterLayer::default()),
-            balance: Some(CommitterLayer::default()),
-            package_versions: Some(CommitterLayer::default()),
-            transaction_bitmap: Some(CommitterLayer::default()),
-            event_bitmap: Some(CommitterLayer::default()),
+            epochs: Some(PipelineConfig::default()),
+            checkpoint_summary: Some(PipelineConfig::default()),
+            checkpoint_contents: Some(PipelineConfig::default()),
+            checkpoint_seq_by_digest: Some(PipelineConfig::default()),
+            transactions: Some(PipelineConfig::default()),
+            tx_seq_by_digest: Some(PipelineConfig::default()),
+            tx_metadata_by_seq: Some(PipelineConfig::default()),
+            effects: Some(PipelineConfig::default()),
+            events: Some(PipelineConfig::default()),
+            objects: Some(PipelineConfig::default()),
+            object_version_by_checkpoint: Some(PipelineConfig::default()),
+            object_by_owner: Some(PipelineConfig::default()),
+            object_by_type: Some(PipelineConfig::default()),
+            balance: Some(PipelineConfig::default()),
+            package_versions: Some(PipelineConfig::default()),
+            transaction_bitmap: Some(PipelineConfig::default()),
+            event_bitmap: Some(PipelineConfig::default()),
         }
+    }
+
+    /// Per-pipeline availability overrides, keyed by pipeline name.
+    /// Field idents match `Processor::NAME` for every pipeline
+    /// (pinned by `availability_override_keys_match_pipeline_names`).
+    fn availability_overrides(&self) -> BTreeMap<String, PipelineAvailability> {
+        // Exhaustive destructure so adding a pipeline field forces a
+        // decision here.
+        let Self {
+            epochs,
+            checkpoint_summary,
+            checkpoint_contents,
+            checkpoint_seq_by_digest,
+            transactions,
+            tx_seq_by_digest,
+            tx_metadata_by_seq,
+            effects,
+            events,
+            objects,
+            object_version_by_checkpoint,
+            object_by_owner,
+            object_by_type,
+            balance,
+            package_versions,
+            transaction_bitmap,
+            event_bitmap,
+        } = self;
+
+        [
+            ("epochs", epochs),
+            ("checkpoint_summary", checkpoint_summary),
+            ("checkpoint_contents", checkpoint_contents),
+            ("checkpoint_seq_by_digest", checkpoint_seq_by_digest),
+            ("transactions", transactions),
+            ("tx_seq_by_digest", tx_seq_by_digest),
+            ("tx_metadata_by_seq", tx_metadata_by_seq),
+            ("effects", effects),
+            ("events", events),
+            ("objects", objects),
+            ("object_version_by_checkpoint", object_version_by_checkpoint),
+            ("object_by_owner", object_by_owner),
+            ("object_by_type", object_by_type),
+            ("balance", balance),
+            ("package_versions", package_versions),
+            ("transaction_bitmap", transaction_bitmap),
+            ("event_bitmap", event_bitmap),
+        ]
+        .into_iter()
+        .filter_map(|(name, entry)| Some((name.to_string(), entry.as_ref()?.availability?)))
+        .collect()
     }
 
     /// The embedded-fullnode cohort: every pipeline this indexer owns
@@ -275,20 +453,20 @@ impl PipelineLayer {
     pub fn embedded() -> Self {
         Self {
             // Live cohort: restored to the tip, follows live.
-            object_by_owner: Some(CommitterLayer::default()),
-            object_by_type: Some(CommitterLayer::default()),
-            balance: Some(CommitterLayer::default()),
+            object_by_owner: Some(PipelineConfig::default()),
+            object_by_type: Some(PipelineConfig::default()),
+            balance: Some(PipelineConfig::default()),
             // History cohort: seeded to L, backfills upward.
             // `object_version_by_checkpoint` and `package_versions` are
             // additionally restored at the tip for their floor rows (see
             // the cohort docs in `restore.rs`).
-            epochs: Some(CommitterLayer::default()),
-            object_version_by_checkpoint: Some(CommitterLayer::default()),
-            package_versions: Some(CommitterLayer::default()),
-            tx_seq_by_digest: Some(CommitterLayer::default()),
-            tx_metadata_by_seq: Some(CommitterLayer::default()),
-            transaction_bitmap: Some(CommitterLayer::default()),
-            event_bitmap: Some(CommitterLayer::default()),
+            epochs: Some(PipelineConfig::default()),
+            object_version_by_checkpoint: Some(PipelineConfig::default()),
+            package_versions: Some(PipelineConfig::default()),
+            tx_seq_by_digest: Some(PipelineConfig::default()),
+            tx_metadata_by_seq: Some(PipelineConfig::default()),
+            transaction_bitmap: Some(PipelineConfig::default()),
+            event_bitmap: Some(PipelineConfig::default()),
             ..Self::default()
         }
     }
@@ -350,6 +528,41 @@ impl From<CommitterConfig> for CommitterLayer {
             write_concurrency: Some(config.write_concurrency),
             collect_interval_ms: Some(config.collect_interval_ms),
             watermark_interval_ms: Some(config.watermark_interval_ms),
+        }
+    }
+}
+
+impl TryFrom<AvailabilityLayer> for PipelineAvailability {
+    type Error = String;
+
+    fn try_from(layer: AvailabilityLayer) -> Result<Self, Self::Error> {
+        match (layer.enabled, layer.max_checkpoint_lag) {
+            (Some(_), Some(_)) => {
+                Err("'enabled' and 'max-checkpoint-lag' are mutually exclusive".to_string())
+            }
+            (Some(true), None) => Ok(Self::Enabled),
+            (Some(false), None) => Ok(Self::Disabled),
+            (None, Some(lag)) => Ok(Self::MaxCheckpointLag(lag)),
+            (None, None) => Err("expected 'enabled' or 'max-checkpoint-lag'".to_string()),
+        }
+    }
+}
+
+impl From<PipelineAvailability> for AvailabilityLayer {
+    fn from(value: PipelineAvailability) -> Self {
+        match value {
+            PipelineAvailability::Enabled => Self {
+                enabled: Some(true),
+                max_checkpoint_lag: None,
+            },
+            PipelineAvailability::Disabled => Self {
+                enabled: Some(false),
+                max_checkpoint_lag: None,
+            },
+            PipelineAvailability::MaxCheckpointLag(lag) => Self {
+                enabled: None,
+                max_checkpoint_lag: Some(lag),
+            },
         }
     }
 }
@@ -437,5 +650,211 @@ mod tests {
         // Unset fields inherit from `base`.
         assert_eq!(merged.collect_interval_ms, 200);
         assert_eq!(merged.watermark_interval_ms, 500);
+    }
+
+    #[test]
+    fn availability_within_tip_respects_lag() {
+        let a = PipelineAvailability::MaxCheckpointLag(100);
+        // At the tip, and exactly at the lag boundary (inclusive), are available.
+        assert!(a.is_available(Some(1_000_000), 1_000_000));
+        assert!(a.is_available(Some(999_900), 1_000_000));
+        // One checkpoint beyond the lag budget is unavailable.
+        assert!(!a.is_available(Some(999_899), 1_000_000));
+        // A watermark momentarily ahead of the recorded tip saturates to zero lag.
+        assert!(a.is_available(Some(1_000_050), 1_000_000));
+        // No watermark yet ⇒ not caught up ⇒ unavailable.
+        assert!(!a.is_available(None, 1_000_000));
+    }
+
+    #[test]
+    fn enabled_and_disabled_ignore_lag() {
+        assert!(PipelineAvailability::Enabled.is_available(None, 1_000_000));
+        assert!(!PipelineAvailability::Disabled.is_available(Some(1_000_000), 1_000_000));
+    }
+
+    #[test]
+    fn availability_default_and_overrides_parse_from_toml() {
+        let config: ServiceConfig = toml::from_str(
+            r#"
+            [availability]
+            max-checkpoint-lag = 100
+
+            [pipeline.balance.availability]
+            enabled = false
+
+            [pipeline.object-by-owner.availability]
+            enabled = true
+
+            [pipeline.epochs.availability]
+            max-checkpoint-lag = 1000
+            "#,
+        )
+        .unwrap();
+
+        let availability = config.availability_config();
+        assert_eq!(
+            availability.policy_for("balance"),
+            Some(PipelineAvailability::Disabled)
+        );
+        assert_eq!(
+            availability.policy_for("object_by_owner"),
+            Some(PipelineAvailability::Enabled)
+        );
+        assert_eq!(
+            availability.policy_for("epochs"),
+            Some(PipelineAvailability::MaxCheckpointLag(1000))
+        );
+        // A pipeline with no override falls back to the default.
+        assert_eq!(
+            availability.policy_for("object_by_type"),
+            Some(PipelineAvailability::MaxCheckpointLag(100))
+        );
+    }
+
+    #[test]
+    fn overrides_without_a_default_gate_only_themselves() {
+        let config: ServiceConfig = toml::from_str(
+            r#"
+            [pipeline.balance.availability]
+            enabled = false
+            "#,
+        )
+        .unwrap();
+
+        let availability = config.availability_config();
+        assert_eq!(
+            availability.policy_for("balance"),
+            Some(PipelineAvailability::Disabled)
+        );
+        assert_eq!(availability.policy_for("object_by_owner"), None);
+        assert!(!availability.is_trivial());
+        assert!(ServiceConfig::default().availability_config().is_trivial());
+    }
+
+    #[test]
+    fn availability_enabled_and_lag_are_mutually_exclusive() {
+        let err = toml::from_str::<ServiceConfig>(
+            r#"
+            [pipeline.balance.availability]
+            enabled = true
+            max-checkpoint-lag = 100
+            "#,
+        )
+        .err()
+        .unwrap();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn empty_availability_sections_are_rejected() {
+        // A policy section exists only to set a policy, so one of its keys is mandatory.
+        for toml in ["[availability]", "[pipeline.balance.availability]"] {
+            let err = toml::from_str::<ServiceConfig>(toml).err().unwrap();
+            assert!(
+                err.to_string()
+                    .contains("expected 'enabled' or 'max-checkpoint-lag'"),
+                "unexpected error for {toml:?}: {err}",
+            );
+        }
+    }
+
+    #[test]
+    fn availability_sections_reject_unknown_fields() {
+        for toml in [
+            "[availability]\nmode = \"off\"",
+            "[pipeline.balance]\nmode = \"off\"",
+            "[pipeline.balance.availability]\nenabled = true\nmode = \"off\"",
+            // Old flat committer keys must fail loudly now that they nest
+            // under `[pipeline.<name>.committer]`.
+            "[pipeline.balance]\nwrite-concurrency = 4",
+            // Misspelled pipeline names are no longer silently ignored.
+            "[pipeline.balanec]\n",
+        ] {
+            let result = toml::from_str::<ServiceConfig>(toml);
+            assert!(result.is_err(), "expected {toml:?} to be rejected");
+        }
+    }
+
+    #[test]
+    fn nested_committer_overrides_still_merge() {
+        let config: ServiceConfig = toml::from_str(
+            r#"
+            [pipeline.balance.committer]
+            write-concurrency = 8
+            "#,
+        )
+        .unwrap();
+        let merged = config
+            .pipeline
+            .balance
+            .unwrap()
+            .committer
+            .finish(CommitterConfig::default());
+        assert_eq!(merged.write_concurrency, 8);
+    }
+
+    #[test]
+    fn empty_pipeline_section_registers_with_defaults_and_no_policy() {
+        let config: ServiceConfig = toml::from_str("[pipeline.balance]").unwrap();
+        assert!(config.pipeline.balance.is_some());
+        assert!(config.availability_config().is_trivial());
+    }
+
+    #[test]
+    fn availability_policies_roundtrip_through_toml() {
+        for policy in [
+            PipelineAvailability::Enabled,
+            PipelineAvailability::Disabled,
+            PipelineAvailability::MaxCheckpointLag(100),
+        ] {
+            let config = ServiceConfig {
+                availability: Some(policy),
+                ..ServiceConfig::default()
+            };
+            let serialized = toml::to_string_pretty(&config).unwrap();
+            let parsed: ServiceConfig = toml::from_str(&serialized).unwrap();
+            assert_eq!(
+                parsed.availability,
+                Some(policy),
+                "roundtrip failed for {policy:?}:\n{serialized}",
+            );
+        }
+    }
+
+    #[test]
+    fn availability_override_keys_match_pipeline_names() {
+        let mut layer = PipelineLayer::all();
+        for entry in [
+            &mut layer.epochs,
+            &mut layer.checkpoint_summary,
+            &mut layer.checkpoint_contents,
+            &mut layer.checkpoint_seq_by_digest,
+            &mut layer.transactions,
+            &mut layer.tx_seq_by_digest,
+            &mut layer.tx_metadata_by_seq,
+            &mut layer.effects,
+            &mut layer.events,
+            &mut layer.objects,
+            &mut layer.object_version_by_checkpoint,
+            &mut layer.object_by_owner,
+            &mut layer.object_by_type,
+            &mut layer.balance,
+            &mut layer.package_versions,
+            &mut layer.transaction_bitmap,
+            &mut layer.event_bitmap,
+        ] {
+            entry.as_mut().unwrap().availability = Some(PipelineAvailability::Enabled);
+        }
+
+        let keys: std::collections::BTreeSet<_> =
+            layer.availability_overrides().into_keys().collect();
+        let names: std::collections::BTreeSet<_> = crate::indexer::restore::ALL_PIPELINES
+            .iter()
+            .map(|n| n.to_string())
+            .collect();
+        assert_eq!(keys, names);
     }
 }

--- a/crates/sui-rpc-store/src/indexer/mod.rs
+++ b/crates/sui-rpc-store/src/indexer/mod.rs
@@ -385,13 +385,16 @@ impl Indexer {
             event_bitmap,
         } = layer;
 
+        // `entry.availability` is deliberately unused here: it is a
+        // read-side serving policy consumed by the reader, orthogonal
+        // to registration — a gated pipeline keeps indexing.
         macro_rules! add {
             ($handler:expr, $cfg:expr) => {
-                if let Some(layer) = $cfg {
+                if let Some(entry) = $cfg {
                     self.sequential_pipeline(
                         $handler,
                         SequentialConfig {
-                            committer: layer.finish(committer.clone()),
+                            committer: entry.committer.finish(committer.clone()),
                             // The synchronizer requires one
                             // checkpoint per write batch; folding
                             // multiple checkpoints into one batch
@@ -756,7 +759,7 @@ mod tests {
         let err = indexer
             .add_pipelines(
                 PipelineLayer {
-                    balance: Some(crate::config::CommitterLayer::default()),
+                    balance: Some(crate::config::PipelineConfig::default()),
                     ..PipelineLayer::default()
                 },
                 CommitterConfig::default(),
@@ -783,7 +786,7 @@ mod tests {
         indexer
             .add_pipelines(
                 PipelineLayer {
-                    balance: Some(crate::config::CommitterLayer::default()),
+                    balance: Some(crate::config::PipelineConfig::default()),
                     ..PipelineLayer::default()
                 },
                 CommitterConfig::default(),

--- a/crates/sui-rpc-store/src/indexer/restore.rs
+++ b/crates/sui-rpc-store/src/indexer/restore.rs
@@ -115,6 +115,31 @@ pub const HISTORY_COHORT: &[&str] = &[
     EventBitmap::NAME,
 ];
 
+/// Every rpc-store pipeline. Kept exhaustive so any new pipeline
+/// added to [`PipelineLayer`](crate::config::PipelineLayer) needs an
+/// explicit decision about restore behaviour (in
+/// [`floor_unrestored_pipelines`]) and gets a stable name for
+/// availability policies.
+pub const ALL_PIPELINES: &[&str] = &[
+    Epochs::NAME,
+    CheckpointSummary::NAME,
+    CheckpointContents::NAME,
+    CheckpointSeqByDigest::NAME,
+    Transactions::NAME,
+    TxSeqByDigest::NAME,
+    TxMetadataBySeq::NAME,
+    Effects::NAME,
+    Events::NAME,
+    Objects::NAME,
+    ObjectVersionByCheckpoint::NAME,
+    ObjectByOwner::NAME,
+    ObjectByType::NAME,
+    Balance::NAME,
+    PackageVersions::NAME,
+    TransactionBitmap::NAME,
+    EventBitmap::NAME,
+];
+
 /// Register every [`Restore`]-implementing pipeline opted in by
 /// `layer` on a [`RestoreDriver`] bound to `db` / `schema` and
 /// `source`, then run the resulting [`Service`].
@@ -208,36 +233,12 @@ pub fn floor_unrestored_pipelines(
         ]
     };
 
-    // Every rpc-store pipeline. Kept exhaustive so any new
-    // pipeline added to `PipelineLayer` needs an explicit
-    // decision here about whether it's a restore-time pipeline
-    // or a tip-only one.
-    let all: &[&'static str] = &[
-        Epochs::NAME,
-        CheckpointSummary::NAME,
-        CheckpointContents::NAME,
-        CheckpointSeqByDigest::NAME,
-        Transactions::NAME,
-        TxSeqByDigest::NAME,
-        TxMetadataBySeq::NAME,
-        Effects::NAME,
-        Events::NAME,
-        Objects::NAME,
-        ObjectVersionByCheckpoint::NAME,
-        ObjectByOwner::NAME,
-        ObjectByType::NAME,
-        Balance::NAME,
-        PackageVersions::NAME,
-        TransactionBitmap::NAME,
-        EventBitmap::NAME,
-    ];
-
     // Use the owned `FrameworkSchema` over `Db` (rather than the
     // borrowed view from `Db::framework`) so the `DbMap`s line up
     // with `Batch::put`'s `R = Db` expectation.
     let framework = FrameworkSchema::new(db.clone());
     let mut batch = db.batch();
-    for name in all.iter().filter(|n| !restored.contains(n)) {
+    for name in ALL_PIPELINES.iter().filter(|n| !restored.contains(n)) {
         let key = PipelineTaskKey::new(*name);
         batch
             .put(&framework.watermarks, &key, &target_watermark)

--- a/crates/sui-rpc-store/src/lib.rs
+++ b/crates/sui-rpc-store/src/lib.rs
@@ -38,8 +38,12 @@ use sui_indexer_alt_framework::metrics::IngestionMetrics;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::service::Service;
 
+pub use crate::config::AvailabilityConfig;
+pub use crate::config::AvailabilityLayer;
 pub use crate::config::CommitterLayer;
 pub use crate::config::ConsistencyConfig;
+pub use crate::config::PipelineAvailability;
+pub use crate::config::PipelineConfig;
 pub use crate::config::PipelineLayer;
 pub use crate::config::PrunerConfig;
 pub use crate::config::RestoreLayer;

--- a/crates/sui-rpc-store/src/reader/indexes.rs
+++ b/crates/sui-rpc-store/src/reader/indexes.rs
@@ -32,9 +32,18 @@ use sui_types::storage::RpcIndexes;
 /// `sui_types::storage::read_store::PackageVersionsIterator`.
 type PackageVersionsIterator<'a> =
     Box<dyn Iterator<Item = Result<(u64, ObjectID), TypedStoreError>> + 'a>;
+use sui_indexer_alt_framework::pipeline::Processor;
 use sui_types::storage::error::Result as StorageResult;
 use typed_store_error::TypedStoreError;
 
+use crate::indexer::balance::Balance;
+use crate::indexer::epochs::Epochs;
+use crate::indexer::event_bitmap::EventBitmap;
+use crate::indexer::object_by_owner::ObjectByOwner;
+use crate::indexer::object_by_type::ObjectByType;
+use crate::indexer::package_versions::PackageVersions;
+use crate::indexer::transaction_bitmap::TransactionBitmap;
+use crate::indexer::tx_metadata_by_seq::TxMetadataBySeq;
 use crate::reader::RpcStoreReader;
 use crate::schema::type_filter::TypeFilter;
 
@@ -69,6 +78,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         &self,
         epoch: sui_types::committee::EpochId,
     ) -> StorageResult<Option<EpochInfo>> {
+        self.require_pipelines(&[Epochs::NAME])?;
         self.schema()
             .get_epoch(epoch)
             .map_err(sui_types::storage::error::Error::custom)
@@ -81,6 +91,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         cursor: Option<OwnedObjectInfo>,
     ) -> StorageResult<Box<dyn Iterator<Item = Result<OwnedObjectInfo, TypedStoreError>> + '_>>
     {
+        self.require_pipelines(&[ObjectByOwner::NAME])?;
         use crate::schema::object_by_owner::{Key, OwnerKind};
         let map = &self.schema().object_by_owner;
         let kind = OwnerKind::AddressOwner(owner);
@@ -122,6 +133,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         parent: ObjectID,
         cursor: Option<DynamicFieldKey>,
     ) -> StorageResult<Box<dyn Iterator<Item = DynamicFieldIteratorItem> + '_>> {
+        self.require_pipelines(&[ObjectByOwner::NAME])?;
         use crate::schema::object_by_owner::{Key, OwnerKind};
         // Dynamic fields are `Field<Name, Value>` objects owned (in the
         // object-owner sense) by `parent`, so they share the `object_by_owner`
@@ -156,6 +168,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
     }
 
     fn get_coin_info(&self, coin_type: &StructTag) -> StorageResult<Option<CoinInfo>> {
+        self.require_pipelines(&[ObjectByType::NAME])?;
         // Coin metadata / treasury cap / regulated coin metadata
         // are typed objects whose Move type wraps the requested
         // `coin_type`. Discover each via an `object_by_type`
@@ -191,6 +204,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         owner: &SuiAddress,
         coin_type: &StructTag,
     ) -> StorageResult<Option<BalanceInfo>> {
+        self.require_pipelines(&[Balance::NAME])?;
         let balance = self
             .schema()
             .get_balance(*owner, coin_type.clone().into())
@@ -210,6 +224,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         owner: &SuiAddress,
         cursor: Option<(SuiAddress, StructTag)>,
     ) -> StorageResult<BalanceIterator<'_>> {
+        self.require_pipelines(&[Balance::NAME])?;
         use crate::schema::balance::{Key, OwnerPrefix};
         let map = &self.schema().balance;
         // When resuming, the page token carries the cursor's coin type -- the
@@ -260,6 +275,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         original_id: ObjectID,
         cursor: Option<u64>,
     ) -> StorageResult<PackageVersionsIterator<'_>> {
+        self.require_pipelines(&[PackageVersions::NAME])?;
         use crate::schema::package_versions::{Key, OriginalIdPrefix};
         // The cursor passed in by `list_package_versions` is the version of the
         // first row of the next page (the previous page popped its
@@ -296,17 +312,33 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
     ) -> StorageResult<Option<CheckpointSequenceNumber>> {
         // Min across all registered pipeline watermarks: every CF
         // has caught up to at least this checkpoint, so reads
-        // against any of them are coherent through here.
+        // against any of them are coherent through here. Pipelines
+        // gated by the availability policy are excluded — their
+        // reads fail as unavailable, so they must not pin this
+        // bound. The tip for lag policies is the MAX over all rows
+        // (including gated ones) to keep the reference stable.
         let framework = sui_consistent_store::FrameworkSchema::new(self.db().clone());
-        let mut min: Option<u64> = None;
+        let mut rows: Vec<(String, u64)> = Vec::new();
         for entry in framework
             .watermarks
             .iter(..)
             .map_err(sui_types::storage::error::Error::custom)?
         {
-            let (_, watermark) = entry.map_err(sui_types::storage::error::Error::custom)?;
-            let hi = watermark.checkpoint_hi_inclusive;
-            min = Some(min.map_or(hi, |m| m.min(hi)));
+            let (key, watermark) = entry.map_err(sui_types::storage::error::Error::custom)?;
+            rows.push((key.0, watermark.checkpoint_hi_inclusive));
+        }
+
+        let tip = rows.iter().map(|(_, hi)| *hi).max().unwrap_or(0);
+        let mut min: Option<u64> = None;
+        for (name, hi) in &rows {
+            let available = match self.availability.policy_for(name) {
+                None => true,
+                Some(policy) => policy.is_available(Some(*hi), tip),
+            };
+            if !available {
+                continue;
+            }
+            min = Some(min.map_or(*hi, |m| m.min(*hi)));
         }
         Ok(min)
     }
@@ -321,6 +353,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
     }
 
     fn ledger_tx_seq_digest(&self, tx_seq: u64) -> StorageResult<Option<LedgerTxSeqDigest>> {
+        self.require_pipelines(&[TxMetadataBySeq::NAME])?;
         let meta = self
             .schema()
             .get_tx_metadata_by_seq(tx_seq)
@@ -340,6 +373,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         end_exclusive: u64,
         descending: bool,
     ) -> StorageResult<LedgerTxSeqDigestIterator<'_>> {
+        self.require_pipelines(&[TxMetadataBySeq::NAME])?;
         use crate::schema::primitives::U64Be;
         let range = (
             Bound::Included(U64Be(start)),
@@ -383,6 +417,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         end_bucket_exclusive: u64,
         descending: bool,
     ) -> StorageResult<LedgerBitmapBucketIterator<'_>> {
+        self.require_pipelines(&[TransactionBitmap::NAME])?;
         let map = &self.schema().transaction_bitmap;
         let lower = crate::schema::transaction_bitmap::Key {
             dimension_key: dimension_key.clone(),
@@ -412,6 +447,7 @@ impl<R: Reader + Send + Sync> RpcIndexes for RpcStoreReader<R> {
         end_bucket_exclusive: u64,
         descending: bool,
     ) -> StorageResult<LedgerBitmapBucketIterator<'_>> {
+        self.require_pipelines(&[EventBitmap::NAME])?;
         let map = &self.schema().event_bitmap;
         let lower = crate::schema::event_bitmap::Key {
             dimension_key: dimension_key.clone(),
@@ -496,6 +532,103 @@ mod tests {
         let (db, schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
         let reader = RpcStoreReader::new(db.clone(), Arc::new(schema));
         (dir, db, reader)
+    }
+
+    #[test]
+    fn gated_index_reads_return_unavailable() {
+        use crate::config::PipelineAvailability;
+        use crate::reader::{availability, seed_watermark};
+        use sui_types::storage::error::Kind;
+
+        let (_dir, db, reader) = setup();
+        // `object_by_owner` is at the tip; `balance` lags it by 100.
+        seed_watermark(&db, "object_by_owner", 200);
+        seed_watermark(&db, "balance", 100);
+
+        let reader = reader.with_availability(availability(
+            Some(PipelineAvailability::MaxCheckpointLag(50)),
+            &[
+                ("balance", PipelineAvailability::Enabled),
+                ("object_by_type", PipelineAvailability::Disabled),
+            ],
+        ));
+
+        // Disabled override.
+        let err = reader.get_coin_info(&a_type()).unwrap_err();
+        assert_eq!(err.kind(), Kind::Unavailable);
+
+        // Lag default gates a pipeline with no watermark (`epochs`).
+        let err = reader.get_epoch_info(0).unwrap_err();
+        assert_eq!(err.kind(), Kind::Unavailable);
+
+        // The tip pipeline is within any lag budget of itself.
+        assert!(
+            reader
+                .owned_objects_iter(sui_types::base_types::SuiAddress::ZERO, None, None)
+                .is_ok()
+        );
+
+        // Enabled override exempts `balance` from the lag default it would
+        // otherwise fail (it is 100 behind, budget 50).
+        assert!(
+            reader
+                .get_balance(&sui_types::base_types::SuiAddress::ZERO, &a_type())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn highest_indexed_excludes_gated_rows() {
+        use crate::config::PipelineAvailability;
+        use crate::reader::{availability, seed_watermark};
+
+        let (_dir, db, reader) = setup();
+        seed_watermark(&db, "object_by_owner", 100);
+        seed_watermark(&db, "epochs", 40);
+
+        // Ungated: the MIN across all rows.
+        assert_eq!(
+            reader.get_highest_indexed_checkpoint_seq_number().unwrap(),
+            Some(40)
+        );
+
+        // Disabling the laggard advances the bound.
+        let gated = reader.clone().with_availability(availability(
+            None,
+            &[("epochs", PipelineAvailability::Disabled)],
+        ));
+        assert_eq!(
+            gated.get_highest_indexed_checkpoint_seq_number().unwrap(),
+            Some(100)
+        );
+
+        // Lag boundary: 60 keeps the laggard (tip 100, distance 60), 59 drops it.
+        let within = reader.clone().with_availability(availability(
+            Some(PipelineAvailability::MaxCheckpointLag(60)),
+            &[],
+        ));
+        assert_eq!(
+            within.get_highest_indexed_checkpoint_seq_number().unwrap(),
+            Some(40)
+        );
+        let beyond = reader.clone().with_availability(availability(
+            Some(PipelineAvailability::MaxCheckpointLag(59)),
+            &[],
+        ));
+        assert_eq!(
+            beyond.get_highest_indexed_checkpoint_seq_number().unwrap(),
+            Some(100)
+        );
+
+        // Every row gated ⇒ no available index data.
+        let all_gated =
+            reader.with_availability(availability(Some(PipelineAvailability::Disabled), &[]));
+        assert_eq!(
+            all_gated
+                .get_highest_indexed_checkpoint_seq_number()
+                .unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/sui-rpc-store/src/reader/layout.rs
+++ b/crates/sui-rpc-store/src/reader/layout.rs
@@ -33,6 +33,7 @@ use move_core_types::annotated_value::MoveTypeLayout;
 use move_core_types::language_storage::StructTag;
 use sui_consistent_store::FrameworkSchema;
 use sui_consistent_store::reader::Reader;
+use sui_indexer_alt_framework::pipeline::Processor;
 use sui_protocol_config::ProtocolConfig;
 use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::ObjectID;
@@ -64,6 +65,14 @@ impl<R: Reader + Send + Sync> RpcStoreReader<R> {
         struct_tag: &StructTag,
         overlay: &ObjectSet,
     ) -> StorageResult<Option<MoveTypeLayout>> {
+        // Layouts read package objects (via `objects`) and the protocol
+        // version (via `epochs`); an error rather than `Ok(None)` lets
+        // clients distinguish "gated" from "layout unknown".
+        self.require_pipelines(&[
+            crate::indexer::objects::Objects::NAME,
+            crate::indexer::epochs::Epochs::NAME,
+        ])?;
+
         let Some(protocol_config) = self.live_protocol_config()? else {
             return Ok(None);
         };

--- a/crates/sui-rpc-store/src/reader/mod.rs
+++ b/crates/sui-rpc-store/src/reader/mod.rs
@@ -32,11 +32,20 @@ mod state_reader;
 use std::sync::Arc;
 
 use sui_consistent_store::Db;
+use sui_consistent_store::FrameworkSchema;
+use sui_consistent_store::PipelineTaskKey;
 use sui_consistent_store::SchemaAtSnapshot;
 use sui_consistent_store::Snapshot;
 use sui_consistent_store::reader::Reader;
+use sui_types::storage::error::Error as StorageError;
+use sui_types::storage::error::Kind as StorageErrorKind;
+use sui_types::storage::error::Result as StorageResult;
+use tracing::debug;
+use tracing::error;
 
 use crate::RpcStoreSchema;
+use crate::config::AvailabilityConfig;
+use crate::config::PipelineAvailability;
 
 /// Adapter exposing [`RpcStoreSchema`] through the
 /// `sui-rpc-api` reader-trait stack.
@@ -63,6 +72,10 @@ pub struct RpcStoreReader<R: Reader = Db> {
 
     /// Typed handles to every CF the read paths exercise.
     schema: Arc<RpcStoreSchema<R>>,
+
+    /// Per-pipeline serving policies. Trivial by default (every
+    /// read served); see [`Self::with_availability`].
+    availability: Arc<AvailabilityConfig>,
 }
 
 impl<R: Reader> RpcStoreReader<R> {
@@ -72,8 +85,27 @@ impl<R: Reader> RpcStoreReader<R> {
     /// Holding both separately is cheap (each is `Arc`-backed) and
     /// avoids a `schema.epochs.reader().db()` style detour inside
     /// hot read paths.
+    ///
+    /// The reader starts with a trivial availability policy (every
+    /// read served) — internal bootstrap readers (e.g. the one
+    /// `seed_current_epoch_start` builds during restore) rely on
+    /// this. Serving deployments opt in via
+    /// [`Self::with_availability`].
     pub fn new(db: Db, schema: Arc<RpcStoreSchema<R>>) -> Self {
-        Self { db, schema }
+        Self {
+            db,
+            schema,
+            availability: Arc::new(AvailabilityConfig::default()),
+        }
+    }
+
+    /// Apply per-pipeline serving policies (see
+    /// [`PipelineAvailability`]): reads that need a gated pipeline
+    /// fail with an unavailable error, and gated pipelines are
+    /// excluded from the cross-pipeline watermark bounds.
+    pub fn with_availability(mut self, availability: AvailabilityConfig) -> Self {
+        self.availability = Arc::new(availability);
+        self
     }
 
     /// Borrow the underlying [`Db`] handle. Used by trait impls
@@ -99,19 +131,32 @@ impl<R: Reader> RpcStoreReader<R> {
     /// executed tip and bounds the checkpoint at which the live-object index
     /// surface is readable. The history cohort backfills independently and is
     /// deliberately excluded here -- its availability is exposed separately.
+    ///
+    /// Pipelines gated by the availability policy are excluded from the MIN
+    /// so they stop pinning the reported tip (their reads fail as unavailable
+    /// instead), and a gated pipeline with no watermark no longer forces
+    /// `None`. `Ok(None)` — including the every-live-pipeline-gated case — is
+    /// the "no available index data" signal consumers already handle.
     pub fn highest_live_committed_checkpoint(
         &self,
-    ) -> sui_types::storage::error::Result<
-        Option<sui_types::messages_checkpoint::CheckpointSequenceNumber>,
-    > {
+    ) -> StorageResult<Option<sui_types::messages_checkpoint::CheckpointSequenceNumber>> {
+        let tip = if self.availability.is_trivial() {
+            None
+        } else {
+            self.watermark_tip()?
+        };
+
         let framework = self.db().framework();
         let mut min_hi: Option<u64> = None;
         for name in crate::LIVE_COHORT {
-            let key = sui_consistent_store::PipelineTaskKey::new(*name);
+            if !self.pipeline_available(name, tip)? {
+                continue;
+            }
+            let key = PipelineTaskKey::new(*name);
             let Some(watermark) = framework
                 .watermarks
                 .get(&key)
-                .map_err(sui_types::storage::error::Error::custom)?
+                .map_err(StorageError::custom)?
             else {
                 return Ok(None);
             };
@@ -119,6 +164,113 @@ impl<R: Reader> RpcStoreReader<R> {
             min_hi = Some(min_hi.map_or(hi, |m| m.min(hi)));
         }
         Ok(min_hi)
+    }
+
+    /// Tip approximation for lag policies: the highest committed watermark
+    /// across all registered pipelines, or `None` on a store with no
+    /// watermarks yet. Equal to the node's executed tip when a tip-following
+    /// pipeline is registered, and the fastest pipeline otherwise.
+    fn watermark_tip(&self) -> StorageResult<Option<u64>> {
+        // The owned `FrameworkSchema` over `Db`: iteration always reads the
+        // tip axis, even for snapshot-bound readers.
+        let framework = FrameworkSchema::new(self.db().clone());
+        let mut max: Option<u64> = None;
+        for entry in framework
+            .watermarks
+            .iter(..)
+            .map_err(StorageError::custom)?
+        {
+            let (_, watermark) = entry.map_err(StorageError::custom)?;
+            let hi = watermark.checkpoint_hi_inclusive;
+            max = Some(max.map_or(hi, |m| m.max(hi)));
+        }
+        Ok(max)
+    }
+
+    /// The committed watermark for one pipeline, `None` if it has none yet.
+    fn committed_checkpoint(&self, pipeline: &str) -> StorageResult<Option<u64>> {
+        let framework = self.db().framework();
+        Ok(framework
+            .watermarks
+            .get(&PipelineTaskKey::new(pipeline))
+            .map_err(StorageError::custom)?
+            .map(|w| w.checkpoint_hi_inclusive))
+    }
+
+    /// Whether `pipeline` may be served, given the memoized watermark `tip`
+    /// (`None` = no watermarks in the store).
+    fn pipeline_available(&self, pipeline: &str, tip: Option<u64>) -> StorageResult<bool> {
+        let Some(policy) = self.availability.policy_for(pipeline) else {
+            return Ok(true);
+        };
+        let committed = match policy {
+            PipelineAvailability::MaxCheckpointLag(_) => self.committed_checkpoint(pipeline)?,
+            _ => None,
+        };
+        Ok(policy.is_available(committed, tip.unwrap_or(0)))
+    }
+
+    /// `Err(Kind::Unavailable)` unless every named pipeline may be served
+    /// under the configured availability policy. Zero-cost when no policy is
+    /// configured; the tip is computed only when a named pipeline has a lag
+    /// policy.
+    pub(crate) fn require_pipelines(&self, pipelines: &[&str]) -> StorageResult<()> {
+        if self.availability.is_trivial() {
+            return Ok(());
+        }
+
+        let mut memo_tip: Option<Option<u64>> = None;
+        for name in pipelines {
+            match self.availability.policy_for(name) {
+                None | Some(PipelineAvailability::Enabled) => {}
+                Some(PipelineAvailability::Disabled) => {
+                    return Err(StorageError::unavailable(format!(
+                        "pipeline {name} is disabled by config"
+                    )));
+                }
+                Some(policy @ PipelineAvailability::MaxCheckpointLag(lag)) => {
+                    let tip = match memo_tip {
+                        Some(tip) => tip,
+                        None => *memo_tip.insert(self.watermark_tip()?),
+                    }
+                    .unwrap_or(0);
+                    let committed = self.committed_checkpoint(name)?;
+                    if !policy.is_available(committed, tip) {
+                        return Err(StorageError::unavailable(match committed {
+                            Some(committed) => format!(
+                                "pipeline {name} is {} checkpoints behind the tip \
+                                 ({committed} < {tip}, max-checkpoint-lag {lag})",
+                                tip.saturating_sub(committed),
+                            ),
+                            None => format!(
+                                "pipeline {name} has no committed watermark yet \
+                                 (max-checkpoint-lag {lag})"
+                            ),
+                        }));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Gate for `Option`-returning trait methods, which cannot carry an
+    /// error: `false` means the caller must return `None` rather than serve
+    /// data from a gated pipeline. Storage errors while evaluating the
+    /// policy also gate (and are logged), matching this module's
+    /// error-suppression convention for `Option` reads.
+    pub(crate) fn pipelines_available(&self, pipelines: &[&str]) -> bool {
+        match self.require_pipelines(pipelines) {
+            Ok(()) => true,
+            Err(e) if e.kind() == StorageErrorKind::Unavailable => {
+                debug!("withholding read: {e}");
+                false
+            }
+            Err(e) => {
+                error!("failed to evaluate availability policy for {pipelines:?}: {e:?}");
+                false
+            }
+        }
     }
 }
 
@@ -134,6 +286,7 @@ impl RpcStoreReader<Db> {
         RpcStoreReader {
             db: self.db.clone(),
             schema: Arc::new(self.schema.at(snap)),
+            availability: self.availability.clone(),
         }
     }
 }
@@ -143,7 +296,40 @@ impl<R: Reader> Clone for RpcStoreReader<R> {
         Self {
             db: self.db.clone(),
             schema: self.schema.clone(),
+            availability: self.availability.clone(),
         }
+    }
+}
+
+/// Test helper: write a committed watermark row for `pipeline`, the
+/// way the framework does after a batch commits.
+#[cfg(test)]
+pub(crate) fn seed_watermark(db: &Db, pipeline: &str, checkpoint_hi: u64) {
+    let framework = FrameworkSchema::new(db.clone());
+    let mut batch = db.batch();
+    batch
+        .put(
+            &framework.watermarks,
+            &PipelineTaskKey::new(pipeline),
+            &sui_consistent_store::Watermark::for_checkpoint(checkpoint_hi),
+        )
+        .unwrap();
+    batch.commit().unwrap();
+}
+
+/// Test helper: an [`AvailabilityConfig`] from a default policy and
+/// per-pipeline overrides.
+#[cfg(test)]
+pub(crate) fn availability(
+    default: Option<PipelineAvailability>,
+    overrides: &[(&str, PipelineAvailability)],
+) -> AvailabilityConfig {
+    AvailabilityConfig {
+        default,
+        pipelines: overrides
+            .iter()
+            .map(|(name, policy)| (name.to_string(), *policy))
+            .collect(),
     }
 }
 
@@ -152,6 +338,15 @@ mod tests {
     use sui_consistent_store::DbOptions;
 
     use super::*;
+
+    fn live_reader(watermarks: &[(&str, u64)]) -> (tempfile::TempDir, RpcStoreReader) {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, schema) = Db::open::<RpcStoreSchema>(dir.path(), DbOptions::default()).unwrap();
+        for (name, hi) in watermarks {
+            seed_watermark(&db, name, *hi);
+        }
+        (dir, RpcStoreReader::new(db, Arc::new(schema)))
+    }
 
     #[test]
     fn new_binds_db_and_schema() {
@@ -180,6 +375,151 @@ mod tests {
                 .get_pruning_watermarks()
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn live_min_is_min_across_cohort_without_policies() {
+        let (_dir, reader) = live_reader(&[
+            ("object_by_owner", 100),
+            ("object_by_type", 90),
+            ("balance", 50),
+        ]);
+        assert_eq!(
+            reader.highest_live_committed_checkpoint().unwrap(),
+            Some(50)
+        );
+    }
+
+    #[test]
+    fn live_min_excludes_disabled_pipeline() {
+        let (_dir, reader) = live_reader(&[
+            ("object_by_owner", 100),
+            ("object_by_type", 90),
+            ("balance", 50),
+        ]);
+        let gated = reader.with_availability(availability(
+            None,
+            &[("balance", PipelineAvailability::Disabled)],
+        ));
+        assert_eq!(gated.highest_live_committed_checkpoint().unwrap(), Some(90));
+    }
+
+    #[test]
+    fn live_min_excludes_lag_gated_pipeline() {
+        // The tip is the highest watermark across all rows (100); `balance`
+        // lags it by 50 checkpoints.
+        let (_dir, reader) = live_reader(&[
+            ("object_by_owner", 100),
+            ("object_by_type", 90),
+            ("balance", 50),
+        ]);
+
+        // A budget of 50 keeps it (lag boundary inclusive).
+        let within = reader.clone().with_availability(availability(
+            Some(PipelineAvailability::MaxCheckpointLag(50)),
+            &[],
+        ));
+        assert_eq!(
+            within.highest_live_committed_checkpoint().unwrap(),
+            Some(50)
+        );
+
+        // A budget of 49 gates it out, advancing the bound.
+        let beyond = reader.with_availability(availability(
+            Some(PipelineAvailability::MaxCheckpointLag(49)),
+            &[],
+        ));
+        assert_eq!(
+            beyond.highest_live_committed_checkpoint().unwrap(),
+            Some(90)
+        );
+    }
+
+    #[test]
+    fn live_min_none_when_all_live_gated() {
+        let (_dir, reader) = live_reader(&[
+            ("object_by_owner", 100),
+            ("object_by_type", 90),
+            ("balance", 50),
+        ]);
+        let gated =
+            reader.with_availability(availability(Some(PipelineAvailability::Disabled), &[]));
+        assert_eq!(gated.highest_live_committed_checkpoint().unwrap(), None);
+    }
+
+    #[test]
+    fn disabled_live_pipeline_without_watermark_no_longer_forces_none() {
+        // `balance` has no watermark: ungated, the live bound is `None`;
+        // disabling it excludes it before the watermark read.
+        let (_dir, reader) = live_reader(&[("object_by_owner", 100), ("object_by_type", 90)]);
+        assert_eq!(reader.highest_live_committed_checkpoint().unwrap(), None);
+
+        let gated = reader.with_availability(availability(
+            None,
+            &[("balance", PipelineAvailability::Disabled)],
+        ));
+        assert_eq!(gated.highest_live_committed_checkpoint().unwrap(), Some(90));
+    }
+
+    #[test]
+    fn require_pipelines_reports_unavailable_kind() {
+        let (_dir, reader) = live_reader(&[("object_by_owner", 100), ("balance", 50)]);
+        let reader = reader.with_availability(availability(
+            Some(PipelineAvailability::MaxCheckpointLag(10)),
+            &[
+                ("balance", PipelineAvailability::Disabled),
+                ("object_by_type", PipelineAvailability::Enabled),
+            ],
+        ));
+
+        // Disabled override.
+        let err = reader.require_pipelines(&["balance"]).unwrap_err();
+        assert_eq!(err.kind(), StorageErrorKind::Unavailable);
+        assert!(format!("{err:?}").contains("disabled by config"), "{err:?}");
+
+        // Lag default: `object_by_owner` is the tip (distance zero).
+        reader.require_pipelines(&["object_by_owner"]).unwrap();
+
+        // Lag default: `epochs` has no watermark at all.
+        let err = reader.require_pipelines(&["epochs"]).unwrap_err();
+        assert_eq!(err.kind(), StorageErrorKind::Unavailable);
+        assert!(
+            format!("{err:?}").contains("no committed watermark"),
+            "{err:?}",
+        );
+
+        // Enabled override exempts from the gating default.
+        reader.require_pipelines(&["object_by_type"]).unwrap();
+
+        // A pipeline with no policy at all... falls back to the default here.
+        let err = reader.require_pipelines(&["transactions"]).unwrap_err();
+        assert_eq!(err.kind(), StorageErrorKind::Unavailable);
+    }
+
+    #[test]
+    fn at_snapshot_inherits_availability() {
+        let (_dir, reader) = live_reader(&[
+            ("object_by_owner", 100),
+            ("object_by_type", 90),
+            ("balance", 50),
+        ]);
+        let reader = reader.with_availability(availability(
+            None,
+            &[("balance", PipelineAvailability::Disabled)],
+        ));
+
+        reader
+            .db()
+            .take_snapshot(sui_consistent_store::Watermark::for_checkpoint(0));
+        let snap = reader.db().at_snapshot(0).expect("snapshot retained");
+        let snap_reader = reader.at_snapshot(&snap);
+
+        let err = snap_reader.require_pipelines(&["balance"]).unwrap_err();
+        assert_eq!(err.kind(), StorageErrorKind::Unavailable);
+        assert_eq!(
+            snap_reader.highest_live_committed_checkpoint().unwrap(),
+            Some(90)
         );
     }
 }

--- a/crates/sui-rpc-store/src/reader/object_store.rs
+++ b/crates/sui-rpc-store/src/reader/object_store.rs
@@ -13,16 +13,21 @@
 //! directly.
 
 use sui_consistent_store::reader::Reader;
+use sui_indexer_alt_framework::pipeline::Processor;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::VersionNumber;
 use sui_types::object::Object;
 use sui_types::storage::ObjectStore;
 use tracing::error;
 
+use crate::indexer::objects::Objects;
 use crate::reader::RpcStoreReader;
 
 impl<R: Reader + Send + Sync> ObjectStore for RpcStoreReader<R> {
     fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+        if !self.pipelines_available(&[Objects::NAME]) {
+            return None;
+        }
         match self.schema().get_object(*object_id) {
             Ok(object) => object,
             Err(e) => {
@@ -33,6 +38,9 @@ impl<R: Reader + Send + Sync> ObjectStore for RpcStoreReader<R> {
     }
 
     fn get_object_by_key(&self, object_id: &ObjectID, version: VersionNumber) -> Option<Object> {
+        if !self.pipelines_available(&[Objects::NAME]) {
+            return None;
+        }
         match self.schema().get_object_by_key(*object_id, version) {
             Ok(object) => object,
             Err(e) => {
@@ -130,6 +138,26 @@ mod tests {
         assert!(
             reader
                 .get_object_by_key(&object.id(), missing_version)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn gated_object_read_withholds_present_row() {
+        use crate::config::PipelineAvailability;
+        use crate::reader::availability;
+
+        let (_dir, db, schema) = open();
+        let object = dummy(ObjectID::from_single_byte(9));
+        seed(&db, &schema, &object);
+
+        let reader = RpcStoreReader::new(db.clone(), Arc::new(schema)).with_availability(
+            availability(None, &[("objects", PipelineAvailability::Disabled)]),
+        );
+        assert!(reader.get_object(&object.id()).is_none());
+        assert!(
+            reader
+                .get_object_by_key(&object.id(), object.version())
                 .is_none()
         );
     }

--- a/crates/sui-rpc-store/src/reader/read_store.rs
+++ b/crates/sui-rpc-store/src/reader/read_store.rs
@@ -13,6 +13,7 @@
 use std::sync::Arc;
 
 use sui_consistent_store::reader::Reader;
+use sui_indexer_alt_framework::pipeline::Processor;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
@@ -35,6 +36,9 @@ use crate::schema::primitives::U64Be;
 
 impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
     fn get_committee(&self, epoch: EpochId) -> Option<Arc<Committee>> {
+        if !self.pipelines_available(&[crate::indexer::epochs::Epochs::NAME]) {
+            return None;
+        }
         match self.schema().get_committee(epoch) {
             Ok(Some(committee)) => Some(Arc::new(committee)),
             Ok(None) => None,
@@ -46,6 +50,7 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
     }
 
     fn get_latest_checkpoint(&self) -> StorageResult<VerifiedCheckpoint> {
+        self.require_pipelines(&[crate::indexer::checkpoint_summary::CheckpointSummary::NAME])?;
         // The latest checkpoint header in `checkpoint_summary` is
         // the highest committed checkpoint. Read paths that require
         // every CF to be in sync at this checkpoint should be
@@ -92,6 +97,12 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
     }
 
     fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {
+        if !self.pipelines_available(&[
+            crate::indexer::checkpoint_seq_by_digest::CheckpointSeqByDigest::NAME,
+            crate::indexer::checkpoint_summary::CheckpointSummary::NAME,
+        ]) {
+            return None;
+        }
         let seq = match self.schema().get_checkpoint_seq_by_digest(digest) {
             Ok(Some(seq)) => seq,
             Ok(None) => return None,
@@ -113,6 +124,10 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Option<VerifiedCheckpoint> {
+        if !self.pipelines_available(&[crate::indexer::checkpoint_summary::CheckpointSummary::NAME])
+        {
+            return None;
+        }
         match self.schema().get_checkpoint_summary(sequence_number) {
             Ok(summary) => summary,
             Err(e) => {
@@ -139,6 +154,11 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Option<CheckpointContents> {
+        if !self
+            .pipelines_available(&[crate::indexer::checkpoint_contents::CheckpointContents::NAME])
+        {
+            return None;
+        }
         match self.schema().get_checkpoint_contents(sequence_number) {
             Ok(contents) => contents,
             Err(e) => {
@@ -152,6 +172,12 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
     }
 
     fn get_transaction(&self, tx_digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
+        if !self.pipelines_available(&[
+            crate::indexer::tx_seq_by_digest::TxSeqByDigest::NAME,
+            crate::indexer::transactions::Transactions::NAME,
+        ]) {
+            return None;
+        }
         let tx_seq = match self.schema().get_tx_seq_by_digest(tx_digest) {
             Ok(Some(seq)) => seq,
             Ok(None) => return None,
@@ -174,6 +200,12 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
     }
 
     fn get_transaction_effects(&self, tx_digest: &TransactionDigest) -> Option<TransactionEffects> {
+        if !self.pipelines_available(&[
+            crate::indexer::tx_seq_by_digest::TxSeqByDigest::NAME,
+            crate::indexer::effects::Effects::NAME,
+        ]) {
+            return None;
+        }
         let tx_seq = match self.schema().get_tx_seq_by_digest(tx_digest) {
             Ok(Some(seq)) => seq,
             Ok(None) => return None,
@@ -193,6 +225,12 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
     }
 
     fn get_events(&self, event_digest: &TransactionDigest) -> Option<TransactionEvents> {
+        if !self.pipelines_available(&[
+            crate::indexer::tx_seq_by_digest::TxSeqByDigest::NAME,
+            crate::indexer::events::Events::NAME,
+        ]) {
+            return None;
+        }
         // `event_digest` is named for the trait but our index
         // resolves by transaction digest (events are keyed by
         // tx_seq in this store).
@@ -217,6 +255,12 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
         &self,
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
+        if !self.pipelines_available(&[
+            crate::indexer::tx_seq_by_digest::TxSeqByDigest::NAME,
+            crate::indexer::effects::Effects::NAME,
+        ]) {
+            return None;
+        }
         let tx_seq = match self.schema().get_tx_seq_by_digest(digest) {
             Ok(Some(seq)) => seq,
             Ok(None) => return None,
@@ -242,6 +286,12 @@ impl<R: Reader + Send + Sync> ReadStore for RpcStoreReader<R> {
         &self,
         digest: &TransactionDigest,
     ) -> Option<CheckpointSequenceNumber> {
+        if !self.pipelines_available(&[
+            crate::indexer::tx_seq_by_digest::TxSeqByDigest::NAME,
+            crate::indexer::tx_metadata_by_seq::TxMetadataBySeq::NAME,
+        ]) {
+            return None;
+        }
         let tx_seq = match self.schema().get_tx_seq_by_digest(digest) {
             Ok(Some(seq)) => seq,
             Ok(None) => return None,
@@ -408,6 +458,28 @@ mod tests {
             .unwrap();
         batch.commit().unwrap();
         assert_eq!(reader.get_lowest_available_checkpoint().unwrap(), 42);
+    }
+
+    #[test]
+    fn gated_checkpoint_reads_are_withheld() {
+        use crate::config::PipelineAvailability;
+        use crate::reader::availability;
+        use sui_types::storage::error::Kind;
+
+        let (_dir, db, reader) = fresh_reader();
+        let summary = seed_checkpoint(&db, &reader, 7);
+        let reader = reader.with_availability(availability(
+            None,
+            &[("checkpoint_summary", PipelineAvailability::Disabled)],
+        ));
+
+        // Result-returning read fails as unavailable...
+        let err = reader.get_latest_checkpoint().unwrap_err();
+        assert_eq!(err.kind(), Kind::Unavailable);
+
+        // ...and Option-returning reads withhold the (present) row.
+        assert!(reader.get_checkpoint_by_sequence_number(7).is_none());
+        assert!(reader.get_checkpoint_by_digest(&summary.digest()).is_none());
     }
 
     #[test]

--- a/crates/sui-types/src/storage/error.rs
+++ b/crates/sui-types/src/storage/error.rs
@@ -23,6 +23,11 @@ pub enum Kind {
     Serialization,
     Missing,
     Custom,
+
+    /// The data exists (or may exist) but the store is currently unwilling to serve it, e.g.
+    /// because the pipeline that produces it is disabled or lagging. Distinct from `Missing` so
+    /// consumers can render it as a retriable "unavailable" condition rather than "not found".
+    Unavailable,
 }
 
 impl Error {
@@ -45,6 +50,10 @@ impl Error {
 
     pub fn custom<E: Into<BoxError>>(e: E) -> Self {
         Self::new(Kind::Custom, Some(e))
+    }
+
+    pub fn unavailable<E: Into<BoxError>>(e: E) -> Self {
+        Self::new(Kind::Unavailable, Some(e))
     }
 
     pub fn kind(&self) -> Kind {


### PR DESCRIPTION
## Description

Read-side companion to the GraphQL per-pipeline availability change (#27176), for the rpc-store stack: operators can gate which index pipelines the embedded (and future standalone) rpc-store serves, per pipeline. A policy is exactly one of `enabled = true` (always serve), `enabled = false` (never serve — a kill-switch), or `max-checkpoint-lag = N` (serve only while the pipeline's committed watermark is within N checkpoints of the tip, approximated as the MAX watermark across pipelines). A global default plus per-pipeline overrides; a pipeline with neither is always served, so nothing changes unless configured.

Gated pipelines fail the reads that need them with a new `Kind::Unavailable` storage error, rendered as gRPC `Code::Unavailable` (a handful of handlers that stringified reader errors into `Internal` now pass the typed error through). They are also excluded from the reader's cross-pipeline watermark MINs (`highest_live_committed_checkpoint`, which bounds the reported tip, and `get_highest_indexed_checkpoint_seq_number`, which bounds the v2alpha list APIs and health) so a gated pipeline stops pinning those bounds. Availability is read-side only: gated pipelines keep indexing, and the synchronizer's snapshot membership is untouched (write-side eviction is a possible follow-up).

Configured in both surfaces:

```toml
# standalone ServiceConfig TOML (the future sui-rpc-node)
[availability]
max-checkpoint-lag = 100

[pipeline.balance.availability]
enabled = false
```

```yaml
# fullnode.yaml (embedded)
rpc:
  enable-indexing: true
  availability:
    max-checkpoint-lag: 100
    pipelines:
      balance:
        enabled: false
```

The embedded path validates the block (unknown pipeline names, both policy keys set) at the top of `bootstrap`, before any potentially hours-long restore. As a side effect of nesting per-pipeline settings, the standalone TOML's committer overrides move from flat `[pipeline.<name>]` keys to `[pipeline.<name>.committer]` (the standalone config has no users yet), and `PipelineLayer` now rejects unknown pipeline names instead of silently ignoring them.

## Test plan

Unit tests cover the policy TOML/YAML parsing (mutual exclusion, empty sections, unknown keys, round-trips, config keys pinned against `ALL_PIPELINES`), the reader gates (`Kind::Unavailable` on Result-returning reads, withheld `None` on Option-returning reads, Enabled override beating a gating default, snapshot readers inheriting policies), both MIN exclusions (boundary-inclusive lag, all-gated ⇒ `None`, a disabled unwatermarked pipeline no longer forcing `None`), the sui-core conversion (unknown-name and both-keys rejection), and the `Unavailable → Code::Unavailable` rendering. New e2e simtests drive a fullnode with `rpc.availability` disabling one pipeline and assert the gated API returns `Unavailable` naming the pipeline, neighbouring APIs keep serving, and both cohorts keep indexing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Fullnodes running the embedded rpc-store (`rpc.enable-indexing: true`) can now gate individual index pipelines with `rpc.availability` in fullnode.yaml: a global default and per-pipeline overrides, each either `enabled: true|false` or `max-checkpoint-lag: N`. Reads needing a gated pipeline return gRPC `Unavailable`, gated pipelines stop pinning the reported tip, and indexing is unaffected. No action is needed unless you opt in.
- [x] gRPC: APIs backed by a pipeline gated via `rpc.availability` return `Code::Unavailable` (naming the pipeline) instead of serving stale data; previously some of these error paths rendered as `Internal`.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
