### PR TITLE
[consensus] add crash-and-restart simtests

### DIFF
--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -3,7 +3,10 @@
 
 use std::{
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
 
@@ -46,14 +49,17 @@ pub struct Config {
 pub struct AuthorityNode {
     inner: Mutex<Option<AuthorityNodeInner>>,
     config: Config,
+    boot_counter: AtomicU64,
     commit_consumer_receiver: Mutex<Option<UnboundedReceiver<CommittedSubDag>>>,
 }
 
 impl AuthorityNode {
     pub fn new(config: Config) -> Self {
+        let boot_counter = AtomicU64::new(config.boot_counter);
         Self {
             inner: Default::default(),
             config,
+            boot_counter,
             commit_consumer_receiver: Mutex::new(None),
         }
     }
@@ -71,9 +77,19 @@ impl AuthorityNode {
             "Validator"
         };
         info!(index = %self.config.authority_index, node_type = node_type, "starting in-memory node");
-        let config = self.config.clone();
+        let mut config = self.config.clone();
+        config.boot_counter = self.boot_counter.fetch_add(1, Ordering::Relaxed);
         *self.inner.lock() = Some(AuthorityNodeInner::spawn(config).await);
         Ok(())
+    }
+
+    /// Return the simulator node ID for the running authority.
+    pub fn sim_node_id(&self) -> sui_simulator::task::NodeId {
+        self.inner
+            .lock()
+            .as_ref()
+            .expect("Node not initialised")
+            .node_id()
     }
 
     pub fn spawn_committed_subdag_consumer(&self) -> Result<()> {
@@ -126,15 +142,26 @@ impl AuthorityNode {
         }
     }
 
+    pub fn transaction_client_if_running(&self) -> Option<Arc<TransactionClient>> {
+        let inner = self.inner.lock();
+        inner
+            .as_ref()
+            .filter(|inner| inner.is_alive())
+            .map(AuthorityNodeInner::transaction_client)
+    }
+
     /// Stop this Node
-    pub fn stop(&self) {
+    pub async fn stop(&self) {
         let node_type = if self.config.observer_network_keypair.is_some() {
             "Observer"
         } else {
             "Validator"
         };
         info!(index =% self.config.authority_index, node_type = node_type, "stopping in-memory node");
-        *self.inner.lock() = None;
+        let inner = self.inner.lock().take();
+        if let Some(inner) = inner {
+            inner.stop().await;
+        }
         info!(index =% self.config.authority_index, node_type = node_type, "node stopped");
     }
 
@@ -147,7 +174,7 @@ impl AuthorityNode {
 pub(crate) struct AuthorityNodeInner {
     handle: Option<NodeHandle>,
     cancel_sender: Option<tokio::sync::watch::Sender<bool>>,
-    consensus_authority: ConsensusAuthority,
+    consensus_authority: Option<ConsensusAuthority>,
     commit_receiver: ArcSwapOption<UnboundedReceiver<CommittedSubDag>>,
     commit_consumer_monitor: Arc<CommitConsumerMonitor>,
 }
@@ -168,6 +195,19 @@ impl Drop for AuthorityNodeInner {
 }
 
 impl AuthorityNodeInner {
+    fn node_id(&self) -> sui_simulator::task::NodeId {
+        self.handle.as_ref().expect("Node handle missing").node_id
+    }
+
+    async fn stop(mut self) {
+        if let Some(cancel_sender) = self.cancel_sender.take() {
+            cancel_sender.send(true).ok();
+        }
+        if let Some(consensus_authority) = self.consensus_authority.take() {
+            consensus_authority.stop().await;
+        }
+    }
+
     /// Spawn a new Node.
     pub async fn spawn(config: Config) -> Self {
         let (startup_sender, mut startup_receiver) = tokio::sync::watch::channel(false);
@@ -249,7 +289,7 @@ impl AuthorityNodeInner {
         Self {
             handle: Some(NodeHandle { node_id: node.id() }),
             cancel_sender: Some(cancel_sender),
-            consensus_authority,
+            consensus_authority: Some(consensus_authority),
             commit_receiver: ArcSwapOption::new(Some(Arc::new(commit_receiver))),
             commit_consumer_monitor,
         }
@@ -285,7 +325,10 @@ impl AuthorityNodeInner {
     }
 
     pub fn transaction_client(&self) -> Arc<TransactionClient> {
-        self.consensus_authority.transaction_client()
+        self.consensus_authority
+            .as_ref()
+            .expect("Consensus authority missing")
+            .transaction_client()
     }
 }
 

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -3,24 +3,35 @@
 
 #[cfg(msim)]
 mod consensus_tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::{sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, HashMap},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicU64, Ordering},
+        },
+        time::Duration,
+    };
 
     use consensus_config::{
         Authority, AuthorityIndex, AuthorityName, Committee, ConsensusProtocolConfig, Epoch,
         NetworkKeyPair, Parameters, ProtocolKeyPair, Stake,
     };
     use consensus_core::NoopTransactionVerifier;
-    use consensus_core::{BlockAPI, BlockStatus, Priority, TransactionVerifier, ValidationError};
+    use consensus_core::{
+        BlockAPI, BlockStatus, CommitIndex, CommitRef, CommittedSubDag, Priority,
+        TransactionVerifier, ValidationError,
+    };
     use consensus_simtests::node::{AuthorityNode, Config};
-    use consensus_types::block::{BlockRef, TransactionIndex};
+    use consensus_types::block::{BlockRef, BlockTimestampMs, TransactionIndex};
     use fastcrypto::traits::{KeyPair as _, ToFromBytes as _};
     use mysten_metrics::RegistryService;
+    use mysten_metrics::monitored_mpsc::UnboundedReceiver;
     use mysten_network::{Multiaddr, multiaddr::Protocol};
+    use parking_lot::Mutex;
     use prometheus::Registry;
-    use rand::{Rng, SeedableRng as _, rngs::StdRng};
+    use rand::{Rng, SeedableRng as _, rngs::StdRng, seq::SliceRandom as _};
     use sui_config::local_ip_utils;
-    use sui_macros::sim_test;
+    use sui_macros::{clear_fail_point, register_fail_points, sim_test};
     use sui_simulator::{
         SimConfig,
         configs::{bimodal_latency_ms, env_config, uniform_latency_ms},
@@ -58,33 +69,19 @@ mod consensus_tests {
 
         let mut authorities = Vec::with_capacity(committee.size());
         let mut transaction_clients = Vec::with_capacity(committee.size());
-        let mut boot_counters = [0; NUM_OF_AUTHORITIES];
-        let mut clock_drifts = [0; NUM_OF_AUTHORITIES];
-        clock_drifts[0] = 50;
-        clock_drifts[1] = 100;
-        clock_drifts[2] = 120;
+        let clock_drifts = test_clock_drifts::<NUM_OF_AUTHORITIES>();
 
+        // Start all authorities except the last one, which is started later to catch up.
         for (authority_index, _authority_info) in committee.authorities() {
-            // Introduce a non-trivial clock drift for the first node (it's time will be ahead of the others). This will provide extra reassurance
-            // around the block timestamp checks.
-            let db_dir = Arc::new(TempDir::new().unwrap());
-            let mut params = default_parameters();
-            params.db_path = db_dir.path().to_path_buf();
-
-            let config = Config {
+            let node = build_node(
+                &committee,
+                &keypairs,
+                &protocol_config,
                 authority_index,
-                db_dir,
-                committee: committee.clone(),
-                keypairs: keypairs.clone(),
-                boot_counter: boot_counters[authority_index],
-                protocol_config: protocol_config.clone(),
-                clock_drift: clock_drifts[authority_index.value() as usize],
-                transaction_verifier: Arc::new(NoopTransactionVerifier {}),
-                parameters: params,
-                observer_network_keypair: None,
-                observer_ip: None,
-            };
-            let node = AuthorityNode::new(config);
+                clock_drifts[authority_index],
+                Arc::new(NoopTransactionVerifier {}),
+                |_| {},
+            );
 
             if authority_index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u32 - 1) {
                 node.start().await.unwrap();
@@ -94,7 +91,6 @@ mod consensus_tests {
                 transaction_clients.push(client);
             }
 
-            boot_counters[authority_index] += 1;
             authorities.push(node);
         }
 
@@ -131,11 +127,213 @@ mod consensus_tests {
         );
     }
 
-    // Tests the fastpath transactions with randomized votes. The test creates a fixed number of transactions,
-    // sends them to random authorities, and randomizes votes on them (accept or reject). The output is verified
-    // by comparing commits across validators and ensuring they are consistent.
+    // Like test_committee_start_simple, but injects probabilistic crashes while the committee is
+    // under load. At key consensus fail points each node has a small chance to kill itself; the
+    // test harness recreates it after a short delay, so the node must recover from its persisted
+    // on-disk state. Verifies that every authority recovers and keeps making commit progress.
     #[sim_test(config = "test_config()")]
-    async fn test_committee_fast_path() {
+    async fn test_consensus_crash_and_restart() {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(RegistryService::new(db_registry));
+        const NUM_OF_AUTHORITIES: usize = 10;
+        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+        let mut protocol_config = ConsensusProtocolConfig::for_testing();
+        protocol_config.set_gc_depth_for_testing(3);
+
+        // Start the whole committee so crashes hit a fully running network.
+        let clock_drifts = test_clock_drifts::<NUM_OF_AUTHORITIES>();
+        let authorities = start_committee(
+            &committee,
+            &keypairs,
+            &protocol_config,
+            &clock_drifts,
+            Arc::new(NoopTransactionVerifier {}),
+            |_, _| {},
+        )
+        .await;
+
+        let crashes = inject_random_crashes(&authorities, Duration::ZERO);
+
+        // Continuously submit transactions while nodes crash and restart, and keep the load
+        // running until the final assertions, so commits contain real traffic rather than only
+        // empty block proposals.
+        let authorities_clone = authorities.clone();
+        let load_handle = tokio::spawn(async move {
+            let mut transaction_id = 0u64;
+            loop {
+                let authority =
+                    &authorities_clone[transaction_id as usize % authorities_clone.len()];
+                if let Some(client) = authority.transaction_client_if_running() {
+                    let _ = client
+                        .submit(
+                            vec![transaction_id.to_le_bytes().to_vec()],
+                            Priority::Normal,
+                        )
+                        .await;
+                }
+                transaction_id += 1;
+                sleep(Duration::from_millis(20)).await;
+            }
+        });
+
+        // Run the network across many crashes and restarts.
+        sleep(Duration::from_secs(120)).await;
+
+        // Ensure the network is still live after crashes stop.
+        crashes.stop().await;
+
+        // Because there is no persistence, commit consumers replay from the start of the commit
+        // sequence on every restart, so right after a restart an authority's handled commit index
+        // climbs from local state alone. 30s is a very generous window to finish replaying before
+        // snapshotting commit indexes, so that progress measured afterwards can be attributed to
+        // the network.
+        sleep(Duration::from_secs(30)).await;
+
+        // 1st snapshot
+        let snapshotted_commit_indexes = commit_indexes(&authorities);
+        tracing::info!(
+            ?snapshotted_commit_indexes,
+            "1st snapshot of commit indexes"
+        );
+
+        // Run the network for longer.
+        sleep(Duration::from_secs(30)).await;
+
+        // Every authority should commit past the 1st snapshot.
+        for i in 0..NUM_OF_AUTHORITIES {
+            let current_committed_index = authorities[i]
+                .commit_consumer_monitor()
+                .highest_handled_commit();
+            let snapshotted_commit_index = snapshotted_commit_indexes[i];
+            assert!(
+                current_committed_index > snapshotted_commit_index,
+                "Authority {i} made no commit progress beyond its snapshotted state: \
+                 {current_committed_index} <= {snapshotted_commit_index}"
+            );
+        }
+
+        load_handle.abort();
+    }
+
+    // Repeatedly restart every validator while the committee is under load. Each pass uses a
+    // different random order and leaves each validator down for either no time or a few seconds.
+    // Verifies that the final instances all reconnect and make new commit progress.
+    #[sim_test(config = "test_config()")]
+    async fn test_consensus_rolling_restarts_all_validators() {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(RegistryService::new(db_registry));
+        const NUM_OF_AUTHORITIES: usize = 4;
+        const NUM_RESTART_ROUNDS: usize = 4;
+        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+        let mut protocol_config = ConsensusProtocolConfig::for_testing();
+        protocol_config.set_gc_depth_for_testing(3);
+
+        let authorities = start_committee(
+            &committee,
+            &keypairs,
+            &protocol_config,
+            &[0; NUM_OF_AUTHORITIES],
+            Arc::new(NoopTransactionVerifier {}),
+            |_, _| {},
+        )
+        .await;
+
+        let load_authorities = authorities.clone();
+        let load_handle = tokio::spawn(async move {
+            let mut transaction_id = 0u64;
+            loop {
+                let authority = &load_authorities[transaction_id as usize % load_authorities.len()];
+                if let Some(client) = authority.transaction_client_if_running() {
+                    let _ = client
+                        .submit(
+                            vec![transaction_id.to_le_bytes().to_vec()],
+                            Priority::Normal,
+                        )
+                        .await;
+                }
+                transaction_id += 1;
+                sleep(Duration::from_millis(20)).await;
+            }
+        });
+
+        // Let the initial instances connect and begin committing before rolling the committee.
+        sleep(Duration::from_secs(10)).await;
+        let mut restart_orders = Vec::with_capacity(NUM_RESTART_ROUNDS);
+        for round in 0..NUM_RESTART_ROUNDS {
+            let restart_order = {
+                let mut rng = rand::thread_rng();
+                loop {
+                    let mut order = (0..NUM_OF_AUTHORITIES).collect::<Vec<_>>();
+                    order.shuffle(&mut rng);
+                    if !restart_orders.contains(&order) {
+                        break order;
+                    }
+                }
+            };
+            tracing::info!(round, ?restart_order, "Starting validator restart round");
+
+            for (position, authority_index) in restart_order.iter().copied().enumerate() {
+                let authority = &authorities[authority_index];
+                tracing::info!(round, authority_index, "Restarting validator");
+                authority.stop().await;
+
+                let downtime_secs = if (round + position) % 2 == 0 {
+                    0
+                } else {
+                    rand::thread_rng().gen_range(1..=3)
+                };
+                tracing::info!(round, authority_index, downtime_secs, "Validator stopped");
+                sleep(Duration::from_secs(downtime_secs)).await;
+
+                authority.start().await.unwrap();
+                authority.spawn_committed_subdag_consumer().unwrap();
+            }
+            restart_orders.push(restart_order);
+        }
+
+        // Every validator has now been replaced for the final time, and each final instance starts
+        // a fresh commit consumer. Because there is no persistence, commit consumers replay from
+        // the start of the commit sequence on every restart, so right after a restart a
+        // validator's handled commit index climbs from local state alone. 30s is a very generous
+        // window to finish replaying before snapshotting commit indexes, so that progress measured
+        // afterwards can be attributed to the network.
+        sleep(Duration::from_secs(30)).await;
+
+        // 1st snapshot
+        let snapshotted_commit_indexes = commit_indexes(&authorities);
+        tracing::info!(
+            ?snapshotted_commit_indexes,
+            "1st snapshot of commit indexes"
+        );
+
+        // Run the network for longer.
+        sleep(Duration::from_secs(30)).await;
+
+        // Every validator should commit past the 1st snapshot, proving the fully restarted
+        // committee reconnected.
+        for (authority_index, authority) in authorities.iter().enumerate() {
+            let current_committed_index =
+                authority.commit_consumer_monitor().highest_handled_commit();
+            let snapshotted_commit_index = snapshotted_commit_indexes[authority_index];
+            assert!(
+                current_committed_index > snapshotted_commit_index,
+                "Authority {authority_index} made no commit progress beyond its snapshotted \
+                 state: {current_committed_index} <= {snapshotted_commit_index}"
+            );
+        }
+
+        load_handle.abort();
+    }
+
+    // Tests consensus transaction voting with randomized votes and random crashes. The test
+    // creates a fixed number of transactions, sends them to random authorities, and randomizes
+    // votes on them (accept or reject), while authorities randomly crash and restart under the
+    // load. The output is verified by comparing commits and transactions across validators and
+    // ensuring they are consistent, including commits replayed after crash recovery.
+    #[sim_test(config = "test_config()")]
+    async fn test_consensus_transaction_votes() {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(RegistryService::new(db_registry));
@@ -148,53 +346,26 @@ mod consensus_tests {
         let mut protocol_config = ConsensusProtocolConfig::for_testing();
         protocol_config.set_gc_depth_for_testing(3);
 
-        let mut authorities = Vec::with_capacity(committee.size());
-        let mut transaction_clients = Vec::with_capacity(committee.size());
-        let mut boot_counters = [0; NUM_OF_AUTHORITIES];
-        let mut clock_drifts = [0; NUM_OF_AUTHORITIES];
-        clock_drifts[0] = 50;
-        clock_drifts[1] = 100;
-        clock_drifts[2] = 120;
-
         // Initialize consensus authorities and transaction clients.
-        for (authority_index, _authority_info) in committee.authorities() {
-            // Introduce clock drifts for the first three nodes (their time will be ahead of the others).
-            // This will provide extra reassurance around the block timestamp checks.
-            let db_dir = Arc::new(TempDir::new().unwrap());
-            let mut params = default_parameters();
-            params.db_path = db_dir.path().to_path_buf();
-
-            let config = Config {
-                authority_index,
-                db_dir,
-                committee: committee.clone(),
-                keypairs: keypairs.clone(),
-                boot_counter: boot_counters[authority_index],
-                protocol_config: protocol_config.clone(),
-                clock_drift: clock_drifts[authority_index.value() as usize],
-                transaction_verifier: Arc::new(RandomizedTransactionVerifier::new(
-                    REJECTION_PROBABILITY,
-                )),
-                parameters: params,
-                observer_network_keypair: None,
-                observer_ip: None,
-            };
-            let node = AuthorityNode::new(config);
-            node.start().await.unwrap();
-            node.spawn_committed_subdag_consumer().unwrap();
-
-            let client = node.transaction_client();
-            transaction_clients.push(client);
-
-            boot_counters[authority_index] += 1;
-            authorities.push(node);
-        }
-
+        let clock_drifts = test_clock_drifts::<NUM_OF_AUTHORITIES>();
+        let authorities = start_committee(
+            &committee,
+            &keypairs,
+            &protocol_config,
+            &clock_drifts,
+            Arc::new(RandomizedTransactionVerifier::new(REJECTION_PROBABILITY)),
+            |_, _| {},
+        )
+        .await;
         // Initialize commit consumers.
         let mut commit_consumer_receivers = vec![];
         for authority in &authorities {
             commit_consumer_receivers.push(authority.commit_consumer_receiver());
         }
+
+        // Space out crashes, so the test finishes within its total time budget even though
+        // sequencing all transactions has to run through crash recoveries.
+        let crashes = inject_random_crashes(&authorities, Duration::from_secs(30));
 
         let mut join_set = JoinSet::new();
         let mut transaction_index = 0;
@@ -215,37 +386,46 @@ mod consensus_tests {
                 transaction_index += 1;
             }
 
-            let index =
-                (transaction_index - num_of_transactions) as usize % transaction_clients.len();
-            let (_block_ref, _indexes, status_waiter) = transaction_clients[index]
-                .submit(transactions, Priority::Normal)
-                .await
-                .unwrap();
-
-            join_set.spawn({
-                let total_sequenced_transactions = total_sequenced_transactions.clone();
-                let total_garbage_collected_transactions =
-                    total_garbage_collected_transactions.clone();
-                async move {
-                    match status_waiter.await {
-                        Ok(BlockStatus::Sequenced(_)) => {
-                            // Just increment the transaction count
-                            total_sequenced_transactions
-                                .fetch_add(num_of_transactions as u64, Ordering::SeqCst);
-                        }
-                        Ok(BlockStatus::GarbageCollected(_)) => {
-                            total_garbage_collected_transactions
-                                .fetch_add(num_of_transactions as u64, Ordering::SeqCst);
-                        }
-                        Err(e) => {
-                            panic!(
-                                "Transactions in range {:?} failed with error: {e}",
-                                transaction_indexes_range
-                            );
+            let index = (transaction_index - num_of_transactions) as usize % authorities.len();
+            // Submit from a separate task: submitting to an authority that is down or
+            // recovering can fail or block until the authority can propose again, and should
+            // not stall the submission loop. Failed submissions are dropped, and the load
+            // keeps flowing through the rest of the committee.
+            if let Some(client) = authorities[index].transaction_client_if_running() {
+                join_set.spawn({
+                    let total_sequenced_transactions = total_sequenced_transactions.clone();
+                    let total_garbage_collected_transactions =
+                        total_garbage_collected_transactions.clone();
+                    async move {
+                        let Ok((_block_ref, _indexes, status_waiter)) =
+                            client.submit(transactions, Priority::Normal).await
+                        else {
+                            // The authority crashed while the transactions were being submitted.
+                            return;
+                        };
+                        match status_waiter.await {
+                            Ok(BlockStatus::Sequenced(_)) => {
+                                // Just increment the transaction count
+                                total_sequenced_transactions
+                                    .fetch_add(num_of_transactions as u64, Ordering::SeqCst);
+                            }
+                            Ok(BlockStatus::GarbageCollected(_)) => {
+                                total_garbage_collected_transactions
+                                    .fetch_add(num_of_transactions as u64, Ordering::SeqCst);
+                            }
+                            Err(e) => {
+                                // The authority crashed before the block was sequenced. The fate
+                                // of these transactions is unknown, so count them as neither
+                                // sequenced nor garbage collected.
+                                tracing::info!(
+                                    "Status of transactions in range {:?} is unknown: {e}",
+                                    transaction_indexes_range
+                                );
+                            }
                         }
                     }
-                }
-            });
+                });
+            }
 
             let sleep_duration = Duration::from_millis(rand::thread_rng().gen_range(1..100));
             sleep(sleep_duration).await;
@@ -256,14 +436,31 @@ mod consensus_tests {
             }
         }
 
+        tracing::info!("Test phase: waiting for transaction statuses");
+
         // Wait for submission transactions to finish.
         while let Some(result) = join_set.join_next().await {
             result.unwrap();
         }
 
+        tracing::info!(
+            "Test phase: stopping crashes. Sequenced {}, garbage collected {}",
+            total_sequenced_transactions.load(Ordering::SeqCst),
+            total_garbage_collected_transactions.load(Ordering::SeqCst)
+        );
+
+        // Stop crashing authorities before comparing commits, so every authority can finish
+        // recovering and make progress.
+        let completed_crashes = crashes.stop().await;
+
+        tracing::info!("Test phase: comparing commits after {completed_crashes} crashes");
+
         // Iterate over the committed sub dags until all the transactions have been committed on finalized sub dags.
         let mut transaction_count = 0;
         let mut total_rejected_transactions = 0;
+        let mut last_seen_commit_indexes: [CommitIndex; NUM_OF_AUTHORITIES] =
+            [0; NUM_OF_AUTHORITIES];
+        let mut observed_commits = vec![ObservedCommits::new(); NUM_OF_AUTHORITIES];
         loop {
             let mut sub_dags = vec![];
             let mut last_sub_dag_commit_ref = None;
@@ -272,23 +469,26 @@ mod consensus_tests {
             // underlying used channel is unbounded we won't have issues we dropped sub dags.
             for authority_index in 0..NUM_OF_AUTHORITIES {
                 tracing::trace!("Waiting for sub dag from authority {authority_index}");
-                if let Some(sub_dag) = timeout(
+                let sub_dag = timeout(
                     Duration::from_secs(90),
-                    commit_consumer_receivers[authority_index].recv(),
+                    next_sub_dag(
+                        &authorities[authority_index],
+                        &mut commit_consumer_receivers[authority_index],
+                        last_seen_commit_indexes[authority_index],
+                        &mut observed_commits[authority_index],
+                    ),
                 )
                 .await
-                .expect("Timeout waiting for subdag")
-                {
-                    if let Some(last_sub_dag_commit_ref) = last_sub_dag_commit_ref {
-                        assert_eq!(last_sub_dag_commit_ref, sub_dag.commit_ref);
-                    } else {
-                        last_sub_dag_commit_ref = Some(sub_dag.commit_ref);
-                    }
+                .expect("Timeout waiting for subdag");
+                last_seen_commit_indexes[authority_index] = sub_dag.commit_ref.index;
 
-                    sub_dags.push(sub_dag);
+                if let Some(last_sub_dag_commit_ref) = last_sub_dag_commit_ref {
+                    assert_eq!(last_sub_dag_commit_ref, sub_dag.commit_ref);
                 } else {
-                    panic!("Commit consumer for authority {authority_index} closed.");
+                    last_sub_dag_commit_ref = Some(sub_dag.commit_ref);
                 }
+
+                sub_dags.push(sub_dag);
             }
 
             tracing::info!(
@@ -355,38 +555,23 @@ mod consensus_tests {
         let mut protocol_config = ConsensusProtocolConfig::for_testing();
         protocol_config.set_gc_depth_for_testing(5);
 
-        let mut authorities = Vec::with_capacity(committee.size());
-        let mut transaction_clients = Vec::with_capacity(committee.size());
-        let mut boot_counters = [0; NUM_OF_AUTHORITIES];
-
         // Start validators with observer server support enabled
         // Note: In production, validators would need observer server ports configured
-        for (authority_index, _) in committee.authorities() {
-            let db_dir = Arc::new(TempDir::new().unwrap());
-            let mut parameters = default_parameters();
-            parameters.db_path = db_dir.path().to_path_buf();
-            parameters.observer.server_port = Some(9600 + authority_index.value() as u16);
-
-            let config = Config {
-                authority_index,
-                db_dir,
-                committee: committee.clone(),
-                keypairs: keypairs.clone(),
-                boot_counter: boot_counters[authority_index],
-                protocol_config: protocol_config.clone(),
-                clock_drift: 0,
-                transaction_verifier: Arc::new(NoopTransactionVerifier {}),
-                parameters,
-                observer_network_keypair: None,
-                observer_ip: None,
-            };
-            let node = AuthorityNode::new(config);
-            node.start().await.unwrap();
-            node.spawn_committed_subdag_consumer().unwrap();
-            transaction_clients.push(node.transaction_client());
-            boot_counters[authority_index] += 1;
-            authorities.push(node);
-        }
+        let authorities = start_committee(
+            &committee,
+            &keypairs,
+            &protocol_config,
+            &[0; NUM_OF_AUTHORITIES],
+            Arc::new(NoopTransactionVerifier {}),
+            |authority_index, parameters| {
+                parameters.observer.server_port = Some(9600 + authority_index.value() as u16);
+            },
+        )
+        .await;
+        let transaction_clients = authorities
+            .iter()
+            .map(|authority| authority.transaction_client())
+            .collect::<Vec<_>>();
 
         // Pre-allocate IPs for Observer nodes so we can configure them properly
         let observer1_ip = local_ip_utils::get_new_ip();
@@ -536,10 +721,10 @@ mod consensus_tests {
         );
 
         // Clean up
-        observer1.stop();
-        observer2.stop();
+        observer1.stop().await;
+        observer2.stop().await;
         for authority in authorities {
-            authority.stop();
+            authority.stop().await;
         }
     }
 
@@ -575,6 +760,260 @@ mod consensus_tests {
         let ip = local_ip_utils::get_new_ip();
 
         local_ip_utils::new_udp_address_for_testing(&ip)
+    }
+
+    // Clock drifts for the first few nodes (their time will be ahead of the others), providing
+    // extra reassurance around the block timestamp checks.
+    fn test_clock_drifts<const N: usize>() -> [BlockTimestampMs; N] {
+        let mut drifts = [0; N];
+        drifts[0] = 50;
+        drifts[1] = 100;
+        drifts[2] = 120;
+        drifts
+    }
+
+    // Builds an AuthorityNode with its own temp DB dir and default parameters, which
+    // `configure_params` can adjust (e.g. to enable the observer server).
+    fn build_node(
+        committee: &Committee,
+        keypairs: &[(NetworkKeyPair, ProtocolKeyPair)],
+        protocol_config: &ConsensusProtocolConfig,
+        authority_index: AuthorityIndex,
+        clock_drift: BlockTimestampMs,
+        transaction_verifier: Arc<dyn TransactionVerifier>,
+        configure_params: impl FnOnce(&mut Parameters),
+    ) -> AuthorityNode {
+        let db_dir = Arc::new(TempDir::new().unwrap());
+        let mut parameters = default_parameters();
+        parameters.db_path = db_dir.path().to_path_buf();
+        configure_params(&mut parameters);
+        AuthorityNode::new(Config {
+            authority_index,
+            db_dir,
+            committee: committee.clone(),
+            keypairs: keypairs.to_vec(),
+            boot_counter: 0,
+            protocol_config: protocol_config.clone(),
+            clock_drift,
+            transaction_verifier,
+            parameters,
+            observer_network_keypair: None,
+            observer_ip: None,
+        })
+    }
+
+    // Builds and starts every authority in the committee, and spawns their committed subdag
+    // consumers.
+    async fn start_committee(
+        committee: &Committee,
+        keypairs: &[(NetworkKeyPair, ProtocolKeyPair)],
+        protocol_config: &ConsensusProtocolConfig,
+        clock_drifts: &[BlockTimestampMs],
+        transaction_verifier: Arc<dyn TransactionVerifier>,
+        configure_params: impl Fn(AuthorityIndex, &mut Parameters),
+    ) -> Vec<Arc<AuthorityNode>> {
+        let mut authorities = Vec::with_capacity(committee.size());
+        for (authority_index, _) in committee.authorities() {
+            let node = build_node(
+                committee,
+                keypairs,
+                protocol_config,
+                authority_index,
+                clock_drifts[authority_index.value()],
+                transaction_verifier.clone(),
+                |parameters| configure_params(authority_index, parameters),
+            );
+            node.start().await.unwrap();
+            node.spawn_committed_subdag_consumer().unwrap();
+            authorities.push(Arc::new(node));
+        }
+        authorities
+    }
+
+    const CRASH_FAIL_POINTS: [&str; 4] = [
+        "consensus-store-before-write",
+        "consensus-store-after-write",
+        "consensus-after-propose",
+        "consensus-after-leader-schedule-change",
+    ];
+
+    // Handle to random crash injection, started with inject_random_crashes().
+    struct RandomCrashes {
+        crash_in_progress: Arc<AtomicBool>,
+        completed_crashes: Arc<AtomicU64>,
+        restart_controller: tokio::task::JoinHandle<()>,
+    }
+
+    // Injects random crashes into the committee: at each of the CRASH_FAIL_POINTS a node has a
+    // small chance to kill itself (the first fail point hit always crashes), and a controller
+    // task recreates the killed node after a short delay, forcing it to recover from its
+    // persisted on-disk state. Only one crash is in flight at a time, and `crash_interval` must
+    // pass after a restart before the next crash: with Duration::ZERO the fail points fire often
+    // enough that some node is always down or restarting, while a longer interval lets the
+    // committee run at full strength between crashes.
+    fn inject_random_crashes(
+        authorities: &[Arc<AuthorityNode>],
+        crash_interval: Duration,
+    ) -> RandomCrashes {
+        let authorities_by_node_id = Arc::new(Mutex::new(
+            authorities
+                .iter()
+                .map(|authority| (authority.sim_node_id(), authority.clone()))
+                .collect::<BTreeMap<_, _>>(),
+        ));
+        let (crash_sender, mut crash_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let crash_in_progress = Arc::new(AtomicBool::new(false));
+        let completed_crashes = Arc::new(AtomicU64::new(0));
+
+        // The full-node fixture used by test_simulated_load_restarts deletes a stopped simulator
+        // node and creates a new one. Do the same here: AuthorityNode owns ConsensusAuthority
+        // outside the simulated task, so an automatic simulator restart would leave the old DB
+        // and network resources alive in the harness.
+        let controller_crash_in_progress = crash_in_progress.clone();
+        let controller_completed_crashes = completed_crashes.clone();
+        let restart_controller = tokio::spawn(async move {
+            while let Some(node_id) = crash_receiver.recv().await {
+                sleep(Duration::from_secs(10)).await;
+                let authority = authorities_by_node_id
+                    .lock()
+                    .remove(&node_id)
+                    .expect("Unknown simulator node requested a restart");
+                authority.stop().await;
+                authority.start().await.unwrap();
+                authority.spawn_committed_subdag_consumer().unwrap();
+                authorities_by_node_id
+                    .lock()
+                    .insert(authority.sim_node_id(), authority);
+                controller_completed_crashes.fetch_add(1, Ordering::Relaxed);
+                sleep(crash_interval).await;
+                controller_crash_in_progress.store(false, Ordering::Release);
+            }
+        });
+
+        let failpoint_crash_in_progress = crash_in_progress.clone();
+        let failpoint_completed_crashes = completed_crashes.clone();
+        register_fail_points(&CRASH_FAIL_POINTS, move || {
+            let should_crash = failpoint_completed_crashes.load(Ordering::Relaxed) == 0
+                || rand::thread_rng().gen_range(0..100) == 0;
+            if should_crash
+                && failpoint_crash_in_progress
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+            {
+                let node_id = sui_simulator::current_simnode_id();
+                tracing::error!(%node_id, "Killing current node");
+                crash_sender.send(node_id).unwrap();
+                sui_simulator::task::shutdown_current_node();
+            }
+        });
+
+        RandomCrashes {
+            crash_in_progress,
+            completed_crashes,
+            restart_controller,
+        }
+    }
+
+    impl RandomCrashes {
+        // Stops injecting crashes, waits for an in-flight restart to complete, and returns the
+        // number of injected crashes. Panics if no crash happened.
+        async fn stop(self) -> u64 {
+            for fail_point in CRASH_FAIL_POINTS {
+                clear_fail_point(fail_point);
+            }
+            while self.crash_in_progress.load(Ordering::Acquire) {
+                sleep(Duration::from_secs(1)).await;
+            }
+            self.restart_controller.abort();
+            let completed_crashes = self.completed_crashes.load(Ordering::Relaxed);
+            assert!(
+                completed_crashes > 0,
+                "Test completed without crashing an authority"
+            );
+            completed_crashes
+        }
+    }
+
+    // Commits already observed from an authority, keyed by commit index. Used to check that commits
+    // replayed after a crash match what the authority output before the crash.
+    type ObservedCommits =
+        HashMap<CommitIndex, (CommitRef, BTreeMap<BlockRef, Vec<TransactionIndex>>)>;
+
+    // Receives the next committed sub dag from the authority, tolerating crashes and restarts of
+    // the authority. When the authority crashes, its commit consumer channel closes: re-acquire
+    // the channel created by the restart. After a restart all commits are replayed from the
+    // start, so commits at or below `last_seen_commit_index` are skipped, after checking that the
+    // replay did not diverge from what was observed before the crash.
+    // Must only be called when no crash can start, e.g. after RandomCrashes::stop(), so the
+    // restarted authority is guaranteed to have a new commit consumer channel available.
+    async fn next_sub_dag(
+        authority: &AuthorityNode,
+        receiver: &mut UnboundedReceiver<CommittedSubDag>,
+        last_seen_commit_index: CommitIndex,
+        observed_commits: &mut ObservedCommits,
+    ) -> CommittedSubDag {
+        loop {
+            let Some(sub_dag) = receiver.recv().await else {
+                *receiver = authority.commit_consumer_receiver();
+                continue;
+            };
+            if sub_dag.commit_ref.index <= last_seen_commit_index {
+                // Commit indexes are contiguous and delivered in order, so every commit at or
+                // below `last_seen_commit_index` has been observed and recorded.
+                let (commit_ref, rejected_transactions_by_block) = observed_commits
+                    .get(&sub_dag.commit_ref.index)
+                    .expect("Commits at or below last_seen_commit_index must have been observed");
+                // Commit contents are recovered from the commit store, so the replayed commit
+                // must be identical.
+                assert_eq!(
+                    *commit_ref, sub_dag.commit_ref,
+                    "Replayed commit at index {} diverged from the commit observed before the \
+                     crash",
+                    sub_dag.commit_ref.index
+                );
+                // A commit only reaches the consumer after CommitFinalizer has persisted its
+                // rejected transactions and flushed storage. So a replayed copy of an observed
+                // commit must have recovered its rejected transactions from storage, and they
+                // must be identical: with the randomized verifier, re-voting instead of reading
+                // storage would diverge. (Commits that were unfinalized at crash time are
+                // legitimately re-voted during recovery, but those never reached the consumer
+                // before the crash and so are never in `observed_commits`.)
+                assert!(
+                    sub_dag.recovered_rejected_transactions,
+                    "Replayed commit {:?} lost its persisted rejected transactions",
+                    sub_dag.commit_ref
+                );
+                assert_eq!(
+                    *rejected_transactions_by_block, sub_dag.rejected_transactions_by_block,
+                    "Replayed commit {:?} diverged from the rejected transactions observed before \
+                     the crash",
+                    sub_dag.commit_ref
+                );
+                continue;
+            }
+            observed_commits.insert(
+                sub_dag.commit_ref.index,
+                (
+                    sub_dag.commit_ref,
+                    sub_dag.rejected_transactions_by_block.clone(),
+                ),
+            );
+            return sub_dag;
+        }
+    }
+
+    // Commit index handled by each authority.
+    //
+    // The commit consumer replays the persisted commit sequence from the start on every restart.
+    // When this snapshot is taken well after the replays have drained (observed replay duration is
+    // in the microseconds, against a drain period of tens of simulated seconds), progress past it
+    // can be attributed to the network — committing as part of the committee or commit sync —
+    // rather than to replay of local state.
+    fn commit_indexes(authorities: &[Arc<AuthorityNode>]) -> Vec<CommitIndex> {
+        authorities
+            .iter()
+            .map(|authority| authority.commit_consumer_monitor().highest_handled_commit())
+            .collect()
     }
 
     // Helper function to create default parameters with custom db_path


### PR DESCRIPTION
## Description 

Stacked on #27319 (consensus-core shutdown cleanup); this PR contains only the simtest changes.

Adds consensus-only simtests that exercise crash recovery under load, modeled on `test_committee_start_simple`:
- `test_consensus_crash_and_restart`: starts a 10-authority committee under continuous transaction load, and registers fail points at key consensus points (store before/after write, after propose, after leader-schedule change) where each node has a small probability of killing itself. The test harness recreates the killed node after a short delay, forcing recovery from persisted on-disk state, and asserts every authority recovers and keeps making commit progress.
- `test_consensus_rolling_restarts_all_validators`: repeatedly restarts every validator in random order under load, with varying downtime, and asserts the fully restarted committee reconnects and makes new commit progress.
- `test_committee_fast_path` is renamed to `test_consensus_transaction_votes` and now runs under the same random crash injection (with a cool-down between crashes so the test fits its time budget). Transactions are submitted from separate tasks so a down or recovering authority cannot stall the load, and the cross-authority commit comparison tolerates restarts by re-acquiring commit consumer channels and skipping replayed commits.

Harness changes:
- The simtest `AuthorityNode` deletes and recreates its simulator node across crashes, and `stop()` awaits `ConsensusAuthority::stop()` before deleting the node, mirroring the full-node restart fixture.
- Committee startup boilerplate and crash injection are shared across the tests.

## Test plan 

- `cargo simtest -p consensus-simtests`: all 10 tests pass, including the new crash-and-restart and rolling-restart tests and the crash-enabled transaction votes test.

