### PR TITLE
[consensus] finish tasks and propagate panics during authority shutdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Individual preferences supersede and extend project preferences:
 
 ### License comments
 
-All new files must start with the following license in comments at the top of the file:
+All applicable source code files must start with the following license in comments at the top of the file:
 
     Copyright (c) Mysten Labs, Inc.
     SPDX-License-Identifier: Apache-2.0
@@ -22,7 +22,7 @@ All new files must start with the following license in comments at the top of th
 # Build a specific crate. Generally don't need to do release build.
 cargo build -p sui-core
 
-# Check code without building (preferred)
+# Check code without code generation or linking (preferred)
 cargo check
 ```
 
@@ -50,7 +50,7 @@ SUI_SKIP_SIMTESTS=1 cargo nextest run -p <crate-name>
 ./scripts/lint.sh
 
 # For formatting:
-cargo fmt --all -- --check
+cargo fmt --all
 
 # Lint a single crate in `crates/`, `consensus/`, `sui-execution/`:
 cargo xclippy -p <crate-name>
@@ -88,10 +88,10 @@ sui/
 3. **Transaction Flow**:
    - User → Fullnode → Validators
    - All user transactions require consensus voting and commit before execution.
-   - Pre and post-consensus fastpath executions have been removed. Surviving mentions of "fastpath" either refer to consensus transaction-voting logic, or should be removed. There is no longer a separate execution path called fastpath.
+   - Pre and post-consensus fastpath executions have been removed. Surviving mentions of "fastpath" refer to consensus transaction-voting logic, owned object logic, or should be reworded or removed. There is no longer a separate execution path called fastpath.
 
 4. **Storage Layer**:
-   - Uses RocksDB for persistent storage
+   - Uses RocksDB or Tidehunter for persistent storage on Sui nodes.
    - Separate stores for permanent, per-epoch, checkpoint, consensus and indexing data
 
 5. **Execution Pipeline**:
@@ -99,17 +99,25 @@ sui/
    - Move VM executes smart contracts with gas metering
    - Parallel execution for non-conflicting transactions
 
+## Development Notes
+
+### Build flags
+
+Sui binaries like sui-node built with `release` profile have `panic=abort` enabled.
+
 ### Test-Only Code
 
 Use `#[cfg(test)]` for test-only code used within the same crate. Use `#[cfg(feature = "testing")]` for test-only code that must be callable cross-crate. For the `testing` feature: define `testing = []` in the crate's `Cargo.toml`, and callers must propagate it via `features = ["testing"]` in their dependency declaration.
 
-### Development Notes
-1. **Testing**:
-   - Use `#[tokio::test]` for async tests, not `#[test]`, to ensure the tests don't panic in simtest mode.
-2. **Protocol Config Changes**:
-   - When modifying `crates/sui-protocol-config/src/lib.rs`, always invoke `/protocol-config` to verify changes are safe. Incorrect changes can break network consensus.
-3. **Raising a PR**:
-   - When opening or updating a PR in this repo, always invoke the `/send-pr` skill.
+Use `#[tokio::test]` for async tests, not `#[test]`.
+
+### Protocol Config Changes:
+
+When modifying `crates/sui-protocol-config/src/lib.rs`, always invoke `/protocol-config` to verify changes are safe. Incorrect changes can break network consensus.
+
+### Raising a PR:
+
+When opening or updating a PR in this repo, always invoke the `/send-pr` skill.
 
 ### Comment Writing Guidelines
 

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::{Arc, Weak},
+    time::Instant,
+};
 
 use consensus_config::{
     Committee, ConsensusProtocolConfig, NetworkKeyPair, NetworkPublicKey, Parameters,
@@ -9,6 +12,7 @@ use consensus_config::{
 };
 use consensus_types::block::Round;
 use itertools::Itertools;
+use mysten_common::debug_fatal;
 use mysten_network::Multiaddr;
 use parking_lot::RwLock;
 use prometheus::Registry;
@@ -142,10 +146,10 @@ enum SubscriberType<N: NetworkManager> {
 }
 
 impl<N: NetworkManager> SubscriberType<N> {
-    fn stop(&self) {
+    async fn stop(&self) {
         match self {
-            SubscriberType::Validator(subscriber) => subscriber.stop(),
-            SubscriberType::Observer(subscriber) => subscriber.stop(),
+            SubscriberType::Validator(subscriber) => subscriber.stop().await,
+            SubscriberType::Observer(subscriber) => subscriber.stop().await,
         }
     }
 }
@@ -159,12 +163,18 @@ where
     transaction_client: Arc<TransactionClient>,
     synchronizer: Arc<SynchronizerHandle>,
     store: Arc<RocksDBStore>,
+    // Only use for verification and logging during shutdown.
+    // To avoid keeping the DagState alive at the end of shutdown, this is only a weak reference.
+    dag_state: Weak<RwLock<DagState>>,
 
     commit_syncer_handle: CommitSyncerHandle,
     round_prober_handle: Option<RoundProberHandle>,
     leader_timeout_handle: LeaderTimeoutTaskHandle,
     core_thread_handle: CoreThreadHandle,
     subscriber: SubscriberType<N>,
+    // Network proxies hold ObserverService weakly, so AuthorityNode keeps the service alive until
+    // the network servers have stopped.
+    observer_service: Option<Arc<ObserverService>>,
     network_manager: N,
 }
 
@@ -406,7 +416,7 @@ where
             store.clone(),
         ));
 
-        let (subscriber, round_prober_handle) = if context.is_validator() {
+        let (subscriber, round_prober_handle, observer_service) = if context.is_validator() {
             let authority_service = Arc::new(AuthorityService::new(
                 context.clone(),
                 block_verifier.clone(),
@@ -451,7 +461,7 @@ where
             );
 
             // Start the observer server if the observer server is enabled in the parameters.
-            if context.parameters.observer.is_server_enabled() {
+            let observer_service = if context.parameters.observer.is_server_enabled() {
                 let observer_service = Arc::new(ObserverService::new(
                     context.clone(),
                     core_dispatcher.clone(),
@@ -465,11 +475,18 @@ where
                     randomness_signature_handler.clone(),
                 ));
                 network_manager
-                    .start_observer_server(observer_service)
+                    .start_observer_server(observer_service.clone())
                     .await;
-            }
+                Some(observer_service)
+            } else {
+                None
+            };
 
-            (SubscriberType::Validator(s), round_prober_handle)
+            (
+                SubscriberType::Validator(s),
+                round_prober_handle,
+                observer_service,
+            )
         } else {
             // Observer node: subscribe to specified peer(s) using ObserverSubscriber
             let observer_client = network_manager.observer_client();
@@ -496,7 +513,7 @@ where
             );
 
             network_manager
-                .start_observer_server(observer_service)
+                .start_observer_server(observer_service.clone())
                 .await;
 
             // Subscribe to peers specified in the configuration
@@ -517,7 +534,11 @@ where
                 observer_subscriber.subscribe(peer_id);
             }
 
-            (SubscriberType::Observer(observer_subscriber), None)
+            (
+                SubscriberType::Observer(observer_subscriber),
+                None,
+                Some(observer_service),
+            )
         };
 
         info!(
@@ -531,47 +552,75 @@ where
             transaction_client: Arc::new(tx_client),
             synchronizer,
             store,
+            dag_state: Arc::downgrade(&dag_state),
             commit_syncer_handle,
             round_prober_handle,
             leader_timeout_handle,
             core_thread_handle,
             subscriber,
+            observer_service,
             network_manager,
         }
     }
 
