### PR TITLE
[cli] Add faucet retry for finding gas coins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14987,6 +14987,7 @@ version = "1.76.0"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
+ "backoff",
  "bin-version",
  "clap",
  "http 1.3.1",

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
+backoff.workspace = true
 bin-version.workspace = true
 clap.workspace = true
 http.workspace = true

--- a/crates/sui-faucet/src/local_faucet.rs
+++ b/crates/sui-faucet/src/local_faucet.rs
@@ -28,6 +28,12 @@ use sui_sdk::wallet_context::WalletContext;
 const GAS_BUDGET: u64 = 10_000_000;
 const NUM_RETRIES: u8 = 2;
 
+/// Number of times to retry the gas-coin scan before giving up. On a freshly created
+/// `--force-regenesis` network the genesis coin objects may not yet be persisted and
+/// readable the instant the cluster reports started — especially on slow or contended
+/// storage — so we retry the scan a bounded number of times before failing.
+const GAS_COIN_LOOKUP_RETRIES: u8 = 3;
+
 pub struct LocalFaucet {
     wallet: WalletContext,
     active_address: SuiAddress,
@@ -176,10 +182,42 @@ impl LocalFaucet {
 /// Finds gas coins with sufficient balance and returns the address to use as the active address
 /// for the faucet. If the initial active address in the wallet does not have enough gas coins,
 /// it will iterate through the addresses to find one with sufficient gas coins.
+///
+/// Retries the scan a bounded number of times (see [`GAS_COIN_LOOKUP_RETRIES`]) so that a
+/// transient startup race — where genesis coins are not yet readable — does not fail the faucet.
 async fn find_gas_coins_and_address(
     wallet: &mut WalletContext,
     config: &FaucetConfig,
 ) -> Result<(Vec<GasCoin>, SuiAddress), FaucetError> {
+    let mut retry_delay = Duration::from_millis(500);
+    // Preserved and returned if every attempt comes up empty, so the caller sees the original
+    // "no coins" message (or the last transient query error) rather than a generic timeout.
+    let mut last_err =
+        FaucetError::Wallet("No address found with sufficient coins".to_string());
+
+    for attempt in 0..=GAS_COIN_LOOKUP_RETRIES {
+        match scan_for_gas_coins(wallet, config).await {
+            Ok(Some(found)) => return Ok(found),
+            Ok(None) => {}
+            Err(e) => last_err = e,
+        }
+
+        if attempt < GAS_COIN_LOOKUP_RETRIES {
+            tokio::time::sleep(retry_delay).await;
+            retry_delay *= 2;
+        }
+    }
+
+    Err(last_err)
+}
+
+/// Scans the wallet's addresses once for a gas coin with a balance of at least `config.amount`,
+/// returning the matching coins and the address that holds them, or `Ok(None)` if no such coin is
+/// currently visible.
+async fn scan_for_gas_coins(
+    wallet: &mut WalletContext,
+    config: &FaucetConfig,
+) -> Result<Option<(Vec<GasCoin>, SuiAddress)>, FaucetError> {
     let active_address = wallet
         .active_address()
         .map_err(|e| FaucetError::Wallet(e.to_string()))?;
@@ -200,13 +238,11 @@ async fn find_gas_coins_and_address(
             .collect();
 
         if !coins.is_empty() {
-            return Ok((coins, address));
+            return Ok(Some((coins, address)));
         }
     }
 
-    Err(FaucetError::Wallet(
-        "No address found with sufficient coins".to_string(),
-    ))
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/crates/sui-faucet/src/local_faucet.rs
+++ b/crates/sui-faucet/src/local_faucet.rs
@@ -224,10 +224,6 @@ async fn scan_for_gas_coins(
     active_address: SuiAddress,
     config: &FaucetConfig,
 ) -> Result<Option<(Vec<GasCoin>, SuiAddress)>, FaucetError> {
-    let active_address = wallet
-        .active_address()
-        .map_err(|e| FaucetError::Wallet(e.to_string()))?;
-
     for address in std::iter::once(active_address).chain(wallet.get_addresses().into_iter()) {
         let coins: Vec<_> = wallet
             .gas_objects(address)

--- a/crates/sui-faucet/src/local_faucet.rs
+++ b/crates/sui-faucet/src/local_faucet.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use anyhow::bail;
+use backoff::ExponentialBackoff;
 use sui_rpc_api::client::ExecutedTransaction;
 use sui_sdk::types::effects::TransactionEffectsAPI;
 use tokio::sync::Mutex;
@@ -28,11 +29,11 @@ use sui_sdk::wallet_context::WalletContext;
 const GAS_BUDGET: u64 = 10_000_000;
 const NUM_RETRIES: u8 = 2;
 
-/// Number of times to retry the gas-coin scan before giving up. On a freshly created
-/// `--force-regenesis` network the genesis coin objects may not yet be persisted and
-/// readable the instant the cluster reports started — especially on slow or contended
-/// storage — so we retry the scan a bounded number of times before failing.
-const GAS_COIN_LOOKUP_RETRIES: u8 = 3;
+/// On a freshly created `--force-regenesis` network the genesis coin objects may not yet be
+/// readable the instant the cluster reports started — especially on slow or contended storage —
+/// so the gas-coin scan is retried with backoff for up to this long before failing.
+const GAS_COIN_LOOKUP_INITIAL_INTERVAL: Duration = Duration::from_millis(200);
+const GAS_COIN_LOOKUP_MAX_ELAPSED_TIME: Duration = Duration::from_secs(10);
 
 pub struct LocalFaucet {
     wallet: WalletContext,
@@ -183,38 +184,44 @@ impl LocalFaucet {
 /// for the faucet. If the initial active address in the wallet does not have enough gas coins,
 /// it will iterate through the addresses to find one with sufficient gas coins.
 ///
-/// Retries the scan a bounded number of times (see [`GAS_COIN_LOOKUP_RETRIES`]) so that a
-/// transient startup race — where genesis coins are not yet readable — does not fail the faucet.
+/// Retries the scan with exponential backoff so that a transient startup race — where genesis
+/// coins are not yet readable — does not fail the faucet.
 async fn find_gas_coins_and_address(
     wallet: &mut WalletContext,
     config: &FaucetConfig,
 ) -> Result<(Vec<GasCoin>, SuiAddress), FaucetError> {
-    let mut retry_delay = Duration::from_millis(500);
-    // Preserved and returned if every attempt comes up empty, so the caller sees the original
-    // "no coins" message (or the last transient query error) rather than a generic timeout.
-    let mut last_err = FaucetError::Wallet("No address found with sufficient coins".to_string());
+    let active_address = wallet
+        .active_address()
+        .map_err(|e| FaucetError::Wallet(e.to_string()))?;
+    let wallet = &*wallet;
 
-    for attempt in 0..=GAS_COIN_LOOKUP_RETRIES {
-        match scan_for_gas_coins(wallet, config).await {
-            Ok(Some(found)) => return Ok(found),
-            Ok(None) => {}
-            Err(e) => last_err = e,
-        }
+    let backoff = ExponentialBackoff {
+        initial_interval: GAS_COIN_LOOKUP_INITIAL_INTERVAL,
+        current_interval: GAS_COIN_LOOKUP_INITIAL_INTERVAL,
+        max_elapsed_time: Some(GAS_COIN_LOOKUP_MAX_ELAPSED_TIME),
+        ..Default::default()
+    };
 
-        if attempt < GAS_COIN_LOOKUP_RETRIES {
-            tokio::time::sleep(retry_delay).await;
-            retry_delay *= 2;
-        }
-    }
+    backoff::future::retry(backoff, || async move {
+        let found = scan_for_gas_coins(wallet, active_address, config)
+            .await
+            .map_err(backoff::Error::transient)?;
 
-    Err(last_err)
+        found.ok_or_else(|| {
+            backoff::Error::transient(FaucetError::Wallet(
+                "No address found with sufficient coins".to_string(),
+            ))
+        })
+    })
+    .await
 }
 
 /// Scans the wallet's addresses once for a gas coin with a balance of at least `config.amount`,
 /// returning the matching coins and the address that holds them, or `Ok(None)` if no such coin is
 /// currently visible.
 async fn scan_for_gas_coins(
-    wallet: &mut WalletContext,
+    wallet: &WalletContext,
+    active_address: SuiAddress,
     config: &FaucetConfig,
 ) -> Result<Option<(Vec<GasCoin>, SuiAddress)>, FaucetError> {
     let active_address = wallet

--- a/crates/sui-faucet/src/local_faucet.rs
+++ b/crates/sui-faucet/src/local_faucet.rs
@@ -192,8 +192,7 @@ async fn find_gas_coins_and_address(
     let mut retry_delay = Duration::from_millis(500);
     // Preserved and returned if every attempt comes up empty, so the caller sees the original
     // "no coins" message (or the last transient query error) rather than a generic timeout.
-    let mut last_err =
-        FaucetError::Wallet("No address found with sufficient coins".to_string());
+    let mut last_err = FaucetError::Wallet("No address found with sufficient coins".to_string());
 
     for attempt in 0..=GAS_COIN_LOOKUP_RETRIES {
         match scan_for_gas_coins(wallet, config).await {


### PR DESCRIPTION
## Description 

On slower hardware (e.g., in a Docker container), the faucet fails to find the gas coins at startup, when used with `sui start`. This should fix it and closes #27240.

## Test plan 

Existing tests. Spinned up a local container and with some hdd contention to be able to reproduce the issue.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
