### PR TITLE
[move-compiler] Fix macro syntax identifiers not being able to start expressions

### DIFF
--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -2500,6 +2500,7 @@ fn at_start_of_exp(context: &mut Context) -> bool {
             | Tok::StringValue
             | Tok::Identifier
             | Tok::RestrictedIdentifier
+            | Tok::SyntaxIdentifier
             | Tok::AtSign
             | Tok::Copy
             | Tok::Move

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/macro_ident_start_of_exp.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/macro_ident_start_of_exp.move
@@ -1,0 +1,25 @@
+module 0x8675309::M {
+    // A macro identifier expression should be recognized as the start of an
+    // expression following `return`, `break`, and `abort`.
+    macro fun r($v: u64): u64 {
+        if ($v > 0) return $v;
+        0
+    }
+
+    macro fun b($v: u64): u64 {
+        loop {
+            if ($v > 0) break $v
+        }
+    }
+
+    macro fun a($v: u64): u64 {
+        if ($v > 0) abort $v;
+        0
+    }
+
+    fun t() {
+        r!(1);
+        b!(1);
+        a!(1);
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/macro_ident_start_of_exp.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/macro_ident_start_of_exp.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+


### PR DESCRIPTION
## Description 

- Syntax identifiers could not start expressions, and as such could not be placed after a return/abort/break. 

## Test plan 

- New tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
