### PR TITLE
ignore .omp/ agent dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 **/.claude/*
 !**/.claude/skills/
 **/.opencode/
+**/.omp/*
 
 # OSX
 .DS_Store


### PR DESCRIPTION
## Description

Ignoring omp's local repo directory, similar to other agent ignores.
