### PR TITLE
Retry checkpoint wait on timeout when executing transactions

### DIFF
--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -236,19 +236,42 @@ impl Client {
         transaction: &Transaction,
     ) -> Result<ExecutedTransaction> {
         const WAIT_FOR_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(30);
+        // A checkpoint-wait timeout does not mean the transaction failed: it has already executed,
+        // and its checkpoint may just be slow to land (e.g. an overloaded node). Retry the wait a
+        // few times before giving up; each attempt subscribes to a fresh checkpoint stream and
+        // returns immediately if the transaction has been checkpointed in the meantime.
+        const MAX_ATTEMPTS: usize = 3;
 
         let request = Self::create_executed_transaction_request(transaction)?;
 
-        let (metadata, response, _extentions) = self
-            .0
-            .clone()
-            .execute_transaction_and_wait_for_checkpoint(request, WAIT_FOR_CHECKPOINT_TIMEOUT)
-            .await
-            .map_err(|e| Status::from_error(e.into()))?
-            .into_parts();
-
-        execute_transaction_response_try_from_proto(&response)
-            .map_err(|e| status_from_error_with_metadata(e, metadata))
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            match self
+                .0
+                .clone()
+                .execute_transaction_and_wait_for_checkpoint(
+                    request.clone(),
+                    WAIT_FOR_CHECKPOINT_TIMEOUT,
+                )
+                .await
+            {
+                Ok(response) => {
+                    let (metadata, response, _extentions) = response.into_parts();
+                    return execute_transaction_response_try_from_proto(&response)
+                        .map_err(|e| status_from_error_with_metadata(e, metadata));
+                }
+                Err(sui_rpc::client::ExecuteAndWaitError::CheckpointTimeout(_))
+                    if attempt < MAX_ATTEMPTS =>
+                {
+                    tracing::warn!(
+                        "transaction executed but checkpoint wait timed out; retrying \
+                         (attempt {attempt}/{MAX_ATTEMPTS})"
+                    );
+                }
+                Err(e) => return Err(Status::from_error(e.into())),
+            }
+        }
     }
 
     fn create_executed_transaction_request(


### PR DESCRIPTION
## Description

`Client::execute_transaction_and_wait_for_checkpoint` gives up after a flat 30s checkpoint wait, even though by that point the transaction has already executed and its checkpoint may just be slow to land. Tests driving transactions through `WalletContext` flake on this: `fuzz_dynamic_committee` failed [in CI](https://github.com/MystenLabs/sui/actions/runs/29061189525/job/86263843868) with "Transaction executed but checkpoint wait timed out" on all four nextest retries (same simtest seed each time), and the same seed passes locally, i.e. the failure is an unlucky checkpoint-timing schedule rather than anything specific to that test.

Retry the wait up to 3 attempts total. Each attempt subscribes to a fresh checkpoint stream (also healing a stalled subscription) and short-circuits through the existing already-checkpointed fast path, so a retry returns immediately once the checkpoint has landed.

## Test plan

Behavior on the success path is unchanged and covered by every e2e test that executes transactions through `WalletContext`. The retried path only differs when a checkpoint takes longer than 30s, which is timing-dependent and not deterministically reproducible; re-running `fuzz_dynamic_committee` under the failing CI seed passes with this change.

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes are not required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Commands that execute a transaction no longer fail with "checkpoint wait timed out" if the fullnode takes longer than 30 seconds to checkpoint an executed transaction; the wait is now retried (up to 90 seconds total) before erroring.
- [ ] Rust SDK:
