### PR TITLE
jsonrpc-alt: split staking reward calculation over multiple PTBs

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
@@ -14,15 +14,31 @@ use sui_indexer_alt_jsonrpc::NodeArgs as JsonRpcNodeArgs;
 use sui_swarm_config::genesis_config::AccountConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_test_transaction_builder::make_staking_transaction;
+use sui_types::SUI_SYSTEM_PACKAGE_ID;
 use sui_types::base_types::ObjectID;
+use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SuiAddress;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
+use sui_types::gas_coin::MIST_PER_SUI;
+use sui_types::governance::ADD_STAKE_FUN_NAME;
 use sui_types::object::Owner;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
+use sui_types::transaction::Argument;
+use sui_types::transaction::CallArg;
+use sui_types::transaction::Command;
+use sui_types::transaction::ObjectArg;
+use sui_types::transaction::TransactionData;
 use sui_types::transaction::TransactionDataAPI;
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
 use url::Url;
+
+// SplitCoins requires fewer than 512 amount arguments.
+const MAX_STAKES_PER_SPLIT: usize = 500;
+const STAKES_PER_CREATION_TX: usize = 580;
+const TEST_GAS_BUDGET: u64 = 50_000_000_000;
 
 struct FnDelegationTestCluster {
     onchain_cluster: TestCluster,
@@ -178,6 +194,67 @@ fn stake_id_projection(result: &Value) -> Vec<(String, Vec<String>)> {
         .collect()
 }
 
+async fn create_many_stakes(
+    cluster: &TestCluster,
+    stake_coin: ObjectRef,
+    validator: SuiAddress,
+    mut count: usize,
+) {
+    let wallet = &cluster.wallet;
+    let gas_price = wallet.get_reference_gas_price().await.unwrap();
+    let accounts_and_objs = wallet.get_all_accounts_and_gas_objects().await.unwrap();
+
+    let (sender, gas_objects) = &accounts_and_objs[0];
+    let gas_object = gas_objects
+        .iter()
+        .copied()
+        .find(|object| object.0 != stake_coin.0)
+        .expect("missing gas object distinct from stake coin");
+
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let system = ptb.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+    let stake_coin = ptb.obj(ObjectArg::ImmOrOwnedObject(stake_coin)).unwrap();
+    let validator = ptb.pure(validator).unwrap();
+    let stake_amount = ptb.pure(MIST_PER_SUI).unwrap();
+
+    while count > 0 {
+        let chunk_size = count.min(MAX_STAKES_PER_SPLIT);
+        let Argument::Result(split_command) = ptb.command(Command::SplitCoins(
+            stake_coin,
+            vec![stake_amount; chunk_size],
+        )) else {
+            unreachable!("SplitCoins should return a command result")
+        };
+
+        for result in 0..chunk_size {
+            ptb.programmable_move_call(
+                SUI_SYSTEM_PACKAGE_ID,
+                SUI_SYSTEM_MODULE_NAME.to_owned(),
+                ADD_STAKE_FUN_NAME.to_owned(),
+                vec![],
+                vec![
+                    system,
+                    Argument::NestedResult(split_command, result as u16),
+                    validator,
+                ],
+            );
+        }
+
+        count -= chunk_size;
+    }
+
+    let transaction_data = TransactionData::new_programmable(
+        *sender,
+        vec![gas_object],
+        ptb.finish(),
+        TEST_GAS_BUDGET,
+        gas_price,
+    );
+
+    let transaction = wallet.sign_transaction(&transaction_data).await;
+    wallet.execute_transaction_must_succeed(transaction).await;
+}
+
 #[tokio::test]
 async fn test_get_stakes_and_by_ids() {
     let test_cluster = FnDelegationTestCluster::new()
@@ -226,6 +303,52 @@ async fn test_get_stakes_and_by_ids() {
 
     // Two responses should match.
     assert_eq!(get_stakes_response, get_stakes_by_ids_response);
+}
+
+#[tokio::test]
+async fn test_get_stakes_batches_reward_calculation() {
+    let test_cluster = FnDelegationTestCluster::new()
+        .await
+        .expect("Failed to create test cluster");
+
+    let validator = test_cluster.get_validator_address().await;
+    let accounts_and_objs = test_cluster
+        .onchain_cluster
+        .wallet
+        .get_all_accounts_and_gas_objects()
+        .await
+        .unwrap();
+
+    let stake_owner = accounts_and_objs[0].0;
+    let stake_coins = [accounts_and_objs[0].1[1], accounts_and_objs[0].1[2]];
+    for stake_coin in stake_coins {
+        create_many_stakes(
+            &test_cluster.onchain_cluster,
+            stake_coin,
+            validator,
+            STAKES_PER_CREATION_TX,
+        )
+        .await;
+    }
+
+    test_cluster.wait_for_indexing().await;
+
+    let response = test_cluster
+        .execute_jsonrpc(
+            "suix_getStakes".to_string(),
+            json!({ "owner": stake_owner }),
+        )
+        .await
+        .unwrap();
+
+    assert!(response["error"].is_null(), "request failed: {response}");
+    let stake_count = response["result"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|delegation| delegation["stakes"].as_array().unwrap().len())
+        .sum::<usize>();
+    assert_eq!(stake_count, STAKES_PER_CREATION_TX * stake_coins.len());
 }
 
 #[tokio::test]

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -4,6 +4,7 @@
 use anyhow::Context;
 use anyhow::anyhow;
 use async_graphql::dataloader::DataLoader;
+use futures::future::try_join_all;
 use prometheus::Registry;
 use prost_types::FieldMask;
 use sui_rpc::field::FieldMaskUtil;
@@ -21,6 +22,10 @@ use url::Url;
 
 use crate::metrics::GrpcMetricsLayer;
 use crate::metrics::GrpcMetricsService;
+
+// Programmable transaction validation requires the command count to be strictly less than the
+// protocol's 1,024-command limit.
+const MAX_REWARDS_PER_PTB: usize = 1023;
 
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct FullnodeArgs {
@@ -159,66 +164,14 @@ impl FullnodeClient {
             .map_err(Into::into)
     }
 
-    /// Construct and dry run a PTB to calculate the rewards for a list of staked SUI objects.
+    /// Construct and dry run PTBs to calculate the rewards for a list of staked SUI objects.
     /// Returns a list of u64 guaranteed to match the order of the input staked SUI ids.
     pub async fn calculate_rewards(&self, staked_sui_ids: &[Address]) -> Result<Vec<u64>, Error> {
-        let mut ptb = proto::ProgrammableTransaction::default()
-            .with_inputs(vec![proto::Input::default().with_object_id("0x5")]);
-        let system_object = proto::Argument::new_input(0);
+        let batches = staked_sui_ids
+            .chunks(MAX_REWARDS_PER_PTB)
+            .map(|batch| self.calculate_rewards_batch(batch));
 
-        for id in staked_sui_ids {
-            let staked_sui = proto::Argument::new_input(ptb.inputs.len() as u16);
-            ptb.inputs.push(proto::Input::default().with_object_id(id));
-            ptb.commands.push(
-                proto::MoveCall::default()
-                    .with_package("0x3")
-                    .with_module("sui_system")
-                    .with_function("calculate_rewards")
-                    .with_arguments(vec![system_object, staked_sui])
-                    .into(),
-            );
-        }
-
-        let transaction = proto::Transaction::default()
-            .with_kind(ptb)
-            .with_sender("0x0");
-
-        let resp = self
-            .simulate_transaction(
-                transaction,
-                false,
-                false,
-                FieldMask::from_paths([
-                    "command_outputs.return_values.value",
-                    "transaction.effects.status",
-                ]),
-            )
-            .await?;
-
-        if !resp.transaction().effects().status().success() {
-            return Err(Error::Internal(anyhow!("transaction execution failed")));
-        }
-
-        if staked_sui_ids.len() != resp.command_outputs.len() {
-            return Err(Error::Internal(anyhow!(
-                "missing transaction command_outputs"
-            )));
-        }
-
-        resp.command_outputs
-            .iter()
-            .map(|output| {
-                // At success, expect every command to guarantee a u64 returned
-                let bcs_rewards = output
-                    .return_values
-                    .first()
-                    .and_then(|o| o.value_opt())
-                    .ok_or_else(|| Error::Internal(anyhow!("missing rewards bcs")))?;
-
-                bcs::from_bytes::<u64>(bcs_rewards.value())
-                    .map_err(|e| Error::Internal(anyhow!("Failed to deserialize rewards: {e}")))
-            })
-            .collect()
+        Ok(try_join_all(batches).await?.into_iter().flatten().collect())
     }
 
     /// Construct and dry run a PTB to get the corresponding validator addresses for a list of
@@ -285,6 +238,66 @@ impl FullnodeClient {
 
                 Address::from_bytes(bcs_address.value())
                     .map_err(|e| Error::Internal(anyhow!("Failed to deserialize address: {e}")))
+            })
+            .collect()
+    }
+
+    async fn calculate_rewards_batch(&self, staked_sui_ids: &[Address]) -> Result<Vec<u64>, Error> {
+        let mut ptb = proto::ProgrammableTransaction::default()
+            .with_inputs(vec![proto::Input::default().with_object_id("0x5")]);
+        let system_object = proto::Argument::new_input(0);
+
+        for id in staked_sui_ids {
+            let staked_sui = proto::Argument::new_input(ptb.inputs.len() as u16);
+            ptb.inputs.push(proto::Input::default().with_object_id(id));
+            ptb.commands.push(
+                proto::MoveCall::default()
+                    .with_package("0x3")
+                    .with_module("sui_system")
+                    .with_function("calculate_rewards")
+                    .with_arguments(vec![system_object, staked_sui])
+                    .into(),
+            );
+        }
+
+        let transaction = proto::Transaction::default()
+            .with_kind(ptb)
+            .with_sender("0x0");
+
+        let resp = self
+            .simulate_transaction(
+                transaction,
+                false,
+                false,
+                FieldMask::from_paths([
+                    "command_outputs.return_values.value",
+                    "transaction.effects.status",
+                ]),
+            )
+            .await?;
+
+        if !resp.transaction().effects().status().success() {
+            return Err(Error::Internal(anyhow!("transaction execution failed")));
+        }
+
+        if staked_sui_ids.len() != resp.command_outputs.len() {
+            return Err(Error::Internal(anyhow!(
+                "missing transaction command_outputs"
+            )));
+        }
+
+        resp.command_outputs
+            .iter()
+            .map(|output| {
+                // At success, expect every command to guarantee a u64 returned
+                let bcs_rewards = output
+                    .return_values
+                    .first()
+                    .and_then(|o| o.value_opt())
+                    .ok_or_else(|| Error::Internal(anyhow!("missing rewards bcs")))?;
+
+                bcs::from_bytes::<u64>(bcs_rewards.value())
+                    .map_err(|e| Error::Internal(anyhow!("Failed to deserialize rewards: {e}")))
             })
             .collect()
     }


### PR DESCRIPTION
## Description

JSONRPC-alt implements `suix_getStakes` via a call to `simulateTransaction`, with a MoveCall for each coin we need to calculate rewards for. This could be a problem if there are more than 1023 coins, since the transaction will be too large to simulate.

This change splits coins over multiple PTBs.

## Test plan

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests \
  --tests jsonrpc_fn_delegation_tests            \
  -- test_get_stakes_batches_reward_calculation
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
