### PR TITLE
Do not floor transaction lookups at the object-pruning watermark

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -689,12 +689,13 @@ impl ReadStore for RpcStoreReadStore {
     }
 
     fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
-        // A consistent read needs both the raw chain data (perpetual
-        // store) and the index rows (rpc-store), so the available range
-        // starts at the higher of the two lower bounds.
-        let perpetual = self.rocks.get_lowest_available_checkpoint()?;
-        let rpc_store = self.reader.get_lowest_available_checkpoint()?;
-        Ok(perpetual.max(rpc_store))
+        // Every transaction and checkpoint read on this store is served from the raw chain
+        // stores, so only their retention bounds it. The rpc-store's index floor is pruned in
+        // lockstep with objects and is carried by `get_lowest_available_checkpoint_objects`;
+        // folding it in here would floor transaction lookups at the object-pruning watermark,
+        // which under aggressive object pruning (`num_epochs_to_retain: 0`) rides within a
+        // couple of checkpoints of the executed tip.
+        self.rocks.get_lowest_available_checkpoint()
     }
 
     fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
@@ -75,7 +75,7 @@ pub fn get_checkpoint(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint_combined()?;
 
     if !(lowest_available_checkpoint..=latest_checkpoint).contains(&sequence_number) {
         return Err(CheckpointNotFoundError::sequence_number(sequence_number).into());

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_service_info.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_service_info.rs
@@ -10,7 +10,7 @@ use sui_sdk_types::Digest;
 #[tracing::instrument(skip(service))]
 pub fn get_service_info(service: &RpcService) -> Result<GetServiceInfoResponse, RpcError> {
     let latest_checkpoint = service.reader.inner().get_latest_checkpoint()?;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint_combined()?;
 
     let mut message = GetServiceInfoResponse::default();
     message.chain_id = Some(Digest::new(service.chain_id().as_bytes().to_owned()).to_string());

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
@@ -73,7 +73,7 @@ pub fn get_transaction(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.inner().get_lowest_available_checkpoint()?;
 
     if !(lowest_available_checkpoint..=latest_checkpoint).contains(&transaction_checkpoint) {
         return Err(TransactionNotFoundError(transaction_digest).into());
@@ -122,7 +122,7 @@ pub fn batch_get_transactions(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = service.reader.inner().get_lowest_available_checkpoint()?;
 
     let transactions = digests
         .into_iter()
@@ -202,6 +202,17 @@ pub(crate) fn render_executed_transaction(
     let objects: ObjectSet = if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD)
         || mask.contains(ExecutedTransaction::EFFECTS_FIELD)
     {
+        // These fields render the transaction's input and output objects, which object pruning
+        // removes independently of transaction data.
+        if checkpoint
+            < service
+                .reader
+                .inner()
+                .get_lowest_available_checkpoint_objects()?
+        {
+            return Err(TransactionNotFoundError(digest).into());
+        }
+
         let mut objects = ObjectSet::default();
 
         let object_keys = sui_types::storage::get_transaction_object_set(

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
@@ -18,6 +18,7 @@ use sui_rpc::proto::sui::rpc::v2::GetTransactionRequest;
 use sui_rpc::proto::sui::rpc::v2::GetTransactionResponse;
 use sui_rpc::proto::sui::rpc::v2::GetTransactionResult;
 use sui_rpc::proto::sui::rpc::v2::Transaction;
+use sui_rpc::proto::sui::rpc::v2::TransactionEffects;
 use sui_rpc::proto::sui::rpc::v2::UserSignature;
 use sui_rpc::proto::timestamp_ms_to_proto;
 use sui_sdk_types::Digest;
@@ -26,6 +27,27 @@ use sui_types::full_checkpoint_content::ObjectSet;
 
 pub const MAX_BATCH_REQUESTS: usize = 200;
 pub const READ_MASK_DEFAULT: &str = crate::read_mask_defaults::TRANSACTION;
+
+fn read_mask_requires_objects(mask: &FieldMaskTree) -> bool {
+    mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD)
+        || mask
+            .subtree(ExecutedTransaction::EFFECTS_FIELD.name)
+            .is_some_and(|effects_mask| {
+                effects_mask.contains(TransactionEffects::CHANGED_OBJECTS_FIELD)
+                    || effects_mask.contains(TransactionEffects::UNCHANGED_CONSENSUS_OBJECTS_FIELD)
+            })
+}
+
+fn lowest_available_checkpoint_for_mask(
+    service: &RpcService,
+    mask: &FieldMaskTree,
+) -> Result<u64, RpcError> {
+    if read_mask_requires_objects(mask) {
+        service.reader.get_lowest_available_checkpoint_combined()
+    } else {
+        Ok(service.reader.inner().get_lowest_available_checkpoint()?)
+    }
+}
 
 #[tracing::instrument(skip(service))]
 pub fn get_transaction(
@@ -73,7 +95,7 @@ pub fn get_transaction(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.inner().get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = lowest_available_checkpoint_for_mask(service, &read_mask)?;
 
     if !(lowest_available_checkpoint..=latest_checkpoint).contains(&transaction_checkpoint) {
         return Err(TransactionNotFoundError(transaction_digest).into());
@@ -122,7 +144,7 @@ pub fn batch_get_transactions(
         .inner()
         .get_latest_checkpoint()?
         .sequence_number;
-    let lowest_available_checkpoint = service.reader.inner().get_lowest_available_checkpoint()?;
+    let lowest_available_checkpoint = lowest_available_checkpoint_for_mask(service, &read_mask)?;
 
     let transactions = digests
         .into_iter()
@@ -199,11 +221,9 @@ pub(crate) fn render_executed_transaction(
 
     let unchanged_loaded_runtime_objects = unchanged_loaded_runtime_objects.unwrap_or_default();
 
-    let objects: ObjectSet = if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD)
-        || mask.contains(ExecutedTransaction::EFFECTS_FIELD)
-    {
-        // These fields render the transaction's input and output objects, which object pruning
-        // removes independently of transaction data.
+    let objects: ObjectSet = if read_mask_requires_objects(mask) {
+        // These fields need historical object contents, which object pruning removes
+        // independently of transaction data.
         if checkpoint
             < service
                 .reader
@@ -279,4 +299,30 @@ pub(crate) fn render_executed_transaction(
     }
 
     Ok(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_dependent_read_masks_require_objects() {
+        for path in [
+            "balance_changes",
+            "effects",
+            "effects.changed_objects",
+            "effects.unchanged_consensus_objects",
+        ] {
+            let mask = FieldMaskTree::from(FieldMask::from_str(path));
+            assert!(read_mask_requires_objects(&mask), "{path}");
+        }
+    }
+
+    #[test]
+    fn object_independent_read_masks_do_not_require_objects() {
+        for path in ["digest", "effects.status", "effects.gas_used"] {
+            let mask = FieldMaskTree::from(FieldMask::from_str(path));
+            assert!(!read_mask_requires_objects(&mask), "{path}");
+        }
+    }
 }

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/ledger_read.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/ledger_read.rs
@@ -90,7 +90,7 @@ pub(super) fn checkpoint_to_tx_range(
 /// from `certified_checkpoints`, which is retained across pruning, so this resolves
 /// even at the floor.
 fn lowest_available_tx_seq(service: &RpcService) -> Result<u64, RpcError> {
-    let lowest_checkpoint = service.reader.get_lowest_available_checkpoint()?;
+    let lowest_checkpoint = service.reader.get_lowest_available_checkpoint_combined()?;
     checkpoint_to_tx_boundary(service, lowest_checkpoint)
 }
 

--- a/crates/sui-rpc-api/src/reader.rs
+++ b/crates/sui-rpc-api/src/reader.rs
@@ -240,17 +240,14 @@ impl StateReader {
             .map(|balance| balance as u64)
     }
 
-    // Return the lowest available checkpoint watermark for which the RPC service can return proper
-    // responses for.
-    pub fn get_lowest_available_checkpoint(&self) -> Result<u64, crate::RpcError> {
-        // This is the lowest lowest_available_checkpoint from the checkpoint store
-        let lowest_available_checkpoint = self.inner().get_lowest_available_checkpoint()?;
-        // This is the lowest lowest_available_checkpoint from the perpetual store
-        let lowest_available_checkpoint_objects =
-            self.inner().get_lowest_available_checkpoint_objects()?;
-
-        // Return the higher of the two for our lower watermark
-        Ok(lowest_available_checkpoint.max(lowest_available_checkpoint_objects))
+    /// The lowest checkpoint for which every kind of data (transactions, effects, events, and
+    /// input/output objects) is still available, i.e. the floor across both retention domains.
+    /// This is the value advertised in response headers and service info; reads that only need
+    /// one domain should use the corresponding store accessor instead.
+    pub fn get_lowest_available_checkpoint_combined(&self) -> Result<u64, crate::RpcError> {
+        let transactions = self.inner().get_lowest_available_checkpoint()?;
+        let objects = self.inner().get_lowest_available_checkpoint_objects()?;
+        Ok(transactions.max(objects))
     }
 }
 

--- a/crates/sui-rpc-api/src/response.rs
+++ b/crates/sui-rpc-api/src/response.rs
@@ -49,7 +49,8 @@ pub async fn append_info_headers(
         );
     }
 
-    if let Ok(lowest_available_checkpoint) = state.reader.get_lowest_available_checkpoint() {
+    if let Ok(lowest_available_checkpoint) = state.reader.get_lowest_available_checkpoint_combined()
+    {
         headers.insert(
             X_SUI_LOWEST_AVAILABLE_CHECKPOINT,
             lowest_available_checkpoint.into(),


### PR DESCRIPTION
## Description

Slight tweak to <https://github.com/MystenLabs/sui/pull/27248> to tighten up the logic on when to require clamping to object pruning floor.
