### PR TITLE
docs: add 6 developer tools to tooling page

### DIFF
--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -322,6 +322,13 @@ export const ToolGrid = ({ children }) => (
   website="https://www.playmove.dev/"
 />
 
+<ToolCard
+  name="Sui Devstack"
+  description="Boot a local Sui stack with Walrus, Seal, DeepBook, and faucets from a single TypeScript config. Publishes packages, funds accounts, and generates typed bindings."
+  install="pnpm create @mysten-incubation/devstack-app@latest my-app"
+  docs="https://ts-sdks-incubation.vercel.app/devstack"
+/>
+
 </ToolGrid>
 
 ## Writing Move
@@ -866,6 +873,20 @@ Block explorers and network monitoring dashboards.
   website="https://rpcs.polymedia.app/"
   community
 />
+
+<ToolCard
+  name="devxplorer"
+  description="Developer-focused explorer built on GraphQL. Works with local and custom RPCs, focusing on transactions, effects, objects, events, packages, and types."
+  website="https://devxplorer.io/"
+  community
+/>
+
+<ToolCard
+  name="Sui Data Stack Explorer"
+  description="AI-native explorer with smart routing across gRPC, GraphQL, and Archival Service. Includes a Pulse checkpoint feed and an object Time Machine for historical inspection."
+  github="https://github.com/abhinavg6/sui-data-stack-explorer"
+  community
+/>
 </ToolGrid>
 
 ## Oracles
@@ -921,6 +942,28 @@ Autonomous agents, verifiable inference, and TEE infrastructure.
   name="Eliza"
   description="Framework for building autonomous agents."
   github="https://github.com/elizaOS/eliza"
+  community
+/>
+
+<ToolCard
+  name="Sui Pilot"
+  description="Claude Code plugin that bundles Sui ecosystem docs, a Move LSP bridge, and formal verification tooling into a doc-first development agent."
+  github="https://github.com/alilloig/sui-pilot"
+  website="https://contract-hero.github.io/sui-pilot/"
+  community
+/>
+
+<ToolCard
+  name="Sui MCP Server"
+  description="Local MCP server exposing 29 agent-callable tools for querying Sui via gRPC, GraphQL, and Archival Service with automatic transport routing."
+  github="https://github.com/abhinavg6/sui-mcp-server"
+  community
+/>
+
+<ToolCard
+  name="Sui Docs MCP (Kapa)"
+  description="Hosted MCP server providing semantic search over Sui documentation for AI tools and agents like Claude Code, Cursor, and VS Code."
+  website="https://sui.mcp.kapa.ai/"
   community
 />
 

--- a/docs/content/getting-started/tooling.mdx
+++ b/docs/content/getting-started/tooling.mdx
@@ -954,14 +954,14 @@ Autonomous agents, verifiable inference, and TEE infrastructure.
 />
 
 <ToolCard
-  name="Sui MCP Server"
+  name="Local Sui MCP Server"
   description="Local MCP server exposing 29 agent-callable tools for querying Sui via gRPC, GraphQL, and Archival Service with automatic transport routing."
   github="https://github.com/abhinavg6/sui-mcp-server"
   community
 />
 
 <ToolCard
-  name="Sui Docs MCP (Kapa)"
+  name="Hosted Sui MCP Server (Kapa)"
   description="Hosted MCP server providing semantic search over Sui documentation for AI tools and agents like Claude Code, Cursor, and VS Code."
   website="https://sui.mcp.kapa.ai/"
   community


### PR DESCRIPTION
## Summary
- **Sui Devstack** (Fundamentals): local full-stack dev environment for Sui/Walrus/DeepBook/Seal from a single TypeScript config
- **devxplorer** (Explorers): developer-focused GraphQL explorer that works with local and custom RPCs
- **Sui Data Stack Explorer** (Explorers): AI-native explorer with smart routing across gRPC, GraphQL, and Archival Service, plus Pulse and Time Machine views
- **Sui Pilot** (AI): Claude Code plugin bundling Sui docs, Move LSP bridge, and formal verification
- **Sui MCP Server** (AI): local MCP server exposing 29 agent-callable tools for querying Sui's data stack
- **Sui Docs MCP / Kapa** (AI): hosted MCP server for semantic search over Sui documentation

## Test plan
- [ ] Verify the docs site builds without errors
- [ ] Check each tool card renders correctly with name, description, and links
- [ ] Confirm search/filter picks up all new entries
- [ ] Spot-check that all external links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)