### PR TITLE
cherry-pick rust-sdk: bump pointer and migrate v2alpha ledger proto changes (#27153)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14743,7 +14743,7 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=43c5bc13202ae398b1519a3eead1f40df8ca277b#43c5bc13202ae398b1519a3eead1f40df8ca277b"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f74b321245d9fa0506cf71441e465b07b90722d7#f74b321245d9fa0506cf71441e465b07b90722d7"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -16727,7 +16727,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=43c5bc13202ae398b1519a3eead1f40df8ca277b#43c5bc13202ae398b1519a3eead1f40df8ca277b"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f74b321245d9fa0506cf71441e465b07b90722d7#f74b321245d9fa0506cf71441e465b07b90722d7"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -16959,7 +16959,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=43c5bc13202ae398b1519a3eead1f40df8ca277b#43c5bc13202ae398b1519a3eead1f40df8ca277b"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f74b321245d9fa0506cf71441e465b07b90722d7#f74b321245d9fa0506cf71441e465b07b90722d7"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -646,9 +646,9 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "b1bda3f855
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b1bda3f8555c5594a4966e850170cc11ecfcf557" }
 
 # core-types from the new sdk for use in gRPC
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "43c5bc13202ae398b1519a3eead1f40df8ca277b", features = [ "hash", "serde" ] }
-sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "43c5bc13202ae398b1519a3eead1f40df8ca277b", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
-sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "43c5bc13202ae398b1519a3eead1f40df8ca277b", features = [ "unstable" ] }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f74b321245d9fa0506cf71441e465b07b90722d7", features = [ "hash", "serde" ] }
+sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f74b321245d9fa0506cf71441e465b07b90722d7", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
+sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f74b321245d9fa0506cf71441e465b07b90722d7", features = [ "unstable" ] }
 
 ### Workspace Members ###
 anemo-benchmark = { path = "crates/anemo-benchmark" }

