### PR TITLE
sui-core: reuse a per-epoch VM instance for transaction simulation

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2472,12 +2472,7 @@ impl AuthorityState {
             )?
         };
 
-        // TODO see if we can spin up a VM once and reuse it
-        let executor = sui_execution::executor(
-            protocol_config,
-            true, // silent
-        )
-        .expect("Creating an executor should not fail here");
+        let executor = epoch_store.simulate_executor();
 
         let (mut kind, signer, gas_data) = transaction.execution_parts();
         let rewritten_inputs = rewrite_transaction_for_coin_reservations(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -293,6 +293,12 @@ type ExecutionModuleCache = SyncModuleCache<ResolverWrapper>;
 // Data related to VM and Move execution and type layout
 pub struct ExecutionComponents {
     pub(crate) executor: Arc<dyn Executor + Send + Sync>,
+    /// A dedicated executor used for transaction simulation
+    /// (dry-run/dev-inspect). Simulation executes arbitrary, unvalidated
+    /// transactions, so it gets its own VM instance to keep its internal
+    /// state (e.g. package caches) isolated from the executor used for
+    /// committed transaction execution.
+    pub(crate) simulate_executor: Arc<dyn Executor + Send + Sync>,
     // TODO: use strategies (e.g. LRU?) to constraint memory usage
     pub(crate) module_cache: Arc<ExecutionModuleCache>,
     metrics: Arc<ResolverMetrics>,
@@ -1425,6 +1431,13 @@ impl AuthorityPerEpochStore {
 
     pub fn executor(&self) -> &Arc<dyn Executor + Send + Sync> {
         &self.execution_component.executor
+    }
+
+    /// The executor dedicated to transaction simulation
+    /// (dry-run/dev-inspect). It is refreshed together with the regular
+    /// executor at epoch boundaries.
+    pub fn simulate_executor(&self) -> &Arc<dyn Executor + Send + Sync> {
+        &self.execution_component.simulate_executor
     }
 
     pub fn set_local_execution_time_channels(
@@ -3390,6 +3403,8 @@ impl ExecutionComponents {
         let silent = true;
         let executor = sui_execution::executor(protocol_config, silent)
             .expect("Creating an executor should not fail here");
+        let simulate_executor = sui_execution::executor(protocol_config, silent)
+            .expect("Creating an executor should not fail here");
 
         let module_cache = Arc::new(SyncModuleCache::new(ResolverWrapper::new(
             store,
@@ -3397,6 +3412,7 @@ impl ExecutionComponents {
         )));
         Self {
             executor,
+            simulate_executor,
             module_cache,
             metrics,
         }


### PR DESCRIPTION
Previously, simulate_transaction created a brand new Move VM on every call. This was a workaround for issues with the old VM implementation that no longer apply.

With this commit, the per-epoch store now holds a dedicated simulate executor in ExecutionComponents, created alongside the normal execution VM and therefore refreshed at the same cadence, on epoch boundaries. All simulate calls (including the insufficient-object-funds retry) now reuse this instance. The simulate VM is kept separate from the normal execution VM so that simulating arbitrary, unvalidated transactions cannot pollute the internal VM state (e.g. package caches) of the executor used for committed transaction execution.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
