### PR TITLE
Stop reading live_owned_object_markers table

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1663,11 +1663,6 @@ impl AuthorityState {
             .expect("must return correct number of effects")
     }
 
-    fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
-        self.get_object_cache_reader()
-            .check_owned_objects_are_live(owned_object_refs)
-    }
-
     /// This function captures the required state to debug a forked transaction.
     /// The dump is written to a file in dir `path`, with name prefixed by the transaction digest.
     /// NOTE: Since this info escapes the validator context,
@@ -1965,10 +1960,6 @@ impl AuthorityState {
             Err(e) => return ExecutionOutput::Fatal(e),
         };
 
-        let owned_object_refs = input_objects.inner().filter_owned_objects();
-        if let Err(e) = self.check_owned_locks(&owned_object_refs) {
-            return ExecutionOutput::Fatal(e);
-        }
         let tx_digest = *certificate.digest();
         let protocol_config = epoch_store.protocol_config();
         let transaction_data = &certificate.data().intent_message().value;

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -20,7 +20,7 @@ use move_core_types::resolver::{ModuleResolver, SerializedPackage};
 use serde::{Deserialize, Serialize};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_macros::fail_point_arg;
-use sui_types::error::{SuiErrorKind, UserInputError};
+use sui_types::error::SuiErrorKind;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::message_envelope::Message;
@@ -29,7 +29,7 @@ use sui_types::storage::{
     get_module, get_package,
 };
 use sui_types::sui_system_state::get_sui_system_state;
-use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure};
+use sui_types::{base_types::SequenceNumber, fp_ensure};
 use tokio::time::Instant;
 use tracing::{debug, info, trace};
 use typed_store::traits::Map;
