### PR TITLE
[move][move-compiler] Remove unused type definitions from HLIR ast definitions

### DIFF
--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -6,6 +6,7 @@ mod state;
 
 use super::{
     absint::*,
+    ast::BasicBlock,
     cfg::{CFG, MutForwardCFG, MutReverseCFG, ReverseCFG},
     locals,
 };
@@ -184,7 +185,7 @@ mod last_usage {
     use move_proc_macros::growing_stack;
 
     use crate::{
-        cfgir::{CFGContext, liveness::state::LivenessState},
+        cfgir::{CFGContext, ast::BasicBlock, liveness::state::LivenessState},
         diag,
         hlir::{
             ast::*,

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
@@ -30,12 +30,12 @@ use move_proc_macros::growing_stack;
 
 use crate::{
     cfgir::{
-        ast::remap_labels,
+        ast::{BasicBlocks, remap_labels},
         cfg::{CFG, MutForwardCFG},
     },
     diagnostics::DiagnosticReporter,
     expansion::ast::Mutability,
-    hlir::ast::{BasicBlocks, Command, Command_, FunctionSignature, Label, SingleType, Value, Var},
+    hlir::ast::{Command, Command_, FunctionSignature, Label, SingleType, Value, Var},
     parser::ast::ConstantName,
     shared::unique_map::UniqueMap,
 };

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/inline_blocks.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/inline_blocks.rs
@@ -6,12 +6,12 @@ use move_proc_macros::growing_stack;
 
 use crate::{
     cfgir::{
-        ast::remap_labels,
+        ast::{BasicBlocks, remap_labels},
         cfg::{CFG, MutForwardCFG},
     },
     diagnostics::DiagnosticReporter,
     expansion::ast::Mutability,
-    hlir::ast::{BasicBlocks, Command_, FunctionSignature, Label, SingleType, Value, Var},
+    hlir::ast::{Command_, FunctionSignature, Label, SingleType, Value, Var},
     parser::ast::ConstantName,
     shared::unique_map::UniqueMap,
 };

--- a/external-crates/move/crates/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/ast.rs
@@ -20,7 +20,7 @@ use crate::{
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeSet, VecDeque},
     sync::Arc,
 };
 
@@ -238,10 +238,6 @@ pub enum Statement_ {
 pub type Statement = Spanned<Statement_>;
 
 pub type Block = VecDeque<Statement>;
-
-pub type BasicBlocks = BTreeMap<Label, BasicBlock>;
-
-pub type BasicBlock = VecDeque<Command>;
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, PartialOrd, Ord)]
 pub struct Label(pub usize);

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -841,7 +841,7 @@ fn function_body(
     mut locals_map: UniqueMap<Var, (Mutability, H::SingleType)>,
     block_info: BTreeMap<H::Label, G::BlockInfo>,
     start: H::Label,
-    blocks_map: H::BasicBlocks,
+    blocks_map: G::BasicBlocks,
 ) -> (Vec<(IR::Var, IR::Type)>, IR::BytecodeBlocks) {
     parameters
         .iter()


### PR DESCRIPTION
## Description 

The `BasicBlock` / `BasicBlocks` form was defined in both `cfgir/ast.rs` and `hlir/ast.rs`, and have been since apparently the beginning of this repo. I got rid of the `hlir/ast.rs` ones, to avoid future confusion.

## Test plan 

Tests all still work.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
