### PR TITLE
Bump ethnum to 1.5.3 to fix build on Rust 1.97+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,9 +5433,9 @@ checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "ethnum"
-version = "1.3.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "euclid"

--- a/examples/rust/basic-sui-indexer/Cargo.lock
+++ b/examples/rust/basic-sui-indexer/Cargo.lock
@@ -2564,9 +2564,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "eyre"

--- a/examples/rust/clickhouse-sui-indexer/Cargo.lock
+++ b/examples/rust/clickhouse-sui-indexer/Cargo.lock
@@ -2654,9 +2654,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "eyre"

--- a/examples/rust/walrus-attributes-indexer/Cargo.lock
+++ b/examples/rust/walrus-attributes-indexer/Cargo.lock
@@ -2540,9 +2540,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "eyre"

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "euclid"


### PR DESCRIPTION
## Description

`ethnum` <= 1.5.2 constructs `std::num::TryFromIntError` via `mem::transmute(())`, which no longer compiles (E0512) on Rust 1.97+ where `TryFromIntError` is no longer zero-sized. This already broke the sui-operations protocol-compatibility job when its runners picked up stable 1.97.0 (ops-side fix: MystenLabs/sui-operations#8349); 1.5.3 replaces the transmute with safe const construction. Lockfile-only bump covering all five checked-in lockfiles: the root workspace, `external-crates/move`, and the three workspace-excluded `examples/rust/*` indexer examples.

## Test plan

`cargo nextest run -p move-core-types -p move-stackless-bytecode` (the two crates depending on ethnum) passes on the pinned Rust 1.92. Each of the three example crates compiles with `cargo check --locked` after the bump.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 