### PR TITLE
[Stress] disable duplicate/amplified submissions by default in bench CLI

### DIFF
--- a/crates/sui-benchmark/src/drivers/mod.rs
+++ b/crates/sui-benchmark/src/drivers/mod.rs
@@ -52,8 +52,10 @@ impl Default for SubmissionAmplification {
 }
 
 impl SubmissionAmplification {
-    // Default values shared between the stress CLI options and simtests, so both
-    // exercise the same duplicate/amplified submission behavior out of the box.
+    // Default values used when duplicate/amplified submissions are explicitly enabled
+    // (e.g. via `default_enabled()` in simtests). The stress CLI defaults to disabled
+    // (zero probabilities), since amplification requires local validator execution and
+    // deployments like Antithesis run stress with `--use-fullnode-for-execution true`.
     pub const DEFAULT_AMPLIFICATION_PROBABILITY: f64 = 0.05;
     pub const DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX: usize = 3;
     pub const DEFAULT_DUPLICATE_PROBABILITY: f64 = 0.02;

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -258,13 +258,17 @@ pub enum RunSpec {
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [5])]
         in_flight_ratio: Vec<u64>,
         // Probability that a logical transaction is submitted to multiple validators.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_PROBABILITY])]
+        // Disabled by default: duplicate/amplified submissions require local validator
+        // execution, and deployments like Antithesis run stress with
+        // --use-fullnode-for-execution true, which is incompatible and fails at startup.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
         amplification_probability: Vec<f64>,
         // Number of validators to submit to when amplification_probability triggers.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_AMPLIFICATION_VALIDATORS_PER_TX])]
         amplification_validators_per_tx: Vec<usize>,
         // Probability that each selected validator receives multiple copies.
-        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_PROBABILITY])]
+        // Disabled by default, see amplification_probability above.
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0.0])]
         duplicate_probability: Vec<f64>,
         // Number of copies sent to each selected validator when duplicate_probability triggers.
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [SubmissionAmplification::DEFAULT_DUPLICATE_COPIES_PER_VALIDATOR])]


### PR DESCRIPTION
## Description 

#27127 enabled submission amplification by default in the stress `bench` CLI (amplification probability 0.05, duplicate probability 0.02). Amplification requires local validator execution, but Antithesis runs stress with `--use-fullnode-for-execution true` (`docker/stress/entrypoint.sh`), so workload configuration bails at startup and the stress container crash-loops without generating any traffic. This is why nearly all reachability assertions have gone unseen in Antithesis reports since the merge (confirmed by a green run with #27127 reverted: https://mysten-labs.slack.com/archives/C07KB2X10TU/p1783966658688209).

Default both probabilities to 0.0 so the feature is opt-in. Simtests are unaffected — they enable it explicitly via `SubmissionAmplification::default_enabled()` and use the local validator proxy, so coverage of duplicate/amplified traffic is retained there.

## Test plan 

Covered by existing tests; `test_simulated_load_basic` continues to exercise amplification via `default_enabled()`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:


---
_Generated by [Claude Code](https://claude.ai/code/session_01TRaYtB9qt2LqEe38eu6UNK)_