### PR TITLE
Remove unused epoch close logic

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -2420,6 +2420,7 @@ mod test {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_split_checkpoints_in_consensus_handler_for_testing(true);
             config.set_merge_randomness_into_checkpoint_for_testing(true);
+            config.set_timestamp_based_epoch_close_for_testing(true);
             config
         });
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4023,22 +4023,11 @@ impl AuthorityState {
         // Terminate all epoch-specific tasks (those started with within_alive_epoch).
         cur_epoch_store.epoch_terminated().await;
 
-        // Safe to being reconfiguration now. No transactions are being executed,
-        // and no epoch-specific tasks are running.
+        // Record metrics in case the node has not observed epoch close in consensus.
+        cur_epoch_store.record_epoch_close_time_once();
 
-        {
-            let state = cur_epoch_store.get_reconfig_state_write_lock_guard();
-            if state.should_accept_user_certs() {
-                // Need to change this so that consensus adapter do not accept certificates from user.
-                // This can happen if our local validator did not initiate epoch change locally,
-                // but 2f+1 nodes already concluded the epoch.
-                //
-                // This lock is essentially a barrier for
-                // `epoch_store.pending_consensus_certificates` table we are reading on the line after this block
-                cur_epoch_store.close_user_certs(state);
-            }
-            // lock is dropped here
-        }
+        // Safe to begin reconfiguration now. No transactions are being executed,
+        // and no epoch-specific tasks are running.
 
         self.get_reconfig_api()
             .clear_state_end_of_epoch(&execution_lock);

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2780,11 +2780,19 @@ impl AuthorityPerEpochStore {
         self.reconfig_state_mem.write()
     }
 
-    pub fn close_user_certs(&self, mut lock_guard: RwLockWriteGuard<'_, ReconfigState>) {
+    /// Persist the local gate used by manual epoch close before sending EndOfPublish.
+    pub(crate) fn close_user_certs_for_manual_epoch_close(
+        &self,
+        mut lock_guard: RwLockWriteGuard<'_, ReconfigState>,
+    ) {
         lock_guard.close_user_certs();
         self.store_reconfig_state(&lock_guard)
             .expect("Updating reconfig state cannot fail");
 
+        self.record_epoch_close_time_once();
+    }
+
+    pub(crate) fn record_epoch_close_time_once(&self) {
         // Set epoch_close_time for metric purpose.
         let mut epoch_close_time = self.epoch_close_time.write();
         if epoch_close_time.is_none() {

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -4,7 +4,6 @@
 use crate::authority::StableSyncAuthoritySigner;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::consensus_adapter::SubmitToConsensus;
-use crate::epoch::reconfiguration::ReconfigurationInitiator;
 use async_trait::async_trait;
 use std::sync::Arc;
 use sui_types::base_types::AuthorityName;
@@ -40,7 +39,6 @@ pub struct SubmitCheckpointToConsensus<T> {
     sender: T,
     signer: StableSyncAuthoritySigner,
     authority: AuthorityName,
-    next_reconfiguration_timestamp_ms: u64,
     log_checkpoint_output: LogCheckpointOutput,
 }
 
@@ -49,14 +47,12 @@ impl<T> SubmitCheckpointToConsensus<T> {
         sender: T,
         signer: StableSyncAuthoritySigner,
         authority: AuthorityName,
-        next_reconfiguration_timestamp_ms: u64,
         metrics: Arc<CheckpointMetrics>,
     ) -> Self {
         Self {
             sender,
             signer,
             authority,
-            next_reconfiguration_timestamp_ms,
             log_checkpoint_output: LogCheckpointOutput::new(metrics),
         }
     }
@@ -73,9 +69,7 @@ impl LogCheckpointOutput {
 }
 
 #[async_trait]
-impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
-    for SubmitCheckpointToConsensus<T>
-{
+impl<T: SubmitToConsensus> CheckpointOutput for SubmitCheckpointToConsensus<T> {
     #[instrument(level = "debug", skip_all)]
     async fn checkpoint_created(
         &self,
@@ -97,9 +91,7 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
 
         if Some(checkpoint_seq) > highest_verified_checkpoint {
             debug!(
-                "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}.
-                {}ms left till end of epoch at timestamp {}",
-                self.next_reconfiguration_timestamp_ms.saturating_sub(checkpoint_timestamp), self.next_reconfiguration_timestamp_ms
+                "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}",
             );
 
             let summary = SignedCheckpointSummary::new(
@@ -132,16 +124,6 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .set(checkpoint_seq as i64);
         }
 
-        if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms
-            && !epoch_store.protocol_config().timestamp_based_epoch_close()
-        {
-            // close_epoch is ok if called multiple times
-            info!(
-                "Closing epoch at sequence {checkpoint_seq} at timestamp {checkpoint_timestamp}. next_reconfiguration_timestamp_ms {}",
-                self.next_reconfiguration_timestamp_ms
-            );
-            self.sender.close_epoch(epoch_store);
-        }
         Ok(())
     }
 }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -306,11 +306,12 @@ impl ConsensusAdapter {
             )?;
         }
 
-        rx_consensus_positions.await.map_err(|e| {
-            SuiError::from(SuiErrorKind::FailedToSubmitToConsensus(format!(
-                "Failed to get consensus position: {e}"
-            )))
-        })?
+        rx_consensus_positions.await.unwrap_or_else(|_| {
+            // The sender is dropped without a reply only when within_alive_epoch
+            // cancels the submission task at epoch end.
+            self.metrics.num_rejected_cert_in_epoch_boundary.inc();
+            Err(SuiErrorKind::ValidatorHaltedAtEpochEnd.into())
+        })
     }
 
     pub fn recover_end_of_publish(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
@@ -747,26 +748,6 @@ impl ConsensusAdapter {
             guard.processed_method.method_name()
         );
 
-        // After a user transaction or soft bundle submission,
-        // send EndOfPublish if the epoch is closing.
-        // EndOfPublish can also be sent during consensus commit handling, checkpoint execution and recovery.
-        if transactions[0].is_user_transaction()
-            && epoch_store.should_send_end_of_publish()
-            && !epoch_store.protocol_config().timestamp_based_epoch_close()
-        {
-            // sending message outside of any locks scope
-            if let Err(err) = self.submit(
-                ConsensusTransaction::new_end_of_publish(self.authority),
-                None,
-                epoch_store,
-                None,
-                None,
-            ) {
-                warn!("Error when sending end of publish message: {:?}", err);
-            } else {
-                info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-            }
-        }
         self.metrics
             .sequencing_certificate_success
             .with_label_values(&[tx_type])
@@ -1021,9 +1002,9 @@ impl ConsensusOverloadChecker for NoopConsensusOverloadChecker {
 }
 
 impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
-    /// This method is called externally to begin reconfiguration
-    /// It sets reconfig state to reject new certificates from user.
-    /// ConsensusAdapter will send EndOfPublish message once pending certificate queue is drained.
+    /// This method is called externally to begin reconfiguration.
+    /// It persists a reconfig state that rejects new user transactions,
+    /// then immediately submits an EndOfPublish message to consensus.
     fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
@@ -1031,7 +1012,7 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
                 // Allow caller to call this method multiple times
                 return;
             }
-            epoch_store.close_user_certs(reconfig_guard);
+            epoch_store.close_user_certs_for_manual_epoch_close(reconfig_guard);
         }
         if epoch_store.should_send_end_of_publish() {
             if let Err(err) = self.submit(

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -77,7 +77,6 @@ use crate::{
         CheckpointHeight, CheckpointRoots, CheckpointService, CheckpointServiceNotify,
         PendingCheckpoint, PendingCheckpointInfo,
     },
-    consensus_adapter::ConsensusAdapter,
     consensus_throughput_calculator::ConsensusThroughputCalculator,
     consensus_types::consensus_output_api::{ConsensusCommitAPI, ParsedTransaction},
     epoch::{
@@ -103,7 +102,6 @@ pub struct ConsensusHandlerInitializer {
     state: Arc<AuthorityState>,
     checkpoint_service: Arc<CheckpointService>,
     epoch_store: Arc<AuthorityPerEpochStore>,
-    consensus_adapter: Arc<ConsensusAdapter>,
     throughput_calculator: Arc<ConsensusThroughputCalculator>,
     backpressure_manager: Arc<BackpressureManager>,
     congestion_logger: Option<Arc<Mutex<CongestionCommitLogger>>>,
@@ -115,7 +113,6 @@ impl ConsensusHandlerInitializer {
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
         epoch_store: Arc<AuthorityPerEpochStore>,
-        consensus_adapter: Arc<ConsensusAdapter>,
         throughput_calculator: Arc<ConsensusThroughputCalculator>,
         backpressure_manager: Arc<BackpressureManager>,
         congestion_log_config: Option<CongestionLogConfig>,
@@ -133,7 +130,6 @@ impl ConsensusHandlerInitializer {
             state,
             checkpoint_service,
             epoch_store,
-            consensus_adapter,
             throughput_calculator,
             backpressure_manager,
             congestion_logger,
@@ -146,18 +142,12 @@ impl ConsensusHandlerInitializer {
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
     ) -> Self {
-        use crate::consensus_test_utils::make_consensus_adapter_for_test;
-        use std::collections::HashSet;
-
         let backpressure_manager = BackpressureManager::new_for_tests();
-        let consensus_adapter =
-            make_consensus_adapter_for_test(state.clone(), HashSet::new(), false, vec![]);
         let consensus_gasless_counter = state.consensus_gasless_counter.clone();
         Self {
             state: state.clone(),
             checkpoint_service,
             epoch_store: state.epoch_store_for_testing().clone(),
-            consensus_adapter,
             throughput_calculator: Arc::new(ConsensusThroughputCalculator::new(
                 None,
                 state.metrics.clone(),
@@ -181,7 +171,6 @@ impl ConsensusHandlerInitializer {
             self.epoch_store.clone(),
             self.checkpoint_service.clone(),
             settlement_scheduler,
-            self.consensus_adapter.clone(),
             self.state.get_object_cache_reader().clone(),
             consensus_committee,
             self.state.metrics.clone(),
@@ -723,9 +712,6 @@ pub struct ConsensusHandler<C> {
     metrics: Arc<AuthorityMetrics>,
     /// Lru cache to quickly discard transactions processed by consensus
     processed_cache: LruCache<SequencedConsensusTransactionKey, ()>,
-    /// Consensus adapter for submitting transactions to consensus
-    consensus_adapter: Arc<ConsensusAdapter>,
-
     /// Using the throughput calculator to record the current consensus throughput
     throughput_calculator: Arc<ConsensusThroughputCalculator>,
 
@@ -768,6 +754,10 @@ fn assert_supported_protocol_config(protocol_config: &ProtocolConfig) {
     assert!(protocol_config.include_cancelled_randomness_txns_in_prologue());
     assert!(protocol_config.fix_checkpoint_signature_mapping());
     assert!(protocol_config.merge_randomness_into_checkpoint());
+    assert!(
+        protocol_config.timestamp_based_epoch_close(),
+        "support for non-timestamp-based epoch close has been removed"
+    );
 }
 
 impl<C> ConsensusHandler<C> {
@@ -775,7 +765,6 @@ impl<C> ConsensusHandler<C> {
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<C>,
         settlement_scheduler: SettlementScheduler,
-        consensus_adapter: Arc<ConsensusAdapter>,
         cache_reader: Arc<dyn ObjectCacheRead>,
         committee: ConsensusCommittee,
         metrics: Arc<AuthorityMetrics>,
@@ -821,7 +810,6 @@ impl<C> ConsensusHandler<C> {
             processed_cache: LruCache::new(
                 NonZeroUsize::new(randomize_cache_capacity_in_tests(PROCESSED_CACHE_CAP)).unwrap(),
             ),
-            consensus_adapter,
             throughput_calculator,
             additional_consensus_state: AdditionalConsensusState::new(
                 commit_rate_estimate_window_size,
@@ -850,7 +838,6 @@ impl<C> ConsensusHandler<C> {
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<C>,
         execution_scheduler_sender: ExecutionSchedulerSender,
-        consensus_adapter: Arc<ConsensusAdapter>,
         cache_reader: Arc<dyn ObjectCacheRead>,
         committee: ConsensusCommittee,
         metrics: Arc<AuthorityMetrics>,
@@ -883,7 +870,6 @@ impl<C> ConsensusHandler<C> {
             processed_cache: LruCache::new(
                 NonZeroUsize::new(randomize_cache_capacity_in_tests(PROCESSED_CACHE_CAP)).unwrap(),
             ),
-            consensus_adapter,
             throughput_calculator,
             additional_consensus_state: AdditionalConsensusState::new(
                 commit_rate_estimate_window_size,
@@ -1282,8 +1268,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         });
 
         fail_point!("crash");
-
-        self.send_end_of_publish_if_needed().await;
     }
 
     fn handle_close_epoch(
@@ -1297,31 +1281,19 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         bool,
         Option<AbandonedDeferredTxns>,
     ) {
-        let timestamp_based_epoch_close = self
+        let timestamp_triggered =
+            commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms();
+        let deadline_reached = self
             .epoch_store
             .protocol_config()
-            .timestamp_based_epoch_close();
-        let timestamp_triggered = timestamp_based_epoch_close
-            && commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms();
-        let deadline_reached = timestamp_based_epoch_close
-            && self
-                .epoch_store
-                .protocol_config()
-                .epoch_close_deadline_ms_as_option()
-                .is_some_and(|deadline_ms| {
-                    commit_info.timestamp
-                        >= self
-                            .epoch_store
-                            .next_reconfiguration_timestamp_ms()
-                            .saturating_add(deadline_ms)
-                });
-        if timestamp_triggered {
-            // close_user_certs() is only needed here when timestamp_based_epoch_close is enabled.
-            let reconfig_guard = self.epoch_store.get_reconfig_state_write_lock_guard();
-            if reconfig_guard.should_accept_user_certs() {
-                self.epoch_store.close_user_certs(reconfig_guard);
-            }
-        }
+            .epoch_close_deadline_ms_as_option()
+            .is_some_and(|deadline_ms| {
+                commit_info.timestamp
+                    >= self
+                        .epoch_store
+                        .next_reconfiguration_timestamp_ms()
+                        .saturating_add(deadline_ms)
+            });
         let collected_eop_quorum =
             self.process_end_of_publish_transactions(state, end_of_publish_transactions);
         if timestamp_triggered || collected_eop_quorum {
@@ -2274,8 +2246,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         false
     }
 
-    /// After we have collected 2f+1 EndOfPublish messages, we call this function every round until the epoch
-    /// ends.
+    /// Once the timestamp deadline is reached or 2f+1 EndOfPublish messages are collected, we call
+    /// this function every round until the epoch ends.
     fn advance_eop_state_machine(
         &self,
         state: &mut CommitHandlerState,
@@ -2287,6 +2259,12 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     ) {
         let mut reconfig_state = self.epoch_store.get_reconfig_state_write_lock_guard();
         let start_state_is_reject_all_tx = reconfig_state.is_reject_all_tx();
+
+        // Record the close time only on the first entry into the state machine.
+        // A manual epoch close records it when closing user certs.
+        if reconfig_state.should_accept_user_certs() {
+            self.epoch_store.record_epoch_close_time_once();
+        }
 
         reconfig_state.close_all_certs();
 
@@ -2984,32 +2962,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         commit_handler_input
     }
-
-    async fn send_end_of_publish_if_needed(&self) {
-        if self
-            .epoch_store
-            .protocol_config()
-            .timestamp_based_epoch_close()
-        {
-            return;
-        }
-        if !self.epoch_store.should_send_end_of_publish() {
-            return;
-        }
-
-        let end_of_publish = ConsensusTransaction::new_end_of_publish(self.epoch_store.name);
-        if let Err(err) =
-            self.consensus_adapter
-                .submit(end_of_publish, None, &self.epoch_store, None, None)
-        {
-            warn!(
-                "Error when sending EndOfPublish message from ConsensusHandler: {:?}",
-                err
-            );
-        } else {
-            info!(epoch=?self.epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-        }
-    }
 }
 
 /// Sends transactions to the execution scheduler in a separate task,
@@ -3475,8 +3427,6 @@ impl CommitIntervalObserver {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use consensus_core::{
         BlockAPI, CommitDigest, CommitRef, CommittedSubDag, TestBlock, Transaction, VerifiedBlock,
     };
@@ -3510,10 +3460,7 @@ mod tests {
         },
         checkpoints::CheckpointServiceNoop,
         consensus_adapter::consensus_tests::test_user_transaction,
-        consensus_test_utils::{
-            TestConsensusCommit, make_consensus_adapter_for_test,
-            setup_consensus_handler_for_testing,
-        },
+        consensus_test_utils::{TestConsensusCommit, setup_consensus_handler_for_testing},
         post_consensus_tx_reorder::PostConsensusTxReorder,
     };
 
@@ -3802,8 +3749,6 @@ mod tests {
         let throughput_calculator = ConsensusThroughputCalculator::new(None, metrics.clone());
 
         let backpressure_manager = BackpressureManager::new_for_tests();
-        let consensus_adapter =
-            make_consensus_adapter_for_test(state.clone(), HashSet::new(), false, vec![]);
         let settlement_scheduler = SettlementScheduler::new(
             state.execution_scheduler().as_ref().clone(),
             state.get_transaction_cache_reader().clone(),
@@ -3813,7 +3758,6 @@ mod tests {
             epoch_store,
             Arc::new(CheckpointServiceNoop {}),
             settlement_scheduler,
-            consensus_adapter,
             state.get_object_cache_reader().clone(),
             consensus_committee.clone(),
             metrics,
@@ -4388,8 +4332,6 @@ mod tests {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput = ConsensusThroughputCalculator::new(None, metrics.clone());
         let backpressure = BackpressureManager::new_for_tests();
-        let consensus_adapter =
-            make_consensus_adapter_for_test(state.clone(), HashSet::new(), false, vec![]);
         let settlement_scheduler = SettlementScheduler::new(
             state.execution_scheduler().as_ref().clone(),
             state.get_transaction_cache_reader().clone(),
@@ -4399,7 +4341,6 @@ mod tests {
             epoch_store.clone(),
             Arc::new(CheckpointServiceNoop {}),
             settlement_scheduler,
-            consensus_adapter,
             state.get_object_cache_reader().clone(),
             consensus_committee.clone(),
             metrics,
@@ -4514,8 +4455,6 @@ mod tests {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput = ConsensusThroughputCalculator::new(None, metrics.clone());
         let backpressure = BackpressureManager::new_for_tests();
-        let consensus_adapter =
-            make_consensus_adapter_for_test(state.clone(), HashSet::new(), false, vec![]);
         let settlement_scheduler = SettlementScheduler::new(
             state.execution_scheduler().as_ref().clone(),
             state.get_transaction_cache_reader().clone(),
@@ -4525,7 +4464,6 @@ mod tests {
             epoch_store.clone(),
             Arc::new(CheckpointServiceNoop {}),
             settlement_scheduler,
-            consensus_adapter,
             state.get_object_cache_reader().clone(),
             consensus_committee.clone(),
             metrics,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1298,7 +1298,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             self.process_end_of_publish_transactions(state, end_of_publish_transactions);
         if timestamp_triggered || collected_eop_quorum {
             let (lock, final_round, abandoned_deferred_txns) =
-                self.advance_eop_state_machine(state, deadline_reached);
+                self.advance_end_of_epoch_state_machine(state, deadline_reached);
             (
                 lock.should_accept_tx(),
                 Some(lock),
@@ -2248,7 +2248,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
     /// Once the timestamp deadline is reached or 2f+1 EndOfPublish messages are collected, we call
     /// this function every round until the epoch ends.
-    fn advance_eop_state_machine(
+    fn advance_end_of_epoch_state_machine(
         &self,
         state: &mut CommitHandlerState,
         deadline_reached: bool,
@@ -3596,7 +3596,7 @@ mod tests {
 
         let (reconfig_state, final_round, abandoned) = setup
             .consensus_handler
-            .advance_eop_state_machine(&mut handler_state, true);
+            .advance_end_of_epoch_state_machine(&mut handler_state, true);
 
         assert!(reconfig_state.is_reject_all_tx());
         assert!(final_round);
@@ -3630,7 +3630,7 @@ mod tests {
 
         let (reconfig_state, final_round, abandoned) = setup
             .consensus_handler
-            .advance_eop_state_machine(&mut handler_state, true);
+            .advance_end_of_epoch_state_machine(&mut handler_state, true);
 
         assert!(reconfig_state.is_reject_all_tx());
         assert!(final_round);

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -6,11 +6,14 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::info;
 
+// Certs are legacy names for transactions before fastpath was removed.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReconfigCertStatus {
     AcceptAllCerts,
 
-    // User certs rejected, but we still accept certs received through consensus.
+    // This state is only used during manual epoch close, to close user transaction submission
+    // and persist the manually closed epoch state.
+    // Transactions received through consensus are still accepted.
     RejectUserCerts,
 
     // All certs rejected, including ones received through consensus.

--- a/crates/sui-core/src/unit_tests/consensus_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/consensus_test_utils.rs
@@ -330,9 +330,6 @@ where
     let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
     let throughput_calculator = ConsensusThroughputCalculator::new(None, metrics.clone());
     let backpressure_manager = BackpressureManager::new_for_tests();
-    let consensus_adapter =
-        make_consensus_adapter_for_test(authority.clone(), HashSet::new(), false, vec![]);
-
     let last_consensus_stats = ExecutionIndicesWithStatsV2 {
         stats: crate::authority::authority_per_epoch_store::ConsensusStats::new(
             consensus_committee.size(),
@@ -358,7 +355,6 @@ where
         epoch_store.clone(),
         checkpoint_service,
         execution_scheduler_sender,
-        consensus_adapter,
         authority.get_object_cache_reader().clone(),
         consensus_committee,
         metrics,

--- a/crates/sui-e2e-tests/tests/coin_registry_tests.rs
+++ b/crates/sui-e2e-tests/tests/coin_registry_tests.rs
@@ -26,6 +26,7 @@ async fn test_create_coin_registry_object() {
             config.set_include_cancelled_randomness_txns_in_prologue_for_testing(true);
             config.set_fix_checkpoint_signature_mapping_for_testing(true);
             config.set_merge_randomness_into_checkpoint_for_testing(true);
+            config.set_timestamp_based_epoch_close_for_testing(true);
             config
         });
 

--- a/crates/sui-e2e-tests/tests/display_registry_tests.rs
+++ b/crates/sui-e2e-tests/tests/display_registry_tests.rs
@@ -21,6 +21,7 @@ async fn test_create_display_registry_object() {
             config.set_authority_capabilities_v2_for_testing(true);
             config.set_split_checkpoints_in_consensus_handler_for_testing(true);
             config.set_merge_randomness_into_checkpoint_for_testing(true);
+            config.set_timestamp_based_epoch_close_for_testing(true);
             config
         });
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1564,7 +1564,6 @@ impl SuiNode {
             state.clone(),
             checkpoint_service.clone(),
             epoch_store.clone(),
-            consensus_adapter.clone(),
             throughput_calculator,
             backpressure_manager,
             config.congestion_log.clone(),
@@ -1644,23 +1643,11 @@ impl SuiNode {
         checkpoint_metrics: Arc<CheckpointMetrics>,
         node_role: NodeRole,
     ) -> Arc<CheckpointService> {
-        let epoch_start_timestamp_ms = epoch_store.epoch_start_state().epoch_start_timestamp_ms();
-        let epoch_duration_ms = epoch_store.epoch_start_state().epoch_duration_ms();
-
-        debug!(
-            "Starting checkpoint service with epoch start timestamp {}
-            and epoch duration {}",
-            epoch_start_timestamp_ms, epoch_duration_ms
-        );
-
         let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.is_validator() {
             Box::new(SubmitCheckpointToConsensus::new(
                 consensus_adapter,
                 state.secret.clone(),
                 config.protocol_public_key(),
-                epoch_start_timestamp_ms
-                    .checked_add(epoch_duration_ms)
-                    .expect("Overflow calculating next_reconfiguration_timestamp_ms"),
                 checkpoint_metrics.clone(),
             ))
         } else {


### PR DESCRIPTION
## Description 

In every network, `EndOfPublish` message is no longer emitted during normal epoch closing. The consensus handler closes the epoch automatically when the consensus commit timestamp reaches the reconfiguration timestamp. The logic to transition into `ReconfigCertStatus::RejectUserCerts` and send `EndOfPublish` message based on timestamp are removed.

`EndOfPublish` message is still sent by manual epoch closing on individual validators. The logic to count `EndOfPublish` quorum and recover manual epoch close state are kept.

`ReconfigCertStatus::RejectUserCerts` is now reserved for manual epoch close.

## Test plan 

CI