### PR TITLE
indexer-alt-framework: skip broadcasting checkpoints below a subscriber's watermark

### DIFF
--- a/crates/sui-futures/src/stream.rs
+++ b/crates/sui-futures/src/stream.rs
@@ -6,6 +6,7 @@ use std::future::poll_fn;
 use std::panic;
 use std::pin::pin;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use futures::FutureExt;
 use futures::future::try_join_all;
@@ -123,6 +124,40 @@ pub trait TrySpawnStreamExt: Stream {
         T: Clone + Send + Sync + 'static,
         E: Send + 'static,
         R: Fn(ConcurrencyStats);
+
+    /// Process each stream item through a spawned task, broadcasting results to a filtered
+    /// subset of channels.
+    ///
+    /// Same as [`try_for_each_broadcast_spawned`](TrySpawnStreamExt::try_for_each_broadcast_spawned),
+    /// but before each send, `filter(i, &value)` is consulted for every channel index `i` (the
+    /// channel's position in `txs`), and the value is only cloned and sent to the channels for
+    /// which it returns `true`. A value that no channel accepts is dropped, which counts as a
+    /// successful send.
+    ///
+    /// The filter may be stateful (`FnMut`): it is shared between all worker tasks behind a
+    /// mutex and invoked once per channel index per value while that (synchronous) lock is
+    /// held, so it must be cheap and must not block. Values are produced by concurrently
+    /// spawned tasks, so the filter observes them in task completion order, not stream order.
+    ///
+    /// Channels that reject a value are not touched by that send, so a closed channel only
+    /// stops the pipeline once the filter routes a value to it. The fill fraction that drives
+    /// adaptive concurrency is the maximum across all channels, including ones the filter is
+    /// currently rejecting.
+    fn try_for_each_broadcast_filtered_spawned<Fut, F, T, E, P, R>(
+        self,
+        config: ConcurrencyConfig,
+        f: F,
+        txs: Vec<mpsc::Sender<T>>,
+        filter: P,
+        report: R,
+    ) -> impl Future<Output = Result<(), Break<E>>>
+    where
+        Fut: Future<Output = Result<T, Break<E>>> + Send + 'static,
+        F: FnMut(Self::Item) -> Fut,
+        T: Clone + Send + Sync + 'static,
+        E: Send + 'static,
+        P: FnMut(usize, &T) -> bool + Send + 'static,
+        R: Fn(ConcurrencyStats);
 }
 
 /// Abstraction over single-channel and broadcast sending so that
@@ -144,8 +179,13 @@ trait Sender: Clone + Send + Sync + 'static {
 /// Single-channel sender.
 struct SingleSender<T>(mpsc::Sender<T>);
 
-/// Broadcast sender that clones the value to all channels.
-struct BroadcastSender<T>(Arc<Vec<mpsc::Sender<T>>>);
+/// Broadcast sender that clones the value to the subset of channels chosen by a shared
+/// (optionally stateful) filter. The unfiltered broadcast path uses this with an always-true
+/// filter.
+struct FilteredBroadcastSender<T, P> {
+    txs: Arc<Vec<mpsc::Sender<T>>>,
+    filter: Arc<Mutex<P>>,
+}
 
 impl ConcurrencyConfig {
     pub fn fixed(n: usize) -> Self {
@@ -310,7 +350,31 @@ impl<S: Stream + Sized + 'static> TrySpawnStreamExt for S {
         E: Send + 'static,
         R: Fn(ConcurrencyStats),
     {
-        adaptive_spawn_send(self, config, f, BroadcastSender(Arc::new(txs)), report).await
+        self.try_for_each_broadcast_filtered_spawned(config, f, txs, |_, _: &T| true, report)
+            .await
+    }
+
+    async fn try_for_each_broadcast_filtered_spawned<Fut, F, T, E, P, R>(
+        self,
+        config: ConcurrencyConfig,
+        f: F,
+        txs: Vec<mpsc::Sender<T>>,
+        filter: P,
+        report: R,
+    ) -> Result<(), Break<E>>
+    where
+        Fut: Future<Output = Result<T, Break<E>>> + Send + 'static,
+        F: FnMut(Self::Item) -> Fut,
+        T: Clone + Send + Sync + 'static,
+        E: Send + 'static,
+        P: FnMut(usize, &T) -> bool + Send + 'static,
+        R: Fn(ConcurrencyStats),
+    {
+        let sender = FilteredBroadcastSender {
+            txs: Arc::new(txs),
+            filter: Arc::new(Mutex::new(filter)),
+        };
+        adaptive_spawn_send(self, config, f, sender, report).await
     }
 }
 
@@ -332,17 +396,44 @@ impl<T: Send + 'static> Sender for SingleSender<T> {
     }
 }
 
