### PR TITLE
[grpc] Build terminal watermark frame at range resolution, consolidate sui-rpc-api frontier watermark construction [2/n]

### DIFF
--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -107,7 +107,12 @@ pub(crate) async fn list_checkpoints(
         .instrument(debug_span!("resolve_cp_range"))
         .await?;
     let end_reason = cp_range.end_reason;
-    let end_position = cp_range.end_position;
+    let terminal_watermark = terminal_boundary_watermark(
+        &options,
+        Position::Checkpoints {
+            checkpoint: cp_range.end_position,
+        },
+    );
     let cp_range = cp_range.range;
 
     if cp_range.is_empty() {
@@ -122,14 +127,8 @@ pub(crate) async fn list_checkpoints(
         // A caught-up tail (e.g. polling at the ledger tip) resolves to an empty
         // range; still surface the terminal boundary so the client learns the
         // final checkpoint is complete without waiting for the next item.
-        let terminal = reached_range_end(end_reason).then(|| {
-            watermark_response(terminal_boundary_watermark(
-                &options,
-                Position::Checkpoints {
-                    checkpoint: end_position,
-                },
-            ))
-        });
+        let terminal =
+            reached_range_end(end_reason).then(|| watermark_response(terminal_watermark));
         return Ok(stream::iter(
             terminal
                 .into_iter()
@@ -274,7 +273,7 @@ pub(crate) async fn list_checkpoints(
                 end_reason
             };
             if reached_range_end(reason) {
-                yield watermark_response(terminal_boundary_watermark(&options, Position::Checkpoints { checkpoint: end_position }));
+                yield watermark_response(terminal_watermark);
             }
             yield end_response(reason);
             info!(
@@ -356,7 +355,7 @@ pub(crate) async fn list_checkpoints(
             end_reason
         };
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(&options, Position::Checkpoints { checkpoint: end_position }));
+            yield watermark_response(terminal_watermark);
         }
         yield end_response(reason);
         info!(

--- a/crates/sui-kv-rpc/src/v2alpha/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_events.rs
@@ -97,8 +97,14 @@ pub(crate) async fn list_events(
         .instrument(debug_span!("resolve_event_range"))
         .await?;
     let end_reason = event_range.end_reason;
-    let end_checkpoint = event_range.end_checkpoint;
-    let end_position = event_range.end_position;
+    let terminal_watermark = terminal_boundary_watermark(
+        &options,
+        Position::Events {
+            checkpoint: event_range.end_checkpoint,
+            tx_seq: event_range.end_position.tx_seq,
+            event_index: event_range.end_position.event_index,
+        },
+    );
     let event_bounds = event_range.bounds;
 
     if event_range.is_empty() {
@@ -114,16 +120,8 @@ pub(crate) async fn list_events(
         // A caught-up tail (e.g. polling at the ledger tip) resolves to an empty
         // range; still surface the terminal boundary so the client learns the
         // final checkpoint is complete without waiting for the next item.
-        let terminal = reached_range_end(end_reason).then(|| {
-            watermark_response(terminal_boundary_watermark(
-                &options,
-                Position::Events {
-                    checkpoint: end_checkpoint,
-                    tx_seq: end_position.tx_seq,
-                    event_index: end_position.event_index,
-                },
-            ))
-        });
+        let terminal =
+            reached_range_end(end_reason).then(|| watermark_response(terminal_watermark));
         return Ok(futures::stream::iter(
             terminal
                 .into_iter()
@@ -312,7 +310,7 @@ pub(crate) async fn list_events(
             end_reason
         };
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(&options, Position::Events { checkpoint: end_checkpoint, tx_seq: end_position.tx_seq, event_index: end_position.event_index }));
+            yield watermark_response(terminal_watermark);
         }
         yield end_response(reason);
         info!(

--- a/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
@@ -93,8 +93,13 @@ pub(crate) async fn list_transactions(
         .instrument(debug_span!("resolve_tx_range"))
         .await?;
     let end_reason = tx_range.end_reason;
-    let end_checkpoint = tx_range.end_checkpoint;
-    let end_position = tx_range.end_position;
+    let terminal_watermark = terminal_boundary_watermark(
+        &options,
+        Position::Transactions {
+            checkpoint: tx_range.end_checkpoint,
+            tx_seq: tx_range.end_position,
+        },
+    );
     let tx_range = tx_range.range;
 
     if tx_range.is_empty() {
@@ -108,15 +113,8 @@ pub(crate) async fn list_transactions(
         // A caught-up tail (e.g. polling at the ledger tip) resolves to an empty
         // range; still surface the terminal boundary so the client learns the
         // final checkpoint is complete without waiting for the next item.
-        let terminal = reached_range_end(end_reason).then(|| {
-            watermark_response(terminal_boundary_watermark(
-                &options,
-                Position::Transactions {
-                    checkpoint: end_checkpoint,
-                    tx_seq: end_position,
-                },
-            ))
-        });
+        let terminal =
+            reached_range_end(end_reason).then(|| watermark_response(terminal_watermark));
         return Ok(futures::stream::iter(
             terminal
                 .into_iter()
@@ -210,7 +208,7 @@ pub(crate) async fn list_transactions(
                 end_reason
             };
             if reached_range_end(reason) {
-                yield watermark_response(terminal_boundary_watermark(&options, Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
+                yield watermark_response(terminal_watermark);
             }
             yield end_response(reason);
             info!(
@@ -315,7 +313,7 @@ pub(crate) async fn list_transactions(
             end_reason
         };
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(&options, Position::Transactions { checkpoint: end_checkpoint, tx_seq: end_position }));
+            yield watermark_response(terminal_watermark);
         }
         yield end_response(reason);
 

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/chunked_scan.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/chunked_scan.rs
@@ -4,20 +4,22 @@
 use std::collections::VecDeque;
 
 use sui_rpc::proto::sui::rpc::v2alpha::QueryEndReason;
-use sui_rpc_cursor::Position;
+use sui_rpc::proto::sui::rpc::v2alpha::Watermark;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::sync::DropGuard;
 
 use crate::RpcError;
 
-/// How a query stream ended, plus the typed exclusive range boundary the scan
-/// reached. The boundary lets the caller build the terminal progress watermark
-/// when the scan completed naturally.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// How a query stream ended, plus the prebuilt terminal boundary watermark.
+/// The watermark's value depends only on the resolved range and the request
+/// ordering, so it is built once at range resolution; the scan contributes
+/// only `reason`, which gates whether the caller emits it (natural completion
+/// only).
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ChunkTerminal {
     pub(crate) reason: QueryEndReason,
-    pub(crate) position: Position,
+    pub(crate) watermark: Watermark,
 }
 
 pub(crate) struct ScanChunkDone<State, Item> {
@@ -201,10 +203,7 @@ mod tests {
                     next_state: (state < 2).then_some(state + 1),
                     terminal: ChunkTerminal {
                         reason: QueryEndReason::CheckpointBound,
-                        position: Position::Transactions {
-                            checkpoint: 0,
-                            tx_seq: 0,
-                        },
+                        watermark: Watermark::default(),
                     },
                     remaining_scan_budget: scan_budget - 1,
                 })
@@ -221,10 +220,7 @@ mod tests {
             scan.into_terminal(),
             Some(ChunkTerminal {
                 reason: QueryEndReason::CheckpointBound,
-                position: Position::Transactions {
-                    checkpoint: 0,
-                    tx_seq: 0
-                },
+                watermark: Watermark::default(),
             })
         );
         assert_eq!(
@@ -246,10 +242,7 @@ mod tests {
                     next_state: None,
                     terminal: ChunkTerminal {
                         reason: QueryEndReason::CheckpointBound,
-                        position: Position::Transactions {
-                            checkpoint: 0,
-                            tx_seq: 0,
-                        },
+                        watermark: Watermark::default(),
                     },
                     remaining_scan_budget: args.scan_budget,
                 })

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
@@ -54,10 +54,8 @@ use super::ledger_read::remaining_range_after;
 use super::ledger_read::sequence_frontier_checkpoint;
 use super::ledger_read::validate_checkpoint_bounds;
 use super::query_end::query_end;
-use crate::ledger_history::watermark::advance_boundary_excluding_cp;
 use crate::ledger_history::watermark::advance_checkpoint_boundary;
-use crate::ledger_history::watermark::boundary_cursor_cp;
-use crate::ledger_history::watermark::boundary_watermark;
+use crate::ledger_history::watermark::frontier_boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::reached_range_end;
 use crate::ledger_history::watermark::terminal_boundary_watermark;
@@ -539,19 +537,8 @@ fn scan_checkpoint_watermark(
     let Some(cp) = sequence_frontier_checkpoint(service, frontier, ascending)? else {
         return Ok(None);
     };
-    // The frontier lands partway through checkpoint `cp`, so `cp` itself is not
-    // yet proven complete — exclude it from the boundary (`cp ∓ 1`). Contrast
-    // the item path, which feeds an emitted (hence complete) cp_seq straight
-    // into `advance_checkpoint_boundary`.
-    let boundary = advance_boundary_excluding_cp(None, cp, options);
     // Checkpoint cursors live in checkpoint space: position == checkpoint.
-    let cursor_cp = boundary_cursor_cp(cp, options.scan_direction());
-    let watermark = boundary_watermark(
-        Position::Checkpoints {
-            checkpoint: cursor_cp,
-        },
-        boundary,
-    );
+    let watermark = frontier_boundary_watermark(options, Position::Checkpoints { checkpoint: cp });
     Ok(Some(watermark_response(watermark)))
 }
 

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
@@ -102,7 +102,6 @@ pub(crate) async fn list_checkpoints(
         filter_query,
     };
 
-    let terminal_options = options.clone();
     Ok(async_stream::try_stream! {
         let mut scan = ChunkedScan::new(
             initial_state,
@@ -132,10 +131,7 @@ pub(crate) async fn list_checkpoints(
         let terminal = scan.into_terminal().expect("query emits terminal state");
         let reason = query_end(emitted, limit_items, terminal.reason);
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(
-                &terminal_options,
-                terminal.position,
-            ));
+            yield watermark_response(terminal.watermark);
         }
         yield end_response(reason);
         info!(
@@ -187,8 +183,7 @@ enum CheckpointScanState {
     Unfiltered {
         range: Range<u64>,
         end_reason: QueryEndReason,
-        end_checkpoint: u64,
-        end_position: u64,
+        terminal_watermark: Watermark,
     },
     Filtered {
         query: BitmapQuery,
@@ -197,8 +192,7 @@ enum CheckpointScanState {
         buffered_cp_seqs: VecDeque<u64>,
         last_cp_seq: Option<u64>,
         end_reason: QueryEndReason,
-        end_checkpoint: u64,
-        end_position: u64,
+        terminal_watermark: Watermark,
     },
 }
 
@@ -232,9 +226,12 @@ fn next_checkpoint_chunk(
             }
             let terminal = ChunkTerminal {
                 reason: cp_range.end_reason,
-                position: Position::Checkpoints {
-                    checkpoint: cp_range.end_position,
-                },
+                watermark: terminal_boundary_watermark(
+                    &options,
+                    Position::Checkpoints {
+                        checkpoint: cp_range.end_position,
+                    },
+                ),
             };
             let range = cp_range.range;
             if range.is_empty() {
@@ -269,15 +266,13 @@ fn next_checkpoint_chunk(
                     buffered_cp_seqs: VecDeque::new(),
                     last_cp_seq: None,
                     end_reason: terminal.reason,
-                    end_checkpoint: cp_range.end_checkpoint,
-                    end_position: cp_range.end_position,
+                    terminal_watermark: terminal.watermark,
                 }
             } else {
                 CheckpointScanState::Unfiltered {
                     range,
                     end_reason: terminal.reason,
-                    end_checkpoint: cp_range.end_checkpoint,
-                    end_position: cp_range.end_position,
+                    terminal_watermark: terminal.watermark,
                 }
             };
             next_checkpoint_chunk(
@@ -295,14 +290,12 @@ fn next_checkpoint_chunk(
         CheckpointScanState::Unfiltered {
             range,
             end_reason,
-            end_checkpoint,
-            end_position,
+            terminal_watermark,
         } => next_unfiltered_checkpoint_chunk(
             service,
             range,
             end_reason,
-            end_checkpoint,
-            end_position,
+            terminal_watermark,
             read_mask,
             options,
             scan_budget,
@@ -316,8 +309,7 @@ fn next_checkpoint_chunk(
             buffered_cp_seqs,
             last_cp_seq,
             end_reason,
-            end_checkpoint,
-            end_position,
+            terminal_watermark,
         } => next_filtered_checkpoint_chunk(
             service,
             query,
@@ -326,8 +318,7 @@ fn next_checkpoint_chunk(
             buffered_cp_seqs,
             last_cp_seq,
             end_reason,
-            end_checkpoint,
-            end_position,
+            terminal_watermark,
             read_mask,
             options,
             scan_budget,
@@ -343,8 +334,7 @@ fn next_unfiltered_checkpoint_chunk(
     service: RpcService,
     range: Range<u64>,
     end_reason: QueryEndReason,
-    end_checkpoint: u64,
-    end_position: u64,
+    terminal_watermark: Watermark,
     read_mask: FieldMaskTree,
     options: QueryOptions,
     scan_budget: usize,
@@ -359,8 +349,7 @@ fn next_unfiltered_checkpoint_chunk(
         .map(|range| CheckpointScanState::Unfiltered {
             range,
             end_reason,
-            end_checkpoint,
-            end_position,
+            terminal_watermark: terminal_watermark.clone(),
         });
     if cancel.is_cancelled() {
         return Err(cancelled());
@@ -373,9 +362,7 @@ fn next_unfiltered_checkpoint_chunk(
         next_state,
         terminal: ChunkTerminal {
             reason: end_reason,
-            position: Position::Checkpoints {
-                checkpoint: end_position,
-            },
+            watermark: terminal_watermark,
         },
         remaining_scan_budget: scan_budget,
     })
@@ -389,8 +376,7 @@ fn next_filtered_checkpoint_chunk(
     mut buffered_cp_seqs: VecDeque<u64>,
     mut last_cp_seq: Option<u64>,
     end_reason: QueryEndReason,
-    end_checkpoint: u64,
-    end_position: u64,
+    terminal_watermark: Watermark,
     read_mask: FieldMaskTree,
     options: QueryOptions,
     scan_budget: usize,
@@ -494,8 +480,7 @@ fn next_filtered_checkpoint_chunk(
                 buffered_cp_seqs,
                 last_cp_seq,
                 end_reason,
-                end_checkpoint,
-                end_position,
+                terminal_watermark: terminal_watermark.clone(),
             },
         )
     };
@@ -527,9 +512,7 @@ fn next_filtered_checkpoint_chunk(
         next_state,
         terminal: ChunkTerminal {
             reason,
-            position: Position::Checkpoints {
-                checkpoint: end_position,
-            },
+            watermark: terminal_watermark,
         },
         remaining_scan_budget,
     })

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
@@ -58,8 +58,7 @@ use super::ledger_read::get_tx_seq_digest_multi;
 use super::ledger_read::lowest_available_tx_seq;
 use super::ledger_read::validate_checkpoint_bounds;
 use crate::ledger_history::watermark::advance_boundary_excluding_cp;
-use crate::ledger_history::watermark::boundary_cursor_cp;
-use crate::ledger_history::watermark::boundary_watermark;
+use crate::ledger_history::watermark::frontier_boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::reached_range_end;
 use crate::ledger_history::watermark::terminal_boundary_watermark;
@@ -222,7 +221,7 @@ fn next_event_chunk(
 ) -> Result<EventChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let mut remaining_scan_budget = scan_budget;
-    let (refs, next_state, terminal, scan_watermark) = match state {
+    let (refs, next_state, terminal, scan_limited, frontier) = match state {
         EventScanState::Init {
             start_checkpoint,
             end_checkpoint,
@@ -325,15 +324,13 @@ fn next_event_chunk(
                 reason,
                 watermark: terminal_watermark,
             };
-            let scan_watermark = scan_event_watermark(
-                &service,
-                &options,
+            (
+                scan.refs,
+                next_state,
+                terminal,
                 scan.scan_limit_hit,
-                scan.refs.is_empty(),
                 scan.frontier,
-                ascending,
-            )?;
-            (scan.refs, next_state, terminal, scan_watermark)
+            )
         }
         EventScanState::Filtered {
             query,
@@ -390,21 +387,21 @@ fn next_event_chunk(
                 reason,
                 watermark: terminal_watermark,
             };
-            let scan_watermark = scan_event_watermark(
-                &service,
-                &options,
-                scan_limited,
-                refs.is_empty(),
-                frontier,
-                ascending,
-            )?;
-            (refs, next_state, terminal, scan_watermark)
+            (refs, next_state, terminal, scan_limited, frontier)
         }
     };
 
     if cancel.is_cancelled() {
         return Err(cancelled());
     }
+    let scan_watermark = scan_event_watermark(
+        &service,
+        &options,
+        scan_limited,
+        refs.is_empty(),
+        frontier,
+        ascending,
+    )?;
     let mut items = render_event_chunk(&service, refs, &read_mask, &options, cancel)?;
     let produced = items.len();
     if let Some(watermark) = scan_watermark {
@@ -419,10 +416,9 @@ fn next_event_chunk(
     })
 }
 
-/// Build the scan watermark frame for a filtered chunk that matched
-/// nothing while the scan budget ran out mid-gap. Resolves the coalesced
-/// frontier to its checkpoint; yields nothing at genesis (asc) where no progress
-/// can be claimed.
+/// Build the scan watermark frame for a chunk that matched nothing while its scan budget (bitmap
+/// buckets when filtered, tx rows when unfiltered) ran out mid-gap. Resolves the coalesced frontier
+/// to its checkpoint; yields nothing at genesis (asc) where no progress can be claimed.
 fn scan_event_watermark(
     service: &RpcService,
     options: &QueryOptions,
@@ -440,15 +436,13 @@ fn scan_event_watermark(
     let Some(cp) = event_frontier_checkpoint(service, frontier, ascending)? else {
         return Ok(None);
     };
-    let boundary = advance_boundary_excluding_cp(None, cp, options);
-    let cursor_cp = boundary_cursor_cp(cp, options.scan_direction());
-    let watermark = boundary_watermark(
+    let watermark = frontier_boundary_watermark(
+        options,
         Position::Events {
-            checkpoint: cursor_cp,
+            checkpoint: cp,
             tx_seq: frontier.tx_seq,
             event_index: frontier.event_index,
         },
-        boundary,
     );
     Ok(Some(watermark_response(watermark)))
 }

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
@@ -103,7 +103,6 @@ pub(crate) async fn list_events(
         filter_query,
     };
 
-    let terminal_options = options.clone();
     Ok(async_stream::try_stream! {
         let unfiltered_row_scan_budget = endpoint.max_limit_items as usize;
         let mut scan = ChunkedScan::new(
@@ -137,10 +136,7 @@ pub(crate) async fn list_events(
         // Natural completion proves the range's final checkpoint complete; emit a
         // terminal watermark carrying that bound and the resume cursor.
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(
-                &terminal_options,
-                terminal.position,
-            ));
+            yield watermark_response(terminal.watermark);
         }
         yield end_response(reason);
         info!(
@@ -199,16 +195,14 @@ enum EventScanState {
         // rows per request.
         row_scan_budget: usize,
         end_reason: QueryEndReason,
-        end_checkpoint: u64,
-        end_position: EventPosition,
+        terminal_watermark: Watermark,
     },
     Filtered {
         query: BitmapQuery,
         bounds: Option<EventScanBounds>,
         pending_bucket: Option<PendingBitmapBucket>,
         end_reason: QueryEndReason,
-        end_checkpoint: u64,
-        end_position: EventPosition,
+        terminal_watermark: Watermark,
     },
 }
 
@@ -246,11 +240,14 @@ fn next_event_chunk(
             }
             let terminal = ChunkTerminal {
                 reason: event_range.end_reason,
-                position: Position::Events {
-                    checkpoint: event_range.end_checkpoint,
-                    tx_seq: event_range.end_position.tx_seq,
-                    event_index: event_range.end_position.event_index,
-                },
+                watermark: terminal_boundary_watermark(
+                    &options,
+                    Position::Events {
+                        checkpoint: event_range.end_checkpoint,
+                        tx_seq: event_range.end_position.tx_seq,
+                        event_index: event_range.end_position.event_index,
+                    },
+                ),
             };
             let bounds = event_range.bounds;
             if event_range.is_empty() {
@@ -268,15 +265,13 @@ fn next_event_chunk(
                     bounds: Some(bounds),
                     pending_bucket: None,
                     end_reason: terminal.reason,
-                    end_checkpoint: event_range.end_checkpoint,
-                    end_position: event_range.end_position,
+                    terminal_watermark: terminal.watermark,
                 },
                 None => EventScanState::Unfiltered {
                     bounds,
                     row_scan_budget: unfiltered_row_scan_budget,
                     end_reason: terminal.reason,
-                    end_checkpoint: event_range.end_checkpoint,
-                    end_position: event_range.end_position,
+                    terminal_watermark: terminal.watermark,
                 },
             };
             return next_event_chunk(
@@ -296,8 +291,7 @@ fn next_event_chunk(
             bounds,
             row_scan_budget,
             end_reason,
-            end_checkpoint,
-            end_position,
+            terminal_watermark,
         } => {
             if cancel.is_cancelled() {
                 return Err(cancelled());
@@ -319,8 +313,7 @@ fn next_event_chunk(
                     bounds,
                     row_scan_budget,
                     end_reason,
-                    end_checkpoint,
-                    end_position,
+                    terminal_watermark: terminal_watermark.clone(),
                 })
             };
             let reason = if request_exhausted {
@@ -330,11 +323,7 @@ fn next_event_chunk(
             };
             let terminal = ChunkTerminal {
                 reason,
-                position: Position::Events {
-                    checkpoint: end_checkpoint,
-                    tx_seq: end_position.tx_seq,
-                    event_index: end_position.event_index,
-                },
+                watermark: terminal_watermark,
             };
             let scan_watermark = scan_event_watermark(
                 &service,
@@ -351,8 +340,7 @@ fn next_event_chunk(
             bounds,
             pending_bucket,
             end_reason,
-            end_checkpoint,
-            end_position,
+            terminal_watermark,
         } => {
             let hit_limit = chunk_item_limit.min(remaining_request_item_limit);
             let chunk_scan_budget = remaining_scan_budget.min(chunk_scan_budget);
@@ -389,8 +377,7 @@ fn next_event_chunk(
                         bounds: hits.next_bounds,
                         pending_bucket: hits.pending_bucket,
                         end_reason,
-                        end_checkpoint,
-                        end_position,
+                        terminal_watermark: terminal_watermark.clone(),
                     },
                 )
             };
@@ -401,11 +388,7 @@ fn next_event_chunk(
             };
             let terminal = ChunkTerminal {
                 reason,
-                position: Position::Events {
-                    checkpoint: end_checkpoint,
-                    tx_seq: end_position.tx_seq,
-                    event_index: end_position.event_index,
-                },
+                watermark: terminal_watermark,
             };
             let scan_watermark = scan_event_watermark(
                 &service,

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
@@ -102,7 +102,6 @@ pub(crate) async fn list_transactions(
         filter_query,
     };
 
-    let terminal_options = options.clone();
     Ok(async_stream::try_stream! {
         let render_contents = should_render_transaction_contents(&read_mask);
         let mut scan = ChunkedScan::new(
@@ -134,10 +133,7 @@ pub(crate) async fn list_transactions(
         let terminal = scan.into_terminal().expect("query emits terminal state");
         let reason = query_end(emitted, limit_items, terminal.reason);
         if reached_range_end(reason) {
-            yield watermark_response(terminal_boundary_watermark(
-                &terminal_options,
-                terminal.position,
-            ));
+            yield watermark_response(terminal.watermark);
         }
         yield end_response(reason);
         info!(
@@ -191,16 +187,14 @@ enum TransactionScanState {
     Unfiltered {
         range: Range<u64>,
         end_reason: QueryEndReason,
-        end_checkpoint: u64,
-        end_position: u64,
+        terminal_watermark: Watermark,
     },
     Filtered {
         query: BitmapQuery,
         range: Option<Range<u64>>,
         pending_bucket: Option<PendingBitmapBucket>,
         end_reason: QueryEndReason,
-        end_checkpoint: u64,
-        end_position: u64,
+        terminal_watermark: Watermark,
     },
 }
 
@@ -239,10 +233,13 @@ fn next_transaction_chunk(
                     resolve_tx_range(&service, start_checkpoint, checkpoint_range, &options)?;
                 let terminal = ChunkTerminal {
                     reason: tx_range.end_reason,
-                    position: Position::Transactions {
-                        checkpoint: tx_range.end_checkpoint,
-                        tx_seq: tx_range.end_position,
-                    },
+                    watermark: terminal_boundary_watermark(
+                        &options,
+                        Position::Transactions {
+                            checkpoint: tx_range.end_checkpoint,
+                            tx_seq: tx_range.end_position,
+                        },
+                    ),
                 };
                 let range = tx_range.range;
                 if range.is_empty() {
@@ -260,14 +257,12 @@ fn next_transaction_chunk(
                         range: Some(range),
                         pending_bucket: None,
                         end_reason: terminal.reason,
-                        end_checkpoint: tx_range.end_checkpoint,
-                        end_position: tx_range.end_position,
+                        terminal_watermark: terminal.watermark,
                     },
                     None => TransactionScanState::Unfiltered {
                         range,
                         end_reason: terminal.reason,
-                        end_checkpoint: tx_range.end_checkpoint,
-                        end_position: tx_range.end_position,
+                        terminal_watermark: terminal.watermark,
                     },
                 };
                 continue;
@@ -275,8 +270,7 @@ fn next_transaction_chunk(
             TransactionScanState::Unfiltered {
                 range,
                 end_reason,
-                end_checkpoint,
-                end_position,
+                terminal_watermark,
             } => {
                 let rows =
                     get_tx_seq_digest_rows(&service, range.clone(), !ascending, chunk_item_limit)?;
@@ -286,15 +280,11 @@ fn next_transaction_chunk(
                     .map(|range| TransactionScanState::Unfiltered {
                         range,
                         end_reason,
-                        end_checkpoint,
-                        end_position,
+                        terminal_watermark: terminal_watermark.clone(),
                     });
                 let terminal = ChunkTerminal {
                     reason: end_reason,
-                    position: Position::Transactions {
-                        checkpoint: end_checkpoint,
-                        tx_seq: end_position,
-                    },
+                    watermark: terminal_watermark,
                 };
                 break (rows, next_state, terminal, None);
             }
@@ -303,8 +293,7 @@ fn next_transaction_chunk(
                 range,
                 pending_bucket,
                 end_reason,
-                end_checkpoint,
-                end_position,
+                terminal_watermark,
             } => {
                 let hit_limit = chunk_item_limit.min(remaining_request_item_limit);
                 let chunk_scan_budget = remaining_scan_budget.min(chunk_scan_budget);
@@ -341,8 +330,7 @@ fn next_transaction_chunk(
                             range: hits.next_range,
                             pending_bucket: hits.pending_bucket,
                             end_reason,
-                            end_checkpoint,
-                            end_position,
+                            terminal_watermark: terminal_watermark.clone(),
                         },
                     )
                 };
@@ -353,10 +341,7 @@ fn next_transaction_chunk(
                 };
                 let terminal = ChunkTerminal {
                     reason,
-                    position: Position::Transactions {
-                        checkpoint: end_checkpoint,
-                        tx_seq: end_position,
-                    },
+                    watermark: terminal_watermark,
                 };
                 // A transaction member id is its own tx_sequence_number, so the
                 // frontier decodes to itself.

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
@@ -35,8 +35,7 @@ use crate::ledger_history::query_options::CheckpointRange;
 use crate::ledger_history::query_options::QueryOptions;
 use crate::ledger_history::query_options::ResolvedRange;
 use crate::ledger_history::watermark::advance_boundary_excluding_cp;
-use crate::ledger_history::watermark::boundary_cursor_cp;
-use crate::ledger_history::watermark::boundary_watermark;
+use crate::ledger_history::watermark::frontier_boundary_watermark;
 use crate::ledger_history::watermark::item_watermark;
 use crate::ledger_history::watermark::reached_range_end;
 use crate::ledger_history::watermark::terminal_boundary_watermark;
@@ -214,7 +213,7 @@ fn next_transaction_chunk(
 ) -> Result<TransactionChunkDone, RpcError> {
     let ascending = options.is_ascending();
     let mut remaining_scan_budget = scan_budget;
-    let (rows, next_state, terminal, scan_watermark) = loop {
+    let (rows, next_state, terminal, scan_limited, frontier) = loop {
         if cancel.is_cancelled() {
             return Err(cancelled());
         }
@@ -286,7 +285,9 @@ fn next_transaction_chunk(
                     reason: end_reason,
                     watermark: terminal_watermark,
                 };
-                break (rows, next_state, terminal, None);
+                // An unfiltered scan spends no budget between items (every row
+                // scanned is an item), so it can never end mid-gap.
+                break (rows, next_state, terminal, false, None);
             }
             TransactionScanState::Filtered {
                 query,
@@ -343,17 +344,7 @@ fn next_transaction_chunk(
                     reason,
                     watermark: terminal_watermark,
                 };
-                // A transaction member id is its own tx_sequence_number, so the
-                // frontier decodes to itself.
-                let scan_watermark = scan_transaction_watermark(
-                    &service,
-                    &options,
-                    scan_limited,
-                    rows.is_empty(),
-                    coalesced_frontier,
-                    ascending,
-                )?;
-                break (rows, next_state, terminal, scan_watermark);
+                break (rows, next_state, terminal, scan_limited, coalesced_frontier);
             }
         }
     };
@@ -361,6 +352,14 @@ fn next_transaction_chunk(
     if cancel.is_cancelled() {
         return Err(cancelled());
     }
+    let scan_watermark = scan_transaction_watermark(
+        &service,
+        &options,
+        scan_limited,
+        rows.is_empty(),
+        frontier,
+        ascending,
+    )?;
     let mut items = render_transaction_rows(
         &service,
         rows,
@@ -382,9 +381,8 @@ fn next_transaction_chunk(
     })
 }
 
-/// Scan watermark for a filtered chunk that matched nothing before the
-/// scan budget ran out mid-gap. A transaction's member id is its own
-/// `tx_sequence_number`, so the frontier decodes to itself.
+/// Scan watermark for a filtered chunk that matched nothing before the scan budget ran out mid-gap.
+/// A transaction's member id is its own `tx_sequence_number`, so the frontier decodes to itself.
 fn scan_transaction_watermark(
     service: &RpcService,
     options: &QueryOptions,
@@ -402,14 +400,12 @@ fn scan_transaction_watermark(
     let Some(cp) = sequence_frontier_checkpoint(service, frontier, ascending)? else {
         return Ok(None);
     };
-    let boundary = advance_boundary_excluding_cp(None, cp, options);
-    let cursor_cp = boundary_cursor_cp(cp, options.scan_direction());
-    let watermark = boundary_watermark(
+    let watermark = frontier_boundary_watermark(
+        options,
         Position::Transactions {
-            checkpoint: cursor_cp,
+            checkpoint: cp,
             tx_seq: frontier,
         },
-        boundary,
     );
     Ok(Some(watermark_response(watermark)))
 }

--- a/crates/sui-rpc-api/src/ledger_history/watermark.rs
+++ b/crates/sui-rpc-api/src/ledger_history/watermark.rs
@@ -121,13 +121,27 @@ pub fn boundary_cursor_cp(cp: u64, direction: ScanDirection) -> u64 {
     }
 }
 
-/// Boundary watermark emitted once a scan has drained its entire resolved
-/// range under natural completion. Unlike per-item watermarks it can claim
-/// the range's final checkpoint complete — `end_checkpoint - 1` ascending
-/// (the exclusive cp upper) or `end_checkpoint` descending (the inclusive cp
-/// lower) — because no further items exist in it within the requested range.
-/// The `(end_checkpoint, end_position)` cursor resumes exactly past the
-/// scanned range.
+/// Build the standalone scan-frontier `Watermark` from a frontier position
+/// carrying its raw containing checkpoint. The frontier lands partway
+/// through that checkpoint, so the frame's two fields project it in
+/// opposite directions: the completion claim excludes it looking backward
+/// ([`advance_boundary_excluding_cp`], `cp ∓ 1`), while the resume cursor
+/// keeps it included looking forward ([`boundary_cursor_cp`] rewrites the
+/// position's cp coordinate; the scalar coordinates pass through).
+pub fn frontier_boundary_watermark(options: &QueryOptions, position: Position) -> Watermark {
+    let cp = position.checkpoint();
+    let boundary = advance_boundary_excluding_cp(None, cp, options);
+    boundary_watermark(
+        position.with_checkpoint(boundary_cursor_cp(cp, options.scan_direction())),
+        boundary,
+    )
+}
+
+/// Boundary watermark emitted once a scan has drained its entire resolved range under natural
+/// completion. Unlike per-item watermarks it can claim the range's final checkpoint complete —
+/// `end_checkpoint - 1` ascending (the exclusive cp upper) or `end_checkpoint` descending (the
+/// inclusive cp lower) — because no further items exist in it within the requested range. The
+/// `(end_checkpoint, end_position)` cursor resumes exactly past the scanned range.
 pub fn terminal_boundary_watermark(options: &QueryOptions, end_position: Position) -> Watermark {
     let end_checkpoint = end_position.checkpoint();
     let boundary = if options.is_ascending() {
@@ -135,10 +149,7 @@ pub fn terminal_boundary_watermark(options: &QueryOptions, end_position: Positio
     } else {
         Some(end_checkpoint)
     };
-    let mut wm = Watermark::default();
-    wm.cursor = Some(CursorToken::boundary(end_position).encode());
-    set_checkpoint_bound(&mut wm, boundary);
-    wm
+    boundary_watermark(end_position, boundary)
 }
 
 /// Whether the scan reached the natural end of the requested range (the
@@ -234,6 +245,40 @@ mod tests {
 
         let wm = item_watermark(pos, None);
         assert_eq!(wm.checkpoint, None);
+    }
+
+    /// A frontier frame projects its raw containing cp in opposite
+    /// directions: the claim excludes it looking backward (`cp ∓ 1`), the
+    /// resume cursor keeps it included looking forward (`cp` ascending,
+    /// `cp + 1` descending); scalar coordinates pass through unchanged.
+    #[test]
+    fn frontier_boundary_watermark_splits_claim_and_resume() {
+        let pos = Position::Transactions {
+            checkpoint: 10,
+            tx_seq: 100,
+        };
+
+        let asc = options(true);
+        let wm = frontier_boundary_watermark(&asc, pos);
+        assert_eq!(wm.checkpoint, Some(9));
+        assert_eq!(
+            wm.cursor.as_ref(),
+            Some(&CursorToken::boundary(pos).encode())
+        );
+
+        let desc = options(false);
+        let wm = frontier_boundary_watermark(&desc, pos);
+        assert_eq!(wm.checkpoint, Some(11));
+        assert_eq!(
+            wm.cursor.as_ref(),
+            Some(
+                &CursorToken::boundary(Position::Transactions {
+                    checkpoint: 11,
+                    tx_seq: 100,
+                })
+                .encode()
+            )
+        );
     }
 
     /// On natural completion the terminal frame claims the range's final

--- a/crates/sui-rpc-cursor/src/lib.rs
+++ b/crates/sui-rpc-cursor/src/lib.rs
@@ -41,6 +41,24 @@ impl Position {
             | Position::Events { checkpoint, .. } => checkpoint,
         }
     }
+
+    /// The same position with its `checkpoint` coordinate replaced; the
+    /// scalar coordinates are preserved.
+    pub fn with_checkpoint(self, checkpoint: u64) -> Self {
+        match self {
+            Position::Checkpoints { .. } => Position::Checkpoints { checkpoint },
+            Position::Transactions { tx_seq, .. } => Position::Transactions { checkpoint, tx_seq },
+            Position::Events {
+                tx_seq,
+                event_index,
+                ..
+            } => Position::Events {
+                checkpoint,
+                tx_seq,
+                event_index,
+            },
+        }
+    }
 }
 
 /// Whether a cursor position is a matched row that was returned to the client (`Item`) or a scan


### PR DESCRIPTION
## Description 

In preparation for making `checkpoint` optional on the inbound cursor.

The deconstructed `checkpoint` and `position` values travel through scan states and stream tails, so an ensuing `Option`al checkpoint would have rippled across the enums and handlers. With this change, subsequent changes are confined to range resolution. We already know the terminal watermark when the range is resolved, so we can initialize it ahead of time to reduce the number of locations we need to pass `Queryoptions` and the soon-to-be optional checkpoint around.

Separately, sui-rpc-api side passes frontier position to `frontier_boundary_watermark` which consolidates setting the completion claim (excluding the frontier checkpoint) and resume cursor 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
