### PR TITLE
[grpc] Remove unused `options` in `item` or `boundary` watermark creation [1/n]

### DIFF
--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -226,7 +226,7 @@ pub(crate) async fn list_checkpoints(
                 match item {
                     Ok(ResolvedWatermarked::Item((cp_seq, cp_data))) => {
                         checkpoint_boundary = advance_checkpoint_boundary(checkpoint_boundary, cp_seq, &options);
-                        let wm = item_watermark(&options, Position::Checkpoints { checkpoint: cp_seq }, checkpoint_boundary);
+                        let wm = item_watermark(Position::Checkpoints { checkpoint: cp_seq }, checkpoint_boundary);
                         emitted += 1;
                         let message =
                             crate::render::checkpoint_to_response(cp_data, &read_mask)?;
@@ -248,7 +248,7 @@ pub(crate) async fn list_checkpoints(
                         if let Some(c) = frontier_to_boundary_candidate(cp_frontier, &options) {
                             checkpoint_boundary = advance_checkpoint_boundary(checkpoint_boundary, c, &options);
                         }
-                        let wm = boundary_watermark(&options, Position::Checkpoints { checkpoint: cp_frontier }, checkpoint_boundary);
+                        let wm = boundary_watermark(Position::Checkpoints { checkpoint: cp_frontier }, checkpoint_boundary);
                         yield watermark_response(wm);
                     }
                     Err(BitmapScanError::ScanLimit) => {
@@ -274,7 +274,7 @@ pub(crate) async fn list_checkpoints(
                 end_reason
             };
             if reached_range_end(reason) {
-                yield watermark_response(terminal_boundary_watermark(&options, Position::Checkpoints { checkpoint: end_position }));
+                yield watermark_response(terminal_boundary_watermark(Position::Checkpoints { checkpoint: end_position }));
             }
             yield end_response(reason);
             info!(
@@ -311,7 +311,7 @@ pub(crate) async fn list_checkpoints(
             match item {
                 Ok(ResolvedWatermarked::Item((cp_seq, cp_data, txs, objects))) => {
                     checkpoint_boundary = advance_checkpoint_boundary(checkpoint_boundary, cp_seq, &options);
-                    let wm = item_watermark(&options, Position::Checkpoints { checkpoint: cp_seq }, checkpoint_boundary);
+                    let wm = item_watermark(Position::Checkpoints { checkpoint: cp_seq }, checkpoint_boundary);
                     let message =
                         render_full_checkpoint(cp_data, txs, objects, &read_mask)?;
                     emitted += 1;
@@ -330,7 +330,7 @@ pub(crate) async fn list_checkpoints(
                     if let Some(c) = frontier_to_boundary_candidate(cp_frontier, &options) {
                         checkpoint_boundary = advance_checkpoint_boundary(checkpoint_boundary, c, &options);
                     }
-                    let wm = boundary_watermark(&options, Position::Checkpoints { checkpoint: cp_frontier }, checkpoint_boundary);
+                    let wm = boundary_watermark(Position::Checkpoints { checkpoint: cp_frontier }, checkpoint_boundary);
                     yield watermark_response(wm);
                 }
                 Err(BitmapScanError::ScanLimit) => {
@@ -356,7 +356,7 @@ pub(crate) async fn list_checkpoints(
             end_reason
         };
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(&options, Position::Checkpoints { checkpoint: end_position }));
+            yield watermark_response(terminal_boundary_watermark(Position::Checkpoints { checkpoint: end_position }));
         }
         yield end_response(reason);
         info!(

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -274,7 +274,7 @@ pub(crate) async fn list_checkpoints(
                 end_reason
             };
             if reached_range_end(reason) {
-                yield watermark_response(terminal_boundary_watermark(Position::Checkpoints { checkpoint: end_position }));
+                yield watermark_response(terminal_boundary_watermark(&options, Position::Checkpoints { checkpoint: end_position }));
             }
             yield end_response(reason);
             info!(
@@ -356,7 +356,7 @@ pub(crate) async fn list_checkpoints(
             end_reason
         };
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(Position::Checkpoints { checkpoint: end_position }));
+            yield watermark_response(terminal_boundary_watermark(&options, Position::Checkpoints { checkpoint: end_position }));
         }
         yield end_response(reason);
         info!(

--- a/crates/sui-kv-rpc/src/v2alpha/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_events.rs
@@ -271,7 +271,6 @@ pub(crate) async fn list_events(
                 Ok(ResolvedWatermarked::Item(rendered)) => {
                     checkpoint_boundary = advance_boundary_excluding_cp(checkpoint_boundary, rendered.checkpoint_number, &options);
                     let wm = item_watermark(
-                        &options,
                         Position::Events { checkpoint: rendered.checkpoint_number, tx_seq: rendered.position.tx_seq, event_index: rendered.position.event_index },
                         checkpoint_boundary,
                     );
@@ -281,7 +280,6 @@ pub(crate) async fn list_events(
                 Ok(ResolvedWatermarked::Watermark { position, cp }) => {
                     checkpoint_boundary = advance_boundary_excluding_cp(checkpoint_boundary, cp, &options);
                     let wm = boundary_watermark(
-                        &options,
                         Position::Events {
                             checkpoint: boundary_cursor_cp(cp, direction),
                             tx_seq: position.tx_seq,

--- a/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
@@ -176,7 +176,7 @@ pub(crate) async fn list_transactions(
                 match item {
                     Ok(ResolvedWatermarked::Item(row)) => {
                         checkpoint_boundary = advance_boundary_excluding_cp(checkpoint_boundary, row.checkpoint_number, &options);
-                        let wm = item_watermark(&options, Position::Transactions { checkpoint: row.checkpoint_number, tx_seq: row.tx_sequence_number }, checkpoint_boundary);
+                        let wm = item_watermark(Position::Transactions { checkpoint: row.checkpoint_number, tx_seq: row.tx_sequence_number }, checkpoint_boundary);
                         emitted += 1;
                         let yield_started = Instant::now();
                         yield transaction_response_from_tx_seq_digest(row, &read_mask, wm);
@@ -184,7 +184,7 @@ pub(crate) async fn list_transactions(
                     }
                     Ok(ResolvedWatermarked::Watermark { position, cp }) => {
                         checkpoint_boundary = advance_boundary_excluding_cp(checkpoint_boundary, cp, &options);
-                        let wm = boundary_watermark(&options, Position::Transactions { checkpoint: boundary_cursor_cp(cp, direction), tx_seq: position }, checkpoint_boundary);
+                        let wm = boundary_watermark(Position::Transactions { checkpoint: boundary_cursor_cp(cp, direction), tx_seq: position }, checkpoint_boundary);
                         yield watermark_response(wm);
                     }
                     Err(BitmapScanError::ScanLimit) => {
@@ -210,7 +210,7 @@ pub(crate) async fn list_transactions(
                 end_reason
             };
             if reached_range_end(reason) {
-                yield watermark_response(terminal_boundary_watermark(&options, Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
+                yield watermark_response(terminal_boundary_watermark(Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
             }
             yield end_response(reason);
             info!(
@@ -278,7 +278,7 @@ pub(crate) async fn list_transactions(
             match item {
                 Ok(ResolvedWatermarked::Item((tx_seq, tx_offset, tx_data, objects))) => {
                     checkpoint_boundary = advance_boundary_excluding_cp(checkpoint_boundary, tx_data.checkpoint_number, &options);
-                    let wm = item_watermark(&options, Position::Transactions { checkpoint: tx_data.checkpoint_number, tx_seq }, checkpoint_boundary);
+                    let wm = item_watermark(Position::Transactions { checkpoint: tx_data.checkpoint_number, tx_seq }, checkpoint_boundary);
                     let render_started = Instant::now();
                     let executed = transaction_to_response(tx_data, &read_mask, &objects, &resolver).await?;
                     ctx.observe_response_render(render_started.elapsed());
@@ -289,7 +289,7 @@ pub(crate) async fn list_transactions(
                 }
                 Ok(ResolvedWatermarked::Watermark { position, cp }) => {
                     checkpoint_boundary = advance_boundary_excluding_cp(checkpoint_boundary, cp, &options);
-                    let wm = boundary_watermark(&options, Position::Transactions { checkpoint: boundary_cursor_cp(cp, direction), tx_seq: position }, checkpoint_boundary);
+                    let wm = boundary_watermark(Position::Transactions { checkpoint: boundary_cursor_cp(cp, direction), tx_seq: position }, checkpoint_boundary);
                     yield watermark_response(wm);
                 }
                 Err(BitmapScanError::ScanLimit) => {
@@ -315,7 +315,7 @@ pub(crate) async fn list_transactions(
             end_reason
         };
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(&options, Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
+            yield watermark_response(terminal_boundary_watermark(Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
         }
         yield end_response(reason);
 
@@ -563,10 +563,6 @@ mod tests {
         }
     }
 
-    fn options() -> QueryOptions {
-        QueryOptions::transactions_from_proto(None, 100, 1_000).unwrap()
-    }
-
     #[test]
     fn renders_transaction_response_from_tx_seq_digest() {
         let row = TxSeqDigestData {
@@ -576,10 +572,8 @@ mod tests {
             tx_offset: 5,
             checkpoint_number: 9,
         };
-        let options = options();
         let wm = || {
             item_watermark(
-                &options,
                 Position::Transactions {
                     checkpoint: row.checkpoint_number,
                     tx_seq: row.tx_sequence_number,

--- a/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
@@ -210,7 +210,7 @@ pub(crate) async fn list_transactions(
                 end_reason
             };
             if reached_range_end(reason) {
-                yield watermark_response(terminal_boundary_watermark(Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
+                yield watermark_response(terminal_boundary_watermark(&options, Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
             }
             yield end_response(reason);
             info!(
@@ -315,7 +315,7 @@ pub(crate) async fn list_transactions(
             end_reason
         };
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
+            yield watermark_response(terminal_boundary_watermark(&options, Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
         }
         yield end_response(reason);
 

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
@@ -564,7 +564,6 @@ fn scan_checkpoint_watermark(
     // Checkpoint cursors live in checkpoint space: position == checkpoint.
     let cursor_cp = boundary_cursor_cp(cp, options.scan_direction());
     let watermark = boundary_watermark(
-        options,
         Position::Checkpoints {
             checkpoint: cursor_cp,
         },
@@ -605,7 +604,6 @@ fn render_checkpoint_seqs(
             service,
             cp_seq,
             read_mask,
-            options,
             checkpoint_boundary,
         )?);
     }
@@ -616,7 +614,6 @@ fn render_checkpoint_seq(
     service: &RpcService,
     cp_seq: u64,
     read_mask: &FieldMaskTree,
-    options: &QueryOptions,
     checkpoint_boundary: Option<u64>,
 ) -> Result<ListCheckpointsResponse, RpcError> {
     let read_mask = read_mask.to_field_mask();
@@ -632,7 +629,6 @@ fn render_checkpoint_seq(
             )
         })?;
     let watermark = item_watermark(
-        options,
         Position::Checkpoints { checkpoint: cp_seq },
         checkpoint_boundary,
     );

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
@@ -460,7 +460,6 @@ fn scan_event_watermark(
     let boundary = advance_boundary_excluding_cp(None, cp, options);
     let cursor_cp = boundary_cursor_cp(cp, options.scan_direction());
     let watermark = boundary_watermark(
-        options,
         Position::Events {
             checkpoint: cursor_cp,
             tx_seq: frontier.tx_seq,
@@ -556,7 +555,6 @@ fn render_event_chunk(
         checkpoint_boundary =
             advance_boundary_excluding_cp(checkpoint_boundary, row.checkpoint_number, options);
         let watermark = item_watermark(
-            options,
             Position::Events {
                 checkpoint: row.checkpoint_number,
                 tx_seq: event_ref.position.tx_seq,

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
@@ -420,7 +420,6 @@ fn scan_transaction_watermark(
     let boundary = advance_boundary_excluding_cp(None, cp, options);
     let cursor_cp = boundary_cursor_cp(cp, options.scan_direction());
     let watermark = boundary_watermark(
-        options,
         Position::Transactions {
             checkpoint: cursor_cp,
             tx_seq: frontier,
@@ -465,7 +464,6 @@ fn render_transaction_rows(
         checkpoint_boundary =
             advance_boundary_excluding_cp(checkpoint_boundary, row.checkpoint_number, options);
         let watermark = item_watermark(
-            options,
             Position::Transactions {
                 checkpoint: row.checkpoint_number,
                 tx_seq: row.tx_sequence_number,

--- a/crates/sui-rpc-api/src/ledger_history/watermark.rs
+++ b/crates/sui-rpc-api/src/ledger_history/watermark.rs
@@ -219,11 +219,11 @@ mod tests {
         );
     }
 
-    /// The already-direction-correct boundary is recorded in the single
-    /// `checkpoint` field as-is. A client reads the bound off the wire frame
-    /// and interprets it per the request's ordering.
+    /// The direction-correct boundary is recorded in the single `checkpoint` field regardless of
+    /// ordering. A client reads the bound off the wire frame and interprets it per the request's
+    /// ordering.
     #[test]
-    fn item_watermark_sets_checkpoint_bound() {
+    fn item_watermark_sets_direction_matching_bound() {
         let pos = Position::Transactions {
             checkpoint: 9,
             tx_seq: 42,

--- a/crates/sui-rpc-api/src/ledger_history/watermark.rs
+++ b/crates/sui-rpc-api/src/ledger_history/watermark.rs
@@ -88,11 +88,7 @@ pub fn advance_boundary_excluding_cp(
 /// plus the current direction-matching checkpoint boundary. `cp` /
 /// `position` are the item's cursor coordinates (`list_checkpoints` passes
 /// its cp_seq for both).
-pub fn item_watermark(
-    _options: &QueryOptions,
-    position: Position,
-    boundary: Option<u64>,
-) -> Watermark {
+pub fn item_watermark(position: Position, boundary: Option<u64>) -> Watermark {
     let mut wm = Watermark::default();
     wm.cursor = Some(CursorToken::item(position).encode());
     set_checkpoint_bound(&mut wm, boundary);
@@ -104,11 +100,7 @@ pub fn item_watermark(
 /// its scan domain (see [`boundary_cursor_cp`] for the per-checkpoint
 /// scanners' direction adjustment); `boundary` is the accumulated
 /// completion boundary.
-pub fn boundary_watermark(
-    _options: &QueryOptions,
-    position: Position,
-    boundary: Option<u64>,
-) -> Watermark {
+pub fn boundary_watermark(position: Position, boundary: Option<u64>) -> Watermark {
     let mut wm = Watermark::default();
     wm.cursor = Some(CursorToken::boundary(position).encode());
     set_checkpoint_bound(&mut wm, boundary);
@@ -227,23 +219,21 @@ mod tests {
         );
     }
 
-    /// The direction-correct boundary is recorded in the single `checkpoint`
-    /// field regardless of ordering. A client reads the bound off the wire
-    /// frame and interprets it per the request's ordering.
+    /// The already-direction-correct boundary is recorded in the single
+    /// `checkpoint` field as-is. A client reads the bound off the wire frame
+    /// and interprets it per the request's ordering.
     #[test]
-    fn item_watermark_sets_direction_matching_bound() {
-        let asc = options(true);
+    fn item_watermark_sets_checkpoint_bound() {
         let pos = Position::Transactions {
             checkpoint: 9,
             tx_seq: 42,
         };
-        let wm = item_watermark(&asc, pos, Some(8));
+        let wm = item_watermark(pos, Some(8));
         assert_eq!(wm.checkpoint, Some(8));
         assert_eq!(wm.cursor.as_ref(), Some(&CursorToken::item(pos).encode()));
 
-        let desc = options(false);
-        let wm = item_watermark(&desc, pos, Some(10));
-        assert_eq!(wm.checkpoint, Some(10));
+        let wm = item_watermark(pos, None);
+        assert_eq!(wm.checkpoint, None);
     }
 
     /// On natural completion the terminal frame claims the range's final


### PR DESCRIPTION
## Description 

Remove unused `_options` from `item_watermark` and `boundary_watermark`

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
