### PR TITLE
[Stress] disable duplicate/amplified traffic by default

### DIFF
--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -258,13 +258,17 @@ pub enum RunSpec {
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [5])]
         in_flight_ratio: Vec<u64>,
         // Probability that a logical transaction is submitted to multiple validators.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_PROBABILITY])]
+        // Defaults to 0.0, which disables amplification; pass the recommended
+        // SubmissionAmplification::DEFAULT_AMPLIFICATION_PROBABILITY to enable it.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
         amplification_probability: Vec<f64>,
         // Number of validators to submit to when amplification_probability triggers.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX])]
         amplification_validators_per_tx: Vec<usize>,
         // Probability that each selected validator receives multiple copies.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_PROBABILITY])]
+        // Defaults to 0.0, which disables duplication; pass the recommended
+        // SubmissionAmplification::DEFAULT_DUPLICATE_PROBABILITY to enable it.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
         duplicate_probability: Vec<f64>,
         // Number of copies sent to each selected validator when duplicate_probability triggers.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_COPIES_PER_VALIDATOR])]

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -27,7 +27,7 @@ mod test {
     };
     use sui_benchmark::{
         FullNodeProxy, LocalValidatorAggregatorProxy, ValidatorProxy,
-        drivers::{Interval, SubmissionAmplification, bench_driver::BenchDriver, driver::Driver},
+        drivers::{Interval, bench_driver::BenchDriver, driver::Driver},
         util::get_ed25519_keypair_from_keystore,
     };
     use sui_config::ExecutionCacheConfig;
@@ -1289,20 +1289,16 @@ mod test {
         )
         .await;
 
-        // Duplicate/amplified validator submissions are only supported by the
-        // LocalValidatorAggregatorProxy, which is used when remote_env is false.
-        let submission_amplification_by_group = if config.remote_env {
-            BTreeMap::new()
-        } else {
-            BTreeMap::from([(0, SubmissionAmplification::default_enabled())])
-        };
-
+        // Duplicate/amplified validator submissions are disabled by default. To
+        // exercise them, pass a per-group SubmissionAmplification::default_enabled()
+        // here (only the LocalValidatorAggregatorProxy used when remote_env is false
+        // supports the direct validator submission path).
         let workloads = WorkloadConfiguration::build(
             workloads_builders,
             bank,
             system_state_observer.clone(),
             gas_request_chunk_size,
-            submission_amplification_by_group,
+            BTreeMap::new(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Description

Alternative to reverting #27127: keep the duplicate/amplified submission machinery but make it off by default. The `stress` CLI amplification/duplicate probabilities now default to `0.0`, and the simtest no longer enables amplification for group 0. Opt in via `--amplification-probability` / `--duplicate-probability` (recommended values remain on `SubmissionAmplification`).

## Test plan

Covered by existing `sui-benchmark` tests.

## Release notes

Check each box that your changes affect. If none of the boxes relate to
your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
