### PR TITLE
[cli] Rework gas selection in the CLI

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -128,6 +128,18 @@ pub(crate) static USER_AGENT: &str =
 /// Only to be used within CLI
 pub const GAS_SAFE_OVERHEAD: u64 = 1000;
 
+/// The protocol limits that bound how many coins a single transaction can drain.
+struct CoinLimits {
+    /// Maximum number of objects a gas payment may contain.
+    max_gas_payment_objects: usize,
+    /// Maximum number of arguments a single command may take. A command's target does not count
+    /// towards this, and the limit is exclusive.
+    max_arguments: usize,
+    /// Maximum number of object inputs a transaction may have. The gas payment does not count
+    /// towards this.
+    max_input_objects: usize,
+}
+
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
 pub enum SuiClientCommands {
@@ -3420,18 +3432,6 @@ pub async fn max_gas_budget(client: &Client) -> Result<u64, anyhow::Error> {
             ),
         },
     )
-}
-
-/// The protocol limits that bound how many coins a single transaction can drain.
-struct CoinLimits {
-    /// Maximum number of objects a gas payment may contain.
-    max_gas_payment_objects: usize,
-    /// Maximum number of arguments a single command may take. A command's target does not count
-    /// towards this, and the limit is exclusive.
-    max_arguments: usize,
-    /// Maximum number of object inputs a transaction may have. The gas payment does not count
-    /// towards this.
-    max_input_objects: usize,
 }
 
 /// Queries the protocol config for the limits that bound how many coins fit in one transaction.

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1369,13 +1369,6 @@ impl SuiClientCommands {
 
                 let is_sui = coin_type_tag == sui_type_tag;
 
-                let TypeTag::Struct(coin_struct_tag) = &coin_type_tag else {
-                    bail!("coin type must be a struct type, got {coin_type_tag}");
-                };
-                let balance_info = client.get_balance(signer, coin_struct_tag).await?;
-                let coin_balance = balance_info.coin_balance();
-                let address_balance = balance_info.address_balance();
-
                 if all_coins {
                     return send_all_coins(
                         context,
@@ -1387,6 +1380,13 @@ impl SuiClientCommands {
                     )
                     .await;
                 }
+
+                let TypeTag::Struct(coin_struct_tag) = &coin_type_tag else {
+                    bail!("coin type must be a struct type, got {coin_type_tag}");
+                };
+                let balance_info = client.get_balance(signer, coin_struct_tag).await?;
+                let coin_balance = balance_info.coin_balance();
+                let address_balance = balance_info.address_balance();
 
                 let (amount, use_address_balance) = if let Some(amount) = amount {
                     let use_address_balance = if stateless {
@@ -3437,28 +3437,6 @@ async fn max_gas_payment_objects(client: &Client) -> Result<usize, anyhow::Error
         })
 }
 
-/// Every `Coin<T>` object owned by `owner`, paired with its value.
-async fn owned_coins(
-    client: &Client,
-    owner: SuiAddress,
-    coin_type_tag: &TypeTag,
-) -> Result<Vec<(ObjectRef, u64)>, anyhow::Error> {
-    let objects: Vec<Object> = client
-        .list_owned_objects(owner, Some(Coin::type_(coin_type_tag.clone())))
-        .try_collect()
-        .await?;
-
-    objects
-        .iter()
-        .map(|object| {
-            let coin = object
-                .as_coin_maybe()
-                .ok_or_else(|| anyhow!("Object {} is not a Coin<{coin_type_tag}>", object.id()))?;
-            Ok((object.compute_object_reference(), coin.value()))
-        })
-        .collect()
-}
-
 /// Send every `Coin<T>` object owned by `signer` to `recipient`'s address balance. The signer's
 /// own address balance is left untouched: only their coin objects are drained.
 async fn send_all_coins(
@@ -3471,108 +3449,57 @@ async fn send_all_coins(
 ) -> Result<SuiClientCommandResult, anyhow::Error> {
     let client = context.grpc_client()?;
     let sui_type_tag = TypeTag::from_str(SUI_COIN_TYPE).expect("SUI_COIN_TYPE should be valid");
-    let is_sui = coin_type_tag == sui_type_tag;
+    ensure!(
+        coin_type_tag == sui_type_tag,
+        "--all-coins is only supported for SUI. Use --amount with --stateless to send another \
+         coin type from your address balance."
+    );
+    // The coins being sent are also what pays for gas, which a sponsor's gas coin cannot do: it is
+    // the sponsor's money that would end up with the recipient.
+    ensure!(
+        gas_data.gas_sponsor.is_none(),
+        "--all-coins cannot be used with a gas sponsor, because the coins being sent are the ones \
+         paying for gas."
+    );
 
-    let mut coins = owned_coins(&client, signer, &coin_type_tag).await?;
+    let coins: Vec<Object> = client
+        .list_owned_objects(signer, Some(Coin::type_(coin_type_tag.clone())))
+        .try_collect()
+        .await?;
     ensure!(!coins.is_empty(), "No coins available to send");
 
-    if is_sui {
-        // The whole (smashed) gas coin is handed to the recipient. Everything the signer owns has
-        // to fit in a single gas payment, so if they hold more coins than that, drain as many as
-        // will fit and let them run the command again for the rest.
-        let max_payment = max_gas_payment_objects(&client).await?;
-        if coins.len() > max_payment {
-            let remaining = coins.len() - max_payment;
-            coins.truncate(max_payment);
-            eprintln!(
-                "Warning: a gas payment holds at most {max_payment} coins, so {remaining} of your \
-                 coins will not be sent. Run the command again to send the rest."
-            );
-        }
+    let mut coin_refs: Vec<ObjectRef> =
+        coins.iter().map(|c| c.compute_object_reference()).collect();
 
-        let coin_refs: Vec<ObjectRef> = coins.iter().map(|(obj_ref, _)| *obj_ref).collect();
-        let coin_total: u64 = coins.iter().map(|(_, value)| value).sum();
-
-        // Moving the gas coin into `coin::send_funds` by value is understood by the execution
-        // layer: the gas coin is consumed and the unused gas budget is refunded into the
-        // recipient's address balance rather than left behind in a coin.
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let recipient_arg = builder.pure(recipient)?;
-        builder.programmable_move_call(
-            SUI_FRAMEWORK_PACKAGE_ID,
-            Identifier::from_str("coin")?,
-            Identifier::from_str("send_funds")?,
-            vec![coin_type_tag.clone()],
-            vec![Argument::GasCoin, recipient_arg],
+    // Every coin has to fit in a single gas payment, so when the signer holds more than that, drain
+    // as many as will fit and let them run the command again for the rest.
+    let max_payment = max_gas_payment_objects(&client).await?;
+    if coin_refs.len() > max_payment {
+        let remaining = coin_refs.len() - max_payment;
+        coin_refs.truncate(max_payment);
+        eprintln!(
+            "Warning: a gas payment holds at most {max_payment} coins, so {remaining} of your \
+             coins will not be sent. Run the command again to send the rest."
         );
-        let tx_kind = TransactionKind::programmable(builder.finish());
-
-        let gas_price = match gas_data.gas_price {
-            Some(gas_price) => gas_price,
-            None => context.get_reference_gas_price().await?,
-        };
-        let gas_budget = match gas_data.gas_budget {
-            Some(gas_budget) => gas_budget,
-            None => {
-                estimate_gas_budget(
-                    context,
-                    signer,
-                    tx_kind.clone(),
-                    gas_price,
-                    vec![],
-                    gas_data.gas_sponsor,
-                )
-                .await?
-            }
-        };
-
-        // The coins pay for gas themselves, so they have to cover the budget. When they can't,
-        // fall through to the shape below, which keeps the gas coin out of the transaction and so
-        // lets the fullnode pay for gas from the signer's address balance instead. A sponsored
-        // transaction also takes that shape: there the gas coin belongs to the sponsor, and it is
-        // the signer's coins we are sending.
-        if coin_total >= gas_budget && gas_data.gas_sponsor.is_none() {
-            return dry_run_or_execute_or_serialize(
-                signer,
-                tx_kind,
-                context,
-                coin_refs,
-                GasDataArgs {
-                    gas_budget: Some(gas_budget),
-                    gas_price: Some(gas_price),
-                    gas_sponsor: gas_data.gas_sponsor,
-                },
-                processing,
-            )
-            .await;
-        }
     }
 
-    // Take the coins as inputs, merge them, and send the merged coin. This never touches the gas
-    // coin, so the fullnode funds gas from the signer's address balance (or, for a non-SUI coin
-    // type, from their SUI coins).
+    // Hand the whole (smashed) gas coin to the recipient. Moving the gas coin into
+    // `coin::send_funds` by value is understood by the execution layer: it consumes the gas coin
+    // and refunds the unused gas budget into the recipient's address balance, so no dust is left
+    // behind. Passing the coins as an explicit gas payment also keeps the fullnode from performing
+    // gas selection, which would otherwise pull in the signer's address balance as well.
     let mut builder = ProgrammableTransactionBuilder::new();
-    let coin_args = coins
-        .iter()
-        .map(|(obj_ref, _)| builder.obj(ObjectArg::ImmOrOwnedObject(*obj_ref)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let (merged, rest) = coin_args
-        .split_first()
-        .expect("coins is non-empty, so there is at least one argument");
-    if !rest.is_empty() {
-        builder.command(Command::MergeCoins(*merged, rest.to_vec()));
-    }
     let recipient_arg = builder.pure(recipient)?;
     builder.programmable_move_call(
         SUI_FRAMEWORK_PACKAGE_ID,
         Identifier::from_str("coin")?,
         Identifier::from_str("send_funds")?,
         vec![coin_type_tag],
-        vec![*merged, recipient_arg],
+        vec![Argument::GasCoin, recipient_arg],
     );
     let tx_kind = TransactionKind::programmable(builder.finish());
 
-    dry_run_or_execute_or_serialize(signer, tx_kind, context, vec![], gas_data, processing).await
+    dry_run_or_execute_or_serialize(signer, tx_kind, context, coin_refs, gas_data, processing).await
 }
 
 /// Ask the fullnode to pick the gas payment for a transaction, and return it along with the
@@ -3614,7 +3541,7 @@ async fn select_gas_with_fullnode(
     Ok((
         gas_data.payment.clone(),
         gas_data.budget,
-        resolved.expiration().clone(),
+        *resolved.expiration(),
     ))
 }
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -3422,21 +3422,54 @@ pub async fn max_gas_budget(client: &Client) -> Result<u64, anyhow::Error> {
     )
 }
 
-/// Queries the protocol config for the maximum number of objects a gas payment may contain.
-async fn max_gas_payment_objects(client: &Client) -> Result<usize, anyhow::Error> {
+/// The protocol limits that bound how many coins a single transaction can drain.
+struct CoinLimits {
+    /// Maximum number of objects a gas payment may contain.
+    max_gas_payment_objects: usize,
+    /// Maximum number of arguments a single command may take. A command's target does not count
+    /// towards this, and the limit is exclusive.
+    max_arguments: usize,
+    /// Maximum number of object inputs a transaction may have. The gas payment does not count
+    /// towards this.
+    max_input_objects: usize,
+}
+
+/// Queries the protocol config for the limits that bound how many coins fit in one transaction.
+async fn coin_limits(client: &Client) -> Result<CoinLimits, anyhow::Error> {
     let cfg = client.get_protocol_config(None).await?;
-    cfg.attributes()
-        .get("max_gas_payment_objects")
-        .and_then(|s| s.parse::<usize>().ok())
-        .ok_or_else(|| {
-            anyhow!(
-                "Could not find the maximum number of gas payment objects in the protocol config."
-            )
-        })
+    let attributes = cfg.attributes();
+    let limit = |name: &str| -> Result<usize, anyhow::Error> {
+        attributes
+            .get(name)
+            .and_then(|s| s.parse().ok())
+            .with_context(|| format!("Could not find {name} in the protocol config."))
+    };
+
+    Ok(CoinLimits {
+        max_gas_payment_objects: limit("max_gas_payment_objects")?,
+        max_arguments: limit("max_arguments")?,
+        max_input_objects: limit("max_input_objects")?,
+    })
+}
+
+/// Warn about, and drop, any coins past what one transaction can hold.
+fn truncate_to_max_coins(coin_refs: &mut Vec<ObjectRef>, max_coins: usize) {
+    if coin_refs.len() > max_coins {
+        let remaining = coin_refs.len() - max_coins;
+        coin_refs.truncate(max_coins);
+        eprintln!(
+            "Warning: a transaction sends at most {max_coins} coins, so {remaining} of your coins \
+             will not be sent. Run the command again to send the rest."
+        );
+    }
 }
 
 /// Send every `Coin<T>` object owned by `signer` to `recipient`'s address balance. The signer's
 /// own address balance is left untouched: only their coin objects are drained.
+///
+/// Every coin is merged into one, which is then sent by value. SUI is what pays for gas, so its
+/// coins go into the gas payment, where gas smashing merges them into the gas coin for nothing;
+/// coins of any other type are ordinary inputs, merged into the first of them.
 async fn send_all_coins(
     context: &mut WalletContext,
     signer: SuiAddress,
@@ -3446,53 +3479,76 @@ async fn send_all_coins(
     processing: TxProcessingArgs,
 ) -> Result<SuiClientCommandResult, anyhow::Error> {
     let client = context.grpc_client()?;
+
+    // For SUI the coins being sent are also what pays for gas, which a sponsor's gas coin cannot do:
+    // it is the sponsor's amount that would end up with the recipient.
+    let is_sui = coin_type_tag == GAS::type_tag();
     ensure!(
-        coin_type_tag == GAS::type_tag(),
-        "--all-coins is only supported for SUI. Use --amount with --stateless to send another \
-         coin type from your address balance."
-    );
-    // The coins being sent are also what pays for gas, which a sponsor's gas coin cannot do: it is
-    // the sponsor's money that would end up with the recipient.
-    ensure!(
-        gas_data.gas_sponsor.is_none(),
-        "--all-coins cannot be used with a gas sponsor, because the coins being sent are the ones \
-         paying for gas."
+        !is_sui || gas_data.gas_sponsor.is_none(),
+        "--all-coins cannot be used with a gas sponsor for SUI coin type, because the coins being \
+         sent are the ones paying for gas."
     );
 
     let coins: Vec<Object> = client
-        .list_owned_objects(signer, Some(GasCoin::type_()))
+        .list_owned_objects(signer, Some(Coin::type_(coin_type_tag.clone())))
         .try_collect()
         .await?;
-    ensure!(!coins.is_empty(), "No coins available to send");
+    ensure!(
+        !coins.is_empty(),
+        "No {coin_type_tag} coins available to send"
+    );
 
     let mut coin_refs: Vec<ObjectRef> =
         coins.iter().map(|c| c.compute_object_reference()).collect();
 
-    // Every coin has to fit in a single gas payment, so when the signer holds more than that, drain
-    // as many as will fit and let them run the command again for the rest.
-    let max_payment = max_gas_payment_objects(&client).await?;
-    if coin_refs.len() > max_payment {
-        let remaining = coin_refs.len() - max_payment;
-        coin_refs.truncate(max_payment);
-        eprintln!(
-            "Warning: a gas payment holds at most {max_payment} coins, so {remaining} of your \
-             coins will not be sent. Run the command again to send the rest."
-        );
+    // Coins that do not fit in the gas payment are merged in by a single `MergeCoins`, so they are
+    // bounded by the per-command argument limit, and each is also a transaction input. For SUI they
+    // are all merge sources; otherwise the first is the merge target, which is not an argument.
+    let limits = coin_limits(&client).await?;
+    let smashed = if is_sui {
+        limits.max_gas_payment_objects
+    } else {
+        0
+    };
+    let max_merged = std::cmp::min(
+        limits.max_arguments - if is_sui { 1 } else { 0 },
+        limits.max_input_objects,
+    );
+    truncate_to_max_coins(&mut coin_refs, smashed + max_merged);
+
+    // Whatever is left in `coin_refs` is the gas payment, which is empty unless the coin is SUI.
+    let merged_refs = coin_refs.split_off(std::cmp::min(coin_refs.len(), smashed));
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let mut merged_args = merged_refs
+        .iter()
+        .map(|r| builder.obj(ObjectArg::ImmOrOwnedObject(*r)))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Gas smashing has already merged the gas payment into the gas coin, so that is what the rest
+    // merge into; without one, the first coin takes the role. `MergeCoins` only borrows its target,
+    // so either way it is still ours to send afterwards.
+    let target = if is_sui {
+        Argument::GasCoin
+    } else {
+        merged_args.remove(0)
+    };
+    if !merged_args.is_empty() {
+        builder.command(Command::MergeCoins(target, merged_args));
     }
 
-    // Hand the whole (smashed) gas coin to the recipient. Moving the gas coin into
-    // `coin::send_funds` by value is understood by the execution layer: it consumes the gas coin
-    // and refunds the unused gas budget into the recipient's address balance, so no dust is left
-    // behind. Passing the coins as an explicit gas payment also keeps the fullnode from performing
-    // gas selection, which would otherwise pull in the signer's address balance as well.
-    let mut builder = ProgrammableTransactionBuilder::new();
+    // Moving the coin into `coin::send_funds` by value is understood by the execution layer: when
+    // it is the gas coin, that consumes it and refunds the unused gas budget into the recipient's
+    // address balance, so no dust is left behind. Passing the SUI coins as an explicit gas payment
+    // also keeps the fullnode from performing gas selection, which would otherwise pull in the
+    // signer's address balance as well.
     let recipient_arg = builder.pure(recipient)?;
     builder.programmable_move_call(
         SUI_FRAMEWORK_PACKAGE_ID,
         Identifier::from_str("coin")?,
         Identifier::from_str("send_funds")?,
         vec![coin_type_tag],
-        vec![Argument::GasCoin, recipient_arg],
+        vec![target, recipient_arg],
     );
     let tx_kind = TransactionKind::programmable(builder.finish());
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -3469,8 +3469,8 @@ fn truncate_to_max_coins(coin_refs: &mut Vec<ObjectRef>, max_coins: usize) {
 /// own address balance is left untouched: only their coin objects are drained.
 ///
 /// Every coin is merged into one, which is then sent by value. SUI is what pays for gas, so its
-/// coins go into the gas payment, where gas smashing merges them into the gas coin for nothing;
-/// coins of any other type are ordinary inputs, merged into the first of them.
+/// coins go into the gas payment, where gas smashing merges them into the gas coin.
+/// Coins of any other type are ordinary inputs, merged into the last of them.
 async fn send_all_coins(
     context: &mut WalletContext,
     signer: SuiAddress,
@@ -3502,20 +3502,17 @@ async fn send_all_coins(
     let mut coin_refs: Vec<ObjectRef> =
         coins.iter().map(|c| c.compute_object_reference()).collect();
 
-    // Coins that do not fit in the gas payment are merged in by a single `MergeCoins`, so they are
-    // bounded by the per-command argument limit, and each is also a transaction input. For SUI they
-    // are all merge sources; otherwise the first is the merge target, which is not an argument.
+    // Coins that do not fit in the gas payment are merged in with `MergeCoins`. Each such coin is a
+    // transaction input, so the merged set is bounded by the input-object limit; the sources are
+    // split across as many `MergeCoins` commands as it takes to stay under the per-command argument
+    // limit. Gas payment coins are validated separately and do not count against the input limit.
     let limits = coin_limits(&client).await?;
     let smashed = if is_sui {
         limits.max_gas_payment_objects
     } else {
         0
     };
-    let max_merged = limits
-        .max_arguments
-        .saturating_sub(is_sui as usize)
-        .min(limits.max_input_objects);
-    truncate_to_max_coins(&mut coin_refs, smashed + max_merged);
+    truncate_to_max_coins(&mut coin_refs, smashed + limits.max_input_objects);
 
     // Whatever is left in `coin_refs` is the gas payment, which is empty unless the coin is SUI.
     let merged_refs = coin_refs.split_off(std::cmp::min(coin_refs.len(), smashed));
@@ -3527,15 +3524,22 @@ async fn send_all_coins(
         .collect::<Result<Vec<_>, _>>()?;
 
     // Gas smashing has already merged the gas payment into the gas coin, so that is what the rest
-    // merge into; without one, the first coin takes the role. `MergeCoins` only borrows its target,
+    // merge into; without one, the last coin takes the role. `MergeCoins` only borrows its target,
     // so either way it is still ours to send afterwards.
     let target = if is_sui {
         Argument::GasCoin
     } else {
-        merged_args.remove(0)
+        merged_args
+            .pop()
+            .context("non-SUI path always has at least one coin to merge into")?
     };
-    if !merged_args.is_empty() {
-        builder.command(Command::MergeCoins(target, merged_args));
+
+    // `MergeCoins` counts only its source list against `max_arguments` (strict `<`), so at most
+    // `max_arguments - 1` sources fit per command; batch the rest across commands, all merging into
+    // the same target.
+    let max_sources = limits.max_arguments.saturating_sub(1).max(1);
+    for sources in merged_args.chunks(max_sources) {
+        builder.command(Command::MergeCoins(target, sources.to_vec()));
     }
 
     // Moving the coin into `coin::send_funds` by value is understood by the execution layer: when

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -89,7 +89,7 @@ use sui_types::{
     signature::GenericSignature,
     sui_sdk_types_conversions::type_tag_sdk_to_core,
     transaction::{
-        Argument, Command, FundsWithdrawalArg, GasData, InputObjectKind, ObjectArg,
+        Argument, Command, FundsWithdrawalArg, GasData, ObjectArg,
         SenderSignedData, SharedObjectMutability, Transaction, TransactionData, TransactionDataAPI,
         TransactionExpiration, TransactionKind,
     },
@@ -1376,11 +1376,19 @@ impl SuiClientCommands {
                 let coin_balance = balance_info.coin_balance();
                 let address_balance = balance_info.address_balance();
 
-                let (amount, use_address_balance) = if all_coins {
-                    // --all-coins uses all coin balance (cannot be combined with --stateless)
-                    ensure!(coin_balance > 0, "No coins available to send");
-                    (coin_balance, false)
-                } else if let Some(amount) = amount {
+                if all_coins {
+                    return send_all_coins(
+                        context,
+                        signer,
+                        recipient,
+                        coin_type_tag,
+                        gas_data,
+                        processing,
+                    )
+                    .await;
+                }
+
+                let (amount, use_address_balance) = if let Some(amount) = amount {
                     let use_address_balance = if stateless {
                         true
                     } else if coin_balance >= amount {
@@ -3416,6 +3424,200 @@ pub async fn max_gas_budget(client: &Client) -> Result<u64, anyhow::Error> {
     )
 }
 
+/// Queries the protocol config for the maximum number of objects a gas payment may contain.
+async fn max_gas_payment_objects(client: &Client) -> Result<usize, anyhow::Error> {
+    let cfg = client.get_protocol_config(None).await?;
+    cfg.attributes()
+        .get("max_gas_payment_objects")
+        .and_then(|s| s.parse::<usize>().ok())
+        .ok_or_else(|| {
+            anyhow!(
+                "Could not find the maximum number of gas payment objects in the protocol config."
+            )
+        })
+}
+
+/// Every `Coin<T>` object owned by `owner`, paired with its value.
+async fn owned_coins(
+    client: &Client,
+    owner: SuiAddress,
+    coin_type_tag: &TypeTag,
+) -> Result<Vec<(ObjectRef, u64)>, anyhow::Error> {
+    let objects: Vec<Object> = client
+        .list_owned_objects(owner, Some(Coin::type_(coin_type_tag.clone())))
+        .try_collect()
+        .await?;
+
+    objects
+        .iter()
+        .map(|object| {
+            let coin = object
+                .as_coin_maybe()
+                .ok_or_else(|| anyhow!("Object {} is not a Coin<{coin_type_tag}>", object.id()))?;
+            Ok((object.compute_object_reference(), coin.value()))
+        })
+        .collect()
+}
+
+/// Send every `Coin<T>` object owned by `signer` to `recipient`'s address balance. The signer's
+/// own address balance is left untouched: only their coin objects are drained.
+async fn send_all_coins(
+    context: &mut WalletContext,
+    signer: SuiAddress,
+    recipient: SuiAddress,
+    coin_type_tag: TypeTag,
+    gas_data: GasDataArgs,
+    processing: TxProcessingArgs,
+) -> Result<SuiClientCommandResult, anyhow::Error> {
+    let client = context.grpc_client()?;
+    let sui_type_tag = TypeTag::from_str(SUI_COIN_TYPE).expect("SUI_COIN_TYPE should be valid");
+    let is_sui = coin_type_tag == sui_type_tag;
+
+    let mut coins = owned_coins(&client, signer, &coin_type_tag).await?;
+    ensure!(!coins.is_empty(), "No coins available to send");
+
+    if is_sui {
+        // The whole (smashed) gas coin is handed to the recipient. Everything the signer owns has
+        // to fit in a single gas payment, so if they hold more coins than that, drain as many as
+        // will fit and let them run the command again for the rest.
+        let max_payment = max_gas_payment_objects(&client).await?;
+        if coins.len() > max_payment {
+            let remaining = coins.len() - max_payment;
+            coins.truncate(max_payment);
+            eprintln!(
+                "Warning: a gas payment holds at most {max_payment} coins, so {remaining} of your \
+                 coins will not be sent. Run the command again to send the rest."
+            );
+        }
+
+        let coin_refs: Vec<ObjectRef> = coins.iter().map(|(obj_ref, _)| *obj_ref).collect();
+        let coin_total: u64 = coins.iter().map(|(_, value)| value).sum();
+
+        // Moving the gas coin into `coin::send_funds` by value is understood by the execution
+        // layer: the gas coin is consumed and the unused gas budget is refunded into the
+        // recipient's address balance rather than left behind in a coin.
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let recipient_arg = builder.pure(recipient)?;
+        builder.programmable_move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::from_str("coin")?,
+            Identifier::from_str("send_funds")?,
+            vec![coin_type_tag.clone()],
+            vec![Argument::GasCoin, recipient_arg],
+        );
+        let tx_kind = TransactionKind::programmable(builder.finish());
+
+        let gas_price = match gas_data.gas_price {
+            Some(gas_price) => gas_price,
+            None => context.get_reference_gas_price().await?,
+        };
+        let gas_budget = match gas_data.gas_budget {
+            Some(gas_budget) => gas_budget,
+            None => {
+                estimate_gas_budget(
+                    context,
+                    signer,
+                    tx_kind.clone(),
+                    gas_price,
+                    vec![],
+                    gas_data.gas_sponsor,
+                )
+                .await?
+            }
+        };
+
+        // The coins pay for gas themselves, so they have to cover the budget. When they can't,
+        // fall through to the shape below, which keeps the gas coin out of the transaction and so
+        // lets the fullnode pay for gas from the signer's address balance instead. A sponsored
+        // transaction also takes that shape: there the gas coin belongs to the sponsor, and it is
+        // the signer's coins we are sending.
+        if coin_total >= gas_budget && gas_data.gas_sponsor.is_none() {
+            return dry_run_or_execute_or_serialize(
+                signer,
+                tx_kind,
+                context,
+                coin_refs,
+                GasDataArgs {
+                    gas_budget: Some(gas_budget),
+                    gas_price: Some(gas_price),
+                    gas_sponsor: gas_data.gas_sponsor,
+                },
+                processing,
+            )
+            .await;
+        }
+    }
+
+    // Take the coins as inputs, merge them, and send the merged coin. This never touches the gas
+    // coin, so the fullnode funds gas from the signer's address balance (or, for a non-SUI coin
+    // type, from their SUI coins).
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let coin_args = coins
+        .iter()
+        .map(|(obj_ref, _)| builder.obj(ObjectArg::ImmOrOwnedObject(*obj_ref)))
+        .collect::<Result<Vec<_>, _>>()?;
+    let (merged, rest) = coin_args
+        .split_first()
+        .expect("coins is non-empty, so there is at least one argument");
+    if !rest.is_empty() {
+        builder.command(Command::MergeCoins(*merged, rest.to_vec()));
+    }
+    let recipient_arg = builder.pure(recipient)?;
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::from_str("coin")?,
+        Identifier::from_str("send_funds")?,
+        vec![coin_type_tag],
+        vec![*merged, recipient_arg],
+    );
+    let tx_kind = TransactionKind::programmable(builder.finish());
+
+    dry_run_or_execute_or_serialize(signer, tx_kind, context, vec![], gas_data, processing).await
+}
+
+/// Ask the fullnode to pick the gas payment for a transaction, and return it along with the
+/// budget and expiration it resolved.
+///
+/// The fullnode applies the same rules as the TypeScript SDK: it pays from `gas_owner`'s address
+/// balance when the transaction never touches the gas coin and that balance covers the budget
+/// (empty payment, `ValidDuring` expiration), pays from their SUI coins otherwise, and when the
+/// transaction *does* use the gas coin it prepends an address balance reservation so both sources
+/// are available. Coins already used as inputs are excluded.
+async fn select_gas_with_fullnode(
+    client: &Client,
+    signer: SuiAddress,
+    tx_kind: &TransactionKind,
+    gas_owner: SuiAddress,
+    gas_budget: u64,
+    gas_price: u64,
+) -> Result<(Vec<ObjectRef>, u64, TransactionExpiration), anyhow::Error> {
+    // An empty payment is what asks the fullnode to perform selection.
+    let tx_data = TransactionData::new_with_gas_coins_allow_sponsor(
+        tx_kind.clone(),
+        signer,
+        vec![],
+        gas_budget,
+        gas_price,
+        gas_owner,
+    );
+
+    debug!("Selecting gas payment");
+    let resolved = client
+        .simulate_transaction(&tx_data, true, true)
+        .await
+        .context("Gas selection failed")?
+        .transaction
+        .transaction;
+    debug!("Finished selecting gas payment");
+
+    let gas_data = resolved.gas_data();
+    Ok((
+        gas_data.payment.clone(),
+        gas_data.budget,
+        resolved.expiration().clone(),
+    ))
+}
+
 /// Dry run, execute, or serialize a transaction.
 ///
 /// This basically extracts the logical code for each command that deals with dry run, executing,
@@ -3535,21 +3737,20 @@ async fn dry_run_or_execute_or_serialize_impl(
         Some(gas_budget) => gas_budget,
         None => {
             debug!("Estimating gas budget");
-            let budget = estimate_gas_budget(
-                context,
-                signer,
-                tx_kind.clone(),
-                gas_price,
-                gas_payment.clone(),
-                gas_sponsor,
-            )
-            .await?;
+            // Estimate against an empty gas payment so the fullnode simulates with a mock gas
+            // coin. Passing the real payment here would have it checked against the very budget
+            // we are trying to compute.
+            let budget =
+                estimate_gas_budget(context, signer, tx_kind.clone(), gas_price, vec![], gas_sponsor)
+                    .await?;
             debug!("Finished estimating gas budget");
             budget
         }
     };
 
-    let (gas_payment, expiration) = if use_address_balance_gas {
+    let gas_owner = gas_sponsor.unwrap_or(signer);
+
+    let (gas_payment, gas_budget, expiration) = if use_address_balance_gas {
         let current_epoch = context.get_current_epoch().await?;
         let chain_id = context.get_chain_identifier().await?;
 
@@ -3561,35 +3762,17 @@ async fn dry_run_or_execute_or_serialize_impl(
             chain: chain_id,
             nonce: rand::random(),
         };
-        (vec![], expiration)
+        (vec![], gas_budget, expiration)
     } else if !gas_payment.is_empty() {
-        (gas_payment, TransactionExpiration::None)
+        (gas_payment, gas_budget, TransactionExpiration::None)
     } else {
-        let input_objects: Vec<_> = tx_kind
-            .input_objects()?
-            .iter()
-            .filter_map(|o| match o {
-                InputObjectKind::ImmOrOwnedMoveObject((id, _, _)) => Some(*id),
-                _ => None,
-            })
-            .collect();
-
-        let gas_payment = client
-            .transaction_builder()
-            .select_gas(
-                gas_sponsor.unwrap_or(signer),
-                None,
-                gas_budget,
-                input_objects,
-                gas_price,
-            )
-            .await?;
-
-        (vec![gas_payment], TransactionExpiration::None)
+        select_gas_with_fullnode(
+            &client, signer, &tx_kind, gas_owner, gas_budget, gas_price,
+        )
+        .await?
     };
 
     debug!("Preparing transaction data");
-    let gas_owner = gas_sponsor.unwrap_or(signer);
     let tx_data = TransactionData::new_with_gas_data_and_expiration(
         tx_kind,
         signer,

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -128,18 +128,6 @@ pub(crate) static USER_AGENT: &str =
 /// Only to be used within CLI
 pub const GAS_SAFE_OVERHEAD: u64 = 1000;
 
-/// The protocol limits that bound how many coins a single transaction can drain.
-struct CoinLimits {
-    /// Maximum number of objects a gas payment may contain.
-    max_gas_payment_objects: usize,
-    /// Maximum number of arguments a single command may take. A command's target does not count
-    /// towards this, and the limit is exclusive.
-    max_arguments: usize,
-    /// Maximum number of object inputs a transaction may have. The gas payment does not count
-    /// towards this.
-    max_input_objects: usize,
-}
-
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
 pub enum SuiClientCommands {
@@ -857,6 +845,18 @@ struct FaucetResponse {
     error: Option<String>,
 }
 
+/// The protocol limits that bound how many coins a single transaction can drain.
+struct CoinLimits {
+    /// Maximum number of objects a gas payment may contain.
+    max_gas_payment_objects: usize,
+    /// Maximum number of arguments a single command may take. A command's target does not count
+    /// towards this, and the limit is exclusive.
+    max_arguments: usize,
+    /// Maximum number of object inputs a transaction may have. The gas payment does not count
+    /// towards this.
+    max_input_objects: usize,
+}
+
 impl SuiClientCommands {
     pub async fn execute(
         self,
@@ -1403,11 +1403,8 @@ impl SuiClientCommands {
                     let use_address_balance = if from_address_balance {
                         ensure!(
                             address_balance >= amount,
-                            "Insufficient address balance to send {} MIST. \
-                            Address balance: {}, Coin balance: {}",
-                            amount,
-                            address_balance,
-                            coin_balance
+                            "Insufficient address balance to send {amount} MIST. \
+                            Address balance: {address_balance}, Coin balance: {coin_balance}"
                         );
                         true
                     } else if coin_balance >= amount {
@@ -1416,11 +1413,8 @@ impl SuiClientCommands {
                         true
                     } else {
                         bail!(
-                            "Insufficient balance to send {} MIST. \
-                            Coin balance: {}, Address balance: {}",
-                            amount,
-                            coin_balance,
-                            address_balance
+                            "Insufficient balance to send {amount} MIST. \
+                            Coin balance: {coin_balance}, Address balance: {address_balance}"
                         );
                     };
                     (amount, use_address_balance)
@@ -3459,14 +3453,16 @@ async fn coin_limits(client: &Client) -> Result<CoinLimits, anyhow::Error> {
 
 /// Warn about, and drop, any coins past what one transaction can hold.
 fn truncate_to_max_coins(coin_refs: &mut Vec<ObjectRef>, max_coins: usize) {
-    if coin_refs.len() > max_coins {
-        let remaining = coin_refs.len() - max_coins;
-        coin_refs.truncate(max_coins);
-        eprintln!(
-            "Warning: a transaction sends at most {max_coins} coins, so {remaining} of your coins \
-             will not be sent. Run the command again to send the rest."
-        );
+    if coin_refs.len() <= max_coins {
+        return;
     }
+
+    let remaining = coin_refs.len() - max_coins;
+    coin_refs.truncate(max_coins);
+    eprintln!(
+        "Warning: a transaction sends at most {max_coins} coins, so {remaining} of your coins \
+         will not be sent. Run the command again to send the rest."
+    );
 }
 
 /// Send every `Coin<T>` object owned by `signer` to `recipient`'s address balance. The signer's
@@ -3515,10 +3511,10 @@ async fn send_all_coins(
     } else {
         0
     };
-    let max_merged = std::cmp::min(
-        limits.max_arguments - if is_sui { 1 } else { 0 },
-        limits.max_input_objects,
-    );
+    let max_merged = limits
+        .max_arguments
+        .saturating_sub(is_sui as usize)
+        .min(limits.max_input_objects);
     truncate_to_max_coins(&mut coin_refs, smashed + max_merged);
 
     // Whatever is left in `coin_refs` is the gas payment, which is empty unless the coin is SUI.

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -422,19 +422,20 @@ pub enum SuiClientCommands {
         amount: Option<u64>,
 
         /// Send all coins of the specified type to the recipient's address balance.
-        /// Conflicts with --amount and --stateless.
-        #[clap(long, conflicts_with_all = ["amount", "stateless"])]
+        /// Conflicts with --amount and --from-address-balance.
+        #[clap(long, conflicts_with_all = ["amount", "from_address_balance"])]
         all_coins: bool,
 
         /// The coin type to send (e.g., "0x2::sui::SUI"). Defaults to SUI.
         #[clap(long, value_parser = parse_sui_type_tag)]
         coin_type: Option<TypeTag>,
 
-        /// If set, draws all funds (including gas payment) from the sender's address balances.
-        /// This creates a fully stateless transaction with no owned object inputs.
+        /// Draw the funds from the sender's address balance rather than from their coins. Without
+        /// this, coins are preferred and the address balance is only used if they cannot cover the
+        /// amount. Either way the recipient is paid into their address balance.
         /// Conflicts with --all-coins.
         #[clap(long, conflicts_with = "all_coins")]
-        stateless: bool,
+        from_address_balance: bool,
 
         #[clap(flatten)]
         gas_data: GasDataArgs,
@@ -1366,7 +1367,7 @@ impl SuiClientCommands {
                 amount,
                 all_coins,
                 coin_type,
-                stateless,
+                from_address_balance,
                 gas_data,
                 processing,
             } => {
@@ -1399,7 +1400,15 @@ impl SuiClientCommands {
                 let address_balance = balance_info.address_balance();
 
                 let (amount, use_address_balance) = if let Some(amount) = amount {
-                    let use_address_balance = if stateless {
+                    let use_address_balance = if from_address_balance {
+                        ensure!(
+                            address_balance >= amount,
+                            "Insufficient address balance to send {} MIST. \
+                            Address balance: {}, Coin balance: {}",
+                            amount,
+                            address_balance,
+                            coin_balance
+                        );
                         true
                     } else if coin_balance >= amount {
                         false
@@ -1445,27 +1454,23 @@ impl SuiClientCommands {
 
                     let tx_kind = TransactionKind::programmable(builder.finish());
 
-                    if stateless {
-                        dry_run_or_execute_or_serialize_with_address_balance_gas(
-                            signer, tx_kind, context, gas_data, processing,
-                        )
-                        .await?
-                    } else {
-                        dry_run_or_execute_or_serialize(
-                            signer,
-                            tx_kind,
-                            context,
-                            vec![],
-                            gas_data,
-                            processing,
-                        )
-                        .await?
-                    }
+                    // Gas is a separate concern from where the funds come from: the withdrawal
+                    // never touches the gas coin, so ordinary selection pays from the sender's
+                    // address balance whenever it can cover the budget, and their coins otherwise.
+                    dry_run_or_execute_or_serialize(
+                        signer,
+                        tx_kind,
+                        context,
+                        vec![],
+                        gas_data,
+                        processing,
+                    )
+                    .await?
                 } else {
                     ensure!(
                         is_sui,
                         "Non-SUI coin transfers using coins require explicit coin selection. \
-                        Use --stateless to transfer from address balance instead."
+                        Use --from-address-balance to transfer from your address balance instead."
                     );
                     let amount_arg = builder.pure(amount)?;
                     let coin_arg =
@@ -3610,51 +3615,6 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
     gas_data: GasDataArgs,
     processing: TxProcessingArgs,
 ) -> Result<SuiClientCommandResult, anyhow::Error> {
-    dry_run_or_execute_or_serialize_impl(
-        signer,
-        tx_kind,
-        context,
-        gas_payment,
-        gas_data,
-        processing,
-        false,
-    )
-    .await
-}
-
-/// Dry run, execute, or serialize a transaction with address balance gas support.
-///
-/// When `use_address_balance_gas` is true, the transaction uses the sender's address balance
-/// for gas payment instead of selecting a gas coin. This requires adding a ValidDuring
-/// expiration for replay protection.
-pub(crate) async fn dry_run_or_execute_or_serialize_with_address_balance_gas(
-    signer: SuiAddress,
-    tx_kind: TransactionKind,
-    context: &mut WalletContext,
-    gas_data: GasDataArgs,
-    processing: TxProcessingArgs,
-) -> Result<SuiClientCommandResult, anyhow::Error> {
-    dry_run_or_execute_or_serialize_impl(
-        signer,
-        tx_kind,
-        context,
-        vec![],
-        gas_data,
-        processing,
-        true,
-    )
-    .await
-}
-
-async fn dry_run_or_execute_or_serialize_impl(
-    signer: SuiAddress,
-    tx_kind: TransactionKind,
-    context: &mut WalletContext,
-    gas_payment: Vec<ObjectRef>,
-    gas_data: GasDataArgs,
-    processing: TxProcessingArgs,
-    use_address_balance_gas: bool,
-) -> Result<SuiClientCommandResult, anyhow::Error> {
     let GasDataArgs {
         gas_budget,
         gas_price,
@@ -3736,20 +3696,7 @@ async fn dry_run_or_execute_or_serialize_impl(
 
     let gas_owner = gas_sponsor.unwrap_or(signer);
 
-    let (gas_payment, gas_budget, expiration) = if use_address_balance_gas {
-        let current_epoch = context.get_current_epoch().await?;
-        let chain_id = context.get_chain_identifier().await?;
-
-        let expiration = TransactionExpiration::ValidDuring {
-            min_epoch: Some(current_epoch),
-            max_epoch: Some(current_epoch.saturating_add(1)),
-            min_timestamp: None,
-            max_timestamp: None,
-            chain: chain_id,
-            nonce: rand::random(),
-        };
-        (vec![], gas_budget, expiration)
-    } else if !gas_payment.is_empty() {
+    let (gas_payment, gas_budget, expiration) = if !gas_payment.is_empty() {
         (gas_payment, gas_budget, TransactionExpiration::None)
     } else {
         select_gas_with_fullnode(&client, signer, &tx_kind, gas_owner, gas_budget, gas_price)

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -89,8 +89,8 @@ use sui_types::{
     signature::GenericSignature,
     sui_sdk_types_conversions::type_tag_sdk_to_core,
     transaction::{
-        Argument, Command, FundsWithdrawalArg, GasData, ObjectArg,
-        SenderSignedData, SharedObjectMutability, Transaction, TransactionData, TransactionDataAPI,
+        Argument, Command, FundsWithdrawalArg, GasData, ObjectArg, SenderSignedData,
+        SharedObjectMutability, Transaction, TransactionData, TransactionDataAPI,
         TransactionExpiration, TransactionKind,
     },
 };
@@ -3740,9 +3740,15 @@ async fn dry_run_or_execute_or_serialize_impl(
             // Estimate against an empty gas payment so the fullnode simulates with a mock gas
             // coin. Passing the real payment here would have it checked against the very budget
             // we are trying to compute.
-            let budget =
-                estimate_gas_budget(context, signer, tx_kind.clone(), gas_price, vec![], gas_sponsor)
-                    .await?;
+            let budget = estimate_gas_budget(
+                context,
+                signer,
+                tx_kind.clone(),
+                gas_price,
+                vec![],
+                gas_sponsor,
+            )
+            .await?;
             debug!("Finished estimating gas budget");
             budget
         }
@@ -3766,10 +3772,8 @@ async fn dry_run_or_execute_or_serialize_impl(
     } else if !gas_payment.is_empty() {
         (gas_payment, gas_budget, TransactionExpiration::None)
     } else {
-        select_gas_with_fullnode(
-            &client, signer, &tx_kind, gas_owner, gas_budget, gas_price,
-        )
-        .await?
+        select_gas_with_fullnode(&client, signer, &tx_kind, gas_owner, gas_budget, gas_price)
+            .await?
     };
 
     debug!("Preparing transaction data");

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -62,7 +62,7 @@ use sui_rpc_api::{
     client::{ExecutedTransaction, SimulateTransactionResponse},
 };
 use sui_sdk::{
-    SUI_COIN_TYPE, SUI_DEVNET_URL, SUI_LOCAL_NETWORK_URL, SUI_LOCAL_NETWORK_URL_0, SUI_TESTNET_URL,
+    SUI_DEVNET_URL, SUI_LOCAL_NETWORK_URL, SUI_LOCAL_NETWORK_URL_0, SUI_TESTNET_URL,
     digests::chain_id_base58,
     sui_client_config::{SuiClientConfig, SuiEnv},
     sui_sdk_types::bcs::ToBcs,
@@ -79,7 +79,7 @@ use sui_types::{
     event::EventID,
     execution_status::{ExecutionFailure, ExecutionStatus},
     gas::GasCostSummary,
-    gas_coin::GasCoin,
+    gas_coin::{GAS, GasCoin},
     message_envelope::Envelope,
     metrics::BytecodeVerifierMetrics,
     move_package::{MovePackage, UpgradeCap},
@@ -1363,11 +1363,9 @@ impl SuiClientCommands {
                 let _ = context.cache_chain_id().await?;
                 let client = context.grpc_client()?;
 
-                let sui_type_tag =
-                    TypeTag::from_str(SUI_COIN_TYPE).expect("SUI_COIN_TYPE should be valid");
-                let coin_type_tag = coin_type.unwrap_or_else(|| sui_type_tag.clone());
+                let coin_type_tag = coin_type.unwrap_or_else(GAS::type_tag);
 
-                let is_sui = coin_type_tag == sui_type_tag;
+                let is_sui = coin_type_tag == GAS::type_tag();
 
                 if all_coins {
                     return send_all_coins(
@@ -3448,9 +3446,8 @@ async fn send_all_coins(
     processing: TxProcessingArgs,
 ) -> Result<SuiClientCommandResult, anyhow::Error> {
     let client = context.grpc_client()?;
-    let sui_type_tag = TypeTag::from_str(SUI_COIN_TYPE).expect("SUI_COIN_TYPE should be valid");
     ensure!(
-        coin_type_tag == sui_type_tag,
+        coin_type_tag == GAS::type_tag(),
         "--all-coins is only supported for SUI. Use --amount with --stateless to send another \
          coin type from your address balance."
     );
@@ -3463,7 +3460,7 @@ async fn send_all_coins(
     );
 
     let coins: Vec<Object> = client
-        .list_owned_objects(signer, Some(Coin::type_(coin_type_tag.clone())))
+        .list_owned_objects(signer, Some(GasCoin::type_()))
         .try_collect()
         .await?;
     ensure!(!coins.is_empty(), "No coins available to send");

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3795,7 +3795,10 @@ async fn test_publish_with_coins_and_address_balance() -> Result<(), anyhow::Err
     assert!(response.transaction.gas_data().payment.is_empty());
     let after = client.get_balance(publisher, &GAS::type_()).await?;
     assert_eq!(after.coin_balance(), before.coin_balance());
-    assert_eq!(sui_coins(&client, publisher).await?.len(), coins_before.len());
+    assert_eq!(
+        sui_coins(&client, publisher).await?.len(),
+        coins_before.len()
+    );
     assert!(after.address_balance() < funded);
 
     Ok(())
@@ -3868,7 +3871,10 @@ async fn test_publish_with_explicit_gas_coin() -> Result<(), anyhow::Error> {
     assert_eq!(payment.len(), 1);
     assert_eq!(payment[0].0, gas_coin);
     assert_eq!(response.effects.gas_object().unwrap().0.0, gas_coin);
-    assert_eq!(sui_coins(&client, publisher).await?.len(), coins_before.len());
+    assert_eq!(
+        sui_coins(&client, publisher).await?.len(),
+        coins_before.len()
+    );
 
     Ok(())
 }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3634,8 +3634,11 @@ async fn publish_with_gas(
 ) -> Result<sui_rpc_api::client::ExecutedTransaction, anyhow::Error> {
     let mut build_config = BuildConfig::new_for_testing().config;
     build_config.install_dir = None;
-    let mut package_path = PathBuf::from(TEST_DATA_DIR);
-    package_path.push("dummy_modules_publish");
+
+    // The package needs an environment matching the cluster it is published to.
+    let chain_id = context.cache_chain_id().await?;
+    let (temp_dir, package_path) =
+        create_temp_dir_with_framework_packages("dummy_modules_publish", Some(chain_id))?;
 
     let result = SuiClientCommands::Publish(PublishArgs {
         package_path,
@@ -3654,6 +3657,7 @@ async fn publish_with_gas(
     let SuiClientCommandResult::TransactionBlock(response) = result else {
         panic!("Publish did not return a transaction block");
     };
+    temp_dir.close()?;
     Ok(response)
 }
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -7,7 +7,6 @@ use std::net::SocketAddr;
 use std::{fs::read_dir, path::PathBuf, str, thread, time::Duration};
 
 use std::env;
-#[cfg(not(msim))]
 use std::str::FromStr;
 
 use expect_test::expect;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -24,6 +24,9 @@ use sui_keys::key_identity::KeyIdentity;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_rpc_api::Client;
 use sui_test_transaction_builder::batch_make_transfer_transactions;
+use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
+use sui_types::TypeTag;
+use sui_types::coin::Coin;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::gas_coin::GAS;
 use sui_types::object::{Object, Owner};
@@ -3715,6 +3718,296 @@ async fn test_send_funds_all_coins() -> Result<(), anyhow::Error> {
         coins_before.coin_balance() as i64 - gas_used
     );
     assert_eq!(recipient_after.coin_balance(), 0);
+
+    Ok(())
+}
+
+/// Publish the `trusted_coin` package and mint one `Coin<TRUSTED_COIN>` per entry in `amounts`, all
+/// owned by `context`'s active address. Returns the minted coin's type.
+async fn publish_and_mint_trusted_coin(
+    context: &mut WalletContext,
+    rgp: u64,
+    amounts: &[u64],
+) -> Result<TypeTag, anyhow::Error> {
+    let response = publish_with_gas(context, vec![]).await?;
+    assert!(
+        response.effects.status().is_ok(),
+        "publishing trusted_coin failed: {:?}",
+        response.effects.status()
+    );
+
+    let package_id = *response
+        .effects
+        .published_packages()
+        .first()
+        .expect("trusted_coin package must be published");
+    let coin_type = TypeTag::from_str(&format!("{package_id}::trusted_coin::TRUSTED_COIN"))?;
+
+    // Look the cap up by type: publishing hands the sender an `UpgradeCap` as well, so being owned
+    // by them is not enough to identify it.
+    let treasury_cap_type = TypeTag::from_str(&format!("0x2::coin::TreasuryCap<{coin_type}>"))?;
+    let TypeTag::Struct(treasury_cap_struct) = treasury_cap_type else {
+        panic!("TreasuryCap must be a struct type");
+    };
+    let client = context.grpc_client()?;
+    let treasury_cap = client
+        .get_owned_objects(
+            context.active_address()?,
+            Some(*treasury_cap_struct),
+            None,
+            None,
+        )
+        .await?
+        .items
+        .first()
+        .expect("trusted_coin init must create a treasury cap")
+        .id();
+
+    let sender = context.active_address()?;
+    for amount in amounts {
+        // `trusted_coin::mint` returns the coin rather than transferring it, and `Call` leaves
+        // return values unused, so mint through the framework's entry function instead.
+        let result = SuiClientCommands::Call {
+            package: SUI_FRAMEWORK_PACKAGE_ID,
+            module: "coin".to_string(),
+            function: "mint_and_transfer".to_string(),
+            type_args: vec![coin_type.clone()],
+            args: vec![
+                SuiJsonValue::new(json!(treasury_cap.to_string()))?,
+                SuiJsonValue::new(json!(amount.to_string()))?,
+                SuiJsonValue::new(json!(sender.to_string()))?,
+            ],
+            payment: PaymentArgs::default(),
+            gas_data: GasDataArgs {
+                gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS),
+                ..Default::default()
+            },
+            processing: TxProcessingArgs::default(),
+        }
+        .execute(context)
+        .await?;
+
+        let SuiClientCommandResult::TransactionBlock(response) = result else {
+            panic!("Call did not return a transaction block");
+        };
+        assert!(
+            response.effects.status().is_ok(),
+            "minting TRUSTED_COIN failed: {:?}",
+            response.effects.status()
+        );
+    }
+
+    Ok(coin_type)
+}
+
+/// The `Coin<T>` objects owned by `address`.
+async fn coins_of_type(
+    client: &Client,
+    address: SuiAddress,
+    coin_type: &TypeTag,
+) -> Result<Vec<Object>, anyhow::Error> {
+    Ok(client
+        .get_owned_objects(address, Some(Coin::type_(coin_type.clone())), None, None)
+        .await?
+        .items)
+}
+
+/// `send-funds --all-coins` drains a non-SUI coin type too. Gas is paid in SUI from a separate
+/// source, so unlike the SUI case the recipient receives the full amount with nothing deducted.
+#[sim_test]
+async fn test_send_funds_all_coins_non_sui() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let recipient_address = addresses[0];
+    let sender = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let amounts = [1_000u64, 2_000, 3_000];
+    let minted: u64 = amounts.iter().sum();
+    let coin_type = publish_and_mint_trusted_coin(context, rgp, &amounts).await?;
+    let TypeTag::Struct(coin_struct_tag) = &coin_type else {
+        panic!("TRUSTED_COIN must be a struct type");
+    };
+
+    let before = client.get_balance(sender, coin_struct_tag).await?;
+    assert_eq!(before.coin_balance(), minted);
+    assert_eq!(
+        coins_of_type(&client, sender, &coin_type).await?.len(),
+        amounts.len()
+    );
+    let sui_before = client.get_balance(sender, &GAS::type_()).await?;
+
+    let result = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: None,
+        all_coins: true,
+        coin_type: Some(coin_type.clone()),
+        stateless: false,
+        gas_data: GasDataArgs::default(),
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "send-funds --all-coins failed: {:?}",
+        response.effects.status()
+    );
+
+    // Every TRUSTED_COIN the sender owned is gone.
+    let sender_after = client.get_balance(sender, coin_struct_tag).await?;
+    assert_eq!(sender_after.coin_balance(), 0);
+    assert!(coins_of_type(&client, sender, &coin_type).await?.is_empty());
+
+    // The recipient received the whole minted amount, with no gas deducted from it.
+    let recipient_after = client
+        .get_balance(recipient_address, coin_struct_tag)
+        .await?;
+    assert_eq!(recipient_after.address_balance(), minted);
+    assert_eq!(recipient_after.coin_balance(), 0);
+
+    // The sender paid for the transfer in SUI instead.
+    let sui_after = client.get_balance(sender, &GAS::type_()).await?;
+    let gas_used = response.effects.gas_cost_summary().net_gas_usage();
+    assert_eq!(
+        sui_after.coin_balance() as i64 + sui_after.address_balance() as i64,
+        sui_before.coin_balance() as i64 + sui_before.address_balance() as i64 - gas_used
+    );
+
+    Ok(())
+}
+
+/// A sender holding exactly one non-SUI coin has nothing to merge it with, and a `MergeCoins` with
+/// no sources is not a valid command, so `--all-coins` has to skip the merge entirely.
+#[sim_test]
+async fn test_send_funds_all_coins_non_sui_single_coin() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let recipient_address = addresses[0];
+    let sender = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let minted = 5_000u64;
+    let coin_type = publish_and_mint_trusted_coin(context, rgp, &[minted]).await?;
+    let TypeTag::Struct(coin_struct_tag) = &coin_type else {
+        panic!("TRUSTED_COIN must be a struct type");
+    };
+    assert_eq!(coins_of_type(&client, sender, &coin_type).await?.len(), 1);
+
+    let result = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: None,
+        all_coins: true,
+        coin_type: Some(coin_type.clone()),
+        stateless: false,
+        gas_data: GasDataArgs::default(),
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "send-funds --all-coins with a single coin failed: {:?}",
+        response.effects.status()
+    );
+
+    assert!(coins_of_type(&client, sender, &coin_type).await?.is_empty());
+    let recipient_after = client
+        .get_balance(recipient_address, coin_struct_tag)
+        .await?;
+    assert_eq!(recipient_after.address_balance(), minted);
+
+    Ok(())
+}
+
+/// `--all-coins` for a non-SUI coin works with a gas sponsor: the sponsor pays SUI gas, which has
+/// nothing to do with the coins being sent. The SUI case still refuses, because there the coins
+/// being sent are the gas payment.
+#[sim_test]
+async fn test_send_funds_all_coins_sponsor() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let recipient_address = addresses[0];
+    let sponsor = test_cluster.get_address_1();
+    let context = &mut test_cluster.wallet;
+
+    let minted = 7_000u64;
+    let coin_type = publish_and_mint_trusted_coin(context, rgp, &[minted, minted]).await?;
+    let TypeTag::Struct(coin_struct_tag) = &coin_type else {
+        panic!("TRUSTED_COIN must be a struct type");
+    };
+
+    let sponsor_before = client.get_balance(sponsor, &GAS::type_()).await?;
+
+    let result = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: None,
+        all_coins: true,
+        coin_type: Some(coin_type.clone()),
+        stateless: false,
+        gas_data: GasDataArgs {
+            gas_sponsor: Some(sponsor),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "sponsored send-funds --all-coins failed: {:?}",
+        response.effects.status()
+    );
+
+    let recipient_after = client
+        .get_balance(recipient_address, coin_struct_tag)
+        .await?;
+    assert_eq!(recipient_after.address_balance(), minted * 2);
+
+    // The sponsor, not the sender, paid the gas.
+    let sponsor_after = client.get_balance(sponsor, &GAS::type_()).await?;
+    let gas_used = response.effects.gas_cost_summary().net_gas_usage();
+    assert_eq!(
+        sponsor_after.coin_balance() as i64 + sponsor_after.address_balance() as i64,
+        sponsor_before.coin_balance() as i64 + sponsor_before.address_balance() as i64 - gas_used
+    );
+
+    // SUI still cannot be sponsored: there the coins being sent are what pays for gas.
+    let err = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: None,
+        all_coins: true,
+        coin_type: None,
+        stateless: false,
+        gas_data: GasDataArgs {
+            gas_sponsor: Some(sponsor),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("cannot be used with a gas sponsor"),
+        "unexpected error: {err}"
+    );
 
     Ok(())
 }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -33,7 +33,8 @@ use sui_types::object::{Object, Owner};
 use sui_types::transaction::{
     CallArg, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
     TEST_ONLY_GAS_UNIT_FOR_PUBLISH, TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN,
-    TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData, TransactionDataAPI, TransactionKind,
+    TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData, TransactionDataAPI, TransactionExpiration,
+    TransactionKind,
 };
 use tokio::time::sleep;
 
@@ -3539,7 +3540,7 @@ async fn test_send_funds_sui() -> Result<(), anyhow::Error> {
         amount: Some(amount),
         all_coins: false,
         coin_type: None,
-        stateless: false,
+        from_address_balance: false,
         gas_data: GasDataArgs {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             ..Default::default()
@@ -3612,7 +3613,7 @@ async fn fund_address_balance(
         amount: Some(amount),
         all_coins: false,
         coin_type: None,
-        stateless: false,
+        from_address_balance: false,
         gas_data: GasDataArgs {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             ..Default::default()
@@ -3688,7 +3689,7 @@ async fn test_send_funds_all_coins() -> Result<(), anyhow::Error> {
         amount: None,
         all_coins: true,
         coin_type: None,
-        stateless: false,
+        from_address_balance: false,
         gas_data: GasDataArgs::default(),
         processing: TxProcessingArgs::default(),
     }
@@ -3843,7 +3844,7 @@ async fn test_send_funds_all_coins_non_sui() -> Result<(), anyhow::Error> {
         amount: None,
         all_coins: true,
         coin_type: Some(coin_type.clone()),
-        stateless: false,
+        from_address_balance: false,
         gas_data: GasDataArgs::default(),
         processing: TxProcessingArgs::default(),
     }
@@ -3905,7 +3906,7 @@ async fn test_send_funds_all_coins_non_sui_single_coin() -> Result<(), anyhow::E
         amount: None,
         all_coins: true,
         coin_type: Some(coin_type.clone()),
-        stateless: false,
+        from_address_balance: false,
         gas_data: GasDataArgs::default(),
         processing: TxProcessingArgs::default(),
     }
@@ -3955,7 +3956,7 @@ async fn test_send_funds_all_coins_sponsor() -> Result<(), anyhow::Error> {
         amount: None,
         all_coins: true,
         coin_type: Some(coin_type.clone()),
-        stateless: false,
+        from_address_balance: false,
         gas_data: GasDataArgs {
             gas_sponsor: Some(sponsor),
             ..Default::default()
@@ -3993,7 +3994,7 @@ async fn test_send_funds_all_coins_sponsor() -> Result<(), anyhow::Error> {
         amount: None,
         all_coins: true,
         coin_type: None,
-        stateless: false,
+        from_address_balance: false,
         gas_data: GasDataArgs {
             gas_sponsor: Some(sponsor),
             ..Default::default()
@@ -4006,6 +4007,279 @@ async fn test_send_funds_all_coins_sponsor() -> Result<(), anyhow::Error> {
     assert!(
         err.to_string()
             .contains("cannot be used with a gas sponsor"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+/// `--from-address-balance` takes the amount out of the sender's address balance even though they
+/// have coins that could cover it. Gas selection then finds that same balance can cover the budget,
+/// so nothing owned is touched at all and the transaction ends up with no owned object inputs.
+#[sim_test]
+async fn test_send_funds_from_address_balance_sui() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let recipient_address = addresses[0];
+    let sender = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let funded = 5_000_000_000u64;
+    fund_address_balance(context, sender, funded, rgp).await?;
+
+    let coins_before = sui_coins(&client, sender).await?;
+    let before = client.get_balance(sender, &GAS::type_()).await?;
+    assert!(!coins_before.is_empty());
+    assert_eq!(before.address_balance(), funded);
+
+    let amount = 1_000_000u64;
+    let result = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: Some(amount),
+        all_coins: false,
+        coin_type: None,
+        from_address_balance: true,
+        gas_data: GasDataArgs::default(),
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "send-funds --from-address-balance failed: {:?}",
+        response.effects.status()
+    );
+
+    // The address balance covered gas as well, so the transaction carries no gas payment. Paying
+    // that way is epoch-scoped, so the fullnode gives it a ValidDuring expiration for replay
+    // protection.
+    assert!(response.transaction.gas_data().payment.is_empty());
+    assert!(matches!(
+        response.transaction.expiration(),
+        TransactionExpiration::ValidDuring { .. }
+    ));
+
+    // The sender's coins are untouched: both the amount and the gas came out of address balance.
+    let after = client.get_balance(sender, &GAS::type_()).await?;
+    assert_eq!(sui_coins(&client, sender).await?.len(), coins_before.len());
+    assert_eq!(after.coin_balance(), before.coin_balance());
+    let gas_used = response.effects.gas_cost_summary().net_gas_usage();
+    assert_eq!(
+        after.address_balance() as i64,
+        funded as i64 - amount as i64 - gas_used
+    );
+
+    let recipient_after = client.get_balance(recipient_address, &GAS::type_()).await?;
+    assert_eq!(recipient_after.address_balance(), amount);
+    assert_eq!(recipient_after.coin_balance(), 0);
+
+    Ok(())
+}
+
+/// `--from-address-balance` works for a non-SUI coin too: the amount comes from the sender's address
+/// balance of that type, and gas from their SUI address balance.
+#[sim_test]
+async fn test_send_funds_from_address_balance_non_sui() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let recipient_address = addresses[0];
+    let sender = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let minted = 10_000u64;
+    // These calls are boxed to keep the futures they build off this test's own stack frame: this
+    // test drives enough transactions to otherwise overflow the stack in debug builds.
+    let coin_type = Box::pin(publish_and_mint_trusted_coin(context, rgp, &[minted])).await?;
+    let TypeTag::Struct(coin_struct_tag) = &coin_type else {
+        panic!("TRUSTED_COIN must be a struct type");
+    };
+
+    // Drain the minted coins into the sender's own address balance, so that the transfer below has
+    // a balance of this type to draw on rather than coin objects.
+    let result = Box::pin(
+        SuiClientCommands::SendFunds {
+            to: KeyIdentity::Address(sender),
+            amount: None,
+            all_coins: true,
+            coin_type: Some(coin_type.clone()),
+            from_address_balance: false,
+            gas_data: GasDataArgs::default(),
+            processing: TxProcessingArgs::default(),
+        }
+        .execute(context),
+    )
+    .await?;
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "draining TRUSTED_COIN into the address balance failed: {:?}",
+        response.effects.status()
+    );
+    assert_eq!(
+        client
+            .get_balance(sender, coin_struct_tag)
+            .await?
+            .address_balance(),
+        minted
+    );
+
+    // Gas is always paid in SUI, so the sender needs a SUI address balance for it to come from.
+    Box::pin(fund_address_balance(context, sender, 5_000_000_000, rgp)).await?;
+    let coins_before = sui_coins(&client, sender).await?;
+
+    let amount = 4_000u64;
+    let result = Box::pin(
+        SuiClientCommands::SendFunds {
+            to: recipient.clone(),
+            amount: Some(amount),
+            all_coins: false,
+            coin_type: Some(coin_type.clone()),
+            from_address_balance: true,
+            gas_data: GasDataArgs::default(),
+            processing: TxProcessingArgs::default(),
+        }
+        .execute(context),
+    )
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "non-SUI send-funds --from-address-balance failed: {:?}",
+        response.effects.status()
+    );
+
+    assert!(response.transaction.gas_data().payment.is_empty());
+    assert_eq!(sui_coins(&client, sender).await?.len(), coins_before.len());
+    assert_eq!(
+        client
+            .get_balance(recipient_address, coin_struct_tag)
+            .await?
+            .address_balance(),
+        amount
+    );
+    assert_eq!(
+        client
+            .get_balance(sender, coin_struct_tag)
+            .await?
+            .address_balance(),
+        minted - amount
+    );
+
+    Ok(())
+}
+
+/// `--from-address-balance` is about where the funds come from, not about gas. Draining the whole
+/// address balance into the amount leaves nothing to pay gas with, so gas selection falls back to
+/// the sender's coins and the transfer still goes through.
+#[sim_test]
+async fn test_send_funds_from_address_balance_gas_falls_back_to_coins() -> Result<(), anyhow::Error>
+{
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let recipient_address = addresses[0];
+    let sender = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    // Fund the address balance with exactly what is about to be sent, leaving nothing for gas.
+    let funded = 1_000_000u64;
+    fund_address_balance(context, sender, funded, rgp).await?;
+
+    let before = client.get_balance(sender, &GAS::type_()).await?;
+    assert!(
+        before.coin_balance() > 0,
+        "the sender needs coins to fall back to"
+    );
+    assert_eq!(before.address_balance(), funded);
+
+    let result = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: Some(funded),
+        all_coins: false,
+        coin_type: None,
+        from_address_balance: true,
+        // Pin the budget so this exercises gas payment rather than budget estimation.
+        gas_data: GasDataArgs {
+            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "send-funds --from-address-balance failed: {:?}",
+        response.effects.status()
+    );
+
+    // Gas came from a coin, so the transaction does carry a gas payment this time.
+    assert!(!response.transaction.gas_data().payment.is_empty());
+
+    // The whole address balance still went to the recipient; only gas came out of the coins.
+    let after = client.get_balance(sender, &GAS::type_()).await?;
+    assert_eq!(after.address_balance(), 0);
+    let gas_used = response.effects.gas_cost_summary().net_gas_usage();
+    assert_eq!(
+        after.coin_balance() as i64,
+        before.coin_balance() as i64 - gas_used
+    );
+
+    let recipient_after = client.get_balance(recipient_address, &GAS::type_()).await?;
+    assert_eq!(recipient_after.address_balance(), funded);
+
+    Ok(())
+}
+
+/// `--from-address-balance` fails up front when the address balance cannot cover the amount, rather
+/// than silently sending from coins instead.
+#[sim_test]
+async fn test_send_funds_from_address_balance_insufficient() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, _addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let sender = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let funded = 1_000_000u64;
+    fund_address_balance(context, sender, funded, rgp).await?;
+
+    let before = client.get_balance(sender, &GAS::type_()).await?;
+    assert!(
+        before.coin_balance() > funded,
+        "the sender's coins must be able to cover what the address balance cannot"
+    );
+
+    let err = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: Some(funded + 1),
+        all_coins: false,
+        coin_type: None,
+        from_address_balance: true,
+        gas_data: GasDataArgs::default(),
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("Insufficient address balance"),
         "unexpected error: {err}"
     );
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3589,6 +3589,290 @@ async fn test_send_funds_sui() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// The `Coin<SUI>` objects owned by `address`.
+async fn sui_coins(client: &Client, address: SuiAddress) -> Result<Vec<Object>, anyhow::Error> {
+    Ok(client
+        .get_owned_objects(address, Some(GasCoin::type_()), None, None)
+        .await?
+        .items)
+}
+
+/// Deposit `amount` MIST from `context`'s active address into `recipient`'s address balance.
+async fn fund_address_balance(
+    context: &mut WalletContext,
+    recipient: SuiAddress,
+    amount: u64,
+    rgp: u64,
+) -> Result<(), anyhow::Error> {
+    let result = SuiClientCommands::SendFunds {
+        to: KeyIdentity::Address(recipient),
+        amount: Some(amount),
+        all_coins: false,
+        coin_type: None,
+        stateless: false,
+        gas_data: GasDataArgs {
+            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(response.effects.status().is_ok());
+    Ok(())
+}
+
+/// Publish a package from `context`'s active address, letting gas selection do its thing unless
+/// `gas` names coins to pay with explicitly.
+async fn publish_with_gas(
+    context: &mut WalletContext,
+    gas: Vec<ObjectID>,
+) -> Result<sui_rpc_api::client::ExecutedTransaction, anyhow::Error> {
+    let mut build_config = BuildConfig::new_for_testing().config;
+    build_config.install_dir = None;
+    let mut package_path = PathBuf::from(TEST_DATA_DIR);
+    package_path.push("dummy_modules_publish");
+
+    let result = SuiClientCommands::Publish(PublishArgs {
+        package_path,
+        build_config,
+        skip_dependency_verification: false,
+        verify_deps: false,
+        with_unpublished_dependencies: false,
+        payment: PaymentArgs { gas },
+        // No budget: exercise estimation as well as selection.
+        gas_data: GasDataArgs::default(),
+        processing: TxProcessingArgs::default(),
+    })
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("Publish did not return a transaction block");
+    };
+    Ok(response)
+}
+
+/// `send-funds --all-coins` drains every coin object the sender owns into the recipient's address
+/// balance, and leaves the sender's own address balance alone.
+#[sim_test]
+async fn test_send_funds_all_coins() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient = &recipients[0];
+    let recipient_address = addresses[0];
+    let sender = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    // Give the sender an address balance too, so we can tell that `--all-coins` leaves it alone.
+    let kept_in_address_balance = 1_000_000_000u64;
+    fund_address_balance(context, sender, kept_in_address_balance, rgp).await?;
+
+    let coins_before = client.get_balance(sender, &GAS::type_()).await?;
+    assert!(coins_before.coin_balance() > 0);
+    assert_eq!(coins_before.address_balance(), kept_in_address_balance);
+
+    let result = SuiClientCommands::SendFunds {
+        to: recipient.clone(),
+        amount: None,
+        all_coins: true,
+        coin_type: None,
+        stateless: false,
+        gas_data: GasDataArgs::default(),
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = result else {
+        panic!("SendFunds did not return a transaction block");
+    };
+    assert!(
+        response.effects.status().is_ok(),
+        "send-funds --all-coins failed: {:?}",
+        response.effects.status()
+    );
+
+    // Every coin the sender owned is gone, and their address balance is untouched.
+    let sender_after = client.get_balance(sender, &GAS::type_()).await?;
+    assert_eq!(sender_after.coin_balance(), 0);
+    assert_eq!(sender_after.address_balance(), kept_in_address_balance);
+    assert!(sui_coins(&client, sender).await?.is_empty());
+
+    // The recipient received the coins, less the gas actually charged, in their address balance.
+    let recipient_after = client.get_balance(recipient_address, &GAS::type_()).await?;
+    let gas_used = response.effects.gas_cost_summary().net_gas_usage();
+    assert_eq!(
+        recipient_after.address_balance() as i64,
+        coins_before.coin_balance() as i64 - gas_used
+    );
+    assert_eq!(recipient_after.coin_balance(), 0);
+
+    Ok(())
+}
+
+/// An address holding only an address balance — no coins at all — can still publish: the fullnode
+/// funds gas from that balance and the transaction carries no gas payment.
+#[sim_test]
+async fn test_publish_with_address_balance_only() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let context = &mut test_cluster.wallet;
+    let client = context.grpc_client()?;
+
+    // A brand new address owns no objects. Fund only its address balance.
+    let result = SuiClientCommands::NewAddress {
+        key_scheme: SignatureScheme::ED25519,
+        alias: None,
+        derivation_path: None,
+        word_length: None,
+    }
+    .execute(context)
+    .await?;
+    let SuiClientCommandResult::NewAddress(new_address) = result else {
+        panic!("NewAddress did not return an address");
+    };
+    let publisher = new_address.address;
+
+    let funded = 5_000_000_000u64;
+    fund_address_balance(context, publisher, funded, rgp).await?;
+
+    let before = client.get_balance(publisher, &GAS::type_()).await?;
+    assert_eq!(before.coin_balance(), 0);
+    assert_eq!(before.address_balance(), funded);
+
+    context.config.active_address = Some(publisher);
+    let response = publish_with_gas(context, vec![]).await?;
+    assert!(
+        response.effects.status().is_ok(),
+        "publish from address balance failed: {:?}",
+        response.effects.status()
+    );
+
+    // Gas came from the address balance: no gas payment, and the balance paid for it.
+    assert!(response.transaction.gas_data().payment.is_empty());
+    let after = client.get_balance(publisher, &GAS::type_()).await?;
+    assert_eq!(after.coin_balance(), 0);
+    assert_eq!(
+        after.address_balance() as i64,
+        funded as i64 - response.effects.gas_cost_summary().net_gas_usage()
+    );
+
+    Ok(())
+}
+
+/// When an address has both coins and an address balance, a publish (which never touches the gas
+/// coin) is funded from the address balance, leaving the coins alone.
+#[sim_test]
+async fn test_publish_with_coins_and_address_balance() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let publisher = test_cluster.get_address_1();
+    let context = &mut test_cluster.wallet;
+    let client = context.grpc_client()?;
+
+    let funded = 5_000_000_000u64;
+    fund_address_balance(context, publisher, funded, rgp).await?;
+
+    let coins_before = sui_coins(&client, publisher).await?;
+    let before = client.get_balance(publisher, &GAS::type_()).await?;
+    assert!(!coins_before.is_empty());
+    assert_eq!(before.address_balance(), funded);
+
+    context.config.active_address = Some(publisher);
+    let response = publish_with_gas(context, vec![]).await?;
+    assert!(
+        response.effects.status().is_ok(),
+        "publish with coins and address balance failed: {:?}",
+        response.effects.status()
+    );
+
+    // The address balance covers the budget, so it pays, and the coins are left as they were.
+    assert!(response.transaction.gas_data().payment.is_empty());
+    let after = client.get_balance(publisher, &GAS::type_()).await?;
+    assert_eq!(after.coin_balance(), before.coin_balance());
+    assert_eq!(sui_coins(&client, publisher).await?.len(), coins_before.len());
+    assert!(after.address_balance() < funded);
+
+    Ok(())
+}
+
+/// With no address balance, gas selection falls back to the sender's coins — all of them, which
+/// the validator smashes into a single coin.
+#[sim_test]
+async fn test_publish_with_coins_only() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let publisher = test_cluster.get_address_1();
+    let context = &mut test_cluster.wallet;
+    let client = context.grpc_client()?;
+
+    let coins_before = sui_coins(&client, publisher).await?;
+    assert!(coins_before.len() > 1, "expected several coins to smash");
+    let before = client.get_balance(publisher, &GAS::type_()).await?;
+    assert_eq!(before.address_balance(), 0);
+
+    context.config.active_address = Some(publisher);
+    let response = publish_with_gas(context, vec![]).await?;
+    assert!(
+        response.effects.status().is_ok(),
+        "publish with coins only failed: {:?}",
+        response.effects.status()
+    );
+
+    // All the coins were selected as payment and smashed into one.
+    assert_eq!(
+        response.transaction.gas_data().payment.len(),
+        coins_before.len()
+    );
+    assert_eq!(sui_coins(&client, publisher).await?.len(), 1);
+    let after = client.get_balance(publisher, &GAS::type_()).await?;
+    assert_eq!(after.address_balance(), 0);
+    assert_eq!(
+        after.coin_balance() as i64,
+        before.coin_balance() as i64 - response.effects.gas_cost_summary().net_gas_usage()
+    );
+
+    Ok(())
+}
+
+/// Naming a gas coin explicitly opts out of gas selection entirely: that coin pays, and the
+/// sender's other coins are untouched.
+#[sim_test]
+async fn test_publish_with_explicit_gas_coin() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let publisher = test_cluster.get_address_1();
+    let context = &mut test_cluster.wallet;
+    let client = context.grpc_client()?;
+
+    // Give the publisher an address balance as well, to show the named coin still wins.
+    fund_address_balance(context, publisher, 5_000_000_000, rgp).await?;
+
+    let coins_before = sui_coins(&client, publisher).await?;
+    let gas_coin = coins_before.first().unwrap().id();
+
+    context.config.active_address = Some(publisher);
+    let response = publish_with_gas(context, vec![gas_coin]).await?;
+    assert!(
+        response.effects.status().is_ok(),
+        "publish with an explicit gas coin failed: {:?}",
+        response.effects.status()
+    );
+
+    // Exactly the named coin paid, and nothing else was consumed or smashed.
+    let payment = &response.transaction.gas_data().payment;
+    assert_eq!(payment.len(), 1);
+    assert_eq!(payment[0].0, gas_coin);
+    assert_eq!(response.effects.gas_object().unwrap().0.0, gas_coin);
+    assert_eq!(sui_coins(&client, publisher).await?.len(), coins_before.len());
+
+    Ok(())
+}
+
 #[sim_test]
 async fn test_transfer() -> Result<(), anyhow::Error> {
     let (mut test_cluster, client, rgp, objects, recipients, addresses) =

--- a/docs/content/onchain-finance/asset-custody/address-balances/using-address-balances.mdx
+++ b/docs/content/onchain-finance/asset-custody/address-balances/using-address-balances.mdx
@@ -64,7 +64,7 @@ sui client ptb \
 
 By default, the command selects coins first and falls back to address balance if coins are insufficient. With `--from-address-balance`, it draws exclusively from the address balance, and fails if that balance cannot cover the amount.
 
-Gas is chosen independently of this flag: it is paid from the sender's address balance whenever that balance covers the budget and the transaction does not use the gas coin, in which case the transaction carries no gas payment and gets a `ValidDuring` expiration for replay protection. Otherwise gas is paid from the sender's coins. So a `--from-address-balance` transfer is usually, but not always, free of owned object inputs.
+The network chooses gas independently of this flag: it pays gas from the sender's address balance whenever that balance covers the budget and the transaction does not use the gas coin, in which case the transaction carries no gas payment and gets a `ValidDuring` expiration for replay protection. Otherwise it pays gas from the sender's coins. So a `--from-address-balance` transfer is usually, but not always, free of owned object inputs.
 
 ### Move functions
 

--- a/docs/content/onchain-finance/asset-custody/address-balances/using-address-balances.mdx
+++ b/docs/content/onchain-finance/asset-custody/address-balances/using-address-balances.mdx
@@ -59,10 +59,12 @@ sui client ptb \
 | `--to` | Recipient address. |
 | `--amount` | Amount to send in MIST. |
 | `--coin-type` | Coin type to send. Defaults to `0x2::sui::SUI`. |
-| `--all-coins` | Send all coin balance of the specified type. Cannot combine with `--stateless`. |
-| `--stateless` | Build a stateless transaction using address balance only (no owned object inputs). Uses `ValidDuring` expiration for replay protection. |
+| `--all-coins` | Send all coin balance of the specified type. Cannot combine with `--from-address-balance`. |
+| `--from-address-balance` | Draw the amount from the sender's address balance rather than their coins. |
 
-By default, the command selects coins first and falls back to address balance if coins are insufficient. With `--stateless`, it draws exclusively from the address balance.
+By default, the command selects coins first and falls back to address balance if coins are insufficient. With `--from-address-balance`, it draws exclusively from the address balance, and fails if that balance cannot cover the amount.
+
+Gas is chosen independently of this flag: it is paid from the sender's address balance whenever that balance covers the budget and the transaction does not use the gas coin, in which case the transaction carries no gas payment and gets a `ValidDuring` expiration for replay protection. Otherwise gas is paid from the sender's coins. So a `--from-address-balance` transfer is usually, but not always, free of owned object inputs.
 
 ### Move functions
 

--- a/docs/content/references/cli/client.mdx
+++ b/docs/content/references/cli/client.mdx
@@ -237,8 +237,10 @@ The most common options are:
 - `--to`: Recipient address (or its keystore alias). Required.
 - `--amount`: Amount to send in the coin's smallest unit (MIST for SUI). Required unless `--all-coins` is set.
 - `--coin-type`: Coin type to send. Defaults to `0x2::sui::SUI`.
-- `--all-coins`: Send all owned coin objects of the specified type (not address-balance funds). Conflicts with `--amount` and `--stateless`.
-- `--stateless`: Draw all funds (including gas) from the sender's address balances, producing a transaction with no owned-object inputs. Conflicts with `--all-coins`.
+- `--all-coins`: Send all owned coin objects of the specified type (not address-balance funds). Conflicts with `--amount` and `--from-address-balance`.
+- `--from-address-balance`: Draw the amount from the sender's address balance rather than their coins. Without it, coins are preferred and the address balance is only used if the coins cannot cover the amount. Conflicts with `--all-coins`.
+
+Either way, the recipient is paid into their address balance. Gas is selected separately: it comes from the sender's address balance when that can cover the budget, and from their coins otherwise.
 
 ### Transfer an object to party ownership
 


### PR DESCRIPTION
## Description 

This PR reworks the gas selection in the CLI to allow for address balances to be used.

The CLI now lets the fullnode select gas, matching what the TS SDK does. When a gas coin is not provided with `--gas`, all of the Coin<SUI> objects are used as the gas payment, and the network smashes them into a single coin. There are two consequences here:
- Available SUI coins for that address get consolidated. After any command where the CLI picks gas for you, expect to hold one SUI coin rather than several. If you rely on holding multiple separate coins (for example, to submit transactions in parallel), name the coin to use with --gas, which opts out of gas selection entirely and leaves your other coins untouched.
- If you hold a SUI address balance and the transaction uses the gas coin, your coins are absorbed into that address balance. They stop existing as coin objects, and gas is charged against the balance.

In exchange, gas selection now works in cases where it previously failed: an address whose SUI is spread across many small coins no longer hits "Cannot find gas coin ... sufficient for the required gas budget", and an address holding only an address balance — with no coins at all — can now run any command.

This PR fixes also the `sui client send-funds --all-coins`. It previously always failed with `InsufficientCoinBalance` when trying to smash your coins and send them to the AB. It now sends every Coin<SUI> object you own to the recipient's address balance, less the gas it costs to do so. Your own address balance is not touched — only your coin objects are used. Use `--from-address-balance` to send funds from your address balance instead.

## Test plan 

Existing tests and new tests to cover for sending funds from all coins to AB, paying for gas with AB, paying for gas with coins, etc.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: new logic for gas selection to allow usage of address balances. Note that if no gas coin is passed, it will smash all available gas coins into one.

Breaking change: `--stateless` is no longer available for `send-funds` command. Use `--from-address-balance` instead to send funds from AB to another address.
- [ ] Rust SDK:
- [ ] Indexing Framework:
