### PR TITLE
[autodebug] test-cluster: stop re-executing final transactions through the fullnode RPC

### DIFF
--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -991,16 +991,15 @@ impl TestCluster {
     /// returns raw effects, events and extra objects returned by the validators,
     /// aggregated manually (without authority aggregator).
     /// It also does not check whether the transaction is executed successfully.
-    /// In order to keep the fullnode up-to-date so that latter queries can read consistent
-    /// results, it calls execute_transaction_may_fail again which goes through fullnode.
-    /// This is less efficient and verbose, but can be used if more details are needed
-    /// from the execution results, and if the transaction is expected to fail.
+    /// Before returning, it waits for the transaction to settle on the fullnode so that
+    /// subsequent queries there read consistent results.
     pub async fn execute_transaction_return_raw_effects(
         &self,
         tx: Transaction,
     ) -> anyhow::Result<(TransactionEffects, TransactionEvents)> {
-        let results = self.submit_and_execute(tx.clone(), None).await?;
-        self.wallet.execute_transaction_may_fail(tx).await.unwrap();
+        let digest = *tx.digest();
+        let results = self.submit_and_execute(tx, None).await?;
+        self.wait_for_tx_settlement(&[digest]).await;
         Ok(results)
     }
 


### PR DESCRIPTION
## Description

Fixes the flaky `fuzz_dynamic_committee` nightly simtest failures ("Transaction executed but checkpoint wait timed out", e.g. https://github.com/MystenLabs/sui/actions/runs/29241365738).

`execute_transaction_return_raw_effects()` finalizes the transaction through the validators and then re-executed it through the fullnode gRPC `execute_transaction_and_wait_for_checkpoint()` to keep fullnode reads consistent. For an already-checkpointed transaction that wait is racy: its checkpoint can stream past before the client subscribes, and the aggressive test-cluster pruner (`num_epochs_to_retain: 0`, running every 2s under msim) then defeats the `GetTransaction` fallback (observed: index had `tx -> checkpoint 41`, available range `[42, 43]`) and can also break response rendering ("missing input object key"). The wait can then only time out, panicking the test even though execution succeeded. Whether a run lands on the bad side of the race depends on scheduling, which is why the same seed passed or failed depending on machine load.

Replace the re-execution with `wait_for_tx_settlement`, which provides the guarantee callers rely on: the transaction's checkpoint is executed on the fullnode and the rpc index reflects it.

## Test plan

- Previously failing seeds 1783937060 (CI), 1783937080, and 1783937115 now pass; `scripts/simtest/seed-search.py` over 200 seeds at concurrency 48 passes 200/200.
- All 78 tests in the five e2e binaries that use this helper (`dynamic_committee_tests`, `shared_objects_tests`, `shared_objects_version_tests`, `transfer_to_object_tests`, `address_balance_tests`) pass under `cargo simtest`.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
