### PR TITLE
sui-benchmark: retry the same transaction on terminal driver errors instead of rebuilding on stale refs

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -43,6 +43,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+use sui_core::transaction_driver::TransactionDriverError;
 use sui_types::committee::Committee;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::messages_grpc::WaitForEffectsResponse;
@@ -239,6 +240,33 @@ enum NextOp {
         payload: Box<dyn Payload>,
     },
     Retry(RetryType),
+}
+
+/// Whether a failed transaction submission should be retried with the exact same
+/// transaction (`NextOp::Retry`), as opposed to giving up on it (`NextOp::Failure`,
+/// which recycles the payload and builds a new transaction on the same input refs).
+///
+/// Every terminal `TransactionDriverError` retries the same digest, because a terminal
+/// error does not prove the transaction is dead: the driver may have timed out
+/// collecting effects acks for a transaction that did finalize, and a transaction
+/// rejected by over 1/3 of validators (e.g. a chained transaction racing its parent's
+/// execution) can still be finalized through a validator that accepted it. In both
+/// cases building a new transaction on the same input refs equivocates, and the payload
+/// wedges permanently — every rebuilt transaction is terminally rejected with "object
+/// version unavailable for consumption". Resubmitting the same digest is
+/// idempotent: validators respond to an already-executed digest with its effects, which
+/// settles the payload with fresh object refs. A genuinely invalid transaction keeps
+/// failing on retry, but that is no worse than rebuilding an equally invalid
+/// transaction from the same payload state, and it stays visible in `num_error`.
+fn should_retry_same_transaction(err: &anyhow::Error) -> bool {
+    if err.downcast_ref::<TransactionDriverError>().is_some() {
+        return true;
+    }
+    // Fullnode-proxy path surfaces TransactionSubmissionError instead.
+    matches!(
+        err.downcast_ref::<TransactionSubmissionError>(),
+        Some(err) if !matches!(err, TransactionSubmissionError::NonRecoverableTransactionError { .. })
+    )
 }
 
 async fn print_and_start_benchmark() -> &'static Instant {
