### PR TITLE
[move-stackless-bytecode-2] Preserve call-site type arguments in RValue::Call

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/structuring/term_reconstruction.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/term_reconstruction.rs
@@ -35,7 +35,12 @@ pub fn exp(
             }
             SI::AssignReg {
                 lhs,
-                rhs: RValue::Call { target, args },
+                rhs:
+                    RValue::Call {
+                        target,
+                        type_arguments: _,
+                        args,
+                    },
             } => {
                 let args = trivials(&mut map, args);
                 let call = Out::Exp::Call((Out::ModuleRef::Qualified(target.0), target.1), args);

--- a/external-crates/move/crates/move-stackless-bytecode-2/src/ast.rs
+++ b/external-crates/move/crates/move-stackless-bytecode-2/src/ast.rs
@@ -3,7 +3,9 @@
 
 use crate::utils::comma_separated;
 
-use move_binary_format::normalized::{Constant, FieldRef, ModuleId, StructRef, Type, VariantRef};
+use move_binary_format::normalized::{
+    Constant, FieldRef, ModuleId, Signature, StructRef, Type, VariantRef,
+};
 use move_core_types::{account_address::AccountAddress, runtime_value::MoveValue};
 use move_symbol_pool::Symbol;
 
@@ -89,6 +91,7 @@ pub struct Register {
 pub enum RValue {
     Call {
         target: (ModuleId<Symbol>, Symbol),
+        type_arguments: Signature<Symbol>,
         args: Vec<Trivial>,
     },
     Primitive {
@@ -325,8 +328,16 @@ impl std::fmt::Display for LocalOp {
 impl std::fmt::Display for RValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RValue::Call { target, args } => {
-                write!(f, "Call {}::{}(", target.0, target.1)?;
+            RValue::Call {
+                target,
+                type_arguments,
+                args,
+            } => {
+                write!(f, "Call {}::{}", target.0, target.1)?;
+                if !type_arguments.is_empty() {
+                    write!(f, "<{}>", comma_separated(type_arguments))?;
+                }
+                write!(f, "(")?;
                 write!(f, "{}", comma_separated(args))?;
                 write!(f, ")")
             }

--- a/external-crates/move/crates/move-stackless-bytecode-2/src/optimizations/inline_immediates.rs
+++ b/external-crates/move/crates/move-stackless-bytecode-2/src/optimizations/inline_immediates.rs
@@ -128,7 +128,11 @@ fn rvalue(env: &mut Env, rv: &mut RValue) {
         }
         RValue::Primitive { op: _, args }
         | RValue::Data { op: _, args }
-        | RValue::Call { target: _, args } => {
+        | RValue::Call {
+            target: _,
+            type_arguments: _,
+            args,
+        } => {
             for arg in args {
                 if let Trivial::Register(reg) = arg
                     && let Some(imm) = env.immediates.remove(&reg.name)

--- a/external-crates/move/crates/move-stackless-bytecode-2/src/translate.rs
+++ b/external-crates/move/crates/move-stackless-bytecode-2/src/translate.rs
@@ -415,7 +415,11 @@ pub(crate) fn bytecode<K: SourceKind>(
             let target = (function_ref.module, function_ref.function);
             Instruction::AssignReg {
                 lhs,
-                rhs: RValue::Call { target, args },
+                rhs: RValue::Call {
+                    target,
+                    type_arguments: function_ref.type_arguments.clone(),
+                    args,
+                },
             }
         }
 

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@no_opt.sbir.snap
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@no_opt.sbir.snap
@@ -1,0 +1,21 @@
+---
+source: crates/move-stackless-bytecode-2/tests/from_source.rs
+---
+  Module: generic_call
+    Function: do_it (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : u64 = Call 0x0::generic_call::phantom_ty<bool>()
+        reg_1 : u64 = Call 0x0::generic_call::id<u64>(reg_0 : u64)
+        Return(reg_1 : u64)
+
+
+    Function: id (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : T0 = Move(lcl_0)
+        Return(reg_0 : T0)
+
+
+    Function: phantom_ty (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : u64 = Immediate(42u64)
+        Return(reg_0 : u64)

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@no_opt.sbir.snap
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@no_opt.sbir.snap
@@ -9,6 +9,18 @@ source: crates/move-stackless-bytecode-2/tests/from_source.rs
         Return(reg_1 : u64)
 
 
+    Function: do_more (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : u64 = Call 0x0::generic_call::phantom_ty<vector<vector<u64>>>()
+        reg_1 : u64 = Call 0x0::generic_call::phantom_ty<0x0::generic_call::Wrapper<vector<bool>>>()
+        reg_2 : u64 = Add(reg_0 : u64, reg_1 : u64)
+        reg_3 : u64 = Call 0x0::generic_call::phantom_ty2<bool, 0x0::generic_call::Wrapper<u64>>()
+        reg_4 : u64 = Add(reg_2 : u64, reg_3 : u64)
+        reg_5 : u64 = Call 0x0::generic_call::phantom_ty<0x0::generic_call::Either<u64, address>>()
+        reg_6 : u64 = Add(reg_4 : u64, reg_5 : u64)
+        Return(reg_6 : u64)
+
+
     Function: id (entry: LBL_0)
       Label LBL_0:
         reg_0 : T0 = Move(lcl_0)
@@ -18,4 +30,10 @@ source: crates/move-stackless-bytecode-2/tests/from_source.rs
     Function: phantom_ty (entry: LBL_0)
       Label LBL_0:
         reg_0 : u64 = Immediate(42u64)
+        Return(reg_0 : u64)
+
+
+    Function: phantom_ty2 (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : u64 = Immediate(43u64)
         Return(reg_0 : u64)

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@opt.sbir.snap
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@opt.sbir.snap
@@ -1,0 +1,20 @@
+---
+source: crates/move-stackless-bytecode-2/tests/from_source.rs
+---
+  Module: generic_call
+    Function: do_it (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : u64 = Call 0x0::generic_call::phantom_ty<bool>()
+        reg_1 : u64 = Call 0x0::generic_call::id<u64>(reg_0 : u64)
+        Return(reg_1 : u64)
+
+
+    Function: id (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : T0 = Move(lcl_0)
+        Return(reg_0 : T0)
+
+
+    Function: phantom_ty (entry: LBL_0)
+      Label LBL_0:
+        Return(Immediate(42u64))

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@opt.sbir.snap
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/basics_generic_call@opt.sbir.snap
@@ -9,6 +9,18 @@ source: crates/move-stackless-bytecode-2/tests/from_source.rs
         Return(reg_1 : u64)
 
 
+    Function: do_more (entry: LBL_0)
+      Label LBL_0:
+        reg_0 : u64 = Call 0x0::generic_call::phantom_ty<vector<vector<u64>>>()
+        reg_1 : u64 = Call 0x0::generic_call::phantom_ty<0x0::generic_call::Wrapper<vector<bool>>>()
+        reg_2 : u64 = Add(reg_0 : u64, reg_1 : u64)
+        reg_3 : u64 = Call 0x0::generic_call::phantom_ty2<bool, 0x0::generic_call::Wrapper<u64>>()
+        reg_4 : u64 = Add(reg_2 : u64, reg_3 : u64)
+        reg_5 : u64 = Call 0x0::generic_call::phantom_ty<0x0::generic_call::Either<u64, address>>()
+        reg_6 : u64 = Add(reg_4 : u64, reg_5 : u64)
+        Return(reg_6 : u64)
+
+
     Function: id (entry: LBL_0)
       Label LBL_0:
         reg_0 : T0 = Move(lcl_0)
@@ -18,3 +30,8 @@ source: crates/move-stackless-bytecode-2/tests/from_source.rs
     Function: phantom_ty (entry: LBL_0)
       Label LBL_0:
         Return(Immediate(42u64))
+
+
+    Function: phantom_ty2 (entry: LBL_0)
+      Label LBL_0:
+        Return(Immediate(43u64))

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/from_source.txt
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/from_source.txt
@@ -1,3 +1,4 @@
 call
+generic_call
 pack
 unpack

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/sources/generic_call.move
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/sources/generic_call.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module basics::generic_call {
+    fun id<T: drop>(x: T): T { x }
+
+    // Type parameter appears in neither the arguments nor the return type, so
+    // the call-site instantiation cannot be reconstructed from register types.
+    fun phantom_ty<T>(): u64 { 42 }
+
+    public fun do_it(): u64 { id<u64>(phantom_ty<bool>()) }
+}

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/sources/generic_call.move
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/basics/sources/generic_call.move
@@ -2,11 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module basics::generic_call {
+    // Only used as call-site type arguments, never constructed.
+    public struct Wrapper<phantom T> has drop {}
+    public enum Either<phantom T, phantom U> has drop { Nothing }
+
     fun id<T: drop>(x: T): T { x }
 
-    // Type parameter appears in neither the arguments nor the return type, so
+    // Type parameters appear in neither the arguments nor the return type, so
     // the call-site instantiation cannot be reconstructed from register types.
     fun phantom_ty<T>(): u64 { 42 }
+    fun phantom_ty2<T, U>(): u64 { 43 }
 
     public fun do_it(): u64 { id<u64>(phantom_ty<bool>()) }
+
+    public fun do_more(): u64 {
+        phantom_ty<vector<vector<u64>>>()
+            + phantom_ty<Wrapper<vector<bool>>>()
+            + phantom_ty2<bool, Wrapper<u64>>()
+            + phantom_ty<Either<u64, address>>()
+    }
 }


### PR DESCRIPTION
## Description

`translate.rs` reads `function_ref.type_arguments` in the `Call` arm but only uses them to type the result registers, then drops them. The instantiation cannot be reconstructed from the AST — a type parameter may appear in neither the arguments nor the returns — and every other generic operation already carries its instantiation. Carry it on `RValue::Call` (one `Rc` clone) so AST consumers such as AOT compilers can monomorphize call sites.

This is the last blocker for migrating off the deprecated `move-stackless-bytecode` crate (see discussion with @cgswords in #27188), whose enum-`match` lowering panic no longer exists in this crate.

Closes #27186

## Test plan

New `generic_call` snapshot test covers the unrecoverable case: `fun phantom_ty<T>(): u64` called as `phantom_ty<bool>()`, where the type argument appears in neither argument nor return types.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
