### PR TITLE
Fix bridge e2e flakiness reading ETH coin from owned-object index

### DIFF
--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -8,6 +8,7 @@ use crate::e2e_tests::test_utils::{
     BridgeTestClusterBuilder, TestClusterWrapperBuilder, get_signatures,
     initiate_bridge_erc20_to_sui, initiate_bridge_eth_to_sui, initiate_bridge_eth_to_sui_v2,
     initiate_bridge_sui_to_eth, initiate_bridge_sui_to_eth_v2, send_eth_tx_and_get_tx_receipt,
+    wait_for_eth_coin_owned_by,
 };
 use crate::encoding::TOKEN_TRANSFER_MESSAGE_VERSION_V2;
 use crate::eth_transaction_builder::build_eth_transaction;
@@ -69,21 +70,7 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
     // There are exactly 1 approved and 1 claimed event
     assert_eq!(events.len(), 2);
 
-    let eth_coin = bridge_test_cluster
-        .grpc_client()
-        .get_owned_objects(sui_address, None, None, None)
-        .await
-        .unwrap()
-        .items
-        .iter()
-        .find(|o| {
-            o.struct_tag()
-                .unwrap()
-                .to_canonical_string(true)
-                .contains("ETH")
-        })
-        .expect("Recipient should have received ETH coin now")
-        .clone();
+    let eth_coin = wait_for_eth_coin_owned_by(&bridge_test_cluster, sui_address, None).await;
     let (_ty, balance) = Coin::extract_balance_if_coin(&eth_coin).unwrap().unwrap();
     assert_eq!(balance, sui_amount);
     info!(
@@ -216,21 +203,7 @@ async fn test_bridge_from_eth_to_sui_to_eth_v2() {
         .await;
     assert_eq!(events.len(), 2);
 
-    let eth_coin = bridge_test_cluster
-        .grpc_client()
-        .get_owned_objects(sui_address, None, None, None)
-        .await
-        .unwrap()
-        .items
-        .iter()
-        .find(|o| {
-            o.struct_tag()
-                .unwrap()
-                .to_canonical_string(true)
-                .contains("ETH")
-        })
-        .expect("Recipient should have received ETH coin now")
-        .clone();
+    let eth_coin = wait_for_eth_coin_owned_by(&bridge_test_cluster, sui_address, None).await;
     let (_ty, balance) = Coin::extract_balance_if_coin(&eth_coin).unwrap().unwrap();
     assert_eq!(balance, sui_amount);
     info!(

--- a/crates/sui-bridge/src/e2e_tests/complex.rs
+++ b/crates/sui-bridge/src/e2e_tests/complex.rs
@@ -6,6 +6,7 @@ use crate::client::bridge_authority_aggregator::BridgeAuthorityAggregator;
 use crate::e2e_tests::test_utils::{
     BridgeTestClusterBuilder, get_signatures, initiate_bridge_eth_to_sui,
     initiate_bridge_sui_to_eth, initiate_bridge_sui_to_eth_v2, send_eth_tx_and_get_tx_receipt,
+    wait_for_eth_coin_owned_by,
 };
 use crate::sui_transaction_builder::build_sui_transaction;
 use crate::types::{BridgeAction, BridgeActionStatus, EmergencyAction, EmergencyActionType};
@@ -179,21 +180,7 @@ async fn test_v2_sui_with_v1_evm() {
     );
 
     // Verify ETH was received on Sui
-    let eth_coin = bridge_test_cluster
-        .grpc_client()
-        .get_owned_objects(sui_address, None, None, None)
-        .await
-        .unwrap()
-        .items
-        .iter()
-        .find(|o| {
-            o.struct_tag()
-                .unwrap()
-                .to_canonical_string(true)
-                .contains("ETH")
-        })
-        .expect("Recipient should have received ETH coin now")
-        .clone();
+    let eth_coin = wait_for_eth_coin_owned_by(&bridge_test_cluster, sui_address, None).await;
     let (_ty, balance) = Coin::extract_balance_if_coin(&eth_coin).unwrap().unwrap();
     assert_eq!(balance, sui_amount);
 
@@ -243,21 +230,10 @@ async fn test_v2_sui_with_v1_evm() {
         timer.elapsed()
     );
 
-    let eth_coin_for_v2 = bridge_test_cluster
-        .grpc_client()
-        .get_owned_objects(sui_address, None, None, None)
-        .await
-        .unwrap()
-        .items
-        .iter()
-        .find(|o| {
-            o.struct_tag()
-                .unwrap()
-                .to_canonical_string(true)
-                .contains("ETH")
-        })
-        .expect("Recipient should have received ETH coin now")
-        .clone();
+    // Exclude the coin from Test 1: it was bridged away in Test 2, but a lagging index may
+    // still list it.
+    let eth_coin_for_v2 =
+        wait_for_eth_coin_owned_by(&bridge_test_cluster, sui_address, Some(eth_coin.id())).await;
 
     // Initiate V2 Sui→ETH deposit (this should work on Sui side)
     let timer = std::time::Instant::now();
@@ -396,21 +372,7 @@ async fn test_v1_deposit_during_v2_upgrade() {
     }
 
     // Verify the ETH coin was received on Sui
-    let eth_coin = bridge_test_cluster
-        .grpc_client()
-        .get_owned_objects(sui_address, None, None, None)
-        .await
-        .unwrap()
-        .items
-        .iter()
-        .find(|o| {
-            o.struct_tag()
-                .unwrap()
-                .to_canonical_string(true)
-                .contains("ETH")
-        })
-        .expect("Recipient should have received ETH coin now")
-        .clone();
+    let eth_coin = wait_for_eth_coin_owned_by(&bridge_test_cluster, sui_address, None).await;
     let (_ty, balance) = Coin::extract_balance_if_coin(&eth_coin).unwrap().unwrap();
     assert_eq!(balance, sui_amount);
     info!("V1 deposit successfully claimed after V2 upgrade - backwards compatibility confirmed!");

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -1577,6 +1577,44 @@ async fn wait_for_transfer_action_status(
     }
 }
 
+/// Polls the fullnode's owned-object index until `address` owns an ETH coin, and returns it.
+/// The index is only updated after the claiming transaction's checkpoint is indexed, so the coin
+/// may not be visible immediately after the transfer's onchain status becomes `Claimed` (which is
+/// read from live object state). `exclude` filters out a coin from an earlier transfer that has
+/// since been bridged away, in case the index still shows it.
+pub async fn wait_for_eth_coin_owned_by(
+    bridge_test_cluster: &BridgeTestCluster,
+    address: SuiAddress,
+    exclude: Option<ObjectID>,
+) -> Object {
+    let now = std::time::Instant::now();
+    loop {
+        let eth_coin = bridge_test_cluster
+            .grpc_client()
+            .get_owned_objects(address, None, None, None)
+            .await
+            .unwrap()
+            .items
+            .iter()
+            .find(|o| {
+                Some(o.id()) != exclude
+                    && o.struct_tag()
+                        .unwrap()
+                        .to_canonical_string(true)
+                        .contains("ETH")
+            })
+            .cloned();
+        if let Some(eth_coin) = eth_coin {
+            return eth_coin;
+        }
+        assert!(
+            now.elapsed().as_secs() <= 60,
+            "Timeout waiting for {address} to own an ETH coin"
+        );
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    }
+}
+
 async fn deposit_eth_to_sui_package(
     sui_client: Client,
     sui_address: SuiAddress,


### PR DESCRIPTION
## Description

The bridge e2e tests read the recipient's ETH coin with a single `get_owned_objects` call right after the transfer's onchain status becomes `Claimed`. The status is read from live object state, but the owned-object index only updates once the claiming transaction's checkpoint is indexed, so the coin may not be listed yet. This raced in CI: `test_v2_sui_with_v1_evm` failed all 4 retries and both `test_bridge_from_eth_to_sui_to_eth` variants went flaky 2/4 in [the same run](https://github.com/MystenLabs/sui/actions/runs/29061189538/job/86263842593).

Replaces the five single-shot reads with a helper that polls the index until the coin appears. The re-read in `test_v2_sui_with_v1_evm` excludes the coin from the earlier transfer, which was already bridged away but could still be listed by a lagging index.

## Test plan

Test-only change; the five affected e2e tests exercise the helper directly, covering both the coin-not-yet-indexed case (poll until visible) and the stale-previous-coin case (exclusion in `test_v2_sui_with_v1_evm`, where the Test 1 coin was bridged away before the Test 3 re-read).

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes are not required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
