### PR TITLE
Do not floor transaction lookups at the object-pruning watermark

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -689,12 +689,13 @@ impl ReadStore for RpcStoreReadStore {
     }
 
     fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
-        // A consistent read needs both the raw chain data (perpetual
-        // store) and the index rows (rpc-store), so the available range
-        // starts at the higher of the two lower bounds.
-        let perpetual = self.rocks.get_lowest_available_checkpoint()?;
-        let rpc_store = self.reader.get_lowest_available_checkpoint()?;
-        Ok(perpetual.max(rpc_store))
+        // Every transaction and checkpoint read on this store is served from the raw chain
+        // stores, so only their retention bounds it. The rpc-store's index floor is pruned in
+        // lockstep with objects and is carried by `get_lowest_available_checkpoint_objects`;
+        // folding it in here would floor transaction lookups at the object-pruning watermark,
+        // which under aggressive object pruning (`num_epochs_to_retain: 0`) rides within a
+        // couple of checkpoints of the executed tip.
+        self.rocks.get_lowest_available_checkpoint()
     }
 
     fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
@@ -75,7 +75,7 @@ pub fn get_checkpoint(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint_combined()?;
 
     if !(lowest_available_checkpoint..=latest_checkpoint).contains(&sequence_number) {
         return Err(CheckpointNotFoundError::sequence_number(sequence_number).into());

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_service_info.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_service_info.rs
@@ -10,7 +10,7 @@ use sui_sdk_types::Digest;
 #[tracing::instrument(skip(service))]
 pub fn get_service_info(service: &RpcService) -> Result<GetServiceInfoResponse, RpcError> {
     let latest_checkpoint = service.reader.inner().get_latest_checkpoint()?;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint_combined()?;
 
     let mut message = GetServiceInfoResponse::default();
     message.chain_id = Some(Digest::new(service.chain_id().as_bytes().to_owned()).to_string());

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
@@ -73,7 +73,7 @@ pub fn get_transaction(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.inner().get_lowest_available_checkpoint()?;
 
     if !(lowest_available_checkpoint..=latest_checkpoint).contains(&transaction_checkpoint) {
         return Err(TransactionNotFoundError(transaction_digest).into());
@@ -122,7 +122,7 @@ pub fn batch_get_transactions(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.inner().get_lowest_available_checkpoint()?;
 
     let transactions = digests
         .into_iter()
@@ -202,6 +202,17 @@ pub(crate) fn render_executed_transaction(
     let objects: ObjectSet = if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD)
         || mask.contains(ExecutedTransaction::EFFECTS_FIELD)
     {
+        // These fields render the transaction's input and output objects, which object pruning
+        // removes independently of transaction data.
+        if checkpoint
+            < service
+                .reader
+                .inner()
+                .get_lowest_available_checkpoint_objects()?
+        {
+            return Err(TransactionNotFoundError(digest).into());
+        }
+
         let mut objects = ObjectSet::default();
 
         let object_keys = sui_types::storage::get_transaction_object_set(

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/ledger_read.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/ledger_read.rs
@@ -90,7 +90,7 @@ pub(super) fn checkpoint_to_tx_range(
 /// from `certified_checkpoints`, which is retained across pruning, so this resolves
 /// even at the floor.
 fn lowest_available_tx_seq(service: &RpcService) -> Result<u64, RpcError> {
-    let lowest_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_checkpoint = service.reader.get_lowest_available_checkpoint_combined()?;
     checkpoint_to_tx_boundary(service, lowest_checkpoint)
 }
 

--- a/crates/sui-rpc-api/src/reader.rs
+++ b/crates/sui-rpc-api/src/reader.rs
@@ -240,17 +240,14 @@ impl StateReader {
             .map(|balance| balance as u64)
     }
 
-    // Return the lowest available checkpoint watermark for which the RPC service can return proper
-    // responses for.
-    pub fn get_lowest_available_checkpoint(&self) -> Result<u64, crate::RpcError> {
-        // This is the lowest lowest_available_checkpoint from the checkpoint store
-        let lowest_available_checkpoint = self.inner().get_lowest_available_checkpoint()?;
-        // This is the lowest lowest_available_checkpoint from the perpetual store
-        let lowest_available_checkpoint_objects =
-            self.inner().get_lowest_available_checkpoint_objects()?;
-
-        // Return the higher of the two for our lower watermark
-        Ok(lowest_available_checkpoint.max(lowest_available_checkpoint_objects))
+    /// The lowest checkpoint for which every kind of data (transactions, effects, events, and
+    /// input/output objects) is still available, i.e. the floor across both retention domains.
+    /// This is the value advertised in response headers and service info; reads that only need
+    /// one domain should use the corresponding store accessor instead.
+    pub fn get_lowest_available_checkpoint_combined(&self) -> Result<u64, crate::RpcError> {
+        let transactions = self.inner().get_lowest_available_checkpoint()?;
+        let objects = self.inner().get_lowest_available_checkpoint_objects()?;
+        Ok(transactions.max(objects))
     }
 }
 

--- a/crates/sui-rpc-api/src/response.rs
+++ b/crates/sui-rpc-api/src/response.rs
@@ -49,7 +49,8 @@ pub async fn append_info_headers(
         );
     }
 
-    if let Ok(lowest_available_checkpoint) = state.reader.get_lowest_available_checkpoint() {
+    if let Ok(lowest_available_checkpoint) = state.reader.get_lowest_available_checkpoint_combined()
+    {
         headers.insert(
             X_SUI_LOWEST_AVAILABLE_CHECKPOINT,
             lowest_available_checkpoint.into(),


### PR DESCRIPTION
## Description

Root cause of the `fuzz_dynamic_committee` simtest flake ("Transaction executed but checkpoint wait timed out", [CI failure](https://github.com/MystenLabs/sui/actions/runs/29061189525/job/86263843868)); replaces #27230, which retried the wait and could not have fixed this.

`GetTransaction` refuses to serve a transaction whose checkpoint is below the lowest-available watermark. Since #25397 that floor includes the object-pruning watermark (and on the embedded rpc-store path, the index floor the object pruner drags along with it — the object pruner prunes the rpc-store history cohort in lockstep). With default object pruning (`num_epochs_to_retain: 0`; in simtest the pruner runs every 2s), the floor trails the executed tip by only a couple of checkpoints — so a transaction checkpointed moments ago is reported `NotFound` while all of its data is still present.

This breaks the already-checkpointed fast path in the SDK's `execute_transaction_and_wait_for_checkpoint`: the fast path exists precisely for the case where the transaction's checkpoint streamed past before the client subscribed, and its spurious `NotFound` leaves the client scanning future checkpoints for a digest that will never appear — a guaranteed 30s timeout on a healthy, fully-caught-up node. Reproduced deterministically with `MSIM_TEST_SEED=1783726865041` / `...047`: the fatal lookup was rejected with `checkpoint 89 outside available range 91..=91`.

The fix keeps the two existing watermarks in their documented roles instead of maxing them together for every read: the transaction lookup is bounded by transaction/checkpoint retention (`ReadStore::get_lowest_available_checkpoint`, restored to that meaning on `RpcStoreReadStore`), and the object bound is checked where object contents are actually read (rendering `balance_changes`/`effects`, which also converts an internal fetch error into `NotFound` for `ListTransactions` on a pruned range). The rpc-store index floor already rides in `get_lowest_available_checkpoint_objects`, so the combined watermark served in response headers and used by checkpoint reads is unchanged. The `StateReader` wrapper method that computes that combined value is renamed to `get_lowest_available_checkpoint_combined` so it can no longer be mistaken for the store-level transaction floor of the same name.

## Test plan

Reproduced the flake deterministically with two seeds found via `seed-search.py` (`MSIM_TEST_SEED=1783726865041` and `1783726865047`, `cargo simtest fuzz_dynamic_committee -p sui-e2e-tests`); both fail on main at the exact CI panic site and pass with this change. Instrumented runs confirm the mechanism: on main the fatal `get_transaction` is rejected by the object-pruning floor (`89 outside 91..=91`), with the fix the transaction floor is checkpoint retention (0) and only benign upper-bound races remain (tx-to-checkpoint mapping momentarily ahead of latest-executed, which the checkpoint stream covers).

## Release notes

Check each box that your change affects. If none of the boxes relate to your changes, release notes are not required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] gRPC: `GetTransaction`/`BatchGetTransactions` no longer report a transaction as not found when only historic object versions below it have been pruned; the object-pruning floor now applies only to requests that render object contents (`balance_changes`/`effects`).
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
