### PR TITLE
Disallow init functions in system packages when building

### DIFF
--- a/crates/sui-framework/tests/build-system-packages.rs
+++ b/crates/sui-framework/tests/build-system-packages.rs
@@ -329,6 +329,13 @@ fn serialize_modules_to_file<'a>(
                 Visibility::Friend => "public(package) ",
                 Visibility::Private => "",
             };
+
+            // Disallow init functions in system packages
+            if def.visibility == Visibility::Private && fn_.as_str() == "init" {
+                anyhow::bail!(
+                    "Module {module_name} has a private init function. This is not allowed in system pacakges."
+                );
+            }
             let entry = if def.is_entry { "entry " } else { "" };
             members.push(format!("{fn_}\n\t{viz}{entry}fun\n\t{module_name}"));
         }


### PR DESCRIPTION
## Description 

Check when building system packages that there aren't any init functions (for now, but hopefully soon we can support this).

## Test plan 

CI + local testing

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
