### PR TITLE
[Stress] disable duplicate/amplified submissions by default

### DIFF
--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -52,8 +52,7 @@ impl Default for SubmissionAmplification {
 }
 
 impl SubmissionAmplification {
-    // Default values shared between the stress CLI options and simtests, so both
-    // exercise the same duplicate/amplified submission behavior out of the box.
+    // Default values for the enabled configuration returned by `default_enabled()`.
     pub const DEFAULT_AMPLIFICATION_PROBABILITY: f64 = 0.05;
     pub const DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX: usize = 3;
     pub const DEFAULT_DUPLICATE_PROBABILITY: f64 = 0.02;

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -258,13 +258,15 @@ pub enum RunSpec {
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [5])]
         in_flight_ratio: Vec<u64>,
         // Probability that a logical transaction is submitted to multiple validators.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_PROBABILITY])]
+        // Defaults to zero, so amplified traffic must be explicitly enabled.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
         amplification_probability: Vec<f64>,
         // Number of validators to submit to when amplification_probability triggers.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX])]
         amplification_validators_per_tx: Vec<usize>,
         // Probability that each selected validator receives multiple copies.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_PROBABILITY])]
+        // Defaults to zero, so duplicate traffic must be explicitly enabled.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
         duplicate_probability: Vec<f64>,
         // Number of copies sent to each selected validator when duplicate_probability triggers.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_COPIES_PER_VALIDATOR])]


### PR DESCRIPTION
## Description 

#27127 defaulted `--amplification-probability` to 0.05 and `--duplicate-probability` to 0.02, so every stress bench run sends duplicate/amplified validator traffic without opting in, and `--use-fullnode-for-execution` fails at startup unless the probabilities are explicitly zeroed.

Default both probabilities to zero so this traffic is opt-in. The per-trigger counts keep their defaults, so enabling only requires setting the probability flags. Simtests still opt in explicitly via `SubmissionAmplification::default_enabled()`.

## Test plan 

Covered by existing tests; simtests continue to exercise the enabled path via `default_enabled()`.