-    pub(crate) async fn stop(mut self) {
+    pub(crate) async fn stop(self) {
+        let Self {
+            context,
+            start_time,
+            transaction_client,
+            synchronizer,
+            store,
+            dag_state,
+            commit_syncer_handle,
+            round_prober_handle,
+            leader_timeout_handle,
+            core_thread_handle,
+            subscriber,
+            observer_service,
+            mut network_manager,
+        } = self;
+
         info!(
             "Stopping authority. Total run time: {:?}",
-            self.start_time.elapsed()
+            start_time.elapsed()
         );
 
         // First shutdown components calling into Core.
-        if let Err(e) = self.synchronizer.stop().await {
-            if e.is_panic() {
-                std::panic::resume_unwind(e.into_panic());
-            }
-            warn!(
-                "Failed to stop synchronizer when shutting down consensus: {:?}",
-                e
-            );
-        };
-        self.commit_syncer_handle.stop().await;
-        if let Some(round_prober_handle) = self.round_prober_handle {
+        synchronizer.stop().await;
+        commit_syncer_handle.stop().await;
+        if let Some(round_prober_handle) = round_prober_handle {
             round_prober_handle.stop().await;
         }
-        self.leader_timeout_handle.stop().await;
+        leader_timeout_handle.stop().await;
         // Shutdown Core to stop block productions and broadcast.
-        self.core_thread_handle.stop().await;
+        core_thread_handle.stop().await;
         // Stop block subscriptions before stopping network server.
-        self.subscriber.stop();
-        self.network_manager.stop().await;
+        subscriber.stop().await;
+        network_manager.stop().await;
 
-        self.context
+        context
             .metrics
             .node_metrics
             .uptime
-            .observe(self.start_time.elapsed().as_secs_f64());
+            .observe(start_time.elapsed().as_secs_f64());
+
+        drop((
+            context,
+            transaction_client,
+            synchronizer,
+            store,
+            subscriber,
+            observer_service,
+            network_manager,
+        ));
+
+        let dag_state_owners = dag_state.strong_count();
+        if dag_state_owners != 0 {
+            debug_fatal!(
+                "DagState still has {} owner(s) after stopping ConsensusAuthority",
+                dag_state_owners
+            );
+        }
     }
 
     pub(crate) fn transaction_client(&self) -> Arc<TransactionClient> {

--- a/consensus/core/src/commit_finalizer.rs
+++ b/consensus/core/src/commit_finalizer.rs
@@ -22,6 +22,7 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
+    task::join_and_propagate_panic,
     transaction_vote_tracker::TransactionVoteTracker,
 };
 
@@ -32,16 +33,31 @@ pub(crate) const INDIRECT_REJECT_DEPTH: Round = 3;
 
 /// Handle to CommitFinalizer, for sending CommittedSubDag.
 pub(crate) struct CommitFinalizerHandle {
-    sender: UnboundedSender<CommittedSubDag>,
+    sender: Option<UnboundedSender<CommittedSubDag>>,
+    task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl CommitFinalizerHandle {
     // Sends a CommittedSubDag to CommitFinalizer, which will finalize it before sending it to execution.
     pub(crate) fn send(&self, commit: CommittedSubDag) -> ConsensusResult<()> {
-        self.sender.send(commit).map_err(|e| {
-            tracing::warn!("Failed to send to commit finalizer, probably due to shutdown: {e:?}");
-            ConsensusError::Shutdown
-        })
+        self.sender
+            .as_ref()
+            .ok_or(ConsensusError::Shutdown)?
+            .send(commit)
+            .map_err(|e| {
+                tracing::warn!(
+                    "Failed to send to commit finalizer, probably due to shutdown: {e:?}"
+                );
+                ConsensusError::Shutdown
+            })
+    }
+
+    pub(crate) async fn stop(&mut self) {
+        // Closing the channel allows CommitFinalizer to drain accepted commits before exiting.
+        self.sender.take();
+        if let Some(task) = self.task.take() {
+            join_and_propagate_panic(task).await;
+        }
     }
 }
 
@@ -106,9 +122,12 @@ impl CommitFinalizer {
     ) -> CommitFinalizerHandle {
         let processor = Self::new(context, dag_state, transaction_vote_tracker, commit_sender);
         let (sender, receiver) = unbounded_channel("consensus_commit_finalizer");
-        let _handle =
+        let task =
             spawn_logged_monitored_task!(processor.run(receiver), "consensus_commit_finalizer");
-        CommitFinalizerHandle { sender }
+        CommitFinalizerHandle {
+            sender: Some(sender),
+            task: Some(task),
+        }
     }
 
     async fn run(mut self, mut receiver: UnboundedReceiver<CommittedSubDag>) {

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -87,6 +87,10 @@ impl CommitObserver {
         observer
     }
 
+    pub(crate) async fn stop(&mut self) {
+        self.commit_finalizer_handle.stop().await;
+    }
+
     /// Creates and returns a list of committed subdags containing committed blocks, from a sequence
     /// of selected leader blocks, and whether they come from local committer or commit sync remotely.
     ///

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -31,7 +31,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use consensus_types::block::BlockRef;
+use consensus_types::block::{BlockRef, TransactionIndex};
 use futures::{StreamExt as _, stream::FuturesOrdered};
 use itertools::Itertools as _;
 use mysten_common::ZipDebugEqIteratorExt;
@@ -63,6 +63,7 @@ use crate::{
     peers_pool::PeersPool,
     round_tracker::RoundTracker,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
+    task::{join_and_propagate_panic, shutdown_join_set},
     transaction_vote_tracker::TransactionVoteTracker,
 };
 
@@ -76,11 +77,7 @@ impl CommitSyncerHandle {
     pub(crate) async fn stop(self) {
         let _ = self.tx_shutdown.send(());
         // Do not abort schedule task, which waits for fetches to shut down.
-        if let Err(e) = self.schedule_task.await
-            && e.is_panic()
-        {
-            std::panic::resume_unwind(e.into_panic());
-        }
+        join_and_propagate_panic(self.schedule_task).await;
     }
 }
 
@@ -177,7 +174,7 @@ where
                         }
                         warn!("Fetch cancelled. CommitSyncer shutting down: {}", e);
                         // If any fetch is cancelled or panicked, try to shutdown and exit the loop.
-                        self.inflight_fetches.shutdown().await;
+                        shutdown_join_set(&mut self.inflight_fetches).await;
                         return;
                     }
                     let (target_end, commits) = result.unwrap();
@@ -186,7 +183,7 @@ where
                 _ = &mut rx_shutdown => {
                     // Shutdown requested.
                     info!("CommitSyncer shutting down ...");
-                    self.inflight_fetches.shutdown().await;
+                    shutdown_join_set(&mut self.inflight_fetches).await;
                     return;
                 }
             }
@@ -573,16 +570,36 @@ where
         // 2. Verify the response contains blocks that can certify the last returned commit,
         // and the returned commits are chained by digests, so earlier commits are certified
         // as well.
-        let (commits, vote_blocks) = Handle::current()
+        let (commits, commit_certifying_blocks_and_votes) = Handle::current()
             .spawn_blocking({
-                let inner = inner.clone();
+                let context = inner.context.clone();
+                let block_verifier = inner.block_verifier.clone();
                 let peer = target_peer.clone();
                 move || {
-                    inner.verify_commits(peer, commit_range, serialized_commits, serialized_blocks)
+                    Inner::<VC, OC>::verify_commits(
+                        &context,
+                        block_verifier.as_ref(),
+                        peer,
+                        commit_range,
+                        serialized_commits,
+                        serialized_blocks,
+                    )
                 }
             })
             .await
             .expect("Spawn blocking should not fail")?;
+
+        // Only the vote tracker needs the reject votes, so move them into it without cloning.
+        // Cheap clones of the blocks are enough for the rest of the fetch handling.
+        let commit_certifying_blocks: Vec<_> = commit_certifying_blocks_and_votes
+            .iter()
+            .map(|(block, _)| block.clone())
+            .collect();
+        if inner.context.protocol_config.transaction_voting_enabled() {
+            inner
+                .transaction_vote_tracker
+                .add_voted_blocks(commit_certifying_blocks_and_votes);
+        }
 
         // 3. Fetch blocks referenced by the commits, from the same peer where commits are fetched.
         let mut block_refs: Vec<_> = commits.iter().flat_map(|c| c.blocks()).cloned().collect();
@@ -664,7 +681,10 @@ where
         }
 
         // 8. Check if the block timestamps are lower than current time - this is for metrics only.
-        for block in fetched_blocks.values().chain(vote_blocks.iter()) {
+        for block in fetched_blocks
+            .values()
+            .chain(commit_certifying_blocks.iter())
+        {
             let now_ms = inner.context.clock.timestamp_utc_ms();
             let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
             if forward_drift == 0 {
@@ -718,7 +738,7 @@ where
                 inner.commit_vote_monitor.observe_block(block);
             }
         }
-        for block in &vote_blocks {
+        for block in &commit_certifying_blocks {
             inner.commit_vote_monitor.observe_block(block);
         }
 
@@ -736,7 +756,7 @@ where
                 }
             }
             // Update from vote blocks
-            for block in &vote_blocks {
+            for block in &commit_certifying_blocks {
                 tracker.update_from_verified_block(&ExtendedBlock {
                     block: block.clone(),
                     excluded_ancestors: vec![],
@@ -744,7 +764,10 @@ where
             }
         }
 
-        Ok(CertifiedCommits::new(certified_commits, vote_blocks))
+        Ok(CertifiedCommits::new(
+            certified_commits,
+            commit_certifying_blocks,
+        ))
     }
 
     fn unhandled_commits_threshold(&self) -> CommitIndex {
@@ -792,15 +815,22 @@ struct Inner<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> {
 }
 
 impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
-    /// Verifies the commits and also certifies them using the provided vote blocks for the last commit. The
-    /// method returns the trusted commits and the votes as verified blocks.
+    /// Verifies the commits and certifies them using the provided vote blocks for the last commit.
+    /// Returns, in order:
+    /// - the verified commit chain as trusted commits;
+    /// - the verified blocks that certify the last commit, paired with locally rejected
+    ///   transaction indices for transaction vote tracking.
     fn verify_commits(
-        &self,
+        context: &Context,
+        block_verifier: &dyn BlockVerifier,
         peer: PeerId,
         commit_range: CommitRange,
         serialized_commits: Vec<Bytes>,
         serialized_vote_blocks: Vec<Bytes>,
-    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
+    ) -> ConsensusResult<(
+        Vec<TrustedCommit>,
+        Vec<(VerifiedBlock, Vec<TransactionIndex>)>,
+    )> {
         // Parse and verify commits.
         let mut commits = Vec::new();
         for serialized in &serialized_commits {
@@ -843,28 +873,24 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
         // Parse and verify blocks. Then accumulate votes on the end commit.
         let end_commit_ref = CommitRef::new(end_commit.index(), *end_commit_digest);
         let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
-        let mut vote_blocks = Vec::new();
+        let mut commit_certifying_blocks = Vec::new();
         for serialized in serialized_vote_blocks {
             let block: SignedBlock =
                 bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedBlock)?;
             // Only block signatures need to be verified, to verify commit votes.
             // But the blocks will be sent to Core, so they need to be fully verified.
             let (block, reject_transaction_votes) =
-                self.block_verifier.verify_and_vote(block, serialized)?;
-            if self.context.protocol_config.transaction_voting_enabled() {
-                self.transaction_vote_tracker
-                    .add_voted_blocks(vec![(block.clone(), reject_transaction_votes)]);
-            }
+                block_verifier.verify_and_vote(block, serialized)?;
             for vote in block.commit_votes() {
                 if *vote == end_commit_ref {
-                    stake_aggregator.add(block.author(), &self.context.committee);
+                    stake_aggregator.add(block.author(), &context.committee);
                 }
             }
-            vote_blocks.push(block);
+            commit_certifying_blocks.push((block, reject_transaction_votes));
         }
 
         // Check if the end commit has enough votes.
-        if !stake_aggregator.reached_threshold(&self.context.committee) {
+        if !stake_aggregator.reached_threshold(&context.committee) {
             return Err(ConsensusError::NotEnoughCommitVotes {
                 stake: stake_aggregator.stake(),
                 peer,
@@ -877,7 +903,7 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
             .zip_debug_eq(serialized_commits)
             .map(|((_d, c), s)| TrustedCommit::new_trusted(c, s))
             .collect();
-        Ok((trusted_commits, vote_blocks))
+        Ok((trusted_commits, commit_certifying_blocks))
     }
 }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -247,23 +247,6 @@ impl Core {
         .recover_observer()
     }
 
-    fn recover_observer(mut self) -> Self {
-        let _s = self
-            .context
-            .metrics
-            .node_metrics
-            .scope_processing_time
-            .with_label_values(&["Core::recover_observer"])
-            .start_timer();
-
-        // Try to commit, since they may not have run after the last storage write.
-        self.try_commit(vec![]).unwrap();
-
-        self.try_signal_new_round();
-
-        self
-    }
-
     fn recover_validator(mut self) -> Self {
         let _s = self
             .context
@@ -314,6 +297,27 @@ impl Core {
         );
 
         self
+    }
+
+    fn recover_observer(mut self) -> Self {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::recover_observer"])
+            .start_timer();
+
+        // Try to commit, since they may not have run after the last storage write.
+        self.try_commit(vec![]).unwrap();
+
+        self.try_signal_new_round();
+
+        self
+    }
+
+    pub(crate) async fn stop(&mut self) {
+        self.commit_observer.stop().await;
     }
 
     /// Calls `BlockManager::try_accept_blocks` and broadcasts each accepted block to any active

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -22,6 +22,7 @@ use crate::{
     core_thread::CoreError::Shutdown,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
+    task::join_and_propagate_panic,
 };
 
 const CORE_THREAD_COMMANDS_CHANNEL_SIZE: usize = 2000;
@@ -86,7 +87,7 @@ impl CoreThreadHandle {
     pub async fn stop(self) {
         // drop the sender, that will force all the other weak senders to not able to upgrade.
         drop(self.sender);
-        self.join_handle.await.ok();
+        join_and_propagate_panic(self.join_handle).await;
     }
 }
 
@@ -100,6 +101,12 @@ struct CoreThread {
 
 impl CoreThread {
     pub async fn run(mut self) -> ConsensusResult<()> {
+        let result = self.run_inner().await;
+        self.core.stop().await;
+        result
+    }
+
+    async fn run_inner(&mut self) -> ConsensusResult<()> {
         tracing::debug!("Started core thread");
 
         loop {

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -13,7 +13,10 @@ use tokio::{
 };
 use tracing::{debug, warn};
 
-use crate::{context::Context, core::CoreSignalsReceivers, core_thread::CoreThreadDispatcher};
+use crate::{
+    context::Context, core::CoreSignalsReceivers, core_thread::CoreThreadDispatcher,
+    task::join_and_propagate_panic,
+};
 
 pub(crate) struct LeaderTimeoutTaskHandle {
     handle: JoinHandle<()>,
@@ -23,7 +26,7 @@ pub(crate) struct LeaderTimeoutTaskHandle {
 impl LeaderTimeoutTaskHandle {
     pub async fn stop(self) {
         self.stop.send(()).ok();
-        self.handle.await.ok();
+        join_and_propagate_panic(self.handle).await;
     }
 }
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -40,6 +40,7 @@ mod stake_aggregator;
 pub mod storage;
 mod subscriber;
 mod synchronizer;
+mod task;
 mod threshold_clock;
 mod transaction;
 mod transaction_vote_tracker;

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    pin::Pin,
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -395,12 +400,25 @@ impl ObserverNetworkClient for TonicObserverClient {
 /// Proxies Observer Tonic requests to ObserverNetworkService.
 /// Extracts peer NodeId from TLS certificates and delegates to the service layer.
 pub(crate) struct ObserverServiceProxy<S: ObserverNetworkService> {
-    service: Arc<S>,
+    // ObserverServiceProxy is cloned into per-connection server tasks, which complete on the
+    // network's schedule during graceful shutdown, and can briefly outlive the node if it is
+    // dropped without stop(). Hold the service weakly so lingering connections cannot extend
+    // the life of the observer service and its state; requests racing shutdown fail with
+    // `unavailable` instead.
+    service: Weak<S>,
 }
 
 impl<S: ObserverNetworkService> ObserverServiceProxy<S> {
     pub(crate) fn new(service: Arc<S>) -> Self {
-        Self { service }
+        Self {
+            service: Arc::downgrade(&service),
+        }
+    }
+
+    fn service(&self) -> Result<Arc<S>, tonic::Status> {
+        self.service
+            .upgrade()
+            .ok_or_else(|| tonic::Status::unavailable("Consensus authority is shutting down"))
     }
 }
 
@@ -426,7 +444,7 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
         let highest_round_per_authority = request.into_inner().highest_round_per_authority;
 
         let block_stream = self
-            .service
+            .service()?
             .handle_stream_blocks(peer_id, highest_round_per_authority)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
@@ -475,7 +493,7 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
         let fetch_after_rounds = inner.fetch_after_rounds;
         let fetch_missing_ancestors = inner.fetch_missing_ancestors;
         let blocks = self
-            .service
+            .service()?
             .handle_fetch_blocks(
                 peer_id,
                 block_refs,
@@ -509,7 +527,7 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
             })?;
         let request = request.into_inner();
         let (commits, certifier_blocks) = self
-            .service
+            .service()?
             .handle_fetch_commits(peer_id, (request.start..=request.end).into())
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -5,7 +5,7 @@ use std::{
     collections::BTreeMap,
     net::{SocketAddr, SocketAddrV4, SocketAddrV6},
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Weak},
     time::{Duration, Instant},
 };
 
@@ -541,12 +541,26 @@ impl ChannelPool {
 /// Proxies Tonic requests to NetworkService with actual handler implementation.
 struct TonicServiceProxy<S: ValidatorNetworkService> {
     context: Arc<Context>,
-    service: Arc<S>,
+    // TonicServiceProxy is cloned into per-connection server tasks, which complete on the
+    // network's schedule during graceful shutdown, and can briefly outlive the node if it is
+    // dropped without stop(). Hold the service weakly so lingering connections cannot extend
+    // the life of the authority service and its state; requests racing shutdown fail with
+    // `unavailable` instead.
+    service: Weak<S>,
 }
 
 impl<S: ValidatorNetworkService> TonicServiceProxy<S> {
     fn new(context: Arc<Context>, service: Arc<S>) -> Self {
-        Self { context, service }
+        Self {
+            context,
+            service: Arc::downgrade(&service),
+        }
+    }
+
+    fn service(&self) -> Result<Arc<S>, tonic::Status> {
+        self.service
+            .upgrade()
+            .ok_or_else(|| tonic::Status::unavailable("Consensus authority is shutting down"))
     }
 }
 
@@ -568,7 +582,7 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
             block,
             excluded_ancestors: vec![],
         };
-        self.service
+        self.service()?
             .handle_send_block(peer_index, block)
             .await
             .map_err(|e| tonic::Status::invalid_argument(format!("{e:?}")))?;
@@ -604,7 +618,7 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
             }
         };
         let stream = self
-            .service
+            .service()?
             .handle_subscribe_blocks(peer_index, first_request.last_received_round)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?
@@ -648,7 +662,7 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
         let fetch_after_rounds = inner.fetch_after_rounds;
         let fetch_missing_ancestors = inner.fetch_missing_ancestors;
         let blocks = self
-            .service
+            .service()?
             .handle_fetch_blocks(
                 peer_index,
                 block_refs,
@@ -680,7 +694,7 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
         };
         let request = request.into_inner();
         let (commits, certifier_blocks) = self
-            .service
+            .service()?
             .handle_fetch_commits(peer_index, (request.start..=request.end).into())
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
@@ -730,7 +744,7 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
         }
 
         let blocks = self
-            .service
+            .service()?
             .handle_fetch_latest_blocks(peer_index, authorities)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
@@ -756,7 +770,7 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
         let (highest_received, highest_accepted) = self
-            .service
+            .service()?
             .handle_get_latest_rounds(peer_index)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, Weak},
     time::Duration,
 };
 
@@ -14,7 +11,8 @@ use futures::StreamExt;
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use parking_lot::Mutex;
 use tokio::{
-    task::{JoinHandle, JoinSet},
+    sync::oneshot,
+    task::{JoinError, JoinHandle, JoinSet},
     time::sleep,
 };
 use tracing::{debug, info, warn};
@@ -26,6 +24,7 @@ use crate::{
     dag_state::DagState,
     error::ConsensusError,
     network::{ObserverNetworkClient, ObserverNetworkService, PeerId, RandomnessSignatureHandler},
+    task::{join_and_propagate_panic, reap_finished_task, shutdown_join_set},
 };
 
 /// ObserverSubscriber manages block stream subscriptions to peers (validators or other observers),
@@ -37,8 +36,41 @@ pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetwor
     observer_service: Arc<S>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     dag_state: Arc<parking_lot::RwLock<DagState>>,
-    subscription: Arc<Mutex<Option<JoinHandle<()>>>>,
+    subscriptions: Mutex<Subscriptions>,
     randomness_signature_handler: Option<Arc<dyn RandomnessSignatureHandler>>,
+}
+
+/// The current and retired subscriptions are tracked under a single lock, so replacing the
+/// current subscription and retiring the previous one is atomic w.r.t. concurrent subscribe()
+/// and stop() calls.
+struct Subscriptions {
+    current: Option<ObserverSubscription>,
+    // Retain replaced subscription tasks so stop() can await them and propagate panics.
+    retired: Vec<ObserverSubscription>,
+}
+
+struct ObserverSubscription {
+    // Signals the subscription task to stop cooperatively, instead of aborting it. Aborting
+    // would drop the block handler JoinSet owned by the task, which aborts the handlers without
+    // awaiting them: they could briefly keep running (holding strong references to the observer
+    // service) and any panic recorded in the set would be discarded. On this signal the task
+    // stops streaming, then cancels the remaining block handlers and awaits their termination,
+    // so join() returns only after no block handler is running and recorded handler panics
+    // have propagated.
+    shutdown_sender: Option<oneshot::Sender<()>>,
+    subscription_task: JoinHandle<()>,
+}
+
+impl ObserverSubscription {
+    fn request_shutdown(&mut self) {
+        if let Some(sender) = self.shutdown_sender.take() {
+            let _ = sender.send(());
+        }
+    }
+
+    async fn join(self) {
+        join_and_propagate_panic(self.subscription_task).await;
+    }
 }
 
 impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, S> {
@@ -56,26 +88,28 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             observer_service,
             commit_vote_monitor,
             dag_state,
-            subscription: Arc::new(Mutex::new(None)),
+            subscriptions: Mutex::new(Subscriptions {
+                current: None,
+                retired: Vec::new(),
+            }),
             randomness_signature_handler,
         }
     }
 
     /// Subscribe to a peer (validator or observer) to receive block streams. The `ObserverSubscriber` can only subscribe to one peer at a time.
-    /// The method will abort the existing subscription (if any) and start a new one.
+    /// The method will stop the existing subscription (if any) and start a new one.
     pub(crate) fn subscribe(&self, peer: PeerId) {
         let context = self.context.clone();
         let network_client = self.network_client.clone();
-        let observer_service = self.observer_service.clone();
+        // ObserverSubscriber already holds these resources strongly. Give subscription tasks weak
+        // references so they do not become additional owners during shutdown.
+        let observer_service = Arc::downgrade(&self.observer_service);
         let commit_vote_monitor = self.commit_vote_monitor.clone();
-        let dag_state = self.dag_state.clone();
+        let dag_state = Arc::downgrade(&self.dag_state);
         let randomness_signature_handler = self.randomness_signature_handler.clone();
 
-        let mut subscription = self.subscription.lock();
-        if let Some(handle) = subscription.take() {
-            handle.abort();
-        }
-        *subscription = Some(spawn_monitored_task!(Self::subscription_loop(
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let subscription_task = spawn_monitored_task!(Self::subscription_loop(
             context,
             network_client,
             observer_service,
@@ -83,25 +117,88 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             dag_state,
             peer,
             randomness_signature_handler,
-        )));
+            shutdown_receiver,
+        ));
+
+        let mut subscriptions = self.subscriptions.lock();
+        // Reap retired subscriptions that have finished, so the list stays bounded under
+        // repeated resubscriptions.
+        subscriptions
+            .retired
+            .retain_mut(|subscription| !reap_finished_task(&mut subscription.subscription_task));
+        let previous_subscription = subscriptions.current.replace(ObserverSubscription {
+            shutdown_sender: Some(shutdown_sender),
+            subscription_task,
+        });
+        if let Some(mut previous_subscription) = previous_subscription {
+            previous_subscription.request_shutdown();
+            subscriptions.retired.push(previous_subscription);
+        }
     }
 
     /// Stop the active subscription (if any).
-    pub(crate) fn stop(&self) {
-        let mut subscription = self.subscription.lock();
-        if let Some(handle) = subscription.take() {
-            handle.abort();
+    pub(crate) async fn stop(&self) {
+        let mut subscriptions = {
+            let mut subscriptions = self.subscriptions.lock();
+            let mut all = std::mem::take(&mut subscriptions.retired);
+            all.extend(subscriptions.current.take());
+            all
+        };
+        for subscription in &mut subscriptions {
+            subscription.request_shutdown();
+        }
+        for subscription in subscriptions {
+            subscription.join().await;
         }
     }
 
     async fn subscription_loop(
         context: Arc<Context>,
         network_client: Arc<C>,
-        observer_service: Arc<S>,
+        observer_service: Weak<S>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
-        dag_state: Arc<parking_lot::RwLock<DagState>>,
+        dag_state: Weak<parking_lot::RwLock<DagState>>,
         peer: PeerId,
         randomness_signature_handler: Option<Arc<dyn RandomnessSignatureHandler>>,
+        mut shutdown_receiver: oneshot::Receiver<()>,
+    ) {
+        let mut tasks = JoinSet::new();
+        {
+            // The `subscription` future borrows `tasks` mutably to spawn block handlers, so it
+            // is scoped to this block. When shutdown is signaled, the select below returns and
+            // `subscription` is dropped at the end of the block. This stops block streaming, but
+            // the current task (subscription_loop) and the block handlers already spawned into
+            // `tasks` keep running. Dropping `subscription` also ends the `&mut tasks` borrow,
+            // so the block handlers in `tasks` can be awaited below.
+            let subscription = Self::run_subscription(
+                context,
+                network_client,
+                observer_service,
+                commit_vote_monitor,
+                dag_state,
+                peer,
+                randomness_signature_handler,
+                &mut tasks,
+            );
+            tokio::pin!(subscription);
+            tokio::select! {
+                _ = &mut shutdown_receiver => {}
+                _ = &mut subscription => {}
+            }
+        }
+
+        shutdown_join_set(&mut tasks).await;
+    }
+
+    async fn run_subscription(
+        context: Arc<Context>,
+        network_client: Arc<C>,
+        observer_service: Weak<S>,
+        commit_vote_monitor: Arc<CommitVoteMonitor>,
+        dag_state: Weak<parking_lot::RwLock<DagState>>,
+        peer: PeerId,
+        randomness_signature_handler: Option<Arc<dyn RandomnessSignatureHandler>>,
+        tasks: &mut JoinSet<()>,
     ) {
         const IMMEDIATE_RETRIES: i64 = 3;
         const MIN_TIMEOUT: Duration = Duration::from_millis(500);
@@ -109,8 +206,8 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             Duration::from_millis(100),
             Duration::from_secs(10),
         );
-
         let mut retries: i64 = 0;
+
         'subscription: loop {
             let mut delay = Duration::ZERO;
             if retries > IMMEDIATE_RETRIES {
@@ -132,6 +229,9 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             // already-seen blocks. Clamp to the GC round, since blocks below it would
             // be skipped anyway.
             let highest_round_per_authority = {
+                let Some(dag_state) = dag_state.upgrade() else {
+                    return;
+                };
                 let ds = dag_state.read();
                 let gc_round = ds.gc_round();
                 let mut rounds = vec![0 as Round; context.committee.size()];
@@ -160,15 +260,19 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                 }
             };
 
-            // On-demand task spawning with atomic counter for tracking active tasks
             let max_parallel_tasks = context.committee.size();
-            let active_tasks = Arc::new(AtomicUsize::new(0));
-            let mut tasks = JoinSet::new();
-
             'stream: loop {
                 let _scope = monitored_scope("ObserverSubscriberStreamConsumer");
 
-                match blocks.next().await {
+                let next_item = tokio::select! {
+                    result = tasks.join_next(), if !tasks.is_empty() => {
+                        Self::handle_task_result(result);
+                        continue 'stream;
+                    }
+                    item = blocks.next(), if tasks.len() < max_parallel_tasks => item,
+                };
+
+                match next_item {
                     Some(item) => {
                         context
                             .metrics
@@ -178,12 +282,15 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
 
                         // During catch-up (commit lagging behind quorum), drop silently --
                         // those rounds will arrive via checkpoint sync, same as lagging validators.
-                        if let Some(handler) = &randomness_signature_handler
-                            && !is_commit_lagging(
+                        let is_commit_lagging = dag_state.upgrade().is_none_or(|dag_state| {
+                            is_commit_lagging(
                                 &context,
                                 dag_state.read().last_commit_index(),
                                 commit_vote_monitor.quorum_commit_index(),
                             )
+                        });
+                        if let Some(handler) = &randomness_signature_handler
+                            && !is_commit_lagging
                         {
                             for sig in item.auxiliary_data.randomness_signatures {
                                 handler.handle_randomness_signature(sig);
@@ -191,37 +298,20 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                         }
 
                         for block in item.blocks {
-                            // Backpressure: wait if we've hit max parallelism
-                            while active_tasks.load(Ordering::Acquire) >= max_parallel_tasks {
-                                // Block until a task completes instead of busy-waiting
-                                match tasks.join_next().await {
-                                    Some(Ok(_)) => {
-                                        // Task completed successfully, counter already decremented
-                                    }
-                                    Some(Err(e)) => {
-                                        warn!("Task failed with error: {}", e);
-                                    }
-                                    None => {
-                                        // This shouldn't happen if our counter is accurate
-                                        warn!(
-                                            "No tasks to join but counter shows {} active tasks",
-                                            active_tasks.load(Ordering::Acquire)
-                                        );
-                                        break;
-                                    }
-                                }
+                            // Backpressure: wait if we've hit max parallelism.
+                            while tasks.len() >= max_parallel_tasks {
+                                Self::handle_task_result(tasks.join_next().await);
                             }
 
-                            // Spawn a new task to handle this block
-                            active_tasks.fetch_add(1, Ordering::AcqRel);
-                            let counter = active_tasks.clone();
                             let observer_service = observer_service.clone();
                             let peer_cloned = peer.clone();
-
                             tasks.spawn(async move {
                                 let _scope =
                                     monitored_scope("ObserverSubscriberTask::handle_block");
 
+                                let Some(observer_service) = observer_service.upgrade() else {
+                                    return;
+                                };
                                 let result = observer_service
                                     .handle_block(peer_cloned.clone(), block)
                                     .await;
@@ -241,9 +331,6 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                                         }
                                     }
                                 }
-
-                                // Decrement counter when done
-                                counter.fetch_sub(1, Ordering::AcqRel);
                             });
                         }
 
@@ -259,36 +346,35 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                 }
             }
 
-            // Wait for all spawned tasks to complete
-            while let Some(result) = tasks.join_next().await {
-                match result {
-                    Ok(_) => {} // Task completed successfully
-                    Err(e) => warn!("Task failed during cleanup: {}", e),
-                }
+            while !tasks.is_empty() {
+                Self::handle_task_result(tasks.join_next().await);
             }
+        }
+    }
 
-            // Sanity check: ensure all tasks have completed
-            let remaining = active_tasks.load(Ordering::Acquire);
-            if remaining > 0 {
-                warn!(
-                    "Warning: {} tasks still marked as active after cleanup",
-                    remaining
-                );
+    fn handle_task_result(result: Option<Result<(), JoinError>>) {
+        if let Some(Err(error)) = result {
+            if error.is_panic() {
+                std::panic::resume_unwind(error.into_panic());
             }
+            warn!("Observer block handler task was cancelled: {error}");
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{future::pending, sync::Arc, time::Duration};
 
     use async_trait::async_trait;
     use bytes::Bytes;
     use consensus_types::block::{BlockRef, Round};
     use futures::stream;
     use parking_lot::{Mutex, RwLock};
-    use tokio::time::sleep;
+    use tokio::{
+        sync::Notify,
+        time::{sleep, timeout},
+    };
 
     use super::*;
     use crate::{
@@ -359,12 +445,24 @@ mod tests {
 
     struct ObserverSubscriberTestService {
         handle_block_calls: Mutex<Vec<(PeerId, Bytes)>>,
+        block_handlers: bool,
+        handler_started: Notify,
     }
 
     impl ObserverSubscriberTestService {
         fn new() -> Self {
             Self {
                 handle_block_calls: Mutex::new(Vec::new()),
+                block_handlers: false,
+                handler_started: Notify::new(),
+            }
+        }
+
+        fn new_blocking() -> Self {
+            Self {
+                handle_block_calls: Mutex::new(Vec::new()),
+                block_handlers: true,
+                handler_started: Notify::new(),
             }
         }
     }
@@ -373,6 +471,10 @@ mod tests {
     impl ObserverNetworkService for ObserverSubscriberTestService {
         async fn handle_block(&self, peer: PeerId, block: Bytes) -> ConsensusResult<()> {
             self.handle_block_calls.lock().push((peer, block));
+            self.handler_started.notify_one();
+            if self.block_handlers {
+                pending::<()>().await;
+            }
             Ok(())
         }
 
@@ -509,7 +611,7 @@ mod tests {
         let count_before_stop = observer_service.handle_block_calls.lock().len();
 
         // Test that stop() still works
-        subscriber.stop();
+        subscriber.stop().await;
 
         // Wait and verify no new blocks are received after stop
         sleep(Duration::from_millis(50)).await;
@@ -518,5 +620,41 @@ mod tests {
             count_before_stop, count_after_stop,
             "No new blocks should be received after stop()"
         );
+    }
+
+    #[tokio::test]
+    async fn test_stop_waits_for_block_handlers() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let observer_service = Arc::new(ObserverSubscriberTestService::new_blocking());
+        let network_client = Arc::new(ObserverSubscriberTestClient::new());
+        let store = Arc::new(MemStore::new());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        let subscriber = ObserverSubscriber::new(
+            context.clone(),
+            network_client,
+            observer_service.clone(),
+            commit_vote_monitor,
+            dag_state,
+            None,
+        );
+
+        let peer = PeerId::Validator(context.committee.to_authority_index(0).unwrap());
+        subscriber.subscribe(peer);
+        timeout(
+            Duration::from_secs(1),
+            observer_service.handler_started.notified(),
+        )
+        .await
+        .expect("Block handler should start");
+        assert!(Arc::strong_count(&observer_service) > 2);
+
+        timeout(Duration::from_secs(1), subscriber.stop())
+            .await
+            .expect("Subscriber should stop after cancelling block handlers");
+        assert_eq!(Arc::strong_count(&observer_service), 2);
     }
 }

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -27,7 +27,7 @@ use tokio::{task::JoinHandle, time::MissedTickBehavior};
 
 use crate::{
     BlockAPI as _, context::Context, core_thread::CoreThreadDispatcher, dag_state::DagState,
-    network::ValidatorNetworkClient, round_tracker::RoundTracker,
+    network::ValidatorNetworkClient, round_tracker::RoundTracker, task::join_and_propagate_panic,
 };
 
 // Handle to control the RoundProber loop and read latest round gaps.
@@ -40,11 +40,7 @@ impl RoundProberHandle {
     pub(crate) async fn stop(self) {
         let _ = self.shutdown_notify.notify();
         // Do not abort prober task, which waits for requests to be cancelled.
-        if let Err(e) = self.prober_task.await
-            && e.is_panic()
-        {
-            std::panic::resume_unwind(e.into_panic());
-        }
+        join_and_propagate_panic(self.prober_task).await;
     }
 }
 

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use consensus_config::AuthorityIndex;
 use consensus_types::block::Round;
@@ -17,6 +20,7 @@ use crate::{
     dag_state::DagState,
     error::ConsensusError,
     network::{ValidatorNetworkClient, ValidatorNetworkService},
+    task::{join_and_propagate_panic, reap_finished_task},
 };
 
 /// Subscriber manages the block stream subscriptions to other peers, taking care of retrying
@@ -30,6 +34,8 @@ pub(crate) struct Subscriber<C: ValidatorNetworkClient, S: ValidatorNetworkServi
     authority_service: Arc<S>,
     dag_state: Arc<RwLock<DagState>>,
     subscriptions: Arc<Mutex<Box<[Option<JoinHandle<()>>]>>>,
+    // Retain replaced subscription tasks so stop() can await them and propagate panics.
+    retired_subscriptions: Arc<Mutex<Vec<JoinHandle<()>>>>,
 }
 
 impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
@@ -48,6 +54,7 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             authority_service,
             dag_state,
             subscriptions: Arc::new(Mutex::new(subscriptions.into_boxed_slice())),
+            retired_subscriptions: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -58,8 +65,10 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         }
         let context = self.context.clone();
         let network_client = self.network_client.clone();
-        let authority_service = self.authority_service.clone();
-        let dag_state = self.dag_state.clone();
+        // Subscriber already holds these resources strongly. Give subscription tasks weak
+        // references so they do not become additional owners during shutdown.
+        let authority_service = Arc::downgrade(&self.authority_service);
+        let dag_state = Arc::downgrade(&self.dag_state);
 
         let mut subscriptions = self.subscriptions.lock();
         self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
@@ -72,10 +81,18 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         )));
     }
 
-    pub(crate) fn stop(&self) {
-        let mut subscriptions = self.subscriptions.lock();
-        for (peer, _) in self.context.committee.authorities() {
-            self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
+    pub(crate) async fn stop(&self) {
+        {
+            let mut subscriptions = self.subscriptions.lock();
+            for (peer, _) in self.context.committee.authorities() {
+                self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
+            }
+        }
+
+        // All retired subscriptions have already been aborted by unsubscribe_locked().
+        let subscriptions = std::mem::take(&mut *self.retired_subscriptions.lock());
+        for subscription in subscriptions {
+            join_and_propagate_panic(subscription).await;
         }
     }
 
@@ -83,6 +100,11 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
         let peer_hostname = &self.context.committee.authority(peer).hostname;
         if let Some(subscription) = subscription.take() {
             subscription.abort();
+            let mut retired_subscriptions = self.retired_subscriptions.lock();
+            // Reap retired subscriptions that have finished, so the list stays bounded under
+            // repeated resubscriptions.
+            retired_subscriptions.retain_mut(|task| !reap_finished_task(task));
+            retired_subscriptions.push(subscription);
         }
         // There is a race between shutting down the subscription task and clearing the metric here.
         // TODO: fix the race when unsubscribe_locked() gets called outside of stop().
@@ -97,8 +119,8 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
     async fn subscription_loop(
         context: Arc<Context>,
         network_client: Arc<C>,
-        authority_service: Arc<S>,
-        dag_state: Arc<RwLock<DagState>>,
+        authority_service: Weak<S>,
+        dag_state: Weak<RwLock<DagState>>,
         peer: AuthorityIndex,
     ) {
         const IMMEDIATE_RETRIES: i64 = 3;
@@ -139,6 +161,9 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
             // reconnection resumes from the latest accepted round rather than re-streaming and
             // re-verifying blocks that have been accepted since this subscription started.
             let last_received: Round = {
+                let Some(dag_state) = dag_state.upgrade() else {
+                    return;
+                };
                 let dag_state = dag_state.read();
                 let gc_round = dag_state.gc_round();
                 dag_state
@@ -198,6 +223,9 @@ impl<C: ValidatorNetworkClient, S: ValidatorNetworkService> Subscriber<C, S> {
                             .subscribed_blocks
                             .with_label_values(&[peer_hostname])
                             .inc();
+                        let Some(authority_service) = authority_service.upgrade() else {
+                            return;
+                        };
                         let result = authority_service.handle_send_block(peer, block).await;
                         if let Err(e) = result {
                             match e {

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -8,7 +8,7 @@ use std::{
 
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
-use consensus_types::block::{BlockRef, Round};
+use consensus_types::block::{BlockRef, Round, TransactionIndex};
 use futures::{StreamExt as _, stream::FuturesUnordered};
 use itertools::Itertools as _;
 use mysten_common::{ZipDebugEqIteratorExt, debug_fatal};
@@ -24,7 +24,7 @@ use tap::TapFallible;
 use tokio::{
     runtime::Handle,
     sync::{mpsc::error::TrySendError, oneshot},
-    task::{JoinError, JoinSet},
+    task::JoinSet,
     time::{Instant, sleep, sleep_until, timeout},
 };
 use tracing::{debug, info, trace, warn};
@@ -41,6 +41,7 @@ use crate::{
     network::{ObserverNetworkClient, PeerId, SynchronizerClient, ValidatorNetworkClient},
     peers_pool::PeersPool,
     round_tracker::RoundTracker,
+    task::shutdown_join_set,
 };
 use crate::{core_thread::CoreThreadDispatcher, transaction_vote_tracker::TransactionVoteTracker};
 
@@ -172,6 +173,9 @@ enum Command {
     },
     FetchOwnLastBlock,
     KickOffScheduler,
+    Shutdown {
+        result: oneshot::Sender<()>,
+    },
 }
 
 pub(crate) struct SynchronizerHandle {
@@ -199,13 +203,18 @@ impl SynchronizerHandle {
         receiver.await.map_err(|_err| ConsensusError::Shutdown)?
     }
 
-    pub(crate) async fn stop(&self) -> Result<(), JoinError> {
+    pub(crate) async fn stop(&self) {
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let _ = self
+            .commands_sender
+            .send(Command::Shutdown {
+                result: shutdown_sender,
+            })
+            .await;
+        let _ = shutdown_receiver.await;
+
         let mut tasks = self.tasks.lock().await;
-        tasks.abort_all();
-        while let Some(result) = tasks.join_next().await {
-            result?
-        }
-        Ok(())
+        shutdown_join_set(&mut tasks).await;
     }
 
     #[cfg(test)]
@@ -438,6 +447,12 @@ where
                                 scheduler_timeout.as_mut().reset(timeout);
                             }
                         }
+                        Command::Shutdown { result } => {
+                            self.shutdown_tasks().await;
+                            self.fetch_block_senders.clear();
+                            let _ = result.send(());
+                            return;
+                        }
                     }
                 },
                 Some(result) = self.fetch_own_last_block_task.join_next(), if !self.fetch_own_last_block_task.is_empty() => {
@@ -472,6 +487,7 @@ where
                     if self.fetch_blocks_scheduler_task.is_empty()
                         && let Err(err) = self.start_fetch_missing_blocks_task().await {
                             debug!("Core is shutting down, synchronizer is shutting down: {err:?}");
+                            self.shutdown_tasks().await;
                             return;
                         };
 
@@ -481,6 +497,13 @@ where
                 }
             }
         }
+    }
+
+    // Must be called before exiting run(), so no task is dropped without being awaited
+    // and task panics propagate.
+    async fn shutdown_tasks(&mut self) {
+        shutdown_join_set(&mut self.fetch_own_last_block_task).await;
+        shutdown_join_set(&mut self.fetch_blocks_scheduler_task).await;
     }
 
     async fn fetch_blocks_from_peer(
@@ -569,23 +592,19 @@ where
         serialized_blocks.truncate(context.parameters.max_blocks_per_sync);
 
         // Verify all the fetched blocks
-        let blocks = Handle::current()
+        let (blocks, voted_blocks) = Handle::current()
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
                 let context = context.clone();
                 let peer = peer.clone();
-                move || {
-                    Self::verify_blocks(
-                        serialized_blocks,
-                        block_verifier,
-                        transaction_vote_tracker,
-                        &context,
-                        peer,
-                    )
-                }
+                move || Self::verify_blocks(serialized_blocks, block_verifier, &context, peer)
             })
             .await
             .expect("Spawn blocking should not fail")?;
+
+        if context.protocol_config.transaction_voting_enabled() {
+            transaction_vote_tracker.add_voted_blocks(voted_blocks);
+        }
 
         // Record commit votes from the verified blocks.
         for block in &blocks {
@@ -675,10 +694,12 @@ where
     fn verify_blocks(
         serialized_blocks: Vec<Bytes>,
         block_verifier: Arc<V>,
-        transaction_vote_tracker: TransactionVoteTracker,
         context: &Context,
         peer: PeerId,
-    ) -> ConsensusResult<Vec<VerifiedBlock>> {
+    ) -> ConsensusResult<(
+        Vec<VerifiedBlock>,
+        Vec<(VerifiedBlock, Vec<TransactionIndex>)>,
+    )> {
         let mut verified_blocks = Vec::new();
         let mut voted_blocks = Vec::new();
         for serialized_block in serialized_blocks {
@@ -726,11 +747,7 @@ where
             voted_blocks.push((verified_block, reject_txn_votes));
         }
 
-        if context.protocol_config.transaction_voting_enabled() {
-            transaction_vote_tracker.add_voted_blocks(voted_blocks);
-        }
-
-        Ok(verified_blocks)
+        Ok((verified_blocks, voted_blocks))
     }
 
     async fn fetch_blocks_request(
@@ -2313,12 +2330,8 @@ mod tests {
             1
         );
 
-        // Ensure that no panic occurred
-        if let Err(err) = handle.stop().await
-            && err.is_panic()
-        {
-            std::panic::resume_unwind(err.into_panic());
-        }
+        // Ensure that no panic occurred: stop() propagates panics from synchronizer tasks.
+        handle.stop().await;
     }
 
     #[tokio::test]

--- a/consensus/core/src/task.rs
+++ b/consensus/core/src/task.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::FutureExt as _;
+use tokio::task::{JoinHandle, JoinSet};
+
+/// Awaits the task and propagates its panic if it panicked. Task cancellation is ignored.
+pub(crate) async fn join_and_propagate_panic<T>(task: JoinHandle<T>) {
+    if let Err(error) = task.await
+        && error.is_panic()
+    {
+        std::panic::resume_unwind(error.into_panic());
+    }
+}
+
+/// Aborts all tasks in the set and awaits them, propagating the first panic among them.
+/// Task cancellations are ignored.
+pub(crate) async fn shutdown_join_set<T: 'static>(tasks: &mut JoinSet<T>) {
+    tasks.abort_all();
+    // Drain the whole set before propagating a panic, so no task is dropped without
+    // being awaited.
+    let mut first_panic = None;
+    while let Some(result) = tasks.join_next().await {
+        if let Err(error) = result
+            && error.is_panic()
+            && first_panic.is_none()
+        {
+            first_panic = Some(error.into_panic());
+        }
+    }
+    if let Some(panic) = first_panic {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+/// Reaps the task if it has finished, propagating its panic if it panicked.
+/// Returns true when the task has been reaped and can be dropped.
+pub(crate) fn reap_finished_task(task: &mut JoinHandle<()>) -> bool {
+    if !task.is_finished() {
+        return false;
+    }
+    // A finished task completes immediately when polled.
+    if let Some(Err(error)) = task.now_or_never()
+        && error.is_panic()
+    {
+        std::panic::resume_unwind(error.into_panic());
+    }
+    true
+}


### PR DESCRIPTION
## Description 

Authority shutdown previously aborted component tasks and dropped their JoinHandles, which could leak resources across an in-process restart and silently swallow task panics. This PR makes shutdown deterministic, in preparation for crash-and-restart simtests (stacked on top as #27311):

- Components stop by finishing their tasks instead of dropping them. Observer subscriptions shut down cooperatively so in-flight block handlers are awaited; replaced subscriptions are retired and joined at stop, with finished tasks reaped on resubscription to keep the retired list bounded. The observer's current and retired subscriptions are tracked under a single lock so replace-and-retire is atomic w.r.t. concurrent subscribe() and stop().
- Subscription and network proxy tasks hold weak references to services, and `AuthorityNode::stop()` verifies DagState ownership was released.
- Task panics propagate consistently through every stop path (core thread, synchronizer, commit syncer, commit finalizer, subscribers) via shared helpers in `consensus/core/src/task.rs`, replacing six hand-rolled abort/join/resume_unwind copies.
- Documents shutdown ownership of consensus components, and avoids deep-cloning reject transaction vote indices in commit syncer fetches.

## Test plan 

- `cargo nextest run -p consensus-core`: all 286 unit tests pass, including new shutdown tests (e.g. `test_stop_waits_for_block_handlers`).
- `cargo simtest -p consensus-simtests`: the existing simtests pass unchanged against the new shutdown behavior.
- clippy (xclippy lint set) and `cargo fmt` clean.