@@ -674,7 +674,7 @@ impl AuthorityStore {
                     )?;
                     if !object.is_child_object() {
                         Self::initialize_live_object_markers(
-                            &perpetual_db.live_owned_object_markers,
+                            &perpetual_db.deprecated_live_owned_object_markers,
                             &mut batch,
                             &[object.compute_object_reference()],
                             true, // is_force_reset
@@ -856,94 +856,6 @@ impl AuthorityStore {
         Ok(())
     }
 
-    /// Gets ObjectLockInfo that represents state of lock on an object.
-    /// Returns UserInputError::ObjectNotFound if cannot find lock record for this object
-    pub(crate) fn get_lock(
-        &self,
-        obj_ref: ObjectRef,
-        epoch_store: &AuthorityPerEpochStore,
-    ) -> SuiLockResult {
-        if self
-            .perpetual_tables
-            .live_owned_object_markers
-            .get(&obj_ref)?
-            .is_none()
-        {
-            return Ok(ObjectLockStatus::LockedAtDifferentVersion {
-                locked_ref: self.get_latest_live_version_for_object_id(obj_ref.0)?,
-            });
-        }
-
-        let tables = epoch_store.tables()?;
-        let epoch_id = epoch_store.epoch();
-
-        if let Some(tx_digest) = tables.get_locked_transaction(&obj_ref)? {
-            Ok(ObjectLockStatus::LockedToTx {
-                locked_by_tx: LockDetailsDeprecated {
-                    epoch: epoch_id,
-                    tx_digest,
-                },
-            })
-        } else {
-            Ok(ObjectLockStatus::Initialized)
-        }
-    }
-
-    /// Returns UserInputError::ObjectNotFound if no lock records found for this object.
-    pub(crate) fn get_latest_live_version_for_object_id(
-        &self,
-        object_id: ObjectID,
-    ) -> SuiResult<ObjectRef> {
-        let mut iterator = self
-            .perpetual_tables
-            .live_owned_object_markers
-            .reversed_safe_iter_with_bounds(
-                None,
-                Some((object_id, SequenceNumber::MAX, ObjectDigest::MAX)),
-            )?;
-        Ok(iterator
-            .next()
-            .transpose()?
-            .and_then(|value| {
-                if value.0.0 == object_id {
-                    Some(value)
-                } else {
-                    None
-                }
-            })
-            .ok_or_else(|| {
-                SuiError::from(UserInputError::ObjectNotFound {
-                    object_id,
-                    version: None,
-                })
-            })?
-            .0)
-    }
-
-    /// Checks multiple object locks exist.
-    /// Returns UserInputError::ObjectNotFound if cannot find lock record for at least one of the objects.
-    /// Returns UserInputError::ObjectVersionUnavailableForConsumption if at least one object lock is not initialized
-    ///     at the given version.
-    pub fn check_owned_objects_are_live(&self, objects: &[ObjectRef]) -> SuiResult {
-        let locks = self
-            .perpetual_tables
-            .live_owned_object_markers
-            .multi_get(objects)?;
-        for (lock, obj_ref) in locks.into_iter().zip_debug_eq(objects) {
-            if lock.is_none() {
-                let latest_lock = self.get_latest_live_version_for_object_id(obj_ref.0)?;
-                fp_bail!(
-                    UserInputError::ObjectVersionUnavailableForConsumption {
-                        provided_obj_ref: *obj_ref,
-                        current_version: latest_lock.1
-                    }
-                    .into()
-                );
-            }
-        }
-        Ok(())
-    }
-
     /// Initialize a lock to None (but exists) for a given list of ObjectRefs.
     /// Returns SuiErrorKind::ObjectLockAlreadyInitialized if the lock already exists and is locked to a transaction
     fn initialize_live_object_markers_impl(
@@ -953,7 +865,7 @@ impl AuthorityStore {
         is_force_reset: bool,
     ) -> SuiResult {
         AuthorityStore::initialize_live_object_markers(
-            &self.perpetual_tables.live_owned_object_markers,
+            &self.perpetual_tables.deprecated_live_owned_object_markers,
             write_batch,
             objects,
             is_force_reset,
@@ -1007,7 +919,7 @@ impl AuthorityStore {
     ) -> SuiResult {
         trace!(?objects, "delete_locks");
         write_batch.delete_batch(
-            &self.perpetual_tables.live_owned_object_markers,
+            &self.perpetual_tables.deprecated_live_owned_object_markers,
             objects.iter(),
         )?;
         Ok(())

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -674,7 +674,7 @@ impl AuthorityStore {
                     )?;
                     if !object.is_child_object() {
                         Self::initialize_live_object_markers(
-                            &perpetual_db.deprecated_live_owned_object_markers,
+                            &perpetual_db.live_owned_object_markers,
                             &mut batch,
                             &[object.compute_object_reference()],
                             true, // is_force_reset
@@ -865,7 +865,7 @@ impl AuthorityStore {
         is_force_reset: bool,
     ) -> SuiResult {
         AuthorityStore::initialize_live_object_markers(
-            &self.perpetual_tables.deprecated_live_owned_object_markers,
+            &self.perpetual_tables.live_owned_object_markers,
             write_batch,
             objects,
             is_force_reset,
@@ -919,7 +919,7 @@ impl AuthorityStore {
     ) -> SuiResult {
         trace!(?objects, "delete_locks");
         write_batch.delete_batch(
-            &self.perpetual_tables.deprecated_live_owned_object_markers,
+            &self.perpetual_tables.live_owned_object_markers,
             objects.iter(),
         )?;
         Ok(())
@@ -1573,8 +1573,10 @@ impl ModuleResolver for ResolverWrapper {
     }
 }
 
+#[cfg(test)]
 pub type SuiLockResult = SuiResult<ObjectLockStatus>;
 
+#[cfg(test)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum ObjectLockStatus {
     Initialized,
@@ -1593,4 +1595,5 @@ pub struct LockDetailsV1Deprecated {
     pub tx_digest: TransactionDigest,
 }
 
+#[cfg(test)]
 pub type LockDetailsDeprecated = LockDetailsV1Deprecated;

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -73,12 +73,13 @@ pub struct AuthorityPerpetualTables {
     /// objects are still accessible!
     pub(crate) objects: DBMap<ObjectKey, StoreObjectWrapper>,
 
-    /// This is a map between object references of currently active objects that can be mutated.
-    ///
-    /// For old epochs, it may also contain the transaction that they are lock on for use by this
-    /// specific validator. The transaction locks themselves are now in AuthorityPerEpochStore.
+    /// DEPRECATED: markers of live address-owned object refs. Nothing reads this table
+    /// anymore; writes are still maintained so that rolling back to a previous binary
+    /// finds a correctly maintained table. The table (and its writes) will be removed
+    /// entirely in a follow-up once this version is deployed everywhere.
     #[rename = "owned_object_transaction_locks"]
-    pub(crate) live_owned_object_markers: DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
+    pub(crate) deprecated_live_owned_object_markers:
+        DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
 
     /// This is a map between the transaction digest and the corresponding transaction that's known to be
     /// executable. This means that it may have been executed locally, or it may have been synced through

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -78,8 +78,7 @@ pub struct AuthorityPerpetualTables {
     /// finds a correctly maintained table. The table (and its writes) will be removed
     /// entirely in a follow-up once this version is deployed everywhere.
     #[rename = "owned_object_transaction_locks"]
-    pub(crate) deprecated_live_owned_object_markers:
-        DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
+    pub(crate) live_owned_object_markers: DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
 
     /// This is a map between the transaction digest and the corresponding transaction that's known to be
     /// executable. This means that it may have been executed locally, or it may have been synced through

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -4,7 +4,9 @@
 use crate::accumulators::funds_read::AccountFundsRead;
 use crate::authority::AuthorityStore;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use crate::authority::authority_store::{ExecutionLockWriteGuard, SuiLockResult};
+use crate::authority::authority_store::ExecutionLockWriteGuard;
+#[cfg(test)]
+use crate::authority::authority_store::SuiLockResult;
 use crate::authority::backpressure::BackpressureManager;
 use crate::authority::epoch_start_configuration::EpochFlag;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
@@ -339,6 +341,8 @@ pub trait ObjectCacheRead: Send + Sync {
         version: SequenceNumber,
     ) -> Option<Object>;
 
+    /// Test-only: production code no longer reads owned-object lock status by ref.
+    #[cfg(test)]
     fn get_lock(&self, obj_ref: ObjectRef, epoch_store: &AuthorityPerEpochStore) -> SuiLockResult;
 
     // This method is considered "private" - only used by multi_get_objects_with_more_accurate_error_return

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -344,10 +344,6 @@ pub trait ObjectCacheRead: Send + Sync {
     // This method is considered "private" - only used by multi_get_objects_with_more_accurate_error_return
     fn _get_live_objref(&self, object_id: ObjectID) -> SuiResult<ObjectRef>;
 
-    // Check that the given set of objects are live at the given version. This is used as a
-    // safety check before execution, and could potentially be deleted or changed to a debug_assert
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> SuiResult;
-
     fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState>;
 
     fn get_bridge_object_unsafe(&self) -> SuiResult<Bridge>;

--- a/crates/sui-core/src/execution_cache/object_locks.rs
+++ b/crates/sui-core/src/execution_cache/object_locks.rs
@@ -3,8 +3,10 @@
 
 use mysten_common::ZipDebugEqIteratorExt;
 
+#[cfg(test)]
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_types::base_types::{ObjectID, ObjectRef};
+#[cfg(test)]
 use sui_types::digests::TransactionDigest;
 use sui_types::error::{SuiErrorKind, SuiResult, UserInputError};
 use sui_types::object::Object;
@@ -20,6 +22,7 @@ impl ObjectLocks {
         Self {}
     }
 
+    #[cfg(test)]
     pub(crate) fn get_transaction_lock(
         &self,
         obj_ref: &ObjectRef,

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -46,7 +46,7 @@ use crate::authority::authority_store::{
 use crate::authority::authority_store_tables::LiveObject;
 use crate::authority::backpressure::BackpressureManager;
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};
-use crate::fallback_fetch::{do_fallback_lookup, do_fallback_lookup_fallible};
+use crate::fallback_fetch::do_fallback_lookup;
 use crate::global_state_hasher::GlobalStateHashStore;
 use crate::transaction_outputs::TransactionOutputs;
 
@@ -784,21 +784,6 @@ impl WritebackCache {
                 CacheResult::Miss
             },
         )
-    }
-
-    fn get_object_by_id_cache_only(
-        &self,
-        request_type: &'static str,
-        object_id: &ObjectID,
-    ) -> CacheResult<(SequenceNumber, Object)> {
-        match self.get_object_entry_by_id_cache_only(request_type, object_id) {
-            CacheResult::Hit((version, entry)) => match entry {
-                ObjectEntry::Object(object) => CacheResult::Hit((version, object)),
-                ObjectEntry::Deleted | ObjectEntry::Wrapped => CacheResult::NegativeHit,
-            },
-            CacheResult::NegativeHit => CacheResult::NegativeHit,
-            CacheResult::Miss => CacheResult::Miss,
-        }
     }
 
     fn get_marker_value_cache_only(
@@ -1901,40 +1886,35 @@ impl ObjectCacheRead for WritebackCache {
 
     fn get_lock(&self, obj_ref: ObjectRef, epoch_store: &AuthorityPerEpochStore) -> SuiLockResult {
         let cur_epoch = epoch_store.epoch();
-        match self.get_object_by_id_cache_only("lock", &obj_ref.0) {
-            CacheResult::Hit((_, obj)) => {
-                let actual_objref = obj.compute_object_reference();
-                if obj_ref != actual_objref {
-                    Ok(ObjectLockStatus::LockedAtDifferentVersion {
-                        locked_ref: actual_objref,
-                    })
-                } else {
-                    // requested object ref is live, check if there is a lock
-                    Ok(
-                        match self
-                            .object_locks
-                            .get_transaction_lock(&obj_ref, epoch_store)?
-                        {
-                            Some(tx_digest) => ObjectLockStatus::LockedToTx {
-                                locked_by_tx: LockDetailsDeprecated {
-                                    epoch: cur_epoch,
-                                    tx_digest,
-                                },
-                            },
-                            None => ObjectLockStatus::Initialized,
+        let Some(obj) = self.get_object_impl("lock", &obj_ref.0) else {
+            return Err(SuiError::from(UserInputError::ObjectNotFound {
+                object_id: obj_ref.0,
+                // even though we know the requested version, we leave it as None to indicate
+                // that the object does not exist at any version
+                version: None,
+            }));
+        };
+        let actual_objref = obj.compute_object_reference();
+        if obj_ref != actual_objref {
+            Ok(ObjectLockStatus::LockedAtDifferentVersion {
+                locked_ref: actual_objref,
+            })
+        } else {
+            // requested object ref is live, check if there is a lock
+            Ok(
+                match self
+                    .object_locks
+                    .get_transaction_lock(&obj_ref, epoch_store)?
+                {
+                    Some(tx_digest) => ObjectLockStatus::LockedToTx {
+                        locked_by_tx: LockDetailsDeprecated {
+                            epoch: cur_epoch,
+                            tx_digest,
                         },
-                    )
-                }
-            }
-            CacheResult::NegativeHit => {
-                Err(SuiError::from(UserInputError::ObjectNotFound {
-                    object_id: obj_ref.0,
-                    // even though we know the requested version, we leave it as None to indicate
-                    // that the object does not exist at any version
-                    version: None,
-                }))
-            }
-            CacheResult::Miss => self.record_db_get("lock").get_lock(obj_ref, epoch_store),
+                    },
+                    None => ObjectLockStatus::Initialized,
+                },
+            )
         }
     }
 
@@ -1949,33 +1929,22 @@ impl ObjectCacheRead for WritebackCache {
     }
 
     fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
-        do_fallback_lookup_fallible(
-            owned_object_refs,
-            |obj_ref| match self.get_object_by_id_cache_only("object_is_live", &obj_ref.0) {
-                CacheResult::Hit((version, obj)) => {
-                    if obj.compute_object_reference() != *obj_ref {
-                        Err(UserInputError::ObjectVersionUnavailableForConsumption {
-                            provided_obj_ref: *obj_ref,
-                            current_version: version,
-                        }
-                        .into())
-                    } else {
-                        Ok(CacheResult::Hit(()))
-                    }
-                }
-                CacheResult::NegativeHit => Err(UserInputError::ObjectNotFound {
+        for obj_ref in owned_object_refs {
+            let Some(obj) = self.get_object_impl("object_is_live", &obj_ref.0) else {
+                return Err(UserInputError::ObjectNotFound {
                     object_id: obj_ref.0,
                     version: None,
                 }
-                .into()),
-                CacheResult::Miss => Ok(CacheResult::Miss),
-            },
-            |remaining| {
-                self.record_db_multi_get("object_is_live", remaining.len())
-                    .check_owned_objects_are_live(remaining)?;
-                Ok(vec![(); remaining.len()])
-            },
-        )?;
+                .into());
+            };
+            if obj.compute_object_reference() != *obj_ref {
+                return Err(UserInputError::ObjectVersionUnavailableForConsumption {
+                    provided_obj_ref: *obj_ref,
+                    current_version: obj.version(),
+                }
+                .into());
+            }
+        }
         Ok(())
     }
 

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -40,9 +40,9 @@
 use crate::accumulators::funds_read::AccountFundsRead;
 use crate::authority::AuthorityStore;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use crate::authority::authority_store::{
-    ExecutionLockWriteGuard, LockDetailsDeprecated, ObjectLockStatus, SuiLockResult,
-};
+use crate::authority::authority_store::ExecutionLockWriteGuard;
+#[cfg(test)]
+use crate::authority::authority_store::{LockDetailsDeprecated, ObjectLockStatus, SuiLockResult};
 use crate::authority::authority_store_tables::LiveObject;
 use crate::authority::backpressure::BackpressureManager;
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};
@@ -76,7 +76,9 @@ use sui_types::base_types::{
 use sui_types::bridge::{Bridge, get_bridge};
 use sui_types::digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
-use sui_types::error::{SuiError, SuiErrorKind, SuiResult, UserInputError};
+#[cfg(test)]
+use sui_types::error::SuiError;
+use sui_types::error::{SuiErrorKind, SuiResult, UserInputError};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::message_envelope::Message;
@@ -1884,6 +1886,7 @@ impl ObjectCacheRead for WritebackCache {
         }
     }
 
+    #[cfg(test)]
     fn get_lock(&self, obj_ref: ObjectRef, epoch_store: &AuthorityPerEpochStore) -> SuiLockResult {
         let cur_epoch = epoch_store.epoch();
         let Some(obj) = self.get_object_impl("lock", &obj_ref.0) else {

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -1928,26 +1928,6 @@ impl ObjectCacheRead for WritebackCache {
         Ok(obj.compute_object_reference())
     }
 
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
-        for obj_ref in owned_object_refs {
-            let Some(obj) = self.get_object_impl("object_is_live", &obj_ref.0) else {
-                return Err(UserInputError::ObjectNotFound {
-                    object_id: obj_ref.0,
-                    version: None,
-                }
-                .into());
-            };
-            if obj.compute_object_reference() != *obj_ref {
-                return Err(UserInputError::ObjectVersionUnavailableForConsumption {
-                    provided_obj_ref: *obj_ref,
-                    current_version: obj.version(),
-                }
-                .into());
-            }
-        }
-        Ok(())
-    }
-
     fn get_highest_pruned_checkpoint(&self) -> Option<CheckpointSequenceNumber> {
         self.store
             .perpetual_tables


### PR DESCRIPTION
## Description

Step 1 of a two-step removal of the `live_owned_object_markers` perpetual table (a legacy liveness index; see #27243 for the full context). This PR stops all reads — `check_owned_objects_are_live` and the test-only `get_lock` are reimplemented on the latest-object read path (`get_object_impl`), which answers exact-ref liveness from the objects table — while **keeping the writes**, so a rollback to a previous binary still finds a correctly maintained table. The field is renamed with a `deprecated_` prefix (the on-disk CF name is unchanged via `#[rename]`).

Step 2 (#27243) removes the writes and the table itself once this version is deployed everywhere.

## Test plan

Covered by existing `sui-core` tests; the writeback-cache and object-lock suites exercise both rewritten readers.

## Release notes

Check each box that your changes affect. If none apply, ignore this section. When releasing, delete unchecked boxes.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
