### PR TITLE
[autodebug] Disable epoch close deadline in shared object congestion control simtest

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -588,6 +588,12 @@ mod test {
         let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, mut config| {
             config.set_per_object_congestion_control_mode_for_testing(mode);
             config.set_max_deferral_rounds_for_congestion_control_for_testing(max_deferral_rounds);
+            // With large max_deferral_rounds and low congestion budgets, transactions can be
+            // legitimately re-deferred for longer than the epoch close deadline, which would
+            // abandon them and fire debug_fatal. Disable the deadline so epoch close blocks
+            // until all deferrals resolve, which is the liveness property this test verifies.
+            // The deadline failsafe has its own dedicated tests.
+            config.disable_epoch_close_deadline_ms_for_testing();
             config
         });
 


### PR DESCRIPTION
## Description

Fixes the nightly simtest failure in `test_simulated_load_shared_object_congestion_control` ([failing run](https://github.com/MystenLabs/sui/actions/runs/29487855284), seeds 71784194734 and 131784194734).

Root cause: the epoch close deadline failsafe introduced in #27300 (`epoch_close_deadline_ms = 120_000`, protocol v130) fires during this test's "large deferral rounds" liveness mode. The test randomly picks `max_deferral_rounds_for_congestion_control` in 500..1000 (vs 10 in production) with very low congestion budgets, so congested transactions are legitimately re-deferred round after round for longer than 120s past the epoch's reconfiguration timestamp — the failing run shows a transaction re-deferred every round from round 30 to round 693, still under its 887-round limit. The failsafe cannot distinguish these still-progressing deferrals from stuck ones, abandons them, and fires `debug_fatal!`, which panics in simtest builds.

Disable the deadline in this test so epoch close blocks until all deferrals resolve, which is the liveness property the test verifies. The failsafe keeps its own dedicated unit tests and e2e simtest. Not a product bug: with production's `max_deferral_rounds = 10`, deferrals resolve within seconds and the deadline can only fire on genuine bugs.

## Test plan

- Both CI-failing seeds (71784194734, 131784194734) reproduced the panic deterministically under exact CI stress conditions (`SIM_STRESS_TEST_DURATION_SECS=300`) before the fix, and pass after it.
- `seed-search.py` on the fixed test: 200/200 seeds passed.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