@@ -894,22 +922,7 @@ async fn run_bench_worker(
                         NextOp::Retry(Box::new((transaction, payload)))
                     }
                     None => {
-                        if err
-                            .downcast::<TransactionSubmissionError>()
-                            .and_then(|err| {
-                                if matches!(
-                                    err,
-                                    TransactionSubmissionError::NonRecoverableTransactionError { .. }
-                                ) {
-                                    Err(err.into())
-                                } else {
-                                    Ok(())
-                                }
-                            })
-                            .is_err()
-                        {
-                            NextOp::Failure { payload }
-                        } else {
+                        if should_retry_same_transaction(&err) {
                             metrics
                                 .num_error
                                 .with_label_values(&[
@@ -919,6 +932,8 @@ async fn run_bench_worker(
                                 ])
                                 .inc();
                             NextOp::Retry(Box::new((transaction, payload)))
+                        } else {
+                            NextOp::Failure { payload }
                         }
                     }
                 }
@@ -1495,6 +1510,42 @@ mod tests {
         fn make_transaction(&mut self) -> Transaction {
             unimplemented!("not needed for recycling tests")
         }
+    }
+
+    #[test]
+    fn test_transaction_driver_errors_retry_same_transaction() {
+        // Terminal driver errors retry the same digest, whether the driver deems them
+        // retriable (timeout: the transaction may have finalized without the client
+        // observing it) or not (validator rejection: the transaction may still be
+        // finalized through a validator that accepted it). Rebuilding a new
+        // transaction on the same input refs instead would equivocate.
+        let timed_out =
+            anyhow::Error::from(TransactionDriverError::TimeoutWithLastRetriableError {
+                last_error: None,
+                attempts: 3,
+                timeout: Duration::from_secs(60),
+            });
+        assert!(should_retry_same_transaction(&timed_out));
+
+        let rejected = anyhow::Error::from(TransactionDriverError::ValidationFailed {
+            error: "object version unavailable for consumption".to_string(),
+        });
+        assert!(should_retry_same_transaction(&rejected));
+    }
+
+    #[test]
+    fn test_submission_errors_keep_legacy_classification() {
+        let non_recoverable =
+            anyhow::Error::from(TransactionSubmissionError::NonRecoverableTransactionError {
+                errors: vec![],
+            });
+        assert!(!should_retry_same_transaction(&non_recoverable));
+
+        let transient = anyhow::Error::from(TransactionSubmissionError::TimeoutBeforeFinality);
+        assert!(should_retry_same_transaction(&transient));
+
+        let opaque = anyhow::anyhow!("connection reset by peer");
+        assert!(!should_retry_same_transaction(&opaque));
     }
 
     #[test]

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -246,27 +246,31 @@ enum NextOp {
 /// transaction (`NextOp::Retry`), as opposed to giving up on it (`NextOp::Failure`,
 /// which recycles the payload and builds a new transaction on the same input refs).
 ///
-/// Every terminal `TransactionDriverError` retries the same digest, because a terminal
-/// error does not prove the transaction is dead: the driver may have timed out
-/// collecting effects acks for a transaction that did finalize, and a transaction
-/// rejected by over 1/3 of validators (e.g. a chained transaction racing its parent's
-/// execution) can still be finalized through a validator that accepted it. In both
-/// cases building a new transaction on the same input refs equivocates, and the payload
-/// wedges permanently — every rebuilt transaction is terminally rejected with "object
-/// version unavailable for consumption". Resubmitting the same digest is
-/// idempotent: validators respond to an already-executed digest with its effects, which
-/// settles the payload with fresh object refs. A genuinely invalid transaction keeps
-/// failing on retry, but that is no worse than rebuilding an equally invalid
-/// transaction from the same payload state, and it stays visible in `num_error`.
+/// A terminal `TransactionDriverError` for a submitted transaction retries the same
+/// digest, because the error does not prove the transaction is dead: the driver may
+/// have timed out collecting effects acks for a transaction that did finalize, and a
+/// transaction rejected by over 1/3 of validators (e.g. a chained transaction racing
+/// its parent's execution) can still be finalized through a validator that accepted
+/// it. In both cases building a new transaction on the same input refs equivocates,
+/// and the payload wedges permanently — every rebuilt transaction is terminally
+/// rejected with "object version unavailable for consumption". Resubmitting the same
+/// digest is idempotent: validators respond to an already-executed digest with its
+/// effects, which settles the payload with fresh object refs.
 fn should_retry_same_transaction(err: &anyhow::Error) -> bool {
-    if err.downcast_ref::<TransactionDriverError>().is_some() {
-        return true;
+    match err.downcast_ref::<TransactionDriverError>() {
+        // ValidationFailed comes only from the driver's local pre-submission checks
+        // (e.g. gas price under an RGP that rose at an epoch boundary), so the
+        // transaction was never sent to any validator: recycling the payload is
+        // equivocation-free, and only a rebuilt transaction can pass the same check.
+        Some(TransactionDriverError::ValidationFailed { .. }) => false,
+        Some(_) => true,
+        // Other proxies surface opaque anyhow errors (and historically
+        // TransactionSubmissionError): keep the legacy classification for them.
+        None => matches!(
+            err.downcast_ref::<TransactionSubmissionError>(),
+            Some(err) if !matches!(err, TransactionSubmissionError::NonRecoverableTransactionError { .. })
+        ),
     }
-    // Fullnode-proxy path surfaces TransactionSubmissionError instead.
-    matches!(
-        err.downcast_ref::<TransactionSubmissionError>(),
-        Some(err) if !matches!(err, TransactionSubmissionError::NonRecoverableTransactionError { .. })
-    )
 }
 
 async fn print_and_start_benchmark() -> &'static Instant {
@@ -1514,11 +1518,11 @@ mod tests {
 
     #[test]
     fn test_transaction_driver_errors_retry_same_transaction() {
-        // Terminal driver errors retry the same digest, whether the driver deems them
-        // retriable (timeout: the transaction may have finalized without the client
-        // observing it) or not (validator rejection: the transaction may still be
-        // finalized through a validator that accepted it). Rebuilding a new
-        // transaction on the same input refs instead would equivocate.
+        // Terminal driver errors for submitted transactions retry the same digest,
+        // whether the driver deems them retriable (timeout: the transaction may have
+        // finalized without the client observing it) or not (validator rejection: the
+        // transaction may still be finalized through a validator that accepted it).
+        // Rebuilding a new transaction on the same input refs instead would equivocate.
         let timed_out =
             anyhow::Error::from(TransactionDriverError::TimeoutWithLastRetriableError {
                 last_error: None,
@@ -1527,10 +1531,19 @@ mod tests {
             });
         assert!(should_retry_same_transaction(&timed_out));
 
-        let rejected = anyhow::Error::from(TransactionDriverError::ValidationFailed {
-            error: "object version unavailable for consumption".to_string(),
+        let rejected = anyhow::Error::from(TransactionDriverError::RejectedByValidators {
+            submission_non_retriable_errors: Default::default(),
+            submission_retriable_errors: Default::default(),
         });
         assert!(should_retry_same_transaction(&rejected));
+
+        // ValidationFailed is a local pre-submission failure: the transaction never
+        // reached a validator, so recycling the payload cannot equivocate, and only a
+        // rebuilt transaction can pick up fresh state (e.g. an increased gas price).
+        let not_submitted = anyhow::Error::from(TransactionDriverError::ValidationFailed {
+            error: "gas price under reference gas price".to_string(),
+        });
+        assert!(!should_retry_same_transaction(&not_submitted));
     }
 
     #[test]


### PR DESCRIPTION
## Description

At 18K TPS on private-testnet, 13 of 40 stress hosts sat pinned at the benchmark's in-flight cap (`target_qps × in_flight_ratio`) with p95 latency near 18s, capping aggregate submitted load at ~17.2K while validators ran with headroom. The bench worker classified retriable errors by downcasting to `TransactionSubmissionError`, which the TransactionDriver proxy path never produces — so every terminal driver error, including an effects-ack timeout for a transaction that actually finalized, recycled the payload with stale object refs. The next transaction built from that payload claimed already-consumed versions (client-side self-equivocation) and was terminally rejected by every validator ("object version unavailable for consumption"), permanently wedging the payload; wedged payloads accumulated until the affected hosts were latency-bound at their in-flight cap.

Fix: terminal `TransactionDriverError`s now retry the same digest, which is idempotent (validators answer an already-executed digest with its effects, settling the payload with fresh refs). The one carve-out is `ValidationFailed`, produced only by local pre-submission checks (gas price under RGP): the transaction was never submitted, so recycling is equivocation-free and rebuilding is the only way to adopt a raised RGP.

## Test plan

Unit tests pin the classifier: driver errors retry the same digest, local `ValidationFailed` recycles, and the legacy `TransactionSubmissionError` classification is unchanged. Diagnosed from the 2026-07-09 private-testnet 18K run (stress-host metrics and logs); validation redeploy on private-testnet pending.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: