### PR TITLE
Remove owned-object lock tables; resolve conflicts from in-memory state + objects table

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -43,6 +43,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+use sui_core::transaction_driver::TransactionDriverError;
 use sui_types::committee::Committee;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::messages_grpc::WaitForEffectsResponse;
@@ -239,6 +240,33 @@ enum NextOp {
         payload: Box<dyn Payload>,
     },
     Retry(RetryType),
+}
+
+/// Whether a failed transaction submission should be retried with the exact same
+/// transaction (`NextOp::Retry`), as opposed to giving up on it (`NextOp::Failure`,
+/// which recycles the payload and builds a new transaction on the same input refs).
+///
+/// Every terminal `TransactionDriverError` retries the same digest, because a terminal
+/// error does not prove the transaction is dead: the driver may have timed out
+/// collecting effects acks for a transaction that did finalize, and a transaction
+/// rejected by over 1/3 of validators (e.g. a chained transaction racing its parent's
+/// execution) can still be finalized through a validator that accepted it. In both
+/// cases building a new transaction on the same input refs equivocates, and the payload
+/// wedges permanently — every rebuilt transaction is terminally rejected with "object
+/// version unavailable for consumption". Resubmitting the same digest is
+/// idempotent: validators respond to an already-executed digest with its effects, which
+/// settles the payload with fresh object refs. A genuinely invalid transaction keeps
+/// failing on retry, but that is no worse than rebuilding an equally invalid
+/// transaction from the same payload state, and it stays visible in `num_error`.
+fn should_retry_same_transaction(err: &anyhow::Error) -> bool {
+    if err.downcast_ref::<TransactionDriverError>().is_some() {
+        return true;
+    }
+    // Fullnode-proxy path surfaces TransactionSubmissionError instead.
+    matches!(
+        err.downcast_ref::<TransactionSubmissionError>(),
+        Some(err) if !matches!(err, TransactionSubmissionError::NonRecoverableTransactionError { .. })
+    )
 }
 
 async fn print_and_start_benchmark() -> &'static Instant {
