### PR TITLE
rpc-api: run transaction simulation on a blocking thread

### DIFF
--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/mod.rs
@@ -45,7 +45,11 @@ impl TransactionExecutionService for RpcService {
         &self,
         request: tonic::Request<SimulateTransactionRequest>,
     ) -> Result<tonic::Response<SimulateTransactionResponse>, tonic::Status> {
-        simulate::simulate_transaction(self, request.into_inner())
+        let service = self.clone();
+        let request = request.into_inner();
+        tokio::task::spawn_blocking(move || simulate::simulate_transaction(&service, request))
+            .await
+            .map_err(|e| tonic::Status::internal(format!("simulate_transaction task failed: {e}")))?
             .map(tonic::Response::new)
             .map_err(Into::into)
     }


### PR DESCRIPTION
Previously, the grpc simulate_transaction handler called the synchronous simulate::simulate_transaction directly from the async handler, blocking a tokio runtime worker thread for the duration of the simulation. Now the call is moved onto a blocking thread via tokio::task::spawn_blocking, and a panic in the blocking task is surfaced as an internal grpc status instead of propagating.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
