### PR TITLE
[source-verification 1] Read a package's publication without loading its graph

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
@@ -78,7 +78,7 @@ pub struct LegacyPackageMetadata {
 pub async fn try_load_legacy_manifest<F: MoveFlavor>(
     path: &PackagePath,
     default_env: &Environment,
-    is_root: bool,
+    display_warnings: bool,
     flavor: &F,
 ) -> anyhow::Result<Option<(FileHandle, ParsedManifest)>> {
     let Ok(file_handle) = FileHandle::new(path.path().join("Move.toml")) else {
@@ -106,7 +106,8 @@ pub async fn try_load_legacy_manifest<F: MoveFlavor>(
     }
 
     debug!("parsing legacy manifest");
-    let manifest = parse_source_manifest::<F>(parsed, is_root, path, default_env, flavor).await?;
+    let manifest =
+        parse_source_manifest::<F>(parsed, display_warnings, path, default_env, flavor).await?;
     debug!("successfully parsed");
     Ok(Some((file_handle, manifest)))
 }
@@ -117,7 +118,7 @@ fn parse_move_manifest_string(manifest_string: &str) -> Result<TV> {
 
 async fn parse_source_manifest<F: MoveFlavor>(
     tval: TV,
-    is_root: bool,
+    display_warnings: bool,
     path: &PackagePath,
     env: &Environment,
     flavor: &F,
@@ -199,7 +200,7 @@ async fn parse_source_manifest<F: MoveFlavor>(
 
             let implicit_dependencies = check_implicits(
                 metadata.legacy_name.as_str(),
-                is_root,
+                display_warnings,
                 &dependencies,
                 metadata.implicit_deps,
                 env,
@@ -257,9 +258,12 @@ async fn parse_source_manifest<F: MoveFlavor>(
 ///  - `implicit_deps_flag` is false,
 ///  - `name` is a system dep name,
 ///  - `deps` contains a system dep name
+///
+/// When `display_warnings` is set and the package redundantly declares an implicit dependency, an
+/// advisory note is printed suggesting its removal.
 async fn check_implicits<F: MoveFlavor>(
     name: &str,
-    is_root: bool,
+    display_warnings: bool,
     deps: &BTreeMap<Identifier, DefaultDependency>,
     implicit_deps_flag: bool,
     env: &Environment,
@@ -286,7 +290,7 @@ async fn check_implicits<F: MoveFlavor>(
         return true;
     }
 
-    if is_root {
+    if display_warnings {
         user_note!(
             "Dependencies on {} are automatically added, but this feature is \
                 disabled for your package because you have explicitly included dependencies on {}. Consider \

--- a/external-crates/move/crates/move-package-alt/src/lib.rs
+++ b/external-crates/move/crates/move-package-alt/src/lib.rs
@@ -28,5 +28,8 @@ pub use flavor::{MoveFlavor, Vanilla};
 pub use graph::{NamedAddress, PackageInfo};
 pub use package::layout::SourcePackageLayout;
 pub use package::{
-    RootPackage, package_impl::cache_package, package_loader::PackageLoader, paths::PackagePath,
+    RootPackage,
+    package_impl::{cache_package, read_publication},
+    package_loader::PackageLoader,
+    paths::PackagePath,
 };

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use derive_where::derive_where;
 use sha2::{Digest as _, Sha256};
@@ -66,6 +66,25 @@ pub struct Package<F: MoveFlavor> {
     pub dummy_addr: OriginalID,
 }
 
+/// Read the publication recorded for `env` at the package rooted in `dir`, consulting the modern
+/// pubfile and then a legacy lockfile, without loading the dependency graph. Returns `None` if the
+/// package records no publication for `env`.
+///
+/// This resolves the publication the same way [`Package::load`] does, so a caller learns a package's
+/// published address exactly as the package system would resolve it when linking against that
+/// package, without paying for a full graph load.
+pub async fn read_publication<F: MoveFlavor>(
+    dir: &Path,
+    env: &Environment,
+    flavor: &F,
+) -> PackageResult<Option<Publication<F>>> {
+    let path = PackagePath::new(dir.to_path_buf())?;
+    let mtx = path.lock()?;
+    let (_, _, publication) =
+        Package::<F>::read_manifest_and_publication(&path, env, true, &mtx, flavor).await?;
+    Ok(publication)
+}
+
 impl<F: MoveFlavor> Package<F> {
     /// Fetch `dep` (relative to `self`) and load a package from the fetched source.
     /// Makes a best effort to translate old-style packages into the current format.
@@ -79,33 +98,8 @@ impl<F: MoveFlavor> Package<F> {
         let flavor = &*config.flavor;
         let path = fetch::fetch(&dep, config.allow_dirty, &config.chain_id).await?;
 
-        // try to load a legacy manifest (with an `[addresses]` section)
-        //   - if it fails, load a modern manifest (and return any errors)
-        let legacy_manifest = path
-            .read_legacy_manifest::<F>(env, dep.is_root(), mtx, flavor)
-            .await?;
-        let (file_handle, manifest) = if let Some(result) = legacy_manifest {
-            result
-        } else {
-            let manifest = Manifest::read_from_file(&path, mtx)?;
-            check_for_environment(&manifest, &env.name, flavor)?;
-
-            (*manifest.file_handle(), manifest.into_parsed())
-        };
-
-        flavor
-            .validate_manifest(&manifest)
-            .map_err(|msg| ManifestError::flavor_rejected_manifest(file_handle, msg))?;
-
-        // try to load the address from the modern lockfile
-        //   - if it fails, look in the legacy data
-        //   - if that fails, use a dummy address
-        let publication = Self::load_publication(&path, env.name(), mtx)?.or_else(|| {
-            manifest
-                .legacy_data
-                .as_ref()
-                .and_then(|legacy| legacy.publication::<F>(env))
-        });
+        let (file_handle, manifest, publication) =
+            Self::read_manifest_and_publication(&path, env, dep.is_root(), mtx, flavor).await?;
 
         // TODO: try to gather dependencies from the modern lockfile
         //   - if it fails (no lockfile / out of date lockfile), compute them from the manifest
@@ -218,6 +212,47 @@ impl<F: MoveFlavor> Package<F> {
 
     pub fn metadata(&self) -> &PackageMetadata {
         &self.metadata
+    }
+
+    /// Read the manifest for the (already-fetched) package at `path` and the publication recorded
+    /// for `env` — from the modern pubfile, falling back to a legacy lockfile — without resolving
+    /// the dependency graph. Shared by [`Self::load`] and [`read_publication`].
+    async fn read_manifest_and_publication(
+        path: &PackagePath,
+        env: &Environment,
+        is_root: bool,
+        mtx: &PackageSystemLock,
+        flavor: &F,
+    ) -> PackageResult<(FileHandle, ParsedManifest, Option<Publication<F>>)> {
+        // try to load a legacy manifest (with an `[addresses]` section)
+        //   - if it fails, load a modern manifest (and return any errors)
+        let legacy_manifest = path
+            .read_legacy_manifest::<F>(env, is_root, mtx, flavor)
+            .await?;
+        let (file_handle, manifest) = if let Some(result) = legacy_manifest {
+            result
+        } else {
+            let manifest = Manifest::read_from_file(path, mtx)?;
+            check_for_environment(&manifest, &env.name, flavor)?;
+
+            (*manifest.file_handle(), manifest.into_parsed())
+        };
+
+        flavor
+            .validate_manifest(&manifest)
+            .map_err(|msg| ManifestError::flavor_rejected_manifest(file_handle, msg))?;
+
+        // try to load the address from the modern lockfile
+        //   - if it fails, look in the legacy data
+        //   - if that fails, there is no recorded publication
+        let publication = Self::load_publication(path, env.name(), mtx)?.or_else(|| {
+            manifest
+                .legacy_data
+                .as_ref()
+                .and_then(|legacy| legacy.publication::<F>(env))
+        });
+
+        Ok((file_handle, manifest, publication))
     }
 
     /// Read the publication for the given environment from the package pubfile.
@@ -589,6 +624,42 @@ mod tests {
 
     /// Create a basic package and then call cache_package on a local dependency to it; check that
     /// the returned fields are correct
+    /// `read_publication` returns the addresses a package recorded, without building its graph.
+    #[test(tokio::test)]
+    async fn read_publication_returns_recorded_addresses() {
+        let scenario = TestPackageGraph::new(["root"])
+            .add_published("a", OriginalID::from(1), PublishedID::from(2))
+            .build();
+
+        let publication = read_publication::<Vanilla>(
+            &scenario.path_for("a"),
+            &Vanilla::default_environment(),
+            &Vanilla::new(),
+        )
+        .await
+        .unwrap()
+        .expect("package records a publication");
+
+        assert_eq!(publication.addresses.original_id, OriginalID::from(1));
+        assert_eq!(publication.addresses.published_at, PublishedID::from(2));
+    }
+
+    /// `read_publication` returns `None` for a package that has not been published.
+    #[test(tokio::test)]
+    async fn read_publication_is_none_when_unpublished() {
+        let scenario = TestPackageGraph::new(["a"]).build();
+
+        let publication = read_publication::<Vanilla>(
+            &scenario.path_for("a"),
+            &Vanilla::default_environment(),
+            &Vanilla::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(publication.is_none());
+    }
+
     #[test(tokio::test)]
     async fn test_cache_package() {
         let scenario = TestPackageGraph::new(["root"])

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -73,15 +73,26 @@ pub struct Package<F: MoveFlavor> {
 /// This resolves the publication the same way [`Package::load`] does, so a caller learns a package's
 /// published address exactly as the package system would resolve it when linking against that
 /// package, without paying for a full graph load.
+///
+/// This acquires an exclusive per-package filesystem lock while it reads, the same lock a
+/// `RootPackage` holds for its package. The lock is not reentrant: do not call this while the
+/// current task already holds it for the same package (for instance, while a `RootPackage` for the
+/// same directory is alive), or the call will deadlock.
 pub async fn read_publication<F: MoveFlavor>(
     dir: &Path,
     env: &Environment,
     flavor: &F,
 ) -> PackageResult<Option<Publication<F>>> {
     let path = PackagePath::new(dir.to_path_buf())?;
+    // TODO: this self-acquires a non-reentrant per-package lock (see the doc comment above). The
+    // clean fix is to centralize the lock in `PackageLoader` and route both `RootPackage`
+    // construction and publication reads through it, so callers share one acquisition rather than
+    // deadlocking on a second one.
     let mtx = path.lock()?;
+    // This reads recorded metadata for a package the caller may not own (for example, verifying
+    // someone else's published source), so it must not emit advice about that package's manifest.
     let (_, _, publication) =
-        Package::<F>::read_manifest_and_publication(&path, env, true, &mtx, flavor).await?;
+        Package::<F>::read_manifest_and_publication(&path, env, false, &mtx, flavor).await?;
     Ok(publication)
 }
 
@@ -217,17 +228,20 @@ impl<F: MoveFlavor> Package<F> {
     /// Read the manifest for the (already-fetched) package at `path` and the publication recorded
     /// for `env` — from the modern pubfile, falling back to a legacy lockfile — without resolving
     /// the dependency graph. Shared by [`Self::load`] and [`read_publication`].
+    ///
+    /// `display_warnings` enables user-facing advice about the package's manifest (such as
+    /// redundant implicit dependencies); pass it only when loading a package the caller authors.
     async fn read_manifest_and_publication(
         path: &PackagePath,
         env: &Environment,
-        is_root: bool,
+        display_warnings: bool,
         mtx: &PackageSystemLock,
         flavor: &F,
     ) -> PackageResult<(FileHandle, ParsedManifest, Option<Publication<F>>)> {
         // try to load a legacy manifest (with an `[addresses]` section)
         //   - if it fails, load a modern manifest (and return any errors)
         let legacy_manifest = path
-            .read_legacy_manifest::<F>(env, is_root, mtx, flavor)
+            .read_legacy_manifest::<F>(env, display_warnings, mtx, flavor)
             .await?;
         let (file_handle, manifest) = if let Some(result) = legacy_manifest {
             result
@@ -622,8 +636,6 @@ mod tests {
         PackageName::new(name.to_string()).unwrap()
     }
 
-    /// Create a basic package and then call cache_package on a local dependency to it; check that
-    /// the returned fields are correct
     /// `read_publication` returns the addresses a package recorded, without building its graph.
     #[test(tokio::test)]
     async fn read_publication_returns_recorded_addresses() {
@@ -744,6 +756,8 @@ mod tests {
         assert!(publication.is_none());
     }
 
+    /// Create a basic package and then call cache_package on a local dependency to it; check that
+    /// the returned fields are correct
     #[test(tokio::test)]
     async fn test_cache_package() {
         let scenario = TestPackageGraph::new(["root"])

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -644,6 +644,90 @@ mod tests {
         assert_eq!(publication.addresses.published_at, PublishedID::from(2));
     }
 
+    /// When a package records a publication in *both* a `Published.toml` and a legacy manifest
+    /// `published-at`, the `Published.toml` address wins. This is the address the package system
+    /// bakes into a dependent's linkage table during publication, so the verifier (which reads it
+    /// through the same path) and a publisher cannot disagree about which address to link.
+    #[test(tokio::test)]
+    async fn published_toml_wins_over_manifest_published_at() {
+        // The legacy manifest records published-at = 0x2 (original 0x1); the Published.toml records a
+        // different address, 0x4 (original 0x3).
+        let pubfile = r#"
+            [published._test_env]
+            chain-id = "_test_env_id"
+            published-at = "0x4"
+            original-id = "0x3"
+            version = 1
+        "#;
+
+        let scenario = TestPackageGraph::new(["root"])
+            .add_package("a", |a| {
+                a.set_legacy()
+                    .publish(OriginalID::from(1), PublishedID::from(2), None)
+                    .add_file("Published.toml", pubfile)
+            })
+            .build();
+
+        let publication = read_publication::<Vanilla>(
+            &scenario.path_for("a"),
+            &Vanilla::default_environment(),
+            &Vanilla::new(),
+        )
+        .await
+        .unwrap()
+        .expect("package records a publication");
+
+        assert_eq!(publication.addresses.published_at, PublishedID::from(4));
+        assert_eq!(publication.addresses.original_id, OriginalID::from(3));
+    }
+
+    /// When a package records a publication in *both* a `Published.toml` and a legacy `Move.lock`
+    /// `[env]` managed section, the `Published.toml` address wins. DeepBook's pre-v6 releases record
+    /// their address in the `[env]` lock, so this is the case retrofitting a `Published.toml` relies
+    /// on; the resolution stays identical for the verifier and for a publisher building linkage.
+    #[test(tokio::test)]
+    async fn published_toml_wins_over_legacy_lock() {
+        // The legacy Move.lock records the managed address 0x6 (original 0x5); the Published.toml
+        // records a different address, 0x4 (original 0x3).
+        let lock = r#"
+            [move]
+            version = 1
+
+            [env._test_env]
+            chain-id = "_test_env_id"
+            original-published-id = "0x5"
+            latest-published-id = "0x6"
+            published-version = "1"
+        "#;
+        let pubfile = r#"
+            [published._test_env]
+            chain-id = "_test_env_id"
+            published-at = "0x4"
+            original-id = "0x3"
+            version = 1
+        "#;
+
+        let scenario = TestPackageGraph::new(["root"])
+            .add_package("a", |a| {
+                a.set_legacy()
+                    .add_file("Move.lock", lock)
+                    .add_file("Published.toml", pubfile)
+            })
+            .build();
+
+        let publication = read_publication::<Vanilla>(
+            &scenario.path_for("a"),
+            &Vanilla::default_environment(),
+            &Vanilla::new(),
+        )
+        .await
+        .unwrap()
+        .expect("package records a publication");
+
+        assert_eq!(publication.addresses.published_at, PublishedID::from(4));
+        assert_eq!(publication.addresses.original_id, OriginalID::from(3));
+    }
+
     /// `read_publication` returns `None` for a package that has not been published.
     #[test(tokio::test)]
     async fn read_publication_is_none_when_unpublished() {

--- a/external-crates/move/crates/move-package-alt/src/package/paths.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/paths.rs
@@ -221,12 +221,12 @@ impl PackagePath {
     pub(crate) async fn read_legacy_manifest<F: MoveFlavor>(
         &self,
         default_env: &Environment,
-        is_root: bool,
+        display_warnings: bool,
         _mtx: &PackageSystemLock,
         flavor: &F,
     ) -> FileResult<Option<(FileHandle, ParsedManifest)>> {
         let path = self.manifest_path().to_path_buf();
-        try_load_legacy_manifest::<F>(self, default_env, is_root, flavor)
+        try_load_legacy_manifest::<F>(self, default_env, display_warnings, flavor)
             .await
             .map_err(|err| FileError::LegacyError {
                 file: path,


### PR DESCRIPTION
## Description

`Package::load` reads the manifest and resolves the publication for an environment — modern pubfile first, then a legacy lockfile — before it resolves dependencies. Factor that into a helper and expose a public `read_publication(dir, env, flavor)` that stops there, so a caller can learn a package's recorded addresses without loading the dependency graph and without reimplementing the modern/legacy precedence.

Base of a stack: source verification (#27213) uses this to resolve the address it verifies against the same way the package system resolves it when linking against the package, so the two cannot disagree.

## Test plan

Unit tests over `read_publication`: it returns the recorded addresses, `None` when unpublished, and — when a package records its publication in more than one place — prefers the `Published.toml` address over both a legacy manifest `published-at` and a legacy `Move.lock` `[env]` address (so the verifier and the package system, which share this resolution, cannot disagree). The refactor leaves `Package::load` calling the extracted helper, so existing tests cover it.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