-impl<T> Clone for BroadcastSender<T> {
+impl<T, P> Clone for FilteredBroadcastSender<T, P> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            txs: self.txs.clone(),
+            filter: self.filter.clone(),
+        }
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> Sender for BroadcastSender<T> {
+impl<T, P> Sender for FilteredBroadcastSender<T, P>
+where
+    T: Clone + Send + Sync + 'static,
+    P: FnMut(usize, &T) -> bool + Send + 'static,
+{
     type Value = T;
 
     async fn send(&self, value: T) -> Result<(), ()> {
-        let (last, rest) = self.0.split_last().ok_or(())?;
+        // No channels at all is treated like all channels being closed.
+        if self.txs.is_empty() {
+            return Err(());
+        }
+
+        // The lock is scoped so the guard is dropped before any await (the guard is !Send, so
+        // holding it across an await would also fail `Sender::send`'s `Send` bound).
+        let keep: Vec<&mpsc::Sender<T>> = {
+            let mut filter = self.filter.lock().unwrap();
+            self.txs
+                .iter()
+                .enumerate()
+                .filter_map(|(i, tx)| (*filter)(i, &value).then_some(tx))
+                .collect()
+        };
+
+        // A value that no channel accepts is dropped, which counts as a successful send.
+        let Some((last, rest)) = keep.split_last() else {
+            return Ok(());
+        };
+
         let rest_fut = try_join_all(rest.iter().map(|tx| {
             let v = value.clone();
             async move { tx.send(v).await.map_err(|_| ()) }
@@ -353,15 +444,15 @@ impl<T: Clone + Send + Sync + 'static> Sender for BroadcastSender<T> {
     }
 
     fn fill(&self) -> f64 {
-        self.0
+        self.txs
             .iter()
             .map(|tx| 1.0 - (tx.capacity() as f64 / tx.max_capacity() as f64))
             .fold(0.0f64, f64::max)
     }
 }
 
-/// Shared adaptive concurrency loop used by both `try_for_each_send_spawned` and
-/// `try_for_each_broadcast_spawned`.
+/// Shared adaptive concurrency loop used by the `try_for_each_send_spawned`,
+/// `try_for_each_broadcast_spawned` and `try_for_each_broadcast_filtered_spawned` methods.
 ///
 /// The algorithm is a result of weeks of trial and error guided by lots of Claude Research queries.
 /// I tried to document where each of the ideas came from in the footnotes of this comment.
@@ -1169,6 +1260,196 @@ mod tests {
                 ConcurrencyConfig::fixed(2),
                 |i| async move { Ok(i) },
                 vec![tx1, tx2],
+                |_| {},
+            )
+            .await;
+
+        assert!(matches!(result, Err(Break::Break)));
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_routes_per_channel() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                |i, v: &u64| {
+                    if i == 0 {
+                        v.is_multiple_of(2)
+                    } else {
+                        !v.is_multiple_of(2)
+                    }
+                },
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        let mut v1 = Vec::new();
+        while let Ok(v) = rx1.try_recv() {
+            v1.push(v);
+        }
+        let mut v2 = Vec::new();
+        while let Ok(v) = rx2.try_recv() {
+            v2.push(v);
+        }
+        v1.sort();
+        v2.sort();
+        assert_eq!(v1, vec![0, 2, 4, 6, 8]);
+        assert_eq!(v2, vec![1, 3, 5, 7, 9]);
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_threshold_filter() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        // The shape the indexing framework uses: each channel has a resume point below which
+        // it does not receive values.
+        let next = [0u64, 5];
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                move |i, v: &u64| *v >= next[i],
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        let mut v1 = Vec::new();
+        while let Ok(v) = rx1.try_recv() {
+            v1.push(v);
+        }
+        let mut v2 = Vec::new();
+        while let Ok(v) = rx2.try_recv() {
+            v2.push(v);
+        }
+        v1.sort();
+        v2.sort();
+        assert_eq!(v1, (0..10).collect::<Vec<_>>());
+        assert_eq!(v2, (5..10).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_drops_unmatched() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                |_, _: &u64| false,
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert!(rx1.try_recv().is_err());
+        assert!(rx2.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_stateful_filter() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, mut rx2) = mpsc::channel(100);
+
+        // Limit 1 makes completion order match stream order, so the stateful cutoff is
+        // deterministic.
+        let mut sent = 0usize;
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(1),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                move |i, _: &u64| {
+                    if i == 0 {
+                        sent += 1;
+                        sent <= 3
+                    } else {
+                        true
+                    }
+                },
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        let mut v1 = Vec::new();
+        while let Ok(v) = rx1.try_recv() {
+            v1.push(v);
+        }
+        let mut v2 = Vec::new();
+        while let Ok(v) = rx2.try_recv() {
+            v2.push(v);
+        }
+        assert_eq!(v1, vec![0, 1, 2]);
+        assert_eq!(v2, (0..10).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_ignores_closed_filtered_out_channel() {
+        let (tx1, mut rx1) = mpsc::channel(100);
+        let (tx2, rx2) = mpsc::channel(100);
+        drop(rx2);
+
+        let result = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok::<_, Break<()>>(i) },
+                vec![tx1, tx2],
+                |i, _: &u64| i == 0,
+                |_| {},
+            )
+            .await;
+
+        assert!(result.is_ok());
+
+        let mut v1 = Vec::new();
+        while let Ok(v) = rx1.try_recv() {
+            v1.push(v);
+        }
+        v1.sort();
+        assert_eq!(v1, (0..10).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_kept_channel_closed() {
+        let (tx1, _rx1) = mpsc::channel(100);
+        let (tx2, rx2) = mpsc::channel(100);
+        drop(rx2);
+
+        let result: Result<(), Break<()>> = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok(i) },
+                vec![tx1, tx2],
+                |_, _: &u64| true,
+                |_| {},
+            )
+            .await;
+
+        assert!(matches!(result, Err(Break::Break)));
+    }
+
+    #[tokio::test]
+    async fn broadcast_filtered_spawned_empty_txs_breaks() {
+        let result: Result<(), Break<()>> = stream::iter(0..10u64)
+            .try_for_each_broadcast_filtered_spawned(
+                ConcurrencyConfig::fixed(2),
+                |i| async move { Ok(i) },
+                Vec::new(),
+                |_, _: &u64| true,
                 |_| {},
             )
             .await;

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -34,6 +34,18 @@ use crate::metrics::CohortMetrics;
 /// path catch up first.
 const STREAMING_CATCHUP_THRESHOLD: u64 = 1_000;
 
+/// A subscription to the ingestion service: the channel checkpoints are delivered on, and the
+/// first checkpoint the subscriber still needs. The broadcaster does not deliver checkpoints
+/// below `next_checkpoint` -- the subscriber has already processed them.
+#[derive(Clone)]
+pub(super) struct Subscriber {
+    /// Checkpoints are delivered on this channel.
+    pub(super) tx: mpsc::Sender<Arc<CheckpointEnvelope>>,
+
+    /// The subscriber's resume point: checkpoints below it are not delivered.
+    pub(super) next_checkpoint: u64,
+}
+
 /// Broadcaster task that manages checkpoint flow and spawns broadcast tasks for ranges
 /// via either streaming or ingesting, or both.
 ///
@@ -46,14 +58,15 @@ const STREAMING_CATCHUP_THRESHOLD: u64 = 1_000;
 ///
 /// Backpressure is **per-subscriber, channel-fill based**: each subscriber's bounded mpsc
 /// channel acts as both transport and the backpressure signal. When any subscriber's channel
-/// fills, [`TrySpawnStreamExt::try_for_each_broadcast_spawned`]'s adaptive controller cuts
-/// ingest concurrency. The task will shut down if the `checkpoints` range completes.
+/// fills, [`TrySpawnStreamExt::try_for_each_broadcast_filtered_spawned`]'s adaptive controller
+/// cuts ingest concurrency. Checkpoints below a subscriber's `next_checkpoint` are not
+/// delivered to it. The task will shut down if the `checkpoints` range completes.
 pub(super) fn broadcaster<R>(
     checkpoints: R,
     streaming_client: Option<ArcStreamingClient>,
     config: IngestionConfig,
     client: IngestionClient,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
 ) -> Service
 where
     R: std::ops::RangeBounds<u64> + Send + 'static,
@@ -155,21 +168,26 @@ where
 
 /// Fetch and broadcast checkpoints from a range [start..end) to subscribers. The adaptive
 /// controller reads the max `fill` across subscribers (channel capacity for bounded,
-/// `len / soft_limit` for unbounded) and adjusts ingest concurrency to match.
+/// `len / soft_limit` for unbounded) and adjusts ingest concurrency to match. Each checkpoint
+/// is only delivered to subscribers whose `next_checkpoint` it has reached.
 fn ingest_and_broadcast_range(
     start: u64,
     end: u64,
     retry_interval: Duration,
     ingest_concurrency: ConcurrencyConfig,
     client: IngestionClient,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
     cohort_metrics: Arc<CohortMetrics>,
 ) -> TaskGuard<Result<(), Break<Error>>> {
     TaskGuard::new(tokio::spawn(async move {
         let concurrency_limit = cohort_metrics.ingestion_concurrency_limit.clone();
         let concurrency_inflight = cohort_metrics.ingestion_concurrency_inflight.clone();
+        let (txs, next_checkpoints): (Vec<_>, Vec<_>) = subscribers
+            .into_iter()
+            .map(|s| (s.tx, s.next_checkpoint))
+            .unzip();
         futures::stream::iter(start..end)
-            .try_for_each_broadcast_spawned(
+            .try_for_each_broadcast_filtered_spawned(
                 ingest_concurrency.into(),
                 |cp| {
                     let client = client.clone();
@@ -180,7 +198,10 @@ fn ingest_and_broadcast_range(
                         Ok(Arc::new(checkpoint_envelope))
                     }
                 },
-                subscribers,
+                txs,
+                move |i, envelope: &Arc<CheckpointEnvelope>| {
+                    *envelope.checkpoint.summary.sequence_number() >= next_checkpoints[i]
+                },
                 move |stats| {
                     concurrency_limit.set(stats.limit as i64);
                     concurrency_inflight.set(stats.inflight as i64);
@@ -199,7 +220,7 @@ async fn setup_streaming_task(
     end_cp: u64,
     streaming_backoff_batch_size: &mut u64,
     config: &IngestionConfig,
-    subscribers: &[mpsc::Sender<Arc<CheckpointEnvelope>>],
+    subscribers: &[Subscriber],
     cohort_metrics: &Arc<CohortMetrics>,
 ) -> (TaskGuard<u64>, u64) {
     // No streaming client configured so we ingest all the way to end_cp.
@@ -291,7 +312,7 @@ async fn stream_and_broadcast_range(
     mut lo: u64,
     hi: u64,
     mut stream: impl Stream<Item = Result<CheckpointEnvelope, Error>> + Unpin,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
     cohort_metrics: Arc<CohortMetrics>,
 ) -> u64 {
     let latest_streamed = cohort_metrics.latest_streamed_checkpoint.clone();
@@ -362,14 +383,18 @@ fn noop_streaming_task(checkpoint_hi: u64) -> TaskGuard<u64> {
     TaskGuard::new(tokio::spawn(async move { checkpoint_hi }))
 }
 
-/// Send a checkpoint to all subscribers. Returns an error if any subscriber's channel is closed.
+/// Send a checkpoint to every subscriber whose `next_checkpoint` it has reached; subscribers
+/// still below their resume point have already processed it. Returns an error if any selected
+/// subscriber's channel is closed.
 async fn send_checkpoint(
     checkpoint_envelope: Arc<CheckpointEnvelope>,
-    subscribers: &[mpsc::Sender<Arc<CheckpointEnvelope>>],
+    subscribers: &[Subscriber],
 ) -> Result<Vec<()>, mpsc::error::SendError<Arc<CheckpointEnvelope>>> {
+    let sequence_number = *checkpoint_envelope.checkpoint.summary.sequence_number();
     let futures = subscribers
         .iter()
-        .map(|s| s.send(checkpoint_envelope.clone()));
+        .filter(|s| s.next_checkpoint <= sequence_number)
+        .map(|s| s.tx.send(checkpoint_envelope.clone()));
     try_join_all(futures).await
 }
 
@@ -449,16 +474,36 @@ mod tests {
         result
     }
 
-    /// Build a subscribers list with a single bounded subscriber of the given capacity. Returns
-    /// the senders vec (to pass into `broadcaster(...)`) and the subscriber's stream.
-    fn single_subscriber(
+    /// Build a single bounded subscriber with the given channel capacity and resume point.
+    /// Returns the subscriber (to pass into `broadcaster(...)`) and its stream.
+    fn subscriber(
         capacity: usize,
+        next_checkpoint: u64,
     ) -> (
-        Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+        Subscriber,
         impl Stream<Item = Arc<CheckpointEnvelope>> + Send + Unpin + 'static,
     ) {
         let (tx, rx) = mpsc::channel(capacity);
-        (vec![tx], tokio_stream::wrappers::ReceiverStream::new(rx))
+        (
+            Subscriber {
+                tx,
+                next_checkpoint,
+            },
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )
+    }
+
+    /// Build a subscribers list with a single bounded subscriber of the given capacity that
+    /// receives everything. Returns the subscribers vec (to pass into `broadcaster(...)`) and
+    /// the subscriber's stream.
+    fn single_subscriber(
+        capacity: usize,
+    ) -> (
+        Vec<Subscriber>,
+        impl Stream<Item = Arc<CheckpointEnvelope>> + Send + Unpin + 'static,
+    ) {
+        let (sub, rx) = subscriber(capacity, 0);
+        (vec![sub], rx)
     }
 
     /// Receive `count` checkpoints from the stream and return their sequence numbers as a BTreeSet.
@@ -552,11 +597,9 @@ mod tests {
 
     #[tokio::test]
     async fn multiple_physical_subscribers() {
-        let (tx1, rx1) = mpsc::channel(1);
-        let (tx2, rx2) = mpsc::channel(1);
-        let subscribers = vec![tx1, tx2];
-        let mut subscriber_rx1 = tokio_stream::wrappers::ReceiverStream::new(rx1);
-        let mut subscriber_rx2 = tokio_stream::wrappers::ReceiverStream::new(rx2);
+        let (sub1, mut subscriber_rx1) = subscriber(1, 0);
+        let (sub2, mut subscriber_rx2) = subscriber(1, 0);
+        let subscribers = vec![sub1, sub2];
 
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
@@ -582,6 +625,85 @@ mod tests {
 
         // The broadcaster should shut down gracefully
         svc.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ingest_skips_below_subscriber_next_checkpoint() {
+        let (sub1, mut rx1) = subscriber(10, 0);
+        let (sub2, mut rx2) = subscriber(10, 5);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..10,
+            None,
+            test_config(),
+            mock_client_with_range(0..10, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        assert_eq!(recv_set(&mut rx1, 10).await, BTreeSet::from_iter(0..10));
+        assert_eq!(recv_set(&mut rx2, 5).await, BTreeSet::from_iter(5..10));
+
+        svc.join().await.unwrap();
+
+        // The broadcaster is done and its senders are dropped: an empty channel here proves
+        // checkpoints below the resume point were never delivered, not merely delivered late.
+        assert!(expect_recv(&mut rx2).await.is_none());
+    }
+
+    /// A dropped subscriber that ingestion has not yet reached does not stop the broadcaster:
+    /// checkpoints below its resume point are never routed to it, so its closed channel goes
+    /// unnoticed for the whole range.
+    #[tokio::test]
+    async fn dropped_filtered_subscriber_does_not_stop_broadcaster() {
+        let (sub1, mut rx1) = subscriber(20, 0);
+        let (sub2, rx2) = subscriber(1, 100);
+        drop(rx2);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..20,
+            None,
+            test_config(),
+            mock_client_with_range(0..20, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        assert_eq!(recv_set(&mut rx1, 20).await, BTreeSet::from_iter(0..20));
+
+        svc.join().await.unwrap();
+    }
+
+    /// Once ingestion reaches a dropped subscriber's resume point, the failed send is noticed
+    /// and the broadcaster winds down without completing the range.
+    #[tokio::test]
+    async fn broadcaster_stops_when_range_reaches_dropped_subscriber() {
+        let (sub1, mut rx1) = subscriber(40, 0);
+        let (sub2, rx2) = subscriber(1, 10);
+        drop(rx2);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..40,
+            None,
+            test_config(),
+            mock_client_with_range(0..40, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        svc.join().await.unwrap();
+
+        // The live subscriber received everything below the dropped subscriber's resume point,
+        // plus at most the few checkpoints that were in flight when the send failure hit.
+        let mut received = BTreeSet::new();
+        while let Some(checkpoint_envelope) = expect_recv(&mut rx1).await {
+            received.insert(*checkpoint_envelope.checkpoint.summary.sequence_number());
+        }
+        assert!(received.is_superset(&BTreeSet::from_iter(0..10)));
+        // With fixed ingest concurrency 2, at most checkpoints 10 and 11 can be in flight when
+        // the first failed send is recorded, and no further tasks spawn after it -- so the live
+        // subscriber can receive checkpoints 0..12 at most.
+        assert!(received.len() <= 12);
     }
 
     // =============== Streaming Tests ==================
@@ -631,6 +753,48 @@ mod tests {
         );
 
         svc.join().await.unwrap();
+    }
+
+    /// The streaming path also skips delivering checkpoints below a subscriber's resume point.
+    #[tokio::test]
+    async fn streaming_skips_below_subscriber_next_checkpoint() {
+        let (sub1, mut rx1) = subscriber(10, 0);
+        let (sub2, mut rx2) = subscriber(10, 5);
+
+        let streaming_client = MockStreamingClient::new(0..10, None);
+
+        let metrics = test_ingestion_metrics();
+        let mut svc = broadcaster(
+            0..10,
+            Some(Arc::new(streaming_client)),
+            test_config(),
+            mock_client_with_range(0..10, metrics.clone()),
+            vec![sub1, sub2],
+        );
+
+        assert_eq!(recv_vec(&mut rx1, 10).await, Vec::from_iter(0..10));
+        assert_eq!(recv_vec(&mut rx2, 5).await, Vec::from_iter(5..10));
+
+        // Everything was delivered by streaming, so the skipped deliveries were the streaming
+        // path's doing, not the ingest path's.
+        assert_eq!(
+            metrics
+                .total_streamed_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            10
+        );
+        assert_eq!(
+            metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            0
+        );
+
+        svc.join().await.unwrap();
+
+        assert!(expect_recv(&mut rx2).await.is_none());
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -14,6 +14,7 @@ use tracing::warn;
 
 use crate::cohort::DEFAULT_MIN_COHORT_BOUNDARY;
 pub use crate::config::ConcurrencyConfig as IngestConcurrencyConfig;
+use crate::ingestion::broadcaster::Subscriber;
 use crate::ingestion::broadcaster::broadcaster;
 use crate::ingestion::error::Error;
 use crate::ingestion::error::Result;
@@ -94,7 +95,7 @@ pub struct IngestionService {
     config: IngestionConfig,
     ingestion_client: IngestionClient,
     streaming_client: Option<ArcStreamingClient>,
-    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
+    subscribers: Vec<Subscriber>,
 }
 
 /// Creates the [IngestionService]s that an indexer runs -- one per cohort of pipelines with
@@ -187,10 +188,21 @@ impl IngestionService {
     /// fills and the adaptive ingestion controller cuts fetch concurrency. Send blocks when the
     /// channel is full.
     ///
+    /// `next_checkpoint` is the first checkpoint this subscriber still needs: the broadcaster
+    /// skips delivering checkpoints below it, on the basis that the subscriber has already
+    /// processed them. Subscribers without a resume point pass `0` to receive everything.
+    ///
     /// Callers typically pass `pipeline::IngestionConfig::subscriber_channel_size()`.
-    pub fn subscribe_bounded(&mut self, size: usize) -> mpsc::Receiver<Arc<CheckpointEnvelope>> {
+    pub fn subscribe_bounded(
+        &mut self,
+        size: usize,
+        next_checkpoint: u64,
+    ) -> mpsc::Receiver<Arc<CheckpointEnvelope>> {
         let (tx, rx) = mpsc::channel(size);
-        self.subscribers.push(tx);
+        self.subscribers.push(Subscriber {
+            tx,
+            next_checkpoint,
+        });
         rx
     }
 
@@ -201,7 +213,8 @@ impl IngestionService {
     /// acts as the backpressure signal: when it fills, the adaptive ingestion controller
     /// throttles fetch concurrency. The slowest subscriber gates ingestion for everyone.
     ///
-    /// If a subscriber closes its channel, the ingestion service shuts down as well.
+    /// If a subscriber closes its channel, the ingestion service shuts down as well, once
+    /// ingestion reaches a checkpoint that subscriber would receive.
     ///
     /// If ingestion reaches the leading edge of the network, it will encounter checkpoints
     /// that do not exist yet. These are retried on a fixed `retry_interval` until they become
@@ -478,7 +491,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(usize::MAX, rx).await;
         let svc = ingestion_service.run(0..).await.unwrap();
 
@@ -500,7 +513,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(1, rx).await;
         let mut svc = ingestion_service.run(0..).await.unwrap();
 
@@ -528,7 +541,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0..).await.unwrap();
 
@@ -555,7 +568,7 @@ mod tests {
 
         let mut ingestion_service = test_ingestion(server.uri(), 1).await;
 
-        let rx = ingestion_service.subscribe_bounded(1);
+        let rx = ingestion_service.subscribe_bounded(1, 0);
         let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0..).await.unwrap();
 
@@ -582,13 +595,13 @@ mod tests {
         let size = 3;
 
         // This subscriber will take its sweet time processing checkpoints.
-        let mut laggard = ingestion_service.subscribe_bounded(size);
+        let mut laggard = ingestion_service.subscribe_bounded(size, 0);
         async fn unblock(laggard: &mut mpsc::Receiver<Arc<CheckpointEnvelope>>) -> u64 {
             let checkpoint_envelope = laggard.recv().await.unwrap();
             checkpoint_envelope.checkpoint.summary.sequence_number
         }
 
-        let rx = ingestion_service.subscribe_bounded(size);
+        let rx = ingestion_service.subscribe_bounded(size, 0);
         let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0..).await.unwrap();
 
@@ -602,6 +615,32 @@ mod tests {
 
         let seqs = subscriber.await.unwrap();
         assert_eq!(seqs, vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    /// Subscribers that registered a resume point only receive checkpoints from that point on;
+    /// earlier checkpoints are not delivered to them at all.
+    #[tokio::test]
+    async fn subscriber_resume_skips_processed_checkpoints() {
+        let server = MockServer::start().await;
+        let times: Mutex<u64> = Mutex::new(0);
+        respond_with(&server, move |_: &Request| {
+            let mut times = times.lock().unwrap();
+            *times += 1;
+            status(StatusCode::OK).set_body_bytes(test_checkpoint_data(*times))
+        })
+        .await;
+        respond_with_chain_id(&server).await;
+
+        let mut ingestion_service = test_ingestion(server.uri(), 1).await;
+
+        let rx_all = ingestion_service.subscribe_bounded(10, 0);
+        let rx_resumed = ingestion_service.subscribe_bounded(10, 3);
+        let all = test_subscriber(6, rx_all).await;
+        let resumed = test_subscriber(3, rx_resumed).await;
+        let _svc = ingestion_service.run(0..).await.unwrap();
+
+        assert_eq!(all.await.unwrap(), vec![0, 1, 2, 3, 4, 5]);
+        assert_eq!(resumed.await.unwrap(), vec![3, 4, 5]);
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -517,8 +517,8 @@ impl<S: ConcurrentStore> Indexer<S> {
             name: H::NAME,
             next_checkpoint,
             build: Box::new(move |ingestion| {
-                let checkpoint_rx =
-                    ingestion.subscribe_bounded(config.ingestion.subscriber_channel_size());
+                let checkpoint_rx = ingestion
+                    .subscribe_bounded(config.ingestion.subscriber_channel_size(), next_checkpoint);
                 concurrent::pipeline::<H>(
                     handler,
                     next_checkpoint,
@@ -572,8 +572,8 @@ impl<T: SequentialStore> Indexer<T> {
             name: H::NAME,
             next_checkpoint,
             build: Box::new(move |ingestion| {
-                let checkpoint_rx =
-                    ingestion.subscribe_bounded(config.ingestion.subscriber_channel_size());
+                let checkpoint_rx = ingestion
+                    .subscribe_bounded(config.ingestion.subscriber_channel_size(), next_checkpoint);
                 sequential::pipeline::<H>(
                     handler,
                     next_checkpoint,
@@ -1316,10 +1316,12 @@ mod tests {
                 .get(),
             24
         );
+        // Pipelines never receive checkpoints below their own watermark, even though the
+        // cohort's ingestion starts at the minimum watermark across members.
         assert_out_of_order!(indexer_metrics, A::NAME, 0);
-        assert_out_of_order!(indexer_metrics, B::NAME, 5);
-        assert_out_of_order!(indexer_metrics, C::NAME, 10);
-        assert_out_of_order!(indexer_metrics, D::NAME, 15);
+        assert_out_of_order!(indexer_metrics, B::NAME, 0);
+        assert_out_of_order!(indexer_metrics, C::NAME, 0);
+        assert_out_of_order!(indexer_metrics, D::NAME, 0);
     }
 
     // test ingestion, no pipelines missing watermarks, first_checkpoint provided
@@ -1364,9 +1366,9 @@ mod tests {
             24
         );
         assert_out_of_order!(metrics, A::NAME, 0);
-        assert_out_of_order!(metrics, B::NAME, 5);
-        assert_out_of_order!(metrics, C::NAME, 10);
-        assert_out_of_order!(metrics, D::NAME, 15);
+        assert_out_of_order!(metrics, B::NAME, 0);
+        assert_out_of_order!(metrics, C::NAME, 0);
+        assert_out_of_order!(metrics, D::NAME, 0);
     }
 
     // test ingestion, some pipelines missing watermarks, no first_checkpoint provided
@@ -1409,9 +1411,9 @@ mod tests {
             30
         );
         assert_out_of_order!(metrics, A::NAME, 0);
-        assert_out_of_order!(metrics, B::NAME, 11);
-        assert_out_of_order!(metrics, C::NAME, 16);
-        assert_out_of_order!(metrics, D::NAME, 21);
+        assert_out_of_order!(metrics, B::NAME, 0);
+        assert_out_of_order!(metrics, C::NAME, 0);
+        assert_out_of_order!(metrics, D::NAME, 0);
     }
 
     // test ingestion, some pipelines missing watermarks, use first_checkpoint
@@ -1455,9 +1457,75 @@ mod tests {
             20
         );
         assert_out_of_order!(metrics, A::NAME, 0);
-        assert_out_of_order!(metrics, B::NAME, 1);
-        assert_out_of_order!(metrics, C::NAME, 6);
-        assert_out_of_order!(metrics, D::NAME, 11);
+        assert_out_of_order!(metrics, B::NAME, 0);
+        assert_out_of_order!(metrics, C::NAME, 0);
+        assert_out_of_order!(metrics, D::NAME, 0);
+    }
+
+    /// Pipelines that share a cohort don't receive checkpoints below their own watermark, even
+    /// though the cohort's ingestion range starts at the minimum watermark across its members.
+    #[tokio::test]
+    async fn test_shared_cohort_pipeline_never_reprocesses_committed_checkpoints() {
+        let registry = Registry::new();
+        let store = FallibleMockStore::default();
+
+        test_pipeline!(A, "concurrent_a");
+        test_pipeline!(B, "concurrent_b");
+
+        let mut conn = store.connect().await.unwrap();
+        set_committer_watermark(&mut conn, A::NAME, 5).await;
+        set_committer_watermark(&mut conn, B::NAME, 20).await;
+
+        let indexer_args = IndexerArgs {
+            last_checkpoint: Some(29),
+            ..Default::default()
+        };
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((30, 1))).await;
+
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+
+        let ingestion_metrics = indexer.ingestion_metrics().clone();
+        let indexer_metrics = indexer.indexer_metrics().clone();
+
+        indexer.run().await.unwrap().join().await.unwrap();
+
+        // Each checkpoint in 6..=29 is fetched exactly once for the cohort.
+        assert_eq!(
+            ingestion_metrics
+                .total_ingested_checkpoints
+                .with_label_values(&["0"])
+                .get(),
+            24
+        );
+
+        // B was only served the checkpoints past its own watermark (21..=29).
+        assert_eq!(
+            indexer_metrics
+                .total_handler_checkpoints_received
+                .get_metric_with_label_values(&[B::NAME])
+                .unwrap()
+                .get(),
+            9
+        );
+        assert_out_of_order!(indexer_metrics, A::NAME, 0);
+        assert_out_of_order!(indexer_metrics, B::NAME, 0);
+
+        // B never re-committed checkpoints at or below its watermark.
+        let committed = store.data.get(B::NAME).unwrap();
+        for cp in 6..21 {
+            assert!(
+                !committed.contains_key(&cp),
+                "B re-committed checkpoint {cp}"
+            );
+        }
+        for cp in 21..30 {
+            assert!(
+                committed.contains_key(&cp),
+                "B did not commit checkpoint {cp}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Within an ingestion cohort, ingestion starts at the minimum watermark across member pipelines, so members that are further ahead receive and reprocess checkpoints they already committed — up to the cohort boundary (25k+ checkpoints) of wasted work per pipeline.

This adds `try_for_each_broadcast_filtered_spawned` to `sui-futures` (broadcast with an optionally stateful per-channel filter), and has each pipeline register its resume point when subscribing so both the ingest and streaming fan-out paths skip checkpoints below it. Filtering below the resume point is safe by construction: `add_pipeline` initializes the watermark row at `next_checkpoint - 1`, so nothing below it is ever needed.

One behavior change to note: subscriber-drop detection is now lazy — a dropped subscriber still below its resume point isn't noticed until ingestion reaches it. Per-pipeline `total_handler_checkpoints_received` / `total_watermarks_out_of_order` metrics will drop toward zero, which is the point.

Stacked on the `evan-wall-mysten/ingestion-cohorts` branch (no PR of its own yet).

## Test plan

New unit tests for the filtered broadcast variant in `sui-futures` (routing, stateful filters, closed-channel semantics), broadcaster/ingestion tests covering resume-point skipping on both the ingest and streaming paths and the lazy drop-detection semantics, and an end-to-end indexer test that a shared-cohort pipeline never re-receives or re-commits checkpoints below its watermark.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] Indexing Framework: `IngestionService::subscribe_bounded` now takes the first checkpoint the subscriber still needs (pass 0 to receive everything); pipelines no longer receive checkpoints below their committed watermark.