@@ -896,22 +924,7 @@ async fn run_bench_worker(
                         NextOp::Retry(Box::new((transaction, payload)))
                     }
                     None => {
-                        if err
-                            .downcast::<TransactionSubmissionError>()
-                            .and_then(|err| {
-                                if matches!(
-                                    err,
-                                    TransactionSubmissionError::NonRecoverableTransactionError { .. }
-                                ) {
-                                    Err(err.into())
-                                } else {
-                                    Ok(())
-                                }
-                            })
-                            .is_err()
-                        {
-                            NextOp::Failure { payload }
-                        } else {
+                        if should_retry_same_transaction(&err) {
                             metrics
                                 .num_error
                                 .with_label_values(&[
@@ -921,6 +934,8 @@ async fn run_bench_worker(
                                 ])
                                 .inc();
                             NextOp::Retry(Box::new((transaction, payload)))
+                        } else {
+                            NextOp::Failure { payload }
                         }
                     }
                 }
@@ -1495,6 +1510,42 @@ mod tests {
         fn make_transaction(&mut self) -> Transaction {
             unimplemented!("not needed for recycling tests")
         }
+    }
+
+    #[test]
+    fn test_transaction_driver_errors_retry_same_transaction() {
+        // Terminal driver errors retry the same digest, whether the driver deems them
+        // retriable (timeout: the transaction may have finalized without the client
+        // observing it) or not (validator rejection: the transaction may still be
+        // finalized through a validator that accepted it). Rebuilding a new
+        // transaction on the same input refs instead would equivocate.
+        let timed_out =
+            anyhow::Error::from(TransactionDriverError::TimeoutWithLastRetriableError {
+                last_error: None,
+                attempts: 3,
+                timeout: Duration::from_secs(60),
+            });
+        assert!(should_retry_same_transaction(&timed_out));
+
+        let rejected = anyhow::Error::from(TransactionDriverError::ValidationFailed {
+            error: "object version unavailable for consumption".to_string(),
+        });
+        assert!(should_retry_same_transaction(&rejected));
+    }
+
+    #[test]
+    fn test_submission_errors_keep_legacy_classification() {
+        let non_recoverable =
+            anyhow::Error::from(TransactionSubmissionError::NonRecoverableTransactionError {
+                errors: vec![],
+            });
+        assert!(!should_retry_same_transaction(&non_recoverable));
+
+        let transient = anyhow::Error::from(TransactionSubmissionError::TimeoutBeforeFinality);
+        assert!(should_retry_same_transaction(&transient));
+
+        let opaque = anyhow::anyhow!("connection reset by peer");
+        assert!(!should_retry_same_transaction(&opaque));
     }
 
     #[test]

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -246,27 +246,31 @@ enum NextOp {
 /// transaction (`NextOp::Retry`), as opposed to giving up on it (`NextOp::Failure`,
 /// which recycles the payload and builds a new transaction on the same input refs).
 ///
-/// Every terminal `TransactionDriverError` retries the same digest, because a terminal
-/// error does not prove the transaction is dead: the driver may have timed out
-/// collecting effects acks for a transaction that did finalize, and a transaction
-/// rejected by over 1/3 of validators (e.g. a chained transaction racing its parent's
-/// execution) can still be finalized through a validator that accepted it. In both
-/// cases building a new transaction on the same input refs equivocates, and the payload
-/// wedges permanently — every rebuilt transaction is terminally rejected with "object
-/// version unavailable for consumption". Resubmitting the same digest is
-/// idempotent: validators respond to an already-executed digest with its effects, which
-/// settles the payload with fresh object refs. A genuinely invalid transaction keeps
-/// failing on retry, but that is no worse than rebuilding an equally invalid
-/// transaction from the same payload state, and it stays visible in `num_error`.
+/// A terminal `TransactionDriverError` for a submitted transaction retries the same
+/// digest, because the error does not prove the transaction is dead: the driver may
+/// have timed out collecting effects acks for a transaction that did finalize, and a
+/// transaction rejected by over 1/3 of validators (e.g. a chained transaction racing
+/// its parent's execution) can still be finalized through a validator that accepted
+/// it. In both cases building a new transaction on the same input refs equivocates,
+/// and the payload wedges permanently — every rebuilt transaction is terminally
+/// rejected with "object version unavailable for consumption". Resubmitting the same
+/// digest is idempotent: validators respond to an already-executed digest with its
+/// effects, which settles the payload with fresh object refs.
 fn should_retry_same_transaction(err: &anyhow::Error) -> bool {
-    if err.downcast_ref::<TransactionDriverError>().is_some() {
-        return true;
+    match err.downcast_ref::<TransactionDriverError>() {
+        // ValidationFailed comes only from the driver's local pre-submission checks
+        // (e.g. gas price under an RGP that rose at an epoch boundary), so the
+        // transaction was never sent to any validator: recycling the payload is
+        // equivocation-free, and only a rebuilt transaction can pass the same check.
+        Some(TransactionDriverError::ValidationFailed { .. }) => false,
+        Some(_) => true,
+        // Other proxies surface opaque anyhow errors (and historically
+        // TransactionSubmissionError): keep the legacy classification for them.
+        None => matches!(
+            err.downcast_ref::<TransactionSubmissionError>(),
+            Some(err) if !matches!(err, TransactionSubmissionError::NonRecoverableTransactionError { .. })
+        ),
     }
-    // Fullnode-proxy path surfaces TransactionSubmissionError instead.
-    matches!(
-        err.downcast_ref::<TransactionSubmissionError>(),
-        Some(err) if !matches!(err, TransactionSubmissionError::NonRecoverableTransactionError { .. })
-    )
 }
 
 async fn print_and_start_benchmark() -> &'static Instant {
@@ -1514,11 +1518,11 @@ mod tests {
 
     #[test]
     fn test_transaction_driver_errors_retry_same_transaction() {
-        // Terminal driver errors retry the same digest, whether the driver deems them
-        // retriable (timeout: the transaction may have finalized without the client
-        // observing it) or not (validator rejection: the transaction may still be
-        // finalized through a validator that accepted it). Rebuilding a new
-        // transaction on the same input refs instead would equivocate.
+        // Terminal driver errors for submitted transactions retry the same digest,
+        // whether the driver deems them retriable (timeout: the transaction may have
+        // finalized without the client observing it) or not (validator rejection: the
+        // transaction may still be finalized through a validator that accepted it).
+        // Rebuilding a new transaction on the same input refs instead would equivocate.
         let timed_out =
             anyhow::Error::from(TransactionDriverError::TimeoutWithLastRetriableError {
                 last_error: None,
@@ -1527,10 +1531,19 @@ mod tests {
             });
         assert!(should_retry_same_transaction(&timed_out));
 
-        let rejected = anyhow::Error::from(TransactionDriverError::ValidationFailed {
-            error: "object version unavailable for consumption".to_string(),
+        let rejected = anyhow::Error::from(TransactionDriverError::RejectedByValidators {
+            submission_non_retriable_errors: Default::default(),
+            submission_retriable_errors: Default::default(),
         });
         assert!(should_retry_same_transaction(&rejected));
+
+        // ValidationFailed is a local pre-submission failure: the transaction never
+        // reached a validator, so recycling the payload cannot equivocate, and only a
+        // rebuilt transaction can pick up fresh state (e.g. an increased gas price).
+        let not_submitted = anyhow::Error::from(TransactionDriverError::ValidationFailed {
+            error: "gas price under reference gas price".to_string(),
+        });
+        assert!(!should_retry_same_transaction(&not_submitted));
     }
 
     #[test]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -708,7 +708,7 @@ impl AuthorityMetrics {
                 "Owned-object lock state resolutions in the consensus handler, by source. \
                  quarantine/deferred/cache resolve from consensus in-memory state; \
                  objects_db is an authoritative latest-object read (in-memory object \
-                 cache first, then DB); backstop is a residual lock-table point read",
+                 cache first, then DB)",
                 &["source"],
                 registry,
             ).unwrap(),
@@ -926,6 +926,16 @@ impl ForkRecoveryState {
 }
 
 pub type PostProcessingOutput = (StagedBatch, IndexStoreCacheUpdates);
+
+/// Outcome of a successful `handle_vote_transaction`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VoteTransactionResult {
+    /// Inputs were validated against live state.
+    Validated,
+    /// Accepted because the transaction is already finalized/executed this epoch. Its
+    /// inputs were consumed by its own execution, so no input-based validation applies.
+    AlreadyFinalized,
+}
 
 pub struct AuthorityState {
     // Fixed size, static, identity of the authority
@@ -1193,7 +1203,7 @@ impl AuthorityState {
         &self,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
-    ) -> SuiResult<()> {
+    ) -> SuiResult<VoteTransactionResult> {
         debug!("handle_vote_transaction");
 
         let _metrics_guard = self
@@ -1221,7 +1231,10 @@ impl AuthorityState {
             || epoch_store.transactions_executed_in_cur_epoch(&[tx_digest])?[0]
         {
             assert_reachable!("transaction recently executed");
-            return Ok(());
+            // No input validation applies: the transaction's own execution consumed its
+            // inputs, so they are (correctly) no longer live. Callers must skip
+            // input-based checks (e.g. immutable-claims verification) for this result.
+            return Ok(VoteTransactionResult::AlreadyFinalized);
         }
 
         if self
@@ -1246,7 +1259,8 @@ impl AuthorityState {
         // in the consensus handler. Validation still runs to prevent spam transactions with
         // invalid object versions, and is necessary to handle recently created objects.
         self.get_cache_writer()
-            .validate_owned_object_versions(&owned_objects)
+            .validate_owned_object_versions(&owned_objects)?;
+        Ok(VoteTransactionResult::Validated)
     }
 
     /// Used for early client validation check for transactions before submission to server.
@@ -4062,6 +4076,12 @@ impl AuthorityState {
 
         self.get_reconfig_api()
             .clear_state_end_of_epoch(&execution_lock);
+        // clear_state_end_of_epoch discards executed-but-not-finalized transaction
+        // outputs, so latest-version observations made during the old epoch are no
+        // longer lower bounds — a bound recorded from discarded execution state could
+        // exceed the reverted durable version and produce a spurious "consumed since
+        // claim" conflict verdict in the new epoch.
+        self.live_object_cache.clear();
         self.check_system_consistency(cur_epoch_store, state_hasher, expensive_safety_check_config);
         self.maybe_reaccumulate_state_hash(
             cur_epoch_store,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3747,7 +3747,9 @@ impl AuthorityState {
             chain_identifier,
             congestion_tracker: Arc::new(CongestionTracker::new()),
             consensus_gasless_counter: Arc::new(ConsensusGaslessCounter::default()),
-            live_object_cache: Arc::new(LiveObjectCache::new()),
+            // Shared with the epoch store (and its successors), which bumps consumed
+            // bounds when the quarantine flushes lock entries.
+            live_object_cache: epoch_store.live_object_cache().clone(),
             traffic_controller,
             fork_recovery_state,
             notify_epoch: tokio::sync::watch::channel(epoch).0,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -18,7 +18,6 @@ use crate::execution_scheduler::ExecutionScheduler;
 use crate::execution_scheduler::funds_withdraw_scheduler::FundsSettlement;
 use crate::gasless_rate_limiter::ConsensusGaslessCounter;
 use crate::jsonrpc_index::CoinIndexKey2;
-use crate::live_object_cache::LiveObjectCache;
 use crate::traffic_controller::TrafficController;
 use crate::traffic_controller::metrics::TrafficControllerMetrics;
 use crate::transaction_outputs::TransactionOutputs;
@@ -990,10 +989,6 @@ pub struct AuthorityState {
 
     /// Consumed by gasless tx rate limiter.
     pub(crate) consensus_gasless_counter: Arc<ConsensusGaslessCounter>,
-
-    /// Lower bounds on latest object versions, warmed by vote-time validation and
-    /// consumed by post-consensus owned-object conflict detection.
-    live_object_cache: Arc<LiveObjectCache>,
 
     /// Traffic controller for Sui core servers (json-rpc, validator service)
     pub traffic_controller: Option<Arc<TrafficController>>,
@@ -3747,9 +3742,6 @@ impl AuthorityState {
             chain_identifier,
             congestion_tracker: Arc::new(CongestionTracker::new()),
             consensus_gasless_counter: Arc::new(ConsensusGaslessCounter::default()),
-            // Shared with the epoch store (and its successors), which bumps consumed
-            // bounds when the quarantine flushes lock entries.
-            live_object_cache: epoch_store.live_object_cache().clone(),
             traffic_controller,
             fork_recovery_state,
             notify_epoch: tokio::sync::watch::channel(epoch).0,
@@ -3823,10 +3815,6 @@ impl AuthorityState {
     // TODO: Consolidate our traits to reduce the number of methods here.
     pub fn get_object_cache_reader(&self) -> &Arc<dyn ObjectCacheRead> {
         &self.execution_cache_trait_pointers.object_cache_reader
-    }
-
-    pub fn live_object_cache(&self) -> &Arc<LiveObjectCache> {
-        &self.live_object_cache
     }
 
     pub fn get_transaction_cache_reader(&self) -> &Arc<dyn TransactionCacheRead> {
@@ -4083,7 +4071,7 @@ impl AuthorityState {
         // longer lower bounds — a bound recorded from discarded execution state could
         // exceed the reverted durable version and produce a spurious "consumed since
         // claim" conflict verdict in the new epoch.
-        self.live_object_cache.clear();
+        cur_epoch_store.live_object_cache().clear();
         self.check_system_consistency(cur_epoch_store, state_hasher, expensive_safety_check_config);
         self.maybe_reaccumulate_state_hash(
             cur_epoch_store,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -18,6 +18,7 @@ use crate::execution_scheduler::ExecutionScheduler;
 use crate::execution_scheduler::funds_withdraw_scheduler::FundsSettlement;
 use crate::gasless_rate_limiter::ConsensusGaslessCounter;
 use crate::jsonrpc_index::CoinIndexKey2;
+use crate::live_object_cache::LiveObjectCache;
 use crate::traffic_controller::TrafficController;
 use crate::traffic_controller::metrics::TrafficControllerMetrics;
 use crate::transaction_outputs::TransactionOutputs;
@@ -337,6 +338,7 @@ pub struct AuthorityMetrics {
     pub consensus_handler_unpaid_amplification_deferrals: IntCounter,
     pub consensus_handler_cancelled_transactions: IntCounter,
     pub consensus_handler_dropped_transactions: IntCounterVec,
+    pub consensus_owned_object_lock_resolutions: IntCounterVec,
     pub consensus_handler_max_object_costs: IntGaugeVec,
     pub consensus_committed_subdags: IntCounterVec,
     pub accumulator_deposits: IntCounter,
@@ -701,6 +703,15 @@ impl AuthorityMetrics {
                 &["reason"],
                 registry,
             ).unwrap(),
+            consensus_owned_object_lock_resolutions: register_int_counter_vec_with_registry!(
+                "consensus_owned_object_lock_resolutions",
+                "Owned-object lock state resolutions in the consensus handler, by source. \
+                 quarantine/deferred/cache resolve from consensus in-memory state; \
+                 objects_db is an authoritative latest-object read (in-memory object \
+                 cache first, then DB); backstop is a residual lock-table point read",
+                &["source"],
+                registry,
+            ).unwrap(),
             consensus_handler_max_object_costs: register_int_gauge_vec_with_registry!(
                 "consensus_handler_max_congestion_control_object_costs",
                 "Max object costs for congestion control in the current consensus commit",
@@ -969,6 +980,10 @@ pub struct AuthorityState {
 
     /// Consumed by gasless tx rate limiter.
     pub(crate) consensus_gasless_counter: Arc<ConsensusGaslessCounter>,
+
+    /// Lower bounds on latest object versions, warmed by vote-time validation and
+    /// consumed by post-consensus owned-object conflict detection.
+    live_object_cache: Arc<LiveObjectCache>,
 
     /// Traffic controller for Sui core servers (json-rpc, validator service)
     pub traffic_controller: Option<Arc<TrafficController>>,
@@ -3718,6 +3733,7 @@ impl AuthorityState {
             chain_identifier,
             congestion_tracker: Arc::new(CongestionTracker::new()),
             consensus_gasless_counter: Arc::new(ConsensusGaslessCounter::default()),
+            live_object_cache: Arc::new(LiveObjectCache::new()),
             traffic_controller,
             fork_recovery_state,
             notify_epoch: tokio::sync::watch::channel(epoch).0,
@@ -3791,6 +3807,10 @@ impl AuthorityState {
     // TODO: Consolidate our traits to reduce the number of methods here.
     pub fn get_object_cache_reader(&self) -> &Arc<dyn ObjectCacheRead> {
         &self.execution_cache_trait_pointers.object_cache_reader
+    }
+
+    pub fn live_object_cache(&self) -> &Arc<LiveObjectCache> {
+        &self.live_object_cache
     }
 
     pub fn get_transaction_cache_reader(&self) -> &Arc<dyn TransactionCacheRead> {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -79,12 +79,8 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::DBMapUtils;
 use typed_store::Map;
 use typed_store::rocks::{DBBatch, DBMap, MetricConf};
-#[cfg(not(tidehunter))]
-use typed_store::rocks::{DBOptions, ReadWriteOptions, default_db_options, read_size_from_env};
 use typed_store::rocksdb::Options;
 
-#[cfg(not(tidehunter))]
-use super::authority_store_tables::ENV_VAR_LOCKS_BLOCK_CACHE_SIZE;
 use super::consensus_tx_status_cache::{ConsensusTxStatus, ConsensusTxStatusCache};
 use super::epoch_start_configuration::EpochStartConfigTrait;
 use super::execution_time_estimator::{ConsensusObservations, ExecutionTimeEstimator};
@@ -431,10 +427,6 @@ pub struct AuthorityPerEpochStore {
 #[derive(DBMapUtils)]
 #[cfg_attr(tidehunter, tidehunter)]
 pub struct AuthorityEpochTables {
-    /// Map from ObjectRef to transaction locking that object
-    #[default_options_override_fn = "owned_object_transaction_locks_table_default_config"]
-    owned_object_locked_transactions: DBMap<ObjectRef, LockDetailsWrapper>,
-
     /// Signatures over transaction effects that we have signed and returned to users.
     /// We store this to avoid re-signing the same effects twice.
     /// Note that this may contain signatures for effects from previous epochs, in the case
@@ -547,17 +539,6 @@ pub struct AuthorityEpochTables {
     pub(crate) dkg_output_v2: DBMap<u64, Option<dkg_v1::Output<PkG, EncG>>>,
 }
 
-#[cfg(not(tidehunter))]
-fn owned_object_transaction_locks_table_default_config() -> DBOptions {
-    DBOptions {
-        options: default_db_options()
-            .optimize_for_write_throughput()
-            .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
-            .options,
-        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(false),
-    }
-}
-
 impl AuthorityEpochTables {
     #[cfg(not(tidehunter))]
     pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
@@ -591,20 +572,10 @@ impl AuthorityEpochTables {
         let builder_checkpoint_summary_v2_config = KeySpaceConfig::new()
             .disable_unload()
             .with_value_cache_size(default_value_cache_size());
-        let object_ref_indexing = KeyIndexing::Hash;
         let tx_digest_indexing = KeyIndexing::key_reduction(32, 0..16);
         let uniform_key = KeyType::uniform(default_cells_per_mutex());
         let sequence_key = KeyType::from_prefix_bits(6 * 8 + 4);
         let configs = vec![
-            (
-                "owned_object_locked_transactions".to_string(),
-                ThConfig::new_with_config_indexing(
-                    object_ref_indexing,
-                    mutexes * 8,
-                    uniform_key,
-                    bloom_config.clone(),
-                ),
-            ),
             (
                 "effects_signatures".to_string(),
                 ThConfig::new_with_rm_prefix_indexing(
@@ -802,25 +773,6 @@ impl AuthorityEpochTables {
         Ok(self
             .last_consensus_stats_v2
             .get(&LAST_CONSENSUS_STATS_ADDR)?)
-    }
-
-    pub fn get_locked_transaction(&self, obj_ref: &ObjectRef) -> SuiResult<Option<LockDetails>> {
-        Ok(self
-            .owned_object_locked_transactions
-            .get(obj_ref)?
-            .map(|l| l.migrate().into_inner()))
-    }
-
-    pub fn multi_get_locked_transactions(
-        &self,
-        owned_input_objects: &[ObjectRef],
-    ) -> SuiResult<Vec<Option<LockDetails>>> {
-        Ok(self
-            .owned_object_locked_transactions
-            .multi_get(owned_input_objects)?
-            .into_iter()
-            .map(|l| l.map(|l| l.migrate().into_inner()))
-            .collect())
     }
 
     fn get_all_deferred_transactions(
@@ -1652,29 +1604,12 @@ impl AuthorityPerEpochStore {
     }
 
     #[cfg(test)]
-    pub fn delete_object_locks_for_test(&self, objects: &[ObjectRef]) {
-        for object in objects {
-            self.tables()
-                .expect("test should not cross epoch boundary")
-                .owned_object_locked_transactions
-                .remove(object)
-                .unwrap();
-        }
-    }
-
-    #[cfg(test)]
     pub fn insert_object_locks_for_test(&self, locks: &[(ObjectRef, TransactionDigest)]) {
-        // Simulates a finalized-but-unexecuted lock holder. Written both to the durable
-        // table (the pre-objects-table representation) and to the deferred-locks map
-        // (where the in-memory resolution finds locks whose holder has not executed and
-        // whose commit is no longer quarantined).
+        // Simulates a finalized-but-unexecuted lock holder via the deferred-locks map,
+        // where conflict resolution finds locks whose holder has not executed and whose
+        // commit is no longer quarantined.
         let mut by_digest: HashMap<TransactionDigest, Vec<ObjectRef>> = HashMap::new();
         for (object, digest) in locks {
-            self.tables()
-                .expect("test should not cross epoch boundary")
-                .owned_object_locked_transactions
-                .insert(object, &LockDetailsWrapper::from(*digest))
-                .unwrap();
             by_digest.entry(*digest).or_default().push(*object);
         }
         let mut deferred_locks = self
@@ -1808,19 +1743,9 @@ impl AuthorityPerEpochStore {
         Ok(cached)
     }
 
-    /// Gets owned object locks, checking quarantine first then falling back to DB.
-    /// After crash recovery, quarantine is empty so we naturally fall back to DB.
-    pub fn get_owned_object_locks(
-        &self,
-        obj_refs: &[ObjectRef],
-    ) -> SuiResult<Vec<Option<LockDetails>>> {
-        let tables = self.tables()?;
-        self.consensus_quarantine
-            .read()
-            .get_owned_object_locks(&tables, obj_refs)
-    }
-
     /// Lock held on `obj_ref` by a commit that is still quarantined (not yet flushed).
+    /// Locks of flushed commits are derivable from the objects table (their holders are
+    /// durably executed) and from the deferred-locks map.
     pub fn get_owned_object_lock_in_memory(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {
         self.consensus_quarantine
             .read()
@@ -1831,35 +1756,6 @@ impl AuthorityPerEpochStore {
     pub fn get_deferred_transaction_lock(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
         self.consensus_output_cache
             .get_deferred_transaction_lock(obj_ref)
-    }
-
-    /// Direct epoch-DB read of the lock table, bypassing the quarantine. Used only as the
-    /// backstop for refs whose object is immutable at the claimed version (see
-    /// docs/objects_locking.md §3.6a); the quarantine layer has already been consulted
-    /// for these refs.
-    pub fn multi_get_owned_object_locks_from_db(
-        &self,
-        obj_refs: &[ObjectRef],
-    ) -> SuiResult<Vec<Option<LockDetails>>> {
-        self.tables()?.multi_get_locked_transactions(obj_refs)
-    }
-
-    /// Batched read of existing owned-object locks, returned as a map containing only
-    /// the refs that are currently locked. The consensus commit handler prefetches the
-    /// cross-commit lock state (constant for the duration of a commit) once with this,
-    /// rather than reading per transaction inside
-    /// `try_acquire_owned_object_locks_post_consensus`.
-    pub fn get_owned_object_locks_map(
-        &self,
-        obj_refs: &[ObjectRef],
-    ) -> SuiResult<HashMap<ObjectRef, LockDetails>> {
-        let locks = self.get_owned_object_locks(obj_refs)?;
-        Ok(obj_refs
-            .iter()
-            .cloned()
-            .zip_eq(locks)
-            .filter_map(|(obj_ref, lock)| lock.map(|lock| (obj_ref, lock)))
-            .collect())
     }
 
     /// Attempts to acquire owned object locks for a transaction post-consensus.
@@ -1943,41 +1839,6 @@ impl AuthorityPerEpochStore {
             .iter()
             .map(|obj_ref| (*obj_ref, tx_digest))
             .collect())
-    }
-
-    /// The pre-objects-table lock acquisition check, over lock state read from the
-    /// quarantine + epoch DB (`get_owned_object_locks_map`). Kept for differential
-    /// validation of the objects-table-based resolution: debug builds run both and
-    /// assert the verdicts match.
-    #[cfg(debug_assertions)]
-    pub fn try_acquire_owned_object_locks_post_consensus_table_based(
-        &self,
-        owned_object_refs: &[ObjectRef],
-        tx_digest: TransactionDigest,
-        current_commit_locks: &HashMap<ObjectRef, TransactionDigest>,
-        existing_locks: &HashMap<ObjectRef, LockDetails>,
-    ) -> SuiResult<()> {
-        for obj_ref in owned_object_refs {
-            if let Some(locked_tx_digest) = current_commit_locks.get(obj_ref)
-                && *locked_tx_digest != tx_digest
-            {
-                return Err(SuiErrorKind::ObjectLockConflict {
-                    obj_ref: *obj_ref,
-                    pending_transaction: *locked_tx_digest,
-                }
-                .into());
-            }
-            if let Some(locked_tx_digest) = existing_locks.get(obj_ref)
-                && *locked_tx_digest != tx_digest
-            {
-                return Err(SuiErrorKind::ObjectLockConflict {
-                    obj_ref: *obj_ref,
-                    pending_transaction: *locked_tx_digest,
-                }
-                .into());
-            }
-        }
-        Ok(())
     }
 
     /// Resolves InputObjectKinds into InputKeys. `assigned_versions` is used to map shared inputs
@@ -3530,40 +3391,6 @@ impl ExecutionComponents {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LockDetailsWrapper {
-    V1(TransactionDigest),
-}
-
-impl LockDetailsWrapper {
-    pub fn migrate(self) -> Self {
-        // TODO: when there are multiple versions, we must iteratively migrate from version N to
-        // N+1 until we arrive at the latest version
-        self
-    }
-
-    // Always returns the most recent version. Older versions are migrated to the latest version at
-    // read time, so there is never a need to access older versions.
-    pub fn inner(&self) -> &LockDetails {
-        match self {
-            Self::V1(v1) => v1,
-
-            // can remove #[allow] when there are multiple versions
-            #[allow(unreachable_patterns)]
-            _ => panic!("lock details should have been migrated to latest version at read time"),
-        }
-    }
-    pub fn into_inner(self) -> LockDetails {
-        match self {
-            Self::V1(v1) => v1,
-
-            // can remove #[allow] when there are multiple versions
-            #[allow(unreachable_patterns)]
-            _ => panic!("lock details should have been migrated to latest version at read time"),
-        }
-    }
-}
-
 pub type LockDetails = TransactionDigest;
 
 /// Resolved cross-commit claim state of an owned object ref, produced by
@@ -3578,11 +3405,4 @@ pub enum LockResolution {
     /// consumed earlier in this epoch by some finalized, executed transaction (whose
     /// digest the objects table does not record).
     ConsumedSinceClaim,
-}
-
-impl From<LockDetails> for LockDetailsWrapper {
-    fn from(details: LockDetails) -> Self {
-        // always use latest version.
-        LockDetailsWrapper::V1(details)
-    }
 }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -970,7 +970,7 @@ impl AuthorityPerEpochStore {
 
         let jwk_aggregator = Mutex::new(jwk_aggregator);
 
-        let consensus_output_cache = ConsensusOutputCache::new(&tables);
+        let consensus_output_cache = ConsensusOutputCache::new(&tables, &*object_store);
 
         let execution_time_observations = tables
             .execution_time_observations
@@ -1664,12 +1664,25 @@ impl AuthorityPerEpochStore {
 
     #[cfg(test)]
     pub fn insert_object_locks_for_test(&self, locks: &[(ObjectRef, TransactionDigest)]) {
+        // Simulates a finalized-but-unexecuted lock holder. Written both to the durable
+        // table (the pre-objects-table representation) and to the deferred-locks map
+        // (where the in-memory resolution finds locks whose holder has not executed and
+        // whose commit is no longer quarantined).
+        let mut by_digest: HashMap<TransactionDigest, Vec<ObjectRef>> = HashMap::new();
         for (object, digest) in locks {
             self.tables()
                 .expect("test should not cross epoch boundary")
                 .owned_object_locked_transactions
                 .insert(object, &LockDetailsWrapper::from(*digest))
                 .unwrap();
+            by_digest.entry(*digest).or_default().push(*object);
+        }
+        let mut deferred_locks = self
+            .consensus_output_cache
+            .deferred_transaction_locks
+            .lock();
+        for (digest, refs) in by_digest {
+            deferred_locks.insert(digest, refs);
         }
     }
 
@@ -1807,6 +1820,30 @@ impl AuthorityPerEpochStore {
             .get_owned_object_locks(&tables, obj_refs)
     }
 
+    /// Lock held on `obj_ref` by a commit that is still quarantined (not yet flushed).
+    pub fn get_owned_object_lock_in_memory(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {
+        self.consensus_quarantine
+            .read()
+            .get_owned_object_lock_in_memory(obj_ref)
+    }
+
+    /// Lock held on `obj_ref` by a currently-deferred transaction.
+    pub fn get_deferred_transaction_lock(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
+        self.consensus_output_cache
+            .get_deferred_transaction_lock(obj_ref)
+    }
+
+    /// Direct epoch-DB read of the lock table, bypassing the quarantine. Used only as the
+    /// backstop for refs whose object is immutable at the claimed version (see
+    /// docs/objects_locking.md §3.6a); the quarantine layer has already been consulted
+    /// for these refs.
+    pub fn multi_get_owned_object_locks_from_db(
+        &self,
+        obj_refs: &[ObjectRef],
+    ) -> SuiResult<Vec<Option<LockDetails>>> {
+        self.tables()?.multi_get_locked_transactions(obj_refs)
+    }
+
     /// Batched read of existing owned-object locks, returned as a map containing only
     /// the refs that are currently locked. The consensus commit handler prefetches the
     /// cross-commit lock state (constant for the duration of a commit) once with this,
@@ -1827,13 +1864,20 @@ impl AuthorityPerEpochStore {
 
     /// Attempts to acquire owned object locks for a transaction post-consensus.
     ///
-    /// Checks whether the object versions are already locked by searching:
+    /// Checks whether the object versions are already claimed by searching:
     /// 1. The current commit (`current_commit_locks`, accumulated as earlier
     ///    transactions in this commit acquire locks).
-    /// 2. `existing_locks`: locks from earlier commits in this epoch (and the DB after
-    ///    crash recovery). These are constant for the duration of a commit, so the
-    ///    caller prefetches them once via `get_owned_object_locks_map` rather than
-    ///    reading per transaction.
+    /// 2. `existing_locks`: the resolved cross-commit lock state (quarantined commits,
+    ///    deferred transactions, objects-table verdicts). Constant for the duration of a
+    ///    commit, so the caller resolves it once for all refs of the commit.
+    ///
+    /// A `ConsumedSinceClaim` resolution means some transaction consumed the ref earlier
+    /// in this epoch; that is a conflict unless the consumer was this very transaction —
+    /// a duplicate sequencing of an already-executed transaction (possible across a
+    /// restart, where the first sequencing's commit was flushed and is not replayed).
+    /// The old lock table resolved that case by digest equality; here it is resolved by
+    /// "this digest already executed in this epoch", which is durably true wherever the
+    /// in-memory layers no longer hold the first sequencing's locks.
     ///
     /// Returns the new locks to add on success, or error if a conflict exists.
     pub fn try_acquire_owned_object_locks_post_consensus(
@@ -1841,8 +1885,11 @@ impl AuthorityPerEpochStore {
         owned_object_refs: &[ObjectRef],
         tx_digest: TransactionDigest,
         current_commit_locks: &HashMap<ObjectRef, TransactionDigest>,
-        existing_locks: &HashMap<ObjectRef, LockDetails>,
+        existing_locks: &HashMap<ObjectRef, LockResolution>,
+        object_cache: &dyn ObjectCacheRead,
     ) -> SuiResult<Vec<(ObjectRef, LockDetails)>> {
+        // Lazily computed: only would-be conflicts on consumed refs need it.
+        let mut already_executed: Option<bool> = None;
         for obj_ref in owned_object_refs {
             // Conflict with a transaction earlier in the same commit.
             if let Some(locked_tx_digest) = current_commit_locks.get(obj_ref)
@@ -1854,7 +1901,72 @@ impl AuthorityPerEpochStore {
                 }
                 .into());
             }
-            // Conflict with a lock from an earlier commit (or crash recovery).
+            match existing_locks.get(obj_ref) {
+                Some(LockResolution::LockedBy(locked_tx_digest))
+                    if *locked_tx_digest != tx_digest =>
+                {
+                    return Err(SuiErrorKind::ObjectLockConflict {
+                        obj_ref: *obj_ref,
+                        pending_transaction: *locked_tx_digest,
+                    }
+                    .into());
+                }
+                Some(LockResolution::ConsumedSinceClaim) => {
+                    let executed = *already_executed.get_or_insert_with(|| {
+                        self.transactions_executed_in_cur_epoch(&[tx_digest])
+                            // A read failure here cannot be resolved deterministically;
+                            // fail loudly instead of guessing.
+                            .expect("cannot read executed transactions")[0]
+                    });
+                    if !executed {
+                        // Winner digest is best-effort error enrichment: the transaction
+                        // that produced the current live version (which for multi-hop
+                        // consumption may be downstream of the actual first consumer).
+                        let pending_transaction = object_cache
+                            .get_object(&obj_ref.0)
+                            .map(|o| o.previous_transaction)
+                            .unwrap_or(TransactionDigest::ZERO);
+                        return Err(SuiErrorKind::ObjectLockConflict {
+                            obj_ref: *obj_ref,
+                            pending_transaction,
+                        }
+                        .into());
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        // No conflicts, so the consumed owned object versions are valid (from preconsensus validation)
+        // and available (from the checks above). Return the new locks to add.
+        Ok(owned_object_refs
+            .iter()
+            .map(|obj_ref| (*obj_ref, tx_digest))
+            .collect())
+    }
+
+    /// The pre-objects-table lock acquisition check, over lock state read from the
+    /// quarantine + epoch DB (`get_owned_object_locks_map`). Kept for differential
+    /// validation of the objects-table-based resolution: debug builds run both and
+    /// assert the verdicts match.
+    #[cfg(debug_assertions)]
+    pub fn try_acquire_owned_object_locks_post_consensus_table_based(
+        &self,
+        owned_object_refs: &[ObjectRef],
+        tx_digest: TransactionDigest,
+        current_commit_locks: &HashMap<ObjectRef, TransactionDigest>,
+        existing_locks: &HashMap<ObjectRef, LockDetails>,
+    ) -> SuiResult<()> {
+        for obj_ref in owned_object_refs {
+            if let Some(locked_tx_digest) = current_commit_locks.get(obj_ref)
+                && *locked_tx_digest != tx_digest
+            {
+                return Err(SuiErrorKind::ObjectLockConflict {
+                    obj_ref: *obj_ref,
+                    pending_transaction: *locked_tx_digest,
+                }
+                .into());
+            }
             if let Some(locked_tx_digest) = existing_locks.get(obj_ref)
                 && *locked_tx_digest != tx_digest
             {
@@ -1865,13 +1977,7 @@ impl AuthorityPerEpochStore {
                 .into());
             }
         }
-
-        // No conflicts, so the consumed owned object versions are valid (from preconsensus validation)
-        // and available (from the checks above). Return the new locks to add.
-        Ok(owned_object_refs
-            .iter()
-            .map(|obj_ref| (*obj_ref, tx_digest))
-            .collect())
+        Ok(())
     }
 
     /// Resolves InputObjectKinds into InputKeys. `assigned_versions` is used to map shared inputs
@@ -3459,6 +3565,20 @@ impl LockDetailsWrapper {
 }
 
 pub type LockDetails = TransactionDigest;
+
+/// Resolved cross-commit claim state of an owned object ref, produced by
+/// `resolve_owned_object_lock_states` (quarantined locks + deferred-transaction locks +
+/// objects-table version verdict) and consumed by
+/// `try_acquire_owned_object_locks_post_consensus`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LockResolution {
+    /// The ref is locked by a known transaction that has not consumed it yet.
+    LockedBy(TransactionDigest),
+    /// The objects table shows a latest version above the claimed version: the ref was
+    /// consumed earlier in this epoch by some finalized, executed transaction (whose
+    /// digest the objects table does not record).
+    ConsumedSinceClaim,
+}
 
 impl From<LockDetails> for LockDetailsWrapper {
     fn from(details: LockDetails) -> Self {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1755,7 +1755,9 @@ impl AuthorityPerEpochStore {
 
     /// Lock held on `obj_ref` by a commit that is still quarantined (not yet flushed).
     /// Locks of flushed commits are derivable from the objects table (their holders are
-    /// durably executed) and from the deferred-locks map.
+    /// durably executed) and from the deferred-locks map. Production resolution reads
+    /// through held guards instead (see `resolve_owned_object_lock_states`).
+    #[cfg(test)]
     pub fn get_owned_object_lock_in_memory(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {
         self.consensus_quarantine
             .read()
@@ -1763,9 +1765,12 @@ impl AuthorityPerEpochStore {
     }
 
     /// Lock held on `obj_ref` by a currently-deferred transaction.
+    #[cfg(test)]
     pub fn get_deferred_transaction_lock(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
         self.consensus_output_cache
-            .get_deferred_transaction_lock(obj_ref)
+            .deferred_transaction_locks
+            .lock()
+            .get(obj_ref)
     }
 
     pub fn live_object_cache(&self) -> &Arc<LiveObjectCache> {
@@ -1789,7 +1794,8 @@ impl AuthorityPerEpochStore {
     /// "this digest already executed in this epoch", which is durably true wherever the
     /// in-memory layers no longer hold the first sequencing's locks.
     ///
-    /// Returns the new locks to add on success, or error if a conflict exists.
+    /// Returns Ok(()) when all locks are acquirable, or error if a conflict exists.
+    /// Pure check: the caller records the acquired locks.
     pub fn try_acquire_owned_object_locks_post_consensus(
         &self,
         owned_object_refs: &[ObjectRef],
@@ -1797,7 +1803,7 @@ impl AuthorityPerEpochStore {
         current_commit_locks: &HashMap<ObjectRef, TransactionDigest>,
         existing_locks: &HashMap<ObjectRef, LockResolution>,
         object_cache: &dyn ObjectCacheRead,
-    ) -> SuiResult<Vec<(ObjectRef, LockDetails)>> {
+    ) -> SuiResult<()> {
         // Lazily computed: only would-be conflicts on consumed refs need it.
         let mut already_executed: Option<bool> = None;
         for obj_ref in owned_object_refs {
@@ -1854,12 +1860,9 @@ impl AuthorityPerEpochStore {
             }
         }
 
-        // No conflicts, so the consumed owned object versions are valid (from preconsensus validation)
-        // and available (from the checks above). Return the new locks to add.
-        Ok(owned_object_refs
-            .iter()
-            .map(|obj_ref| (*obj_ref, tx_digest))
-            .collect())
+        // No conflicts, so the consumed owned object versions are valid (from
+        // preconsensus validation) and available (from the checks above).
+        Ok(())
     }
 
     /// Resolves InputObjectKinds into InputKeys. `assigned_versions` is used to map shared inputs

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -118,6 +118,7 @@ use crate::epoch::reconfiguration::ReconfigState;
 use crate::execution_cache::ObjectCacheRead;
 use crate::execution_cache::cache_types::CacheResult;
 use crate::fallback_fetch::do_fallback_lookup;
+use crate::live_object_cache::LiveObjectCache;
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::signature_verifier::*;
 use crate::stake_aggregator::{GenericMultiStakeAggregator, StakeAggregator};
@@ -321,6 +322,12 @@ pub struct AuthorityPerEpochStore {
     pub(crate) consensus_quarantine: RwLock<ConsensusOutputQuarantine>,
     /// Holds variouis data from consensus_quarantine in a more easily accessible form.
     pub(crate) consensus_output_cache: ConsensusOutputCache,
+
+    /// Lower bounds on latest object versions, shared with `AuthorityState` and the
+    /// consensus components (vote-time warming, conflict resolution). Held here so the
+    /// quarantine flush can bump bounds for consumed lock refs before dropping their
+    /// in-memory lock entries.
+    live_object_cache: Arc<LiveObjectCache>,
 
     protocol_config: ProtocolConfig,
 
@@ -807,6 +814,7 @@ impl AuthorityPerEpochStore {
         previous_epoch_last_checkpoint: CheckpointSequenceNumber,
         submitted_transaction_cache_metrics: Arc<SubmittedTransactionCacheMetrics>,
         fullnode_sync_mode: Option<FullNodeSyncMode>,
+        live_object_cache: Arc<LiveObjectCache>,
     ) -> SuiResult<Arc<Self>> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -972,6 +980,7 @@ impl AuthorityPerEpochStore {
             protocol_config,
             tables: ArcSwapOption::new(Some(Arc::new(tables))),
             consensus_output_cache,
+            live_object_cache,
             consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
                 highest_executed_checkpoint,
                 metrics.clone(),
@@ -1212,6 +1221,7 @@ impl AuthorityPerEpochStore {
             epoch_last_checkpoint,
             self.submitted_transaction_cache.metrics(),
             fullnode_sync_mode,
+            self.live_object_cache.clone(),
         )
     }
 
@@ -1756,6 +1766,10 @@ impl AuthorityPerEpochStore {
     pub fn get_deferred_transaction_lock(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
         self.consensus_output_cache
             .get_deferred_transaction_lock(obj_ref)
+    }
+
+    pub fn live_object_cache(&self) -> &Arc<LiveObjectCache> {
+        &self.live_object_cache
     }
 
     /// Attempts to acquire owned object locks for a transaction post-consensus.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1808,12 +1808,19 @@ impl AuthorityPerEpochStore {
                     .into());
                 }
                 Some(LockResolution::ConsumedSinceClaim) => {
-                    let executed = *already_executed.get_or_insert_with(|| {
-                        self.transactions_executed_in_cur_epoch(&[tx_digest])
-                            // A read failure here cannot be resolved deterministically;
-                            // fail loudly instead of guessing.
-                            .expect("cannot read executed transactions")[0]
-                    });
+                    let executed = match already_executed {
+                        Some(executed) => executed,
+                        None => {
+                            // Propagated on failure (e.g. EpochEnded racing this check
+                            // on the submission path); a verdict cannot be derived from
+                            // a failed read. The consensus handler treats non-conflict
+                            // errors as fatal (it must not guess either way).
+                            let executed =
+                                self.transactions_executed_in_cur_epoch(&[tx_digest])?[0];
+                            already_executed = Some(executed);
+                            executed
+                        }
+                    };
                     if !executed {
                         // Winner digest is best-effort error enrichment: the transaction
                         // that produced the current live version (which for multi-hop

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -17,6 +17,7 @@ use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
 use futures::stream::FuturesUnordered;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::resolver::{ModuleResolver, SerializedPackage};
+#[cfg(test)]
 use serde::{Deserialize, Serialize};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_macros::fail_point_arg;
@@ -1470,6 +1471,7 @@ pub enum ObjectLockStatus {
     LockedAtDifferentVersion { locked_ref: ObjectRef },
 }
 
+#[cfg(test)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LockDetailsV1Deprecated {
     pub epoch: EpochId,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -20,7 +20,6 @@ use move_core_types::resolver::{ModuleResolver, SerializedPackage};
 use serde::{Deserialize, Serialize};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_macros::fail_point_arg;
-use sui_types::error::SuiErrorKind;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::message_envelope::Message;
@@ -33,14 +32,10 @@ use sui_types::{base_types::SequenceNumber, fp_ensure};
 use tokio::time::Instant;
 use tracing::{debug, info, trace};
 use typed_store::traits::Map;
-use typed_store::{
-    TypedStoreError,
-    rocks::{DBBatch, DBMap},
-};
+use typed_store::{TypedStoreError, rocks::DBBatch};
 
 use super::authority_store_tables::LiveObject;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
-use mysten_common::ZipDebugEqIteratorExt;
 use mysten_common::sync::notify_read::NotifyRead;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
@@ -571,14 +566,6 @@ impl AuthorityStore {
             std::iter::once((ObjectKey::from(object_ref), store_object)),
         )?;
 
-        // Update the index
-        if object.get_single_owner().is_some() {
-            // Only initialize lock for address owned objects.
-            if !object.is_child_object() {
-                self.initialize_live_object_markers_impl(&mut write_batch, &[object_ref], false)?;
-            }
-        }
-
         write_batch.write()?;
 
         Ok(())
@@ -588,28 +575,15 @@ impl AuthorityStore {
     #[instrument(level = "debug", skip_all)]
     pub(crate) fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> SuiResult<()> {
         let mut batch = self.perpetual_tables.objects.batch();
-        let ref_and_objects: Vec<_> = objects
-            .iter()
-            .map(|o| (o.compute_object_reference(), o))
-            .collect();
 
         batch.insert_batch(
             &self.perpetual_tables.objects,
-            ref_and_objects
-                .iter()
-                .map(|(oref, o)| (ObjectKey::from(oref), get_store_object((*o).clone()))),
-        )?;
-
-        let non_child_object_refs: Vec<_> = ref_and_objects
-            .iter()
-            .filter(|(_, object)| !object.is_child_object())
-            .map(|(oref, _)| *oref)
-            .collect();
-
-        self.initialize_live_object_markers_impl(
-            &mut batch,
-            &non_child_object_refs,
-            false, // is_force_reset
+            objects.iter().map(|o| {
+                (
+                    ObjectKey::from(o.compute_object_reference()),
+                    get_store_object(o.clone()),
+                )
+            }),
         )?;
 
         batch.write()?;
@@ -672,14 +646,6 @@ impl AuthorityStore {
                             store_object_wrapper,
                         )),
                     )?;
-                    if !object.is_child_object() {
-                        Self::initialize_live_object_markers(
-                            &perpetual_db.live_owned_object_markers,
-                            &mut batch,
-                            &[object.compute_object_reference()],
-                            true, // is_force_reset
-                        )?;
-                    }
                 }
                 LiveObject::Wrapped(object_key) => {
                     batch.insert_batch(
@@ -761,8 +727,6 @@ impl AuthorityStore {
             written,
             events,
             unchanged_loaded_runtime_objects,
-            locks_to_delete,
-            new_locks_to_init,
             ..
         } = tx_outputs;
 
@@ -833,12 +797,6 @@ impl AuthorityStore {
             )?;
         }
 
-        self.initialize_live_object_markers_impl(write_batch, new_locks_to_init, false)?;
-
-        // Note: deletes locks for received objects as well (but not for objects that were in
-        // `Receiving` arguments which were not received)
-        self.delete_live_object_markers(write_batch, locks_to_delete)?;
-
         debug!(effects_digest = ?effects.digest(), "commit_certificate finished");
 
         Ok(())
@@ -853,75 +811,6 @@ impl AuthorityStore {
             [(tx.digest(), tx.clone().into_unsigned().serializable_ref())],
         )?;
         batch.write()?;
-        Ok(())
-    }
-
-    /// Initialize a lock to None (but exists) for a given list of ObjectRefs.
-    /// Returns SuiErrorKind::ObjectLockAlreadyInitialized if the lock already exists and is locked to a transaction
-    fn initialize_live_object_markers_impl(
-        &self,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-        is_force_reset: bool,
-    ) -> SuiResult {
-        AuthorityStore::initialize_live_object_markers(
-            &self.perpetual_tables.live_owned_object_markers,
-            write_batch,
-            objects,
-            is_force_reset,
-        )
-    }
-
-    pub fn initialize_live_object_markers(
-        live_object_marker_table: &DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-        is_force_reset: bool,
-    ) -> SuiResult {
-        trace!(?objects, "initialize_locks");
-
-        if !is_force_reset {
-            let live_object_markers = live_object_marker_table.multi_get(objects)?;
-            // If any live_object_markers exist and are not None, return errors for them
-            // Note we don't check if there is a pre-existing lock. this is because initializing the live
-            // object marker will not overwrite the lock and cause the validator to equivocate.
-            let existing_live_object_markers: Vec<ObjectRef> = live_object_markers
-                .iter()
-                .zip_debug_eq(objects)
-                .filter_map(|(lock_opt, objref)| {
-                    lock_opt.clone().flatten().map(|_tx_digest| *objref)
-                })
-                .collect();
-            if !existing_live_object_markers.is_empty() {
-                info!(
-                    ?existing_live_object_markers,
-                    "Cannot initialize live_object_markers because some exist already"
-                );
-                return Err(SuiErrorKind::ObjectLockAlreadyInitialized {
-                    refs: existing_live_object_markers,
-                }
-                .into());
-            }
-        }
-
-        write_batch.insert_batch(
-            live_object_marker_table,
-            objects.iter().map(|obj_ref| (obj_ref, None)),
-        )?;
-        Ok(())
-    }
-
-    /// Removes locks for a given list of ObjectRefs.
-    fn delete_live_object_markers(
-        &self,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-    ) -> SuiResult {
-        trace!(?objects, "delete_locks");
-        write_batch.delete_batch(
-            &self.perpetual_tables.live_owned_object_markers,
-            objects.iter(),
-        )?;
         Ok(())
     }
 
@@ -1579,11 +1468,6 @@ pub enum ObjectLockStatus {
     Initialized,
     LockedToTx { locked_by_tx: LockDetailsDeprecated },
     LockedAtDifferentVersion { locked_ref: ObjectRef },
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LockDetailsWrapperDeprecated {
-    V1(LockDetailsV1Deprecated),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::authority::authority_store::LockDetailsWrapperDeprecated;
 #[cfg(tidehunter)]
 use crate::authority::epoch_marker_key::EPOCH_MARKER_KEY_SIZE;
 use crate::authority::epoch_marker_key::EpochMarkerKey;
@@ -72,13 +71,6 @@ pub struct AuthorityPerpetualTables {
     /// been written out, and which must be retried. But, they cannot be retried unless their input
     /// objects are still accessible!
     pub(crate) objects: DBMap<ObjectKey, StoreObjectWrapper>,
-
-    /// DEPRECATED: markers of live address-owned object refs. Nothing reads this table
-    /// anymore; writes are still maintained so that rolling back to a previous binary
-    /// finds a correctly maintained table. The table (and its writes) will be removed
-    /// entirely in a follow-up once this version is deployed everywhere.
-    #[rename = "owned_object_transaction_locks"]
-    pub(crate) live_owned_object_markers: DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
 
     /// This is a map between the transaction digest and the corresponding transaction that's known to be
     /// executable. This means that it may have been executed locally, or it may have been synced through
@@ -187,10 +179,6 @@ impl AuthorityPerpetualTables {
                 objects_table_config(db_options.clone()),
             ),
             (
-                "owned_object_transaction_locks".to_string(),
-                owned_object_transaction_locks_table_config(db_options.clone()),
-            ),
-            (
                 "transactions".to_string(),
                 transactions_table_config(db_options.clone()),
             ),
@@ -252,10 +240,6 @@ impl AuthorityPerpetualTables {
         let epoch_tx_digest_prefix_key =
             KeyType::from_prefix_bits((8/*EpochId*/ + 8/*TransactionDigest prefix*/) * 8 + 12);
         let object_indexing = KeyIndexing::fixed(32 + 8); //  KeyIndexing::key_reduction(32 + 8, 16..(32 + 8));
-        // todo can figure way to scramble off 8 bytes in the middle
-        let obj_ref_size = 32 + 8 + 32 + 8;
-        let owned_object_transaction_locks_indexing =
-            KeyIndexing::key_reduction(obj_ref_size, 16..(obj_ref_size - 16));
 
         let mut objects_config = KeySpaceConfig::new()
             .with_max_dirty_keys(16 * default_max_dirty_keys())
@@ -272,17 +256,6 @@ impl AuthorityPerpetualTables {
                     mutexes * 4,
                     KeyType::uniform(1),
                     objects_config,
-                ),
-            ),
-            (
-                "owned_object_transaction_locks".to_string(),
-                ThConfig::new_with_config_indexing(
-                    owned_object_transaction_locks_indexing,
-                    mutexes * 16,
-                    KeyType::uniform(default_cells_per_mutex()),
-                    bloom_config
-                        .clone()
-                        .with_max_dirty_keys(16 * default_max_dirty_keys()),
                 ),
             ),
             (
@@ -948,18 +921,6 @@ impl Iterator for LiveSetIter<'_> {
 }
 
 // These functions are used to initialize the DB tables
-#[cfg(not(tidehunter))]
-fn owned_object_transaction_locks_table_config(db_options: DBOptions) -> DBOptions {
-    DBOptions {
-        options: db_options
-            .clone()
-            .optimize_for_write_throughput()
-            .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
-            .options,
-        rw_options: db_options.rw_options.set_ignore_range_deletions(false),
-    }
-}
-
 #[cfg(not(tidehunter))]
 fn objects_table_config(db_options: DBOptions) -> DBOptions {
     db_options

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -27,8 +27,6 @@ use typed_store::{DBMapUtils, DbIterator};
 #[cfg(not(tidehunter))]
 const ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE: &str = "OBJECTS_BLOCK_CACHE_MB";
 #[cfg(not(tidehunter))]
-pub(crate) const ENV_VAR_LOCKS_BLOCK_CACHE_SIZE: &str = "LOCKS_BLOCK_CACHE_MB";
-#[cfg(not(tidehunter))]
 const ENV_VAR_TRANSACTIONS_BLOCK_CACHE_SIZE: &str = "TRANSACTIONS_BLOCK_CACHE_MB";
 #[cfg(not(tidehunter))]
 const ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE: &str = "EFFECTS_BLOCK_CACHE_MB";

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -70,6 +70,14 @@ pub(crate) struct ConsensusCommitOutput {
     next_shared_object_versions: Option<HashMap<ConsensusObjectSequenceKey, SequenceNumber>>,
 
     deferred_txns: Vec<(DeferralKey, Vec<VerifiedExecutableTransactionWithAliases>)>,
+
+    // Previously-deferred transactions reloaded by this commit that did not re-defer
+    // (scheduled or cancelled - both execute). Their deferred-locks map entries are
+    // removed when this commit flushes: the flush gate guarantees they are executed by
+    // then, so the objects table takes over conflict coverage with no gap. (Removing at
+    // reload would open a window - reload until flush - where the locks are in no
+    // in-memory layer and the transaction may not have executed yet.)
+    finalized_reloaded_deferred_txns: Vec<TransactionDigest>,
     deleted_deferred_txns: BTreeSet<DeferralKey>,
 
     // checkpoint state
@@ -209,6 +217,11 @@ impl ConsensusCommitOutput {
     pub fn delete_loaded_deferred_transactions(&mut self, deferral_keys: &[DeferralKey]) {
         self.deleted_deferred_txns
             .extend(deferral_keys.iter().cloned());
+    }
+
+    pub fn set_finalized_reloaded_deferred_txns(&mut self, digests: Vec<TransactionDigest>) {
+        assert!(self.finalized_reloaded_deferred_txns.is_empty());
+        self.finalized_reloaded_deferred_txns = digests;
     }
 
     pub fn insert_pending_checkpoint(&mut self, checkpoint: PendingCheckpoint) {
@@ -404,10 +417,12 @@ impl ConsensusCommitOutput {
 /// Deferred transactions are the one class of finalized transactions whose locks the
 /// objects table cannot reproduce: they hold locks from their first appearance but have
 /// not executed, so their inputs are still at the claimed versions. This map keeps those
-/// locks in memory so post-consensus conflict detection does not need the durable lock
-/// table for them. Maintained by the consensus handler alongside `deferred_transactions`:
-/// entries are inserted on deferral and removed on reload (at which point the reloaded
-/// transaction re-acquires into the current commit's locks or re-defers).
+/// locks in memory so post-consensus conflict detection does not need a durable lock
+/// table for them. Entries are inserted by the consensus handler on deferral and removed
+/// when the commit that reloaded the transaction for scheduling *flushes* (by which
+/// point the transaction is executed and the objects table takes over coverage) —
+/// mirroring the lifetime of the durable deferred-transactions table entry, whose
+/// deletion is part of that same flush.
 #[derive(Default)]
 pub(crate) struct DeferredTransactionLocks {
     by_ref: HashMap<ObjectRef, TransactionDigest>,
@@ -434,6 +449,10 @@ impl DeferredTransactionLocks {
 
     pub fn get(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
         self.by_ref.get(obj_ref).copied()
+    }
+
+    pub fn contains_tx(&self, digest: &TransactionDigest) -> bool {
+        self.by_tx.contains_key(digest)
     }
 }
 
@@ -473,8 +492,8 @@ impl ConsensusOutputCache {
         // versions (it holds their locks and has not executed - and its commit was flushed,
         // so all producing transactions have been executed locally), which makes
         // immutability decidable per ref. A byzantine under-claim can make this a subset of
-        // the originally-acquired set for immutable refs only; the lock-table backstop in
-        // conflict resolution covers exactly that case.
+        // the originally-acquired set for immutable refs only - quorum-unreachable once
+        // strict vote-time claims verification is universal.
         let mut deferred_transaction_locks = DeferredTransactionLocks::default();
         for transactions in deferred_transactions.values() {
             for tx in transactions {
@@ -743,6 +762,18 @@ impl ConsensusOutputQuarantine {
                 self.remove_processed_consensus_messages(&output);
                 self.remove_congestion_control_debts(&output);
                 self.remove_owned_object_locks(&output);
+                // Reloaded deferred transactions covered by this commit are executed by
+                // now (the flush gate requires their checkpoints executed), so the
+                // objects table covers their consumed inputs from here on.
+                if !output.finalized_reloaded_deferred_txns.is_empty() {
+                    let mut deferred_locks = epoch_store
+                        .consensus_output_cache
+                        .deferred_transaction_locks
+                        .lock();
+                    for digest in &output.finalized_reloaded_deferred_txns {
+                        deferred_locks.remove_tx(digest);
+                    }
+                }
                 output.write_to_batch(epoch_store, batch)?;
             }
         }

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::authority_per_epoch_store::{
-    AuthorityEpochTables, EncG, ExecutionIndicesWithStatsV2, LockDetails, LockDetailsWrapper, PkG,
+    AuthorityEpochTables, EncG, ExecutionIndicesWithStatsV2, LockDetails, PkG,
 };
 use crate::authority::transaction_deferral::DeferralKey;
 use crate::checkpoints::BuilderCheckpointSummary;
@@ -306,15 +306,6 @@ impl ConsensusCommitOutput {
 
         if let Some(next_versions) = self.next_shared_object_versions {
             batch.insert_batch(&tables.next_shared_object_versions_v2, next_versions)?;
-        }
-
-        if !self.owned_object_locks.is_empty() {
-            batch.insert_batch(
-                &tables.owned_object_locked_transactions,
-                self.owned_object_locks
-                    .into_iter()
-                    .map(|(obj_ref, lock)| (obj_ref, LockDetailsWrapper::from(lock))),
-            )?;
         }
 
         batch.delete_batch(
@@ -896,30 +887,6 @@ impl ConsensusOutputQuarantine {
         obj_ref: &ObjectRef,
     ) -> Option<LockDetails> {
         self.owned_object_locks.get(obj_ref).copied()
-    }
-
-    /// Gets owned object locks, checking quarantine first then falling back to DB.
-    /// After crash recovery, quarantine is empty so we naturally fall back to DB.
-    pub(super) fn get_owned_object_locks(
-        &self,
-        tables: &AuthorityEpochTables,
-        obj_refs: &[ObjectRef],
-    ) -> SuiResult<Vec<Option<LockDetails>>> {
-        Ok(do_fallback_lookup(
-            obj_refs,
-            |obj_ref| {
-                if let Some(lock) = self.owned_object_locks.get(obj_ref) {
-                    CacheResult::Hit(Some(*lock))
-                } else {
-                    CacheResult::Miss
-                }
-            },
-            |obj_refs| {
-                tables
-                    .multi_get_locked_transactions(obj_refs)
-                    .expect("db error")
-            },
-        ))
     }
 
     pub(super) fn get_highest_pending_checkpoint_height(&self) -> Option<CheckpointHeight> {

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -939,7 +939,7 @@ impl ConsensusOutputQuarantine {
     /// In-memory-only lock lookup: locks acquired by commits that are still quarantined
     /// (not yet flushed to the epoch DB). Used by the objects-table-based conflict
     /// resolution, which covers flushed commits via the objects table instead of the DB.
-    pub(super) fn get_owned_object_lock_in_memory(
+    pub(crate) fn get_owned_object_lock_in_memory(
         &self,
         obj_ref: &ObjectRef,
     ) -> Option<LockDetails> {

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -1269,6 +1269,79 @@ mod tests {
         // Both outputs drained.
         assert_eq!(quarantine.output_queue_len_for_testing(), 0);
     }
+
+    // Regression test: transaction T defers in commit C1 (locks in C1's output and the
+    // deferred-locks map) and is reloaded for scheduling in a later commit C2. C1 can
+    // flush before C2; T's conflict coverage must survive that window even though the
+    // flat quarantine map drops C1's entries at C1's flush — the deferred-locks entry
+    // lives until C2 flushes, by which point T is executed and the objects table covers
+    // its consumed inputs.
+    #[tokio::test]
+    async fn test_deferred_lock_coverage_survives_deferring_commit_flush() {
+        use sui_types::base_types::ObjectDigest;
+
+        let state = TestAuthorityBuilder::new().build().await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        let metrics = epoch_store.metrics.clone();
+        let mut quarantine = ConsensusOutputQuarantine::new(0, metrics);
+
+        let t_digest = TransactionDigest::random();
+        let lock_ref: ObjectRef = (
+            ObjectID::random(),
+            SequenceNumber::from_u64(1),
+            ObjectDigest::random(),
+        );
+
+        // C1: T is finalized and deferred - locks acquired into the output, refs into
+        // the deferred-locks map (as the deferral bookkeeping does).
+        let mut c1 = make_output(1, 1, true);
+        c1.set_owned_object_locks([(lock_ref, t_digest)].into_iter().collect());
+        epoch_store
+            .consensus_output_cache
+            .deferred_transaction_locks
+            .lock()
+            .insert(t_digest, vec![lock_ref]);
+        quarantine.push_consensus_output(c1, &epoch_store).unwrap();
+
+        assert_eq!(
+            quarantine.get_owned_object_lock_in_memory(&lock_ref),
+            Some(t_digest)
+        );
+
+        // C2: reloads T for scheduling (T does not re-defer).
+        let mut c2 = make_output(2, 2, true);
+        c2.set_finalized_reloaded_deferred_txns(vec![t_digest]);
+        quarantine.push_consensus_output(c2, &epoch_store).unwrap();
+
+        // Flush C1 only.
+        let pc = epoch_store.protocol_config();
+        quarantine.insert_builder_summary(1, make_builder_summary(1, 1, pc));
+        let mut batch = epoch_store.db_batch_for_test();
+        quarantine
+            .update_highest_executed_checkpoint(1, &epoch_store, &mut batch)
+            .unwrap();
+        batch.write().unwrap();
+        assert_eq!(quarantine.output_queue_len_for_testing(), 1);
+
+        // The flat map dropped C1's entry, but the deferred-locks map still covers T.
+        assert_eq!(quarantine.get_owned_object_lock_in_memory(&lock_ref), None);
+        assert_eq!(
+            epoch_store.get_deferred_transaction_lock(&lock_ref),
+            Some(t_digest)
+        );
+
+        // Flush C2: T is executed by then (flush gate), so the deferred entry is
+        // released and the objects table takes over.
+        quarantine.insert_builder_summary(2, make_builder_summary(2, 2, pc));
+        let mut batch = epoch_store.db_batch_for_test();
+        quarantine
+            .update_highest_executed_checkpoint(2, &epoch_store, &mut batch)
+            .unwrap();
+        batch.write().unwrap();
+        assert_eq!(quarantine.output_queue_len_for_testing(), 0);
+        assert_eq!(epoch_store.get_deferred_transaction_lock(&lock_ref), None);
+    }
 }
 
 #[cfg(test)]

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -27,6 +27,8 @@ use sui_types::executable_transaction::{
 use sui_types::execution::ExecutionTimeObservationKey;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::messages_consensus::AuthorityIndex;
+use sui_types::storage::ObjectStore;
+use sui_types::transaction::{InputObjectKind, TransactionDataAPI};
 use sui_types::{
     base_types::{ConsensusObjectSequenceKey, ObjectID},
     digests::TransactionDigest,
@@ -406,6 +408,44 @@ impl ConsensusCommitOutput {
     }
 }
 
+/// Owned-object lock refs held by currently-deferred transactions.
+///
+/// Deferred transactions are the one class of finalized transactions whose locks the
+/// objects table cannot reproduce: they hold locks from their first appearance but have
+/// not executed, so their inputs are still at the claimed versions. This map keeps those
+/// locks in memory so post-consensus conflict detection does not need the durable lock
+/// table for them. Maintained by the consensus handler alongside `deferred_transactions`:
+/// entries are inserted on deferral and removed on reload (at which point the reloaded
+/// transaction re-acquires into the current commit's locks or re-defers).
+#[derive(Default)]
+pub(crate) struct DeferredTransactionLocks {
+    by_ref: HashMap<ObjectRef, TransactionDigest>,
+    by_tx: HashMap<TransactionDigest, Vec<ObjectRef>>,
+}
+
+impl DeferredTransactionLocks {
+    pub fn insert(&mut self, digest: TransactionDigest, refs: Vec<ObjectRef>) {
+        for obj_ref in &refs {
+            self.by_ref.insert(*obj_ref, digest);
+        }
+        self.by_tx.insert(digest, refs);
+    }
+
+    /// Removes and returns the lock refs held by `digest`. The caller decides whether
+    /// they re-enter this map (re-deferral) or the current commit's locks (scheduling).
+    pub fn remove_tx(&mut self, digest: &TransactionDigest) -> Option<Vec<ObjectRef>> {
+        let refs = self.by_tx.remove(digest)?;
+        for obj_ref in &refs {
+            self.by_ref.remove(obj_ref);
+        }
+        Some(refs)
+    }
+
+    pub fn get(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
+        self.by_ref.get(obj_ref).copied()
+    }
+}
+
 /// ConsensusOutputCache holds outputs of consensus processing that do not need to be committed to disk.
 /// Data quarantining guarantees that all of this data will be used (e.g. for building checkpoints)
 /// before the consensus commit from which it originated is marked as processed. Therefore we can rely
@@ -415,6 +455,10 @@ pub(crate) struct ConsensusOutputCache {
     // - hence no need for a DashMap.
     pub(crate) deferred_transactions:
         Mutex<BTreeMap<DeferralKey, Vec<VerifiedExecutableTransactionWithAliases>>>,
+
+    // Read by the consensus handler and the transaction submission path; written only by
+    // the consensus handler.
+    pub(crate) deferred_transaction_locks: Mutex<DeferredTransactionLocks>,
 
     // user_signatures_for_checkpoints is written to by consensus handler and read from by checkpoint builder
     // The critical sections are small in both cases so a DashMap is probably not helpful.
@@ -427,15 +471,33 @@ pub(crate) struct ConsensusOutputCache {
 }
 
 impl ConsensusOutputCache {
-    pub(crate) fn new(tables: &AuthorityEpochTables) -> Self {
+    pub(crate) fn new(tables: &AuthorityEpochTables, object_store: &dyn ObjectStore) -> Self {
         let deferred_transactions = tables
             .get_all_deferred_transactions()
             .expect("load deferred transactions cannot fail");
+
+        // Rebuild the in-memory locks of deferred transactions. The stored transactions do
+        // not carry their immutable-object claims, so the lock set is re-derived from live
+        // objects: a deferred transaction's owned inputs are still live at their claimed
+        // versions (it holds their locks and has not executed - and its commit was flushed,
+        // so all producing transactions have been executed locally), which makes
+        // immutability decidable per ref. A byzantine under-claim can make this a subset of
+        // the originally-acquired set for immutable refs only; the lock-table backstop in
+        // conflict resolution covers exactly that case.
+        let mut deferred_transaction_locks = DeferredTransactionLocks::default();
+        for transactions in deferred_transactions.values() {
+            for tx in transactions {
+                let digest = *tx.tx().digest();
+                let refs = derive_deferred_owned_lock_refs(object_store, tx);
+                deferred_transaction_locks.insert(digest, refs);
+            }
+        }
 
         let executed_in_epoch_cache_capacity = 50_000;
 
         Self {
             deferred_transactions: Mutex::new(deferred_transactions),
+            deferred_transaction_locks: Mutex::new(deferred_transaction_locks),
             user_signatures_for_checkpoints: Default::default(),
             executed_in_epoch: RwLock::new(DashMap::with_shard_amount(2048)),
             executed_in_epoch_cache: MokaCache::builder(8)
@@ -446,6 +508,10 @@ impl ConsensusOutputCache {
                 .eviction_policy(EvictionPolicy::lru())
                 .build(),
         }
+    }
+
+    pub fn get_deferred_transaction_lock(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
+        self.deferred_transaction_locks.lock().get(obj_ref)
     }
 
     pub fn executed_in_current_epoch(&self, digest: &TransactionDigest) -> bool {
@@ -477,6 +543,34 @@ impl ConsensusOutputCache {
             executed_in_epoch.remove(tx_digest);
         }
     }
+}
+
+/// The owned-object lock refs a deferred transaction holds, re-derived from live objects:
+/// every non-immutable `ImmOrOwnedMoveObject` input (immutable inputs were claimed at vote
+/// time and excluded from lock acquisition). Any ref in an unexpected state (missing, or
+/// not live at the claimed version - which the held lock should preclude) is included
+/// conservatively: the durable lock table holds every originally-acquired ref, so
+/// over-inclusion here can only reproduce a lock that really exists.
+fn derive_deferred_owned_lock_refs(
+    object_store: &dyn ObjectStore,
+    tx: &VerifiedExecutableTransactionWithAliases,
+) -> Vec<ObjectRef> {
+    let Ok(input_objects) = tx.tx().transaction_data().input_objects() else {
+        // Finalized transactions have valid input objects; stay conservative if not.
+        return Vec::new();
+    };
+    input_objects
+        .iter()
+        .filter_map(|kind| match kind {
+            InputObjectKind::ImmOrOwnedMoveObject(obj_ref) => {
+                match object_store.get_object(&obj_ref.0) {
+                    Some(object) if object.version() == obj_ref.1 && object.is_immutable() => None,
+                    _ => Some(*obj_ref),
+                }
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 /// ConsensusOutputQuarantine holds outputs of consensus processing in memory until the checkpoints
@@ -792,6 +886,16 @@ impl ConsensusOutputQuarantine {
                     .expect("db error")
             },
         ))
+    }
+
+    /// In-memory-only lock lookup: locks acquired by commits that are still quarantined
+    /// (not yet flushed to the epoch DB). Used by the objects-table-based conflict
+    /// resolution, which covers flushed commits via the objects table instead of the DB.
+    pub(super) fn get_owned_object_lock_in_memory(
+        &self,
+        obj_ref: &ObjectRef,
+    ) -> Option<LockDetails> {
+        self.owned_object_locks.get(obj_ref).copied()
     }
 
     /// Gets owned object locks, checking quarantine first then falling back to DB.
@@ -1166,5 +1270,45 @@ mod tests {
         // C2 has height=5 <= 5, drained=true => drain boundary at index 1.
         // Both outputs drained.
         assert_eq!(quarantine.output_queue_len_for_testing(), 0);
+    }
+}
+
+#[cfg(test)]
+mod deferred_locks_tests {
+    use super::*;
+    use sui_types::base_types::{ObjectDigest, SequenceNumber};
+
+    fn obj_ref(version: u64) -> ObjectRef {
+        (
+            ObjectID::random(),
+            SequenceNumber::from_u64(version),
+            ObjectDigest::random(),
+        )
+    }
+
+    #[test]
+    fn test_deferred_transaction_locks() {
+        let mut locks = DeferredTransactionLocks::default();
+        let tx1 = TransactionDigest::random();
+        let tx2 = TransactionDigest::random();
+        let (a, b, c) = (obj_ref(1), obj_ref(2), obj_ref(3));
+
+        locks.insert(tx1, vec![a, b]);
+        locks.insert(tx2, vec![c]);
+        assert_eq!(locks.get(&a), Some(tx1));
+        assert_eq!(locks.get(&b), Some(tx1));
+        assert_eq!(locks.get(&c), Some(tx2));
+
+        // Removal returns the refs and clears both indexes.
+        let removed = locks.remove_tx(&tx1).unwrap();
+        assert_eq!(removed, vec![a, b]);
+        assert_eq!(locks.get(&a), None);
+        assert_eq!(locks.get(&b), None);
+        assert_eq!(locks.get(&c), Some(tx2));
+        assert_eq!(locks.remove_tx(&tx1), None);
+
+        // Re-deferral cycle: insert again after removal.
+        locks.insert(tx1, vec![a]);
+        assert_eq!(locks.get(&a), Some(tx1));
     }
 }

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -761,19 +761,45 @@ impl ConsensusOutputQuarantine {
                 self.remove_shared_object_next_versions(&output);
                 self.remove_processed_consensus_messages(&output);
                 self.remove_congestion_control_debts(&output);
-                self.remove_owned_object_locks(&output);
-                // Reloaded deferred transactions covered by this commit are executed by
-                // now (the flush gate requires their checkpoints executed), so the
-                // objects table covers their consumed inputs from here on.
-                if !output.finalized_reloaded_deferred_txns.is_empty() {
+                // Lock refs dropped by this flush belong to executed transactions (the
+                // flush gate requires the commit's checkpoints executed), so their
+                // consumed version-bounds are recorded in the live-object cache BEFORE
+                // the in-memory lock entries disappear. Any conflict resolution that
+                // misses the memory layers therefore sees the bumps - this ordering is
+                // what makes cached bounds decisive verdicts and keeps steady-state
+                // resolution off the DB. (This runs under the quarantine write lock, so
+                // for quarantined locks the bumps are visible to any reader that
+                // observes the removal.)
+                //
+                // Exception: refs of transactions that this commit DEFERRED have not
+                // executed - their entries in the deferred-locks map shield them from
+                // resolution, and their bumps happen at the flush of the commit that
+                // eventually schedules them (below).
+                let live_object_cache = epoch_store.live_object_cache();
+                {
                     let mut deferred_locks = epoch_store
                         .consensus_output_cache
                         .deferred_transaction_locks
                         .lock();
+                    for obj_ref in output.owned_object_locks.keys() {
+                        if deferred_locks.get(obj_ref).is_none() {
+                            live_object_cache.record_consumed(obj_ref);
+                        }
+                    }
+                    // Reloaded deferred transactions covered by this commit are
+                    // executed by now as well; bump their refs and release their
+                    // deferred-locks entries. Both happen inside the map's critical
+                    // section, so readers observe either the entry or the bump - never
+                    // neither.
                     for digest in &output.finalized_reloaded_deferred_txns {
-                        deferred_locks.remove_tx(digest);
+                        if let Some(refs) = deferred_locks.remove_tx(digest) {
+                            for obj_ref in &refs {
+                                live_object_cache.record_consumed(obj_ref);
+                            }
+                        }
                     }
                 }
+                self.remove_owned_object_locks(&output);
                 output.write_to_batch(epoch_store, batch)?;
             }
         }
@@ -1341,6 +1367,16 @@ mod tests {
         batch.write().unwrap();
         assert_eq!(quarantine.output_queue_len_for_testing(), 0);
         assert_eq!(epoch_store.get_deferred_transaction_lock(&lock_ref), None);
+
+        // The flush bumped the live-object cache bound past the consumed version, so
+        // conflict resolution derives "consumed" from memory.
+        assert_eq!(
+            epoch_store.live_object_cache().get(&lock_ref.0),
+            Some(crate::live_object_cache::VersionLowerBound::Version {
+                version: lock_ref.1.next(),
+                immutable: false,
+            })
+        );
     }
 }
 

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -282,6 +282,12 @@ impl ConsensusCommitOutput {
         self.owned_object_locks = locks;
     }
 
+    /// Locks acquired by this commit's transactions (deferral bookkeeping derives a
+    /// deferred transaction's lock set from this map).
+    pub fn owned_object_locks(&self) -> &HashMap<ObjectRef, LockDetails> {
+        &self.owned_object_locks
+    }
+
     pub fn write_to_batch(
         self,
         epoch_store: &AuthorityPerEpochStore,
@@ -518,10 +524,6 @@ impl ConsensusOutputCache {
                 .eviction_policy(EvictionPolicy::lru())
                 .build(),
         }
-    }
-
-    pub fn get_deferred_transaction_lock(&self, obj_ref: &ObjectRef) -> Option<TransactionDigest> {
-        self.deferred_transaction_locks.lock().get(obj_ref)
     }
 
     pub fn executed_in_current_epoch(&self, digest: &TransactionDigest) -> bool {
@@ -1374,7 +1376,6 @@ mod tests {
             epoch_store.live_object_cache().get(&lock_ref.0),
             Some(crate::live_object_cache::VersionLowerBound::Version {
                 version: lock_ref.1.next(),
-                immutable: false,
             })
         );
     }

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -18,6 +18,7 @@ use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::randomness::RandomnessManager;
 use crate::execution_cache::build_execution_cache;
 use crate::jsonrpc_index::IndexStore;
+use crate::live_object_cache::LiveObjectCache;
 use crate::mock_consensus::{ConsensusMode, MockConsensusClient};
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::randomness_round_receiver::RandomnessRoundReceiverHandle;
@@ -329,6 +330,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             0,
             Arc::new(SubmittedTransactionCacheMetrics::new(&registry)),
             None,
+            Arc::new(LiveObjectCache::new()),
         )
         .expect("failed to create authority per epoch store");
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1001,7 +1001,6 @@ impl ValidatorService {
                     let (existing_locks, _stats) = resolve_owned_object_lock_states(
                         &epoch_store,
                         state.get_object_cache_reader().as_ref(),
-                        state.live_object_cache(),
                         &owned_object_refs,
                     );
                     if let Err(error) = epoch_store.try_acquire_owned_object_locks_post_consensus(

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -70,7 +70,7 @@ use crate::gasless_rate_limiter::GaslessRateLimiter;
 use crate::{
     authority::{AuthorityState, consensus_tx_status_cache::ConsensusTxStatus},
     consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, ConsensusOverloadChecker},
-    consensus_handler::SequencedConsensusTransactionKey,
+    consensus_handler::{SequencedConsensusTransactionKey, resolve_owned_object_lock_states},
     traffic_controller::{TrafficController, parse_ip, policies::TrafficTally},
 };
 use crate::{
@@ -973,11 +973,11 @@ impl ValidatorService {
                 // error lets the client stop retrying instead of polling for effects that
                 // will never come.
                 //
-                // First check the epoch owned-object lock table with the same conflict
-                // logic the consensus handler uses post-consensus. Locks are never
-                // released within an epoch, so this reports the conflict even before the
-                // winner executes, while the loser's input versions still validate as
-                // live.
+                // First resolve the claim state of the owned inputs with the same
+                // conflict logic the consensus handler uses post-consensus. Locks are
+                // never released within an epoch, so this reports the conflict even
+                // before the winner executes, while the loser's input versions still
+                // validate as live.
                 if let Ok(input_objects) = verified_transaction
                     .tx()
                     .data()
@@ -998,13 +998,18 @@ impl ValidatorService {
                             _ => None,
                         })
                         .collect();
-                    let existing_locks =
-                        epoch_store.get_owned_object_locks_map(&owned_object_refs)?;
+                    let (existing_locks, _stats) = resolve_owned_object_lock_states(
+                        &epoch_store,
+                        state.get_object_cache_reader().as_ref(),
+                        state.live_object_cache(),
+                        &owned_object_refs,
+                    );
                     if let Err(error) = epoch_store.try_acquire_owned_object_locks_post_consensus(
                         &owned_object_refs,
                         tx_digest,
                         &HashMap::new(),
                         &existing_locks,
+                        state.get_object_cache_reader().as_ref(),
                     ) {
                         debug!(
                             ?tx_digest,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -141,6 +141,7 @@ pub(crate) fn resolve_owned_object_lock_states(
     live_object_cache: &LiveObjectCache,
     obj_refs: &[ObjectRef],
 ) -> (HashMap<ObjectRef, LockResolution>, LockResolutionStats) {
+    let _scope = monitored_scope("ConsensusCommitHandler::resolve_owned_object_locks");
     let mut stats = LockResolutionStats::default();
     let mut resolutions = HashMap::new();
 
@@ -156,58 +157,49 @@ pub(crate) fn resolve_owned_object_lock_states(
             continue;
         }
         let claimed_version = obj_ref.1;
-        // The cache is decisive only in the consumed direction: it is a lower bound, so
-        // a bound above the claimed version proves consumption. A bound at or below the
-        // claimed version proves nothing - a consumer may have executed and had its
-        // commit flushed (leaving no in-memory trace) after the bound was recorded - so
-        // every potential-clear goes to the authoritative read below, which sees flushed
-        // consumption because flushed transactions are durably executed. (A clear-side
-        // shortcut requires bumping the bounds of flushed lock refs when the quarantine
-        // drops them; left for a follow-up.)
-        if let Some(VersionLowerBound::Version { version, .. }) = live_object_cache.get(&obj_ref.0)
-            && version > claimed_version
-        {
-            stats.cache += 1;
-            resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
-            continue;
-        }
-        stats.objects_db += 1;
-        match object_cache.get_object(&obj_ref.0) {
-            Some(object) => {
-                live_object_cache.record_object(&object);
-                let latest_version = object.version();
-                if latest_version > claimed_version {
+        // Cached bounds are decisive in both directions once the memory layers missed:
+        // above the claimed version ⇒ consumed (lower-bound property); at or below it
+        // (including known-absent, the pipelined case) ⇒ unclaimed. The clear direction
+        // is sound because every way a consumption can leave the memory layers bumps
+        // the bound first: quarantine/deferred flush bumps happen before entry removal
+        // (see commit_with_batch), executions flushed before a restart are visible to
+        // every post-restart warm (the cache is process-lifetime), and bounds recorded
+        // from discarded end-of-epoch state are cleared at reconfiguration.
+        match live_object_cache.get(&obj_ref.0) {
+            Some(VersionLowerBound::Version { version, .. }) => {
+                stats.cache += 1;
+                if version > claimed_version {
                     resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
                 }
-                // Live at or below the claimed version: unclaimed (below ⇒ a pipelined
-                // input whose producer has not executed locally yet; the producer's
-                // finalization precedes the claimant's votes, so any lock on this ref
-                // would still be quarantined and caught above).
+                continue;
+            }
+            Some(VersionLowerBound::KnownAbsent) => {
+                stats.cache += 1;
+                continue;
+            }
+            None => (),
+        }
+        // Authoritative, tombstone-aware latest read (in-memory object cache first).
+        stats.objects_db += 1;
+        match object_cache.get_latest_object_ref_or_tombstone(obj_ref.0) {
+            Some(latest_ref) => {
+                live_object_cache.record(
+                    obj_ref.0,
+                    VersionLowerBound::Version {
+                        version: latest_ref.1,
+                        immutable: false,
+                    },
+                );
+                if latest_ref.1 > claimed_version {
+                    resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
+                }
+                // Latest at or below the claimed version: unclaimed (below ⇒ a
+                // pipelined input whose producer has not executed locally yet; the
+                // producer's finalization precedes the claimant's votes, so any lock on
+                // this ref would still be in the memory layers and caught above).
             }
             None => {
-                // Deleted (tombstone) or never existed - disambiguate.
-                match object_cache.get_latest_object_ref_or_tombstone(obj_ref.0) {
-                    Some(latest_ref) => {
-                        if !latest_ref.2.is_alive() {
-                            live_object_cache.record(
-                                obj_ref.0,
-                                VersionLowerBound::Version {
-                                    version: latest_ref.1,
-                                    immutable: false,
-                                },
-                            );
-                        }
-                        // A live ref here means the object appeared between the two
-                        // reads; both reads are valid observations, and version
-                        // monotonicity keeps the verdict below correct either way.
-                        if latest_ref.1 > claimed_version {
-                            resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
-                        }
-                    }
-                    None => {
-                        live_object_cache.record_absent(obj_ref.0);
-                    }
-                }
+                live_object_cache.record_absent(obj_ref.0);
             }
         }
     }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -62,7 +62,7 @@ use crate::{
         AuthorityMetrics, AuthorityState, ExecutionEnv,
         authority_per_epoch_store::{
             AuthorityPerEpochStore, CancelConsensusCertificateReason, ConsensusStats,
-            ConsensusStatsAPI, ExecutionIndices, ExecutionIndicesWithStatsV2,
+            ConsensusStatsAPI, ExecutionIndices, ExecutionIndicesWithStatsV2, LockResolution,
             consensus_quarantine::ConsensusCommitOutput,
         },
         backpressure::{BackpressureManager, BackpressureSubscriber},
@@ -87,6 +87,7 @@ use crate::{
     execution_cache::ObjectCacheRead,
     execution_scheduler::{SettlementBatchInfo, SettlementScheduler},
     gasless_rate_limiter::ConsensusGaslessCounter,
+    live_object_cache::{LiveObjectCache, VersionLowerBound},
     post_consensus_tx_reorder::PostConsensusTxReorder,
     traffic_controller::{TrafficController, policies::TrafficTally},
 };
@@ -97,6 +98,138 @@ struct FilteredConsensusOutput {
     transactions: Vec<(SequencedConsensusTransactionKind, u32)>,
     owned_object_locks: HashMap<ObjectRef, TransactionDigest>,
     dropped_transaction_keys: Vec<ConsensusTransactionKey>,
+    /// Lock refs of each finalized user transaction, consumed by deferral bookkeeping
+    /// (a deferred transaction's refs move into the deferred-locks map).
+    finalized_lock_sets: HashMap<TransactionDigest, Vec<ObjectRef>>,
+}
+
+/// Per-source counters from resolving owned-object lock state, recorded into metrics by
+/// the consensus handler ("remaining lookups" observability: `objects_db` and `backstop`
+/// are the residual DB reads; everything else is memory).
+#[derive(Default)]
+pub struct LockResolutionStats {
+    pub quarantine: u64,
+    pub deferred: u64,
+    pub cache: u64,
+    pub objects_db: u64,
+    pub backstop: u64,
+}
+
+/// Resolves the cross-commit claim state of owned object refs for post-consensus
+/// conflict detection, without reading the owned-object lock table (except the narrow
+/// immutable backstop). Layers, per ref (see docs/objects_locking.md Part 3):
+///
+/// 1. Quarantined (un-flushed) commit locks - in memory.
+/// 2. Deferred-transaction locks - in memory (finalized but unexecuted, so invisible to
+///    the objects table).
+/// 3. Live-object cache - a monotone lower bound on latest versions; decisive only in
+///    the consumed direction (bound above the claimed version ⇒ consumed).
+/// 4. Latest-object read (authoritative, tombstone-aware; served from the in-memory
+///    object cache when hot): latest version above the claimed version ⇒ consumed by an
+///    earlier finalized transaction of this epoch; at or below it (or absent) ⇒
+///    unclaimed. Locks of flushed commits are covered because flushed transactions are
+///    durably executed and execution always bumps every locked ref.
+/// 5. Lock-table backstop, only for refs whose object is immutable at exactly the
+///    claimed version: an immutable ref can be locked (byzantine under-claiming of
+///    immutable inputs) but never bumps, so the objects table cannot see the lock. The
+///    table is still written, making this exact. Never hit by honest traffic - claimed
+///    immutable inputs are excluded from lock sets before resolution.
+///
+/// Refs absent from the returned map are unclaimed. Read errors are fail-stop: a
+/// validator that cannot resolve deterministically must not guess.
+pub(crate) fn resolve_owned_object_lock_states(
+    epoch_store: &AuthorityPerEpochStore,
+    object_cache: &dyn ObjectCacheRead,
+    live_object_cache: &LiveObjectCache,
+    obj_refs: &[ObjectRef],
+) -> (HashMap<ObjectRef, LockResolution>, LockResolutionStats) {
+    let mut stats = LockResolutionStats::default();
+    let mut resolutions = HashMap::new();
+    let mut backstop_refs = Vec::new();
+
+    for obj_ref in obj_refs {
+        if let Some(lock) = epoch_store.get_owned_object_lock_in_memory(obj_ref) {
+            stats.quarantine += 1;
+            resolutions.insert(*obj_ref, LockResolution::LockedBy(lock));
+            continue;
+        }
+        if let Some(lock) = epoch_store.get_deferred_transaction_lock(obj_ref) {
+            stats.deferred += 1;
+            resolutions.insert(*obj_ref, LockResolution::LockedBy(lock));
+            continue;
+        }
+        let claimed_version = obj_ref.1;
+        // The cache is decisive only in the consumed direction: it is a lower bound, so
+        // a bound above the claimed version proves consumption. A bound at or below the
+        // claimed version proves nothing - a consumer may have executed and had its
+        // commit flushed (leaving no in-memory trace) after the bound was recorded - so
+        // every potential-clear goes to the authoritative read below, which sees flushed
+        // consumption because flushed transactions are durably executed. (A clear-side
+        // shortcut requires bumping the bounds of flushed lock refs when the quarantine
+        // drops them; left for a follow-up.)
+        if let Some(VersionLowerBound::Version { version, .. }) = live_object_cache.get(&obj_ref.0)
+            && version > claimed_version
+        {
+            stats.cache += 1;
+            resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
+            continue;
+        }
+        stats.objects_db += 1;
+        match object_cache.get_object(&obj_ref.0) {
+            Some(object) => {
+                live_object_cache.record_object(&object);
+                let latest_version = object.version();
+                if latest_version > claimed_version {
+                    resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
+                } else if latest_version == claimed_version && object.is_immutable() {
+                    backstop_refs.push(*obj_ref);
+                }
+                // Live at or below the claimed version and not immutable-at-claim:
+                // unclaimed (below ⇒ a pipelined input whose producer has not executed
+                // locally yet; the producer's finalization precedes the claimant's votes,
+                // so any lock on this ref would still be quarantined and caught above).
+            }
+            None => {
+                // Deleted (tombstone) or never existed - disambiguate.
+                match object_cache.get_latest_object_ref_or_tombstone(obj_ref.0) {
+                    Some(latest_ref) => {
+                        if !latest_ref.2.is_alive() {
+                            live_object_cache.record(
+                                obj_ref.0,
+                                VersionLowerBound::Version {
+                                    version: latest_ref.1,
+                                    immutable: false,
+                                },
+                            );
+                        }
+                        // A live ref here means the object appeared between the two
+                        // reads; both reads are valid observations, and version
+                        // monotonicity keeps the verdict below correct either way.
+                        if latest_ref.1 > claimed_version {
+                            resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
+                        }
+                    }
+                    None => {
+                        live_object_cache.record_absent(obj_ref.0);
+                    }
+                }
+            }
+        }
+    }
+
+    if !backstop_refs.is_empty() {
+        stats.backstop += backstop_refs.len() as u64;
+        let locks = epoch_store
+            .multi_get_owned_object_locks_from_db(&backstop_refs)
+            .expect("cannot read owned object lock table");
+        for (obj_ref, lock) in itertools::zip_eq(backstop_refs, locks) {
+            if let Some(lock) = lock {
+                resolutions.insert(obj_ref, LockResolution::LockedBy(lock));
+            }
+        }
+    }
+
+    (resolutions, stats)
 }
 
 pub struct ConsensusHandlerInitializer {
@@ -190,6 +323,7 @@ impl ConsensusHandlerInitializer {
             self.state.traffic_controller.clone(),
             self.congestion_logger.clone(),
             self.consensus_gasless_counter.clone(),
+            self.state.live_object_cache().clone(),
         )
     }
 }
@@ -739,6 +873,10 @@ pub struct ConsensusHandler<C> {
 
     consensus_gasless_counter: Arc<ConsensusGaslessCounter>,
 
+    /// Lower bounds on latest object versions, warmed by vote-time validation; consulted
+    /// by owned-object conflict resolution before reading the objects table.
+    live_object_cache: Arc<LiveObjectCache>,
+
     checkpoint_queue: Mutex<CheckpointQueue>,
 }
 
@@ -784,6 +922,7 @@ impl<C> ConsensusHandler<C> {
         traffic_controller: Option<Arc<TrafficController>>,
         congestion_logger: Option<Arc<Mutex<CongestionCommitLogger>>>,
         consensus_gasless_counter: Arc<ConsensusGaslessCounter>,
+        live_object_cache: Arc<LiveObjectCache>,
     ) -> Self {
         assert_supported_protocol_config(epoch_store.protocol_config());
 
@@ -830,6 +969,7 @@ impl<C> ConsensusHandler<C> {
             traffic_controller,
             congestion_logger,
             consensus_gasless_counter,
+            live_object_cache,
             checkpoint_queue: Mutex::new(CheckpointQueue::new(
                 last_built_timestamp,
                 checkpoint_height,
@@ -892,6 +1032,7 @@ impl<C> ConsensusHandler<C> {
             traffic_controller,
             congestion_logger: None,
             consensus_gasless_counter: Arc::new(ConsensusGaslessCounter::default()),
+            live_object_cache: Arc::new(LiveObjectCache::new()),
             checkpoint_queue: Mutex::new(CheckpointQueue::new(
                 last_built_timestamp,
                 checkpoint_height,
@@ -924,6 +1065,18 @@ struct CommitHandlerState {
     initial_reconfig_state: ReconfigState,
     // Occurrence counts for user transactions, used for unpaid amplification detection.
     occurrence_counts: HashMap<TransactionDigest, u32>,
+    // Owned-object locks acquired in this commit: the filter's acquisitions plus
+    // re-acquisitions by reloaded deferred transactions that get scheduled. Moved into
+    // `output` once scheduling decisions are final.
+    owned_object_locks: HashMap<ObjectRef, TransactionDigest>,
+    // Lock refs of each finalized user transaction of this commit; deferral bookkeeping
+    // moves a deferred transaction's refs into the deferred-locks map.
+    finalized_lock_sets: HashMap<TransactionDigest, Vec<ObjectRef>>,
+    // Lock refs captured from the deferred-locks map when their transactions were
+    // reloaded this commit. Re-deferred transactions move theirs back into the
+    // deferred-locks map; the rest (scheduled or cancelled) re-acquire into
+    // `owned_object_locks` so coverage is continuous until they execute.
+    reloaded_deferred_lock_refs: HashMap<TransactionDigest, Vec<ObjectRef>>,
 }
 
 impl CommitHandlerState {
@@ -1081,21 +1234,26 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 .get_reconfig_state_read_lock_guard()
                 .clone(),
             occurrence_counts: HashMap::new(),
+            owned_object_locks: HashMap::new(),
+            finalized_lock_sets: HashMap::new(),
+            reloaded_deferred_lock_refs: HashMap::new(),
         };
 
         let FilteredConsensusOutput {
             transactions,
             owned_object_locks,
             dropped_transaction_keys,
+            finalized_lock_sets,
         } = self.filter_consensus_txns(
             state.initial_reconfig_state.clone(),
             &commit_info,
             transactions,
         );
-        // Buffer owned object locks for batch write.
-        if !owned_object_locks.is_empty() {
-            state.output.set_owned_object_locks(owned_object_locks);
-        }
+        // Locks move into the output after scheduling decisions: reloaded deferred
+        // transactions that get scheduled re-acquire into this map during
+        // collect_transactions_to_schedule.
+        state.owned_object_locks = owned_object_locks;
+        state.finalized_lock_sets = finalized_lock_sets;
 
         // Still record the dropped transactions as consensus message processed.
         for key in dropped_transaction_keys {
@@ -1153,6 +1311,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             &commit_info,
             user_transactions,
         );
+
+        // Buffer owned object locks for batch write, now that reloaded deferred
+        // transactions have re-acquired theirs.
+        let owned_object_locks = std::mem::take(&mut state.owned_object_locks);
+        if !owned_object_locks.is_empty() {
+            state.output.set_owned_object_locks(owned_object_locks);
+        }
 
         let (should_accept_tx, lock, final_round) =
             self.handle_close_epoch(&mut state, &commit_info, end_of_publish_transactions);
@@ -1415,10 +1580,60 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 .consensus_output_cache
                 .deferred_transactions
                 .lock();
+            let mut deferred_locks = self
+                .epoch_store
+                .consensus_output_cache
+                .deferred_transaction_locks
+                .lock();
             for (key, txns) in deferred_txns.into_iter() {
                 total_deferred_txns += txns.len();
+                // Move each deferred transaction's lock refs into the deferred-locks
+                // map: from this commit's acquisitions (fresh deferral) or from the
+                // refs captured at reload (re-deferral).
+                for tx in &txns {
+                    let digest = *tx.tx().digest();
+                    let refs = state
+                        .finalized_lock_sets
+                        .remove(&digest)
+                        .or_else(|| state.reloaded_deferred_lock_refs.remove(&digest))
+                        .unwrap_or_else(|| {
+                            debug_fatal!(
+                                "deferred transaction {:?} has no recorded lock refs",
+                                digest
+                            );
+                            // Conservative superset: all ImmOrOwned inputs. Can only
+                            // over-cover refs the transaction claimed as immutable.
+                            tx.tx()
+                                .transaction_data()
+                                .input_objects()
+                                .map(|kinds| {
+                                    kinds
+                                        .iter()
+                                        .filter_map(|kind| match kind {
+                                            InputObjectKind::ImmOrOwnedMoveObject(obj_ref) => {
+                                                Some(*obj_ref)
+                                            }
+                                            _ => None,
+                                        })
+                                        .collect()
+                                })
+                                .unwrap_or_default()
+                        });
+                    deferred_locks.insert(digest, refs);
+                }
                 deferred_transactions.insert(key, txns.clone());
                 state.output.defer_transactions(key, txns);
+            }
+        }
+
+        // Reloaded deferred transactions that did not re-defer are being scheduled (or
+        // cancelled, which still executes). Re-acquire their locks into this commit's
+        // output so in-memory coverage is continuous from deferred-locks map to
+        // quarantine to (post-flush) the objects table. Re-writing the same key/value
+        // into the lock table is idempotent.
+        for (digest, refs) in std::mem::take(&mut state.reloaded_deferred_lock_refs) {
+            for obj_ref in refs {
+                state.owned_object_locks.insert(obj_ref, digest);
             }
         }
 
@@ -1939,6 +2154,28 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             vec![]
         };
 
+        // Capture the reloaded transactions' lock refs out of the deferred-locks map.
+        // Whether each transaction re-defers (refs go back into the map) or gets
+        // scheduled/cancelled (refs re-acquire into this commit's locks) is decided in
+        // collect_transactions_to_schedule.
+        {
+            let mut deferred_locks = self
+                .epoch_store
+                .consensus_output_cache
+                .deferred_transaction_locks
+                .lock();
+            for digest in previously_deferred_tx_digests.keys() {
+                if let Some(refs) = deferred_locks.remove_tx(digest) {
+                    state.reloaded_deferred_lock_refs.insert(*digest, refs);
+                } else {
+                    debug_fatal!(
+                        "reloaded deferred transaction {:?} missing from deferred-locks map",
+                        digest
+                    );
+                }
+            }
+        }
+
         (
             deferred_txs,
             deferred_randomness_txs,
@@ -2349,6 +2586,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let _scope = monitored_scope("ConsensusCommitHandler::filter_consensus_txns");
         let mut transactions = Vec::new();
         let mut owned_object_locks = HashMap::new();
+        let mut finalized_lock_sets = HashMap::new();
         let mut dropped_transaction_keys = Vec::new();
         // Consensus transaction status updates are collected here and flushed in a
         // single batched write (one lock acquisition, notifications outside the lock)
@@ -2358,31 +2596,51 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let mut num_finalized_user_transactions = vec![0; self.committee.size()];
         let mut num_rejected_user_transactions = vec![0; self.committee.size()];
 
-        // Prefetch the cross-commit owned-object lock state for the whole commit in one
-        // batched read. These locks are constant for the duration of a commit (new locks
-        // are only written at commit end), so this replaces the per-transaction
-        // quarantine+DB lookup that try_acquire_owned_object_locks_post_consensus used to
-        // do. Over-reading refs of transactions that are later filtered out is harmless.
-        let existing_locks = {
-            let mut prefetch_refs: Vec<ObjectRef> = Vec::new();
-            for (_block, parsed_transactions) in &block_transactions {
-                for parsed in parsed_transactions {
-                    if let ConsensusTransactionKind::UserTransactionV2(tx_with_claims) =
-                        &parsed.transaction.kind
-                        && let Some(refs) = owned_object_refs_to_lock(tx_with_claims)
-                    {
-                        prefetch_refs.extend(refs);
-                    }
+        // Resolve the cross-commit owned-object claim state for the whole commit up
+        // front. This state is constant for the duration of a commit: new locks are only
+        // written at commit end, deferred-lock changes happen after filtering, and the
+        // objects-table verdicts are stable for refs the in-memory layers do not cover.
+        // Over-reading refs of transactions that are later filtered out is harmless.
+        let mut prefetch_refs: Vec<ObjectRef> = Vec::new();
+        for (_block, parsed_transactions) in &block_transactions {
+            for parsed in parsed_transactions {
+                if let ConsensusTransactionKind::UserTransactionV2(tx_with_claims) =
+                    &parsed.transaction.kind
+                    && let Some(refs) = owned_object_refs_to_lock(tx_with_claims)
+                {
+                    prefetch_refs.extend(refs);
                 }
             }
-            prefetch_refs.sort();
-            prefetch_refs.dedup();
-            // On a read error fall back to an empty map (treat refs as unlocked) — the
-            // same lenient behavior the per-transaction read had.
-            self.epoch_store
-                .get_owned_object_locks_map(&prefetch_refs)
-                .unwrap_or_default()
-        };
+        }
+        prefetch_refs.sort();
+        prefetch_refs.dedup();
+        let (existing_locks, resolution_stats) = resolve_owned_object_lock_states(
+            &self.epoch_store,
+            self.cache_reader.as_ref(),
+            &self.live_object_cache,
+            &prefetch_refs,
+        );
+        for (source, count) in [
+            ("quarantine", resolution_stats.quarantine),
+            ("deferred", resolution_stats.deferred),
+            ("cache", resolution_stats.cache),
+            ("objects_db", resolution_stats.objects_db),
+            ("backstop", resolution_stats.backstop),
+        ] {
+            self.metrics
+                .consensus_owned_object_lock_resolutions
+                .with_label_values(&[source])
+                .inc_by(count);
+        }
+
+        // Differential validation of the objects-table-based resolution against the lock
+        // table (which is still fully written): both paths must produce identical
+        // verdicts for every transaction. Debug builds only (includes simtests).
+        #[cfg(debug_assertions)]
+        let table_locks = self
+            .epoch_store
+            .get_owned_object_locks_map(&prefetch_refs)
+            .unwrap_or_default();
 
         for (block, parsed_transactions) in block_transactions {
             let author = block.author.value();
@@ -2601,16 +2859,42 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         continue;
                     };
 
-                    match self
+                    let acquire_result = self
                         .epoch_store
                         .try_acquire_owned_object_locks_post_consensus(
                             &owned_object_refs,
                             *tx.digest(),
                             &owned_object_locks,
                             &existing_locks,
-                        ) {
+                            self.cache_reader.as_ref(),
+                        );
+
+                    #[cfg(debug_assertions)]
+                    {
+                        let table_result = self
+                            .epoch_store
+                            .try_acquire_owned_object_locks_post_consensus_table_based(
+                                &owned_object_refs,
+                                *tx.digest(),
+                                &owned_object_locks,
+                                &table_locks,
+                            );
+                        assert_eq!(
+                            acquire_result.is_ok(),
+                            table_result.is_ok(),
+                            "owned-object conflict verdict diverged from lock table for tx {:?} \
+                             (objects-based: {:?}, table-based: {:?}, refs: {:?})",
+                            tx.digest(),
+                            acquire_result.as_ref().err(),
+                            table_result.as_ref().err(),
+                            owned_object_refs,
+                        );
+                    }
+
+                    match acquire_result {
                         Ok(new_locks) => {
                             owned_object_locks.extend(new_locks.into_iter());
+                            finalized_lock_sets.insert(*tx.digest(), owned_object_refs);
                             // Lock acquisition succeeded - now set Finalized status
                             status_updates.push((position, ConsensusTxStatus::Finalized));
                             num_finalized_user_transactions[author] += 1;
@@ -2667,6 +2951,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             transactions,
             owned_object_locks,
             dropped_transaction_keys,
+            finalized_lock_sets,
         }
     }
 
@@ -3479,6 +3764,7 @@ mod tests {
             state.traffic_controller.clone(),
             None,
             state.consensus_gasless_counter.clone(),
+            state.live_object_cache().clone(),
         );
 
         // AND create test user transactions alternating between owned and shared input.
@@ -4065,6 +4351,7 @@ mod tests {
             state.traffic_controller.clone(),
             None,
             state.consensus_gasless_counter.clone(),
+            state.live_object_cache().clone(),
         );
 
         handler.handle_consensus_commit_for_test(commit).await;
@@ -4191,6 +4478,7 @@ mod tests {
             state.traffic_controller.clone(),
             None,
             state.consensus_gasless_counter.clone(),
+            state.live_object_cache().clone(),
         );
 
         handler.handle_consensus_commit_for_test(commit).await;

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -89,7 +89,7 @@ use crate::{
     execution_cache::ObjectCacheRead,
     execution_scheduler::{SettlementBatchInfo, SettlementScheduler},
     gasless_rate_limiter::ConsensusGaslessCounter,
-    live_object_cache::{LiveObjectCache, VersionLowerBound},
+    live_object_cache::VersionLowerBound,
     post_consensus_tx_reorder::PostConsensusTxReorder,
     traffic_controller::{TrafficController, policies::TrafficTally},
 };
@@ -100,16 +100,13 @@ struct FilteredConsensusOutput {
     transactions: Vec<(SequencedConsensusTransactionKind, u32)>,
     owned_object_locks: HashMap<ObjectRef, TransactionDigest>,
     dropped_transaction_keys: Vec<ConsensusTransactionKey>,
-    /// Lock refs of each finalized user transaction, consumed by deferral bookkeeping
-    /// (a deferred transaction's refs move into the deferred-locks map).
-    finalized_lock_sets: HashMap<TransactionDigest, Vec<ObjectRef>>,
 }
 
 /// Per-source counters from resolving owned-object lock state, recorded into metrics by
 /// the consensus handler ("remaining lookups" observability: `objects_db` counts
 /// authoritative latest-object reads; everything else is consensus in-memory state).
 #[derive(Default)]
-pub struct LockResolutionStats {
+pub(crate) struct LockResolutionStats {
     pub quarantine: u64,
     pub deferred: u64,
     pub cache: u64,
@@ -122,8 +119,9 @@ pub struct LockResolutionStats {
 /// 1. Quarantined (un-flushed) commit locks - in memory.
 /// 2. Deferred-transaction locks - in memory (finalized but unexecuted, so invisible to
 ///    the objects table).
-/// 3. Live-object cache - a monotone lower bound on latest versions; decisive only in
-///    the consumed direction (bound above the claimed version ⇒ consumed).
+/// 3. Live-object cache - a monotone lower bound on latest versions, decisive in both
+///    directions: above the claimed version ⇒ consumed; at or below it (or known
+///    absent) ⇒ unclaimed.
 /// 4. Latest-object read (authoritative, tombstone-aware; served from the in-memory
 ///    object cache when hot): latest version above the claimed version ⇒ consumed by an
 ///    earlier finalized transaction of this epoch; at or below it (or absent) ⇒
@@ -138,10 +136,10 @@ pub struct LockResolutionStats {
 pub(crate) fn resolve_owned_object_lock_states(
     epoch_store: &AuthorityPerEpochStore,
     object_cache: &dyn ObjectCacheRead,
-    live_object_cache: &LiveObjectCache,
     obj_refs: &[ObjectRef],
 ) -> (HashMap<ObjectRef, LockResolution>, LockResolutionStats) {
     let _scope = monitored_scope("ConsensusCommitHandler::resolve_owned_object_locks");
+    let live_object_cache = epoch_store.live_object_cache();
     let mut stats = LockResolutionStats::default();
     let mut resolutions = HashMap::new();
 
@@ -178,7 +176,7 @@ pub(crate) fn resolve_owned_object_lock_states(
         // every post-restart warm (the cache is process-lifetime), and bounds recorded
         // from discarded end-of-epoch state are cleared at reconfiguration.
         match live_object_cache.get(&obj_ref.0) {
-            Some(VersionLowerBound::Version { version, .. }) => {
+            Some(VersionLowerBound::Version { version }) => {
                 stats.cache += 1;
                 if version > claimed_version {
                     resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
@@ -193,27 +191,17 @@ pub(crate) fn resolve_owned_object_lock_states(
         }
         // Authoritative, tombstone-aware latest read (in-memory object cache first).
         stats.objects_db += 1;
-        match object_cache.get_latest_object_ref_or_tombstone(obj_ref.0) {
-            Some(latest_ref) => {
-                live_object_cache.record(
-                    obj_ref.0,
-                    VersionLowerBound::Version {
-                        version: latest_ref.1,
-                        immutable: false,
-                    },
-                );
-                if latest_ref.1 > claimed_version {
-                    resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
-                }
-                // Latest at or below the claimed version: unclaimed (below ⇒ a
-                // pipelined input whose producer has not executed locally yet; the
-                // producer's finalization precedes the claimant's votes, so any lock on
-                // this ref would still be in the memory layers and caught above).
-            }
-            None => {
-                live_object_cache.record_absent(obj_ref.0);
-            }
+        let latest_ref = object_cache.get_latest_object_ref_or_tombstone(obj_ref.0);
+        live_object_cache.record_latest_lookup(obj_ref.0, latest_ref.map(|r| r.1));
+        if let Some(latest_ref) = latest_ref
+            && latest_ref.1 > claimed_version
+        {
+            resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
         }
+        // Latest at or below the claimed version (or absent): unclaimed (below ⇒ a
+        // pipelined input whose producer has not executed locally yet; the producer's
+        // finalization precedes the claimant's votes, so any lock on this ref would
+        // still be in the memory layers and caught above).
     }
 
     (resolutions, stats)
@@ -310,7 +298,6 @@ impl ConsensusHandlerInitializer {
             self.state.traffic_controller.clone(),
             self.congestion_logger.clone(),
             self.consensus_gasless_counter.clone(),
-            self.state.live_object_cache().clone(),
         )
     }
 }
@@ -860,10 +847,6 @@ pub struct ConsensusHandler<C> {
 
     consensus_gasless_counter: Arc<ConsensusGaslessCounter>,
 
-    /// Lower bounds on latest object versions, warmed by vote-time validation; consulted
-    /// by owned-object conflict resolution before reading the objects table.
-    live_object_cache: Arc<LiveObjectCache>,
-
     checkpoint_queue: Mutex<CheckpointQueue>,
 }
 
@@ -909,7 +892,6 @@ impl<C> ConsensusHandler<C> {
         traffic_controller: Option<Arc<TrafficController>>,
         congestion_logger: Option<Arc<Mutex<CongestionCommitLogger>>>,
         consensus_gasless_counter: Arc<ConsensusGaslessCounter>,
-        live_object_cache: Arc<LiveObjectCache>,
     ) -> Self {
         assert_supported_protocol_config(epoch_store.protocol_config());
 
@@ -956,7 +938,6 @@ impl<C> ConsensusHandler<C> {
             traffic_controller,
             congestion_logger,
             consensus_gasless_counter,
-            live_object_cache,
             checkpoint_queue: Mutex::new(CheckpointQueue::new(
                 last_built_timestamp,
                 checkpoint_height,
@@ -1019,7 +1000,6 @@ impl<C> ConsensusHandler<C> {
             traffic_controller,
             congestion_logger: None,
             consensus_gasless_counter: Arc::new(ConsensusGaslessCounter::default()),
-            live_object_cache: Arc::new(LiveObjectCache::new()),
             checkpoint_queue: Mutex::new(CheckpointQueue::new(
                 last_built_timestamp,
                 checkpoint_height,
@@ -1052,13 +1032,6 @@ struct CommitHandlerState {
     initial_reconfig_state: ReconfigState,
     // Occurrence counts for user transactions, used for unpaid amplification detection.
     occurrence_counts: HashMap<TransactionDigest, u32>,
-    // Owned-object locks acquired in this commit: the filter's acquisitions plus
-    // re-acquisitions by reloaded deferred transactions that get scheduled. Moved into
-    // `output` once scheduling decisions are final.
-    owned_object_locks: HashMap<ObjectRef, TransactionDigest>,
-    // Lock refs of each finalized user transaction of this commit; deferral bookkeeping
-    // moves a deferred transaction's refs into the deferred-locks map.
-    finalized_lock_sets: HashMap<TransactionDigest, Vec<ObjectRef>>,
 }
 
 impl CommitHandlerState {
@@ -1216,25 +1189,23 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 .get_reconfig_state_read_lock_guard()
                 .clone(),
             occurrence_counts: HashMap::new(),
-            owned_object_locks: HashMap::new(),
-            finalized_lock_sets: HashMap::new(),
         };
 
         let FilteredConsensusOutput {
             transactions,
             owned_object_locks,
             dropped_transaction_keys,
-            finalized_lock_sets,
         } = self.filter_consensus_txns(
             state.initial_reconfig_state.clone(),
             &commit_info,
             transactions,
         );
-        // Locks move into the output after scheduling decisions: reloaded deferred
-        // transactions that get scheduled re-acquire into this map during
-        // collect_transactions_to_schedule.
-        state.owned_object_locks = owned_object_locks;
-        state.finalized_lock_sets = finalized_lock_sets;
+        // Locks of reloaded deferred transactions are NOT re-acquired here: their
+        // deferred-locks map entries stay in place until this commit flushes, which is
+        // when the flush gate guarantees they are executed (see consensus_quarantine).
+        if !owned_object_locks.is_empty() {
+            state.output.set_owned_object_locks(owned_object_locks);
+        }
 
         // Still record the dropped transactions as consensus message processed.
         for key in dropped_transaction_keys {
@@ -1292,12 +1263,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             &commit_info,
             user_transactions,
         );
-
-        // Buffer owned object locks into the output.
-        let owned_object_locks = std::mem::take(&mut state.owned_object_locks);
-        if !owned_object_locks.is_empty() {
-            state.output.set_owned_object_locks(owned_object_locks);
-        }
 
         let (should_accept_tx, lock, final_round) =
             self.handle_close_epoch(&mut state, &commit_info, end_of_publish_transactions);
@@ -1556,6 +1521,28 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let mut total_deferred_txns = 0;
         let mut redeferred_digests = HashSet::new();
         {
+            // Fresh deferrals move this commit's acquired lock refs into the
+            // deferred-locks map. The refs are recovered by inverting the commit's lock
+            // map: a ref maps to a digest iff that transaction acquired it (first
+            // writer wins; only same-digest duplicates overwrite). Re-deferrals
+            // (reloaded transactions deferring again) already have their entry - it is
+            // only removed when the commit that schedules the transaction flushes.
+            // Note an empty lock set is legal (all owned inputs claimed immutable,
+            // address-balance gas), so fresh deferrals are pre-seeded with empty sets.
+            let mut fresh_lock_sets: HashMap<TransactionDigest, Vec<ObjectRef>> = deferred_txns
+                .values()
+                .flat_map(|txns| txns.iter().map(|tx| *tx.tx().digest()))
+                .filter(|digest| !previously_deferred_tx_digests.contains_key(digest))
+                .map(|digest| (digest, Vec::new()))
+                .collect();
+            if !fresh_lock_sets.is_empty() {
+                for (obj_ref, digest) in state.output.owned_object_locks() {
+                    if let Some(refs) = fresh_lock_sets.get_mut(digest) {
+                        refs.push(*obj_ref);
+                    }
+                }
+            }
+
             let mut deferred_transactions = self
                 .epoch_store
                 .consensus_output_cache
@@ -1571,36 +1558,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 for tx in &txns {
                     let digest = *tx.tx().digest();
                     redeferred_digests.insert(digest);
-                    // Fresh deferrals move this commit's acquired lock refs into the
-                    // deferred-locks map. Re-deferrals already have their entry (it is
-                    // only removed when the commit that schedules the transaction
-                    // flushes).
-                    if let Some(refs) = state.finalized_lock_sets.remove(&digest) {
+                    if let Some(refs) = fresh_lock_sets.remove(&digest) {
                         deferred_locks.insert(digest, refs);
-                    } else if !deferred_locks.contains_tx(&digest) {
-                        debug_fatal!(
-                            "deferred transaction {:?} has no recorded lock refs",
-                            digest
+                    } else {
+                        debug_assert!(
+                            deferred_locks.contains_tx(&digest),
+                            "re-deferred transaction {digest:?} has no deferred-locks entry"
                         );
-                        // Conservative superset: all ImmOrOwned inputs. Can only
-                        // over-cover refs the transaction claimed as immutable.
-                        let refs = tx
-                            .tx()
-                            .transaction_data()
-                            .input_objects()
-                            .map(|kinds| {
-                                kinds
-                                    .iter()
-                                    .filter_map(|kind| match kind {
-                                        InputObjectKind::ImmOrOwnedMoveObject(obj_ref) => {
-                                            Some(*obj_ref)
-                                        }
-                                        _ => None,
-                                    })
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                        deferred_locks.insert(digest, refs);
                     }
                 }
                 deferred_transactions.insert(key, txns.clone());
@@ -2550,7 +2514,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let _scope = monitored_scope("ConsensusCommitHandler::filter_consensus_txns");
         let mut transactions = Vec::new();
         let mut owned_object_locks = HashMap::new();
-        let mut finalized_lock_sets = HashMap::new();
         let mut dropped_transaction_keys = Vec::new();
         // Consensus transaction status updates are collected here and flushed in a
         // single batched write (one lock acquisition, notifications outside the lock)
@@ -2560,28 +2523,31 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let mut num_finalized_user_transactions = vec![0; self.committee.size()];
         let mut num_rejected_user_transactions = vec![0; self.committee.size()];
 
-        // Resolve the cross-commit owned-object claim state for the whole commit up
-        // front. This state is constant for the duration of a commit: new locks are only
-        // written at commit end, deferred-lock changes happen after filtering, and the
-        // objects-table verdicts are stable for refs the in-memory layers do not cover.
-        // Over-reading refs of transactions that are later filtered out is harmless.
-        let mut prefetch_refs: Vec<ObjectRef> = Vec::new();
+        // Compute each transaction's lock set once (reused by the per-transaction
+        // acquisition below) and resolve the cross-commit owned-object claim state for
+        // the whole commit up front. That state is constant for the duration of a
+        // commit: new locks are only written at commit end, deferred-lock changes
+        // happen after filtering, and the objects-table verdicts are stable for refs
+        // the in-memory layers do not cover. Over-reading refs of transactions that
+        // are later filtered out is harmless. Absence from the map means the
+        // transaction's input objects are invalid.
+        let mut lock_sets: HashMap<TransactionDigest, Vec<ObjectRef>> = HashMap::new();
         for (_block, parsed_transactions) in &block_transactions {
             for parsed in parsed_transactions {
                 if let ConsensusTransactionKind::UserTransactionV2(tx_with_claims) =
                     &parsed.transaction.kind
                     && let Some(refs) = owned_object_refs_to_lock(tx_with_claims)
                 {
-                    prefetch_refs.extend(refs);
+                    lock_sets.insert(*tx_with_claims.tx().digest(), refs);
                 }
             }
         }
+        let mut prefetch_refs: Vec<ObjectRef> = lock_sets.values().flatten().copied().collect();
         prefetch_refs.sort();
         prefetch_refs.dedup();
         let (existing_locks, resolution_stats) = resolve_owned_object_lock_states(
             &self.epoch_store,
             self.cache_reader.as_ref(),
-            &self.live_object_cache,
             &prefetch_refs,
         );
         for (source, count) in [
@@ -2794,7 +2760,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     &parsed.transaction.kind
                 {
                     let tx = tx_with_claims.tx();
-                    let Some(owned_object_refs) = owned_object_refs_to_lock(tx_with_claims) else {
+                    let Some(owned_object_refs) = lock_sets.get(tx.digest()) else {
                         // Invalid input object error is deterministic across all validators.
                         self.metrics
                             .consensus_handler_dropped_transactions
@@ -2816,7 +2782,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     let acquire_result = self
                         .epoch_store
                         .try_acquire_owned_object_locks_post_consensus(
-                            &owned_object_refs,
+                            owned_object_refs,
                             *tx.digest(),
                             &owned_object_locks,
                             &existing_locks,
@@ -2824,9 +2790,9 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         );
 
                     match acquire_result {
-                        Ok(new_locks) => {
-                            owned_object_locks.extend(new_locks.into_iter());
-                            finalized_lock_sets.insert(*tx.digest(), owned_object_refs);
+                        Ok(()) => {
+                            owned_object_locks
+                                .extend(owned_object_refs.iter().map(|r| (*r, *tx.digest())));
                             // Lock acquisition succeeded - now set Finalized status
                             status_updates.push((position, ConsensusTxStatus::Finalized));
                             num_finalized_user_transactions[author] += 1;
@@ -2892,7 +2858,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             transactions,
             owned_object_locks,
             dropped_transaction_keys,
-            finalized_lock_sets,
         }
     }
 
@@ -3705,7 +3670,6 @@ mod tests {
             state.traffic_controller.clone(),
             None,
             state.consensus_gasless_counter.clone(),
-            state.live_object_cache().clone(),
         );
 
         // AND create test user transactions alternating between owned and shared input.
@@ -4292,7 +4256,6 @@ mod tests {
             state.traffic_controller.clone(),
             None,
             state.consensus_gasless_counter.clone(),
-            state.live_object_cache().clone(),
         );
 
         handler.handle_consensus_commit_for_test(commit).await;
@@ -4419,7 +4382,6 @@ mod tests {
             state.traffic_controller.clone(),
             None,
             state.consensus_gasless_counter.clone(),
-            state.live_object_cache().clone(),
         );
 
         handler.handle_consensus_commit_for_test(commit).await;

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -16,7 +16,8 @@ use consensus_types::block::TransactionIndex;
 use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use lru::LruCache;
 use mysten_common::{
-    assert_reachable, assert_sometimes, debug_fatal, random_util::randomize_cache_capacity_in_tests,
+    assert_reachable, assert_sometimes, debug_fatal, fatal,
+    random_util::randomize_cache_capacity_in_tests,
 };
 use mysten_metrics::{
     monitored_future,
@@ -36,6 +37,7 @@ use sui_types::{
     },
     crypto::RandomnessRound,
     digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest, Digest},
+    error::SuiErrorKind,
     executable_transaction::{
         TrustedExecutableTransaction, VerifiedExecutableTransaction,
         VerifiedExecutableTransactionWithAliases,
@@ -1053,11 +1055,6 @@ struct CommitHandlerState {
     // Lock refs of each finalized user transaction of this commit; deferral bookkeeping
     // moves a deferred transaction's refs into the deferred-locks map.
     finalized_lock_sets: HashMap<TransactionDigest, Vec<ObjectRef>>,
-    // Lock refs captured from the deferred-locks map when their transactions were
-    // reloaded this commit. Re-deferred transactions move theirs back into the
-    // deferred-locks map; the rest (scheduled or cancelled) re-acquire into
-    // `owned_object_locks` so coverage is continuous until they execute.
-    reloaded_deferred_lock_refs: HashMap<TransactionDigest, Vec<ObjectRef>>,
 }
 
 impl CommitHandlerState {
@@ -1217,7 +1214,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             occurrence_counts: HashMap::new(),
             owned_object_locks: HashMap::new(),
             finalized_lock_sets: HashMap::new(),
-            reloaded_deferred_lock_refs: HashMap::new(),
         };
 
         let FilteredConsensusOutput {
@@ -1293,8 +1289,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             user_transactions,
         );
 
-        // Buffer owned object locks for batch write, now that reloaded deferred
-        // transactions have re-acquired theirs.
+        // Buffer owned object locks into the output.
         let owned_object_locks = std::mem::take(&mut state.owned_object_locks);
         if !owned_object_locks.is_empty() {
             state.output.set_owned_object_locks(owned_object_locks);
@@ -1555,6 +1550,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         }
 
         let mut total_deferred_txns = 0;
+        let mut redeferred_digests = HashSet::new();
         {
             let mut deferred_transactions = self
                 .epoch_store
@@ -1568,39 +1564,40 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 .lock();
             for (key, txns) in deferred_txns.into_iter() {
                 total_deferred_txns += txns.len();
-                // Move each deferred transaction's lock refs into the deferred-locks
-                // map: from this commit's acquisitions (fresh deferral) or from the
-                // refs captured at reload (re-deferral).
                 for tx in &txns {
                     let digest = *tx.tx().digest();
-                    let refs = state
-                        .finalized_lock_sets
-                        .remove(&digest)
-                        .or_else(|| state.reloaded_deferred_lock_refs.remove(&digest))
-                        .unwrap_or_else(|| {
-                            debug_fatal!(
-                                "deferred transaction {:?} has no recorded lock refs",
-                                digest
-                            );
-                            // Conservative superset: all ImmOrOwned inputs. Can only
-                            // over-cover refs the transaction claimed as immutable.
-                            tx.tx()
-                                .transaction_data()
-                                .input_objects()
-                                .map(|kinds| {
-                                    kinds
-                                        .iter()
-                                        .filter_map(|kind| match kind {
-                                            InputObjectKind::ImmOrOwnedMoveObject(obj_ref) => {
-                                                Some(*obj_ref)
-                                            }
-                                            _ => None,
-                                        })
-                                        .collect()
-                                })
-                                .unwrap_or_default()
-                        });
-                    deferred_locks.insert(digest, refs);
+                    redeferred_digests.insert(digest);
+                    // Fresh deferrals move this commit's acquired lock refs into the
+                    // deferred-locks map. Re-deferrals already have their entry (it is
+                    // only removed when the commit that schedules the transaction
+                    // flushes).
+                    if let Some(refs) = state.finalized_lock_sets.remove(&digest) {
+                        deferred_locks.insert(digest, refs);
+                    } else if !deferred_locks.contains_tx(&digest) {
+                        debug_fatal!(
+                            "deferred transaction {:?} has no recorded lock refs",
+                            digest
+                        );
+                        // Conservative superset: all ImmOrOwned inputs. Can only
+                        // over-cover refs the transaction claimed as immutable.
+                        let refs = tx
+                            .tx()
+                            .transaction_data()
+                            .input_objects()
+                            .map(|kinds| {
+                                kinds
+                                    .iter()
+                                    .filter_map(|kind| match kind {
+                                        InputObjectKind::ImmOrOwnedMoveObject(obj_ref) => {
+                                            Some(*obj_ref)
+                                        }
+                                        _ => None,
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        deferred_locks.insert(digest, refs);
+                    }
                 }
                 deferred_transactions.insert(key, txns.clone());
                 state.output.defer_transactions(key, txns);
@@ -1608,14 +1605,18 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         }
 
         // Reloaded deferred transactions that did not re-defer are being scheduled (or
-        // cancelled, which still executes). Re-acquire their locks into this commit's
-        // output so in-memory coverage is continuous from deferred-locks map to
-        // quarantine to (post-flush) the objects table. Re-writing the same key/value
-        // into the lock table is idempotent.
-        for (digest, refs) in std::mem::take(&mut state.reloaded_deferred_lock_refs) {
-            for obj_ref in refs {
-                state.owned_object_locks.insert(obj_ref, digest);
-            }
+        // cancelled, which still executes). Their deferred-locks entries stay in place
+        // until this commit flushes - the flush gate guarantees they are executed by
+        // then, at which point the objects table covers their consumed inputs.
+        let finalized_reloaded: Vec<TransactionDigest> = previously_deferred_tx_digests
+            .keys()
+            .filter(|digest| !redeferred_digests.contains(*digest))
+            .copied()
+            .collect();
+        if !finalized_reloaded.is_empty() {
+            state
+                .output
+                .set_finalized_reloaded_deferred_txns(finalized_reloaded);
         }
 
         self.metrics
@@ -2134,28 +2135,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         } else {
             vec![]
         };
-
-        // Capture the reloaded transactions' lock refs out of the deferred-locks map.
-        // Whether each transaction re-defers (refs go back into the map) or gets
-        // scheduled/cancelled (refs re-acquire into this commit's locks) is decided in
-        // collect_transactions_to_schedule.
-        {
-            let mut deferred_locks = self
-                .epoch_store
-                .consensus_output_cache
-                .deferred_transaction_locks
-                .lock();
-            for digest in previously_deferred_tx_digests.keys() {
-                if let Some(refs) = deferred_locks.remove_tx(digest) {
-                    state.reloaded_deferred_lock_refs.insert(*digest, refs);
-                } else {
-                    debug_fatal!(
-                        "reloaded deferred transaction {:?} missing from deferred-locks map",
-                        digest
-                    );
-                }
-            }
-        }
 
         (
             deferred_txs,
@@ -2849,6 +2828,15 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                             num_finalized_user_transactions[author] += 1;
                         }
                         Err(e) => {
+                            // Only a lock conflict is a deterministic drop verdict. Any
+                            // other error is a failed read - the verdict cannot be
+                            // derived, and guessing either way risks a fork.
+                            if !matches!(e.as_inner(), SuiErrorKind::ObjectLockConflict { .. }) {
+                                fatal!(
+                                    "cannot resolve owned-object locks for {:?}: {e}",
+                                    tx.digest()
+                                );
+                            }
                             debug!("Dropping transaction {}: {}", tx.digest(), e);
                             self.metrics
                                 .consensus_handler_dropped_transactions

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -104,20 +104,18 @@ struct FilteredConsensusOutput {
 }
 
 /// Per-source counters from resolving owned-object lock state, recorded into metrics by
-/// the consensus handler ("remaining lookups" observability: `objects_db` and `backstop`
-/// are the residual DB reads; everything else is memory).
+/// the consensus handler ("remaining lookups" observability: `objects_db` counts
+/// authoritative latest-object reads; everything else is consensus in-memory state).
 #[derive(Default)]
 pub struct LockResolutionStats {
     pub quarantine: u64,
     pub deferred: u64,
     pub cache: u64,
     pub objects_db: u64,
-    pub backstop: u64,
 }
 
 /// Resolves the cross-commit claim state of owned object refs for post-consensus
-/// conflict detection, without reading the owned-object lock table (except the narrow
-/// immutable backstop). Layers, per ref (see docs/objects_locking.md Part 3):
+/// conflict detection. Layers, per ref (see docs/objects_locking.md Part 3):
 ///
 /// 1. Quarantined (un-flushed) commit locks - in memory.
 /// 2. Deferred-transaction locks - in memory (finalized but unexecuted, so invisible to
@@ -128,12 +126,10 @@ pub struct LockResolutionStats {
 ///    object cache when hot): latest version above the claimed version ⇒ consumed by an
 ///    earlier finalized transaction of this epoch; at or below it (or absent) ⇒
 ///    unclaimed. Locks of flushed commits are covered because flushed transactions are
-///    durably executed and execution always bumps every locked ref.
-/// 5. Lock-table backstop, only for refs whose object is immutable at exactly the
-///    claimed version: an immutable ref can be locked (byzantine under-claiming of
-///    immutable inputs) but never bumps, so the objects table cannot see the lock. The
-///    table is still written, making this exact. Never hit by honest traffic - claimed
-///    immutable inputs are excluded from lock sets before resolution.
+///    durably executed and execution always bumps every locked ref - with one carve-out:
+///    a lock on a ref that is immutable at its claimed version never bumps. Such locks
+///    require an under-claimed immutable input, which strict vote-time claims
+///    verification makes quorum-unreachable; safe once that verification is universal.
 ///
 /// Refs absent from the returned map are unclaimed. Read errors are fail-stop: a
 /// validator that cannot resolve deterministically must not guess.
@@ -145,7 +141,6 @@ pub(crate) fn resolve_owned_object_lock_states(
 ) -> (HashMap<ObjectRef, LockResolution>, LockResolutionStats) {
     let mut stats = LockResolutionStats::default();
     let mut resolutions = HashMap::new();
-    let mut backstop_refs = Vec::new();
 
     for obj_ref in obj_refs {
         if let Some(lock) = epoch_store.get_owned_object_lock_in_memory(obj_ref) {
@@ -181,13 +176,11 @@ pub(crate) fn resolve_owned_object_lock_states(
                 let latest_version = object.version();
                 if latest_version > claimed_version {
                     resolutions.insert(*obj_ref, LockResolution::ConsumedSinceClaim);
-                } else if latest_version == claimed_version && object.is_immutable() {
-                    backstop_refs.push(*obj_ref);
                 }
-                // Live at or below the claimed version and not immutable-at-claim:
-                // unclaimed (below ⇒ a pipelined input whose producer has not executed
-                // locally yet; the producer's finalization precedes the claimant's votes,
-                // so any lock on this ref would still be quarantined and caught above).
+                // Live at or below the claimed version: unclaimed (below ⇒ a pipelined
+                // input whose producer has not executed locally yet; the producer's
+                // finalization precedes the claimant's votes, so any lock on this ref
+                // would still be quarantined and caught above).
             }
             None => {
                 // Deleted (tombstone) or never existed - disambiguate.
@@ -213,18 +206,6 @@ pub(crate) fn resolve_owned_object_lock_states(
                         live_object_cache.record_absent(obj_ref.0);
                     }
                 }
-            }
-        }
-    }
-
-    if !backstop_refs.is_empty() {
-        stats.backstop += backstop_refs.len() as u64;
-        let locks = epoch_store
-            .multi_get_owned_object_locks_from_db(&backstop_refs)
-            .expect("cannot read owned object lock table");
-        for (obj_ref, lock) in itertools::zip_eq(backstop_refs, locks) {
-            if let Some(lock) = lock {
-                resolutions.insert(obj_ref, LockResolution::LockedBy(lock));
             }
         }
     }
@@ -2625,22 +2606,12 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             ("deferred", resolution_stats.deferred),
             ("cache", resolution_stats.cache),
             ("objects_db", resolution_stats.objects_db),
-            ("backstop", resolution_stats.backstop),
         ] {
             self.metrics
                 .consensus_owned_object_lock_resolutions
                 .with_label_values(&[source])
                 .inc_by(count);
         }
-
-        // Differential validation of the objects-table-based resolution against the lock
-        // table (which is still fully written): both paths must produce identical
-        // verdicts for every transaction. Debug builds only (includes simtests).
-        #[cfg(debug_assertions)]
-        let table_locks = self
-            .epoch_store
-            .get_owned_object_locks_map(&prefetch_refs)
-            .unwrap_or_default();
 
         for (block, parsed_transactions) in block_transactions {
             let author = block.author.value();
@@ -2868,28 +2839,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                             &existing_locks,
                             self.cache_reader.as_ref(),
                         );
-
-                    #[cfg(debug_assertions)]
-                    {
-                        let table_result = self
-                            .epoch_store
-                            .try_acquire_owned_object_locks_post_consensus_table_based(
-                                &owned_object_refs,
-                                *tx.digest(),
-                                &owned_object_locks,
-                                &table_locks,
-                            );
-                        assert_eq!(
-                            acquire_result.is_ok(),
-                            table_result.is_ok(),
-                            "owned-object conflict verdict diverged from lock table for tx {:?} \
-                             (objects-based: {:?}, table-based: {:?}, refs: {:?})",
-                            tx.digest(),
-                            acquire_result.as_ref().err(),
-                            table_result.as_ref().err(),
-                            owned_object_refs,
-                        );
-                    }
 
                     match acquire_result {
                         Ok(new_locks) => {
@@ -3997,10 +3946,10 @@ mod tests {
             NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Dropped)
         ));
 
-        let locks = epoch_store
-            .get_owned_object_locks_map(&[owned_object_ref])
-            .unwrap();
-        assert_eq!(locks.get(&owned_object_ref), Some(&winner_digest));
+        assert_eq!(
+            epoch_store.get_owned_object_lock_in_memory(&owned_object_ref),
+            Some(winner_digest)
+        );
         assert!(
             epoch_store
                 .is_consensus_message_processed(&winner_key)

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -145,13 +145,25 @@ pub(crate) fn resolve_owned_object_lock_states(
     let mut stats = LockResolutionStats::default();
     let mut resolutions = HashMap::new();
 
+    // One lock acquisition per layer for the whole batch, not per ref: per-ref
+    // acquisition queues behind quarantine flushes (long write-lock critical sections)
+    // once per ref. Holding the read guard across the batch also makes the entire
+    // resolution atomic with respect to flushes, so the bump-before-removal ordering
+    // the cache verdicts rely on cannot interleave mid-batch. Lock order (quarantine →
+    // deferred) matches the flush path.
+    let quarantine = epoch_store.consensus_quarantine.read();
+    let deferred_locks = epoch_store
+        .consensus_output_cache
+        .deferred_transaction_locks
+        .lock();
+
     for obj_ref in obj_refs {
-        if let Some(lock) = epoch_store.get_owned_object_lock_in_memory(obj_ref) {
+        if let Some(lock) = quarantine.get_owned_object_lock_in_memory(obj_ref) {
             stats.quarantine += 1;
             resolutions.insert(*obj_ref, LockResolution::LockedBy(lock));
             continue;
         }
-        if let Some(lock) = epoch_store.get_deferred_transaction_lock(obj_ref) {
+        if let Some(lock) = deferred_locks.get(obj_ref) {
             stats.deferred += 1;
             resolutions.insert(*obj_ref, LockResolution::LockedBy(lock));
             continue;

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -31,7 +31,9 @@ use tap::TapFallible;
 use tracing::{debug, info, instrument, warn};
 
 use crate::{
-    authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
+    authority::{
+        AuthorityState, VoteTransactionResult, authority_per_epoch_store::AuthorityPerEpochStore,
+    },
     checkpoints::CheckpointServiceNotify,
 };
 
@@ -306,8 +308,16 @@ impl SuiTxValidator {
         }
 
         let inner_tx = verified_tx.into_tx();
-        self.authority_state
+        let vote_result = self
+            .authority_state
             .handle_vote_transaction(epoch_store, inner_tx.clone())?;
+
+        if vote_result == VoteTransactionResult::AlreadyFinalized {
+            // The transaction's own execution consumed its inputs, so input-based claims
+            // verification would spuriously reject a transaction that is already final.
+            // Duplicate sequencing is handled post-consensus by the same-digest carve-out.
+            return Ok(());
+        }
 
         if !claimed_immutable_ids.is_empty() {
             assert_reachable!("transaction has immutable input object claims");

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -311,18 +311,23 @@ impl SuiTxValidator {
 
         if !claimed_immutable_ids.is_empty() {
             assert_reachable!("transaction has immutable input object claims");
-            let owned_object_refs: HashSet<ObjectRef> = inner_tx
-                .data()
-                .transaction_data()
-                .input_objects()?
-                .iter()
-                .filter_map(|obj| match obj {
-                    InputObjectKind::ImmOrOwnedMoveObject(obj_ref) => Some(*obj_ref),
-                    _ => None,
-                })
-                .collect();
-            self.verify_immutable_object_claims(&claimed_immutable_ids, owned_object_refs)?;
         }
+        // Runs even when nothing is claimed: an immutable input with an empty claims list
+        // must be vote-rejected (ImmutableObjectNotClaimed). Post-consensus conflict
+        // detection derives lock sets from these claims, so an under-claiming transaction
+        // must never reach quorum. The objects were just read by
+        // validate_owned_object_versions, so this re-read is cache-hot.
+        let owned_object_refs: HashSet<ObjectRef> = inner_tx
+            .data()
+            .transaction_data()
+            .input_objects()?
+            .iter()
+            .filter_map(|obj| match obj {
+                InputObjectKind::ImmOrOwnedMoveObject(obj_ref) => Some(*obj_ref),
+                _ => None,
+            })
+            .collect();
+        self.verify_immutable_object_claims(&claimed_immutable_ids, owned_object_refs)?;
 
         Ok(())
     }
@@ -366,6 +371,11 @@ impl SuiTxValidator {
             let input_ref = input_refs_by_id.get(object_id).unwrap();
             match obj_opt {
                 Some(o) => {
+                    // Warm the live-object cache for post-consensus conflict detection.
+                    // Rejected votes warm too - the observed version is a valid lower
+                    // bound either way. Absent objects are deliberately not recorded:
+                    // this read cannot distinguish deletion tombstones from true absence.
+                    self.authority_state.live_object_cache().record_object(&o);
                     // The object read here might drift from the one read earlier in validate_owned_object_versions(),
                     // so re-check if input reference still matches actual object.
                     let actual_ref = o.compute_object_reference();

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -211,6 +211,31 @@ impl SuiTxValidator {
             let tx_digest = *tx.tx().digest();
             if let Err(error) = self.vote_transaction(epoch_store, tx) {
                 debug!(?tx_digest, "Voting to reject transaction: {error}");
+                // A not-found input is usually pipelined: created by a transaction that
+                // has not executed locally yet. Warm the live-object cache with an
+                // authoritative (tombstone-aware) observation so the commit handler can
+                // resolve the ref from memory if the transaction still gets finalized
+                // by validators that were further ahead.
+                if let SuiErrorKind::UserInputError {
+                    error: UserInputError::ObjectNotFound { object_id, .. },
+                } = error.as_inner()
+                {
+                    let live_object_cache = self.authority_state.live_object_cache();
+                    match self
+                        .authority_state
+                        .get_object_cache_reader()
+                        .get_latest_object_ref_or_tombstone(*object_id)
+                    {
+                        Some(latest_ref) => live_object_cache.record(
+                            *object_id,
+                            crate::live_object_cache::VersionLowerBound::Version {
+                                version: latest_ref.1,
+                                immutable: false,
+                            },
+                        ),
+                        None => live_object_cache.record_absent(*object_id),
+                    }
+                }
                 self.metrics
                     .transaction_reject_votes
                     .with_label_values(&[error.to_variant_name()])

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -220,21 +220,13 @@ impl SuiTxValidator {
                     error: UserInputError::ObjectNotFound { object_id, .. },
                 } = error.as_inner()
                 {
-                    let live_object_cache = self.authority_state.live_object_cache();
-                    match self
+                    let latest_ref = self
                         .authority_state
                         .get_object_cache_reader()
-                        .get_latest_object_ref_or_tombstone(*object_id)
-                    {
-                        Some(latest_ref) => live_object_cache.record(
-                            *object_id,
-                            crate::live_object_cache::VersionLowerBound::Version {
-                                version: latest_ref.1,
-                                immutable: false,
-                            },
-                        ),
-                        None => live_object_cache.record_absent(*object_id),
-                    }
+                        .get_latest_object_ref_or_tombstone(*object_id);
+                    epoch_store
+                        .live_object_cache()
+                        .record_latest_lookup(*object_id, latest_ref.map(|r| r.1));
                 }
                 self.metrics
                     .transaction_reject_votes
@@ -410,7 +402,7 @@ impl SuiTxValidator {
                     // Rejected votes warm too - the observed version is a valid lower
                     // bound either way. Absent objects are deliberately not recorded:
                     // this read cannot distinguish deletion tombstones from true absence.
-                    self.authority_state.live_object_cache().record_object(&o);
+                    self.epoch_store.live_object_cache().record_object(&o);
                     // The object read here might drift from the one read earlier in validate_owned_object_versions(),
                     // so re-check if input reference still matches actual object.
                     let actual_ref = o.compute_object_reference();

--- a/crates/sui-core/src/execution_cache/object_locks.rs
+++ b/crates/sui-core/src/execution_cache/object_locks.rs
@@ -28,7 +28,9 @@ impl ObjectLocks {
         obj_ref: &ObjectRef,
         epoch_store: &AuthorityPerEpochStore,
     ) -> SuiResult<Option<TransactionDigest>> {
-        epoch_store.tables()?.get_locked_transaction(obj_ref)
+        Ok(epoch_store
+            .get_owned_object_lock_in_memory(obj_ref)
+            .or_else(|| epoch_store.get_deferred_transaction_lock(obj_ref)))
     }
 
     pub(crate) fn clear(&self) {

--- a/crates/sui-core/src/execution_cache/object_locks.rs
+++ b/crates/sui-core/src/execution_cache/object_locks.rs
@@ -3,11 +3,7 @@
 
 use mysten_common::ZipDebugEqIteratorExt;
 
-#[cfg(test)]
-use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_types::base_types::{ObjectID, ObjectRef};
-#[cfg(test)]
-use sui_types::digests::TransactionDigest;
 use sui_types::error::{SuiErrorKind, SuiResult, UserInputError};
 use sui_types::object::Object;
 use sui_types::storage::ObjectStore;
@@ -15,97 +11,73 @@ use tracing::{debug, instrument};
 
 use super::writeback_cache::WritebackCache;
 
-pub(super) struct ObjectLocks {}
-
-impl ObjectLocks {
-    pub fn new() -> Self {
-        Self {}
+fn verify_live_object(obj_ref: &ObjectRef, live_object: &Object) -> SuiResult {
+    debug_assert_eq!(obj_ref.0, live_object.id());
+    if obj_ref.1 != live_object.version() {
+        debug!(
+            "object version unavailable for consumption: {:?} (current: {})",
+            obj_ref,
+            live_object.version()
+        );
+        return Err(SuiErrorKind::UserInputError {
+            error: UserInputError::ObjectVersionUnavailableForConsumption {
+                provided_obj_ref: *obj_ref,
+                current_version: live_object.version(),
+            },
+        }
+        .into());
     }
 
-    #[cfg(test)]
-    pub(crate) fn get_transaction_lock(
-        &self,
-        obj_ref: &ObjectRef,
-        epoch_store: &AuthorityPerEpochStore,
-    ) -> SuiResult<Option<TransactionDigest>> {
-        Ok(epoch_store
-            .get_owned_object_lock_in_memory(obj_ref)
-            .or_else(|| epoch_store.get_deferred_transaction_lock(obj_ref)))
+    let live_digest = live_object.digest();
+    if obj_ref.2 != live_digest {
+        return Err(SuiErrorKind::UserInputError {
+            error: UserInputError::InvalidObjectDigest {
+                object_id: obj_ref.0,
+                expected_digest: live_digest,
+            },
+        }
+        .into());
     }
 
-    pub(crate) fn clear(&self) {
-        // No-op: pre-consensus locking is disabled, so there's no in-memory lock state to clear.
-        // Lock state is managed in the database via post-consensus locking.
-    }
+    Ok(())
+}
 
-    fn verify_live_object(obj_ref: &ObjectRef, live_object: &Object) -> SuiResult {
-        debug_assert_eq!(obj_ref.0, live_object.id());
-        if obj_ref.1 != live_object.version() {
-            debug!(
-                "object version unavailable for consumption: {:?} (current: {})",
-                obj_ref,
-                live_object.version()
-            );
+fn multi_get_objects_must_exist(
+    cache: &WritebackCache,
+    object_ids: &[ObjectID],
+) -> SuiResult<Vec<Object>> {
+    let objects = cache.multi_get_objects(object_ids);
+    let mut result = Vec::with_capacity(objects.len());
+    for (i, object) in objects.into_iter().enumerate() {
+        if let Some(object) = object {
+            result.push(object);
+        } else {
             return Err(SuiErrorKind::UserInputError {
-                error: UserInputError::ObjectVersionUnavailableForConsumption {
-                    provided_obj_ref: *obj_ref,
-                    current_version: live_object.version(),
+                error: UserInputError::ObjectNotFound {
+                    object_id: object_ids[i],
+                    version: None,
                 },
             }
             .into());
         }
+    }
+    Ok(result)
+}
 
-        let live_digest = live_object.digest();
-        if obj_ref.2 != live_digest {
-            return Err(SuiErrorKind::UserInputError {
-                error: UserInputError::InvalidObjectDigest {
-                    object_id: obj_ref.0,
-                    expected_digest: live_digest,
-                },
-            }
-            .into());
-        }
+/// Validates owned object versions and digests without acquiring locks.
+/// Used to validate objects before signing, since locking happens post-consensus.
+#[instrument(level = "debug", skip_all)]
+pub(super) fn validate_owned_object_versions(
+    cache: &WritebackCache,
+    owned_input_objects: &[ObjectRef],
+) -> SuiResult {
+    let object_ids = owned_input_objects.iter().map(|o| o.0).collect::<Vec<_>>();
+    let live_objects = multi_get_objects_must_exist(cache, &object_ids)?;
 
-        Ok(())
+    // Validate that all objects are live and versions/digests match
+    for (obj_ref, live_object) in owned_input_objects.iter().zip_debug_eq(live_objects.iter()) {
+        verify_live_object(obj_ref, live_object)?;
     }
 
-    fn multi_get_objects_must_exist(
-        cache: &WritebackCache,
-        object_ids: &[ObjectID],
-    ) -> SuiResult<Vec<Object>> {
-        let objects = cache.multi_get_objects(object_ids);
-        let mut result = Vec::with_capacity(objects.len());
-        for (i, object) in objects.into_iter().enumerate() {
-            if let Some(object) = object {
-                result.push(object);
-            } else {
-                return Err(SuiErrorKind::UserInputError {
-                    error: UserInputError::ObjectNotFound {
-                        object_id: object_ids[i],
-                        version: None,
-                    },
-                }
-                .into());
-            }
-        }
-        Ok(result)
-    }
-
-    /// Validates owned object versions and digests without acquiring locks.
-    /// Used to validate objects before signing, since locking happens post-consensus.
-    #[instrument(level = "debug", skip_all)]
-    pub(crate) fn validate_owned_object_versions(
-        cache: &WritebackCache,
-        owned_input_objects: &[ObjectRef],
-    ) -> SuiResult {
-        let object_ids = owned_input_objects.iter().map(|o| o.0).collect::<Vec<_>>();
-        let live_objects = Self::multi_get_objects_must_exist(cache, &object_ids)?;
-
-        // Validate that all objects are live and versions/digests match
-        for (obj_ref, live_object) in owned_input_objects.iter().zip_debug_eq(live_objects.iter()) {
-            Self::verify_live_object(obj_ref, live_object)?;
-        }
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -164,8 +164,6 @@ impl Scenario {
             markers: Default::default(),
             wrapped: Default::default(),
             deleted: Default::default(),
-            locks_to_delete: Default::default(),
-            new_locks_to_init: Default::default(),
             written: Default::default(),
         }
     }
@@ -220,9 +218,6 @@ impl Scenario {
     pub fn with_child(&mut self, short_id: u32, owner: u32) {
         let owner_id = self.id_map.get(&owner).expect("no such object");
         let object = Self::new_child(*owner_id);
-        self.outputs
-            .new_locks_to_init
-            .push(object.compute_object_reference());
         let id = object.id();
         assert!(self.id_map.insert(short_id, id).is_none());
         self.outputs.written.insert(id, object.clone());
@@ -233,9 +228,6 @@ impl Scenario {
         // for every id in short_ids, create an object with that id if it doesn't exist
         for short_id in short_ids {
             let object = Self::new_object();
-            self.outputs
-                .new_locks_to_init
-                .push(object.compute_object_reference());
             let id = object.id();
             assert!(self.id_map.insert(*short_id, id).is_none());
             self.outputs.written.insert(id, object.clone());
@@ -274,14 +266,8 @@ impl Scenario {
         for short_id in short_ids {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.get(id).cloned().expect("object not found");
-            self.outputs
-                .locks_to_delete
-                .push(object.compute_object_reference());
             let object = Self::inc_version_by(object, delta);
             self.objects.insert(*id, object.clone());
-            self.outputs
-                .new_locks_to_init
-                .push(object.compute_object_reference());
             self.outputs.written.insert(object.id(), object);
         }
     }
@@ -293,7 +279,6 @@ impl Scenario {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.remove(id).expect("object not found");
             let mut object_ref = object.compute_object_reference();
-            self.outputs.locks_to_delete.push(object_ref);
             // in the authority this would be set to the lamport version of the tx
             object_ref.1.increment();
             self.outputs.deleted.push(object_ref.into());
@@ -307,7 +292,6 @@ impl Scenario {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.get(id).cloned().expect("object not found");
             let mut object_ref = object.compute_object_reference();
-            self.outputs.locks_to_delete.push(object_ref);
             // in the authority this would be set to the lamport version of the tx
             object_ref.1.increment();
             self.outputs.wrapped.push(object_ref.into());
@@ -316,16 +300,16 @@ impl Scenario {
 
     pub fn with_received(&mut self, short_ids: &[u32]) {
         // for every id in short_ids, assert than an object with that id exists, that
-        // it has a new lock (which proves it was mutated) and then write a received
-        // marker for it
+        // it has been written at its current version (which proves it was mutated) and
+        // then write a received marker for it
         for short_id in short_ids {
             let id = self.id_map.get(short_id).expect("object not found");
             let object = self.objects.get(id).cloned().expect("object not found");
-            self.outputs
-                .new_locks_to_init
-                .iter()
-                .find(|o| **o == object.compute_object_reference())
-                .expect("received object must have new lock");
+            assert_eq!(
+                self.outputs.written.get(id),
+                Some(&object),
+                "received object must have been mutated"
+            );
             self.outputs.markers.push((
                 object.compute_full_object_reference().into(),
                 MarkerValue::Received,

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -99,7 +99,6 @@ use super::{
     ExecutionCacheWrite, ObjectCacheRead, StateSyncAPI, TestingAPI, TransactionCacheRead,
     cache_types::{CacheResult, CachedVersionMap, IsNewer, MonotonicCache},
     implement_passthrough_traits,
-    object_locks::ObjectLocks,
 };
 
 #[cfg(test)]
@@ -446,8 +445,6 @@ pub struct WritebackCache {
     // - note that we removed any unfinalized packages from the cache during revert_state_update().
     packages: MokaCache<ObjectID, PackageObject>,
 
-    object_locks: ObjectLocks,
-
     executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
     object_notify_read: NotifyRead<InputKey, ()>,
 
@@ -513,7 +510,6 @@ impl WritebackCache {
                 config.object_by_id_cache_size(),
             )),
             packages,
-            object_locks: ObjectLocks::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
             object_notify_read: NotifyRead::new(),
             store,
@@ -1335,8 +1331,6 @@ impl WritebackCache {
 
         self.dirty.clear();
 
-        info!("clearing old transaction locks");
-        self.object_locks.clear();
         info!("clearing object per epoch marker table");
         self.store
             .clear_object_per_epoch_marker_table(execution_guard)
@@ -1905,9 +1899,9 @@ impl ObjectCacheRead for WritebackCache {
         } else {
             // requested object ref is live, check if there is a lock
             Ok(
-                match self
-                    .object_locks
-                    .get_transaction_lock(&obj_ref, epoch_store)?
+                match epoch_store
+                    .get_owned_object_lock_in_memory(&obj_ref)
+                    .or_else(|| epoch_store.get_deferred_transaction_lock(&obj_ref))
                 {
                     Some(tx_digest) => ObjectLockStatus::LockedToTx {
                         locked_by_tx: LockDetailsDeprecated {
@@ -2329,7 +2323,7 @@ impl TransactionCacheRead for WritebackCache {
 
 impl ExecutionCacheWrite for WritebackCache {
     fn validate_owned_object_versions(&self, owned_input_objects: &[ObjectRef]) -> SuiResult {
-        ObjectLocks::validate_owned_object_versions(self, owned_input_objects)
+        super::object_locks::validate_owned_object_versions(self, owned_input_objects)
     }
 
     fn write_transaction_outputs(&self, epoch_id: EpochId, tx_outputs: Arc<TransactionOutputs>) {

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -28,6 +28,7 @@ mod fallback_fetch;
 pub mod gasless_rate_limiter;
 pub mod global_state_hasher;
 pub mod jsonrpc_index;
+pub mod live_object_cache;
 pub mod metrics;
 pub mod mock_checkpoint_builder;
 pub mod mock_consensus;

--- a/crates/sui-core/src/live_object_cache.rs
+++ b/crates/sui-core/src/live_object_cache.rs
@@ -15,12 +15,13 @@
 //! Correctness rests on observations being lower bounds: versions never
 //! decrease, and objects never disappear once they (or their tombstones)
 //! exist, so any previously observed state is a valid lower bound on the
-//! current state. This means the cache needs no invalidation, arbitrary
-//! eviction is safe, and a stale entry can only cause a fallback read, never a
-//! wrong verdict: conflict resolution treats a bound as decisive only in the
-//! consumed direction (bound above the claimed version), and everything else
-//! falls back to an authoritative read of latest-object state (see
-//! `docs/objects_locking.md` §3.5/§3.6a).
+//! current state. This means the cache needs no invalidation and arbitrary
+//! eviction is safe. Bounds are decisive in both directions: above the
+//! claimed version ⇒ consumed; at or below it ⇒ unclaimed, which is sound
+//! because every path that removes a lock from the in-memory layers bumps the
+//! bound past the consumed version first (`record_consumed` at quarantine
+//! flush, before entry removal), and present entries are only ever max-merged
+//! upward (see `record`). See `docs/objects_locking.md` §3.5/§3.6a.
 //!
 //! Entries do not survive restarts (in-memory) and are cleared at epoch
 //! reconfiguration: observations can include executed-but-not-finalized state,
@@ -41,33 +42,18 @@ pub enum VersionLowerBound {
     /// The object id had no version and no tombstone at observation time.
     KnownAbsent,
     /// The latest version was at least `version` at observation time.
-    Version {
-        version: SequenceNumber,
-        /// Whether the object was immutable at exactly `version`. Ownership of
-        /// a given version never changes, so this bit is stable per version.
-        /// Tombstones record `false`.
-        immutable: bool,
-    },
+    Version { version: SequenceNumber },
 }
 
 impl VersionLowerBound {
-    pub fn from_object(object: &Object) -> Self {
-        VersionLowerBound::Version {
-            version: object.version(),
-            immutable: object.is_immutable(),
-        }
-    }
-
     fn version_key(&self) -> Option<SequenceNumber> {
         match self {
             VersionLowerBound::KnownAbsent => None,
-            VersionLowerBound::Version { version, .. } => Some(*version),
+            VersionLowerBound::Version { version } => Some(*version),
         }
     }
 
-    /// The greater (more informative) of two bounds. `KnownAbsent` is the
-    /// bottom element. Equal versions carry equal `immutable` bits, so which
-    /// one wins is immaterial.
+    /// The greater of two bounds. `KnownAbsent` is the bottom element.
     fn merge(self, other: Self) -> Self {
         if other.version_key() > self.version_key() {
             other
@@ -113,9 +99,12 @@ impl LiveObjectCache {
     }
 
     /// Record an observed bound, keeping the max of the existing and new
-    /// bounds. (A plain overwrite would also be correct — every observation is
-    /// a valid lower bound — but max-merge avoids a slow observer regressing a
-    /// fresher entry into extra fallback reads.)
+    /// bounds. Max-merge is load-bearing, not an optimization: warms taken
+    /// outside the quarantine guard (the vote path) can hold a pre-execution
+    /// observation and land AFTER the flush hook's `record_consumed` bump for
+    /// the same object. A plain overwrite would regress the bump while the
+    /// entry is present, and conflict resolution would then decisively (and
+    /// wrongly) clear a consumed ref (see `resolve_owned_object_lock_states`).
     pub fn record(&self, id: ObjectID, bound: VersionLowerBound) {
         let mut shard = self.shard(&id).write();
         if let Some(existing) = shard.get_mut(&id) {
@@ -133,7 +122,12 @@ impl LiveObjectCache {
     }
 
     pub fn record_object(&self, object: &Object) {
-        self.record(object.id(), VersionLowerBound::from_object(object));
+        self.record(
+            object.id(),
+            VersionLowerBound::Version {
+                version: object.version(),
+            },
+        );
     }
 
     /// Record that an id had no version and no tombstone. Only call this from
@@ -142,6 +136,18 @@ impl LiveObjectCache {
     /// returns `None` for a deleted object must not be recorded as absent.
     pub fn record_absent(&self, id: ObjectID) {
         self.record(id, VersionLowerBound::KnownAbsent);
+    }
+
+    /// Record the result of an authoritative, tombstone-aware latest-ref
+    /// lookup (`get_latest_object_ref_or_tombstone`). `None` means the id has
+    /// no version and no tombstone; this must NOT be fed from live-object
+    /// reads, which also return `None` for deleted objects (see
+    /// `record_absent`).
+    pub fn record_latest_lookup(&self, id: ObjectID, latest_version: Option<SequenceNumber>) {
+        match latest_version {
+            Some(version) => self.record(id, VersionLowerBound::Version { version }),
+            None => self.record_absent(id),
+        }
     }
 
     /// Record that `obj_ref` was consumed: its holder executed, so the latest
@@ -157,7 +163,6 @@ impl LiveObjectCache {
             obj_ref.0,
             VersionLowerBound::Version {
                 version: obj_ref.1.next(),
-                immutable: false,
             },
         );
     }
@@ -189,7 +194,6 @@ mod tests {
     fn version(v: u64) -> VersionLowerBound {
         VersionLowerBound::Version {
             version: SequenceNumber::from_u64(v),
-            immutable: false,
         }
     }
 
@@ -217,24 +221,25 @@ mod tests {
     }
 
     #[test]
-    fn test_immutable_bit_follows_version() {
+    fn test_consumed_bump_is_never_regressed_by_stale_warm() {
+        // The contract that makes decisive-clear verdicts sound: once
+        // record_consumed bumps a bound, a later warm carrying a stale
+        // pre-execution observation must not regress it.
         let cache = LiveObjectCache::with_capacity(100);
         let id = ObjectID::random();
-
-        cache.record(
+        let consumed_ref = (
             id,
-            VersionLowerBound::Version {
-                version: SequenceNumber::from_u64(2),
-                immutable: true,
-            },
+            SequenceNumber::from_u64(5),
+            sui_types::digests::ObjectDigest::random(),
         );
-        cache.record(id, version(1));
-        assert_eq!(
-            cache.get(&id),
-            Some(VersionLowerBound::Version {
-                version: SequenceNumber::from_u64(2),
-                immutable: true,
-            })
-        );
+
+        cache.record_consumed(&consumed_ref);
+        assert_eq!(cache.get(&id), Some(version(6)));
+
+        // A vote-thread warm that read the object at v5 before execution.
+        cache.record(id, version(5));
+        assert_eq!(cache.get(&id), Some(version(6)));
+        cache.record_latest_lookup(id, Some(SequenceNumber::from_u64(5)));
+        assert_eq!(cache.get(&id), Some(version(6)));
     }
 }

--- a/crates/sui-core/src/live_object_cache.rs
+++ b/crates/sui-core/src/live_object_cache.rs
@@ -1,0 +1,184 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A monotone lower bound on the latest version of objects, used to accelerate
+//! post-consensus owned-object conflict detection.
+//!
+//! The consensus commit handler decides conflicts with the rule
+//! `conflict ⟺ latest_version(id) > claimed_version` (see
+//! `docs/objects_locking.md` Part 3). Reading the objects table for that on the
+//! CPU-bound handler thread is expensive, so this cache memoizes *observations*
+//! of latest-object state made elsewhere — primarily by vote-time validation in
+//! `SuiTxValidator`, which reads every owned input of every transaction it
+//! votes on, shortly before the same refs reach the commit handler.
+//!
+//! Correctness rests on observations being lower bounds: versions never
+//! decrease, and objects never disappear once they (or their tombstones)
+//! exist, so any previously observed state is a valid lower bound on the
+//! current state. This means the cache needs no invalidation, arbitrary
+//! eviction is safe, and a stale entry can only cause a fallback read, never a
+//! wrong verdict: conflict resolution treats a bound as decisive only in the
+//! consumed direction (bound above the claimed version), and everything else
+//! falls back to an authoritative read of latest-object state (see
+//! `docs/objects_locking.md` §3.5/§3.6a).
+//!
+//! Entries are process-lifetime and epoch-agnostic (version bounds stay valid
+//! across epoch boundaries and are naturally empty after a restart).
+
+use moka::sync::SegmentedCache as MokaCache;
+use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::object::Object;
+
+/// A lower bound on the latest version of an object, from an authoritative
+/// read of latest-object state (live object cache / objects table).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VersionLowerBound {
+    /// The object id had no version and no tombstone at observation time.
+    KnownAbsent,
+    /// The latest version was at least `version` at observation time.
+    Version {
+        version: SequenceNumber,
+        /// Whether the object was immutable at exactly `version`. Ownership of
+        /// a given version never changes, so this bit is stable per version.
+        /// Tombstones record `false`.
+        immutable: bool,
+    },
+}
+
+impl VersionLowerBound {
+    pub fn from_object(object: &Object) -> Self {
+        VersionLowerBound::Version {
+            version: object.version(),
+            immutable: object.is_immutable(),
+        }
+    }
+
+    fn version_key(&self) -> Option<SequenceNumber> {
+        match self {
+            VersionLowerBound::KnownAbsent => None,
+            VersionLowerBound::Version { version, .. } => Some(*version),
+        }
+    }
+
+    /// The greater (more informative) of two bounds. `KnownAbsent` is the
+    /// bottom element. Equal versions carry equal `immutable` bits, so which
+    /// one wins is immaterial.
+    fn merge(self, other: Self) -> Self {
+        if other.version_key() > self.version_key() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+pub struct LiveObjectCache {
+    entries: MokaCache<ObjectID, VersionLowerBound>,
+}
+
+const DEFAULT_CAPACITY: u64 = 1_000_000;
+
+impl LiveObjectCache {
+    pub fn new() -> Self {
+        let capacity = std::env::var("LIVE_OBJECT_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_CAPACITY);
+        Self::with_capacity(capacity)
+    }
+
+    pub fn with_capacity(capacity: u64) -> Self {
+        Self {
+            entries: MokaCache::builder(8).max_capacity(capacity).build(),
+        }
+    }
+
+    /// Record an observed bound, keeping the max of the existing and new
+    /// bounds. (A plain overwrite would also be correct — every observation is
+    /// a valid lower bound — but max-merge avoids a slow observer regressing a
+    /// fresher entry into extra fallback reads.)
+    pub fn record(&self, id: ObjectID, bound: VersionLowerBound) {
+        self.entries.entry(id).and_upsert_with(|existing| {
+            existing.map_or(bound, |entry| entry.into_value().merge(bound))
+        });
+    }
+
+    pub fn record_object(&self, object: &Object) {
+        self.record(object.id(), VersionLowerBound::from_object(object));
+    }
+
+    /// Record that an id had no version and no tombstone. Only call this from
+    /// reads that distinguish tombstones from true absence
+    /// (`get_latest_object_ref_or_tombstone`-style); a live-object read that
+    /// returns `None` for a deleted object must not be recorded as absent.
+    pub fn record_absent(&self, id: ObjectID) {
+        self.record(id, VersionLowerBound::KnownAbsent);
+    }
+
+    pub fn get(&self, id: &ObjectID) -> Option<VersionLowerBound> {
+        self.entries.get(id)
+    }
+}
+
+impl Default for LiveObjectCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn version(v: u64) -> VersionLowerBound {
+        VersionLowerBound::Version {
+            version: SequenceNumber::from_u64(v),
+            immutable: false,
+        }
+    }
+
+    #[test]
+    fn test_monotone_merge() {
+        let cache = LiveObjectCache::with_capacity(100);
+        let id = ObjectID::random();
+
+        assert_eq!(cache.get(&id), None);
+
+        cache.record_absent(id);
+        assert_eq!(cache.get(&id), Some(VersionLowerBound::KnownAbsent));
+
+        cache.record(id, version(5));
+        assert_eq!(cache.get(&id), Some(version(5)));
+
+        // Older observations never regress the bound.
+        cache.record(id, version(3));
+        assert_eq!(cache.get(&id), Some(version(5)));
+        cache.record_absent(id);
+        assert_eq!(cache.get(&id), Some(version(5)));
+
+        cache.record(id, version(7));
+        assert_eq!(cache.get(&id), Some(version(7)));
+    }
+
+    #[test]
+    fn test_immutable_bit_follows_version() {
+        let cache = LiveObjectCache::with_capacity(100);
+        let id = ObjectID::random();
+
+        cache.record(
+            id,
+            VersionLowerBound::Version {
+                version: SequenceNumber::from_u64(2),
+                immutable: true,
+            },
+        );
+        cache.record(id, version(1));
+        assert_eq!(
+            cache.get(&id),
+            Some(VersionLowerBound::Version {
+                version: SequenceNumber::from_u64(2),
+                immutable: true,
+            })
+        );
+    }
+}

--- a/crates/sui-core/src/live_object_cache.rs
+++ b/crates/sui-core/src/live_object_cache.rs
@@ -22,8 +22,12 @@
 //! falls back to an authoritative read of latest-object state (see
 //! `docs/objects_locking.md` §3.5/§3.6a).
 //!
-//! Entries are process-lifetime and epoch-agnostic (version bounds stay valid
-//! across epoch boundaries and are naturally empty after a restart).
+//! Entries do not survive restarts (in-memory) and are cleared at epoch
+//! reconfiguration: observations can include executed-but-not-finalized state,
+//! which end-of-epoch clearing discards, invalidating the lower-bound property
+//! for bounds recorded from it. Within an epoch (and across intra-epoch
+//! restarts) the property holds - replayed commits re-execute, so state only
+//! advances.
 
 use moka::sync::SegmentedCache as MokaCache;
 use sui_types::base_types::{ObjectID, SequenceNumber};
@@ -117,6 +121,13 @@ impl LiveObjectCache {
 
     pub fn get(&self, id: &ObjectID) -> Option<VersionLowerBound> {
         self.entries.get(id)
+    }
+
+    /// Drop all bounds. MUST be called at epoch reconfiguration: end-of-epoch state
+    /// clearing discards executed-but-not-finalized transaction outputs, so bounds
+    /// recorded from that state are no longer lower bounds of durable latest versions.
+    pub fn clear(&self) {
+        self.entries.invalidate_all();
     }
 }
 

--- a/crates/sui-core/src/live_object_cache.rs
+++ b/crates/sui-core/src/live_object_cache.rs
@@ -29,7 +29,8 @@
 //! restarts) the property holds - replayed commits re-execute, so state only
 //! advances.
 
-use moka::sync::SegmentedCache as MokaCache;
+use parking_lot::RwLock;
+use std::collections::HashMap;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
 use sui_types::object::Object;
 
@@ -76,11 +77,19 @@ impl VersionLowerBound {
     }
 }
 
+/// Sharded flat map rather than an LRU cache: the quarantine flush bumps bounds for
+/// every flushed lock ref while holding the quarantine write lock, so writes must be a
+/// couple of hash-map operations, not an eviction-policy update. Bounded by dropping
+/// *inserts* (never updates) when a shard is full after evicting one arbitrary entry —
+/// both are sound: a missing entry falls back to an authoritative read, while updates of
+/// present entries (which consumption bumps rely on) always succeed.
 pub struct LiveObjectCache {
-    entries: MokaCache<ObjectID, VersionLowerBound>,
+    shards: Vec<RwLock<HashMap<ObjectID, VersionLowerBound>>>,
+    capacity_per_shard: usize,
 }
 
-const DEFAULT_CAPACITY: u64 = 1_000_000;
+const DEFAULT_CAPACITY: usize = 1_000_000;
+const SHARDS: usize = 64;
 
 impl LiveObjectCache {
     pub fn new() -> Self {
@@ -91,10 +100,16 @@ impl LiveObjectCache {
         Self::with_capacity(capacity)
     }
 
-    pub fn with_capacity(capacity: u64) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            entries: MokaCache::builder(8).max_capacity(capacity).build(),
+            shards: (0..SHARDS).map(|_| RwLock::new(HashMap::new())).collect(),
+            capacity_per_shard: (capacity / SHARDS).max(1),
         }
+    }
+
+    fn shard(&self, id: &ObjectID) -> &RwLock<HashMap<ObjectID, VersionLowerBound>> {
+        // ObjectIDs are hash digests; the first byte is uniform.
+        &self.shards[id.as_ref()[0] as usize % SHARDS]
     }
 
     /// Record an observed bound, keeping the max of the existing and new
@@ -102,9 +117,19 @@ impl LiveObjectCache {
     /// a valid lower bound — but max-merge avoids a slow observer regressing a
     /// fresher entry into extra fallback reads.)
     pub fn record(&self, id: ObjectID, bound: VersionLowerBound) {
-        self.entries.entry(id).and_upsert_with(|existing| {
-            existing.map_or(bound, |entry| entry.into_value().merge(bound))
-        });
+        let mut shard = self.shard(&id).write();
+        if let Some(existing) = shard.get_mut(&id) {
+            *existing = existing.merge(bound);
+            return;
+        }
+        if shard.len() >= self.capacity_per_shard {
+            // Evict one arbitrary entry to make room; evicting is always sound
+            // (a missing entry just means an authoritative fallback read).
+            if let Some(&victim) = shard.keys().next() {
+                shard.remove(&victim);
+            }
+        }
+        shard.insert(id, bound);
     }
 
     pub fn record_object(&self, object: &Object) {
@@ -138,14 +163,16 @@ impl LiveObjectCache {
     }
 
     pub fn get(&self, id: &ObjectID) -> Option<VersionLowerBound> {
-        self.entries.get(id)
+        self.shard(id).read().get(id).copied()
     }
 
     /// Drop all bounds. MUST be called at epoch reconfiguration: end-of-epoch state
     /// clearing discards executed-but-not-finalized transaction outputs, so bounds
     /// recorded from that state are no longer lower bounds of durable latest versions.
     pub fn clear(&self) {
-        self.entries.invalidate_all();
+        for shard in &self.shards {
+            shard.write().clear();
+        }
     }
 }
 

--- a/crates/sui-core/src/live_object_cache.rs
+++ b/crates/sui-core/src/live_object_cache.rs
@@ -30,7 +30,7 @@
 //! advances.
 
 use moka::sync::SegmentedCache as MokaCache;
-use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
 use sui_types::object::Object;
 
 /// A lower bound on the latest version of an object, from an authoritative
@@ -117,6 +117,24 @@ impl LiveObjectCache {
     /// returns `None` for a deleted object must not be recorded as absent.
     pub fn record_absent(&self, id: ObjectID) {
         self.record(id, VersionLowerBound::KnownAbsent);
+    }
+
+    /// Record that `obj_ref` was consumed: its holder executed, so the latest
+    /// version is at least one past the consumed version. Called when the
+    /// quarantine (or the deferred-locks map) drops a flushed commit's lock
+    /// refs — the flush gate guarantees the holder executed — and MUST be
+    /// called before the corresponding in-memory lock entry is removed, so
+    /// that any conflict resolution that misses the memory layers observes
+    /// the bump. This ordering is what makes a cached bound at or below a
+    /// claimed version a decisive "unclaimed" verdict.
+    pub fn record_consumed(&self, obj_ref: &ObjectRef) {
+        self.record(
+            obj_ref.0,
+            VersionLowerBound::Version {
+                version: obj_ref.1.next(),
+                immutable: false,
+            },
+        );
     }
 
     pub fn get(&self, id: &ObjectID) -> Option<VersionLowerBound> {

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use sui_types::accumulator_event::AccumulatorEvent;
-use sui_types::base_types::{FullObjectID, ObjectRef};
+use sui_types::base_types::FullObjectID;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::full_checkpoint_content::ObjectSet;
 use sui_types::inner_temporary_store::{InnerTemporaryStore, WrittenObjects};
@@ -25,8 +25,6 @@ pub struct TransactionOutputs {
     pub markers: Vec<(FullObjectKey, MarkerValue)>,
     pub wrapped: Vec<ObjectKey>,
     pub deleted: Vec<ObjectKey>,
-    pub locks_to_delete: Vec<ObjectRef>,
-    pub new_locks_to_init: Vec<ObjectRef>,
     pub written: WrittenObjects,
 }
 
@@ -41,7 +39,7 @@ impl TransactionOutputs {
         let InnerTemporaryStore {
             input_objects,
             stream_ended_consensus_objects,
-            mutable_inputs,
+            mutable_inputs: _,
             written,
             events,
             accumulator_events,
@@ -73,7 +71,7 @@ impl TransactionOutputs {
         // removals from consensus in the marker table. For deleted entries in the marker table we
         // need to make sure we don't accidentally overwrite entries.
         let markers: Vec<_> = {
-            let received = received_objects.clone().map(|objref| {
+            let received = received_objects.map(|objref| {
                 (
                     // TODO: Add support for receiving consensus objects. For now this assumes fastpath.
                     FullObjectKey::new(FullObjectID::new(objref.0, None), objref.1),
@@ -161,25 +159,6 @@ impl TransactionOutputs {
                 .collect()
         };
 
-        let locks_to_delete: Vec<_> = mutable_inputs
-            .into_iter()
-            .filter_map(|(id, ((version, digest), owner))| {
-                owner.is_address_owned().then_some((id, version, digest))
-            })
-            .chain(received_objects)
-            .collect();
-
-        let new_locks_to_init: Vec<_> = written
-            .values()
-            .filter_map(|new_object| {
-                if new_object.is_address_owned() {
-                    Some(new_object.compute_object_reference())
-                } else {
-                    None
-                }
-            })
-            .collect();
-
         let deleted = effects
             .deleted()
             .into_iter()
@@ -198,8 +177,6 @@ impl TransactionOutputs {
             markers,
             wrapped,
             deleted,
-            locks_to_delete,
-            new_locks_to_init,
             written,
         }
     }
@@ -222,8 +199,6 @@ impl TransactionOutputs {
             markers: vec![],
             wrapped: vec![],
             deleted: vec![],
-            locks_to_delete: vec![],
-            new_locks_to_init: vec![],
             written: WrittenObjects::new(),
         }
     }

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -1055,7 +1055,7 @@ async fn execute_transfer_with_price(
             .into_tx();
         authority_state
             .handle_vote_transaction(&epoch_store, tx)
-            .map(|()| None)
+            .map(|_| None)
     };
     TransferResult {
         authority_state,

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -492,8 +492,10 @@ async fn test_submit_transaction_consensus_message_processed() {
 
 // Test that resubmitting a consensus-processed transaction whose owned inputs are no
 // longer live (e.g. a dropped owned-object conflict loser after the winner executed)
-// returns the concrete, non-retriable validation error instead of the generic,
-// retriable TransactionProcessing suppression.
+// returns a concrete, non-retriable error instead of the generic, retriable
+// TransactionProcessing suppression. The conflict resolution derives "consumed since
+// claim" from the objects table and names the winner from the live object's
+// previous_transaction.
 #[tokio::test]
 async fn test_submit_transaction_consensus_message_processed_with_stale_inputs() {
     let test_context = TestContext::new().await;
@@ -543,11 +545,10 @@ async fn test_submit_transaction_consensus_message_processed_with_stale_inputs()
             assert!(
                 matches!(
                     error.as_inner(),
-                    SuiErrorKind::UserInputError {
-                        error: UserInputError::ObjectVersionUnavailableForConsumption { .. }
-                    }
+                    SuiErrorKind::ObjectLockConflict { pending_transaction, .. }
+                        if *pending_transaction == *winner.digest()
                 ),
-                "expected stale-version rejection, got: {error}"
+                "expected lock-conflict rejection naming the winner, got: {error}"
             );
         }
         other => panic!("Expected Rejected response, got {other:?}"),

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -96,7 +96,9 @@ fn get_accounts_and_coins(
 fn process_zklogin_tx(tx: Transaction, state: &Arc<AuthorityState>) -> SuiResult<()> {
     let epoch_store = state.epoch_store_for_testing();
     let verified_tx = VerifiedTransaction::new_from_verified(tx);
-    state.handle_vote_transaction(&epoch_store, verified_tx)
+    state
+        .handle_vote_transaction(&epoch_store, verified_tx)
+        .map(|_| ())
 }
 
 fn transfer_with_account(
@@ -127,7 +129,7 @@ fn transfer_with_account(
         .verify_transaction_require_no_aliases(tx)
         .unwrap()
         .into_tx();
-    state.handle_vote_transaction(&epoch_store, tx)
+    state.handle_vote_transaction(&epoch_store, tx).map(|_| ())
 }
 
 fn handle_move_call_transaction(
@@ -158,7 +160,7 @@ fn handle_move_call_transaction(
         .verify_transaction_require_no_aliases(tx)
         .unwrap()
         .into_tx();
-    state.handle_vote_transaction(&epoch_store, tx)
+    state.handle_vote_transaction(&epoch_store, tx).map(|_| ())
 }
 
 fn assert_denied<T: std::fmt::Debug>(result: &SuiResult<T>) {
@@ -203,7 +205,9 @@ fn submit_gasless_with_account(
     let tx = to_sender_signed_transaction(data, &sender_account.1);
     let epoch_store = state.epoch_store_for_testing();
     let verified_tx = VerifiedTransaction::new_from_verified(tx);
-    state.handle_vote_transaction(&epoch_store, verified_tx)
+    state
+        .handle_vote_transaction(&epoch_store, verified_tx)
+        .map(|_| ())
 }
 
 #[tokio::test]

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -3282,7 +3282,7 @@ async fn test_reject_signing_transaction_executed_in_previous_epoch() {
                 err_str
             );
         }
-        Ok(()) => {
+        Ok(_) => {
             panic!(
                 "Expected handle_vote_transaction to fail for transaction executed in previous epoch"
             );

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -38,6 +38,7 @@ use sui_core::consensus_adapter::ConsensusClient;
 use sui_core::consensus_manager::UpdatableConsensusClient;
 use sui_core::epoch::randomness::RandomnessManager;
 use sui_core::execution_cache::build_execution_cache;
+use sui_core::live_object_cache::LiveObjectCache;
 use sui_core::randomness_round_receiver::{RandomnessRoundReceiver, RandomnessRoundReceiverHandle};
 use sui_network::endpoint_manager::{AddressSource, EndpointId};
 use sui_network::validator::server::SUI_TLS_SERVER_NAME;
@@ -633,6 +634,7 @@ impl SuiNode {
                 &registry_service.default_registry(),
             )),
             config.fullnode_sync_mode,
+            Arc::new(LiveObjectCache::new()),
         )?;
 
         info!("created epoch store");

--- a/docs/objects_locking.md
+++ b/docs/objects_locking.md
@@ -691,8 +691,13 @@ lower bound on latest versions**, not a snapshot of liveness:
     is immune (flushed ⇒ executed ⇒ bumped). A clear-side shortcut becomes sound by
     bumping the cached bound of every flushed lock ref to `version+1` at the moment the
     quarantine drops it (cache bump happens-before quarantine removal ⇒ any resolution
-    missing the quarantine sees the bump) — deliberately left out of PR 1 to keep its
-    correctness argument minimal; candidate follow-up alongside PR 2.
+    missing the quarantine sees the bump). **Implemented 2026-07-15** after the first
+    private-testnet run showed the handler saturated (filter at ~0.6 util, ~15k/s
+    authoritative reads): flush-time bumps in `commit_with_batch` (skipping refs still
+    held by the deferred-locks map — their holders haven't executed; they bump when the
+    scheduling commit flushes), decisive clear verdicts for bounds ≤ claimed and
+    KnownAbsent, vote-time authoritative warming of not-found inputs (the pipelined
+    case), and a single `get_latest_object_ref_or_tombstone` as the residual fallback.
   - Cache **miss** ⇒ authoritative read, same as above. `source=objects_db` in the
     resolution metric counts these authoritative reads.
 - Consequences: no invalidation protocol, LRU/TTL eviction is always safe (eviction just

--- a/docs/objects_locking.md
+++ b/docs/objects_locking.md
@@ -786,9 +786,11 @@ sequencing discipline. Two seams to implement carefully (the debug double-read
 differentially tests both): deferred-map seeding must reproduce the exact lock set
 (owned refs always; actually-immutable refs excluded — a byzantine under-claim that
 slips through in the mixed era is covered by the backstop, and becomes impossible once
-strict voting is universal); and a re-loaded deferred tx must re-acquire into the current
-commit's locks when it leaves the deferred map, or there is a coverage gap between reload
-and execution (`latest == v`, owned, no memory layer).
+strict voting is universal); and a re-loaded deferred tx must stay covered between reload
+and execution (`latest == v`, owned) — its deferred-locks map entry is kept until the
+*reloading* commit's flush (the flush gate guarantees execution by then), rather than
+re-acquiring into the current commit's locks, whose flush-time key removal would erase
+the re-acquired entry early.
 
 **PR 2 (deletion)** removes the backstop + table + writes + `LockDetailsWrapper` +
 quarantine lock plumbing + debug compare. Its safety condition is the deploy discipline

--- a/docs/objects_locking.md
+++ b/docs/objects_locking.md
@@ -1,0 +1,841 @@
+# Owned-object locking: `owned_object_locked_transactions` and `live_owned_object_markers`
+
+Survey of how these two tables are used today (as of `main`, 2026-07-10), written as
+groundwork for removing them and replacing them with in-memory owned-object lock tracking
+that uses the `objects` table as the source of truth. Line numbers are as of this date and
+will drift; function names are the stable reference. Untracked / scratch.
+
+> **Status update (2026-07-10):** the `live_owned_object_markers` removal described in
+> §10 is implemented in draft PR #27243 (`andll/remove-live-owned-object-markers`) —
+> markers deleted outright; `check_owned_objects_are_live` and `get_lock` reimplemented on
+> `get_object_impl` (objects table, dirty-aware). Sections describing the marker table
+> document the pre-removal state. `owned_object_locked_transactions` is untouched.
+>
+> **Status update (2026-07-15):** Part 3 (below) is the replacement design for
+> `owned_object_locked_transactions`: quarantine map + deferred-locks map + objects-table
+> version verdict, accelerated by a vote-warmed `LiveObjectCache`. Feasibility: yes, with
+> three amendments (monotone version rule instead of liveness, deferred/same-digest gap
+> fillers, strict immutable-claims voting + immutable backstop). No protocol flag needed
+> (§3.6a); two PRs: reads swapped with debug double-read, then table deletion.
+> Implementation in progress on `andll/owned-object-locks-in-memory`.
+
+---
+
+## Part 1 — TL;DR (for humans)
+
+There are two tables with confusingly similar names and completely different jobs. Both are
+leftovers of the pre-consensus locking design that was removed when all user transactions
+started going through consensus (PR #24676 "Disable Owned Object Locking", Dec 2025, and
+cleanup #25150, Feb 2026).
+
+### `live_owned_object_markers` — perpetual DB, all node types
+
+- `DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>` in `AuthorityPerpetualTables`
+  (`authority_store_tables.rs:81`). On-disk column-family name is still the old
+  `owned_object_transaction_locks` (via `#[rename]`). The value is **always written as
+  `None`** — it is a pure existence marker; the value type survives only for legacy DB
+  compatibility.
+- **Why it existed:** the `objects` table stores *all* versions of every object, so a
+  point read there can only answer "did (X, v) ever exist" — not "is (X, v, digest) the
+  *current live* version". Answering liveness from `objects` requires a latest-version
+  lookup (a bounded reverse seek, or the in-memory object-by-id cache). The marker table
+  was a **materialized index that made exact-ref liveness a single point get**: key
+  present ⇔ this exact ref is the live version of an address-owned
+  (`Owner::AddressOwner`) object.
+- **Writes:** maintained atomically with `objects` in the per-checkpoint commit batch
+  (`AuthorityStore::write_one_transaction_outputs`): insert a marker for each
+  address-owned output, delete for each consumed address-owned input and received object.
+  Also written by genesis init and formal-snapshot restore. Durability is
+  checkpoint-gated, like all transaction outputs.
+- **Reads — hot function, cold table (easy to get wrong):**
+  - It was **not** the system's primary liveness guard. Vote-time validation
+    (`validate_owned_object_versions`) — the thing that actually keeps stale-version
+    transactions out of consensus — always read live objects, never markers (§4).
+  - Its one hot consumer was `check_owned_objects_are_live`, a defense-in-depth assert
+    run before executing **every** certificate (failure is `fatal!` — node crash). The
+    *function* is hot, but it is cache-first: the in-memory object-by-id/dirty caches
+    answer nearly every query, and the marker *table* was only touched on a full
+    in-memory miss (cold objects).
+  - The remaining reads: `get_latest_live_version_for_object_id`, a reverse scan used on
+    failure paths to report "the live version is actually X", and `get_lock` /
+    `ObjectLockStatus` — **dead in production**, only unit tests call it.
+- **What replaces it (PR #27243, deletes the table):** the `objects` table becomes the
+  sole source of truth for liveness. The assert and `get_lock` go through
+  `get_object_impl` (object-by-id cache → dirty set → **latest-version reverse seek on
+  `objects`**) and compare the full ref against the live object; error enrichment reports
+  the live version from the same lookup; the writes simply stop. Semantics are unchanged
+  on the dominant cache-hit path and strictly stricter on the miss path (the old fallback
+  trusted marker existence, which stale genesis-era markers could fool). The cost trade:
+  on a cold miss, a per-object reverse seek on `objects` replaces a batched point get on
+  markers — that seek is the price of deleting the index — in exchange every transaction
+  stops paying two marker writes per owned object plus a marker multi-get in the commit
+  path, and the whole write-heavy keyspace goes away. Vote-time validation is untouched;
+  it never used the table.
+
+### `owned_object_locked_transactions` — per-epoch DB, validators only
+
+- `DBMap<ObjectRef, LockDetailsWrapper>` in `AuthorityEpochTables`
+  (`authority_per_epoch_store.rs:430`); `LockDetails = TransactionDigest`.
+- Semantics: post-consensus equivocation protection. When the consensus commit handler
+  processes a finalized `UserTransactionV2`, it "locks" every owned input ref (including
+  gas) to the transaction digest. The first transaction to claim a ref in an epoch wins;
+  any later transaction claiming the same ref is deterministically **dropped** by every
+  validator (`ObjectLockConflict`). Locks are **never released during an epoch** — the
+  whole epoch DB is deleted after reconfiguration, which is how locks are released.
+- Writes are **not** immediate: locks accumulate in the in-memory
+  `ConsensusOutputQuarantine` and are flushed to the epoch DB (atomically with
+  `last_consensus_stats_v2`, the consensus replay watermark) only once the checkpoints
+  covering the commit are certified and executed.
+- Reads always go through the quarantine first, falling back to the DB
+  (`AuthorityPerEpochStore::get_owned_object_locks`). Readers: the consensus handler's
+  per-commit prefetch, and the transaction-submission path (to give clients a terminal
+  conflict error instead of a retriable one).
+- Fullnodes have the table but never write or read it.
+
+### The two key nuances (restart & DB divergence)
+
+**Recovery on restart.** The quarantine is volatile. On restart, consensus replays every
+commit after the durable `last_consensus_stats_v2` watermark, and the commit handler
+re-runs lock acquisition from scratch. This is safe because lock acquisition is a **pure
+conflict check** — it never looks at object liveness — so it produces identical results
+even though the perpetual DB may already contain the effects of the replayed transactions
+(inputs consumed, objects gone). Because the watermark and the locks are written in one
+batch, "the commit's locks are durable" ⇔ "the commit will not be replayed"; there is no
+partially-recovered lock state.
+
+**Epoch-DB vs perpetual-DB divergence.** The perpetual DB is always *ahead or equal*: the
+checkpoint executor commits transaction outputs (perpetual) *before* it advances the
+quarantine watermark that flushes locks (epoch). The reverse direction can't happen. The
+tolerated divergence — outputs durable, locks not — is exactly what liveness-free replay
+handles. Across epochs, the divergence is by design: markers persist, locks evaporate with
+the old epoch DB, so an object locked-but-not-consumed in epoch N is lockable by a
+different transaction in epoch N+1.
+
+---
+
+## Part 2 — Details (for a future AI working on the replacement)
+
+### 1. Physical definitions
+
+**`live_owned_object_markers`** — `crates/sui-core/src/authority/authority_store_tables.rs:76-81`
+
+```rust
+#[rename = "owned_object_transaction_locks"]
+pub(crate) live_owned_object_markers: DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
+```
+
+- `LockDetailsWrapperDeprecated::V1(LockDetailsV1Deprecated { epoch, tx_digest })` is
+  defined at the bottom of `authority_store.rs` (~line 1673). New code always writes
+  `None`. A `Some(...)` value can only exist in a DB written before the lock split
+  (pre-2024 era; the split was gated by the now-deprecated
+  `EpochFlag::_ObjectLockSplitTablesDeprecated`). The only code that looks at the value is
+  the conflict guard in `initialize_live_object_markers` (errors with
+  `ObjectLockAlreadyInitialized` if it finds `Some`); everything else checks key existence.
+- RocksDB config: `owned_object_transaction_locks_table_config`
+  (`authority_store_tables.rs:952`) — write-throughput-optimized, block cache from env
+  `LOCKS_BLOCK_CACHE_MB` (default 1 GiB), range deletions respected.
+- TideHunter config (`authority_store_tables.rs:257-287`): keyspace
+  `owned_object_transaction_locks`, `KeyIndexing::key_reduction(80, 16..64)` — the index
+  key keeps serialized-ObjectRef bytes [16..64), i.e. drops the first 16 bytes of the
+  ObjectID and the tail of the digest. Consequence: the index preserves per-object grouping
+  and version order only through the ObjectID's *last* 16 bytes (relies on their
+  uniqueness), which is what makes `reversed_safe_iter_with_bounds` in
+  `get_latest_live_version_for_object_id` still work. `mutexes * 16`, bloom filter, high
+  dirty-key allowance — it is tuned as a write-heavy table.
+
+**`owned_object_locked_transactions`** — `crates/sui-core/src/authority/authority_per_epoch_store.rs:428-430`
+
+```rust
+#[default_options_override_fn = "owned_object_transaction_locks_table_default_config"]
+owned_object_locked_transactions: DBMap<ObjectRef, LockDetailsWrapper>,
+```
+
+- `LockDetailsWrapper::V1(TransactionDigest)`, `LockDetails = TransactionDigest`
+  (`authority_per_epoch_store.rs:3410-3451`). Reads go through `.migrate().into_inner()`
+  (migration is a no-op today; the wrapper exists for future versioning).
+- RocksDB config (`authority_per_epoch_store.rs:544-553`): same
+  `LOCKS_BLOCK_CACHE_MB`-driven config as the perpetual table.
+- TideHunter config (`authority_per_epoch_store.rs:592-601`): `KeyIndexing::Hash` —
+  **point lookups only, no ordered iteration is possible**, which is fine because nothing
+  ever iterates this table. `mutexes * 8`, bloom filter.
+- The epoch DB lives in `<epochs-dir>/epoch_<N>`; old directories are deleted by
+  `AuthorityPerEpochStorePruner` (`authority_per_epoch_store_pruner.rs`). That deletion is
+  the only "release" of locks.
+
+### 2. Exactly which refs end up in each table
+
+**Markers** (`TransactionOutputs::build_transaction_outputs`, `transaction_outputs.rs:156-173`):
+
+- `new_locks_to_init` = every written output object with `owner.is_address_owned()`, i.e.
+  **strictly `Owner::AddressOwner`**. Not shared, not immutable, not `ObjectOwner` (child),
+  not `ConsensusAddressOwner`, not `Party`.
+- `locks_to_delete` = mutable inputs whose owner was `AddressOwner`, **plus** received
+  objects (Receiving args that were actually received — determined by membership in
+  `effects.modified_at_versions()`). Receiving args that were *not* received keep their
+  markers (comment at `authority_store.rs:838-839`).
+- Deleted / wrapped objects: their input marker is deleted via `locks_to_delete` (they were
+  address-owned mutable inputs); tombstones go to the `objects` table only. An object that
+  is later unwrapped reappears in `written` and gets a fresh marker at its new version.
+- **Genesis and snapshot-restore use a different filter**: `!object.is_child_object()`
+  (`bulk_insert_genesis_objects` at `authority_store.rs:589-618`, snapshot restore's
+  `insert_objects_chunk` at `authority_store.rs:657-703`, called from
+  `sui-snapshot/src/reader.rs:552` with `is_force_reset = true`). This writes markers for
+  **shared, immutable and package objects too**. Those extra markers are never deleted
+  (those objects are never address-owned mutable inputs), so:
+  - a genesis/restored node's marker table is a strict superset of an organically-grown
+    one;
+  - a shared object created at genesis keeps a marker at its genesis version forever while
+    its real version advances — a permanently *stale* marker.
+  This is benign today only because all production readers query refs that transactions
+  claim as address-owned inputs. Do **not** treat the marker table as an exact index of
+  live owned objects.
+- `insert_genesis_object`/`insert_object_direct` (single-object variant, slightly different
+  filter again: `get_single_owner().is_some() && !is_child_object()`) is test-only
+  ("TODO: delete this method entirely").
+
+**Locks** (`owned_object_refs_to_lock`, `consensus_handler.rs:3206-3229`):
+
+- Key set = all `InputObjectKind::ImmOrOwnedMoveObject` refs of the transaction
+  (**including gas coins**) minus the transaction's *claimed immutable* object IDs.
+- The immutable-claims come from `UserTransactionV2` (`PlainTransactionWithClaims`); they
+  are attested by the submitting validator and verified against real objects at vote time
+  by `SuiTxValidator` (`consensus_validator.rs:~350-395`). This exists precisely so the
+  commit handler never has to read the object store to distinguish immutable from owned.
+  An unclaimed-but-actually-immutable input would be locked unnecessarily (harmless).
+- The locked ref may **not** be address-owned by execution time (e.g. the object became
+  `ConsensusAddressOwner` between signing and execution — see the re-audit comment in
+  `execute_certificate`, `authority.rs:1955-1966`). Locks are conflict bookkeeping, not
+  ownership statements; the key sets of the two tables are related but not identical.
+
+### 3. Write paths
+
+**Markers — execution/commit pipeline (all node types):**
+
+1. Execution writes `TransactionOutputs` into the writeback cache **dirty set only**
+   (`WritebackCache::write_transaction_outputs`). Nothing durable yet; the coherent
+   `object_by_id_cache` is updated so readers see the new state.
+2. The checkpoint executor, per checkpoint and in sequence-number order
+   (`checkpoint_executor/mod.rs:415-453`): `build_db_batch(epoch, tx_digests)` →
+   `AuthorityStore::write_one_transaction_outputs` per tx, which in **one `DBBatch`**
+   writes effects, executed_effects, transactions, objects, per-epoch markers, events, and:
+   - `initialize_live_object_markers_impl(batch, new_locks_to_init, is_force_reset=false)`
+     (`authority_store.rs:836`)
+   - `delete_live_object_markers(batch, locks_to_delete)` (`authority_store.rs:840`)
+   Then `commit_transaction_outputs` writes the batch and moves entries dirty→cached.
+3. Idempotency: re-committing the same checkpoint after a crash rewrites identical data.
+   Initializing a marker over an existing `None` marker is fine (the
+   `ObjectLockAlreadyInitialized` error fires only on legacy `Some` values); deletes are
+   idempotent.
+4. `is_force_reset=true` (snapshot restore) skips the legacy-value check entirely.
+
+**Locks — consensus commit pipeline (validators only):**
+
+1. `ConsensusCommitHandler::filter_consensus_txns` (`consensus_handler.rs:2452-2781`):
+   - Prefetches the cross-commit lock state for **all** owned refs of all
+     `UserTransactionV2`s in the commit in one batched read:
+     `get_owned_object_locks_map(&prefetch_refs)` (`consensus_handler.rs:2476-2495`).
+     NOTE: a DB read error here degrades to "treat everything as unlocked"
+     (`.unwrap_or_default()`) — a deliberate leniency inherited from the old
+     per-transaction read; it is a (theoretical) determinism/fork hazard to be aware of.
+   - Per accepted user transaction, **after** all other drop-filters (reconfig state,
+     end-of-publish, deprecated kinds):
+     `try_acquire_owned_object_locks_post_consensus(refs, digest, current_commit_locks, existing_locks)`
+     (`authority_per_epoch_store.rs:1825-1861`). This is a **pure function** over the two
+     maps: conflict iff some ref is held by a *different* digest. Same-digest re-lock
+     succeeds (idempotency for duplicate sequencing and replay). **No liveness check, no
+     object reads.**
+   - Winner: locks accumulate into the commit-local map, status `Finalized`.
+   - Loser: dropped — `ConsensusTxStatus::Dropped`, reject reason recorded
+     (`set_rejection_vote_reason`), key still marked consensus-processed (so waiters
+     resolve and resubmission is suppressed), metric
+     `consensus_handler_dropped_transactions{reason="lock_conflict"}`.
+2. Lock acquisition happens **before deduplication** (`handle_consensus_commit`,
+   `consensus_handler.rs:1165-1185`): a transaction sequenced in two commits re-locks
+   identically in the second commit and is then deduped from scheduling.
+3. Deferral interaction: congestion-control deferral happens *after* filtering, so
+   **deferred transactions hold their locks from first appearance**; when re-loaded from
+   the deferred-transactions table in a later commit they do *not* re-acquire.
+4. The accumulated map goes into `ConsensusCommitOutput::set_owned_object_locks`
+   (`consensus_quarantine.rs:265`) and the whole output is pushed into the quarantine
+   (`consensus_handler.rs:1305` → `push_consensus_output`).
+5. There is **no delete path** during the epoch (only a `#[cfg(test)]` helper,
+   `delete_object_locks_for_test`). The table is append-only within an epoch.
+
+### 4. Read paths (complete inventory)
+
+**Markers:**
+
+| Caller | Path | Notes |
+| --- | --- | --- |
+| `execute_certificate` → `check_owned_locks` (`authority.rs:1666-1669, 1968-1971`) | `ObjectCacheRead::check_owned_objects_are_live` | Runs for **every** certificate execution on every node type, right before the VM. Failure → `ExecutionOutput::Fatal` → `fatal!` (process abort, `execution_driver.rs:134-136`). |
+| `WritebackCache::check_owned_objects_are_live` (`writeback_cache.rs:1951-1980`) | cache-first, DB fallback | Hits `object_by_id_cache` per ref; only cache **misses** reach `AuthorityStore::check_owned_objects_are_live` (`authority_store.rs:927-945`) which `multi_get`s the marker table. |
+| `AuthorityStore::get_latest_live_version_for_object_id` (`authority_store.rs:893-921`) | reverse scan over markers bounded by `(id, MAX, MAX)` | Error-path enrichment only: distinguishes `ObjectVersionUnavailableForConsumption { current_version }` (marker exists at another version) from `ObjectNotFound` (no marker at all). Depends on ≤1 marker per object id — true organically, violated only by genesis/restore junk entries (§2). |
+| `ObjectCacheRead::get_lock` (`writeback_cache.rs:1902-1939`, `authority_store.rs:861-890`) | markers + epoch lock table | **Unit-test-only.** `handle_object_info_request` now returns `lock_for_debugging: None` unconditionally (`authority.rs:3417-3419`). `ObjectLockStatus`, `LockDetailsDeprecated`, and `ObjectLocks::get_transaction_lock` exist only for this path. |
+
+Note on the DB fallback (correction, verified 2026-07-10): `get_object_by_id_cache_only` →
+`get_object_entry_by_id_cache_only` consults the moka-backed `object_by_id_cache` **and,
+on miss, the `dirty.objects` set and the committed object cache**
+(`with_locked_cache_entries`, `writeback_cache.rs:777-786`). So a `CacheResult::Miss` here
+means the object has no in-memory state at all and the durable DB is authoritative — there
+is no dirty-eviction hole. A replacement that answers liveness from "objects" gets this
+for free by using `get_object_impl` (object-by-id cache → dirty → cached → DB), which is
+the standard latest-object read path.
+
+**Locks:**
+
+| Caller | Path | Notes |
+| --- | --- | --- |
+| Consensus handler prefetch (`consensus_handler.rs:2476-2495`) | `get_owned_object_locks_map` → `get_owned_object_locks` (`authority_per_epoch_store.rs:1786-1812`) → quarantine `do_fallback_lookup` (`consensus_quarantine.rs:799-819`) | Quarantine in-memory map first, epoch DB fallback. "After crash recovery, quarantine is empty so we naturally fall back to DB." |
+| Submit path (`authority_server.rs:963-1020`) | same quarantine-aware read + `try_acquire_owned_object_locks_post_consensus` with empty `current_commit_locks` | Runs only for digests already consensus-processed but without effects. Purpose: convert the generic retriable "TransactionProcessing" suppression into a terminal `ObjectLockConflict { pending_transaction }` so clients stop retrying a dropped conflict-loser **before the winner executes** (while the loser's inputs still validate as live). After the winner executes, the subsequent `handle_vote_transaction` revalidation produces the terminal stale-version error instead. |
+| `ObjectLocks::get_transaction_lock` (`execution_cache/object_locks.rs:23-29`) | raw `tables.get_locked_transaction` — **bypasses the quarantine** | Only reachable from test-only `get_lock`. Inconsistency worth knowing about, not fixing. |
+| Test helpers | `insert_object_locks_for_test` / `delete_object_locks_for_test`, direct map asserts in `consensus_handler.rs` tests | |
+
+**What does *not* read locks or markers:** transaction signing/voting. Since
+post-consensus locking, `handle_vote_transaction` (`authority.rs:1152-1210`; called from
+`SuiTxValidator::vote_transaction` and the submit path) validates owned inputs with
+`validate_owned_object_versions` (`execution_cache/object_locks.rs:89-105`), which reads
+**live objects** via the object cache and compares version+digest. The objects table is
+already the source of truth at vote time. Fullnode-side pre-validation
+(`check_transaction_validity`) likewise uses live objects only.
+
+**Why `validate_owned_object_versions` exists (the liveness/conflict split).** Post-consensus
+lock acquisition checks *only conflicts, never liveness* — it would happily lock a version
+that never existed, a wrong digest, or a version consumed in a previous epoch. Liveness
+must therefore be verified somewhere, and it **cannot** be verified post-consensus:
+liveness is time-dependent (an input can be consumed between vote and commit, and
+crash-replay re-processes commits whose winners' inputs are already durably consumed), so
+a liveness check in the commit handler would give different answers on replay → different
+Finalized/Dropped sets → checkpoint fork. Votes are allowed to be time-dependent because
+quorum certification is what makes the aggregate deterministic. Hence the split:
+**liveness pre-consensus** (per-validator vote, objects-based, non-deterministic OK),
+**conflicts post-consensus** (deterministic, append-only lock table). The two compose with
+no gap because "live at vote time" can only become stale via consumption *within the same
+epoch* (invariant 3: consumed-within-epoch ⇒ locked), which the conflict check covers.
+It also keeps object reads out of the CPU-bound commit handler (same reason
+immutable-object claims exist) and rejects invalid-version spam before it consumes
+consensus bandwidth. This makes the execution-time `check_owned_objects_are_live` purely
+a third-layer defense-in-depth assert, not a primary guard.
+
+### 5. Durability model and the quarantine (the epoch-DB side of divergence)
+
+`ConsensusOutputQuarantine` (`consensus_quarantine.rs:484-747`) holds each commit's
+`ConsensusCommitOutput` in memory:
+
+- On push, locks are mirrored into a flat `owned_object_locks: HashMap<ObjectRef,
+  LockDetails>` used by reads (`insert_owned_object_locks`). On flush they are removed
+  from the map (safe even with duplicate same-digest entries across commits, because the
+  DB then serves the same value).
+- **Flush rule** (`commit_with_batch`, `consensus_quarantine.rs:589-670`): when
+  `handle_finalized_checkpoint` advances `highest_executed_checkpoint`, pop builder
+  summaries with `seq ≤ highest_executed`, derive the highest committed checkpoint
+  *height*, then flush the queue **prefix** up to the last output within that height whose
+  `checkpoint_queue_drained` flag is true (a "drain point": after that commit's checkpoint
+  flush there were no pending roots, so nothing built later can reference it). Outputs past
+  the last drain point stay quarantined and are fully replayed on restart.
+- Each flushed `ConsensusCommitOutput::write_to_batch` (`consensus_quarantine.rs:270-406`)
+  writes, in **one `DBBatch`**: `consensus_message_processed`, `end_of_publish`,
+  reconfig state, **`last_consensus_stats_v2`** (the replay watermark),
+  `next_shared_object_versions_v2`, **`owned_object_locked_transactions`**, deferred-tx
+  add/removes, randomness/DKG/JWK state, congestion debts. The same batch (built in
+  `handle_finalized_checkpoint`, `authority_per_epoch_store.rs:1959-1991`) also deletes
+  `signed_effects_digests` for the finalized digests.
+- Therefore: **a commit's locks are durable ⇔ the commit is marked processed ⇔ the commit
+  will not be replayed.** There is no partial per-commit lock durability.
+- There is also an opportunistic flush inside `push_consensus_output` for the case where
+  state sync / checkpoint execution ran ahead of local consensus.
+
+**Ordering vs the perpetual DB.** In the checkpoint executor pipeline
+(`checkpoint_executor/mod.rs:415-457`) the order per checkpoint is strictly:
+`build_db_batch` → `commit_transaction_outputs` (perpetual DB durable: objects, effects,
+**markers**) → `handle_finalized_checkpoint` (epoch DB durable: **locks**, watermark). The
+flush gate additionally requires the commit's checkpoints to be *executed*, and the drain
+rule requires all the commit's roots to be inside built checkpoints at or below that
+height. Net invariant:
+
+> **For every flushed commit, all of its finalized transactions' outputs are already
+> durable in the perpetual DB.** The epoch DB's lock state never runs ahead of the
+> perpetual DB; it only lags.
+
+### 6. Restart recovery, step by step (validator)
+
+1. `AuthorityPerEpochStore::new` reopens the epoch DB and builds an **empty** quarantine
+   seeded with `highest_executed_checkpoint` from the checkpoint store
+   (`authority_per_epoch_store.rs:1010-1019`). No lock state is loaded into memory —
+   reads just fall through to the DB.
+2. `ConsensusCommitHandler::new` recovers `last_consensus_stats` from the epoch DB
+   (`consensus_handler.rs:859-867`) — the value last written by a quarantine flush.
+3. `consensus_manager/mod.rs:302-309`: consensus is asked to replay from
+   `last_processed_commit_index - consensus_num_requested_prior_commits_at_startup`.
+   Commits `≤ last_processed_at_startup` go to `handle_prior_consensus_commit`
+   (state-observation only, no lock effects); commits above it are re-processed by the
+   full `handle_consensus_commit` path (`consensus_handler.rs:3156-3170`).
+4. Replayed commits re-run `filter_consensus_txns`: the prefetch sees exactly the flushed
+   lock state (quarantine empty → DB), and `try_acquire_owned_object_locks_post_consensus`
+   re-derives identical Finalized/Dropped decisions because it is deterministic and
+   liveness-free. Locks re-enter the quarantine and will re-flush.
+5. Already-executed replayed transactions are not re-executed: scheduling/execution dedups
+   on `executed_effects` (`is_tx_already_executed`), and effects-equivocation is prevented
+   independently by `signed_effects_digests` (entries for un-finalized txns survive
+   restart). Pending checkpoints are rebuilt by the same replay ("full-replay ... with
+   correct root reconstruction", `consensus_quarantine.rs:636-640`).
+6. Perpetual side: if the crash hit between `commit_transaction_outputs` and the
+   checkpoint-store watermark bump, the checkpoint executor simply re-commits the same
+   checkpoint — marker init/delete are idempotent (§3).
+
+Fullnodes: nothing to recover — they never populate the lock table, and markers are
+maintained purely by (re-)executing checkpoints.
+
+### 7. Epoch boundary
+
+At reconfiguration, with all execution paused under the execution write-lock:
+
+- `clear_state_end_of_epoch_impl` (`writeback_cache.rs:1315-1357`) **discards** all dirty
+  (executed-but-not-checkpointed) transaction outputs and invalidates their cache entries.
+  Those transactions' marker/object writes never become durable — this replaced the old
+  `revert_state_update` machinery; there is no on-disk revert anywhere.
+  (`object_locks.clear()` is an explicit no-op; the "per-epoch marker tables" cleared next
+  are `object_per_epoch_marker_table{,_v2}` — *different tables*, do not confuse them with
+  the live markers.)
+- The new `AuthorityPerEpochStore` opens a fresh `epoch_<N+1>` directory: the lock table
+  starts empty. Equivocation protection deliberately resets: an object locked but never
+  consumed in epoch N can be locked by a *different* transaction in epoch N+1.
+- Old epoch directories (and all their locks) are removed later by
+  `AuthorityPerEpochStorePruner`.
+- The perpetual markers carry across epochs untouched. (The table comment "for old epochs
+  it may also contain the transaction they are locked on" refers to pre-split legacy
+  values, which nothing reads.)
+
+### 8. Divergence matrix
+
+| # | Scenario | State | How it is handled |
+| --- | --- | --- | --- |
+| D1 | Crash after `commit_transaction_outputs`, before quarantine flush | Perpetual has outputs (markers updated, inputs gone); epoch DB has no locks, watermark not advanced | Consensus replays the commit; lock acquisition is liveness-free and deterministic → same decisions; execution layer dedups already-executed txns. **This is the load-bearing divergence.** |
+| D2 | Epoch DB ahead of perpetual for a commit | — | Cannot happen: flush is gated on the commit's checkpoints being built *and executed*, and outputs are committed earlier in the same pipeline (§5). |
+| D3 | Crash between perpetual commit and checkpoint-store `highest_executed` bump | Outputs durable, watermark stale | Checkpoint re-executed/re-committed on restart; all writes idempotent. `highest_committed_checkpoint` (singleton in the same perpetual batch) exists for consumers that can't tolerate even this lag. |
+| D4 | Locks exist for transactions that never execute (deferred at epoch end, conflict losers' *winners* deferred, cancelled) | Epoch DB has locks; perpetual never sees the tx | Benign within the epoch (that's the point: keep losers out); resolved by epoch-DB deletion at reconfig. Deferred txns themselves are durable in `deferred_transactions_with_aliases_v3` (flushed in the same batches) and re-loaded on restart via `ConsensusOutputCache::new`. |
+| D5 | Executed-but-unfinalized txns at epoch end | Markers/objects updated only in the dirty cache | Dirty cache dropped at reconfig (§7); durable state = exactly the checkpointed prefix. |
+| D6 | Marker table contains genesis/snapshot junk (shared/immutable/package refs, possibly stale versions) | Markers ⊃ live address-owned refs | Benign: production readers only query refs claimed as address-owned inputs (§2, §4). |
+| D7 | Dirty-window liveness reads | Durable markers lag executed state | Bridged by the in-memory read path: object_by_id cache plus, on miss, the `dirty.objects` set (§4 correction). The DB fallback is only reached for objects with no in-memory state, for which durable state is authoritative. |
+| D8 | Cross-epoch: locked-in-N, consumed-in-N+1 by another tx | Marker live throughout; N's lock gone | By design — per-epoch equivocation scope. Vote-time validation in N+1 checks liveness against objects, and N+1's lock table starts clean. |
+
+### 9. Invariants the current design relies on (the replacement must preserve or consciously re-derive)
+
+1. **Determinism across validators and across replay** — the Finalized/Dropped decision
+   per transaction feeds checkpoint contents. Any nondeterminism here is a fork. This is
+   node-local state (not protocol-visible), so a redesign needs no protocol gate *iff* its
+   decisions are bit-identical in all reachable states — including edge behaviors like the
+   lenient `unwrap_or_default()` on prefetch read errors.
+2. **Liveness-freedom of post-consensus acquisition** — replay (D1) executes lock
+   acquisition for transactions whose inputs are already consumed durably. Any replacement
+   check of the form "input must be live in the objects table" breaks replay for
+   already-executed winners unless it treats "consumed" as "locked" correctly.
+3. **Consumed-within-epoch ⇒ locked** — within an epoch, every consumption of an owned ref
+   was performed by a finalized tx that holds the lock; so conflict-checking against locks
+   subsumes liveness-checking. Safety against *stale-version* claims (versions consumed in
+   earlier epochs, or never-existing versions) comes from vote-time validation: acceptance
+   requires a quorum of accept votes, hence honest validators validated version+digest
+   against live objects at vote time.
+4. **Locks are never released within an epoch** — a conflict loser must stay dropped even
+   after the winner executes and the objects table has moved past the contested version.
+   With locks removed, "input version < live version" (objects table) reproduces the
+   conflict verdict for *executed* winners; **deferred** winners are the case where the
+   lock is the only record (their inputs are still live) — recoverable from the deferred
+   table.
+5. **Same-digest idempotency** — duplicate sequencing across commits and crash-replay both
+   re-acquire; `lock_holder == self` must succeed.
+6. **Flushed ⇒ durable** — every flushed commit's finalized txns are durably executed
+   (§5). This is what would let a replacement rebuild "consumed by whom is irrelevant, just
+   consumed" for the non-replayed history from the objects table + deferred table alone.
+7. **Atomicity pairings** — markers with objects (one perpetual batch per checkpoint);
+   locks with the replay watermark (one epoch batch per commit). The second pairing is what
+   makes recovery all-or-nothing per commit.
+8. **Exact-ref liveness assert before execution** — `check_owned_objects_are_live` is
+   fatal-on-failure. A replacement either reimplements it against the objects table
+   (latest-version lookup must consult dirty state, §4) or removes it deliberately.
+
+### 10. Practical considerations for the replacement project
+
+- **Startup rebuild recipe** for an in-memory lock map: (a) un-flushed commits — rebuilt
+  for free by consensus replay (this is exactly how the quarantine map is rebuilt today);
+  (b) flushed commits — every finalized tx is either durably executed (its consumed inputs
+  are absent/superseded in the objects table → conflicts derivable without knowing the
+  digest) or sitting in the deferred-transactions table (its owned refs re-derivable from
+  the stored transactions). Cancelled transactions execute (consuming gas), so they fall
+  under (a)/(b) like everything else.
+- **What you lose without the digest**: `ObjectLockConflict { pending_transaction }` names
+  the winner in client-facing errors and reject reasons; the submit-path pre-check
+  (`authority_server.rs:963-1020`) uses it to emit a terminal error for conflict losers
+  *before* the winner executes. Post-execution, the existing `handle_vote_transaction`
+  revalidation already produces an equivalent terminal error from live-object state, so
+  the gap is only the window between "winner finalized" and "winner executed" (and error
+  message quality).
+- **Consensus-handler hot path**: today's cost is one batched `multi_get` on the lock
+  table per commit plus pure in-memory checks. The handler is single-threaded and
+  CPU-bound at high TPS (see `docs/consensus-handler-optimization.md`); an objects-table
+  latest-version prefetch for all owned refs of a commit would be strictly more expensive
+  than the lock-table point-gets unless served from the in-memory structures. Keeping the
+  whole current-epoch lock set in memory is the cheap option but is unbounded
+  (≈ owned-input refs × finalized TPS × epoch seconds: at 15k TPS with ~2 owned refs/tx
+  and 24h epochs that is ~2.6B entries × ~100B ≈ hundreds of GB — too big), which is
+  presumably why the plan is objects-table-as-source-of-truth for the executed portion
+  plus a bounded in-memory map for the un-executed portion (quarantine-resident commits +
+  deferred txns) — mirroring invariant 6.
+- **`get_latest_live_version_for_object_id` replacement**: `objects`-table reverse scan per
+  id already exists (`get_latest_object_ref_or_tombstone`); on TideHunter the objects
+  keyspace uses fixed 40-byte index keys, so per-id ordered scans work.
+- **Deleting the tables**: both are plain struct fields + ThConfig entries; TideHunter
+  supports outright table deletion (no `cfg` retention dance needed). For RocksDB,
+  removing a `DBMapUtils` field means the CF is no longer opened — verify whether
+  typed-store drops unknown on-disk CFs automatically or whether a manual drop/migration
+  is needed for existing deployments. The `#[rename]`/deprecated-type machinery
+  (`LockDetailsWrapperDeprecated`, `LockDetailsDeprecated`, `ObjectLockStatus`,
+  `ObjectLocks::get_transaction_lock`, `ObjectCacheRead::get_lock`) all goes with them.
+- **Snapshot restore / genesis** must stop writing markers (`insert_objects_chunk`,
+  `bulk_insert_genesis_objects`); nothing else consumes what they write, so this is
+  removal-only.
+- **Test surface**: `#[cfg(test)]` helpers `insert/delete_object_locks_for_test`
+  (`authority_per_epoch_store.rs:1640-1660`); unit tests calling `get_lock`
+  (`authority_tests.rs`, `transaction_tests.rs`); consensus-handler tests asserting
+  `get_owned_object_locks_map` contents and the `lock_conflict` drop metric; equivocation
+  e2e/simtests.
+- **Observability**: `consensus_handler_dropped_transactions{reason="lock_conflict"}`,
+  `consensus_quarantine_queue_size`, cache metrics labeled `"lock"`/`"object_is_live"`
+  (`record_db_get`/`record_db_multi_get` in the writeback cache).
+
+### 11. One-paragraph history (why the code looks like this)
+
+Originally validators acquired owned-object locks at signing time
+(`acquire_transaction_locks`) and the perpetual table stored the locking tx (hence the
+on-disk name `owned_object_transaction_locks` and the `Option<LockDetails…>` value). The
+lock *contents* were then split into the per-epoch DB (epoch-scoped equivocation,
+`EpochFlag::_ObjectLockSplitTablesDeprecated`), leaving the perpetual table as a bare
+existence marker (renamed in code to `live_owned_object_markers`). With Mysticeti fastpath
+removal (all user transactions through consensus), pre-consensus locking was disabled
+entirely (#24676, Dec 2025) and replaced by post-consensus lock acquisition in the commit
+handler; the leftover flag plumbing was removed in #25150 (Feb 2026). What remains is the
+machinery described above: markers as an execution-time safety assert plus error
+enrichment, and the epoch lock table as the post-consensus conflict arbiter.
+
+---
+
+## Part 3 — Replacement design: `owned_object_locked_transactions` → in-memory maps + objects-table verdict + `LiveObjectCache` (2026-07-15)
+
+Assessment of the proposal: *"a `LiveObjectCache` primitive warmed by `SuiTxValidator`
+when a transaction is first seen; the consensus handler consults the cache (falling back
+to the objects table), caching both positive and negative results, with a metric for
+remaining lookups; and address restartability given that handler state is per-epoch while
+objects are perpetual."*
+
+**Verdict: feasible, with no new durable state.** The durable lock table can be deleted
+outright. But the proposal needs three amendments to be fork-safe, each derived below:
+
+1. The objects-table verdict must be the **monotone version rule** `conflict ⟺
+   latest_version(id) > claimed_version`, *not* a liveness check ("is this exact ref
+   live") — liveness has a false-drop fork for pipelined transactions (§3.2).
+2. Two gap fillers where the objects table cannot answer: a **deferred-locks map**
+   (finalized-but-never-executed transactions are invisible to the objects table, §3.4)
+   and a **same-digest carve-out via `executed_effects`** (duplicate sequencing across a
+   restart, §3.3 case D).
+3. A reachability cleanup: **strict immutable-claims voting** (today's exact-match
+   check is skipped when the claims list is empty — `consensus_validator.rs:312`), plus a
+   narrow **immutable backstop** table read that makes the swap unconditionally
+   equivalent to the old logic, so no protocol flag is needed (§3.6a).
+
+Verified production usage as of today (branch `andll/deprecate-live-owned-object-marker-reads`):
+
+| Site | What it does |
+| --- | --- |
+| `authority_per_epoch_store.rs:436` | table definition; ThConfig at `:600`; point get/multi-get at `:807`/`:814`; test helpers at `:1659-1670` |
+| `consensus_handler.rs:2366-2385` | per-commit batched prefetch of cross-commit lock state (`get_owned_object_locks_map(...).unwrap_or_default()`) |
+| `consensus_handler.rs:2604-2629` | per-tx `try_acquire_owned_object_locks_post_consensus` (pure function over the two maps, `authority_per_epoch_store.rs:1839`) |
+| `consensus_quarantine.rs:311` | the only write — quarantine flush batch, atomic with `last_consensus_stats_v2` |
+| `consensus_quarantine.rs:799-819` | quarantined-map-first read with DB fallback (`insert`/`remove_owned_object_locks` at `:736-746` — the map holds exactly the un-flushed window) |
+| `authority_server.rs:1002-1003` | submit-path pre-check to give clients a terminal `ObjectLockConflict` before the winner executes |
+
+### 3.1 The decision procedure
+
+Per commit (same batched shape as today's prefetch): collect all `owned_object_refs_to_lock`
+refs; then per transaction, per ref, in order:
+
+1. **`current_commit_locks`** (unchanged) — refs locked earlier in this commit. Different
+   digest ⇒ conflict; same ⇒ ok.
+2. **Quarantine map** (`owned_object_locks`, unchanged, keyed by full `ObjectRef`) — locks
+   of finalized txs in un-flushed commits. Different digest ⇒ conflict.
+3. **Deferred-locks map** (new, §3.4) — owned refs of currently-deferred transactions.
+   Different digest ⇒ conflict.
+4. **Objects-table verdict** (new; through `LiveObjectCache`, §3.5, falling back to the
+   real latest-object read): `latest_version(id) > claimed_v` ⇒ *tentative conflict*;
+   otherwise (absent, `<`, or `==`) ⇒ no conflict.
+5. **Same-digest carve-out** (only on tentative conflict from step 4): if
+   `executed_effects` contains the claimant's own digest, the claimant already executed —
+   treat as a successful same-digest re-acquire (§3.3 case D). Otherwise: conflict, drop.
+
+Winners insert their refs into `current_commit_locks` and, at commit end, into the
+quarantine output exactly as today. The flush batch simply stops writing the lock table;
+`last_consensus_stats_v2` and everything else in the batch is unchanged, so the flush
+gate (commit's checkpoints built *and executed*) keeps guaranteeing the invariant the
+fallback relies on: **flushed ⇒ every finalized tx of the commit is durably executed**.
+
+### 3.2 Why the monotone version rule, not liveness
+
+A liveness check ("claimed ref is the live version") forks on pipelined submissions.
+Client submits tx1, then tx2 consuming tx1's output `(id, v)`. tx2 can be finalized once
+2f+1 validators have executed tx1 and vote accept. When the handler on a *lagging*
+validator (tx1 finalized but not yet locally executed) processes tx2, `(id, v)` does not
+exist in its objects table; a liveness rule would drop tx2 there and finalize it on
+up-to-date validators — checkpoint fork. Under the version rule the lagging validator
+sees `latest(id) < v` (or absent) ⇒ no conflict — same verdict as the up-to-date
+validator's `latest == v`. Note the old design agrees: lock acquisition never looked at
+objects at all, so tx2 simply acquired.
+
+The version rule is safe to evaluate against a *moving* objects table because of a
+freshness sandwich proven in §3.3: whenever the two sides of the comparison could differ
+across validators, the ref is guaranteed to be covered by an earlier (memory) layer.
+
+### 3.3 Determinism argument
+
+Definitions: at a given consensus position, let S = the map {owned ref → digest} of all
+finalized txs so far this epoch (the abstract state the old table materialized). The
+procedure must compute "ref ∈ S with different digest" identically on every validator, in
+every reachable state, including crash-replay and restarts.
+
+Load-bearing invariants (all verified in code today):
+
+- **(I1) Execution always bumps every locked ref.** `ensure_active_inputs_mutated`
+  (`temporary_store.rs:424`) runs on *every* execution path — success, Move abort,
+  out-of-gas (all three reset paths in `gas_charger.rs:395,510,517`), congestion/randomness
+  cancellation, and the IFFW short-circuit (`execution_engine.rs:422`). Deleted/wrapped
+  inputs get tombstones at the lamport version. So for an executed tx, every ref in its
+  lock set satisfies `latest(id) > v` — *provided the lock set contains no immutable
+  objects*, which is what strict claims voting guarantees (§3.6): immutable inputs are
+  excluded from `exclusive_mutable_inputs` (`transaction.rs:5056`) and never bump.
+- **(I2) Flushed ⇒ durably executed** (unchanged flush gate, §5 of Part 2).
+- **(I3) Quorum-unreachability of stale claims.** A finalized `UserTransactionV2` needs
+  2f+1 accept votes; ≥ f+1 honest voters ran `validate_owned_object_versions`
+  (`object_locks.rs:92`) against live objects *in this epoch* (epoch N starts only after
+  epoch N-1 is fully executed everywhere). So no finalized tx claims a ref consumed in a
+  prior epoch, a never-existing version, or a wrong digest.
+- **(I4) Post-restart coverage.** Consensus replays every commit after
+  `last_consensus_stats_v2`; the quarantine map is rebuilt by that replay (this is already
+  how it works). So the union quarantine-map ∪ deferred-map ∪ {flushed executed txs}
+  covers all of S.
+
+Case analysis for a ref `(id, v)` reaching step 4 (missed all memory layers), where some
+finalized tx W ≠ claimant consumed `(id, v)` this epoch (i.e. the true verdict is
+conflict): W is not in the memory layers ⇒ by I4, W's commit was flushed pre-restart ⇒ by
+I2 W executed before the restart ⇒ by I1 `latest(id) > v` durably, on this validator, at
+all times after restart ⇒ step 4 says conflict. ✓ Conversely if no such W exists: any
+`latest(id) > v` observation would imply a this-epoch consumer (prior-epoch consumers are
+quorum-unreachable by I3 — the claimant got finalized) — contradiction; so every validator
+observes `latest(id) ≤ v` or absent at step 4 ⇒ no conflict. ✓ The objects table *does*
+move underneath the handler (execution is async), but only via this-epoch finalized
+consumers, and those are always in a memory layer on the validators where they haven't
+yet reached the objects table — the comparison can never straddle the transition.
+
+**Case D — duplicate sequencing across restart** (the one place the pure version rule
+diverges from the old table): tx X finalized in commit A, commit A flushed, X executed,
+crash, restart; X appears again in commit B (post-watermark, replayed). Old design:
+same-digest re-lock succeeds ⇒ Finalized (then deduped from scheduling). New step 4:
+`latest > v` ⇒ tentative conflict — wrong, and non-restarted validators (memory hit,
+same digest) would say Finalized ⇒ fork. The carve-out repairs it: X's own
+`executed_effects` are durable (I2 applied to commit A), so restarted validators also
+conclude Finalized. The carve-out cannot mask a real conflict: if a *different* winner W
+holds a ref and claimant X also has executed effects, X must itself have acquired that
+ref earlier — impossible while W holds it. And it does not resurrect previously-*dropped*
+duplicates: dropped txs never execute, so they have no effects and still fall through to
+conflict (matching the old table, which still holds W's digest).
+
+### 3.4 Deferred-locks map
+
+Deferred transactions are the one class of finalized txs that hold locks but may not
+execute for a long time (congestion deferral) — invisible to the objects table, and their
+quarantine entries flush away. Today the durable table covers them; the replacement needs
+an explicit in-memory map: owned refs → digest for every currently-deferred transaction.
+
+- **Maintenance:** insert when a commit defers a tx; remove when the tx is re-loaded into
+  a commit (at which point it either re-locks into that commit's output as a finalized tx,
+  is re-deferred, or is cancelled — and cancelled txs execute, so I1 covers them after).
+- **Startup:** seed from `deferred_transactions_with_aliases_v3`, which is already loaded
+  wholesale at startup (`ConsensusOutputCache::new`, `consensus_quarantine.rs:431-438`);
+  owned refs are derivable from the stored transactions via `owned_object_refs_to_lock`.
+- **Bound:** proportional to the deferred backlog (small; already bounded by congestion
+  control), not to epoch length.
+- Epoch-end: deferred txs that never re-load are cancelled or dropped at reconfig along
+  with all per-epoch state — nothing to clean up, same as today.
+
+### 3.5 `LiveObjectCache` — semantics that make it correct with zero invalidation
+
+The objects-table read in step 4 is the only remaining DB touch, and it sits on the
+CPU-bound single-threaded handler (`docs/consensus-handler-optimization.md`). The cache's
+job is to make it a hash lookup. The crucial design choice: the cache is a **monotone
+lower bound on latest versions**, not a snapshot of liveness:
+
+- Entry: `ObjectID → LowerBound` where `LowerBound ∈ {KnownAbsent, Version(v)}`;
+  `KnownAbsent < Version(_)`, merges are max-merge (never decrease). No digests, no
+  ownership, no per-ref keys.
+- **Warm sources:** (a) the vote path — `validate_owned_object_versions` and
+  `verify_immutable_object_claims` already hold the loaded objects (`object_locks.rs:97`,
+  `consensus_validator.rs:357`); warm on *accept and reject alike* — a rejection for
+  `ObjectNotFound` warms `KnownAbsent` (this is the "negative result" that saves the
+  pipelined-tx lookup), a version-mismatch rejection warms the actual latest. (b) step-4
+  fallback reads. (c) optionally, execution output commits (free monotone bumps).
+- **Verdict from a hit (corrected 2026-07-15 during implementation):**
+  - `cached > v` ⇒ conflict is *safe to conclude*: cached is a lower bound, so
+    `true_latest > v`.
+  - `cached ≤ v` ⇒ **not decisive** — an earlier draft argued this implies no conflict
+    because any post-warm consumer would be in the quarantine map; that is wrong: the
+    quarantine holds only *un-flushed* commits, so a consumer that finalized, executed,
+    and had its commit flushed after the warm leaves no in-memory trace while the stale
+    bound still reads `== v`. All potential-clears therefore take the authoritative
+    latest-object read (object-by-id cache → dirty → DB — usually a memory hit), which
+    is immune (flushed ⇒ executed ⇒ bumped). A clear-side shortcut becomes sound by
+    bumping the cached bound of every flushed lock ref to `version+1` at the moment the
+    quarantine drops it (cache bump happens-before quarantine removal ⇒ any resolution
+    missing the quarantine sees the bump) — deliberately left out of PR 1 to keep its
+    correctness argument minimal; candidate follow-up alongside PR 2.
+  - Cache **miss** ⇒ authoritative read, same as above. `source=objects_db` in the
+    resolution metric counts these authoritative reads.
+- Consequences: no invalidation protocol, LRU/TTL eviction is always safe (eviction just
+  converts hits into metered fallbacks), restart-cold is safe, and the cache can live at
+  the `AuthorityState`/cache layer with **no epoch scoping** — version lower bounds are
+  valid forever (perpetual semantics), which neatly sidesteps the per-epoch vs perpetual
+  split for the cache itself. Clearing it at epoch boundaries is optional hygiene.
+- Sizing: it needs to retain the vote→commit window. At 15k TPS × ~3 owned refs × ~60 s
+  of in-flight window ≈ 2.7M entries ≈ low hundreds of MB with headroom; cap and let the
+  metric confirm.
+- Warm-coverage note: every validator votes on every block it verifies
+  (`verify_and_vote_batch`), so vote-time warming covers essentially all refs the handler
+  will query — the residual DB lookups are restarts (cold cache + replay), commits
+  containing blocks the validator never voted on (catch-up paths), and evictions.
+
+A leaner v0 alternative: skip the dedicated primitive and let step 4 call the existing
+`multi_get_objects` path (`object_by_id_cache` → dirty → DB) with the metric attached.
+That already serves hot objects from memory; what it lacks is negative caching (pipelined
+inputs miss to a DB reverse-seek every time) and eviction isolation from general read
+traffic. Ship the metric first; add the dedicated cache if the residual is material.
+
+### 3.6 Behavior deltas, reachability cleanup, and rollout
+
+The Finalized/Dropped decision feeds checkpoints, so old and new procedures must agree in
+every *reachable* state, including mixed fleets. Deltas found:
+
+1. **Unclaimed-immutable inputs — reachable today, must be closed first.**
+   `verify_immutable_object_claims` is exact-match both directions
+   (`ImmutableObjectNotClaimed`, `consensus_validator.rs:411-419`) but is only invoked
+   when the claims list is non-empty (`:312`). A tx with immutable inputs and an *empty*
+   claims list passes voting (immutable objects always match version/digest), gets its
+   immutable refs locked, and — since immutable refs never bump (I1 fails for them) — the
+   new fallback would say "no conflict" where the old table says "conflict", *and* the new
+   design disagrees with itself across a restart. Two-part fix: (a) drop the `is_empty()`
+   short-circuit so honest validators vote-reject unclaimed-immutable inputs, making such
+   finalized txs quorum-unreachable — cheap (the objects are already loaded in the vote
+   path), and byzantine-only exposure (claims are attached by the *submitting validator*;
+   an honest submitter cannot under-claim, since owner changes bump versions and would
+   fail vote-time version checks instead); (b) until (a) is universal, the **immutable
+   backstop** (§3.6a) covers the case exactly.
+2. **Garbage refs** (never-existing versions, wrong digests, prior-epoch-consumed):
+   verdicts differ from the old table in principle but are quorum-unreachable (I3) —
+   mixed fleets agree on all reachable inputs.
+3. **Prefetch read-error leniency.** Today a lock-table read error degrades to
+   "everything unlocked" (`consensus_handler.rs:2380-2384`) — already a theoretical fork
+   hazard. The replacement must **fail-stop** on step-4 read errors instead
+   (`expect`/`fatal!`): a validator that cannot answer deterministically must not answer.
+4. **Conflict-error digest quality.** `ObjectLockConflict { pending_transaction }` names
+   the winner. Memory layers still have digests; the step-4 path recovers the winner
+   from the latest object's `previous_transaction` (multi-hop consumption names a
+   downstream consumer; deletion tombstones store no digest → `ZERO`). Affects error
+   text and the submit-path pre-check (`authority_server.rs`) — that path is best-effort
+   client UX, not determinism-critical, and reuses the same layered read. One observable
+   submit-path change (implemented, test updated): a consumed input now reports
+   `ObjectLockConflict` naming the consumer even when the winner has already executed,
+   where the old path fell through to revalidation's
+   `ObjectVersionUnavailableForConsumption`. Both are terminal; the new error is more
+   informative.
+
+### 3.6a Cutover without a protocol flag (revised 2026-07-15)
+
+An earlier draft gated the read-swap on a protocol feature flag. It is unnecessary: the
+new procedure can be made **unconditionally bit-identical to the old one** with a single
+narrow backstop, because a case analysis of the fallback shows only one state where a
+flushed lock can hide from the memory layers + objects verdict. When the fallback reads
+the latest object for claimed `(id, v)`:
+
+- `latest > v` → conflict either way (I1).
+- `latest == v`, owner **owned** → a flushed lock on `(id, v)` is impossible: flushed ⇒
+  executed (I2) ⇒ would have bumped (I1). Deferred lockers (flushed-but-not-executed) are
+  caught by the deferred map before the fallback.
+- `latest < v` **or id absent** → a flushed lock is impossible by **prefix-flush
+  ordering**: the locker's accept votes required `(id, v)` to exist at honest voters, so
+  the producing tx was finalized in an earlier commit; the quarantine flushes commits
+  strictly in order, so the locker cannot be flushed while the producer is not — and a
+  flushed producer means the object exists locally at `≥ v`. (This is also why pipelined
+  inputs never need a table read.)
+- `latest == v`, owner **immutable** → the one undecidable case (an unclaimed-immutable
+  lock, delta 1). **Backstop: point-read the lock table** (writes continue in PR 1, so it
+  is complete) and conflict iff hit. Never fires for honest traffic — claimed immutables
+  are excluded from lock sets before any lookup — so the hot path is untouched.
+
+With the backstop, old and new verdicts agree in *all* states, not just quorum-reachable
+ones, so PR 1 is a plain binary rollout: no protocol version, no epoch alignment, no
+sequencing discipline. Two seams to implement carefully (the debug double-read
+differentially tests both): deferred-map seeding must reproduce the exact lock set
+(owned refs always; actually-immutable refs excluded — a byzantine under-claim that
+slips through in the mixed era is covered by the backstop, and becomes impossible once
+strict voting is universal); and a re-loaded deferred tx must re-acquire into the current
+commit's locks when it leaves the deferred map, or there is a coverage gap between reload
+and execution (`latest == v`, owned, no memory layer).
+
+**PR 2 (deletion)** removes the backstop + table + writes + `LockDetailsWrapper` +
+quarantine lock plumbing + debug compare. Its safety condition is the deploy discipline
+already planned for the markers step 2: PR 1 everywhere (strict voting universal ⇒
+unclaimed-immutable txs can no longer finalize) **plus one epoch boundary** (locks taken
+on unclaimed-immutable refs during the mixed era die with their epoch DB). Deletion
+itself is simpler than the markers case — per-epoch table, no data migration; remove the
+field + ThConfig entry (tidehunter supports outright deletion; old RocksDB epoch dirs are
+pruned wholesale).
+
+### 3.7 Restartability summary (the per-epoch vs perpetual question)
+
+No new durable state is introduced; the answer to "handler state is per-epoch but objects
+are perpetual" is that the durable lock table was only ever needed *behind* the flush
+horizon, and behind the flush horizon the perpetual objects table is guaranteed complete
+(I2 + I1) — with the deferred table (per-epoch, already flushed atomically with the
+watermark today) covering the one exception. In front of the flush horizon, consensus
+replay rebuilds the quarantine map exactly as it does today. The watermark
+(`last_consensus_stats_v2`) keeps its existing batch and gating; the epoch DB keeps being
+"never ahead of perpetual"; nothing about D1-D8 (§8) changes except that D1's "epoch DB
+has no locks" becomes universal and harmless by construction.
+
+### 3.8 Metrics
+
+- `consensus_handler_owned_ref_lock_checks{source, verdict}` — source ∈ {current_commit,
+  quarantine, deferred, cache, objects_db, lock_table_backstop}, verdict ∈ {clear,
+  conflict, same_digest}. The user-requested "remaining lookups" metric is
+  `source="objects_db"`; expect ~0 in steady state, spikes on restart/catch-up;
+  alertable. `lock_table_backstop` should be identically 0 for honest traffic.
+- `live_object_cache_{entries,inserts{source=vote|fallback|execution},evictions}`.
+- Keep `consensus_handler_dropped_transactions{reason="lock_conflict"}` for continuity;
+  existing tests assert on it.
+
+### 3.9 Alternatives considered
+
+- **Whole-epoch in-memory lock map, no fallback:** unbounded (~hundreds of GB at 15k TPS
+  × 24h epochs, §10) — rejected.
+- **Keep the durable table but prune flushed-executed locks:** shrinks the table to
+  ~deferred-backlog size but keeps every write on the flush path and every negative
+  lookup in the handler — most of the cost, little of the win. The pruned residue is
+  exactly what the deferred table already stores.
+- **Move conflict detection to vote time:** impossible — votes are per-validator and
+  time-dependent; the conflict decision must be post-consensus-deterministic.
+- **Reuse `object_by_id_cache` instead of a new primitive:** viable v0 (see §3.5); lacks
+  negative caching and retention control.
+
+### 3.10 What this buys
+
+At 15k TPS with ~2-3 owned refs/tx: eliminates 30-45k point writes/s into the largest
+epoch-DB keyspace (WAL + compaction + tidehunter dirty-key pressure for the whole epoch),
+eliminates the per-commit batched *negative* multi-get against that ever-growing table
+from the CPU-bound handler (replaced by hash lookups on three small maps + a cache), and
+collapses epoch-DB size/pruning cost. Costs: the deferred map (small), the cache (capped),
+the residual metered objects-table reads, and a determinism argument that now spans three
+subsystems — which is what §3.3 is for.


### PR DESCRIPTION
## Description

Removes the `owned_object_locked_transactions` epoch table and the `live_owned_object_markers` perpetual table: at high TPS the lock table is the largest epoch-DB keyspace (one point write per owned ref per finalized transaction, never deleted within an epoch), and the commit handler's per-commit prefetch is a batched negative lookup against it on the CPU-bound handler thread.

Structured as three commits, each independently deployable:

1. **Read swap** — all production reads move off the lock table (verdict-identical to the table-based logic via a narrow backstop; debug builds run both paths and assert equality per transaction). Safe as a plain binary rollout.
2. **Delete `live_owned_object_markers`** — the read-side deprecation merged in #27251; this drops the writes and the table (from draft #27243).
3. **Delete `owned_object_locked_transactions`** — drops the writes, the table, the backstop, and the debug double-read. Deploy constraint: everywhere-deployed commit 1 (strict claims voting universal) plus one epoch boundary; the backstop's only reachable case (byzantine under-claimed immutable input) is quorum-unreachable from then on.

Post-consensus conflict detection now resolves each claimed ref through layers: current-commit locks → quarantine map (un-flushed commits, unchanged structure) → a new deferred-locks map (deferred transactions are finalized-but-unexecuted, the one class of locks the objects table cannot reproduce; seeded at startup from the durable deferred-transactions table) → a new `LiveObjectCache` (monotone lower bound on latest versions, warmed by vote-time validation; decisive only in the consumed direction) → an authoritative tombstone-aware latest-object read, where `latest_version(id) > claimed_version ⇒ consumed this epoch ⇒ conflict`. This last verdict is sound because flushed commits' transactions are durably executed and execution version-bumps every locked ref on every path (including aborts and cancellations); a consumed verdict against a transaction that itself already executed (duplicate sequencing across restart) resolves as a same-digest re-acquire via `transactions_executed_in_cur_epoch`.

Also included:

- Vote-time immutable-claims verification now runs even when the claims list is empty, so unclaimed-immutable inputs are vote-rejected (`ImmutableObjectNotClaimed`). Claims are attached by the submitting validator, so only byzantine/buggy submitters are affected. Once universal, this makes the backstop provably dead, unblocking PR 2.
- The submit-path pre-check uses the same resolution. Observable change: a consumed input now reports terminal `ObjectLockConflict` naming the consumer (from the live object's `previous_transaction`) instead of falling through to the stale-version revalidation error.
- Resolution read errors are fail-stop, replacing the previous `unwrap_or_default()` leniency (a read error cannot be deterministically treated as "unlocked").
- New metric `consensus_owned_object_lock_resolutions{source}`; `objects_db` and `backstop` are the residual non-consensus-memory lookups (backstop expected to be 0 for honest traffic).

Full design and determinism argument: `docs/objects_locking.md` Part 3 (committed in this PR).

## Test plan

- Debug-build differential check: every existing test that drives the commit handler asserts objects-based verdicts == table-based verdicts per transaction; full `sui-core` lib suite passes (740/740).
- New unit tests: `LiveObjectCache` monotone merge; `DeferredTransactionLocks` insert/remove/re-insert.
- Updated `test_submit_transaction_consensus_message_processed_with_stale_inputs` to assert the new, more specific `ObjectLockConflict` naming the winner; `insert_object_locks_for_test` now also populates the deferred-locks map, matching the state it simulates.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Validators resolve post-consensus owned-object conflicts from in-memory state and the objects table instead of reading the per-epoch lock table. Transactions with immutable inputs missing the immutable-object claim are now rejected at vote time. Resubmitting a transaction whose owned input was consumed this epoch returns `ObjectLockConflict` naming the consuming transaction.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: 