--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -202,12 +202,12 @@ async fn fetch_settlements_for_range(
     use futures::StreamExt;
 
     let filter = build_affected_object_filter(stream_head_object_id);
-    let read_mask = FieldMask::from_paths(["checkpoint"]);
+    let read_mask = FieldMask::from_paths(["checkpoint", "transaction_index"]);
     let mut all = Vec::new();
     let mut cursor: Option<Vec<u8>> = None;
 
     loop {
-        let mut options = QueryOptions::default().with_limit_items(1000);
+        let mut options = QueryOptions::default().with_limit(1000);
         if let Some(c) = cursor.clone() {
             options.set_after(c);
         }
@@ -238,9 +238,13 @@ async fn fetch_settlements_for_range(
                         .ok_or_else(|| {
                             tonic::Status::internal("settlement tx missing checkpoint")
                         })?;
-                    let tx_offset = item.transaction_offset.ok_or_else(|| {
-                        tonic::Status::internal("settlement tx missing transaction_offset")
-                    })?;
+                    let tx_offset = item
+                        .transaction
+                        .as_ref()
+                        .and_then(|tx| tx.transaction_index)
+                        .ok_or_else(|| {
+                            tonic::Status::internal("settlement tx missing transaction_index")
+                        })?;
                     all.push((checkpoint, tx_offset));
                 }
                 Some(list_transactions_response::Response::Watermark(w)) => {
@@ -249,7 +253,7 @@ async fn fetch_settlements_for_range(
                     }
                 }
                 Some(list_transactions_response::Response::End(end)) => {
-                    end_reason = QueryEndReason::try_from(end.reason).ok();
+                    end_reason = Some(end.reason());
                 }
                 Some(_) | None => {}
             }
@@ -364,11 +368,21 @@ async fn fetch_list_events_page(
     Ok((events, last_cursor))
 }
 
-/// Read mask covering everything the in-tree `AuthenticatedEvent`
-/// converter needs from a v2alpha `EventItem`. The server's default mask
-/// drops `contents`, so we request the full event explicitly.
+/// Read mask covering everything the in-tree `AuthenticatedEvent` converter
+/// needs from a v2alpha `EventItem`: the event body plus its ledger-position
+/// fields (`checkpoint`, `transaction_index`, `event_index`), which the list
+/// endpoint only populates when requested.
 fn full_event_read_mask() -> FieldMask {
-    FieldMask::from_paths(["package_id", "module", "sender", "event_type", "contents"])
+    FieldMask::from_paths([
+        "package_id",
+        "module",
+        "sender",
+        "event_type",
+        "contents",
+        "checkpoint",
+        "transaction_index",
+        "event_index",
+    ])
 }
 
 /// Issue one `ListEvents` call for the given stream and return the events
@@ -384,7 +398,7 @@ async fn query_authenticated_events(
 
     let mut options = QueryOptions::default();
     if let Some(size) = page_size {
-        options.set_limit_items(size);
+        options.set_limit(size);
     }
     let request = ListEventsRequest::default()
         .with_read_mask(full_event_read_mask())
@@ -416,7 +430,7 @@ async fn list_authenticated_events(
     loop {
         let mut options = QueryOptions::default();
         if let Some(size) = page_size {
-            options.set_limit_items(size);
+            options.set_limit(size);
         }
         if let Some(cursor) = next_cursor.clone() {
             options.set_after(cursor);
@@ -1204,13 +1218,12 @@ async fn test_object_inclusion_proof_returns_non_inclusion() {
     let stream_id = SuiAddress::from(package_id);
     let event_stream_head_id = get_event_stream_head_object_id(stream_id).unwrap();
 
-    let highest_checkpoint = test_cluster.fullnode_handle.sui_node.with(|node| {
-        node.state()
-            .get_checkpoint_store()
-            .get_highest_executed_checkpoint_seq_number()
-            .unwrap()
-            .unwrap()
-    });
+    let highest_checkpoint = test_cluster
+        .grpc_client()
+        .get_latest_checkpoint()
+        .await
+        .unwrap()
+        .sequence_number;
 
     let mut proof_client =
         connect_with_retry(|| ProofServiceClient::connect(test_cluster.rpc_url().to_owned())).await;

--- a/crates/sui-e2e-tests/tests/rpc/restore.rs
+++ b/crates/sui-e2e-tests/tests/rpc/restore.rs
@@ -277,7 +277,7 @@ async fn list_transaction_digests_by_sender(rpc_url: &str, sender: SuiAddress) -
         .await
         .unwrap();
     let mut options = QueryOptions::default();
-    options.limit_items = Some(500);
+    options.limit = Some(500);
     let mut request = ListTransactionsRequest::default();
     request.read_mask = Some(FieldMask::from_paths(["digest"]));
     request.filter = Some(sender_filter(sender));

--- a/crates/sui-e2e-tests/tests/rpc/rpc_index_restore.rs
+++ b/crates/sui-e2e-tests/tests/rpc/rpc_index_restore.rs
@@ -261,7 +261,7 @@ async fn list_transaction_digests_by_sender(rpc_url: &str, sender: SuiAddress) -
         .await
         .unwrap();
     let mut options = QueryOptions::default();
-    options.limit_items = Some(500);
+    options.limit = Some(500);
     let mut request = ListTransactionsRequest::default();
     request.read_mask = Some(FieldMask::from_paths(["digest"]));
     request.filter = Some(sender_filter(sender));

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/list_ledger_history.rs
@@ -84,7 +84,7 @@ struct CheckpointsResult {
 
 fn query_options(limit_items: u32) -> QueryOptions {
     let mut options = QueryOptions::default();
-    options.limit_items = Some(limit_items);
+    options.limit = Some(limit_items);
     options
 }
 
@@ -102,7 +102,7 @@ fn query_options_maybe_after(limit_items: u32, after: Option<Bytes>) -> QueryOpt
 
 fn query_options_descending(limit_items: u32) -> QueryOptions {
     let mut options = query_options(limit_items);
-    options.ordering = Ordering::Descending as i32;
+    options.ordering = Some(Ordering::Descending as i32);
     options
 }
 
@@ -127,7 +127,7 @@ fn query_options_between(limit_items: u32, after: Bytes, before: Bytes) -> Query
 
 fn query_options_between_descending(limit_items: u32, after: Bytes, before: Bytes) -> QueryOptions {
     let mut options = query_options_between(limit_items, after, before);
-    options.ordering = Ordering::Descending as i32;
+    options.ordering = Some(Ordering::Descending as i32);
     options
 }
 
@@ -243,11 +243,40 @@ fn transaction_digest_set(result: &TransactionsResult) -> HashSet<String> {
         .collect()
 }
 
+/// The event's ledger position now lives on the embedded `Event`, not the
+/// enclosing `EventItem`; these accessors read it back for assertions.
+fn event_transaction_digest(item: &EventItem) -> Option<String> {
+    item.event
+        .as_ref()
+        .and_then(|event| event.transaction_digest.clone())
+}
+
+fn event_checkpoint(item: &EventItem) -> Option<u64> {
+    item.event.as_ref().and_then(|event| event.checkpoint)
+}
+
+fn event_index_of(item: &EventItem) -> Option<u32> {
+    item.event.as_ref().and_then(|event| event.event_index)
+}
+
+/// Event read mask requesting the event type plus the ledger-position fields
+/// (`checkpoint`, `transaction_digest`, `event_index`) that the list endpoint
+/// only populates when they are asked for. Used by the event tests, which
+/// assert on those positions.
+fn event_type_and_position_mask() -> FieldMask {
+    FieldMask::from_paths([
+        "event_type",
+        "checkpoint",
+        "transaction_digest",
+        "event_index",
+    ])
+}
+
 fn event_digest_set(result: &EventsResult) -> HashSet<String> {
     result
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect()
 }
 
@@ -284,10 +313,7 @@ async fn list_transactions_result(
             list_transactions_response::Response::End(end_frame) => {
                 assert!(!end, "duplicate end frame");
                 end = true;
-                end_reason = Some(
-                    QueryEndReason::try_from(end_frame.reason)
-                        .expect("valid list_transactions end reason"),
-                );
+                end_reason = Some(end_frame.reason());
             }
             other => panic!("unexpected list_transactions response frame: {other:?}"),
         }
@@ -329,10 +355,7 @@ async fn list_events_result(
             list_events_response::Response::End(end_frame) => {
                 assert!(!end, "duplicate end frame");
                 end = true;
-                end_reason = Some(
-                    QueryEndReason::try_from(end_frame.reason)
-                        .expect("valid list_events end reason"),
-                );
+                end_reason = Some(end_frame.reason());
             }
             other => panic!("unexpected list_events response frame: {other:?}"),
         }
@@ -376,10 +399,7 @@ async fn list_checkpoints_result(
             list_checkpoints_response::Response::End(end_frame) => {
                 assert!(!end, "duplicate end frame");
                 end = true;
-                end_reason = Some(
-                    QueryEndReason::try_from(end_frame.reason)
-                        .expect("valid list_checkpoints end reason"),
-                );
+                end_reason = Some(end_frame.reason());
             }
             other => panic!("unexpected list_checkpoints response frame: {other:?}"),
         }
@@ -699,7 +719,7 @@ fn tx_emit_module_literal(path: &str) -> TransactionLiteral {
 
 fn tx_event_type_literal(path: &str) -> TransactionLiteral {
     let mut et = EventTypeFilter::default();
-    et.r#type = Some(path.to_string());
+    et.event_type = Some(path.to_string());
     tx_include(transaction_predicate::Predicate::EventType(et))
 }
 
@@ -795,7 +815,7 @@ fn ev_emit_module(path: &str) -> EventFilter {
 
 fn ev_event_type(path: &str) -> EventFilter {
     let mut et = EventTypeFilter::default();
-    et.r#type = Some(path.to_string());
+    et.event_type = Some(path.to_string());
     ev_filter(vec![ev_include(event_predicate::Predicate::EventType(et))])
 }
 
@@ -1238,7 +1258,7 @@ async fn test_list_events_unfiltered_and_emit_module_filter() {
     let mut client = new_ledger_client(&cluster).await;
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
     assert_event_cursors(&resp);
@@ -1249,7 +1269,7 @@ async fn test_list_events_unfiltered_and_emit_module_filter() {
     let event_type = resp
         .events
         .iter()
-        .find(|event| event.transaction_digest.as_deref() == Some(event_digest.as_str()))
+        .find(|event| event_transaction_digest(event).as_deref() == Some(event_digest.as_str()))
         .and_then(|event| event.event.as_ref())
         .and_then(|event| event.event_type.as_deref())
         .expect("emitted event type should be present");
@@ -1257,7 +1277,7 @@ async fn test_list_events_unfiltered_and_emit_module_filter() {
 
     let module = format!("{}::emit_test_event", pkg.to_canonical_string(true));
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_emit_module(&module));
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
@@ -1296,7 +1316,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         let mut client = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.start_checkpoint = Some(start);
             req.end_checkpoint = Some(end);
             req.filter = Some(filter);
@@ -1337,7 +1357,7 @@ async fn test_list_events_query_options_multi_event_tx() {
 
     let mut client_for_exact = client.clone();
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(start);
     req.end_checkpoint = Some(end);
     req.filter = Some(ev_emit_module(&module));
@@ -1350,7 +1370,7 @@ async fn test_list_events_query_options_multi_event_tx() {
 
     let mut client_for_bounds = client.clone();
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(start);
     req.end_checkpoint = Some(end);
     req.filter = Some(ev_emit_module(&module));
@@ -1364,7 +1384,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         let module = module.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.start_checkpoint = Some(start);
             req.end_checkpoint = Some(end);
             req.filter = Some(ev_emit_module(&module));
@@ -1390,7 +1410,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         .iter()
         .chain(rp2.events.iter())
         .chain(rp3.events.iter())
-        .map(|event| (event.transaction_digest.clone(), event.event_index))
+        .map(|event| (event_transaction_digest(event), event_index_of(event)))
         .collect();
     let mut deduped = reverse_keys.clone();
     deduped.sort_unstable();
@@ -1399,7 +1419,7 @@ async fn test_list_events_query_options_multi_event_tx() {
 
     let mut client_after_exact = client.clone();
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(start);
     req.end_checkpoint = Some(end);
     req.filter = Some(ev_emit_module(&module));
@@ -1447,7 +1467,7 @@ async fn test_list_events_filter_predicates() {
         let mut client = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.filter = Some(filter);
             req.options = Some(query_options(100));
             list_events_result(&mut client, req).await
@@ -1514,7 +1534,7 @@ async fn test_list_events_filter_predicates() {
         "event_stream_head should return only authenticated event"
     );
     assert_eq!(
-        resp.events[0].transaction_digest.as_deref(),
+        event_transaction_digest(&resp.events[0]).as_deref(),
         Some(auth_digest.as_str())
     );
     let event_type = resp.events[0]
@@ -1566,7 +1586,7 @@ async fn test_list_events_combinators() {
     let module = format!("{}::emit_test_event", pkg.to_canonical_string(true));
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_and(vec![ev_sender(sender_a), ev_emit_module(&module)]));
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
@@ -1581,7 +1601,7 @@ async fn test_list_events_combinators() {
     );
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_filter(vec![
         ev_sender_literal(sender_a),
         ev_not_sender_literal(sender_b),
@@ -1632,7 +1652,7 @@ async fn test_list_events_unanchored_negation() {
     // synthesized EventExtant include actually anchors the term so the driver
     // walks the event space rather than rejecting the filter.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_not_sender_only_filter(sender_b));
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
@@ -1649,7 +1669,7 @@ async fn test_list_events_unanchored_negation() {
 
     // Symmetric case: `NOT sender = A` returns B's event.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_not_sender_only_filter(sender_a));
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
@@ -1668,7 +1688,7 @@ async fn test_list_events_unanchored_negation() {
     // come back. Exercises the dedup path: the synthetic EventExtant leaf
     // is shared across both terms and must only be scanned once.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_or(vec![
         vec![ev_not_sender_literal(sender_a)],
         vec![ev_not_sender_literal(sender_b)],
@@ -1854,7 +1874,7 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     assert_eq!(resp.end_reason, Some(QueryEndReason::LedgerTip));
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(beyond_tip);
     req.options = Some(query_options(10));
     let resp = list_events_result(&mut client, req).await;
@@ -1887,7 +1907,7 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     assert!(resp.end);
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_sender(never_sender));
     req.options = Some(query_options(10));
     let resp = list_events_result(&mut client, req).await;
@@ -1911,7 +1931,7 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     expect_invalid_list_transactions(&mut client, req).await;
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(ev_event_type("0x1<u64>"));
@@ -1959,7 +1979,7 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     let mut bad_options = query_options(10);
-    bad_options.ordering = 99;
+    bad_options.ordering = Some(99);
     req.options = Some(bad_options);
     expect_invalid_list_transactions(&mut client, req).await;
 
@@ -1972,7 +1992,7 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     expect_invalid_list_transactions(&mut client, req).await;
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(EventFilter::default());
@@ -2012,7 +2032,7 @@ async fn test_list_filter_edge_cases_and_limit_caps() {
     list_transactions_result(&mut client, req).await;
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.options = Some(query_options(oversized));
     list_events_result(&mut client, req).await;
 }
@@ -2387,10 +2407,10 @@ async fn test_list_checkpoints_read_masks_and_empty_range() {
 
 // list_checkpoints dedupes cp_seq, so an emitted checkpoint is proven complete:
 // its item watermark must claim its OWN sequence number as the covered boundary
-// (checkpoint_hi == sequence_number ascending, checkpoint_lo == sequence_number
-// descending), not sequence_number ∓ 1. This pins the item path onto
-// `advance_checkpoint_boundary`; the previous (buggy) `advance_boundary_excluding_cp`
-// path under-claimed by one. Also asserts the wire-documented monotonicity.
+// (`checkpoint` == sequence_number, in either ordering), not sequence_number ∓ 1.
+// This pins the item path onto `advance_checkpoint_boundary`; the previous
+// (buggy) `advance_boundary_excluding_cp` path under-claimed by one. Also asserts
+// the wire-documented monotonicity.
 #[sim_test]
 async fn test_list_checkpoints_item_watermark_boundary() {
     let cluster = new_cluster().await;
@@ -2418,18 +2438,14 @@ async fn test_list_checkpoints_item_watermark_boundary() {
         let seq = checkpoint_sequence(item);
         let wm = item.watermark.as_ref().expect("checkpoint item watermark");
         assert_eq!(
-            wm.checkpoint_hi,
+            wm.checkpoint,
             Some(seq),
             "ascending checkpoint item should claim its own sequence number complete"
-        );
-        assert_eq!(
-            wm.checkpoint_lo, None,
-            "ascending item must set only checkpoint_hi"
         );
         if let Some(prev) = prev_hi {
             assert!(
                 seq >= prev,
-                "checkpoint_hi must be non-decreasing ascending"
+                "checkpoint boundary must be non-decreasing ascending"
             );
         }
         prev_hi = Some(seq);
@@ -2451,18 +2467,14 @@ async fn test_list_checkpoints_item_watermark_boundary() {
         let seq = checkpoint_sequence(item);
         let wm = item.watermark.as_ref().expect("checkpoint item watermark");
         assert_eq!(
-            wm.checkpoint_lo,
+            wm.checkpoint,
             Some(seq),
             "descending checkpoint item should claim its own sequence number complete"
-        );
-        assert_eq!(
-            wm.checkpoint_hi, None,
-            "descending item must set only checkpoint_lo"
         );
         if let Some(prev) = prev_lo {
             assert!(
                 seq <= prev,
-                "checkpoint_lo must be non-increasing descending"
+                "checkpoint boundary must be non-increasing descending"
             );
         }
         prev_lo = Some(seq);
@@ -2472,9 +2484,8 @@ async fn test_list_checkpoints_item_watermark_boundary() {
 // The contrast that makes the checkpoint assertion above meaningful: list_events
 // scans WITHIN a checkpoint, so an event at checkpoint C does not prove C
 // complete (more matches may sit at higher event_seqs). The covered boundary
-// must therefore EXCLUDE C itself — checkpoint_hi == C - 1 ascending,
-// checkpoint_lo == C + 1 descending — i.e. the under-claim is correct here and a
-// bug for checkpoints.
+// must therefore EXCLUDE C itself — `checkpoint` == C - 1 ascending, C + 1
+// descending — i.e. the under-claim is correct here and a bug for checkpoints.
 #[sim_test]
 async fn test_list_events_item_watermark_boundary() {
     let cluster = new_cluster().await;
@@ -2488,7 +2499,7 @@ async fn test_list_events_item_watermark_boundary() {
     let mut client = new_ledger_client(&cluster).await;
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(start);
     req.end_checkpoint = Some(end);
     req.filter = Some(ev_emit_module(&module));
@@ -2497,30 +2508,26 @@ async fn test_list_events_item_watermark_boundary() {
     assert!(!resp.events.is_empty(), "expected matching events");
     let mut prev_hi: Option<u64> = None;
     for item in &resp.events {
-        let cp = item.checkpoint.expect("event item checkpoint");
+        let cp = event_checkpoint(item).expect("event item checkpoint");
         assert!(cp >= 1, "user events are never in the genesis checkpoint");
         let expected_hi = cp - 1;
         let wm = item.watermark.as_ref().expect("event item watermark");
         assert_eq!(
-            wm.checkpoint_hi,
+            wm.checkpoint,
             Some(expected_hi),
             "ascending event item must under-claim its own checkpoint (C - 1)"
-        );
-        assert_eq!(
-            wm.checkpoint_lo, None,
-            "ascending item sets only checkpoint_hi"
         );
         if let Some(prev) = prev_hi {
             assert!(
                 expected_hi >= prev,
-                "event checkpoint_hi must be non-decreasing ascending"
+                "event checkpoint boundary must be non-decreasing ascending"
             );
         }
         prev_hi = Some(expected_hi);
     }
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(start);
     req.end_checkpoint = Some(end);
     req.filter = Some(ev_emit_module(&module));
@@ -2529,22 +2536,18 @@ async fn test_list_events_item_watermark_boundary() {
     assert!(!resp.events.is_empty(), "expected matching events");
     let mut prev_lo: Option<u64> = None;
     for item in &resp.events {
-        let cp = item.checkpoint.expect("event item checkpoint");
+        let cp = event_checkpoint(item).expect("event item checkpoint");
         let expected_lo = cp + 1;
         let wm = item.watermark.as_ref().expect("event item watermark");
         assert_eq!(
-            wm.checkpoint_lo,
+            wm.checkpoint,
             Some(expected_lo),
             "descending event item must under-claim its own checkpoint (C + 1)"
-        );
-        assert_eq!(
-            wm.checkpoint_hi, None,
-            "descending item sets only checkpoint_lo"
         );
         if let Some(prev) = prev_lo {
             assert!(
                 expected_lo <= prev,
-                "event checkpoint_lo must be non-increasing descending"
+                "event checkpoint boundary must be non-increasing descending"
             );
         }
         prev_lo = Some(expected_lo);
@@ -2587,10 +2590,10 @@ async fn test_list_checkpoints_terminal_watermark() {
         .checkpoints
         .last()
         .and_then(|item| item.watermark.as_ref())
-        .and_then(|wm| wm.checkpoint_hi)
-        .expect("last item checkpoint_hi");
+        .and_then(|wm| wm.checkpoint)
+        .expect("last item checkpoint boundary");
     assert!(
-        terminal.checkpoint_hi.is_some_and(|hi| hi >= last_item_hi),
+        terminal.checkpoint.is_some_and(|hi| hi >= last_item_hi),
         "terminal watermark must not regress the covered boundary"
     );
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/kv_rpc_tests.rs
@@ -104,9 +104,32 @@ struct CheckpointsResult {
 }
 
 fn request_ordering(options: Option<&QueryOptions>) -> Ordering {
-    options
-        .and_then(|o| Ordering::try_from(o.ordering).ok())
-        .unwrap_or(Ordering::Ascending)
+    options.map(|o| o.ordering()).unwrap_or(Ordering::Ascending)
+}
+
+/// The event's ledger position now lives on the embedded `Event`, not the
+/// enclosing `EventItem`; these accessors read it back for assertions.
+fn event_transaction_digest(item: &EventItem) -> Option<String> {
+    item.event
+        .as_ref()
+        .and_then(|event| event.transaction_digest.clone())
+}
+
+fn event_index_of(item: &EventItem) -> Option<u32> {
+    item.event.as_ref().and_then(|event| event.event_index)
+}
+
+/// Event read mask requesting the event type plus the ledger-position fields
+/// (`checkpoint`, `transaction_digest`, `event_index`) that the list endpoint
+/// only populates when they are asked for. Used by the event tests, which
+/// assert on those positions.
+fn event_type_and_position_mask() -> FieldMask {
+    FieldMask::from_paths([
+        "event_type",
+        "checkpoint",
+        "transaction_digest",
+        "event_index",
+    ])
 }
 
 fn standalone_watermark_count<T>(frames: &[(WmFrame, T)]) -> usize {
@@ -118,7 +141,7 @@ fn standalone_watermark_count<T>(frames: &[(WmFrame, T)]) -> usize {
 
 fn query_options(limit_items: u32) -> QueryOptions {
     let mut options = QueryOptions::default();
-    options.limit_items = Some(limit_items);
+    options.limit = Some(limit_items);
     options
 }
 
@@ -137,7 +160,7 @@ fn query_options_maybe_after(limit_items: u32, after: Option<prost::bytes::Bytes
 fn query_options_descending_before(limit_items: u32, before: prost::bytes::Bytes) -> QueryOptions {
     let mut options = query_options(limit_items);
     options.before = Some(before);
-    options.ordering = Ordering::Descending as i32;
+    options.ordering = Some(Ordering::Descending as i32);
     options
 }
 
@@ -152,7 +175,7 @@ fn query_options_descending_maybe_before(
 
 fn query_options_descending(limit_items: u32) -> QueryOptions {
     let mut options = query_options(limit_items);
-    options.ordering = Ordering::Descending as i32;
+    options.ordering = Some(Ordering::Descending as i32);
     options
 }
 
@@ -173,7 +196,7 @@ fn query_options_between_descending(
     before: prost::bytes::Bytes,
 ) -> QueryOptions {
     let mut options = query_options_between(limit_items, after, before);
-    options.ordering = Ordering::Descending as i32;
+    options.ordering = Some(Ordering::Descending as i32);
     options
 }
 
@@ -245,12 +268,12 @@ fn assert_item_limit_end(end: bool, reason: Option<QueryEndReason>) {
 /// Walks every Watermark frame (item-embedded + standalone) in delivery order
 /// and asserts the per-frame wire contract:
 ///   - `cursor` is always populated.
-///   - Direction-matching field is set: `checkpoint_hi` on ascending,
-///     `checkpoint_lo` on descending; the other direction's field is `None`.
-///   - Where the direction-matching field is set, the sequence of values is
-///     monotonic (non-decreasing ascending, non-increasing descending). It
-///     may be `None` early in a scan that has not yet crossed a checkpoint
-///     boundary; those frames are skipped for the monotonicity check.
+///   - The single `checkpoint` boundary carries the direction-correct value
+///     (inclusive upper bound ascending, inclusive lower bound descending).
+///   - Where `checkpoint` is set, the sequence of values is monotonic
+///     (non-decreasing ascending, non-increasing descending). It may be `None`
+///     early in a scan that has not yet crossed a checkpoint boundary; those
+///     frames are skipped for the monotonicity check.
 fn assert_watermark_contract(frames: &[(WmFrame, Watermark)], ordering: Ordering) {
     let mut last_bound: Option<u64> = None;
     for (kind, wm) in frames {
@@ -258,40 +281,23 @@ fn assert_watermark_contract(frames: &[(WmFrame, Watermark)], ordering: Ordering
             wm.cursor.is_some(),
             "{kind:?} watermark must carry a cursor"
         );
-        match ordering {
-            Ordering::Ascending => {
-                assert!(
-                    wm.checkpoint_lo.is_none(),
-                    "ascending {kind:?} watermark must not set checkpoint_lo"
-                );
-                if let Some(hi) = wm.checkpoint_hi {
-                    if let Some(prev) = last_bound {
-                        assert!(
-                            hi >= prev,
-                            "ascending checkpoint_hi must be non-decreasing \
-                             (prev {prev}, got {hi} on {kind:?})"
-                        );
-                    }
-                    last_bound = Some(hi);
+        if let Some(bound) = wm.checkpoint {
+            if let Some(prev) = last_bound {
+                match ordering {
+                    Ordering::Ascending => assert!(
+                        bound >= prev,
+                        "ascending checkpoint boundary must be non-decreasing \
+                         (prev {prev}, got {bound} on {kind:?})"
+                    ),
+                    Ordering::Descending => assert!(
+                        bound <= prev,
+                        "descending checkpoint boundary must be non-increasing \
+                         (prev {prev}, got {bound} on {kind:?})"
+                    ),
+                    other => panic!("unexpected ordering: {other:?}"),
                 }
             }
-            Ordering::Descending => {
-                assert!(
-                    wm.checkpoint_hi.is_none(),
-                    "descending {kind:?} watermark must not set checkpoint_hi"
-                );
-                if let Some(lo) = wm.checkpoint_lo {
-                    if let Some(prev) = last_bound {
-                        assert!(
-                            lo <= prev,
-                            "descending checkpoint_lo must be non-increasing \
-                             (prev {prev}, got {lo} on {kind:?})"
-                        );
-                    }
-                    last_bound = Some(lo);
-                }
-            }
-            other => panic!("unexpected ordering: {other:?}"),
+            last_bound = Some(bound);
         }
     }
 }
@@ -355,10 +361,7 @@ async fn list_transactions_result(
             list_transactions_response::Response::End(end_frame) => {
                 assert!(!end, "duplicate end frame");
                 end = true;
-                end_reason = Some(
-                    QueryEndReason::try_from(end_frame.reason)
-                        .expect("valid list_transactions end reason"),
-                );
+                end_reason = Some(end_frame.reason());
             }
             other => panic!("unexpected list_transactions response frame: {other:?}"),
         }
@@ -408,10 +411,7 @@ async fn list_events_result(
             list_events_response::Response::End(end_frame) => {
                 assert!(!end, "duplicate end frame");
                 end = true;
-                end_reason = Some(
-                    QueryEndReason::try_from(end_frame.reason)
-                        .expect("valid list_events end reason"),
-                );
+                end_reason = Some(end_frame.reason());
             }
             other => panic!("unexpected list_events response frame: {other:?}"),
         }
@@ -461,10 +461,7 @@ async fn list_checkpoints_result(
             list_checkpoints_response::Response::End(end_frame) => {
                 assert!(!end, "duplicate end frame");
                 end = true;
-                end_reason = Some(
-                    QueryEndReason::try_from(end_frame.reason)
-                        .expect("valid list_checkpoints end reason"),
-                );
+                end_reason = Some(end_frame.reason());
             }
             other => panic!("unexpected list_checkpoints response frame: {other:?}"),
         }
@@ -746,7 +743,7 @@ fn tx_emit_module_literal(path: &str) -> TransactionLiteral {
 
 fn tx_event_type_literal(path: &str) -> TransactionLiteral {
     let mut et = EventTypeFilter::default();
-    et.r#type = Some(path.to_string());
+    et.event_type = Some(path.to_string());
     tx_include(transaction_predicate::Predicate::EventType(et))
 }
 
@@ -842,7 +839,7 @@ fn ev_emit_module(path: &str) -> EventFilter {
 
 fn ev_event_type(path: &str) -> EventFilter {
     let mut et = EventTypeFilter::default();
-    et.r#type = Some(path.to_string());
+    et.event_type = Some(path.to_string());
     ev_filter(vec![ev_include(event_predicate::Predicate::EventType(et))])
 }
 
@@ -1413,7 +1410,7 @@ async fn test_list_events_unfiltered() {
         .unwrap();
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.options = Some(query_options(100));
 
     let resp = list_events_result(&mut client, req).await;
@@ -1423,8 +1420,9 @@ async fn test_list_events_unfiltered() {
     assert!(!resp.events.is_empty(), "expected at least 1 event");
 
     let found = resp.events.iter().any(|e| {
-        e.transaction_digest
+        e.event
             .as_ref()
+            .and_then(|ev| ev.transaction_digest.as_ref())
             .is_some_and(|d| d == &event_tx_digest.to_string())
     });
     assert!(found, "expected to find event from tx {event_tx_digest}");
@@ -1434,8 +1432,9 @@ async fn test_list_events_unfiltered() {
         .events
         .iter()
         .find(|e| {
-            e.transaction_digest
+            e.event
                 .as_ref()
+                .and_then(|ev| ev.transaction_digest.as_ref())
                 .is_some_and(|d| d == &event_tx_digest.to_string())
         })
         .unwrap();
@@ -1501,7 +1500,7 @@ async fn test_list_events_unfiltered_row_cap_scan_limit_resumes() {
     // First page: an unfiltered scan over the whole indexed range. The request
     // limit is large; the SCAN_LIMIT is driven by the source row cap, not it.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.options = Some(query_options(100));
     let first = list_events_result(&mut client, req).await;
     assert_eq!(
@@ -1523,7 +1522,7 @@ async fn test_list_events_unfiltered_row_cap_scan_limit_resumes() {
         iterations += 1;
         assert!(iterations <= 16, "resume loop did not terminate");
         let mut req = ListEventsRequest::default();
-        req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+        req.read_mask = Some(event_type_and_position_mask());
         req.options = Some(query_options_maybe_after(100, cursor.clone()));
         let page = list_events_result(&mut client, req).await;
         reason = page.end_reason.expect("each page carries an end reason");
@@ -1581,7 +1580,7 @@ async fn test_list_events_with_emit_module_filter() {
     ))]);
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(filter);
     req.options = Some(query_options(100));
 
@@ -1645,7 +1644,7 @@ async fn test_list_events_query_options() {
 
     // Paginate with limit_items=1.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(event_start);
     req.end_checkpoint = Some(event_end);
     req.filter = Some(ev_filter.clone());
@@ -1662,7 +1661,7 @@ async fn test_list_events_query_options() {
     let cursor = event_end_cursor(&response1, "first response should have an end cursor");
 
     let mut req2 = ListEventsRequest::default();
-    req2.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req2.read_mask = Some(event_type_and_position_mask());
     req2.start_checkpoint = Some(event_start);
     req2.end_checkpoint = Some(event_end);
     req2.filter = Some(ev_filter.clone());
@@ -1691,7 +1690,7 @@ async fn test_list_events_query_options() {
     );
 
     let mut reverse_req = ListEventsRequest::default();
-    reverse_req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    reverse_req.read_mask = Some(event_type_and_position_mask());
     reverse_req.start_checkpoint = Some(event_start);
     reverse_req.end_checkpoint = Some(event_end);
     reverse_req.filter = Some(ev_filter.clone());
@@ -1705,7 +1704,7 @@ async fn test_list_events_query_options() {
         "first reverse response should have an end cursor",
     );
     let mut reverse_req2 = ListEventsRequest::default();
-    reverse_req2.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    reverse_req2.read_mask = Some(event_type_and_position_mask());
     reverse_req2.start_checkpoint = Some(event_start);
     reverse_req2.end_checkpoint = Some(event_end);
     reverse_req2.filter = Some(ev_filter.clone());
@@ -1715,12 +1714,13 @@ async fn test_list_events_query_options() {
     assert_event_cursors(&reverse2);
 
     assert_ne!(
-        reverse1.events[0].transaction_digest, reverse2.events[0].transaction_digest,
+        event_transaction_digest(&reverse1.events[0]),
+        event_transaction_digest(&reverse2.events[0]),
         "reverse responses should move backward"
     );
 
     let mut exact_req = ListEventsRequest::default();
-    exact_req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    exact_req.read_mask = Some(event_type_and_position_mask());
     exact_req.start_checkpoint = Some(event_start);
     exact_req.end_checkpoint = Some(event_end);
     exact_req.filter = Some(ev_filter.clone());
@@ -1736,7 +1736,7 @@ async fn test_list_events_query_options() {
         last_event_cursor(&exact_result, "exact event response should have a cursor");
 
     let mut bounded_req = ListEventsRequest::default();
-    bounded_req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    bounded_req.read_mask = Some(event_type_and_position_mask());
     bounded_req.start_checkpoint = Some(event_start);
     bounded_req.end_checkpoint = Some(event_end);
     bounded_req.filter = Some(ev_filter.clone());
@@ -1754,7 +1754,7 @@ async fn test_list_events_query_options() {
     assert_eq!(bounded.end_reason, Some(QueryEndReason::CursorBound));
 
     let mut bounded_desc_req = ListEventsRequest::default();
-    bounded_desc_req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    bounded_desc_req.read_mask = Some(event_type_and_position_mask());
     bounded_desc_req.start_checkpoint = Some(event_start);
     bounded_desc_req.end_checkpoint = Some(event_end);
     bounded_desc_req.filter = Some(ev_filter.clone());
@@ -1772,7 +1772,7 @@ async fn test_list_events_query_options() {
     assert_eq!(bounded_desc.end_reason, Some(QueryEndReason::CursorBound));
 
     let mut exact_next_req = ListEventsRequest::default();
-    exact_next_req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    exact_next_req.read_mask = Some(event_type_and_position_mask());
     exact_next_req.start_checkpoint = Some(event_start);
     exact_next_req.end_checkpoint = Some(event_end);
     exact_next_req.filter = Some(ev_filter);
@@ -1980,7 +1980,7 @@ async fn test_list_events_sender_or_filter() {
         let mut c = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.filter = Some(filter);
             req.options = Some(query_options(100));
             list_events_result(&mut c, req).await
@@ -1990,7 +1990,7 @@ async fn test_list_events_sender_or_filter() {
         result
             .events
             .iter()
-            .filter_map(|e| e.transaction_digest.clone())
+            .filter_map(event_transaction_digest)
             .collect::<std::collections::HashSet<_>>()
     };
 
@@ -2041,7 +2041,7 @@ async fn test_list_event_stream_head_filter() {
         .unwrap();
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_event_stream_head(pkg));
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
@@ -2054,7 +2054,7 @@ async fn test_list_event_stream_head_filter() {
     let event = &resp.events[0];
     let digest_string = digest.to_string();
     assert_eq!(
-        event.transaction_digest.as_deref(),
+        event_transaction_digest(event).as_deref(),
         Some(digest_string.as_str())
     );
     let event_type = event
@@ -2384,7 +2384,7 @@ async fn test_list_events_event_type_cascading_and_generics() {
         let mut c = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.filter = Some(filter);
             req.options = Some(query_options(100));
             list_events_result(&mut c, req).await
@@ -2397,7 +2397,7 @@ async fn test_list_events_event_type_cascading_and_generics() {
     let digests: Vec<String> = resp
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect();
     assert!(
         digests.contains(&digest_u64.to_string()) && digests.contains(&digest_addr.to_string()),
@@ -2410,7 +2410,7 @@ async fn test_list_events_event_type_cascading_and_generics() {
     let digests: Vec<String> = resp
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect();
     assert!(
         digests.contains(&digest_u64.to_string()) && !digests.contains(&digest_addr.to_string()),
@@ -2423,7 +2423,7 @@ async fn test_list_events_event_type_cascading_and_generics() {
     let digests: Vec<String> = resp
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect();
     assert!(
         digests.contains(&digest_u64.to_string()) && digests.contains(&digest_addr.to_string()),
@@ -2477,7 +2477,7 @@ async fn test_list_events_combinator_and() {
     let filter = ev_and(vec![ev_sender(sender_a), ev_emit_module(&module)]);
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(filter);
     req.options = Some(query_options(100));
 
@@ -2485,7 +2485,7 @@ async fn test_list_events_combinator_and() {
     let digests: Vec<String> = resp
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect();
 
     assert!(
@@ -2547,7 +2547,7 @@ async fn test_list_events_combinator_or_not() {
     ]);
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(filter);
     req.options = Some(query_options(100));
 
@@ -2555,7 +2555,7 @@ async fn test_list_events_combinator_or_not() {
     let digests: Vec<String> = resp
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect();
 
     assert!(
@@ -2613,14 +2613,14 @@ async fn test_list_events_unanchored_negation() {
     // Exclude-only term: `NOT sender = B` anchors on the stored EventExtant
     // marker and returns every event whose sender is not B.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_not_sender_only_filter(sender_b));
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
     let digests: Vec<String> = resp
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect();
     assert!(
         digests.contains(&digest_a.to_string()),
@@ -2633,14 +2633,14 @@ async fn test_list_events_unanchored_negation() {
 
     // Symmetric case: `NOT sender = A` returns B's event.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_not_sender_only_filter(sender_a));
     req.options = Some(query_options(100));
     let resp = list_events_result(&mut client, req).await;
     let digests: Vec<String> = resp
         .events
         .iter()
-        .filter_map(|e| e.transaction_digest.clone())
+        .filter_map(event_transaction_digest)
         .collect();
     assert!(
         digests.contains(&digest_b.to_string()),
@@ -2725,7 +2725,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         let mut c = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.start_checkpoint = Some(emit_start);
             req.end_checkpoint = Some(emit_end);
             req.filter = Some(filter);
@@ -2774,7 +2774,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         let mut c = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.start_checkpoint = Some(emit_start);
             req.end_checkpoint = Some(emit_end);
             req.options = Some(query_options_maybe_after(3, cursor));
@@ -2807,7 +2807,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         .iter()
         .chain(up2.events.iter())
         .chain(up3.events.iter())
-        .map(|e| (e.transaction_digest.clone(), e.event_index))
+        .map(|e| (event_transaction_digest(e), event_index_of(e)))
         .collect();
     assert_eq!(unfiltered_keys.len(), 8, "8 total unfiltered events");
     let mut deduped = unfiltered_keys.clone();
@@ -2823,7 +2823,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         let mut c = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.start_checkpoint = Some(emit_start);
             req.end_checkpoint = Some(emit_end);
             req.filter = Some(filter);
@@ -2855,7 +2855,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         .iter()
         .chain(rp2.events.iter())
         .chain(rp3.events.iter())
-        .map(|e| (e.transaction_digest.clone(), e.event_index))
+        .map(|e| (event_transaction_digest(e), event_index_of(e)))
         .collect();
     assert_eq!(reverse_keys.len(), 8, "8 total reverse events");
     let mut deduped = reverse_keys.clone();
@@ -2867,7 +2867,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         let mut c = client.clone();
         async move {
             let mut req = ListEventsRequest::default();
-            req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+            req.read_mask = Some(event_type_and_position_mask());
             req.start_checkpoint = Some(emit_start);
             req.end_checkpoint = Some(emit_end);
             req.options = Some(query_options_descending_maybe_before(3, cursor));
@@ -2906,7 +2906,7 @@ async fn test_list_events_query_options_multi_event_tx() {
         .iter()
         .chain(up2.events.iter())
         .chain(up3.events.iter())
-        .map(|e| (e.transaction_digest.clone(), e.event_index))
+        .map(|e| (event_transaction_digest(e), event_index_of(e)))
         .collect();
     assert_eq!(
         unfiltered_reverse_keys.len(),
@@ -2948,7 +2948,7 @@ async fn test_list_filter_edge_cases() {
     assert_transaction_cursors(&resp);
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(9999);
     req.options = Some(query_options(10));
     let resp = list_events_result(&mut client, req).await;
@@ -2972,7 +2972,7 @@ async fn test_list_filter_edge_cases() {
     assert_transaction_cursors(&resp);
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_sender(never_sender));
     req.options = Some(query_options(10));
     let resp = list_events_result(&mut client, req).await;
@@ -3007,7 +3007,7 @@ async fn test_list_filter_edge_cases() {
 
     // Malformed EventType (generics without a name) → InvalidArgument.
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(ev_event_type("0x1<u64>"));
@@ -3064,7 +3064,7 @@ async fn test_list_filter_edge_cases() {
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     let mut bad_options = query_options(10);
-    bad_options.ordering = 99;
+    bad_options.ordering = Some(99);
     req.options = Some(bad_options);
     expect_invalid_list_transactions(&mut client, req).await;
 
@@ -3077,7 +3077,7 @@ async fn test_list_filter_edge_cases() {
     expect_invalid_list_transactions(&mut client, req).await;
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.start_checkpoint = Some(0);
     req.end_checkpoint = Some(DEFAULT_CHECKPOINT_RANGE_END);
     req.filter = Some(EventFilter::default());
@@ -3136,7 +3136,7 @@ async fn test_list_limit_items_over_cap_is_coerced() {
     list_transactions_result(&mut client, req).await;
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.options = Some(query_options(oversized));
     list_events_result(&mut client, req).await;
 }
@@ -3970,7 +3970,7 @@ async fn test_list_events_sparse_filter_emits_watermarks() {
         .unwrap();
 
     let mut req = ListEventsRequest::default();
-    req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    req.read_mask = Some(event_type_and_position_mask());
     req.filter = Some(ev_sender(sender_b));
     req.options = Some(query_options(100));
 
@@ -3990,7 +3990,7 @@ async fn test_list_events_sparse_filter_emits_watermarks() {
 
     let last_cursor = resp.end_cursor.clone().expect("trailing cursor present");
     let mut next_req = ListEventsRequest::default();
-    next_req.read_mask = Some(FieldMask::from_paths(["event_type"]));
+    next_req.read_mask = Some(event_type_and_position_mask());
     next_req.filter = Some(ev_sender(sender_b));
     next_req.options = Some(query_options_after(100, last_cursor));
     let next_resp = list_events_result(&mut client, next_req).await;

--- a/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/alpha_ledger_grpc_reader.rs
@@ -51,7 +51,7 @@ pub struct StreamPage<T> {
 enum FrameKind<T> {
     Item { payload: T, cursor: Bytes },
     Watermark { cursor: Option<Bytes> },
-    End { reason: i32 },
+    End { reason: proto::QueryEndReason },
     Unknown,
 }
 
@@ -160,13 +160,10 @@ impl<T> StreamPage<T> {
                 }
             }
             FrameKind::End { reason } => {
-                // Fold an unknown reason into `Unspecified` so `None` remains unambiguous shorthand
-                // for "no End frame received" (i.e. the deadline cut the stream short).
-                self.end_reason =
-                    Some(proto::QueryEndReason::try_from(reason).unwrap_or_else(|_| {
-                        warn!(reason, "unknown QueryEndReason");
-                        proto::QueryEndReason::Unspecified
-                    }));
+                // `QueryEnd::reason()` folds an absent or unknown reason into
+                // `Unspecified`, so `None` here remains unambiguous shorthand for
+                // "no End frame received" (i.e. the deadline cut the stream short).
+                self.end_reason = Some(reason);
                 return true;
             }
             FrameKind::Unknown => {
@@ -211,7 +208,9 @@ impl TryFrom<proto::ListTransactionsResponse> for FrameKind<ExecutedTransaction>
             Response::Watermark(watermark) => FrameKind::Watermark {
                 cursor: watermark.cursor,
             },
-            Response::End(end) => FrameKind::End { reason: end.reason },
+            Response::End(end) => FrameKind::End {
+                reason: end.reason(),
+            },
             _ => FrameKind::Unknown,
         })
     }
@@ -299,7 +298,7 @@ mod tests {
 
     fn end_response(reason: proto::QueryEndReason) -> proto::ListTransactionsResponse {
         let mut end = proto::QueryEnd::default();
-        end.reason = reason as i32;
+        end.reason = Some(reason as i32);
         let mut response = proto::ListTransactionsResponse::default();
         response.response = Some(proto::list_transactions_response::Response::End(end));
         response
@@ -469,7 +468,7 @@ mod tests {
     #[test]
     fn apply_end_with_unknown_reason_folds_to_unspecified() {
         let mut end = proto::QueryEnd::default();
-        end.reason = i32::MAX;
+        end.reason = Some(i32::MAX);
         let mut response = proto::ListTransactionsResponse::default();
         response.response = Some(proto::list_transactions_response::Response::End(end));
 

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -510,7 +510,7 @@ fn response_for(watermark: Watermark, message: Checkpoint) -> ListCheckpointsRes
 
 fn end_response(reason: QueryEndReason) -> ListCheckpointsResponse {
     let mut end = QueryEnd::default();
-    end.reason = reason as i32;
+    end.reason = Some(reason as i32);
 
     let mut response = ListCheckpointsResponse::default();
     response.response = Some(list_checkpoints_response::Response::End(end));

--- a/crates/sui-kv-rpc/src/v2alpha/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_events.rs
@@ -501,12 +501,25 @@ async fn render_event(
             .map(Box::new);
     }
 
+    // The event's ledger position rides on the `Event` message itself rather
+    // than the enclosing `EventItem`; populate each position field only when the
+    // read mask requests it. Authenticated-stream clients that need to
+    // reconstruct the `EventCommitment` leaf ask for these paths.
+    if read_mask.contains(ProtoEvent::CHECKPOINT_FIELD.name) {
+        proto_event.checkpoint = Some(tx.checkpoint_number);
+    }
+    if read_mask.contains(ProtoEvent::TRANSACTION_DIGEST_FIELD.name) {
+        proto_event.transaction_digest = Some(tx.digest.to_string());
+    }
+    if read_mask.contains(ProtoEvent::TRANSACTION_INDEX_FIELD.name) {
+        proto_event.transaction_index = event_ref.tx_seq_digest.map(|row| row.tx_offset as u64);
+    }
+    if read_mask.contains(ProtoEvent::EVENT_INDEX_FIELD.name) {
+        proto_event.event_index = Some(event_ref.event_idx);
+    }
+
     let mut item = EventItem::default();
-    item.checkpoint = Some(tx.checkpoint_number);
-    item.event_index = Some(event_ref.event_idx);
-    item.transaction_digest = Some(tx.digest.to_string());
     item.event = Some(proto_event);
-    item.transaction_offset = event_ref.tx_seq_digest.map(|row| row.tx_offset as u64);
 
     Ok(RenderedEvent {
         item,
@@ -517,7 +530,7 @@ async fn render_event(
 
 fn end_response(reason: QueryEndReason) -> ListEventsResponse {
     let mut end = QueryEnd::default();
-    end.reason = reason as i32;
+    end.reason = Some(reason as i32);
 
     let mut response = ListEventsResponse::default();
     response.response = Some(list_events_response::Response::End(end));
@@ -704,10 +717,10 @@ mod tests {
 
     fn options(ordering: Ordering) -> QueryOptions {
         let mut request = sui_rpc::proto::sui::rpc::v2alpha::QueryOptions::default();
-        request.ordering = match ordering {
+        request.ordering = Some(match ordering {
             Ordering::Ascending => 0,
             Ordering::Descending => 1,
-        };
+        });
 
         QueryOptions::from_proto(Some(&request), 100, 100, QueryType::Events).unwrap()
     }

--- a/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_transactions.rs
@@ -283,7 +283,7 @@ pub(crate) async fn list_transactions(
                     ctx.observe_response_render(render_started.elapsed());
                     emitted += 1;
                     let yield_started = Instant::now();
-                    yield transaction_item_response(wm, executed, tx_offset);
+                    yield transaction_item_response(wm, executed, tx_offset, &read_mask);
                     ctx.observe_stream_item_yield_wait(yield_started.elapsed());
                 }
                 Ok(ResolvedWatermarked::Watermark { position, cp }) => {
@@ -429,12 +429,16 @@ async fn fetch_transactions(
 }
 
 fn should_render_transaction_contents(read_mask: &FieldMaskTree) -> bool {
+    // `digest`, `checkpoint`, and `transaction_index` are all available from the
+    // tx_seq_digest index row, so a mask limited to them skips the full
+    // transaction fetch.
     let paths = read_mask.to_field_mask().paths;
     paths.is_empty()
-        || paths.len() > 2
+        || paths.len() > 3
         || paths.iter().any(|path| {
             path != ExecutedTransaction::DIGEST_FIELD.name
                 && path != ExecutedTransaction::CHECKPOINT_FIELD.name
+                && path != ExecutedTransaction::TRANSACTION_INDEX_FIELD.name
         })
 }
 
@@ -451,7 +455,7 @@ fn transaction_response_from_tx_seq_digest(
         transaction.checkpoint = Some(row.checkpoint_number);
     }
 
-    transaction_item_response(watermark, transaction, row.tx_offset)
+    transaction_item_response(watermark, transaction, row.tx_offset, read_mask)
 }
 
 /// Determine the tx_sequence_number scan window from the logical checkpoint
@@ -509,13 +513,20 @@ async fn checkpoint_to_tx_boundary(
 
 fn transaction_item_response(
     watermark: Watermark,
-    transaction: ExecutedTransaction,
+    mut transaction: ExecutedTransaction,
     tx_offset: u32,
+    read_mask: &FieldMaskTree,
 ) -> ListTransactionsResponse {
+    // The within-checkpoint position rides on the `ExecutedTransaction` rather
+    // than the enclosing `TransactionItem`; populate it only when the read mask
+    // requests it.
+    if read_mask.contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name) {
+        transaction.transaction_index = Some(tx_offset as u64);
+    }
+
     let mut item = TransactionItem::default();
     item.transaction = Some(transaction);
     item.watermark = Some(watermark);
-    item.transaction_offset = Some(tx_offset as u64);
 
     let mut response = ListTransactionsResponse::default();
     response.response = Some(list_transactions_response::Response::Item(item));
@@ -524,7 +535,7 @@ fn transaction_item_response(
 
 fn end_response(reason: QueryEndReason) -> ListTransactionsResponse {
     let mut end = QueryEnd::default();
-    end.reason = reason as i32;
+    end.reason = Some(reason as i32);
 
     let mut response = ListTransactionsResponse::default();
     response.response = Some(list_transactions_response::Response::End(end));
@@ -584,19 +595,27 @@ mod tests {
             digest_wm.cursor.as_ref(),
             Some(&options.cursor_for_item(row.checkpoint_number, 42))
         );
-        assert_eq!(digest_wm.checkpoint_hi, Some(8));
-        assert_eq!(
-            digest_wm.checkpoint_lo, None,
-            "ascending scan must not set checkpoint_lo"
-        );
-        assert_eq!(
-            digest_only.transaction_offset,
-            Some(row.tx_offset as u64),
-            "within-checkpoint offset should propagate to the item"
-        );
+        assert_eq!(digest_wm.checkpoint, Some(8));
         let transaction = digest_only.transaction.expect("executed transaction");
+        assert_eq!(
+            transaction.transaction_index, None,
+            "transaction_index must be omitted when the read mask does not request it"
+        );
         assert_eq!(transaction.digest, Some(row.digest.to_string()));
         assert_eq!(transaction.checkpoint, None);
+
+        let with_index = unwrap_item(transaction_response_from_tx_seq_digest(
+            row,
+            &read_mask(&["digest", "transaction_index"]),
+            wm(),
+        ));
+        let transaction = with_index.transaction.expect("executed transaction");
+        assert_eq!(
+            transaction.transaction_index,
+            Some(row.tx_offset as u64),
+            "within-checkpoint offset should propagate when requested"
+        );
+        assert_eq!(transaction.digest, Some(row.digest.to_string()));
 
         let checkpoint_only = unwrap_item(transaction_response_from_tx_seq_digest(
             row,

--- a/crates/sui-light-client/src/authenticated_events/mod.rs
+++ b/crates/sui-light-client/src/authenticated_events/mod.rs
@@ -101,13 +101,15 @@ impl TryFrom<EventItem> for AuthenticatedEvent {
             contents: event_bytes.to_vec(),
         };
 
-        let checkpoint = item
+        // The ledger position now lives on the `Event` message rather than the
+        // enclosing `EventItem`.
+        let checkpoint = proto_event
             .checkpoint
             .ok_or_else(|| ClientError::InternalError("Missing checkpoint".to_string()))?;
-        let transaction_offset = item
-            .transaction_offset
-            .ok_or_else(|| ClientError::InternalError("Missing transaction_offset".to_string()))?;
-        let event_index = item
+        let transaction_offset = proto_event
+            .transaction_index
+            .ok_or_else(|| ClientError::InternalError("Missing transaction_index".to_string()))?;
+        let event_index = proto_event
             .event_index
             .ok_or_else(|| ClientError::InternalError("Missing event_index".to_string()))?;
 

--- a/crates/sui-light-client/src/authenticated_events/stream.rs
+++ b/crates/sui-light-client/src/authenticated_events/stream.rs
@@ -74,15 +74,24 @@ impl EventStreamState {
         let mut new_events: Vec<AuthenticatedEvent> = Vec::new();
         let start_checkpoint = self.next_checkpoint;
 
-        let mut options = QueryOptions::default().with_limit_items(self.config.page_size);
+        let mut options = QueryOptions::default().with_limit(self.config.page_size);
         if let Some(cursor) = self.next_cursor.as_ref() {
             options.set_after(cursor.clone());
         }
-        // Request every field the in-tree `AuthenticatedEvent` converter
-        // needs. The server's default event read mask drops `contents`, so
-        // we ask for the full event explicitly.
-        let read_mask =
-            FieldMask::from_paths(["package_id", "module", "sender", "event_type", "contents"]);
+        // Request every field the in-tree `AuthenticatedEvent` converter needs:
+        // the event body plus its ledger-position fields (`checkpoint`,
+        // `transaction_index`, `event_index`), which the list endpoint only
+        // populates when the read mask asks for them.
+        let read_mask = FieldMask::from_paths([
+            "package_id",
+            "module",
+            "sender",
+            "event_type",
+            "contents",
+            "checkpoint",
+            "transaction_index",
+            "event_index",
+        ]);
         let request = ListEventsRequest::default()
             .with_read_mask(read_mask)
             .with_start_checkpoint(start_checkpoint)
@@ -114,7 +123,7 @@ impl EventStreamState {
                     }
                 }
                 Some(list_events_response::Response::End(end)) => {
-                    end_reason = QueryEndReason::try_from(end.reason).ok();
+                    end_reason = Some(end.reason());
                 }
                 Some(_) | None => {}
             }
@@ -380,15 +389,15 @@ async fn fetch_settlements_for_range(
     end_checkpoint_exclusive: u64,
 ) -> Result<Vec<(u64, u64)>, ClientError> {
     let filter = build_affected_object_filter(stream_object_id);
-    // We only need `checkpoint` from the embedded transaction — the
-    // `transaction_offset` is a top-level field on every `TransactionItem`.
-    let read_mask = FieldMask::from_paths(["checkpoint"]);
+    // We need `checkpoint` and the `transaction_index` position field from each
+    // settlement transaction.
+    let read_mask = FieldMask::from_paths(["checkpoint", "transaction_index"]);
 
     let mut all: Vec<(u64, u64)> = Vec::new();
     let mut cursor: Option<Vec<u8>> = None;
 
     loop {
-        let mut options = QueryOptions::default().with_limit_items(1000);
+        let mut options = QueryOptions::default().with_limit(1000);
         if let Some(c) = cursor.clone() {
             options.set_after(c);
         }
@@ -426,11 +435,15 @@ async fn fetch_settlements_for_range(
                                 "settlement transaction missing checkpoint".to_string(),
                             )
                         })?;
-                    let tx_offset = item.transaction_offset.ok_or_else(|| {
-                        ClientError::InternalError(
-                            "settlement transaction missing transaction_offset".to_string(),
-                        )
-                    })?;
+                    let tx_offset = item
+                        .transaction
+                        .as_ref()
+                        .and_then(|tx| tx.transaction_index)
+                        .ok_or_else(|| {
+                            ClientError::InternalError(
+                                "settlement transaction missing transaction_index".to_string(),
+                            )
+                        })?;
                     all.push((checkpoint, tx_offset));
                 }
                 Some(list_transactions_response::Response::Watermark(w)) => {
@@ -439,7 +452,7 @@ async fn fetch_settlements_for_range(
                     }
                 }
                 Some(list_transactions_response::Response::End(end)) => {
-                    end_reason = QueryEndReason::try_from(end.reason).ok();
+                    end_reason = Some(end.reason());
                 }
                 Some(_) | None => {}
             }

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_checkpoints.rs
@@ -664,7 +664,7 @@ fn watermark_response(watermark: Watermark) -> ListCheckpointsResponse {
 
 fn end_response(reason: QueryEndReason) -> ListCheckpointsResponse {
     let mut end = QueryEnd::default();
-    end.reason = reason as i32;
+    end.reason = Some(reason as i32);
 
     let mut response = ListCheckpointsResponse::default();
     response.response = Some(list_checkpoints_response::Response::End(end));

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_events.rs
@@ -620,7 +620,6 @@ fn render_event_chunk(
                     ),
                 )
             })?;
-        #[allow(unused_mut)]
         let mut proto_event = service.render_event_to_proto(
             event,
             read_mask,
@@ -631,6 +630,22 @@ fn render_event_chunk(
                 bcs.value = Some(vec![0xDE, 0xAD, 0xBE, 0xEF].into());
             }
         });
+        // The event's ledger position rides on the `Event` message itself
+        // rather than the enclosing `EventItem`; populate each position field
+        // only when the read mask requests it. Authenticated-stream clients that
+        // need to reconstruct the `EventCommitment` leaf ask for these paths.
+        if read_mask.contains(ProtoEvent::CHECKPOINT_FIELD.name) {
+            proto_event.checkpoint = Some(row.checkpoint_number);
+        }
+        if read_mask.contains(ProtoEvent::TRANSACTION_DIGEST_FIELD.name) {
+            proto_event.transaction_digest = Some(row.digest.to_string());
+        }
+        if read_mask.contains(ProtoEvent::TRANSACTION_INDEX_FIELD.name) {
+            proto_event.transaction_index = Some(row.tx_offset as u64);
+        }
+        if read_mask.contains(ProtoEvent::EVENT_INDEX_FIELD.name) {
+            proto_event.event_index = Some(event_ref.event_idx);
+        }
         checkpoint_boundary =
             advance_boundary_excluding_cp(checkpoint_boundary, row.checkpoint_number, options);
         let watermark = item_watermark(
@@ -642,10 +657,6 @@ fn render_event_chunk(
 
         let mut item = EventItem::default();
         item.watermark = Some(watermark);
-        item.checkpoint = Some(row.checkpoint_number);
-        item.event_index = Some(event_ref.event_idx);
-        item.transaction_digest = Some(row.digest.to_string());
-        item.transaction_offset = Some(row.tx_offset as u64);
         item.event = Some(proto_event);
 
         let mut response = ListEventsResponse::default();
@@ -821,7 +832,7 @@ fn watermark_response(watermark: Watermark) -> ListEventsResponse {
 
 fn end_response(reason: QueryEndReason) -> ListEventsResponse {
     let mut end = QueryEnd::default();
-    end.reason = reason as i32;
+    end.reason = Some(reason as i32);
 
     let mut response = ListEventsResponse::default();
     response.response = Some(list_events_response::Response::End(end));

--- a/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
+++ b/crates/sui-rpc-api/src/grpc/v2alpha/ledger_service/list_transactions.rs
@@ -471,7 +471,7 @@ fn render_transaction_rows(
                 row.checkpoint_number,
                 read_mask,
             )?;
-            transaction_item_response(watermark, transaction, row.tx_offset)
+            transaction_item_response(watermark, transaction, row.tx_offset, read_mask)
         } else {
             let mut transaction = ExecutedTransaction::default();
             if read_mask.contains(ExecutedTransaction::DIGEST_FIELD.name) {
@@ -480,7 +480,7 @@ fn render_transaction_rows(
             if read_mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name) {
                 transaction.checkpoint = Some(row.checkpoint_number);
             }
-            transaction_item_response(watermark, transaction, row.tx_offset)
+            transaction_item_response(watermark, transaction, row.tx_offset, read_mask)
         };
         items.push(response);
     }
@@ -500,12 +500,16 @@ pub(crate) fn validate_read_mask(read_mask: Option<FieldMask>) -> Result<FieldMa
 }
 
 fn should_render_transaction_contents(read_mask: &FieldMaskTree) -> bool {
+    // `digest`, `checkpoint`, and `transaction_index` are all available from the
+    // tx_seq_digest index row, so a mask limited to them skips the full
+    // transaction fetch.
     let paths = read_mask.to_field_mask().paths;
     paths.is_empty()
-        || paths.len() > 2
+        || paths.len() > 3
         || paths.iter().any(|path| {
             path != ExecutedTransaction::DIGEST_FIELD.name
                 && path != ExecutedTransaction::CHECKPOINT_FIELD.name
+                && path != ExecutedTransaction::TRANSACTION_INDEX_FIELD.name
         })
 }
 
@@ -534,13 +538,20 @@ fn resolve_tx_range(
 
 fn transaction_item_response(
     watermark: Watermark,
-    transaction: ExecutedTransaction,
+    mut transaction: ExecutedTransaction,
     tx_offset: u32,
+    read_mask: &FieldMaskTree,
 ) -> ListTransactionsResponse {
+    // The within-checkpoint position rides on the `ExecutedTransaction` rather
+    // than the enclosing `TransactionItem`; populate it only when the read mask
+    // requests it.
+    if read_mask.contains(ExecutedTransaction::TRANSACTION_INDEX_FIELD.name) {
+        transaction.transaction_index = Some(tx_offset as u64);
+    }
+
     let mut item = TransactionItem::default();
     item.watermark = Some(watermark);
     item.transaction = Some(transaction);
-    item.transaction_offset = Some(tx_offset as u64);
 
     let mut response = ListTransactionsResponse::default();
     response.response = Some(list_transactions_response::Response::Item(item));
@@ -555,7 +566,7 @@ fn watermark_response(watermark: Watermark) -> ListTransactionsResponse {
 
 fn end_response(reason: QueryEndReason) -> ListTransactionsResponse {
     let mut end = QueryEnd::default();
-    end.reason = reason as i32;
+    end.reason = Some(reason as i32);
 
     let mut response = ListTransactionsResponse::default();
     response.response = Some(list_transactions_response::Response::End(end));

--- a/crates/sui-rpc-api/src/ledger_history/filter.rs
+++ b/crates/sui-rpc-api/src/ledger_history/filter.rs
@@ -291,7 +291,7 @@ fn convert_transaction_predicate(
             convert_emit_module(f, &format!("{field_prefix}.emit_module.module"))
         }
         transaction_predicate::Predicate::EventType(f) => {
-            convert_event_type(f, &format!("{field_prefix}.event_type.type"))
+            convert_event_type(f, &format!("{field_prefix}.event_type.event_type"))
         }
         transaction_predicate::Predicate::EventStreamHead(f) => {
             convert_event_stream_head(f, &format!("{field_prefix}.event_stream_head.stream_id"))
@@ -323,7 +323,7 @@ fn convert_event_predicate(
             convert_emit_module(f, &format!("{field_prefix}.emit_module.module"))
         }
         event_predicate::Predicate::EventType(f) => {
-            convert_event_type(f, &format!("{field_prefix}.event_type.type"))
+            convert_event_type(f, &format!("{field_prefix}.event_type.event_type"))
         }
         event_predicate::Predicate::EventStreamHead(f) => {
             convert_event_stream_head(f, &format!("{field_prefix}.event_stream_head.stream_id"))
@@ -423,7 +423,7 @@ fn convert_emit_module(f: &EmitModuleFilter, field: &str) -> Result<Vec<u8>, Rpc
 }
 
 fn convert_event_type(f: &EventTypeFilter, field: &str) -> Result<Vec<u8>, RpcError> {
-    let s = f.r#type.as_deref().ok_or_else(|| {
+    let s = f.event_type.as_deref().ok_or_else(|| {
         FieldViolation::new(field)
             .with_description("type is required")
             .with_reason(ErrorReason::FieldMissing)

--- a/crates/sui-rpc-api/src/ledger_history/query_options.rs
+++ b/crates/sui-rpc-api/src/ledger_history/query_options.rs
@@ -64,11 +64,11 @@ impl QueryOptions {
         query_type: QueryType,
     ) -> Result<Self, RpcError> {
         let limit_items = request
-            .and_then(|options| options.limit_items)
+            .and_then(|options| options.limit)
             .unwrap_or(default_limit_items)
             .clamp(1, max_limit_items) as usize;
 
-        let ordering = match request.map(|options| options.ordering) {
+        let ordering = match request.and_then(|options| options.ordering) {
             None | Some(ORDERING_ASCENDING) => Ordering::Ascending,
             Some(ORDERING_DESCENDING) => Ordering::Descending,
             Some(_) => {
@@ -391,10 +391,10 @@ mod tests {
         let after = CursorToken::item(QueryType::Transactions, 2, 20).encode();
         let before = CursorToken::item(QueryType::Transactions, 3, 30).encode();
         let mut request = ProtoQueryOptions::default();
-        request.limit_items = Some(500);
+        request.limit = Some(500);
         request.after = Some(after);
         request.before = Some(before);
-        request.ordering = ProtoOrdering::Descending as i32;
+        request.ordering = Some(ProtoOrdering::Descending as i32);
 
         let options = query_options_from_proto(Some(&request)).unwrap();
 
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn clamps_limit_items_and_defaults_to_ascending() {
         let mut request = ProtoQueryOptions::default();
-        request.limit_items = Some(5_000);
+        request.limit = Some(5_000);
 
         let options = query_options_from_proto(Some(&request)).unwrap();
 
@@ -449,7 +449,7 @@ mod tests {
         assert!(query_options_from_proto(Some(&request)).is_err());
 
         let mut request = ProtoQueryOptions::default();
-        request.ordering = 99;
+        request.ordering = Some(99);
         assert!(query_options_from_proto(Some(&request)).is_err());
     }
 
@@ -480,7 +480,7 @@ mod tests {
         let token = CursorToken::item(QueryType::Transactions, 9, 9).encode();
         let mut request = ProtoQueryOptions::default();
         request.after = Some(token);
-        request.ordering = ProtoOrdering::Descending as i32;
+        request.ordering = Some(ProtoOrdering::Descending as i32);
 
         let options = query_options_from_proto(Some(&request)).unwrap();
         let range = CheckpointRange::from_request(Some(1_000), Some(1_100), 2_000).unwrap();

--- a/crates/sui-rpc-api/src/ledger_history/watermark.rs
+++ b/crates/sui-rpc-api/src/ledger_history/watermark.rs
@@ -6,10 +6,10 @@
 //! Both ledger-history backends — the fullnode (`sui-rpc-api`) and bigtable
 //! (`sui-kv-rpc`) — and all three list handlers (`list_transactions`,
 //! `list_events`, `list_checkpoints`) emit the same wire `Watermark`: a resume
-//! cursor plus a direction-matching completion boundary (`checkpoint_hi`
-//! ascending / `checkpoint_lo` descending). The cursor encoding and the
-//! boundary bookkeeping are identical; what differs per API is how a scan
-//! position resolves into a completion-boundary candidate:
+//! cursor plus a completion boundary (`checkpoint`, the inclusive boundary
+//! checkpoint the scan has fully covered in the request's ordering direction).
+//! The cursor encoding and the boundary bookkeeping are identical; what differs
+//! per API is how a scan position resolves into a completion-boundary candidate:
 //!
 //! - `list_transactions` / `list_events` scan within a checkpoint, so an
 //!   item at cp `C` does NOT prove `C` complete (more matches may sit at
@@ -30,15 +30,12 @@ use sui_rpc::proto::sui::rpc::v2alpha::Watermark;
 
 use crate::ledger_history::query_options::QueryOptions;
 
-/// Populate the direction-matching field of a `Watermark` from the
-/// per-scan boundary value. Exactly one of `checkpoint_hi` /
-/// `checkpoint_lo` is set, never both.
-fn set_checkpoint_bound(wm: &mut Watermark, options: &QueryOptions, boundary: Option<u64>) {
-    if options.is_ascending() {
-        wm.checkpoint_hi = boundary;
-    } else {
-        wm.checkpoint_lo = boundary;
-    }
+/// Populate the completion-boundary `checkpoint` field of a `Watermark` from
+/// the per-scan boundary value. The value already carries the direction-correct
+/// meaning (inclusive upper bound ascending, inclusive lower bound descending);
+/// the single wire field records it regardless of ordering.
+fn set_checkpoint_bound(wm: &mut Watermark, boundary: Option<u64>) {
+    wm.checkpoint = boundary;
 }
 
 /// Fold an already-resolved completion-boundary `candidate` into the
@@ -98,7 +95,7 @@ pub fn item_watermark(
 ) -> Watermark {
     let mut wm = Watermark::default();
     wm.cursor = Some(options.cursor_for_item(cp, position));
-    set_checkpoint_bound(&mut wm, options, boundary);
+    set_checkpoint_bound(&mut wm, boundary);
     wm
 }
 
@@ -115,7 +112,7 @@ pub fn boundary_watermark(
 ) -> Watermark {
     let mut wm = Watermark::default();
     wm.cursor = Some(options.cursor_for_boundary(cursor_cp, position));
-    set_checkpoint_bound(&mut wm, options, boundary);
+    set_checkpoint_bound(&mut wm, boundary);
     wm
 }
 
@@ -152,7 +149,7 @@ pub fn terminal_boundary_watermark(
     };
     let mut wm = Watermark::default();
     wm.cursor = Some(options.cursor_for_boundary(end_checkpoint, end_position));
-    set_checkpoint_bound(&mut wm, options, boundary);
+    set_checkpoint_bound(&mut wm, boundary);
     wm
 }
 
@@ -174,11 +171,11 @@ mod tests {
 
     fn options(ascending: bool) -> QueryOptions {
         let mut request = sui_rpc::proto::sui::rpc::v2alpha::QueryOptions::default();
-        request.ordering = if ascending {
+        request.ordering = Some(if ascending {
             sui_rpc::proto::sui::rpc::v2alpha::Ordering::Ascending as i32
         } else {
             sui_rpc::proto::sui::rpc::v2alpha::Ordering::Descending as i32
-        };
+        });
         QueryOptions::from_proto(Some(&request), 100, 100, QueryType::Transactions).unwrap()
     }
 
@@ -234,39 +231,36 @@ mod tests {
         );
     }
 
-    /// Ascending stores the boundary in `checkpoint_hi`; descending in
-    /// `checkpoint_lo`. A client reads the direction-correct bound off the
-    /// wire frame without knowing the request's ordering.
+    /// The direction-correct boundary is recorded in the single `checkpoint`
+    /// field regardless of ordering. A client reads the bound off the wire
+    /// frame and interprets it per the request's ordering.
     #[test]
     fn item_watermark_sets_direction_matching_bound() {
         let asc = options(true);
         let wm = item_watermark(&asc, 9, 42, Some(8));
-        assert_eq!(wm.checkpoint_hi, Some(8));
-        assert_eq!(wm.checkpoint_lo, None);
+        assert_eq!(wm.checkpoint, Some(8));
         assert_eq!(wm.cursor.as_ref(), Some(&asc.cursor_for_item(9, 42)));
 
         let desc = options(false);
         let wm = item_watermark(&desc, 9, 42, Some(10));
-        assert_eq!(wm.checkpoint_hi, None);
-        assert_eq!(wm.checkpoint_lo, Some(10));
+        assert_eq!(wm.checkpoint, Some(10));
     }
 
     /// On natural completion the terminal frame claims the range's final
     /// checkpoint complete: ascending uses `end_checkpoint - 1` and resumes
     /// from `(end_checkpoint, end_position)`; descending stores the range's
-    /// lowest checkpoint (inclusive) in `checkpoint_lo`.
+    /// lowest checkpoint (inclusive). Both land in the single `checkpoint`
+    /// field.
     #[test]
     fn terminal_boundary_watermark_claims_final_checkpoint() {
         let asc = options(true);
         let wm = terminal_boundary_watermark(&asc, 10, 100);
-        assert_eq!(wm.checkpoint_hi, Some(9));
-        assert_eq!(wm.checkpoint_lo, None);
+        assert_eq!(wm.checkpoint, Some(9));
         assert_eq!(wm.cursor.as_ref(), Some(&asc.cursor_for_boundary(10, 100)));
 
         let desc = options(false);
         let wm = terminal_boundary_watermark(&desc, 10, 100);
-        assert_eq!(wm.checkpoint_lo, Some(10));
-        assert_eq!(wm.checkpoint_hi, None);
+        assert_eq!(wm.checkpoint, Some(10));
         assert_eq!(wm.cursor.as_ref(), Some(&desc.cursor_for_boundary(10, 100)));
     }
 


### PR DESCRIPTION
Update the `sui-rust-sdk` git pointers and adapt to the four v2alpha ledger service proto changes that came with them:

- `EventTypeFilter.type` was renamed to `event_type`.
- `QueryOptions.limit_items` became `limit`, and `ordering` became optional. `QueryEnd.reason` became optional; consumers now read it through the generated `reason()` accessor, which defaults an absent or unknown value to `QUERY_END_REASON_UNSPECIFIED`.
- `Watermark.checkpoint_hi` and `checkpoint_lo` were merged into a single `checkpoint` field carrying the direction-correct completion boundary.
- `TransactionItem.transaction_offset` was removed in favor of `ExecutedTransaction.transaction_index`, and `EventItem` was slimmed to `{event, watermark}` with its ledger position (`checkpoint`, `transaction_digest`, `transaction_index`, `event_index`) moved onto the embedded `Event`.

Both list backends (`sui-rpc-api` and `sui-kv-rpc`) now populate the relocated position fields on the message unconditionally, since the list endpoints always report where an item sits regardless of the read mask, which the authenticated-events light client and the e2e tests rely on. The light client, the alpha ledger gRPC reader, and the affected tests were updated to read from the new field locations.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
