### PR TITLE
[jsonrpc-alt] Add `getProtocolConfig` and `devInspectExecuteTransactionBlock` apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15526,6 +15526,7 @@ dependencies = [
  "sui-pg-db",
  "sui-protocol-config",
  "sui-rpc",
+ "sui-sdk-types",
  "sui-sql-macro",
  "sui-types",
  "telemetry-subscribers",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
@@ -78,8 +78,10 @@ async fn test_specific_version() {
     let mut cluster = FullCluster::new().await.unwrap();
     cluster.create_checkpoint().await;
 
-    let min = ProtocolVersion::MIN.as_u64();
-    let response = get_protocol_config(&cluster, json!([min.to_string()])).await;
+    // The simulator's chain runs at the max supported version, so that is the only version the
+    // indexer has records for.
+    let version = ProtocolVersion::MAX.as_u64();
+    let response = get_protocol_config(&cluster, json!([version.to_string()])).await;
     assert!(
         response["error"].is_null(),
         "RPC error: {}",
@@ -88,25 +90,27 @@ async fn test_specific_version() {
 
     assert_eq!(
         response["result"]["protocolVersion"].as_str().unwrap(),
-        min.to_string(),
+        version.to_string(),
     );
 }
 
 #[tokio::test]
-async fn test_unsupported_version() {
+async fn test_unknown_version() {
     telemetry_subscribers::init_for_testing();
     let mut cluster = FullCluster::new().await.unwrap();
     cluster.create_checkpoint().await;
 
-    let unsupported = ProtocolVersion::MAX.as_u64() + 1;
-    let response = get_protocol_config(&cluster, json!([unsupported.to_string()])).await;
+    // Configs are served from the database, so any version the indexer has not seen -- here, a
+    // version the chain has not reached -- is not found.
+    let unknown = ProtocolVersion::MAX.as_u64() + 1;
+    let response = get_protocol_config(&cluster, json!([unknown.to_string()])).await;
 
     assert_eq!(response["error"]["code"], -32602);
     assert!(
         response["error"]["message"]
             .as_str()
             .unwrap()
-            .contains("Unsupported protocol version"),
+            .contains("not found"),
         "Unexpected error message: {}",
         response["error"]["message"],
     );

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use reqwest::Client;
+use serde_json::Value;
+use serde_json::json;
+use sui_indexer_alt_e2e_tests::FullCluster;
+use sui_protocol_config::Chain;
+use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::ProtocolVersion;
+
+async fn get_protocol_config(cluster: &FullCluster, params: Value) -> Value {
+    let query = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "sui_getProtocolConfig",
+        "params": params,
+    });
+
+    let response = Client::new()
+        .post(cluster.jsonrpc_url())
+        .json(&query)
+        .send()
+        .await
+        .expect("Request to JSON-RPC server failed");
+
+    response
+        .json()
+        .await
+        .expect("Failed to parse JSON-RPC response")
+}
+
+#[tokio::test]
+async fn test_latest_version() {
+    telemetry_subscribers::init_for_testing();
+    let mut cluster = FullCluster::new().await.unwrap();
+
+    // Make sure the genesis epoch start has been indexed.
+    cluster.create_checkpoint().await;
+
+    let response = get_protocol_config(&cluster, json!([])).await;
+    assert!(response["error"].is_null(), "RPC error: {}", response["error"]);
+
+    let result = &response["result"];
+    let min = ProtocolVersion::MIN.as_u64().to_string();
+    let max = ProtocolVersion::MAX.as_u64().to_string();
+
+    // The simulator runs at the maximum supported protocol version.
+    assert_eq!(result["protocolVersion"].as_str().unwrap(), max);
+    assert_eq!(result["minSupportedProtocolVersion"].as_str().unwrap(), min);
+    assert_eq!(result["maxSupportedProtocolVersion"].as_str().unwrap(), max);
+
+    // Spot check the contents of each table against the protocol config the response was
+    // generated from.
+    let config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown);
+
+    assert_eq!(
+        result["attributes"]["max_tx_gas"],
+        json!({ "u64": config.max_tx_gas().to_string() }),
+    );
+
+    let feature_flags = result["featureFlags"].as_object().unwrap();
+    assert_eq!(feature_flags.len(), config.feature_map().len());
+
+    // `configs` is a complete view: it includes both attributes and feature flags.
+    let configs = result["configs"].as_object().unwrap();
+    assert!(configs.len() >= feature_flags.len());
+    assert!(!configs["max_tx_gas"].is_null());
+}
+
+#[tokio::test]
+async fn test_specific_version() {
+    telemetry_subscribers::init_for_testing();
+    let mut cluster = FullCluster::new().await.unwrap();
+    cluster.create_checkpoint().await;
+
+    let min = ProtocolVersion::MIN.as_u64();
+    let response = get_protocol_config(&cluster, json!([min.to_string()])).await;
+    assert!(response["error"].is_null(), "RPC error: {}", response["error"]);
+
+    assert_eq!(
+        response["result"]["protocolVersion"].as_str().unwrap(),
+        min.to_string(),
+    );
+}
+
+#[tokio::test]
+async fn test_unsupported_version() {
+    telemetry_subscribers::init_for_testing();
+    let mut cluster = FullCluster::new().await.unwrap();
+    cluster.create_checkpoint().await;
+
+    let unsupported = ProtocolVersion::MAX.as_u64() + 1;
+    let response = get_protocol_config(&cluster, json!([unsupported.to_string()])).await;
+
+    assert_eq!(response["error"]["code"], -32602);
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Unsupported protocol version"),
+        "Unexpected error message: {}",
+        response["error"]["message"],
+    );
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
@@ -39,7 +39,11 @@ async fn test_latest_version() {
     cluster.create_checkpoint().await;
 
     let response = get_protocol_config(&cluster, json!([])).await;
-    assert!(response["error"].is_null(), "RPC error: {}", response["error"]);
+    assert!(
+        response["error"].is_null(),
+        "RPC error: {}",
+        response["error"]
+    );
 
     let result = &response["result"];
     let min = ProtocolVersion::MIN.as_u64().to_string();
@@ -76,7 +80,11 @@ async fn test_specific_version() {
 
     let min = ProtocolVersion::MIN.as_u64();
     let response = get_protocol_config(&cluster, json!([min.to_string()])).await;
-    assert!(response["error"].is_null(), "RPC error: {}", response["error"]);
+    assert!(
+        response["error"].is_null(),
+        "RPC error: {}",
+        response["error"]
+    );
 
     assert_eq!(
         response["result"]["protocolVersion"].as_str().unwrap(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_protocol_config_tests.rs
@@ -32,7 +32,6 @@ async fn get_protocol_config(cluster: &FullCluster, params: Value) -> Value {
 
 #[tokio::test]
 async fn test_latest_version() {
-    telemetry_subscribers::init_for_testing();
     let mut cluster = FullCluster::new().await.unwrap();
 
     // Make sure the genesis epoch start has been indexed.
@@ -74,7 +73,6 @@ async fn test_latest_version() {
 
 #[tokio::test]
 async fn test_specific_version() {
-    telemetry_subscribers::init_for_testing();
     let mut cluster = FullCluster::new().await.unwrap();
     cluster.create_checkpoint().await;
 
@@ -96,7 +94,6 @@ async fn test_specific_version() {
 
 #[tokio::test]
 async fn test_unknown_version() {
-    telemetry_subscribers::init_for_testing();
     let mut cluster = FullCluster::new().await.unwrap();
     cluster.create_checkpoint().await;
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -30,9 +30,6 @@ use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_pg_db::DbArgs;
 use sui_pg_db::temp::TempDb;
 use sui_pg_db::temp::get_available_port;
-use sui_rpc::field::FieldMask;
-use sui_rpc::field::FieldMaskUtil;
-use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_swarm_config::genesis_config::AccountConfig;
 use sui_types::MOVE_STDLIB_PACKAGE_ID;
 use sui_types::TypeTag;
@@ -135,7 +132,9 @@ impl WriteTestCluster {
         // checkpoint, so wait for it before handing the cluster to a test.
         tokio::time::timeout(Duration::from_secs(60), async {
             loop {
-                let response = cluster.execute_jsonrpc("sui_getProtocolConfig", json!([])).await;
+                let response = cluster
+                    .execute_jsonrpc("sui_getProtocolConfig", json!([]))
+                    .await;
                 if matches!(&response, Ok(r) if r["error"].is_null()) {
                     break;
                 }
@@ -185,6 +184,23 @@ impl WriteTestCluster {
     }
 
     async fn execute_jsonrpc(&self, method: &str, params: Value) -> anyhow::Result<Value> {
+        self.execute_jsonrpc_at(self.rpc_url.clone(), method, params)
+            .await
+    }
+
+    /// Send a JSON-RPC request to the fullnode's legacy JSON-RPC server (rather than the
+    /// indexer's JSON-RPC server), to compare implementations of the same method.
+    async fn execute_fullnode_jsonrpc(&self, method: &str, params: Value) -> anyhow::Result<Value> {
+        let url = Url::parse(self.onchain_cluster.rpc_url()).context("Invalid fullnode URL")?;
+        self.execute_jsonrpc_at(url, method, params).await
+    }
+
+    async fn execute_jsonrpc_at(
+        &self,
+        url: Url,
+        method: &str,
+        params: Value,
+    ) -> anyhow::Result<Value> {
         let query = json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -194,7 +210,7 @@ impl WriteTestCluster {
 
         let response = self
             .client
-            .post(self.rpc_url.clone())
+            .post(url)
             .json(&query)
             .send()
             .await
@@ -715,7 +731,6 @@ async fn test_execute_and_dry_run_gas_costs_agree() {
 
 #[tokio::test]
 async fn test_dev_inspect_returns_values() {
-    telemetry_subscribers::init_for_testing();
     let cluster = WriteTestCluster::new().await.unwrap();
     let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
 
@@ -764,7 +779,6 @@ async fn test_dev_inspect_returns_values() {
 
 #[tokio::test]
 async fn test_dev_inspect_synthesized_transaction_defaults() {
-    telemetry_subscribers::init_for_testing();
     let cluster = WriteTestCluster::new().await.unwrap();
     let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
     let reference_gas_price = cluster.onchain_cluster.get_reference_gas_price().await;
@@ -801,7 +815,6 @@ async fn test_dev_inspect_synthesized_transaction_defaults() {
 
 #[tokio::test]
 async fn test_dev_inspect_with_checks_enabled() {
-    telemetry_subscribers::init_for_testing();
     let cluster = WriteTestCluster::new().await.unwrap();
     let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
 
@@ -830,7 +843,6 @@ async fn test_dev_inspect_with_checks_enabled() {
 
 #[tokio::test]
 async fn test_dev_inspect_execution_failure() {
-    telemetry_subscribers::init_for_testing();
     let cluster = WriteTestCluster::new().await.unwrap();
     let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
 
@@ -852,88 +864,71 @@ async fn test_dev_inspect_execution_failure() {
 }
 
 #[tokio::test]
-async fn test_dev_inspect_matches_grpc_simulation() {
-    use sui_rpc::proto::sui::rpc::v2::transaction_execution_service_client::TransactionExecutionServiceClient;
-
+async fn test_dev_inspect_matches_fullnode_jsonrpc() {
     telemetry_subscribers::init_for_testing();
     let cluster = WriteTestCluster::new().await.unwrap();
     let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
 
-    let response = cluster
-        .execute_jsonrpc(
-            "sui_devInspectTransactionBlock",
-            json!({
-                "sender_address": sender.to_string(),
-                "tx_bytes": encode_transaction_kind(&option_none_transaction_kind()),
-                "additional_args": { "showRawTxnDataAndEffects": true },
-            }),
-        )
+    // Successful execution: the responses must match in full, including the raw transaction
+    // bytes (proving the synthesized TransactionData is identical) and effects.
+    let params = json!({
+        "sender_address": sender.to_string(),
+        "tx_bytes": encode_transaction_kind(&option_none_transaction_kind()),
+        "additional_args": { "showRawTxnDataAndEffects": true },
+    });
+
+    let indexer = cluster
+        .execute_jsonrpc("sui_devInspectTransactionBlock", params.clone())
+        .await
+        .unwrap();
+    let fullnode = cluster
+        .execute_fullnode_jsonrpc("sui_devInspectTransactionBlock", params)
         .await
         .unwrap();
 
-    let result = &response["result"];
-    assert_eq!(result["effects"]["status"]["status"], "success");
+    assert!(
+        indexer["error"].is_null(),
+        "indexer RPC error: {}",
+        indexer["error"]
+    );
+    assert!(
+        fullnode["error"].is_null(),
+        "fullnode RPC error: {}",
+        fullnode["error"]
+    );
+    assert_eq!(indexer["result"], fullnode["result"]);
 
-    // Re-run the exact transaction the RPC synthesized (from its raw bytes) against the
-    // fullnode's gRPC simulation endpoint with checks disabled -- the primitive dev-inspect is
-    // built on -- and check that the RPC response is a faithful rendering of the gRPC response.
-    let mut proto_tx = proto::Transaction::default();
-    proto_tx.bcs = Some(json_bytes(&result["rawTxnData"]).into());
+    // Failed execution: the responses must match except for the `error` message -- the fullnode
+    // stringifies the executor's error, which is not part of the gRPC simulate response that the
+    // indexer's implementation is built on, so the indexer recovers a differently-formatted
+    // message from the effects' execution status.
+    let params = json!({
+        "sender_address": sender.to_string(),
+        "tx_bytes": encode_transaction_kind(&divide_by_zero_transaction_kind()),
+    });
 
-    let request = proto::SimulateTransactionRequest::new(proto_tx)
-        .with_read_mask(FieldMask::from_paths([
-            "transaction.effects.bcs",
-            "command_outputs",
-        ]))
-        .with_checks(proto::simulate_transaction_request::TransactionChecks::Disabled)
-        .with_do_gas_selection(false);
-
-    let mut grpc =
-        TransactionExecutionServiceClient::connect(cluster.onchain_cluster.rpc_url().to_string())
-            .await
-            .unwrap();
-
-    let simulated = grpc
-        .simulate_transaction(request)
+    let indexer = cluster
+        .execute_jsonrpc("sui_devInspectTransactionBlock", params.clone())
         .await
-        .unwrap()
-        .into_inner();
+        .unwrap();
+    let fullnode = cluster
+        .execute_fullnode_jsonrpc("sui_devInspectTransactionBlock", params)
+        .await
+        .unwrap();
 
-    // The effects must be byte-identical.
-    let grpc_effects = simulated
-        .transaction
-        .as_ref()
-        .unwrap()
-        .effects
-        .as_ref()
-        .unwrap()
-        .bcs
-        .as_ref()
-        .unwrap()
-        .value()
-        .to_vec();
-    assert_eq!(json_bytes(&result["rawEffects"]), grpc_effects);
+    let mut indexer_result = indexer["result"].clone();
+    let mut fullnode_result = fullnode["result"].clone();
 
-    // Return values must match, value for value and type for type.
-    let results = result["results"].as_array().unwrap();
-    assert_eq!(results.len(), simulated.command_outputs.len());
-    for (json_result, grpc_result) in results.iter().zip(&simulated.command_outputs) {
-        let json_returns = json_result["returnValues"].as_array().unwrap();
-        assert_eq!(json_returns.len(), grpc_result.return_values.len());
-        for (json_return, grpc_return) in json_returns.iter().zip(&grpc_result.return_values) {
-            let grpc_bcs = grpc_return.value.as_ref().unwrap();
-            assert_eq!(json_bytes(&json_return[0]), grpc_bcs.value().to_vec());
+    let indexer_error = indexer_result.as_object_mut().unwrap().remove("error");
+    let fullnode_error = fullnode_result.as_object_mut().unwrap().remove("error");
+    assert!(indexer_error.is_some_and(|e| !e.is_null()));
+    assert!(fullnode_error.is_some_and(|e| !e.is_null()));
 
-            let json_type: TypeTag = json_return[1].as_str().unwrap().parse().unwrap();
-            let grpc_type: TypeTag = grpc_bcs.name().parse().unwrap();
-            assert_eq!(json_type, grpc_type);
-        }
-    }
+    assert_eq!(indexer_result, fullnode_result);
 }
 
 #[tokio::test]
 async fn test_dev_inspect_invalid_tx_bytes() {
-    telemetry_subscribers::init_for_testing();
     let cluster = WriteTestCluster::new().await.unwrap();
     let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -6,6 +6,9 @@ use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 
 use anyhow::Context;
+use fastcrypto::encoding::Base64;
+use fastcrypto::encoding::Encoding;
+use move_core_types::ident_str;
 use prometheus::Registry;
 use reqwest::Client;
 use serde_json::Value;
@@ -26,7 +29,16 @@ use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_pg_db::DbArgs;
 use sui_pg_db::temp::TempDb;
 use sui_pg_db::temp::get_available_port;
+use sui_rpc::field::FieldMask;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_swarm_config::genesis_config::AccountConfig;
+use sui_types::MOVE_STDLIB_PACKAGE_ID;
+use sui_types::TypeTag;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::TransactionData;
+use sui_types::transaction::TransactionDataAPI;
+use sui_types::transaction::TransactionKind;
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
 use url::Url;
@@ -175,6 +187,51 @@ impl WriteTestCluster {
             .await
             .context("Failed to parse JSON-RPC response")
     }
+}
+
+/// BCS- and Base64-encode a `TransactionKind`, the input format for
+/// `sui_devInspectTransactionBlock`.
+fn encode_transaction_kind(kind: &TransactionKind) -> String {
+    Base64::encode(bcs::to_bytes(kind).expect("Failed to serialize TransactionKind"))
+}
+
+/// Extract a byte vector from a JSON array of numbers.
+fn json_bytes(value: &Value) -> Vec<u8> {
+    value
+        .as_array()
+        .expect("Expected a JSON array of bytes")
+        .iter()
+        .map(|b| b.as_u64().unwrap() as u8)
+        .collect()
+}
+
+/// A transaction that calls the non-entry function `std::option::none<u64>()` and leaves its
+/// result unused -- only valid under dev-inspect.
+fn option_none_transaction_kind() -> TransactionKind {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.programmable_move_call(
+        MOVE_STDLIB_PACKAGE_ID,
+        ident_str!("option").to_owned(),
+        ident_str!("none").to_owned(),
+        vec![TypeTag::U64],
+        vec![],
+    );
+    TransactionKind::programmable(builder.finish())
+}
+
+/// A transaction that fails execution with an arithmetic error (division by zero).
+fn divide_by_zero_transaction_kind() -> TransactionKind {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let one = builder.pure(1u64).expect("Failed to create pure input");
+    let zero = builder.pure(0u64).expect("Failed to create pure input");
+    builder.programmable_move_call(
+        MOVE_STDLIB_PACKAGE_ID,
+        ident_str!("u64").to_owned(),
+        ident_str!("divide_and_round_up").to_owned(),
+        vec![],
+        vec![one, zero],
+    );
+    TransactionKind::programmable(builder.finish())
 }
 
 #[tokio::test]
@@ -636,4 +693,238 @@ async fn test_execute_and_dry_run_gas_costs_agree() {
         dry_run["result"]["effects"]["gasUsed"],
         execute["result"]["effects"]["gasUsed"],
     );
+}
+
+#[tokio::test]
+async fn test_dev_inspect_returns_values() {
+    telemetry_subscribers::init_for_testing();
+    let cluster = WriteTestCluster::new().await.unwrap();
+    let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
+
+    let response = cluster
+        .execute_jsonrpc(
+            "sui_devInspectTransactionBlock",
+            json!({
+                "sender_address": sender.to_string(),
+                "tx_bytes": encode_transaction_kind(&option_none_transaction_kind()),
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response["error"].is_null(),
+        "RPC error: {}",
+        response["error"]
+    );
+
+    let result = &response["result"];
+    assert_eq!(result["effects"]["status"]["status"], "success");
+    assert!(result["error"].is_null());
+
+    // One command, returning `std::option::Option<u64>`. The BCS encoding of `none` is a single
+    // zero byte (an empty vector).
+    let results = result["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+
+    let return_values = results[0]["returnValues"].as_array().unwrap();
+    assert_eq!(return_values.len(), 1);
+    assert_eq!(return_values[0][0], json!([0]));
+    assert!(
+        return_values[0][1]
+            .as_str()
+            .unwrap()
+            .contains("option::Option<u64>"),
+        "Unexpected return type: {}",
+        return_values[0][1],
+    );
+
+    // Raw transaction data and effects were not requested.
+    assert!(result["rawTxnData"].is_null());
+    assert!(result["rawEffects"].is_null());
+}
+
+#[tokio::test]
+async fn test_dev_inspect_synthesized_transaction_defaults() {
+    telemetry_subscribers::init_for_testing();
+    let cluster = WriteTestCluster::new().await.unwrap();
+    let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
+    let reference_gas_price = cluster.onchain_cluster.get_reference_gas_price().await;
+
+    let response = cluster
+        .execute_jsonrpc(
+            "sui_devInspectTransactionBlock",
+            json!({
+                "sender_address": sender.to_string(),
+                "tx_bytes": encode_transaction_kind(&option_none_transaction_kind()),
+                "additional_args": { "showRawTxnDataAndEffects": true },
+            }),
+        )
+        .await
+        .unwrap();
+
+    let result = &response["result"];
+    assert_eq!(result["effects"]["status"]["status"], "success");
+
+    // The raw transaction data reflects the synthesized `TransactionData`: gas price defaults to
+    // the reference gas price, the sender sponsors the gas, and the gas payment is left empty (a
+    // mock gas coin is injected fullnode-side).
+    let tx_data: TransactionData = bcs::from_bytes(&json_bytes(&result["rawTxnData"])).unwrap();
+    assert_eq!(tx_data.sender(), sender);
+
+    let gas_data = tx_data.gas_data();
+    assert_eq!(gas_data.owner, sender);
+    assert_eq!(gas_data.price, reference_gas_price);
+    assert!(gas_data.payment.is_empty());
+    assert!(gas_data.budget > 0);
+
+    assert!(!result["rawEffects"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_dev_inspect_with_checks_enabled() {
+    telemetry_subscribers::init_for_testing();
+    let cluster = WriteTestCluster::new().await.unwrap();
+    let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
+
+    let response = cluster
+        .execute_jsonrpc(
+            "sui_devInspectTransactionBlock",
+            json!({
+                "sender_address": sender.to_string(),
+                "tx_bytes": encode_transaction_kind(&option_none_transaction_kind()),
+                "additional_args": { "skipChecks": false },
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response["error"].is_null(),
+        "RPC error: {}",
+        response["error"]
+    );
+
+    let result = &response["result"];
+    assert_eq!(result["effects"]["status"]["status"], "success");
+    assert_eq!(result["results"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_dev_inspect_execution_failure() {
+    telemetry_subscribers::init_for_testing();
+    let cluster = WriteTestCluster::new().await.unwrap();
+    let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
+
+    let response = cluster
+        .execute_jsonrpc(
+            "sui_devInspectTransactionBlock",
+            json!({
+                "sender_address": sender.to_string(),
+                "tx_bytes": encode_transaction_kind(&divide_by_zero_transaction_kind()),
+            }),
+        )
+        .await
+        .unwrap();
+
+    let result = &response["result"];
+    assert_eq!(result["effects"]["status"]["status"], "failure");
+    assert!(!result["error"].is_null(), "Expected an execution error");
+    assert!(result["results"].is_null());
+}
+
+#[tokio::test]
+async fn test_dev_inspect_matches_grpc_simulation() {
+    use sui_rpc::proto::sui::rpc::v2::transaction_execution_service_client::TransactionExecutionServiceClient;
+
+    telemetry_subscribers::init_for_testing();
+    let cluster = WriteTestCluster::new().await.unwrap();
+    let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
+
+    let response = cluster
+        .execute_jsonrpc(
+            "sui_devInspectTransactionBlock",
+            json!({
+                "sender_address": sender.to_string(),
+                "tx_bytes": encode_transaction_kind(&option_none_transaction_kind()),
+                "additional_args": { "showRawTxnDataAndEffects": true },
+            }),
+        )
+        .await
+        .unwrap();
+
+    let result = &response["result"];
+    assert_eq!(result["effects"]["status"]["status"], "success");
+
+    // Re-run the exact transaction the RPC synthesized (from its raw bytes) against the
+    // fullnode's gRPC simulation endpoint with checks disabled -- the primitive dev-inspect is
+    // built on -- and check that the RPC response is a faithful rendering of the gRPC response.
+    let mut proto_tx = proto::Transaction::default();
+    proto_tx.bcs = Some(json_bytes(&result["rawTxnData"]).into());
+
+    let request = proto::SimulateTransactionRequest::new(proto_tx)
+        .with_read_mask(FieldMask::from_paths([
+            "transaction.effects.bcs",
+            "command_outputs",
+        ]))
+        .with_checks(proto::simulate_transaction_request::TransactionChecks::Disabled)
+        .with_do_gas_selection(false);
+
+    let mut grpc =
+        TransactionExecutionServiceClient::connect(cluster.onchain_cluster.rpc_url().to_string())
+            .await
+            .unwrap();
+
+    let simulated = grpc.simulate_transaction(request).await.unwrap().into_inner();
+
+    // The effects must be byte-identical.
+    let grpc_effects = simulated
+        .transaction
+        .as_ref()
+        .unwrap()
+        .effects
+        .as_ref()
+        .unwrap()
+        .bcs
+        .as_ref()
+        .unwrap()
+        .value()
+        .to_vec();
+    assert_eq!(json_bytes(&result["rawEffects"]), grpc_effects);
+
+    // Return values must match, value for value and type for type.
+    let results = result["results"].as_array().unwrap();
+    assert_eq!(results.len(), simulated.command_outputs.len());
+    for (json_result, grpc_result) in results.iter().zip(&simulated.command_outputs) {
+        let json_returns = json_result["returnValues"].as_array().unwrap();
+        assert_eq!(json_returns.len(), grpc_result.return_values.len());
+        for (json_return, grpc_return) in json_returns.iter().zip(&grpc_result.return_values) {
+            let grpc_bcs = grpc_return.value.as_ref().unwrap();
+            assert_eq!(json_bytes(&json_return[0]), grpc_bcs.value().to_vec());
+
+            let json_type: TypeTag = json_return[1].as_str().unwrap().parse().unwrap();
+            let grpc_type: TypeTag = grpc_bcs.name().parse().unwrap();
+            assert_eq!(json_type, grpc_type);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_dev_inspect_invalid_tx_bytes() {
+    telemetry_subscribers::init_for_testing();
+    let cluster = WriteTestCluster::new().await.unwrap();
+    let sender = cluster.onchain_cluster.wallet.get_addresses()[0];
+
+    let response = cluster
+        .execute_jsonrpc(
+            "sui_devInspectTransactionBlock",
+            json!({
+                "sender_address": sender.to_string(),
+                "tx_bytes": "invalid_tx_bytes",
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response["error"]["code"], -32602);
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -875,7 +875,11 @@ async fn test_dev_inspect_matches_grpc_simulation() {
             .await
             .unwrap();
 
-    let simulated = grpc.simulate_transaction(request).await.unwrap().into_inner();
+    let simulated = grpc
+        .simulate_transaction(request)
+        .await
+        .unwrap()
+        .into_inner();
 
     // The effects must be byte-identical.
     let grpc_effects = simulated

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -4,6 +4,7 @@
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use anyhow::Context;
 use fastcrypto::encoding::Base64;
@@ -121,13 +122,30 @@ impl WriteTestCluster {
         .await
         .context("Failed to start JSON-RPC server")?;
 
-        Ok(Self {
+        let cluster = Self {
             onchain_cluster,
             rpc_url,
             service: rpc_service.merge(indexer_service),
             database,
             client: Client::new(),
+        };
+
+        // Dev-inspect reads its gas defaults from `kv_epoch_starts` and `kv_protocol_configs`.
+        // The latter is only populated once the indexer's pipeline processes the genesis
+        // checkpoint, so wait for it before handing the cluster to a test.
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                let response = cluster.execute_jsonrpc("sui_getProtocolConfig", json!([])).await;
+                if matches!(&response, Ok(r) if r["error"].is_null()) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
         })
+        .await
+        .context("Timed out waiting for the genesis protocol config to be indexed")?;
+
+        Ok(cluster)
     }
 
     async fn transfer_transaction(&self) -> anyhow::Result<(String, String, Vec<String>)> {

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -68,6 +68,7 @@ sui-open-rpc-macros.workspace = true
 sui-package-resolver.workspace = true
 sui-protocol-config.workspace = true
 sui-rpc.workspace = true
+sui-sdk-types.workspace = true
 sui-sql-macro.workspace = true
 sui-types.workspace = true
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod governance;
 pub(crate) mod move_utils;
 pub(crate) mod name_service;
 pub(crate) mod objects;
+pub(crate) mod protocol;
 pub(crate) mod rpc_module;
 pub(crate) mod transactions;
 pub mod write;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/protocol.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/protocol.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context as _;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+use sui_indexer_alt_schema::schema::kv_epoch_starts;
+use sui_json_rpc_types::ProtocolConfigResponse;
+use sui_open_rpc::Module;
+use sui_open_rpc_macros::open_rpc;
+use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::ProtocolVersion;
+use sui_types::sui_serde::BigInt;
+
+use crate::api::rpc_module::RpcModule;
+use crate::context::Context;
+use crate::error::RpcError;
+use crate::error::invalid_params;
+
+#[open_rpc(namespace = "sui", tag = "Protocol API")]
+#[rpc(server, namespace = "sui")]
+trait ProtocolApi {
+    /// Return the protocol config table for the given version number.
+    /// If the version number is not specified, the protocol config for the latest indexed epoch is
+    /// returned.
+    #[method(name = "getProtocolConfig")]
+    async fn get_protocol_config(
+        &self,
+        /// An optional protocol version specifier. If omitted, the protocol config for the latest indexed epoch will be returned.
+        version: Option<BigInt<u64>>,
+    ) -> RpcResult<ProtocolConfigResponse>;
+}
+
+pub(crate) struct Protocol(pub Context);
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
+    ProtocolVersionUnsupported(u64, u64),
+}
+
+#[async_trait::async_trait]
+impl ProtocolApiServer for Protocol {
+    async fn get_protocol_config(
+        &self,
+        version: Option<BigInt<u64>>,
+    ) -> RpcResult<ProtocolConfigResponse> {
+        Ok(protocol_config_response(&self.0, version).await?)
+    }
+}
+
+impl RpcModule for Protocol {
+    fn schema(&self) -> Module {
+        ProtocolApiOpenRpc::module_doc()
+    }
+
+    fn into_impl(self) -> jsonrpsee::RpcModule<Self> {
+        self.into_rpc()
+    }
+}
+
+/// Load data and generate response for `getProtocolConfig`.
+async fn protocol_config_response(
+    ctx: &Context,
+    version: Option<BigInt<u64>>,
+) -> Result<ProtocolConfigResponse, RpcError<Error>> {
+    let version = match version {
+        Some(version) => *version,
+        None => latest_protocol_version(ctx).await?,
+    };
+
+    let chain = ctx
+        .chain_identifier()
+        .context("Chain identifier not available")?
+        .chain();
+
+    let config =
+        ProtocolConfig::get_for_version_if_supported(version.into(), chain).ok_or_else(|| {
+            invalid_params(Error::ProtocolVersionUnsupported(
+                ProtocolVersion::MIN.as_u64(),
+                ProtocolVersion::MAX.as_u64(),
+            ))
+        })?;
+
+    Ok(ProtocolConfigResponse::from(config))
+}
+
+/// Fetch the protocol version of the latest epoch from the database.
+async fn latest_protocol_version(ctx: &Context) -> Result<u64, RpcError<Error>> {
+    use kv_epoch_starts::dsl as e;
+
+    let mut conn = ctx
+        .pg_reader()
+        .connect()
+        .await
+        .context("Failed to connect to the database")?;
+
+    let version: i64 = conn
+        .first(
+            e::kv_epoch_starts
+                .select(e::protocol_version)
+                .order(e::epoch.desc()),
+        )
+        .await
+        .context("Failed to fetch the latest protocol version")?;
+
+    Ok(version as u64)
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/protocol.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/protocol.rs
@@ -1,16 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use anyhow::Context as _;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
+use serde_json::Value;
+use sui_indexer_alt_schema::epochs::StoredFeatureFlag;
+use sui_indexer_alt_schema::epochs::StoredProtocolConfig;
 use sui_indexer_alt_schema::schema::kv_epoch_starts;
+use sui_indexer_alt_schema::schema::kv_feature_flags;
+use sui_indexer_alt_schema::schema::kv_protocol_configs;
 use sui_json_rpc_types::ProtocolConfigResponse;
+use sui_json_rpc_types::SuiProtocolConfigValue;
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
-use sui_protocol_config::ProtocolConfig;
 use sui_protocol_config::ProtocolVersion;
 use sui_types::sui_serde::BigInt;
 
@@ -22,9 +29,8 @@ use crate::error::invalid_params;
 #[open_rpc(namespace = "sui", tag = "Protocol API")]
 #[rpc(server, namespace = "sui")]
 trait ProtocolApi {
-    /// Return the protocol config table for the given version number.
-    /// If the version number is not specified, the protocol config for the latest indexed epoch is
-    /// returned.
+    /// Return the protocol config table for the given version number. If the version number is not
+    /// specified, the protocol config for the latest indexed epoch is returned.
     #[method(name = "getProtocolConfig")]
     async fn get_protocol_config(
         &self,
@@ -37,8 +43,8 @@ pub(crate) struct Protocol(pub Context);
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
-    ProtocolVersionUnsupported(u64, u64),
+    #[error("Protocol version {0} not found")]
+    ProtocolVersionNotFound(u64),
 }
 
 #[async_trait::async_trait]
@@ -62,29 +68,79 @@ impl RpcModule for Protocol {
 }
 
 /// Load data and generate response for `getProtocolConfig`.
+///
+/// The response is built from the `kv_protocol_configs` and `kv_feature_flags` tables (which the
+/// indexer materializes at each epoch boundary), rather than from this binary's own
+/// `ProtocolConfig`, so that the RPC keeps serving correct values when the chain's protocol version
+/// is newer than the binary.
+///
+/// The tables store values stringified, which costs some fidelity compared to the legacy response:
+/// only protocol versions the indexer has seen can be served; `attributes` reports every integer as
+/// `u64` (declared widths are not preserved); and in `configs`, all numbers are JSON strings
+/// (legacy rendered u16/u32 fields as JSON numbers) and non-scalar values are absent.
 async fn protocol_config_response(
     ctx: &Context,
     version: Option<BigInt<u64>>,
 ) -> Result<ProtocolConfigResponse, RpcError<Error>> {
+    use kv_feature_flags::dsl as f;
+    use kv_protocol_configs::dsl as p;
+
     let version = match version {
         Some(version) => *version,
         None => latest_protocol_version(ctx).await?,
     };
 
-    let chain = ctx
-        .chain_identifier()
-        .context("Chain identifier not available")?
-        .chain();
+    let mut conn = ctx
+        .pg_reader()
+        .connect()
+        .await
+        .context("Failed to connect to the database")?;
 
-    let config =
-        ProtocolConfig::get_for_version_if_supported(version.into(), chain).ok_or_else(|| {
-            invalid_params(Error::ProtocolVersionUnsupported(
-                ProtocolVersion::MIN.as_u64(),
-                ProtocolVersion::MAX.as_u64(),
-            ))
-        })?;
+    let stored_configs: Vec<StoredProtocolConfig> = conn
+        .results(p::kv_protocol_configs.filter(p::protocol_version.eq(version as i64)))
+        .await
+        .context("Failed to fetch protocol configs")?;
 
-    Ok(ProtocolConfigResponse::from(config))
+    let stored_flags: Vec<StoredFeatureFlag> = conn
+        .results(f::kv_feature_flags.filter(f::protocol_version.eq(version as i64)))
+        .await
+        .context("Failed to fetch feature flags")?;
+
+    if stored_configs.is_empty() && stored_flags.is_empty() {
+        return Err(invalid_params(Error::ProtocolVersionNotFound(version)));
+    }
+
+    let feature_flags: BTreeMap<String, bool> = stored_flags
+        .into_iter()
+        .map(|flag| (flag.flag_name, flag.flag_value))
+        .collect();
+
+    // `configs` is the complete view of the protocol config: attributes that are set at this
+    // version, merged with the feature flags.
+    let mut attributes = BTreeMap::new();
+    let mut configs = BTreeMap::new();
+    for config in stored_configs {
+        if let Some(value) = &config.config_value {
+            configs.insert(config.config_name.clone(), raw_config_to_json(value));
+        }
+        let attribute = config.config_value.as_deref().and_then(parse_attribute);
+        attributes.insert(config.config_name, attribute);
+    }
+
+    for (flag, value) in &feature_flags {
+        configs.insert(flag.clone(), Value::Bool(*value));
+    }
+
+    Ok(ProtocolConfigResponse {
+        // Min and max supported versions are properties of a binary -- these are the versions this
+        // RPC's own software knows about, which may trail the version being served.
+        min_supported_protocol_version: ProtocolVersion::MIN,
+        max_supported_protocol_version: ProtocolVersion::MAX,
+        protocol_version: version.into(),
+        feature_flags,
+        attributes,
+        configs,
+    })
 }
 
 /// Fetch the protocol version of the latest epoch from the database.
@@ -107,4 +163,27 @@ async fn latest_protocol_version(ctx: &Context) -> Result<u64, RpcError<Error>> 
         .context("Failed to fetch the latest protocol version")?;
 
     Ok(version as u64)
+}
+
+/// Recover a typed attribute value from its stored string representation. The database does not
+/// preserve integer widths, so all integer values parse as `u64`.
+fn parse_attribute(value: &str) -> Option<SuiProtocolConfigValue> {
+    match value {
+        "true" => Some(SuiProtocolConfigValue::Bool(true)),
+        "false" => Some(SuiProtocolConfigValue::Bool(false)),
+        _ => value.parse().ok().map(SuiProtocolConfigValue::U64),
+    }
+}
+
+/// Convert a stored config value to its JSON representation: booleans as booleans, everything
+/// else as a string. Numbers are uniformly strings (rather than following the legacy convention
+/// of rendering u16/u32 as JSON numbers) because the stored value does not carry its declared
+/// width, and inferring it from the magnitude would make a config's JSON type change when its
+/// value grows.
+fn raw_config_to_json(value: &str) -> Value {
+    match value {
+        "true" => Value::Bool(true),
+        "false" => Value::Bool(false),
+        _ => Value::String(value.to_owned()),
+    }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
@@ -4,20 +4,32 @@
 mod response;
 
 use anyhow::Context as _;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
 use fastcrypto::encoding::Base64;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use prost_types::FieldMask;
+use sui_indexer_alt_schema::schema::kv_epoch_starts;
+use sui_json_rpc_types::DevInspectArgs;
+use sui_json_rpc_types::DevInspectResults;
 use sui_json_rpc_types::DryRunTransactionBlockResponse;
 use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
+use sui_protocol_config::ProtocolConfig;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2 as proto;
+use sui_types::base_types::SuiAddress;
 use sui_types::crypto::ToFromBytes;
 use sui_types::signature::GenericSignature;
+use sui_types::sui_serde::BigInt;
+use sui_types::transaction::GasData;
 use sui_types::transaction::TransactionData;
+use sui_types::transaction::TransactionDataV1;
+use sui_types::transaction::TransactionExpiration;
+use sui_types::transaction::TransactionKind;
 use sui_types::transaction_driver_types::ExecuteTransactionRequestType;
 
 use crate::api::rpc_module::RpcModule;
@@ -43,6 +55,23 @@ pub trait WriteApi {
         /// The request type, derived from `SuiTransactionBlockResponseOptions` if None
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionBlockResponse>;
+
+    /// Runs the transaction in dev-inspect mode. Which allows for nearly any
+    /// transaction (or Move call) with any arguments. Detailed results are
+    /// provided, including both the transaction effects and any return values.
+    #[method(name = "devInspectTransactionBlock")]
+    async fn dev_inspect_transaction_block(
+        &self,
+        sender_address: SuiAddress,
+        /// BCS encoded TransactionKind(as opposed to TransactionData, which include gasBudget and gasPrice)
+        tx_bytes: Base64,
+        /// Gas is not charged, but gas usage is still calculated. Default to use reference gas price
+        gas_price: Option<BigInt<u64>>,
+        /// The epoch to perform the call. Will be set from the system state object if not provided
+        epoch: Option<BigInt<u64>>,
+        /// Additional arguments including gas_budget, gas_objects, gas_sponsor and skip_checks.
+        additional_args: Option<DevInspectArgs>,
+    ) -> RpcResult<DevInspectResults>;
 
     /// Return transaction execution effects including the gas cost summary,
     /// while the effects are not committed to the chain.
@@ -89,6 +118,25 @@ impl WriteApiServer for Write {
     ) -> RpcResult<SuiTransactionBlockResponse> {
         Ok(self
             .execute_transaction_block_impl(tx_bytes, signatures, options, request_type)
+            .await?)
+    }
+
+    async fn dev_inspect_transaction_block(
+        &self,
+        sender_address: SuiAddress,
+        tx_bytes: Base64,
+        gas_price: Option<BigInt<u64>>,
+        // The legacy fullnode implementation also ignores this argument.
+        _epoch: Option<BigInt<u64>>,
+        additional_args: Option<DevInspectArgs>,
+    ) -> RpcResult<DevInspectResults> {
+        Ok(self
+            .dev_inspect_transaction_block_impl(
+                sender_address,
+                tx_bytes,
+                gas_price,
+                additional_args,
+            )
             .await?)
     }
 
@@ -141,6 +189,87 @@ impl Write {
         response::transaction(&self.context, tx_data, parsed_sigs, executed_tx, &options).await
     }
 
+    async fn dev_inspect_transaction_block_impl(
+        &self,
+        sender_address: SuiAddress,
+        tx_bytes: Base64,
+        gas_price: Option<BigInt<u64>>,
+        additional_args: Option<DevInspectArgs>,
+    ) -> Result<DevInspectResults, RpcError<Error>> {
+        let client = self.context.fullnode_client()?;
+
+        let DevInspectArgs {
+            gas_sponsor,
+            gas_budget,
+            gas_objects,
+            skip_checks,
+            show_raw_txn_data_and_effects,
+        } = additional_args.unwrap_or_default();
+
+        let skip_checks = skip_checks.unwrap_or(true);
+        let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
+
+        let kind = parse_transaction_kind(&tx_bytes)?;
+        let (reference_gas_price, max_tx_gas) = gas_defaults(&self.context).await?;
+
+        // Synthesize the full TransactionData the caller would have signed, the same way the
+        // legacy fullnode implementation does. An empty gas payment is replaced by a mock gas
+        // coin on the fullnode during simulation.
+        let tx_data = TransactionData::V1(TransactionDataV1 {
+            kind,
+            sender: sender_address,
+            gas_data: GasData {
+                payment: gas_objects.unwrap_or_default(),
+                owner: gas_sponsor.unwrap_or(sender_address),
+                price: gas_price.map(|price| *price).unwrap_or(reference_gas_price),
+                budget: gas_budget.map(|budget| *budget).unwrap_or(max_tx_gas),
+            },
+            expiration: TransactionExpiration::None,
+        });
+
+        // Capture raw bytes before simulation, which replaces an empty gas payment with a mock
+        // gas coin reference.
+        let raw_txn_data = if show_raw_txn_data_and_effects {
+            bcs::to_bytes(&tx_data).context("Failed to serialize transaction data")?
+        } else {
+            vec![]
+        };
+
+        let mut proto_tx = proto::Transaction::default();
+        proto_tx.bcs = Some(
+            proto::Bcs::serialize(&tx_data).context("Failed to serialize transaction for gRPC")?,
+        );
+
+        let read_mask = FieldMask::from_paths([
+            "transaction.effects.bcs",
+            "transaction.events.bcs",
+            "command_outputs",
+        ]);
+
+        // Sending BCS TransactionData makes the fullnode skip transaction resolution and gas
+        // selection, and allows it to inject a mock gas coin -- the exact code path the legacy
+        // devInspect implementation uses.
+        let grpc_response = client
+            .simulate_transaction(proto_tx, !skip_checks, false, read_mask)
+            .await
+            .map_err(grpc_error_to_rpc_error)?;
+
+        let executed_tx = grpc_response
+            .transaction
+            .as_ref()
+            .context("Missing transaction in dev inspect gRPC response")?;
+
+        response::dev_inspect(
+            &self.context,
+            tx_data,
+            executed_tx,
+            &grpc_response.command_outputs,
+            raw_txn_data,
+            show_raw_txn_data_and_effects,
+        )
+        .await
+    }
+
     async fn dry_run_transaction_block_impl(
         &self,
         tx_bytes: Base64,
@@ -183,6 +312,52 @@ impl Write {
         )
         .await
     }
+}
+
+/// Fetch the reference gas price of the latest epoch, and the maximum gas budget under the
+/// protocol version that epoch started with. These are the defaults dev-inspect uses when the
+/// request does not specify a gas price or budget.
+async fn gas_defaults(ctx: &Context) -> Result<(u64, u64), RpcError<Error>> {
+    use kv_epoch_starts::dsl as e;
+
+    let mut conn = ctx
+        .pg_reader()
+        .connect()
+        .await
+        .context("Failed to connect to the database")?;
+
+    let (protocol_version, reference_gas_price): (i64, i64) = conn
+        .first(
+            e::kv_epoch_starts
+                .select((e::protocol_version, e::reference_gas_price))
+                .order(e::epoch.desc()),
+        )
+        .await
+        .context("Failed to fetch latest epoch's gas parameters")?;
+
+    let chain = ctx
+        .chain_identifier()
+        .context("Chain identifier not available")?
+        .chain();
+
+    let config =
+        ProtocolConfig::get_for_version_if_supported((protocol_version as u64).into(), chain)
+            .with_context(|| {
+                format!("Protocol version {protocol_version} of the latest epoch is not supported")
+            })?;
+
+    Ok((reference_gas_price as u64, config.max_tx_gas()))
+}
+
+fn parse_transaction_kind(tx_bytes: &Base64) -> Result<TransactionKind, RpcError<Error>> {
+    let raw_tx_bytes = tx_bytes
+        .to_vec()
+        .map_err(|e| invalid_params(Error::InvalidTransactionBytes(e.to_string())))?;
+    bcs::from_bytes(&raw_tx_bytes).map_err(|e| {
+        invalid_params(Error::InvalidTransactionBytes(format!(
+            "Failed to deserialize TransactionKind: {e}"
+        )))
+    })
 }
 
 fn parse_transaction_data(tx_bytes: &Base64) -> Result<TransactionData, RpcError<Error>> {

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
@@ -25,10 +25,7 @@ use sui_types::base_types::SuiAddress;
 use sui_types::crypto::ToFromBytes;
 use sui_types::signature::GenericSignature;
 use sui_types::sui_serde::BigInt;
-use sui_types::transaction::GasData;
 use sui_types::transaction::TransactionData;
-use sui_types::transaction::TransactionDataV1;
-use sui_types::transaction::TransactionExpiration;
 use sui_types::transaction::TransactionKind;
 use sui_types::transaction_driver_types::ExecuteTransactionRequestType;
 
@@ -40,15 +37,17 @@ use crate::error::invalid_params;
 #[open_rpc(namespace = "sui", tag = "Write API")]
 #[rpc(server, client, namespace = "sui")]
 pub trait WriteApi {
-    /// Execute the transaction with options to show different information in the response.
-    /// The only supported request type is `WaitForEffectsCert`: waits for TransactionEffectsCert and then return to client.
-    /// `WaitForLocalExecution` mode has been deprecated.
+    /// Execute the transaction with options to show different information in the response. The only
+    /// supported request type is `WaitForEffectsCert`: waits for TransactionEffectsCert and then
+    /// return to client. `WaitForLocalExecution` mode has been deprecated.
     #[method(name = "executeTransactionBlock")]
     async fn execute_transaction_block(
         &self,
         /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
         tx_bytes: Base64,
-        /// A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.
+        /// A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string).
+        /// Signature is committed to the intent message of the transaction data, as base-64 encoded
+        /// string.
         signatures: Vec<Base64>,
         /// options for specifying the content to be returned
         options: Option<SuiTransactionBlockResponseOptions>,
@@ -56,18 +55,20 @@ pub trait WriteApi {
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionBlockResponse>;
 
-    /// Runs the transaction in dev-inspect mode. Which allows for nearly any
-    /// transaction (or Move call) with any arguments. Detailed results are
-    /// provided, including both the transaction effects and any return values.
+    /// Runs the transaction in dev-inspect mode, which allows for nearly any transaction (or Move
+    /// call) with any arguments. Detailed results are provided, including both the transaction
+    /// effects and any return values.
     #[method(name = "devInspectTransactionBlock")]
     async fn dev_inspect_transaction_block(
         &self,
         sender_address: SuiAddress,
-        /// BCS encoded TransactionKind(as opposed to TransactionData, which include gasBudget and gasPrice)
+        /// BCS encoded TransactionKind(as opposed to TransactionData, which include gasBudget and
+        /// gasPrice).
         tx_bytes: Base64,
-        /// Gas is not charged, but gas usage is still calculated. Default to use reference gas price
+        /// Gas is not charged, but gas usage is still calculated. Default to use reference gas
+        /// price.
         gas_price: Option<BigInt<u64>>,
-        /// The epoch to perform the call. Will be set from the system state object if not provided
+        /// The epoch to perform the call. Will be set from the system state object if not provided.
         epoch: Option<BigInt<u64>>,
         /// Additional arguments including gas_budget, gas_objects, gas_sponsor and skip_checks.
         additional_args: Option<DevInspectArgs>,
@@ -212,23 +213,22 @@ impl Write {
         let kind = parse_transaction_kind(&tx_bytes)?;
         let (reference_gas_price, max_tx_gas) = gas_defaults(&self.context).await?;
 
-        // Synthesize the full TransactionData the caller would have signed, the same way the
-        // legacy fullnode implementation does. An empty gas payment is replaced by a mock gas
-        // coin on the fullnode during simulation.
-        let tx_data = TransactionData::V1(TransactionDataV1 {
+        // Synthesize the full TransactionData the caller would have signed, the same way the legacy
+        // fullnode implementation does. An empty gas payment is replaced by a mock gas coin on the
+        // fullnode during simulation.
+        let tx_data = TransactionData::new_with_gas_coins_allow_sponsor(
             kind,
-            sender: sender_address,
-            gas_data: GasData {
-                payment: gas_objects.unwrap_or_default(),
-                owner: gas_sponsor.unwrap_or(sender_address),
-                price: gas_price.map(|price| *price).unwrap_or(reference_gas_price),
-                budget: gas_budget.map(|budget| *budget).unwrap_or(max_tx_gas),
-            },
-            expiration: TransactionExpiration::None,
-        });
+            sender_address,
+            gas_objects.unwrap_or_default(),
+            gas_budget.map(|budget| *budget).unwrap_or(max_tx_gas),
+            gas_price.map(|price| *price).unwrap_or(reference_gas_price),
+            gas_sponsor.unwrap_or(sender_address),
+        );
 
-        // Capture raw bytes before simulation, which replaces an empty gas payment with a mock
-        // gas coin reference.
+        // The raw transaction data reflects what the caller specified: the gas payment stays empty
+        // here, and the mock gas coin the fullnode injects during simulation only shows up in the
+        // effects (matching the legacy implementation, which captures these bytes before simulation
+        // for the same reason).
         let raw_txn_data = if show_raw_txn_data_and_effects {
             bcs::to_bytes(&tx_data).context("Failed to serialize transaction data")?
         } else {

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
@@ -45,9 +45,7 @@ pub trait WriteApi {
         &self,
         /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
         tx_bytes: Base64,
-        /// A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string).
-        /// Signature is committed to the intent message of the transaction data, as base-64 encoded
-        /// string.
+        /// A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.
         signatures: Vec<Base64>,
         /// options for specifying the content to be returned
         options: Option<SuiTransactionBlockResponseOptions>,
@@ -62,11 +60,9 @@ pub trait WriteApi {
     async fn dev_inspect_transaction_block(
         &self,
         sender_address: SuiAddress,
-        /// BCS encoded TransactionKind(as opposed to TransactionData, which include gasBudget and
-        /// gasPrice).
+        /// BCS encoded TransactionKind (as opposed to TransactionData, which includes gasBudget and gasPrice).
         tx_bytes: Base64,
-        /// Gas is not charged, but gas usage is still calculated. Default to use reference gas
-        /// price.
+        /// Gas is not charged, but gas usage is still calculated. Default to use reference gas price.
         gas_price: Option<BigInt<u64>>,
         /// The epoch to perform the call. Will be set from the system state object if not provided.
         epoch: Option<BigInt<u64>>,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
@@ -5,12 +5,14 @@ mod response;
 
 use anyhow::Context as _;
 use diesel::ExpressionMethods;
+use diesel::JoinOnDsl;
 use diesel::QueryDsl;
 use fastcrypto::encoding::Base64;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use prost_types::FieldMask;
 use sui_indexer_alt_schema::schema::kv_epoch_starts;
+use sui_indexer_alt_schema::schema::kv_protocol_configs;
 use sui_json_rpc_types::DevInspectArgs;
 use sui_json_rpc_types::DevInspectResults;
 use sui_json_rpc_types::DryRunTransactionBlockResponse;
@@ -18,7 +20,6 @@ use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
-use sui_protocol_config::ProtocolConfig;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_types::base_types::SuiAddress;
@@ -310,11 +311,16 @@ impl Write {
     }
 }
 
-/// Fetch the reference gas price of the latest epoch, and the maximum gas budget under the
-/// protocol version that epoch started with. These are the defaults dev-inspect uses when the
-/// request does not specify a gas price or budget.
+/// Fetch the reference gas price of the latest epoch, and the maximum gas budget under the protocol
+/// version that epoch started with. These are the defaults dev-inspect uses when the request does
+/// not specify a gas price or budget.
+///
+/// The max budget is read from `kv_protocol_configs` (rather than this binary's own
+/// `ProtocolConfig`) so that the RPC keeps working when the chain's protocol version is newer than
+/// the binary.
 async fn gas_defaults(ctx: &Context) -> Result<(u64, u64), RpcError<Error>> {
     use kv_epoch_starts::dsl as e;
+    use kv_protocol_configs::dsl as p;
 
     let mut conn = ctx
         .pg_reader()
@@ -322,27 +328,26 @@ async fn gas_defaults(ctx: &Context) -> Result<(u64, u64), RpcError<Error>> {
         .await
         .context("Failed to connect to the database")?;
 
-    let (protocol_version, reference_gas_price): (i64, i64) = conn
+    // The inner join skips epoch rows whose protocol configs have not been indexed yet, falling
+    // back to the previous epoch's values for the duration of that (sub-second) window, rather than
+    // failing the request.
+    let (reference_gas_price, max_tx_gas): (i64, Option<String>) = conn
         .first(
             e::kv_epoch_starts
-                .select((e::protocol_version, e::reference_gas_price))
-                .order(e::epoch.desc()),
+                .inner_join(p::kv_protocol_configs.on(p::protocol_version.eq(e::protocol_version)))
+                .filter(p::config_name.eq("max_tx_gas"))
+                .order(e::epoch.desc())
+                .select((e::reference_gas_price, p::config_value)),
         )
         .await
-        .context("Failed to fetch latest epoch's gas parameters")?;
+        .context("Failed to fetch the latest epoch's gas parameters")?;
 
-    let chain = ctx
-        .chain_identifier()
-        .context("Chain identifier not available")?
-        .chain();
+    let max_tx_gas: u64 = max_tx_gas
+        .context("max_tx_gas is not set")?
+        .parse()
+        .context("Failed to parse max_tx_gas")?;
 
-    let config =
-        ProtocolConfig::get_for_version_if_supported((protocol_version as u64).into(), chain)
-            .with_context(|| {
-                format!("Protocol version {protocol_version} of the latest epoch is not supported")
-            })?;
-
-    Ok((reference_gas_price as u64, config.max_tx_gas()))
+    Ok((reference_gas_price as u64, max_tx_gas))
 }
 
 fn parse_transaction_kind(tx_bytes: &Base64) -> Result<TransactionKind, RpcError<Error>> {

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
@@ -134,10 +134,10 @@ pub(super) async fn dev_inspect(
 
     let effects = effects_response(&effects)?;
 
-    // The legacy implementation derives `error` from the execution result, which is not part of
-    // the gRPC simulate response, so recover it from the effects' execution status. On failure,
-    // command outputs are not reported (matching the legacy behavior of returning `results:
-    // None` alongside an error).
+    // Like the legacy implementation, exactly one of `results` and `error` is set, depending on
+    // whether execution succeeded. The error message itself may be different. Legacy stringifies
+    // the executor's `ExecutionError`, which is not part of the gRPC simulate response. Here, it is
+    // recovered from the effects' execution status instead.
     let (results, error) = match effects.status() {
         SuiExecutionStatus::Success => (
             Some(
@@ -410,23 +410,7 @@ fn command_output_value(
 
 /// Convert an argument from the gRPC response into the JSON-RPC response type.
 fn sui_argument(argument: &proto::Argument) -> Result<SuiArgument, RpcError<Error>> {
-    use proto::argument::ArgumentKind;
-
-    Ok(match argument.kind() {
-        ArgumentKind::Gas => SuiArgument::GasCoin,
-        ArgumentKind::Input => SuiArgument::Input(argument.input() as u16),
-        ArgumentKind::Result => match argument.subresult {
-            Some(subresult) => {
-                SuiArgument::NestedResult(argument.result() as u16, subresult as u16)
-            }
-            None => SuiArgument::Result(argument.result() as u16),
-        },
-        // Covers `ArgumentKind::Unknown` as well as variants introduced by future proto updates
-        // (the enum is `#[non_exhaustive]`).
-        _ => {
-            return Err(crate::error::internal_error!(
-                "Unknown argument kind in command output"
-            ));
-        }
-    })
+    let argument = sui_sdk_types::Argument::try_from(argument)
+        .context("Invalid argument in command output")?;
+    Ok(sui_types::transaction::Argument::from(argument).into())
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
@@ -421,7 +421,9 @@ fn sui_argument(argument: &proto::Argument) -> Result<SuiArgument, RpcError<Erro
             }
             None => SuiArgument::Result(argument.result() as u16),
         },
-        ArgumentKind::Unknown => {
+        // Covers `ArgumentKind::Unknown` as well as variants introduced by future proto updates
+        // (the enum is `#[non_exhaustive]`).
+        _ => {
             return Err(crate::error::internal_error!(
                 "Unknown argument kind in command output"
             ));

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
@@ -8,15 +8,21 @@ use anyhow::Context as _;
 use move_core_types::annotated_value::MoveDatatypeLayout;
 use move_core_types::annotated_value::MoveTypeLayout;
 use sui_json_rpc_types::BalanceChange as SuiBalanceChange;
+use sui_json_rpc_types::DevInspectResults;
 use sui_json_rpc_types::DryRunTransactionBlockResponse;
 use sui_json_rpc_types::ObjectChange as SuiObjectChange;
+use sui_json_rpc_types::SuiArgument;
 use sui_json_rpc_types::SuiEvent;
+use sui_json_rpc_types::SuiExecutionResult;
+use sui_json_rpc_types::SuiExecutionStatus;
 use sui_json_rpc_types::SuiTransactionBlock;
 use sui_json_rpc_types::SuiTransactionBlockData;
 use sui_json_rpc_types::SuiTransactionBlockEffects;
+use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_json_rpc_types::SuiTransactionBlockEvents;
 use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
+use sui_json_rpc_types::SuiTypeTag;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use sui_types::TypeTag;
 use sui_types::base_types::ObjectID;
@@ -106,6 +112,52 @@ pub(super) async fn dry_run(
         input: input(ctx, tx_data, vec![]).await?.data,
         execution_error_source: None,
         suggested_gas_price,
+    })
+}
+
+pub(super) async fn dev_inspect(
+    ctx: &Context,
+    tx_data: TransactionData,
+    executed_tx: &proto::ExecutedTransaction,
+    command_outputs: &[proto::CommandResult],
+    raw_txn_data: Vec<u8>,
+    show_raw_txn_data_and_effects: bool,
+) -> Result<DevInspectResults, RpcError<Error>> {
+    let effects = deserialize_effects(executed_tx)?;
+    let tx_digest = tx_data.digest();
+
+    let raw_effects = if show_raw_txn_data_and_effects {
+        raw_effects(executed_tx)?
+    } else {
+        vec![]
+    };
+
+    let effects = effects_response(&effects)?;
+
+    // The legacy implementation derives `error` from the execution result, which is not part of
+    // the gRPC simulate response, so recover it from the effects' execution status. On failure,
+    // command outputs are not reported (matching the legacy behavior of returning `results:
+    // None` alongside an error).
+    let (results, error) = match effects.status() {
+        SuiExecutionStatus::Success => (
+            Some(
+                command_outputs
+                    .iter()
+                    .map(execution_result)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            None,
+        ),
+        SuiExecutionStatus::Failure { error } => (None, Some(error.clone())),
+    };
+
+    Ok(DevInspectResults {
+        effects,
+        events: events(ctx, tx_digest, executed_tx).await?,
+        results,
+        error,
+        raw_txn_data,
+        raw_effects,
     })
 }
 
@@ -307,4 +359,72 @@ fn effects_response(
         .clone()
         .try_into()
         .context("Failed to convert effects into JSON-RPC response type")?)
+}
+
+/// Convert a single command's outputs from the gRPC response into the dev-inspect execution
+/// result response type.
+fn execution_result(
+    command_result: &proto::CommandResult,
+) -> Result<SuiExecutionResult, RpcError<Error>> {
+    let return_values = command_result
+        .return_values
+        .iter()
+        .map(command_output_value)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mutable_reference_outputs = command_result
+        .mutated_by_ref
+        .iter()
+        .map(|output| {
+            let argument = sui_argument(
+                output
+                    .argument
+                    .as_ref()
+                    .context("Missing argument in mutated-by-ref command output")?,
+            )?;
+            let (bytes, type_tag) = command_output_value(output)?;
+            Ok::<_, RpcError<Error>>((argument, bytes, type_tag))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    })
+}
+
+/// Extract the BCS bytes and type of a command output from the gRPC response.
+fn command_output_value(
+    output: &proto::CommandOutput,
+) -> Result<(Vec<u8>, SuiTypeTag), RpcError<Error>> {
+    let bcs = output
+        .value
+        .as_ref()
+        .context("Missing value in command output")?;
+
+    let type_tag = TypeTag::from_str(bcs.name())
+        .with_context(|| format!("Invalid type in command output: {:?}", bcs.name()))?;
+
+    Ok((bcs.value().to_vec(), SuiTypeTag::from(type_tag)))
+}
+
+/// Convert an argument from the gRPC response into the JSON-RPC response type.
+fn sui_argument(argument: &proto::Argument) -> Result<SuiArgument, RpcError<Error>> {
+    use proto::argument::ArgumentKind;
+
+    Ok(match argument.kind() {
+        ArgumentKind::Gas => SuiArgument::GasCoin,
+        ArgumentKind::Input => SuiArgument::Input(argument.input() as u16),
+        ArgumentKind::Result => match argument.subresult {
+            Some(subresult) => {
+                SuiArgument::NestedResult(argument.result() as u16, subresult as u16)
+            }
+            None => SuiArgument::Result(argument.result() as u16),
+        },
+        ArgumentKind::Unknown => {
+            return Err(crate::error::internal_error!(
+                "Unknown argument kind in command output"
+            ));
+        }
+    })
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -34,6 +34,7 @@ use crate::api::move_utils::MoveUtils;
 use crate::api::name_service::NameService;
 use crate::api::objects::Objects;
 use crate::api::objects::QueryObjects;
+use crate::api::protocol::Protocol;
 use crate::api::rpc_module::RpcModule;
 use crate::api::transactions::QueryTransactions;
 use crate::api::transactions::Transactions;
@@ -308,6 +309,7 @@ pub async fn start_rpc(
     rpc.add_module(MoveUtils(context.clone()))?;
     rpc.add_module(NameService(context.clone()))?;
     rpc.add_module(Objects(context.clone()))?;
+    rpc.add_module(Protocol(context.clone()))?;
     rpc.add_module(QueryObjects(context.clone()))?;
     rpc.add_module(QueryTransactions(context.clone()))?;
     rpc.add_module(Transactions(context.clone()))?;


### PR DESCRIPTION
## Description 

Add `getProtocolConfig` and `devInspectExecuteTransactionBlock` reading from `kv_epoch_starts` for relevant info (protocol config, ref gas price, and so on)

## Test plan 

new e2e tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
