### PR TITLE
Various sui-kv-rpc improvements

### DIFF
--- a/crates/sui-kv-rpc/src/bigtable_client.rs
+++ b/crates/sui-kv-rpc/src/bigtable_client.rs
@@ -58,24 +58,27 @@ use sui_types::storage::ObjectKey;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 
-/// Stage label values for the `permit_wait_ms` metric. `&'static str` so they
+/// Stage label values for the permit timing metrics. `&'static str` so they
 /// satisfy `with_label_values` zero-allocation.
 pub(crate) mod stage {
     pub const TRANSACTIONS: &str = "transactions";
     pub const OBJECTS: &str = "objects";
     pub const TX_SEQ_DIGEST: &str = "tx_seq_digest";
+    pub const TX_CP_RESOLVE: &str = "tx_cp_resolve";
     pub const CHECKPOINTS: &str = "checkpoints";
 }
 
 /// Histograms for tuning the request-scoped `BigTableClient` semaphore.
-/// Cardinality is bounded: 3 methods × 4 stages = 12 series for
-/// `permit_wait_ms`, 3 series for the request-end `permits_peak` and
-/// `ops_total` histograms.
+/// Cardinality is bounded: 3 methods × 5 stages = 15 series each for
+/// `permit_wait_ms` and `permit_hold_ms`, and 3 series each for the request-end
+/// `permits_peak` and `ops_total` histograms.
 #[derive(Clone)]
 pub(crate) struct Metrics {
     /// Time spent waiting for one limiter permit, recorded once per successful
     /// `acquire_owned()` call.
     pub permit_wait_ms: HistogramVec,
+    /// Time one limiter permit is held from acquisition through release.
+    pub permit_hold_ms: HistogramVec,
     /// Peak in-use permit count observed during a single request, recorded
     /// once when the request's `BigTableClient` is dropped.
     pub permits_peak: HistogramVec,
@@ -95,11 +98,22 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            permit_hold_ms: register_histogram_vec_with_registry!(
+                "kv_rpc_bigtable_permit_hold_ms",
+                "Time a request-scoped BigTable limiter permit is held, from successful acquire to release (the gated stream's full drain or drop).",
+                &["method", "stage"],
+                prometheus::exponential_buckets(0.5, 2.0, 16).unwrap(),
+                registry,
+            )
+            .unwrap(),
             permits_peak: register_histogram_vec_with_registry!(
                 "kv_rpc_bigtable_permits_peak",
                 "Peak in-use BigTable limiter permits observed during a single list request.",
                 &["method"],
-                vec![1.0, 2.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0],
+                vec![
+                    1.0, 2.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0, 65.0, 80.0,
+                    100.0, 130.0, 166.0, 200.0,
+                ],
                 registry,
             )
             .unwrap(),
@@ -290,7 +304,7 @@ impl BigTableClient {
         &self,
         tx_sequence_numbers: &[u64],
     ) -> Result<Vec<(u64, CheckpointSequenceNumber)>, RpcError> {
-        let _permit = self.acquire(stage::CHECKPOINTS).await?;
+        let _permit = self.acquire(stage::TX_CP_RESOLVE).await?;
         self.inner
             .clone()
             .resolve_tx_checkpoints(tx_sequence_numbers)
@@ -305,7 +319,7 @@ impl BigTableClient {
         tx_sequence_numbers: Vec<u64>,
     ) -> Result<BoxStream<'static, Result<(u64, CheckpointSequenceNumber), anyhow::Error>>, RpcError>
     {
-        let permit = self.acquire(stage::CHECKPOINTS).await?;
+        let permit = self.acquire(stage::TX_CP_RESOLVE).await?;
         let inner = self
             .inner
             .clone()
@@ -431,10 +445,18 @@ pub(crate) type WmResolverFut =
 struct LimitedPermit {
     _permit: OwnedSemaphorePermit,
     context: Arc<BigTableClientContext>,
+    stage: &'static str,
+    acquired_at: Instant,
 }
 
 impl Drop for LimitedPermit {
     fn drop(&mut self) {
+        let hold_ms = self.acquired_at.elapsed().as_secs_f64() * 1000.0;
+        self.context
+            .metrics
+            .permit_hold_ms
+            .with_label_values(&[self.context.method, self.stage])
+            .observe(hold_ms);
         record_release(&self.context);
     }
 }
@@ -446,10 +468,13 @@ async fn acquire_limited(
 ) -> Result<LimitedPermit, tokio::sync::AcquireError> {
     let start = Instant::now();
     let permit = limiter.acquire_owned().await?;
-    record_acquired(&context, stage, start.elapsed());
+    let acquired_at = Instant::now();
+    record_acquired(&context, stage, acquired_at.duration_since(start));
     Ok(LimitedPermit {
         _permit: permit,
         context,
+        stage,
+        acquired_at,
     })
 }
 
@@ -657,6 +682,37 @@ mod tests {
             histogram_sample_count(family(&families, "kv_rpc_bigtable_ops_total")),
             1,
             "ops_total observed once on context drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn limited_permit_records_hold_once_on_drop() {
+        let (metrics, registry) = Metrics::for_testing();
+        let context = test_context(metrics, "list_transactions");
+        let limiter = Arc::new(Semaphore::new(1));
+
+        let permit = acquire_limited(limiter.clone(), context.clone(), stage::TX_CP_RESOLVE)
+            .await
+            .unwrap();
+        assert_eq!(limiter.available_permits(), 0);
+
+        drop(permit);
+        assert_eq!(limiter.available_permits(), 1);
+        drop(context);
+
+        let families = registry.gather();
+        let permit_hold = family(&families, "kv_rpc_bigtable_permit_hold_ms");
+        assert_eq!(histogram_sample_count(permit_hold), 1);
+        let labels = permit_hold.get_metric()[0].get_label();
+        assert!(
+            labels
+                .iter()
+                .any(|label| label.name() == "method" && label.value() == "list_transactions")
+        );
+        assert!(
+            labels
+                .iter()
+                .any(|label| label.name() == "stage" && label.value() == "tx_cp_resolve")
         );
     }
 

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -17,6 +17,7 @@ use sui_kvstore::validate_pipeline_name;
 use crate::default_service_info_watermark_pipelines;
 
 const DEFAULT_LEDGER_HISTORY_METHOD_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_RENDER_AHEAD: usize = 4;
 const DEFAULT_BITMAP_BUCKET_BUDGET_TX: u64 = 1_024;
 const DEFAULT_BITMAP_BUCKET_BUDGET_EVENT: u64 = 1_024;
 const DEFAULT_MAX_BITMAP_FILTER_LITERALS: usize = 10;
@@ -30,19 +31,23 @@ const DEFAULT_STAGE_CONCURRENCY: usize = 10;
 struct LedgerHistoryMethodDefaults {
     default_limit_items: u32,
     max_limit_items: u32,
+    render_ahead: usize,
 }
 
 const LIST_TRANSACTIONS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMethodDefaults {
     default_limit_items: 50,
     max_limit_items: 500,
+    render_ahead: DEFAULT_RENDER_AHEAD,
 };
 const LIST_EVENTS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMethodDefaults {
     default_limit_items: 50,
     max_limit_items: 1_000,
+    render_ahead: DEFAULT_RENDER_AHEAD,
 };
 const LIST_CHECKPOINTS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMethodDefaults {
     default_limit_items: 10,
     max_limit_items: 100,
+    render_ahead: DEFAULT_RENDER_AHEAD,
 };
 
 /// Per-endpoint tunables for one ledger-history list API. Every field is
@@ -62,6 +67,12 @@ pub struct LedgerHistoryMethodConfig {
     /// Upper bound a request's `limit_items` is clamped to.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_limit_items: Option<u32>,
+
+    /// Bounds admitted render tasks and retained rendered responses for this
+    /// endpoint's render-ahead stage. Defaults to `4`; `1` serializes rendering
+    /// with emission.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub render_ahead: Option<usize>,
 }
 
 /// A [`LedgerHistoryMethodConfig`] with all defaults applied.
@@ -70,6 +81,7 @@ pub struct ResolvedLedgerHistoryMethodConfig {
     pub timeout: Duration,
     pub default_limit_items: u32,
     pub max_limit_items: u32,
+    pub render_ahead: usize,
 }
 
 impl LedgerHistoryMethodConfig {
@@ -88,6 +100,9 @@ impl LedgerHistoryMethodConfig {
             max_limit_items: this
                 .and_then(|c| c.max_limit_items)
                 .unwrap_or(defaults.max_limit_items),
+            render_ahead: this
+                .and_then(|c| c.render_ahead)
+                .unwrap_or(defaults.render_ahead),
         }
     }
 }
@@ -287,6 +302,16 @@ impl LedgerHistoryConfig {
     /// leaving the client a cursorless `QueryEnd` it cannot resume from. Mirrors
     /// the fullnode side's `LedgerHistoryConfig::validate`.
     pub fn validate(&self) -> anyhow::Result<()> {
+        for (name, endpoint) in [
+            ("list_transactions", self.list_transactions()),
+            ("list_events", self.list_events()),
+            ("list_checkpoints", self.list_checkpoints()),
+        ] {
+            anyhow::ensure!(
+                endpoint.render_ahead > 0,
+                "ledger_history.{name}.render_ahead must be greater than zero",
+            );
+        }
         anyhow::ensure!(
             self.max_bitmap_filter_literals() > 0,
             "ledger_history.max_bitmap_filter_literals must be greater than zero",
@@ -563,6 +588,19 @@ mod tests {
     #[test]
     fn validate_accepts_defaults() {
         LedgerHistoryConfig::default().validate().unwrap();
+        assert_eq!(
+            LedgerHistoryConfig::default()
+                .list_checkpoints()
+                .render_ahead,
+            4
+        );
+        assert_eq!(
+            LedgerHistoryConfig::default()
+                .list_transactions()
+                .render_ahead,
+            4
+        );
+        assert_eq!(LedgerHistoryConfig::default().list_events().render_ahead, 4);
     }
 
     #[test]
@@ -624,13 +662,33 @@ stages:
     }
 
     #[test]
+    fn validate_rejects_zero_render_ahead() {
+        let cfg = LedgerHistoryConfig {
+            list_events: Some(LedgerHistoryMethodConfig {
+                render_ahead: Some(0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = cfg
+            .validate()
+            .expect_err("zero render_ahead must fail validation");
+        assert!(
+            err.to_string()
+                .contains("ledger_history.list_events.render_ahead"),
+            "{err}"
+        );
+    }
+
+    #[test]
     fn partial_yaml_falls_back_to_defaults() {
-        // Only one nested knob set; everything else must resolve to defaults.
+        // Only one endpoint is customized; everything else must resolve to defaults.
         let yaml = r#"
 instance-id: my-instance
 ledger-history:
   list-transactions:
     max-limit-items: 7
+    render-ahead: 3
   bitmap-bucket-budget-tx: 2048
 "#;
         let cfg: KvRpcConfig = serde_yaml::from_str(yaml).unwrap();
@@ -643,6 +701,8 @@ ledger-history:
         // Untouched sibling falls back to the per-endpoint default.
         assert_eq!(lh.list_transactions().default_limit_items, 50);
         assert_eq!(lh.bitmap_bucket_budget_tx(), 2048);
+        assert_eq!(lh.list_transactions().render_ahead, 3);
+        assert_eq!(lh.list_events().render_ahead, 4);
         assert_eq!(lh.bitmap_bucket_budget_event(), 1024);
         lh.validate().unwrap();
     }

--- a/crates/sui-kv-rpc/src/config.rs
+++ b/crates/sui-kv-rpc/src/config.rs
@@ -16,15 +16,18 @@ use sui_kvstore::validate_pipeline_name;
 
 use crate::default_service_info_watermark_pipelines;
 
-const DEFAULT_LEDGER_HISTORY_METHOD_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_LEDGER_HISTORY_METHOD_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_RENDER_AHEAD: usize = 4;
-const DEFAULT_BITMAP_BUCKET_BUDGET_TX: u64 = 1_024;
-const DEFAULT_BITMAP_BUCKET_BUDGET_EVENT: u64 = 1_024;
+const DEFAULT_BITMAP_BUCKET_BUDGET_TX: u64 = 4_000;
+const DEFAULT_BITMAP_BUCKET_BUDGET_EVENT: u64 = 4_000;
 const DEFAULT_MAX_BITMAP_FILTER_LITERALS: usize = 10;
 const DEFAULT_BITMAP_DRAIN_PROBE_ROWS: u32 = 50;
-const DEFAULT_REQUEST_BIGTABLE_CONCURRENCY: usize = 10;
+const DEFAULT_REQUEST_BIGTABLE_CONCURRENCY: usize = 50;
 const DEFAULT_STAGE_CHUNK_SIZE: usize = 100;
-const DEFAULT_STAGE_CONCURRENCY: usize = 10;
+const DEFAULT_TX_SEQ_DIGEST_STAGE_CONCURRENCY: usize = 10;
+const DEFAULT_TRANSACTIONS_STAGE_CONCURRENCY: usize = 25;
+const DEFAULT_OBJECTS_STAGE_CONCURRENCY: usize = 50;
+const DEFAULT_CHECKPOINTS_STAGE_CONCURRENCY: usize = 10;
 
 /// Built-in per-endpoint defaults. These differ per endpoint (e.g. checkpoints
 /// page smaller than transactions).
@@ -46,7 +49,7 @@ const LIST_EVENTS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMethodDef
 };
 const LIST_CHECKPOINTS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMethodDefaults {
     default_limit_items: 10,
-    max_limit_items: 100,
+    max_limit_items: 50,
     render_ahead: DEFAULT_RENDER_AHEAD,
 };
 
@@ -56,7 +59,8 @@ const LIST_CHECKPOINTS_DEFAULTS: LedgerHistoryMethodDefaults = LedgerHistoryMeth
 #[derive(Clone, Debug, Default, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct LedgerHistoryMethodConfig {
-    /// Per-request wall-clock timeout, in milliseconds. Defaults to `5000`.
+    /// Wall-clock budget covering computation and response delivery. Defaults
+    /// to `30000`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
 
@@ -130,7 +134,8 @@ pub struct StageConfig {
 
     /// Max in-flight chunk fetches for this stage. Independent of
     /// `request_bigtable_concurrency`, which still caps total concurrent reads
-    /// across all stages within a request. Defaults to `10`.
+    /// across all stages within a request. Defaults are table-specific; see
+    /// [`StagesConfig::stage`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub concurrency: Option<usize>,
 }
@@ -143,14 +148,14 @@ pub struct ResolvedStageConfig {
 }
 
 impl StageConfig {
-    fn resolve(this: Option<&StageConfig>) -> ResolvedStageConfig {
+    fn resolve(this: Option<&StageConfig>, default_concurrency: usize) -> ResolvedStageConfig {
         ResolvedStageConfig {
             chunk_size: this
                 .and_then(|c| c.chunk_size)
                 .unwrap_or(DEFAULT_STAGE_CHUNK_SIZE),
             concurrency: this
                 .and_then(|c| c.concurrency)
-                .unwrap_or(DEFAULT_STAGE_CONCURRENCY),
+                .unwrap_or(default_concurrency),
         }
     }
 }
@@ -161,18 +166,20 @@ impl StageConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct StagesConfig {
     /// Reads of the `tx_seq_digest` table (sequence number -> digest/checkpoint).
+    /// Defaults to `10`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_seq_digest: Option<StageConfig>,
 
-    /// Reads of the `transactions` table (digest -> transaction body).
+    /// Reads of the `transactions` table (digest -> transaction body). Defaults
+    /// to `25`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transactions: Option<StageConfig>,
 
-    /// Multi-get reads of the `objects` table.
+    /// Multi-get reads of the `objects` table. Defaults to `50`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub objects: Option<StageConfig>,
 
-    /// Reads of the `checkpoints` table.
+    /// Reads of the `checkpoints` table. Defaults to `10`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoints: Option<StageConfig>,
 }
@@ -187,11 +194,17 @@ impl StagesConfig {
         }
     }
 
-    /// Resolved tunables for one pipeline stage. Unset stages fall back to the
-    /// built-in chunk size (`100`) and stage concurrency (`10`); the latter is
-    /// independent of `request_bigtable_concurrency`.
+    /// Resolved tunables for one pipeline stage. Unset stages use chunk size
+    /// `100` and table-specific concurrency: tx-sequence-to-digest `10`,
+    /// transactions `25`, objects `50`, and checkpoints `10`.
     pub fn stage(&self, stage: PipelineStage) -> ResolvedStageConfig {
-        StageConfig::resolve(self.get(stage))
+        let default_concurrency = match stage {
+            PipelineStage::TxSeqDigest => DEFAULT_TX_SEQ_DIGEST_STAGE_CONCURRENCY,
+            PipelineStage::Transactions => DEFAULT_TRANSACTIONS_STAGE_CONCURRENCY,
+            PipelineStage::Objects => DEFAULT_OBJECTS_STAGE_CONCURRENCY,
+            PipelineStage::Checkpoints => DEFAULT_CHECKPOINTS_STAGE_CONCURRENCY,
+        };
+        StageConfig::resolve(self.get(stage), default_concurrency)
     }
 }
 
@@ -222,7 +235,7 @@ pub struct LedgerHistoryConfig {
     /// to `max_bitmap_filter_literals`. Exhausting it ends the query with
     /// `SCAN_LIMIT` and a resume cursor.
     ///
-    /// Defaults to `1024` if not specified.
+    /// Defaults to `4000` if not specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bitmap_bucket_budget_tx: Option<u64>,
 
@@ -231,7 +244,7 @@ pub struct LedgerHistoryConfig {
     /// is tuned separately even though both default to the same number. Same
     /// fetched-vs-evaluated semantics as `bitmap_bucket_budget_tx`.
     ///
-    /// Defaults to `1024` if not specified.
+    /// Defaults to `4000` if not specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bitmap_bucket_budget_event: Option<u64>,
 
@@ -416,7 +429,7 @@ pub struct KvRpcConfig {
     /// the point-get and list APIs. Bitmap scans are not gated by this; their
     /// fanout is bounded by `ledger_history.max_bitmap_filter_literals`.
     ///
-    /// Defaults to `10` if not specified.
+    /// Defaults to `50` if not specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_bigtable_concurrency: Option<usize>,
 
@@ -622,7 +635,7 @@ stages:
 
         let transactions = stages.stage(PipelineStage::Transactions);
         assert_eq!(transactions.chunk_size, 25);
-        assert_eq!(transactions.concurrency, 10);
+        assert_eq!(transactions.concurrency, 25);
 
         // Untouched stage is fully default.
         let checkpoints = stages.stage(PipelineStage::Checkpoints);
@@ -703,7 +716,7 @@ ledger-history:
         assert_eq!(lh.bitmap_bucket_budget_tx(), 2048);
         assert_eq!(lh.list_transactions().render_ahead, 3);
         assert_eq!(lh.list_events().render_ahead, 4);
-        assert_eq!(lh.bitmap_bucket_budget_event(), 1024);
+        assert_eq!(lh.bitmap_bucket_budget_event(), 4000);
         lh.validate().unwrap();
     }
 }

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -75,6 +75,7 @@ pub(crate) struct KvRpcMetrics {
     response_page_bytes: HistogramVec,
     stream_first_item_latency_ms: HistogramVec,
     stream_item_yield_wait_ms: HistogramVec,
+    final_stream_poll_wait_ms: HistogramVec,
     bitmap_buckets_evaluated: HistogramVec,
     bitmap_buckets_discarded: HistogramVec,
     bitmap_leaf_seeks: HistogramVec,
@@ -86,33 +87,41 @@ impl KvRpcMetrics {
             bigtable_limiter: BigTableLimiterMetrics::new(registry),
             response_render_latency_ms: register_histogram_vec_with_registry!(
                 "kv_rpc_response_render_latency_ms",
-                "Wall time spent rendering one list response item.",
-                &["method"],
-                prometheus::exponential_buckets(0.01, 2.0, 18).unwrap(),
+                "Wall time spent rendering one consumed or emitted List response item. Histogram sums across concurrent render work are not an additive request critical-path waterfall. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(0.01, 2.0, 24).unwrap(),
                 registry,
             )
             .unwrap(),
             response_page_bytes: register_histogram_vec_with_registry!(
                 "kv_rpc_response_page_bytes",
-                "Protobuf encoded size of one list response frame at emission.",
-                &["method"],
+                "Protobuf encoded size of one List response frame at emission, measured with encoded_len without serializing or copying the response for metrics. The histogram sum reports response-byte throughput. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+                &["method", "resolution"],
                 prometheus::exponential_buckets(1_024.0, 2.0, 17).unwrap(),
                 registry,
             )
             .unwrap(),
             stream_first_item_latency_ms: register_histogram_vec_with_registry!(
                 "kv_rpc_stream_first_item_latency_ms",
-                "Wall time from list stream construction until its first item is ready to yield.",
-                &["method"],
-                prometheus::exponential_buckets(1.0, 2.0, 14).unwrap(),
+                "Wall time from List request start to the first data item. If watermark frames are yielded first, this can include time coupled to downstream polling. Do not treat it as purely server-owned latency or page on it alone without checking yield-wait and backpressure. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(1.0, 2.0, 17).unwrap(),
                 registry,
             )
             .unwrap(),
             stream_item_yield_wait_ms: register_histogram_vec_with_registry!(
                 "kv_rpc_stream_item_yield_wait_ms",
-                "Wall time from yielding one list response item until the stream is polled again.",
-                &["method"],
-                prometheus::exponential_buckets(0.01, 2.0, 18).unwrap(),
+                "Wall time from yielding one inner List data item until the handler stream is polled again. It may include mpsc blocking, tonic/protobuf/Hyper/H2 work, executor scheduling, network flow control, and client drain. It is a broad downstream transport-consumption and backpressure signal, not proof of a slow client; correlate it with payload bytes, client telemetry, and network metrics. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(0.01, 2.0, 24).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            final_stream_poll_wait_ms: register_histogram_vec_with_registry!(
+                "kv_rpc_final_stream_poll_wait_ms",
+                "Wall time from polling the final resolved response stream until the poll returns data, a watermark, an error, or EOF. Excludes time when downstream backpressure prevents the response producer from being polled. May include hydration, scheduling, and render work performed inside the upstream stream. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+                &["method", "resolution"],
+                prometheus::exponential_buckets(0.01, 2.0, 24).unwrap(),
                 registry,
             )
             .unwrap(),
@@ -145,31 +154,58 @@ impl KvRpcMetrics {
         })
     }
 
-    fn observe_response_render(&self, method: &'static str, elapsed: std::time::Duration) {
+    fn observe_response_render(
+        &self,
+        method: &'static str,
+        resolution: &'static str,
+        elapsed: std::time::Duration,
+    ) {
         self.response_render_latency_ms
-            .with_label_values(&[method])
+            .with_label_values(&[method, resolution])
             .observe(elapsed.as_secs_f64() * 1000.0);
     }
 
-    fn observe_response_page_bytes(&self, method: &'static str, bytes: usize) {
+    fn observe_response_page_bytes(
+        &self,
+        method: &'static str,
+        resolution: &'static str,
+        bytes: usize,
+    ) {
         self.response_page_bytes
-            .with_label_values(&[method])
+            .with_label_values(&[method, resolution])
             .observe(bytes as f64);
     }
 
     fn observe_stream_first_item_latency(
         &self,
         method: &'static str,
+        resolution: &'static str,
         elapsed: std::time::Duration,
     ) {
         self.stream_first_item_latency_ms
-            .with_label_values(&[method])
+            .with_label_values(&[method, resolution])
             .observe(elapsed.as_secs_f64() * 1000.0);
     }
 
-    fn observe_stream_item_yield_wait(&self, method: &'static str, elapsed: std::time::Duration) {
+    fn observe_stream_item_yield_wait(
+        &self,
+        method: &'static str,
+        resolution: &'static str,
+        elapsed: std::time::Duration,
+    ) {
         self.stream_item_yield_wait_ms
-            .with_label_values(&[method])
+            .with_label_values(&[method, resolution])
+            .observe(elapsed.as_secs_f64() * 1000.0);
+    }
+
+    fn observe_final_stream_poll_wait(
+        &self,
+        method: &'static str,
+        resolution: &'static str,
+        elapsed: std::time::Duration,
+    ) {
+        self.final_stream_poll_wait_ms
+            .with_label_values(&[method, resolution])
             .observe(elapsed.as_secs_f64() * 1000.0);
     }
 

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 
 use anyhow::ensure;
 use prometheus::HistogramVec;
+use prometheus::IntCounterVec;
 use prometheus::Registry;
 use prometheus::register_histogram_vec_with_registry;
+use prometheus::register_int_counter_vec_with_registry;
 use sui_kvstore::ALPHA_PIPELINE_NAMES;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::CHECKPOINTS_BY_DIGEST_PIPELINE;
@@ -74,8 +76,9 @@ pub(crate) struct KvRpcMetrics {
     bigtable_limiter: Arc<BigTableLimiterMetrics>,
     response_render_latency_ms: HistogramVec,
     response_page_bytes: HistogramVec,
-    stream_first_item_latency_ms: HistogramVec,
-    stream_item_yield_wait_ms: HistogramVec,
+    stream_first_frame_latency_ms: HistogramVec,
+    stream_frame_yield_wait_ms: HistogramVec,
+    stream_watermark_frames_total: IntCounterVec,
     final_stream_poll_wait_ms: HistogramVec,
     bitmap_buckets_evaluated: HistogramVec,
     bitmap_buckets_discarded: HistogramVec,
@@ -96,25 +99,32 @@ impl KvRpcMetrics {
             .unwrap(),
             response_page_bytes: register_histogram_vec_with_registry!(
                 "kv_rpc_response_page_bytes",
-                "Protobuf encoded size of one List response frame at emission, measured with encoded_len without serializing or copying the response for metrics. The histogram sum reports response-byte throughput. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+                "Protobuf encoded size of data-bearing List response frames, measured with encoded_len without serializing or copying the response for metrics. Watermark-only and terminal-only frames are excluded and counted by kv_rpc_stream_watermark_frames_total. The histogram sum reports data-page byte throughput. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
                 &["method", "resolution"],
                 prometheus::exponential_buckets(1_024.0, 2.0, 17).unwrap(),
                 registry,
             )
             .unwrap(),
-            stream_first_item_latency_ms: register_histogram_vec_with_registry!(
-                "kv_rpc_stream_first_item_latency_ms",
-                "Wall time from List request start to the first data item. If watermark frames are yielded first, this can include time coupled to downstream polling. Do not treat it as purely server-owned latency or page on it alone without checking yield-wait and backpressure. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+            stream_first_frame_latency_ms: register_histogram_vec_with_registry!(
+                "kv_rpc_stream_first_frame_latency_ms",
+                "Wall time from List request start to the first response frame of any kind, the client's first actionable signal; a watermark carries the resume cursor. Do not treat it as purely server-owned latency or page on it alone without checking yield-wait and backpressure. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
                 &["method", "resolution"],
                 prometheus::exponential_buckets(1.0, 2.0, 17).unwrap(),
                 registry,
             )
             .unwrap(),
-            stream_item_yield_wait_ms: register_histogram_vec_with_registry!(
-                "kv_rpc_stream_item_yield_wait_ms",
-                "Wall time from yielding one inner List data item until the handler stream is polled again. It may include mpsc blocking, tonic/protobuf/Hyper/H2 work, executor scheduling, network flow control, and client drain. It is a broad downstream transport-consumption and backpressure signal, not proof of a slow client; correlate it with payload bytes, client telemetry, and network metrics. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
+            stream_frame_yield_wait_ms: register_histogram_vec_with_registry!(
+                "kv_rpc_stream_frame_yield_wait_ms",
+                "Wall time from yielding one List response frame of any kind until the handler stream is polled again. It may include mpsc blocking, tonic/protobuf/Hyper/H2 work, executor scheduling, network flow control, and client drain. It is a broad downstream transport-consumption and backpressure signal, not proof of a slow client; correlate it with payload bytes, client telemetry, and network metrics. The resolution label is the coarse response detail selected from the read mask; it does not describe filter or scan complexity.",
                 &["method", "resolution"],
                 prometheus::exponential_buckets(0.01, 2.0, 24).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            stream_watermark_frames_total: register_int_counter_vec_with_registry!(
+                "kv_rpc_stream_watermark_frames_total",
+                "Total non-data List response frames (watermark-only and terminal-only) emitted by streaming List APIs.",
+                &["method"],
                 registry,
             )
             .unwrap(),
@@ -177,26 +187,32 @@ impl KvRpcMetrics {
             .observe(bytes as f64);
     }
 
-    fn observe_stream_first_item_latency(
+    fn observe_stream_first_frame_latency(
         &self,
         method: &'static str,
         resolution: &'static str,
         elapsed: std::time::Duration,
     ) {
-        self.stream_first_item_latency_ms
+        self.stream_first_frame_latency_ms
             .with_label_values(&[method, resolution])
             .observe(elapsed.as_secs_f64() * 1000.0);
     }
 
-    fn observe_stream_item_yield_wait(
+    fn observe_stream_frame_yield_wait(
         &self,
         method: &'static str,
         resolution: &'static str,
         elapsed: std::time::Duration,
     ) {
-        self.stream_item_yield_wait_ms
+        self.stream_frame_yield_wait_ms
             .with_label_values(&[method, resolution])
             .observe(elapsed.as_secs_f64() * 1000.0);
+    }
+
+    fn inc_stream_watermark_frames(&self, method: &'static str) {
+        self.stream_watermark_frames_total
+            .with_label_values(&[method])
+            .inc();
     }
 
     fn observe_final_stream_poll_wait(

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -473,7 +473,6 @@ impl KvRpcServer {
                     file_descriptor_sets.iter().copied(),
                 )?,
             )
-            .add_service(LedgerServiceServer::new(self));
             .add_service(ledger_service_with_response_compression(self));
 
         if config.enable_reflection {

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -22,6 +22,7 @@ use sui_package_resolver::PackageStore;
 use sui_package_resolver::PackageStoreWithLruCache;
 use sui_package_resolver::Resolver;
 use sui_rpc::proto::sui::rpc::v2::GetServiceInfoResponse;
+use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerService;
 use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerServiceServer;
 use sui_rpc_api::ServerVersion;
 use sui_types::digests::ChainIdentifier;
@@ -255,6 +256,13 @@ pub struct ServerConfig {
     pub enable_experimental_query_apis: bool,
 }
 
+fn ledger_service_with_response_compression<T>(service: T) -> LedgerServiceServer<T>
+where
+    T: LedgerService,
+{
+    LedgerServiceServer::new(service).send_compressed(tonic::codec::CompressionEncoding::Zstd)
+}
+
 impl KvRpcServer {
     pub async fn new(
         instance_id: String,
@@ -466,6 +474,7 @@ impl KvRpcServer {
                 )?,
             )
             .add_service(LedgerServiceServer::new(self));
+            .add_service(ledger_service_with_response_compression(self));
 
         if config.enable_reflection {
             let mut reflection_v1_builder = tonic_reflection::server::Builder::configure();

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -72,6 +72,8 @@ pub type PackageResolver = Arc<Resolver<Arc<dyn PackageStore>>>;
 pub(crate) struct KvRpcMetrics {
     bigtable_limiter: Arc<BigTableLimiterMetrics>,
     response_render_latency_ms: HistogramVec,
+    response_page_bytes: HistogramVec,
+    stream_first_item_latency_ms: HistogramVec,
     stream_item_yield_wait_ms: HistogramVec,
     bitmap_buckets_evaluated: HistogramVec,
     bitmap_buckets_discarded: HistogramVec,
@@ -87,6 +89,22 @@ impl KvRpcMetrics {
                 "Wall time spent rendering one list response item.",
                 &["method"],
                 prometheus::exponential_buckets(0.01, 2.0, 18).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            response_page_bytes: register_histogram_vec_with_registry!(
+                "kv_rpc_response_page_bytes",
+                "Protobuf encoded size of one list response frame at emission.",
+                &["method"],
+                prometheus::exponential_buckets(1_024.0, 2.0, 17).unwrap(),
+                registry,
+            )
+            .unwrap(),
+            stream_first_item_latency_ms: register_histogram_vec_with_registry!(
+                "kv_rpc_stream_first_item_latency_ms",
+                "Wall time from list stream construction until its first item is ready to yield.",
+                &["method"],
+                prometheus::exponential_buckets(1.0, 2.0, 14).unwrap(),
                 registry,
             )
             .unwrap(),
@@ -129,6 +147,22 @@ impl KvRpcMetrics {
 
     fn observe_response_render(&self, method: &'static str, elapsed: std::time::Duration) {
         self.response_render_latency_ms
+            .with_label_values(&[method])
+            .observe(elapsed.as_secs_f64() * 1000.0);
+    }
+
+    fn observe_response_page_bytes(&self, method: &'static str, bytes: usize) {
+        self.response_page_bytes
+            .with_label_values(&[method])
+            .observe(bytes as f64);
+    }
+
+    fn observe_stream_first_item_latency(
+        &self,
+        method: &'static str,
+        elapsed: std::time::Duration,
+    ) {
+        self.stream_first_item_latency_ms
             .with_label_values(&[method])
             .observe(elapsed.as_secs_f64() * 1000.0);
     }

--- a/crates/sui-kv-rpc/src/operation.rs
+++ b/crates/sui-kv-rpc/src/operation.rs
@@ -118,6 +118,15 @@ impl QueryContext {
         self.metrics.observe_response_render(self.method, elapsed);
     }
 
+    pub(crate) fn observe_response_page_bytes(&self, bytes: usize) {
+        self.metrics.observe_response_page_bytes(self.method, bytes);
+    }
+
+    pub(crate) fn observe_stream_first_item_latency(&self, elapsed: std::time::Duration) {
+        self.metrics
+            .observe_stream_first_item_latency(self.method, elapsed);
+    }
+
     pub(crate) fn observe_stream_item_yield_wait(&self, elapsed: std::time::Duration) {
         self.metrics
             .observe_stream_item_yield_wait(self.method, elapsed);

--- a/crates/sui-kv-rpc/src/operation.rs
+++ b/crates/sui-kv-rpc/src/operation.rs
@@ -122,22 +122,26 @@ impl QueryContext {
             .observe_response_page_bytes(self.method, resolution, bytes);
     }
 
-    pub(crate) fn observe_stream_first_item_latency(
+    pub(crate) fn observe_stream_first_frame_latency(
         &self,
         resolution: &'static str,
         elapsed: std::time::Duration,
     ) {
         self.metrics
-            .observe_stream_first_item_latency(self.method, resolution, elapsed);
+            .observe_stream_first_frame_latency(self.method, resolution, elapsed);
     }
 
-    pub(crate) fn observe_stream_item_yield_wait(
+    pub(crate) fn observe_stream_frame_yield_wait(
         &self,
         resolution: &'static str,
         elapsed: std::time::Duration,
     ) {
         self.metrics
-            .observe_stream_item_yield_wait(self.method, resolution, elapsed);
+            .observe_stream_frame_yield_wait(self.method, resolution, elapsed);
+    }
+
+    pub(crate) fn inc_stream_watermark_frames(&self) {
+        self.metrics.inc_stream_watermark_frames(self.method);
     }
 
     pub(crate) async fn next_response_item<T>(

--- a/crates/sui-kv-rpc/src/operation.rs
+++ b/crates/sui-kv-rpc/src/operation.rs
@@ -4,6 +4,7 @@
 use std::future::Future;
 use std::time::Duration;
 
+use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
 use sui_inverted_index::BitmapQuery;
@@ -114,22 +115,51 @@ impl QueryContext {
         self.ledger_history.bitmap_skip_policy()
     }
 
-    pub(crate) fn observe_response_render(&self, elapsed: std::time::Duration) {
-        self.metrics.observe_response_render(self.method, elapsed);
-    }
-
-    pub(crate) fn observe_response_page_bytes(&self, bytes: usize) {
-        self.metrics.observe_response_page_bytes(self.method, bytes);
-    }
-
-    pub(crate) fn observe_stream_first_item_latency(&self, elapsed: std::time::Duration) {
+    pub(crate) fn observe_response_render(
+        &self,
+        resolution: &'static str,
+        elapsed: std::time::Duration,
+    ) {
         self.metrics
-            .observe_stream_first_item_latency(self.method, elapsed);
+            .observe_response_render(self.method, resolution, elapsed);
     }
 
-    pub(crate) fn observe_stream_item_yield_wait(&self, elapsed: std::time::Duration) {
+    pub(crate) fn observe_response_page_bytes(&self, resolution: &'static str, bytes: usize) {
         self.metrics
-            .observe_stream_item_yield_wait(self.method, elapsed);
+            .observe_response_page_bytes(self.method, resolution, bytes);
+    }
+
+    pub(crate) fn observe_stream_first_item_latency(
+        &self,
+        resolution: &'static str,
+        elapsed: std::time::Duration,
+    ) {
+        self.metrics
+            .observe_stream_first_item_latency(self.method, resolution, elapsed);
+    }
+
+    pub(crate) fn observe_stream_item_yield_wait(
+        &self,
+        resolution: &'static str,
+        elapsed: std::time::Duration,
+    ) {
+        self.metrics
+            .observe_stream_item_yield_wait(self.method, resolution, elapsed);
+    }
+
+    pub(crate) async fn next_response_item<T>(
+        &self,
+        resolution: &'static str,
+        stream: &mut BoxStream<'static, T>,
+    ) -> Option<T> {
+        let poll_started_at = Instant::now();
+        let item = stream.next().await;
+        self.metrics.observe_final_stream_poll_wait(
+            self.method,
+            resolution,
+            poll_started_at.elapsed(),
+        );
+        item
     }
 
     pub(crate) fn transaction_filter_query(

--- a/crates/sui-kv-rpc/src/operation.rs
+++ b/crates/sui-kv-rpc/src/operation.rs
@@ -45,7 +45,6 @@ pub(crate) struct QueryContext {
     method: &'static str,
     checkpoint_hi_exclusive: u64,
     ledger_history: LedgerHistoryConfig,
-    request_bigtable_concurrency: usize,
     stages: StagesConfig,
 }
 
@@ -57,7 +56,6 @@ impl QueryContext {
         method: &'static str,
         checkpoint_hi_exclusive: u64,
         ledger_history: LedgerHistoryConfig,
-        request_bigtable_concurrency: usize,
         stages: StagesConfig,
     ) -> Self {
         Self {
@@ -67,7 +65,6 @@ impl QueryContext {
             method,
             checkpoint_hi_exclusive,
             ledger_history,
-            request_bigtable_concurrency,
             stages,
         }
     }
@@ -91,10 +88,6 @@ impl QueryContext {
 
     pub(crate) fn checkpoint_hi_exclusive(&self) -> u64 {
         self.checkpoint_hi_exclusive
-    }
-
-    pub(crate) fn request_bigtable_concurrency(&self) -> usize {
-        self.request_bigtable_concurrency
     }
 
     /// Per-request evaluated-bucket budget for `spec`. Handlers pass this
@@ -234,7 +227,6 @@ impl KvRpcServer {
             operation,
             self.cached_checkpoint_hi_exclusive().await?,
             self.ledger_history.clone(),
-            self.request_bigtable_concurrency,
             self.stages.clone(),
         ))
     }

--- a/crates/sui-kv-rpc/src/pipeline.rs
+++ b/crates/sui-kv-rpc/src/pipeline.rs
@@ -8,9 +8,9 @@ use std::future::Future;
 use std::sync::Arc;
 use std::task::Poll;
 
-use futures::future;
 use futures::StreamExt;
 use futures::TryStreamExt;
+use futures::future;
 use futures::stream;
 use futures::stream::BoxStream;
 use sui_futures::task::TaskGuard;
@@ -973,6 +973,73 @@ pub(crate) enum ResolvedWatermarked<T, P = u64> {
     Watermark { position: P, cp: u64 },
 }
 
+#[derive(Debug)]
+pub(crate) enum RenderAheadError<UpstreamError, RenderError> {
+    Upstream(UpstreamError),
+    Render(RenderError),
+}
+
+/// Render resolved items concurrently while preserving item, watermark, and
+/// error order.
+///
+/// The returned stream is lazy until polled. Ordered buffering admits at most
+/// `look_ahead` render tasks, and `look_ahead = 1` serializes rendering with
+/// downstream emission. Dropping the stream aborts admitted tasks through their
+/// [`TaskGuard`]s. Completed responses retained behind an earlier frame are
+/// bounded by `look_ahead * rendered page size`; a full-mask fat checkpoint
+/// page is about 4–5 MB.
+pub(crate) fn render_ahead<I, O, P, UpstreamError, RenderError, RenderFut>(
+    upstream: BoxStream<'static, Result<ResolvedWatermarked<I, P>, UpstreamError>>,
+    look_ahead: usize,
+    render: impl Fn(I) -> RenderFut + Send + Sync + 'static,
+) -> BoxStream<
+    'static,
+    Result<ResolvedWatermarked<O, P>, RenderAheadError<UpstreamError, RenderError>>,
+>
+where
+    I: Send + 'static,
+    O: Send + 'static,
+    P: Send + 'static,
+    UpstreamError: Send + 'static,
+    RenderError: Send + 'static,
+    RenderFut: Future<Output = Result<O, RenderError>> + Send + 'static,
+{
+    assert!(look_ahead > 0, "render_ahead: look_ahead must be > 0");
+    let render = Arc::new(render);
+
+    upstream
+        .map(move |frame| {
+            let render = render.clone();
+            match frame {
+                Ok(ResolvedWatermarked::Item(item)) => {
+                    let render_task =
+                        TaskGuard::new(tokio::spawn(async move { render(item).await }));
+                    future::Either::Left(async move {
+                        match render_task.await {
+                            Ok(Ok(output)) => Ok(ResolvedWatermarked::Item(output)),
+                            Ok(Err(error)) => Err(RenderAheadError::Render(error)),
+                            Err(join_error) => {
+                                surface_panic(Err(join_error));
+                                std::future::pending().await
+                            }
+                        }
+                    })
+                }
+                Ok(ResolvedWatermarked::Watermark { position, cp }) => {
+                    future::Either::Right(future::ready(Ok(ResolvedWatermarked::Watermark {
+                        position,
+                        cp,
+                    })))
+                }
+                Err(error) => {
+                    future::Either::Right(future::ready(Err(RenderAheadError::Upstream(error))))
+                }
+            }
+        })
+        .buffered(look_ahead)
+        .boxed()
+}
+
 /// Terminal outcome from [`resolve_scan_watermarks`].
 ///
 /// A scan limit always carries the authoritative terminal position in the same
@@ -1226,6 +1293,178 @@ mod tests {
         fn drop(&mut self) {
             self.active.fetch_sub(1, Ordering::SeqCst);
         }
+    }
+
+    #[tokio::test]
+    async fn render_ahead_completes_admitted_work_without_consumer_polls() {
+        let upstream: BoxStream<'static, Result<ResolvedWatermarked<u64>, RpcError>> =
+            stream::iter([
+                Ok(ResolvedWatermarked::Item(0u64)),
+                Ok(ResolvedWatermarked::Item(1u64)),
+            ])
+            .boxed();
+        let started = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(3));
+        let completion_notify = Arc::new(Notify::new());
+        let mut stream = render_ahead(upstream, 2, {
+            let started = started.clone();
+            let completed = completed.clone();
+            let barrier = barrier.clone();
+            let completion_notify = completion_notify.clone();
+            move |item| {
+                let started = started.clone();
+                let completed = completed.clone();
+                let barrier = barrier.clone();
+                let completion_notify = completion_notify.clone();
+                async move {
+                    started.fetch_add(1, Ordering::SeqCst);
+                    barrier.wait().await;
+                    if completed.fetch_add(1, Ordering::SeqCst) + 1 == 2 {
+                        completion_notify.notify_one();
+                    }
+                    Ok::<_, RpcError>(item)
+                }
+            }
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(started.load(Ordering::SeqCst), 0);
+
+        let first_poll =
+            futures::future::poll_fn(|cx| Poll::Ready(stream.poll_next_unpin(cx))).await;
+        assert!(first_poll.is_pending());
+
+        timeout(Duration::from_millis(500), barrier.wait())
+            .await
+            .expect("admitted renders did not reach the barrier");
+        timeout(Duration::from_millis(500), completion_notify.notified())
+            .await
+            .expect("admitted renders did not complete");
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+        assert_eq!(completed.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn render_ahead_preserves_items_and_watermarks_in_input_order() {
+        let upstream: BoxStream<'static, Result<ResolvedWatermarked<u64>, RpcError>> =
+            stream::iter([
+                Ok(ResolvedWatermarked::Item(0u64)),
+                Ok(ResolvedWatermarked::Watermark {
+                    position: 10,
+                    cp: 20,
+                }),
+                Ok(ResolvedWatermarked::Item(1u64)),
+            ])
+            .boxed();
+        let release_first = Arc::new(Notify::new());
+        let second_completed = Arc::new(Notify::new());
+        let mut stream = render_ahead(upstream, 3, {
+            let release_first = release_first.clone();
+            let second_completed = second_completed.clone();
+            move |item| {
+                let release_first = release_first.clone();
+                let second_completed = second_completed.clone();
+                async move {
+                    if item == 0 {
+                        release_first.notified().await;
+                    } else {
+                        second_completed.notify_one();
+                    }
+                    Ok::<_, RpcError>(item)
+                }
+            }
+        });
+
+        let first_poll =
+            futures::future::poll_fn(|cx| Poll::Ready(stream.poll_next_unpin(cx))).await;
+        assert!(first_poll.is_pending());
+        timeout(Duration::from_millis(500), second_completed.notified())
+            .await
+            .expect("later render did not complete");
+        release_first.notify_one();
+
+        match stream.next().await {
+            Some(Ok(ResolvedWatermarked::Item(0))) => {}
+            _ => panic!("expected item 0 first"),
+        }
+        match stream.next().await {
+            Some(Ok(ResolvedWatermarked::Watermark {
+                position: 10,
+                cp: 20,
+            })) => {}
+            _ => panic!("expected watermark second"),
+        }
+        match stream.next().await {
+            Some(Ok(ResolvedWatermarked::Item(1))) => {}
+            _ => panic!("expected item 1 third"),
+        }
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_render_ahead_stream_aborts_render_tasks() {
+        let upstream: BoxStream<'static, Result<ResolvedWatermarked<u64>, RpcError>> =
+            stream::iter([Ok(ResolvedWatermarked::Item(0u64))]).boxed();
+        let limiter = Arc::new(Semaphore::new(1));
+        let mut stream = render_ahead(upstream, 1, {
+            let limiter = limiter.clone();
+            move |_item| {
+                let limiter = limiter.clone();
+                async move {
+                    let _permit =
+                        limiter.clone().acquire_owned().await.map_err(|_| {
+                            RpcError::new(tonic::Code::Internal, "test limiter closed")
+                        })?;
+                    std::future::pending::<Result<u64, RpcError>>().await
+                }
+            }
+        });
+
+        let first_poll =
+            futures::future::poll_fn(|cx| Poll::Ready(stream.poll_next_unpin(cx))).await;
+        assert!(first_poll.is_pending());
+        wait_for_available_permits(&limiter, 0).await;
+
+        drop(stream);
+        wait_for_available_permits(&limiter, 1).await;
+    }
+
+    #[tokio::test]
+    async fn render_ahead_propagates_render_error() {
+        let upstream: BoxStream<'static, Result<ResolvedWatermarked<u64>, RpcError>> =
+            stream::iter([Ok(ResolvedWatermarked::Item(0u64))]).boxed();
+        let mut stream = render_ahead(upstream, 1, |_item| async move {
+            Err::<u64, _>(RpcError::new(tonic::Code::Internal, "boom"))
+        });
+
+        let error = match stream.next().await {
+            Some(Err(RenderAheadError::Render(error))) => error,
+            _ => panic!("expected render error"),
+        };
+        let status: tonic::Status = error.into();
+        assert_eq!(status.message(), "boom");
+    }
+
+    #[tokio::test]
+    async fn render_ahead_resurfaces_render_panic() {
+        use futures::FutureExt;
+        let upstream: BoxStream<'static, Result<ResolvedWatermarked<u64>, RpcError>> =
+            stream::iter([Ok(ResolvedWatermarked::Item(0u64))]).boxed();
+        let stream = render_ahead(upstream, 1, |_item| async move {
+            if std::hint::black_box(true) {
+                panic!("render boom");
+            }
+            Ok::<_, RpcError>(0u64)
+        });
+
+        let outcome = std::panic::AssertUnwindSafe(stream.try_collect::<Vec<_>>())
+            .catch_unwind()
+            .await;
+        assert!(
+            outcome.is_err(),
+            "render panic must surface, not silently truncate the stream"
+        );
     }
 
     /// Wrap an iterator of plain values into a `Watermarked` upstream for
@@ -2477,12 +2716,9 @@ mod tests {
         timeout(Duration::from_millis(500), barrier.wait())
             .await
             .expect("admitted fetches did not reach the barrier");
-        timeout(
-            Duration::from_millis(500),
-            completion_notify.notified(),
-        )
-        .await
-        .expect("admitted fetches did not complete");
+        timeout(Duration::from_millis(500), completion_notify.notified())
+            .await
+            .expect("admitted fetches did not complete");
         assert_eq!(started.load(Ordering::SeqCst), 2);
         assert_eq!(completed.load(Ordering::SeqCst), 2);
     }
@@ -2500,9 +2736,10 @@ mod tests {
             move |_keys: Vec<i32>| {
                 let limiter = limiter_for_fetch.clone();
                 async move {
-                    let _permit = limiter.clone().acquire_owned().await.map_err(|_| {
-                        RpcError::new(tonic::Code::Internal, "test limiter closed")
-                    })?;
+                    let _permit =
+                        limiter.clone().acquire_owned().await.map_err(|_| {
+                            RpcError::new(tonic::Code::Internal, "test limiter closed")
+                        })?;
                     std::future::pending::<Result<HashMap<i32, i32>, RpcError>>().await
                 }
             },

--- a/crates/sui-kv-rpc/src/pipeline.rs
+++ b/crates/sui-kv-rpc/src/pipeline.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::task::Poll;
 
+use futures::future;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream;
@@ -540,8 +541,21 @@ pub(crate) type MarkedKeyedDownstream<I, K, V, E, P = u64> =
 ///   budget — fat-item splits parallelize naturally rather than serializing
 ///   inside one slot.
 ///
-/// Output is in input order. Partial batches flush at upstream `Pending`
-/// boundaries, not held across them.
+/// The returned stream is lazy until its first poll. Ordered
+/// `.buffered(max_concurrent_fetches)` admission spawns each non-empty fetch,
+/// allowing it to finish independently of downstream response polling; no-op
+/// groups, watermarks, and upstream errors remain inline-ready. Dropping the
+/// stream drops the buffered futures' [`TaskGuard`]s and aborts live fetches.
+///
+/// Completed result maps can remain buffered while a consumer stalls. Per
+/// stage, this is bounded by
+/// `max_concurrent_fetches * max_keys_per_request * row size`, trading memory
+/// for earlier release of request-scoped backend permits, as in
+/// [`pipelined_chunks`].
+///
+/// Output and watermarks preserve input order. Partial batches flush at
+/// upstream `Pending` boundaries, and a terminal error deliberately does not
+/// flush a watermark held by the reassembler.
 pub(crate) fn pipelined_keyed_batches<I, K, V, P, E, FetchFut>(
     upstream: MarkedKeyedUpstream<I, K, E, P>,
     upstream_chunk_size: usize,
@@ -571,12 +585,13 @@ where
     );
     let fetch = Arc::new(fetch);
     // Flat pipeline: each `ChunkInput` expands into a Vec<FetchRequest>,
-    // those flatten into a single stream, each request runs as a future
-    // through ONE `.buffered(max_concurrent_fetches)` (so total in-flight
-    // fetches across all chunks is bounded by N, not N*N). The reassembler
-    // drains the buffered results in input order; watermarks ride through
-    // as zero-cost `FetchRequest::Watermark` units that resolve instantly
-    // and the reassembler passes them straight through between batches.
+    // those flatten into a single stream, and ordered
+    // `.buffered(max_concurrent_fetches)` admits at most N live fetch tasks
+    // across all chunks. Non-empty fetches drain and decode in spawned tasks;
+    // no-op groups, watermarks, and upstream errors remain inline-ready. The
+    // reassembler consumes results in input order and passes watermarks between
+    // batches. Dropping the returned stream drops the buffered `TaskGuard`s
+    // and aborts live fetches.
     let fetch_results = chunks_with_watermarks(upstream, upstream_chunk_size)
         .map_ok(move |input| {
             let requests = match input {
@@ -588,30 +603,49 @@ where
         .try_flatten()
         .map(move |request_res| {
             let fetch = fetch.clone();
-            async move {
-                match request_res? {
-                    FetchRequest::NewGroup {
+            let fetch_task = match request_res {
+                Err(error) => return future::Either::Right(future::ready(Err(error))),
+                Ok(FetchRequest::NewGroup {
+                    items,
+                    keys,
+                    requests_total,
+                }) if keys.is_empty() => {
+                    return future::Either::Right(future::ready(Ok(FetchResult::NewGroup {
                         items,
-                        keys,
                         requests_total,
-                    } => {
-                        let map = if keys.is_empty() {
-                            HashMap::new()
-                        } else {
-                            fetch(keys).await?
-                        };
-                        Ok::<_, E>(FetchResult::NewGroup {
-                            items,
-                            requests_total,
-                            map,
-                        })
-                    }
-                    FetchRequest::Continuation { keys } => Ok(FetchResult::Continuation {
-                        map: fetch(keys).await?,
-                    }),
-                    FetchRequest::Watermark(pos) => Ok(FetchResult::Watermark(pos)),
+                        map: HashMap::new(),
+                    })));
                 }
-            }
+                Ok(FetchRequest::NewGroup {
+                    items,
+                    keys,
+                    requests_total,
+                }) => tokio::spawn(async move {
+                    Ok::<_, E>(FetchResult::NewGroup {
+                        items,
+                        requests_total,
+                        map: fetch(keys).await?,
+                    })
+                }),
+                Ok(FetchRequest::Continuation { keys }) => tokio::spawn(async move {
+                    Ok::<_, E>(FetchResult::Continuation {
+                        map: fetch(keys).await?,
+                    })
+                }),
+                Ok(FetchRequest::Watermark(pos)) => {
+                    return future::Either::Right(future::ready(Ok(FetchResult::Watermark(pos))));
+                }
+            };
+            let fetch_task = TaskGuard::new(fetch_task);
+            future::Either::Left(async move {
+                match fetch_task.await {
+                    Ok(result) => result,
+                    Err(join_error) => {
+                        surface_panic(Err(join_error));
+                        std::future::pending().await
+                    }
+                }
+            })
         })
         .buffered(max_concurrent_fetches);
 
@@ -1168,6 +1202,8 @@ mod tests {
     use std::time::Duration;
 
     use futures::stream;
+    use tokio::sync::Barrier;
+    use tokio::sync::Notify;
     use tokio::sync::Semaphore;
     use tokio::sync::oneshot;
     use tokio::time::timeout;
@@ -2396,6 +2432,89 @@ mod tests {
             elapsed < Duration::from_millis(250),
             "fat-item chunks should run in parallel; got {elapsed:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn keyed_batch_fetches_complete_without_consumer_polls() {
+        let upstream = iter_upstream(vec![Ok((0u32, vec![10])), Ok((1u32, vec![20]))]);
+        let started = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(3));
+        let completion_notify = Arc::new(Notify::new());
+        let started_for_fetch = started.clone();
+        let completed_for_fetch = completed.clone();
+        let barrier_for_fetch = barrier.clone();
+        let completion_notify_for_fetch = completion_notify.clone();
+        let mut stream = pipelined_keyed_batches::<u32, i32, i32, u64, _, _>(
+            upstream,
+            2,
+            1,
+            2,
+            move |keys: Vec<i32>| {
+                let started = started_for_fetch.clone();
+                let completed = completed_for_fetch.clone();
+                let barrier = barrier_for_fetch.clone();
+                let completion_notify = completion_notify_for_fetch.clone();
+                async move {
+                    started.fetch_add(1, Ordering::SeqCst);
+                    barrier.wait().await;
+                    let map = keys.into_iter().map(|key| (key, key)).collect();
+                    if completed.fetch_add(1, Ordering::SeqCst) + 1 == 2 {
+                        completion_notify.notify_one();
+                    }
+                    Ok::<_, RpcError>(map)
+                }
+            },
+        );
+
+        tokio::task::yield_now().await;
+        assert_eq!(started.load(Ordering::SeqCst), 0);
+
+        let first_poll =
+            futures::future::poll_fn(|cx| Poll::Ready(stream.poll_next_unpin(cx))).await;
+        assert!(first_poll.is_pending());
+
+        timeout(Duration::from_millis(500), barrier.wait())
+            .await
+            .expect("admitted fetches did not reach the barrier");
+        timeout(
+            Duration::from_millis(500),
+            completion_notify.notified(),
+        )
+        .await
+        .expect("admitted fetches did not complete");
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+        assert_eq!(completed.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn dropping_keyed_batch_stream_aborts_fetch() {
+        let upstream = iter_upstream(vec![Ok((0u32, vec![10]))]);
+        let limiter = Arc::new(Semaphore::new(1));
+        let limiter_for_fetch = limiter.clone();
+        let mut stream = pipelined_keyed_batches::<u32, i32, i32, u64, _, _>(
+            upstream,
+            1,
+            1,
+            1,
+            move |_keys: Vec<i32>| {
+                let limiter = limiter_for_fetch.clone();
+                async move {
+                    let _permit = limiter.clone().acquire_owned().await.map_err(|_| {
+                        RpcError::new(tonic::Code::Internal, "test limiter closed")
+                    })?;
+                    std::future::pending::<Result<HashMap<i32, i32>, RpcError>>().await
+                }
+            },
+        );
+
+        let first_poll =
+            futures::future::poll_fn(|cx| Poll::Ready(stream.poll_next_unpin(cx))).await;
+        assert!(first_poll.is_pending());
+        wait_for_available_permits(&limiter, 0).await;
+
+        drop(stream);
+        wait_for_available_permits(&limiter, 1).await;
     }
 
     #[tokio::test]

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use bytes::Bytes;
@@ -9,6 +10,7 @@ use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream;
 use futures::stream::BoxStream;
+use prost::Message;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::ScanStop;
 use sui_kvstore::BitmapIndexSpec;
@@ -45,11 +47,13 @@ use crate::bigtable_client::stage;
 use crate::config::PipelineStage;
 use crate::operation::QueryContext;
 use crate::pipeline::InputOrderEmitter;
+use crate::pipeline::RenderAheadError;
 use crate::pipeline::ResolvedScanStop;
 use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
 use crate::pipeline::dedup_consecutive;
 use crate::pipeline::pipelined_chunks;
+use crate::pipeline::render_ahead;
 use crate::pipeline::resolve_scan_watermarks;
 use crate::pipeline::take_items;
 use crate::render::render_full_checkpoint;
@@ -96,7 +100,7 @@ pub(crate) async fn list_checkpoints(
                 .with_description(format!("invalid read_mask path: {path}"))
                 .with_reason(ErrorReason::FieldInvalid)
         })?;
-        FieldMaskTree::from(read_mask)
+        Arc::new(FieldMaskTree::from(read_mask))
     };
     let options = QueryOptions::checkpoints_from_proto(
         request.options.as_ref(),
@@ -130,7 +134,7 @@ pub(crate) async fn list_checkpoints(
         );
         // Empty resolved ranges still surface their terminal cursor, but
         // natural completion claims no checkpoint coverage.
-        return Ok(stream::iter([Ok(range_end_response(
+        let response = range_end_response(
             &options,
             exhaustion,
             Position::Checkpoints {
@@ -139,7 +143,11 @@ pub(crate) async fn list_checkpoints(
             None,
             true,
         )
-        .0)])
+        .0;
+        return Ok(async_stream::try_stream! {
+            ctx.observe_response_page_bytes(response.encoded_len());
+            yield response;
+        }
         .boxed());
     }
 
@@ -245,14 +253,68 @@ pub(crate) async fn list_checkpoints(
         std::convert::identity,
     );
 
-    // Stage E: sync render — build the requested Checkpoint shape (CPU-only,
-    // with no further IO).
-    Ok(async_stream::try_stream! {
-        futures::pin_mut!(checkpoint_stream);
+    // Stage E: bounded ordered render-ahead builds the requested Checkpoint shape (CPU-only, with no further IO).
+    let rendered_stream = render_ahead(checkpoint_stream, endpoint.render_ahead, {
+        let read_mask = read_mask.clone();
+        move |item| {
+            let read_mask = read_mask.clone();
+            async move {
+                let item_checkpoint = match &item {
+                    CheckpointListItem::Summary(item_checkpoint, _) => *item_checkpoint,
+                    CheckpointListItem::Full((item_checkpoint, _, _, _)) => *item_checkpoint,
+                };
+                let render_started = Instant::now();
+                let message = match item {
+                    CheckpointListItem::Summary(_, cp_data) => {
+                        crate::render::checkpoint_to_response(cp_data, &read_mask)?
+                    }
+                    CheckpointListItem::Full((_, cp_data, txs, objects)) => {
+                        render_full_checkpoint(cp_data, txs, objects, &read_mask)?
+                    }
+                };
+                Ok::<_, RpcError>((item_checkpoint, message, render_started.elapsed()))
+            }
+        }
+    });
+
+    Ok(drive_rendered_checkpoints(
+        ctx,
+        rendered_stream,
+        options,
+        exhaustion,
+        range_end_position,
+        entry_checkpoint,
+        direction,
+        filtered,
+        started,
+    ))
+}
+
+fn drive_rendered_checkpoints(
+    ctx: QueryContext,
+    rendered_stream: BoxStream<
+        'static,
+        Result<
+            ResolvedWatermarked<(u64, Checkpoint, Duration)>,
+            RenderAheadError<ResolvedScanStop<u64>, RpcError>,
+        >,
+    >,
+    options: QueryOptions,
+    exhaustion: RangeExhaustion,
+    range_end_position: u64,
+    entry_checkpoint: u64,
+    direction: ScanDirection,
+    filtered: bool,
+    started: Instant,
+) -> ListCheckpointsStream {
+    async_stream::try_stream! {
+        futures::pin_mut!(rendered_stream);
+        let limit_items = options.limit_items;
+        let ordering = options.ordering;
         let mut emitted = 0usize;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
-            let Some(item) = checkpoint_stream.next().await else {
+            let Some(item) = rendered_stream.next().await else {
                 let (response, reason) = range_end_response(
                     &options,
                     exhaustion,
@@ -262,15 +324,16 @@ pub(crate) async fn list_checkpoints(
                     covered_checkpoint_bound,
                     false,
                 );
+                ctx.observe_response_page_bytes(response.encoded_len());
                 yield response;
                 break reason;
             };
             match item {
-                Ok(ResolvedWatermarked::Item(item)) => {
-                    let item_checkpoint = match &item {
-                        CheckpointListItem::Summary(item_checkpoint, _) => *item_checkpoint,
-                        CheckpointListItem::Full((item_checkpoint, _, _, _)) => *item_checkpoint,
-                    };
+                Ok(ResolvedWatermarked::Item((
+                    item_checkpoint,
+                    message,
+                    render_duration,
+                ))) => {
                     // Checkpoint items are emitted in scan order and deduped, so
                     // emitting this item proves its checkpoint fully covered.
                     covered_checkpoint_bound = Some(item_checkpoint);
@@ -280,29 +343,25 @@ pub(crate) async fn list_checkpoints(
                         },
                         covered_checkpoint_bound,
                     );
-                    let render_started = Instant::now();
-                    let message = match item {
-                        CheckpointListItem::Summary(_, cp_data) => {
-                            crate::render::checkpoint_to_response(cp_data, &read_mask)?
-                        }
-                        CheckpointListItem::Full((_, cp_data, txs, objects)) => {
-                            render_full_checkpoint(cp_data, txs, objects, &read_mask)?
-                        }
-                    };
-                    ctx.observe_response_render(render_started.elapsed());
+                    ctx.observe_response_render(render_duration);
                     emitted += 1;
                     let mut response = response_for(watermark, message);
-                    let yield_started = Instant::now();
-                    if emitted == limit_items {
+                    let item_limit = emitted == limit_items;
+                    if item_limit {
                         let mut end = QueryEnd::default();
                         end.reason = Some(QueryEndReason::ItemLimit as i32);
                         response.end = Some(end);
-                        yield response;
-                        ctx.observe_stream_item_yield_wait(yield_started.elapsed());
-                        break QueryEndReason::ItemLimit;
                     }
+                    ctx.observe_response_page_bytes(response.encoded_len());
+                    if emitted == 1 {
+                        ctx.observe_stream_first_item_latency(started.elapsed());
+                    }
+                    let yield_started = Instant::now();
                     yield response;
                     ctx.observe_stream_item_yield_wait(yield_started.elapsed());
+                    if item_limit {
+                        break QueryEndReason::ItemLimit;
+                    }
                 }
                 Ok(ResolvedWatermarked::Watermark {
                     position: _,
@@ -315,18 +374,23 @@ pub(crate) async fn list_checkpoints(
                         &options,
                         &mut covered_checkpoint_bound,
                     );
-                    yield watermark_response(watermark);
+                    let response = watermark_response(watermark);
+                    ctx.observe_response_page_bytes(response.encoded_len());
+                    yield response;
                 }
-                Err(stop) => {
-                    yield terminal_response_from_scan_stop(
+                Err(RenderAheadError::Upstream(stop)) => {
+                    let response = terminal_response_from_scan_stop(
                         stop,
                         &options,
                         direction,
                         entry_checkpoint,
                         &mut covered_checkpoint_bound,
                     )?;
+                    ctx.observe_response_page_bytes(response.encoded_len());
+                    yield response;
                     break QueryEndReason::ScanLimit;
                 }
+                Err(RenderAheadError::Render(error)) => Err(error)?,
             }
         };
         info!(
@@ -339,7 +403,7 @@ pub(crate) async fn list_checkpoints(
             "list_checkpoints: done"
         );
     }
-    .boxed())
+    .boxed()
 }
 
 /// Convert the checkpoint containing a transaction-space scan frontier into a
@@ -602,10 +666,136 @@ fn clamp_cp_frontier_past_last(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prometheus::proto::MetricFamily;
     use sui_rpc_cursor::CursorToken;
 
     use crate::v2::test_utils::ascending_options;
     use crate::v2::test_utils::query_context;
+    use crate::v2::test_utils::query_context_with_registry;
+
+    fn histogram_family<'a>(families: &'a [MetricFamily], name: &str) -> &'a MetricFamily {
+        families
+            .iter()
+            .find(|family| family.name() == name)
+            .unwrap_or_else(|| panic!("metric family {name} not registered"))
+    }
+
+    fn histogram_sample_count(family: &MetricFamily) -> u64 {
+        family
+            .get_metric()
+            .iter()
+            .map(|metric| metric.get_histogram().get_sample_count())
+            .sum()
+    }
+
+    fn histogram_sample_sum(family: &MetricFamily) -> f64 {
+        family
+            .get_metric()
+            .iter()
+            .map(|metric| metric.get_histogram().get_sample_sum())
+            .sum()
+    }
+
+    fn assert_method_label(family: &MetricFamily, expected_method: &str) {
+        assert_eq!(
+            family.get_metric().len(),
+            1,
+            "expected one method series for {}",
+            family.name()
+        );
+        assert!(
+            family.get_metric()[0]
+                .get_label()
+                .iter()
+                .any(|label| label.name() == "method" && label.value() == expected_method),
+            "{} lacks method={expected_method}",
+            family.name()
+        );
+    }
+
+    #[tokio::test]
+    async fn item_limit_remains_fused_to_limit_item_after_render_ahead() {
+        let (ctx, registry, server) = query_context_with_registry("list_checkpoints", 10).await;
+        let mut proto_options = ascending_options();
+        proto_options.limit = Some(3);
+        let options = QueryOptions::checkpoints_from_proto(Some(&proto_options), 10, 100).unwrap();
+        let rendered_stream = stream::iter([
+            Ok::<_, RenderAheadError<ResolvedScanStop<u64>, RpcError>>(ResolvedWatermarked::Item(
+                (7, Checkpoint::default(), Duration::from_millis(1)),
+            )),
+            Ok(ResolvedWatermarked::Item((
+                8,
+                Checkpoint::default(),
+                Duration::from_millis(1),
+            ))),
+            Ok(ResolvedWatermarked::Item((
+                9,
+                Checkpoint::default(),
+                Duration::from_millis(1),
+            ))),
+        ])
+        .boxed();
+
+        let responses: Vec<_> = drive_rendered_checkpoints(
+            ctx,
+            rendered_stream,
+            options,
+            RangeExhaustion::CheckpointBound,
+            10,
+            7,
+            ScanDirection::Ascending,
+            false,
+            Instant::now(),
+        )
+        .try_collect()
+        .await
+        .expect("collect rendered checkpoint responses");
+        server.abort();
+
+        assert_eq!(responses.len(), 3, "item limit emits no terminal frame");
+        for (index, (response, checkpoint)) in responses.iter().zip([7u64, 8, 9]).enumerate() {
+            assert!(
+                response.checkpoint.is_some(),
+                "response {index} has payload"
+            );
+            let watermark = response
+                .watermark
+                .as_ref()
+                .unwrap_or_else(|| panic!("response {index} has watermark"));
+            assert_eq!(
+                watermark.cursor.as_ref(),
+                Some(&CursorToken::item(Position::Checkpoints { checkpoint }).encode())
+            );
+            assert_eq!(watermark.checkpoint, Some(checkpoint));
+            if index < 2 {
+                assert!(response.end.is_none(), "response {index} is not terminal");
+            } else {
+                assert_eq!(
+                    response.end.as_ref().map(|end| end.reason()),
+                    Some(QueryEndReason::ItemLimit)
+                );
+            }
+        }
+
+        let expected_page_bytes = responses
+            .iter()
+            .map(|response| response.encoded_len() as f64)
+            .sum::<f64>();
+        let families = registry.gather();
+        let render_latency = histogram_family(&families, "kv_rpc_response_render_latency_ms");
+        let yield_wait = histogram_family(&families, "kv_rpc_stream_item_yield_wait_ms");
+        let page_bytes = histogram_family(&families, "kv_rpc_response_page_bytes");
+        let first_item_latency = histogram_family(&families, "kv_rpc_stream_first_item_latency_ms");
+
+        for family in [render_latency, yield_wait, page_bytes, first_item_latency] {
+            assert_method_label(family, "list_checkpoints");
+        }
+        assert_eq!(histogram_sample_count(render_latency), 3);
+        assert_eq!(histogram_sample_count(yield_wait), 3);
+        assert_eq!(histogram_sample_count(page_bytes), 3);
+        assert_eq!(histogram_sample_count(first_item_latency), 1);
+        assert_eq!(histogram_sample_sum(page_bytes), expected_page_bytes);
+    }
 
     #[tokio::test]
     async fn natural_empty_range_emits_one_standalone_terminal_boundary() {

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -65,6 +65,13 @@ const READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::CHECKPOINT;
 
 pub(crate) type ListCheckpointsStream =
     BoxStream<'static, Result<ListCheckpointsResponse, RpcError>>;
+type RenderedCheckpointStream = BoxStream<
+    'static,
+    Result<
+        ResolvedWatermarked<(u64, Checkpoint, Duration)>,
+        RenderAheadError<ResolvedScanStop<u64>, RpcError>,
+    >,
+>;
 
 enum CheckpointListItem {
     Summary(u64, CheckpointData),
@@ -303,13 +310,7 @@ pub(crate) async fn list_checkpoints(
 
 fn drive_rendered_checkpoints(
     ctx: QueryContext,
-    mut rendered_stream: BoxStream<
-        'static,
-        Result<
-            ResolvedWatermarked<(u64, Checkpoint, Duration)>,
-            RenderAheadError<ResolvedScanStop<u64>, RpcError>,
-        >,
-    >,
+    mut rendered_stream: RenderedCheckpointStream,
     resolution: &'static str,
     options: QueryOptions,
     exhaustion: RangeExhaustion,
@@ -677,6 +678,7 @@ fn clamp_cp_frontier_past_last(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mysten_common::ZipDebugEqIteratorExt;
     use sui_rpc_cursor::CursorToken;
 
     use crate::v2::test_utils::{
@@ -740,7 +742,9 @@ mod tests {
         server.abort();
 
         assert_eq!(responses.len(), 3, "item limit emits no terminal frame");
-        for (index, (response, checkpoint)) in responses.iter().zip([7u64, 8, 9]).enumerate() {
+        for (index, (response, checkpoint)) in
+            responses.iter().zip_debug_eq([7u64, 8, 9]).enumerate()
+        {
             assert!(
                 response.checkpoint.is_some(),
                 "response {index} has payload"

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -71,6 +71,14 @@ enum CheckpointListItem {
     Full(resolve::ResolvedCp),
 }
 
+fn checkpoint_resolution(needs_objects: bool, needs_transactions_or_objects: bool) -> &'static str {
+    match (needs_objects, needs_transactions_or_objects) {
+        (true, _) => "objects",
+        (false, true) => "transactions",
+        (false, false) => "summary",
+    }
+}
+
 pub(crate) async fn list_checkpoints(
     ctx: QueryContext,
     request: ListCheckpointsRequest,
@@ -102,6 +110,9 @@ pub(crate) async fn list_checkpoints(
         })?;
         Arc::new(FieldMaskTree::from(read_mask))
     };
+    let needs_objects = read_mask.contains(Checkpoint::OBJECTS_FIELD);
+    let needs_full = needs_transactions_or_objects(&read_mask);
+    let resolution = checkpoint_resolution(needs_objects, needs_full);
     let options = QueryOptions::checkpoints_from_proto(
         request.options.as_ref(),
         endpoint.default_limit_items,
@@ -145,13 +156,12 @@ pub(crate) async fn list_checkpoints(
         )
         .0;
         return Ok(async_stream::try_stream! {
-            ctx.observe_response_page_bytes(response.encoded_len());
+            ctx.observe_response_page_bytes(resolution, response.encoded_len());
             yield response;
         }
         .boxed());
     }
 
-    let needs_full = needs_transactions_or_objects(&read_mask);
     let cp_columns: Arc<[&'static str]> = list_checkpoint_columns(&read_mask, needs_full).into();
 
     // Stage A: discover checkpoint rows for the requested response. Filtered
@@ -280,6 +290,7 @@ pub(crate) async fn list_checkpoints(
     Ok(drive_rendered_checkpoints(
         ctx,
         rendered_stream,
+        resolution,
         options,
         exhaustion,
         range_end_position,
@@ -292,13 +303,14 @@ pub(crate) async fn list_checkpoints(
 
 fn drive_rendered_checkpoints(
     ctx: QueryContext,
-    rendered_stream: BoxStream<
+    mut rendered_stream: BoxStream<
         'static,
         Result<
             ResolvedWatermarked<(u64, Checkpoint, Duration)>,
             RenderAheadError<ResolvedScanStop<u64>, RpcError>,
         >,
     >,
+    resolution: &'static str,
     options: QueryOptions,
     exhaustion: RangeExhaustion,
     range_end_position: u64,
@@ -308,13 +320,12 @@ fn drive_rendered_checkpoints(
     started: Instant,
 ) -> ListCheckpointsStream {
     async_stream::try_stream! {
-        futures::pin_mut!(rendered_stream);
         let limit_items = options.limit_items;
         let ordering = options.ordering;
         let mut emitted = 0usize;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
-            let Some(item) = rendered_stream.next().await else {
+            let Some(item) = ctx.next_response_item(resolution, &mut rendered_stream).await else {
                 let (response, reason) = range_end_response(
                     &options,
                     exhaustion,
@@ -324,7 +335,7 @@ fn drive_rendered_checkpoints(
                     covered_checkpoint_bound,
                     false,
                 );
-                ctx.observe_response_page_bytes(response.encoded_len());
+                ctx.observe_response_page_bytes(resolution, response.encoded_len());
                 yield response;
                 break reason;
             };
@@ -343,7 +354,7 @@ fn drive_rendered_checkpoints(
                         },
                         covered_checkpoint_bound,
                     );
-                    ctx.observe_response_render(render_duration);
+                    ctx.observe_response_render(resolution, render_duration);
                     emitted += 1;
                     let mut response = response_for(watermark, message);
                     let item_limit = emitted == limit_items;
@@ -352,13 +363,13 @@ fn drive_rendered_checkpoints(
                         end.reason = Some(QueryEndReason::ItemLimit as i32);
                         response.end = Some(end);
                     }
-                    ctx.observe_response_page_bytes(response.encoded_len());
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
                     if emitted == 1 {
-                        ctx.observe_stream_first_item_latency(started.elapsed());
+                        ctx.observe_stream_first_item_latency(resolution, started.elapsed());
                     }
                     let yield_started = Instant::now();
                     yield response;
-                    ctx.observe_stream_item_yield_wait(yield_started.elapsed());
+                    ctx.observe_stream_item_yield_wait(resolution, yield_started.elapsed());
                     if item_limit {
                         break QueryEndReason::ItemLimit;
                     }
@@ -375,7 +386,7 @@ fn drive_rendered_checkpoints(
                         &mut covered_checkpoint_bound,
                     );
                     let response = watermark_response(watermark);
-                    ctx.observe_response_page_bytes(response.encoded_len());
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
                     yield response;
                 }
                 Err(RenderAheadError::Upstream(stop)) => {
@@ -386,7 +397,7 @@ fn drive_rendered_checkpoints(
                         entry_checkpoint,
                         &mut covered_checkpoint_bound,
                     )?;
-                    ctx.observe_response_page_bytes(response.encoded_len());
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
                     yield response;
                     break QueryEndReason::ScanLimit;
                 }
@@ -666,55 +677,30 @@ fn clamp_cp_frontier_past_last(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prometheus::proto::MetricFamily;
     use sui_rpc_cursor::CursorToken;
 
-    use crate::v2::test_utils::ascending_options;
-    use crate::v2::test_utils::query_context;
-    use crate::v2::test_utils::query_context_with_registry;
+    use crate::v2::test_utils::{
+        LIST_PIPELINE_METRICS, ascending_options, assert_list_histogram_absent, list_histogram,
+        query_context, query_context_with_registry,
+    };
 
-    fn histogram_family<'a>(families: &'a [MetricFamily], name: &str) -> &'a MetricFamily {
-        families
-            .iter()
-            .find(|family| family.name() == name)
-            .unwrap_or_else(|| panic!("metric family {name} not registered"))
-    }
-
-    fn histogram_sample_count(family: &MetricFamily) -> u64 {
-        family
-            .get_metric()
-            .iter()
-            .map(|metric| metric.get_histogram().get_sample_count())
-            .sum()
-    }
-
-    fn histogram_sample_sum(family: &MetricFamily) -> f64 {
-        family
-            .get_metric()
-            .iter()
-            .map(|metric| metric.get_histogram().get_sample_sum())
-            .sum()
-    }
-
-    fn assert_method_label(family: &MetricFamily, expected_method: &str) {
-        assert_eq!(
-            family.get_metric().len(),
-            1,
-            "expected one method series for {}",
-            family.name()
-        );
-        assert!(
-            family.get_metric()[0]
-                .get_label()
-                .iter()
-                .any(|label| label.name() == "method" && label.value() == expected_method),
-            "{} lacks method={expected_method}",
-            family.name()
-        );
+    #[test]
+    fn resolution_uses_validated_read_mask_predicates() {
+        let mut masks =
+            "sequence_number;transactions.digest;objects;transactions.digest,objects".split(';');
+        let actual: [&str; 4] = std::array::from_fn(|_| {
+            let mask = FieldMask::from_str(masks.next().unwrap());
+            mask.validate::<Checkpoint>()
+                .expect("valid checkpoint mask");
+            let mask = FieldMaskTree::from(mask);
+            let objects = mask.contains(Checkpoint::OBJECTS_FIELD);
+            checkpoint_resolution(objects, needs_transactions_or_objects(&mask))
+        });
+        assert_eq!(actual, ["summary", "transactions", "objects", "objects"]);
     }
 
     #[tokio::test]
-    async fn item_limit_remains_fused_to_limit_item_after_render_ahead() {
+    async fn item_limit_records_complete_metric_matrix_after_render_ahead() {
         let (ctx, registry, server) = query_context_with_registry("list_checkpoints", 10).await;
         let mut proto_options = ascending_options();
         proto_options.limit = Some(3);
@@ -739,6 +725,7 @@ mod tests {
         let responses: Vec<_> = drive_rendered_checkpoints(
             ctx,
             rendered_stream,
+            checkpoint_resolution(true, true),
             options,
             RangeExhaustion::CheckpointBound,
             10,
@@ -782,24 +769,28 @@ mod tests {
             .map(|response| response.encoded_len() as f64)
             .sum::<f64>();
         let families = registry.gather();
-        let render_latency = histogram_family(&families, "kv_rpc_response_render_latency_ms");
-        let yield_wait = histogram_family(&families, "kv_rpc_stream_item_yield_wait_ms");
-        let page_bytes = histogram_family(&families, "kv_rpc_response_page_bytes");
-        let first_item_latency = histogram_family(&families, "kv_rpc_stream_first_item_latency_ms");
-
-        for family in [render_latency, yield_wait, page_bytes, first_item_latency] {
-            assert_method_label(family, "list_checkpoints");
+        for (name, count) in [
+            ("kv_rpc_response_render_latency_ms", 3),
+            ("kv_rpc_stream_item_yield_wait_ms", 3),
+            ("kv_rpc_response_page_bytes", 3),
+            ("kv_rpc_stream_first_item_latency_ms", 1),
+            ("kv_rpc_final_stream_poll_wait_ms", 3),
+        ] {
+            let histogram = list_histogram(&families, name, "list_checkpoints", "objects");
+            assert_eq!(histogram.get_sample_count(), count);
         }
-        assert_eq!(histogram_sample_count(render_latency), 3);
-        assert_eq!(histogram_sample_count(yield_wait), 3);
-        assert_eq!(histogram_sample_count(page_bytes), 3);
-        assert_eq!(histogram_sample_count(first_item_latency), 1);
-        assert_eq!(histogram_sample_sum(page_bytes), expected_page_bytes);
+        let page_bytes = list_histogram(
+            &families,
+            "kv_rpc_response_page_bytes",
+            "list_checkpoints",
+            "objects",
+        );
+        assert_eq!(page_bytes.get_sample_sum(), expected_page_bytes);
     }
 
     #[tokio::test]
-    async fn natural_empty_range_emits_one_standalone_terminal_boundary() {
-        let (ctx, server) = query_context("test_list_checkpoints_natural_end", 10).await;
+    async fn empty_range_metric_coverage_records_only_terminal_page_bytes() {
+        let (ctx, registry, server) = query_context_with_registry("list_checkpoints", 10).await;
         let mut request = ListCheckpointsRequest::default();
         request.start_checkpoint = Some(0);
         request.end_checkpoint = Some(0);
@@ -832,6 +823,20 @@ mod tests {
             CursorToken::boundary(Position::Checkpoints { checkpoint: 0 }).encode();
         assert_eq!(watermark.cursor.as_ref(), Some(&expected_cursor));
         assert_eq!(watermark.checkpoint, None);
+        let families = registry.gather();
+        let page_bytes = list_histogram(
+            &families,
+            "kv_rpc_response_page_bytes",
+            "list_checkpoints",
+            "summary",
+        );
+        assert_eq!(page_bytes.get_sample_count(), 1);
+        assert_eq!(page_bytes.get_sample_sum(), response.encoded_len() as f64);
+        for name in LIST_PIPELINE_METRICS {
+            if name != "kv_rpc_response_page_bytes" {
+                assert_list_histogram_absent(&families, name);
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -280,6 +280,7 @@ pub(crate) async fn list_checkpoints(
                         },
                         covered_checkpoint_bound,
                     );
+                    let render_started = Instant::now();
                     let message = match item {
                         CheckpointListItem::Summary(_, cp_data) => {
                             crate::render::checkpoint_to_response(cp_data, &read_mask)?
@@ -288,16 +289,20 @@ pub(crate) async fn list_checkpoints(
                             render_full_checkpoint(cp_data, txs, objects, &read_mask)?
                         }
                     };
+                    ctx.observe_response_render(render_started.elapsed());
                     emitted += 1;
                     let mut response = response_for(watermark, message);
+                    let yield_started = Instant::now();
                     if emitted == limit_items {
                         let mut end = QueryEnd::default();
                         end.reason = Some(QueryEndReason::ItemLimit as i32);
                         response.end = Some(end);
                         yield response;
+                        ctx.observe_stream_item_yield_wait(yield_started.elapsed());
                         break QueryEndReason::ItemLimit;
                     }
                     yield response;
+                    ctx.observe_stream_item_yield_wait(yield_started.elapsed());
                 }
                 Ok(ResolvedWatermarked::Watermark {
                     position: _,

--- a/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2/list_checkpoints.rs
@@ -163,8 +163,11 @@ pub(crate) async fn list_checkpoints(
         )
         .0;
         return Ok(async_stream::try_stream! {
-            ctx.observe_response_page_bytes(resolution, response.encoded_len());
+            ctx.inc_stream_watermark_frames();
+            ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+            let yield_started = Instant::now();
             yield response;
+            ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
         }
         .boxed());
     }
@@ -324,6 +327,7 @@ fn drive_rendered_checkpoints(
         let limit_items = options.limit_items;
         let ordering = options.ordering;
         let mut emitted = 0usize;
+        let mut first_frame_emitted = false;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
             let Some(item) = ctx.next_response_item(resolution, &mut rendered_stream).await else {
@@ -336,8 +340,13 @@ fn drive_rendered_checkpoints(
                     covered_checkpoint_bound,
                     false,
                 );
-                ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                ctx.inc_stream_watermark_frames();
+                if !first_frame_emitted {
+                    ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                }
+                let yield_started = Instant::now();
                 yield response;
+                ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                 break reason;
             };
             match item {
@@ -365,12 +374,13 @@ fn drive_rendered_checkpoints(
                         response.end = Some(end);
                     }
                     ctx.observe_response_page_bytes(resolution, response.encoded_len());
-                    if emitted == 1 {
-                        ctx.observe_stream_first_item_latency(resolution, started.elapsed());
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                        first_frame_emitted = true;
                     }
                     let yield_started = Instant::now();
                     yield response;
-                    ctx.observe_stream_item_yield_wait(resolution, yield_started.elapsed());
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                     if item_limit {
                         break QueryEndReason::ItemLimit;
                     }
@@ -387,8 +397,14 @@ fn drive_rendered_checkpoints(
                         &mut covered_checkpoint_bound,
                     );
                     let response = watermark_response(watermark);
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                        first_frame_emitted = true;
+                    }
+                    let yield_started = Instant::now();
                     yield response;
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                 }
                 Err(RenderAheadError::Upstream(stop)) => {
                     let response = terminal_response_from_scan_stop(
@@ -398,8 +414,13 @@ fn drive_rendered_checkpoints(
                         entry_checkpoint,
                         &mut covered_checkpoint_bound,
                     )?;
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                    }
+                    let yield_started = Instant::now();
                     yield response;
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                     break QueryEndReason::ScanLimit;
                 }
                 Err(RenderAheadError::Render(error)) => Err(error)?,
@@ -682,8 +703,8 @@ mod tests {
     use sui_rpc_cursor::CursorToken;
 
     use crate::v2::test_utils::{
-        LIST_PIPELINE_METRICS, ascending_options, assert_list_histogram_absent, list_histogram,
-        query_context, query_context_with_registry,
+        LIST_PIPELINE_METRICS, ascending_options, assert_list_metric_absent, list_counter,
+        list_histogram, query_context, query_context_with_registry,
     };
 
     #[test]
@@ -775,9 +796,9 @@ mod tests {
         let families = registry.gather();
         for (name, count) in [
             ("kv_rpc_response_render_latency_ms", 3),
-            ("kv_rpc_stream_item_yield_wait_ms", 3),
+            ("kv_rpc_stream_frame_yield_wait_ms", 3),
             ("kv_rpc_response_page_bytes", 3),
-            ("kv_rpc_stream_first_item_latency_ms", 1),
+            ("kv_rpc_stream_first_frame_latency_ms", 1),
             ("kv_rpc_final_stream_poll_wait_ms", 3),
         ] {
             let histogram = list_histogram(&families, name, "list_checkpoints", "objects");
@@ -790,10 +811,11 @@ mod tests {
             "objects",
         );
         assert_eq!(page_bytes.get_sample_sum(), expected_page_bytes);
+        assert_list_metric_absent(&families, "kv_rpc_stream_watermark_frames_total");
     }
 
     #[tokio::test]
-    async fn empty_range_metric_coverage_records_only_terminal_page_bytes() {
+    async fn empty_range_metric_coverage_records_terminal_frame_metrics() {
         let (ctx, registry, server) = query_context_with_registry("list_checkpoints", 10).await;
         let mut request = ListCheckpointsRequest::default();
         request.start_checkpoint = Some(0);
@@ -828,17 +850,17 @@ mod tests {
         assert_eq!(watermark.cursor.as_ref(), Some(&expected_cursor));
         assert_eq!(watermark.checkpoint, None);
         let families = registry.gather();
-        let page_bytes = list_histogram(
-            &families,
-            "kv_rpc_response_page_bytes",
-            "list_checkpoints",
-            "summary",
-        );
-        assert_eq!(page_bytes.get_sample_count(), 1);
-        assert_eq!(page_bytes.get_sample_sum(), response.encoded_len() as f64);
         for name in LIST_PIPELINE_METRICS {
-            if name != "kv_rpc_response_page_bytes" {
-                assert_list_histogram_absent(&families, name);
+            match name {
+                "kv_rpc_stream_first_frame_latency_ms" | "kv_rpc_stream_frame_yield_wait_ms" => {
+                    let histogram = list_histogram(&families, name, "list_checkpoints", "summary");
+                    assert_eq!(histogram.get_sample_count(), 1);
+                }
+                "kv_rpc_stream_watermark_frames_total" => {
+                    let counter = list_counter(&families, name, "list_checkpoints");
+                    assert_eq!(counter.value(), 1.0);
+                }
+                _ => assert_list_metric_absent(&families, name),
             }
         }
     }

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -128,8 +128,11 @@ pub(crate) async fn list_events(
         };
         let response = range_end_response(&options, exhaustion, terminal_position, None, true).0;
         return Ok(async_stream::try_stream! {
-            ctx.observe_response_page_bytes(resolution, response.encoded_len());
+            ctx.inc_stream_watermark_frames();
+            ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+            let yield_started = Instant::now();
             yield response;
+            ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
         }
         .boxed());
     }
@@ -265,6 +268,7 @@ pub(crate) async fn list_events(
 
     Ok(async_stream::try_stream! {
         let mut emitted = 0usize;
+        let mut first_frame_emitted = false;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
             let Some(item) = ctx.next_response_item(resolution, &mut rendered_stream).await else {
@@ -280,8 +284,13 @@ pub(crate) async fn list_events(
                     covered_checkpoint_bound,
                     false,
                 );
-                ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                ctx.inc_stream_watermark_frames();
+                if !first_frame_emitted {
+                    ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                }
+                let yield_started = Instant::now();
                 yield response;
+                ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                 break reason;
             };
             match item {
@@ -311,12 +320,13 @@ pub(crate) async fn list_events(
                         response.end = Some(end);
                     }
                     ctx.observe_response_page_bytes(resolution, response.encoded_len());
-                    if emitted == 1 {
-                        ctx.observe_stream_first_item_latency(resolution, started.elapsed());
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                        first_frame_emitted = true;
                     }
                     let yield_started = Instant::now();
                     yield response;
-                    ctx.observe_stream_item_yield_wait(resolution, yield_started.elapsed());
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                     if item_limit {
                         break QueryEndReason::ItemLimit;
                     }
@@ -334,8 +344,14 @@ pub(crate) async fn list_events(
                         Some(checkpoint_at_frontier),
                     )?;
                     let response = watermark_response(watermark);
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                        first_frame_emitted = true;
+                    }
+                    let yield_started = Instant::now();
                     yield response;
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                 }
                 Err(RenderAheadError::Upstream(stop)) => {
                     let response = terminal_response_from_scan_stop(
@@ -345,8 +361,13 @@ pub(crate) async fn list_events(
                         entry_checkpoint,
                         &mut covered_checkpoint_bound,
                     )?;
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                    }
+                    let yield_started = Instant::now();
                     yield response;
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                     break QueryEndReason::ScanLimit;
                 }
                 Err(RenderAheadError::Render(error)) => Err(error)?,
@@ -844,7 +865,7 @@ mod tests {
     use super::*;
     use crate::v2::test_utils::query_context_with_mock_and_registry as metric_context;
     use crate::v2::test_utils::{
-        LIST_PIPELINE_METRICS, ascending_options, assert_list_histogram_absent, list_histogram,
+        ascending_options, assert_list_metric_absent, list_counter, list_histogram,
         query_context_with_registry,
     };
     use move_core_types::ident_str;
@@ -886,9 +907,9 @@ mod tests {
             let families = registry.gather();
             for (name, sample_count) in [
                 ("kv_rpc_response_render_latency_ms", 1),
-                ("kv_rpc_response_page_bytes", responses.len() as u64),
-                ("kv_rpc_stream_first_item_latency_ms", 1),
-                ("kv_rpc_stream_item_yield_wait_ms", 1),
+                ("kv_rpc_response_page_bytes", 1),
+                ("kv_rpc_stream_first_frame_latency_ms", 1),
+                ("kv_rpc_stream_frame_yield_wait_ms", responses.len() as u64),
             ] {
                 let histogram = list_histogram(&families, name, "list_events", "no_json");
                 assert_eq!(histogram.get_sample_count(), sample_count);
@@ -903,9 +924,16 @@ mod tests {
                 page_bytes.get_sample_sum(),
                 responses
                     .iter()
+                    .filter(|response| response.event.is_some())
                     .map(|response| response.encoded_len() as f64)
                     .sum::<f64>()
             );
+            let watermark_frames = list_counter(
+                &families,
+                "kv_rpc_stream_watermark_frames_total",
+                "list_events",
+            );
+            assert_eq!(watermark_frames.value(), (responses.len() - 1) as f64);
             let final_poll = list_histogram(
                 &families,
                 "kv_rpc_final_stream_poll_wait_ms",
@@ -915,26 +943,29 @@ mod tests {
             assert_eq!(final_poll.get_sample_count(), responses.len() as u64);
         } else {
             let first = responses.try_next().await.unwrap().unwrap();
-            assert_eq!(first.event, Some(expected));
+            assert_eq!(first.event, Some(expected.clone()));
+            let second = responses.try_next().await.unwrap().unwrap();
+            assert_eq!(second.event, Some(expected));
             tokio::task::yield_now().await;
             drop(responses);
             let families = registry.gather();
-            for name in [
-                "kv_rpc_response_render_latency_ms",
-                "kv_rpc_response_page_bytes",
-                "kv_rpc_stream_first_item_latency_ms",
+            for (name, sample_count) in [
+                ("kv_rpc_response_render_latency_ms", 2),
+                ("kv_rpc_response_page_bytes", 2),
+                ("kv_rpc_stream_first_frame_latency_ms", 1),
+                ("kv_rpc_stream_frame_yield_wait_ms", 1),
             ] {
                 let histogram = list_histogram(&families, name, "list_events", "no_json");
-                assert_eq!(histogram.get_sample_count(), 1);
+                assert_eq!(histogram.get_sample_count(), sample_count);
             }
-            assert_list_histogram_absent(&families, "kv_rpc_stream_item_yield_wait_ms");
+            assert_list_metric_absent(&families, "kv_rpc_stream_watermark_frames_total");
             let final_poll = list_histogram(
                 &families,
                 "kv_rpc_final_stream_poll_wait_ms",
                 "list_events",
                 "no_json",
             );
-            assert_eq!(final_poll.get_sample_count(), 1);
+            assert_eq!(final_poll.get_sample_count(), 2);
         }
         server.abort();
     }
@@ -976,7 +1007,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_ledger_metric_coverage_records_only_event_terminal_page_bytes() {
+    async fn empty_ledger_metric_coverage_records_event_terminal_frame_metrics() {
         let (ctx, registry, server) = query_context_with_registry("list_events", 0).await;
         let mut request = ListEventsRequest::default();
         request.read_mask = Some(FieldMask::from_paths(["event_type"]));
@@ -1010,19 +1041,26 @@ mod tests {
         assert_eq!(watermark.cursor.as_ref(), Some(&expected_cursor));
         assert_eq!(watermark.checkpoint, None);
         let families = registry.gather();
-        let page_bytes = list_histogram(
-            &families,
+        for name in [
+            "kv_rpc_response_render_latency_ms",
             "kv_rpc_response_page_bytes",
-            "list_events",
-            "no_json",
-        );
-        assert_eq!(page_bytes.get_sample_count(), 1);
-        assert_eq!(page_bytes.get_sample_sum(), response.encoded_len() as f64);
-        for name in LIST_PIPELINE_METRICS {
-            if name != "kv_rpc_response_page_bytes" {
-                assert_list_histogram_absent(&families, name);
-            }
+            "kv_rpc_final_stream_poll_wait_ms",
+        ] {
+            assert_list_metric_absent(&families, name);
         }
+        for name in [
+            "kv_rpc_stream_first_frame_latency_ms",
+            "kv_rpc_stream_frame_yield_wait_ms",
+        ] {
+            let histogram = list_histogram(&families, name, "list_events", "no_json");
+            assert_eq!(histogram.get_sample_count(), 1);
+        }
+        let watermark_frames = list_counter(
+            &families,
+            "kv_rpc_stream_watermark_frames_total",
+            "list_events",
+        );
+        assert_eq!(watermark_frames.value(), 1.0);
     }
     use std::ops::Bound;
     use sui_rpc_api::ledger_history::query_options::Ordering;

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -50,10 +50,12 @@ use crate::bigtable_client::BigTableClient;
 use crate::config::PipelineStage;
 use crate::operation::QueryContext;
 use crate::pipeline::InputOrderEmitter;
+use crate::pipeline::RenderAheadError;
 use crate::pipeline::ResolvedScanStop;
 use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
 use crate::pipeline::pipelined_chunks;
+use crate::pipeline::render_ahead;
 use crate::pipeline::resolve_scan_watermarks;
 use crate::pipeline::take_items;
 use crate::render::render_json;
@@ -139,7 +141,6 @@ pub(crate) async fn list_events(
     // Stage A: stream of EventRefs. Filtered requests discover event positions
     // through the event bitmap. Unfiltered requests scan tx_seq_digest rows and
     // expand each row's event_count into concrete EventRefs.
-    let request_bigtable_concurrency = ctx.request_bigtable_concurrency();
     let event_ref_stream: BoxStream<
         'static,
         Result<Watermarked<EventRef, EventPosition>, ScanStop>,
@@ -224,55 +225,47 @@ pub(crate) async fn list_events(
         },
     );
 
-    // Stage D: render. `buffered` (ordered) lets per-event JSON rendering
-    // overlap while preserving input ref order in the output. Frontier
-    // watermarks pass through unchanged.
+    let event_stream = resolve_scan_watermarks(
+        tx_ref_stream,
+        client.event_wm_resolver(direction),
+        frontier_to_position,
+    );
+
+    // Stage D: render. Spawned render tasks are admitted up to this endpoint's
+    // render-ahead bound. Admitted tasks run freely while their results remain
+    // ordered, and frontier watermarks pass through unchanged.
     //
     // Package resolution uses the server-global `PackageResolver`, backed by
     // a cross-request LRU over the raw BigTable client. It is intentionally
     // outside this request's downstream BigTable semaphore: tying a global
     // cache miss to one request's budget would let that request's budget stall
-    // unrelated requests waiting on the same package. The local buffer below
-    // only bounds how many render/package-resolution attempts this request
-    // runs concurrently.
+    // unrelated requests waiting on the same package. The admission bound
+    // limits this request's concurrent render/package-resolution attempts.
     //
     // TODO: add global single-flight dedupe around package cache misses so
     // concurrent requests for the same uncached package share one BigTable
     // fetch.
-    let event_stream = tx_ref_stream
-        .map(move |item| {
+    let rendered_stream = render_ahead(event_stream, endpoint.render_ahead, {
+        let resolver = resolver.clone();
+        let read_mask = read_mask.clone();
+        move |(event_ref, tx)| {
             let resolver = resolver.clone();
             let read_mask = read_mask.clone();
             async move {
-                match item? {
-                    Watermarked::Item((event_ref, tx)) => {
-                        let rendered =
-                            render_event(event_ref, tx, &read_mask, &resolver, wants_json)
-                                .await
-                                .map_err(|e| ScanStop::Fault(anyhow::Error::new(e)))?;
-                        Ok::<Watermarked<RenderedEvent, EventPosition>, ScanStop>(
-                            Watermarked::Item(rendered),
-                        )
-                    }
-                    Watermarked::Watermark(p) => Ok(Watermarked::Watermark(p)),
-                }
+                let render_started = Instant::now();
+                let rendered =
+                    render_event(event_ref, tx, &read_mask, &resolver, wants_json).await?;
+                Ok::<_, RpcError>((rendered, render_started.elapsed()))
             }
-        })
-        .buffered(request_bigtable_concurrency)
-        .boxed();
-
-    let event_stream = resolve_scan_watermarks(
-        event_stream,
-        client.event_wm_resolver(direction),
-        frontier_to_position,
-    );
+        }
+    });
 
     Ok(async_stream::try_stream! {
-        futures::pin_mut!(event_stream);
+        futures::pin_mut!(rendered_stream);
         let mut emitted = 0usize;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
-            let Some(item) = event_stream.next().await else {
+            let Some(item) = rendered_stream.next().await else {
                 let terminal_position = Position::Events {
                     checkpoint: range_end_checkpoint,
                     tx_seq: range_end_position.tx_seq,
@@ -289,7 +282,7 @@ pub(crate) async fn list_events(
                 break reason;
             };
             match item {
-                Ok(ResolvedWatermarked::Item(rendered)) => {
+                Ok(ResolvedWatermarked::Item((rendered, render_elapsed))) => {
                     let item_checkpoint = rendered.checkpoint_number;
                     covered_checkpoint_bound = advance_covered_bound_before_checkpoint(
                         covered_checkpoint_bound,
@@ -306,6 +299,7 @@ pub(crate) async fn list_events(
                         covered_checkpoint_bound,
                     );
                     emitted += 1;
+                    ctx.observe_response_render(render_elapsed);
                     let mut response = event_item_response(rendered.event, watermark);
                     if emitted == limit_items {
                         let mut end = QueryEnd::default();
@@ -330,7 +324,7 @@ pub(crate) async fn list_events(
                     )?;
                     yield watermark_response(watermark);
                 }
-                Err(stop) => {
+                Err(RenderAheadError::Upstream(stop)) => {
                     yield terminal_response_from_scan_stop(
                         stop,
                         &options,
@@ -340,6 +334,7 @@ pub(crate) async fn list_events(
                     )?;
                     break QueryEndReason::ScanLimit;
                 }
+                Err(RenderAheadError::Render(error)) => Err(error)?,
             }
         };
         info!(

--- a/crates/sui-kv-rpc/src/v2/list_events.rs
+++ b/crates/sui-kv-rpc/src/v2/list_events.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
+use prost::Message;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::ScanStop;
 use sui_inverted_index::event_seq;
@@ -64,6 +65,10 @@ const EVENT_READ_MASK_DEFAULT: &str = sui_rpc_api::read_mask_defaults::EVENT;
 
 pub(crate) type ListEventsStream = BoxStream<'static, Result<ListEventsResponse, RpcError>>;
 
+fn event_resolution(wants_json: bool) -> &'static str {
+    if wants_json { "json" } else { "no_json" }
+}
+
 pub(crate) async fn list_events(
     ctx: QueryContext,
     request: ListEventsRequest,
@@ -93,6 +98,7 @@ pub(crate) async fn list_events(
     let ordering = options.ordering;
     let direction = options.scan_direction();
     let wants_json = read_mask.contains(ProtoEvent::JSON_FIELD.name);
+    let resolution = event_resolution(wants_json);
 
     let event_range = resolve_event_range(&client, checkpoint_range, &options)
         .instrument(debug_span!("resolve_event_range"))
@@ -120,14 +126,11 @@ pub(crate) async fn list_events(
             tx_seq: range_end_position.tx_seq,
             event_index: range_end_position.event_index,
         };
-        return Ok(futures::stream::iter([Ok(range_end_response(
-            &options,
-            exhaustion,
-            terminal_position,
-            None,
-            true,
-        )
-        .0)])
+        let response = range_end_response(&options, exhaustion, terminal_position, None, true).0;
+        return Ok(async_stream::try_stream! {
+            ctx.observe_response_page_bytes(resolution, response.encoded_len());
+            yield response;
+        }
         .boxed());
     }
 
@@ -245,7 +248,7 @@ pub(crate) async fn list_events(
     // TODO: add global single-flight dedupe around package cache misses so
     // concurrent requests for the same uncached package share one BigTable
     // fetch.
-    let rendered_stream = render_ahead(event_stream, endpoint.render_ahead, {
+    let mut rendered_stream = render_ahead(event_stream, endpoint.render_ahead, {
         let resolver = resolver.clone();
         let read_mask = read_mask.clone();
         move |(event_ref, tx)| {
@@ -261,11 +264,10 @@ pub(crate) async fn list_events(
     });
 
     Ok(async_stream::try_stream! {
-        futures::pin_mut!(rendered_stream);
         let mut emitted = 0usize;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
-            let Some(item) = rendered_stream.next().await else {
+            let Some(item) = ctx.next_response_item(resolution, &mut rendered_stream).await else {
                 let terminal_position = Position::Events {
                     checkpoint: range_end_checkpoint,
                     tx_seq: range_end_position.tx_seq,
@@ -278,6 +280,7 @@ pub(crate) async fn list_events(
                     covered_checkpoint_bound,
                     false,
                 );
+                ctx.observe_response_page_bytes(resolution, response.encoded_len());
                 yield response;
                 break reason;
             };
@@ -299,16 +302,24 @@ pub(crate) async fn list_events(
                         covered_checkpoint_bound,
                     );
                     emitted += 1;
-                    ctx.observe_response_render(render_elapsed);
+                    ctx.observe_response_render(resolution, render_elapsed);
                     let mut response = event_item_response(rendered.event, watermark);
-                    if emitted == limit_items {
+                    let item_limit = emitted == limit_items;
+                    if item_limit {
                         let mut end = QueryEnd::default();
                         end.reason = Some(QueryEndReason::ItemLimit as i32);
                         response.end = Some(end);
-                        yield response;
+                    }
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    if emitted == 1 {
+                        ctx.observe_stream_first_item_latency(resolution, started.elapsed());
+                    }
+                    let yield_started = Instant::now();
+                    yield response;
+                    ctx.observe_stream_item_yield_wait(resolution, yield_started.elapsed());
+                    if item_limit {
                         break QueryEndReason::ItemLimit;
                     }
-                    yield response;
                 }
                 Ok(ResolvedWatermarked::Watermark {
                     position,
@@ -322,16 +333,20 @@ pub(crate) async fn list_events(
                         position,
                         Some(checkpoint_at_frontier),
                     )?;
-                    yield watermark_response(watermark);
+                    let response = watermark_response(watermark);
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    yield response;
                 }
                 Err(RenderAheadError::Upstream(stop)) => {
-                    yield terminal_response_from_scan_stop(
+                    let response = terminal_response_from_scan_stop(
                         stop,
                         &options,
                         direction,
                         entry_checkpoint,
                         &mut covered_checkpoint_bound,
                     )?;
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    yield response;
                     break QueryEndReason::ScanLimit;
                 }
                 Err(RenderAheadError::Render(error)) => Err(error)?,
@@ -823,17 +838,146 @@ async fn checkpoint_to_tx_boundary(
 
 #[cfg(test)]
 mod tests {
+    use sui_kvstore::testing::insert_checkpoint_rows;
     use sui_types::digests::TransactionDigest;
 
     use super::*;
+    use crate::v2::test_utils::query_context_with_mock_and_registry as metric_context;
+    use crate::v2::test_utils::{
+        LIST_PIPELINE_METRICS, ascending_options, assert_list_histogram_absent, list_histogram,
+        query_context_with_registry,
+    };
+    use move_core_types::ident_str;
+    use sui_rpc::proto::sui::rpc::v2 as proto;
     use sui_rpc_cursor::CursorToken;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
+    use sui_types::{base_types::ObjectID, event::Event, gas_coin::GAS};
 
-    use crate::v2::test_utils::ascending_options;
-    use crate::v2::test_utils::query_context;
+    fn resolution(request: &mut ListEventsRequest, path: &str) -> &'static str {
+        request.read_mask = Some(FieldMask::from_paths([path]));
+        let mask = validate_event_read_mask(request.read_mask.take()).unwrap();
+        event_resolution(mask.contains(ProtoEvent::JSON_FIELD.name))
+    }
+
+    async fn assert_event_metrics(count: usize) {
+        let event = Event::new(
+            &ObjectID::ZERO,
+            ident_str!("metrics"),
+            TestCheckpointBuilder::derive_address(1),
+            GAS::type_(),
+            vec![],
+        );
+        let checkpoint = TestCheckpointBuilder::new(0)
+            .start_transaction(1)
+            .with_events(vec![event.clone(); count])
+            .finish_transaction()
+            .build_checkpoint();
+        let (ctx, registry, mock, server) = metric_context("list_events", 1).await;
+        insert_checkpoint_rows(&mock, &checkpoint).await;
+        let mut request = ListEventsRequest::default();
+        request.read_mask = Some(FieldMask::from_paths(["event_type"]));
+        request.options = Some(ascending_options());
+        request.options.as_mut().unwrap().limit = (count == 2).then_some(2);
+        let mask = validate_event_read_mask(request.read_mask.clone()).unwrap();
+        let expected = ProtoEvent::merge_from(&event, &mask);
+        let mut responses = list_events(ctx, request).await.unwrap();
+        if count == 1 {
+            let responses = responses.try_collect::<Vec<_>>().await.unwrap();
+            let families = registry.gather();
+            for (name, sample_count) in [
+                ("kv_rpc_response_render_latency_ms", 1),
+                ("kv_rpc_response_page_bytes", responses.len() as u64),
+                ("kv_rpc_stream_first_item_latency_ms", 1),
+                ("kv_rpc_stream_item_yield_wait_ms", 1),
+            ] {
+                let histogram = list_histogram(&families, name, "list_events", "no_json");
+                assert_eq!(histogram.get_sample_count(), sample_count);
+            }
+            let page_bytes = list_histogram(
+                &families,
+                "kv_rpc_response_page_bytes",
+                "list_events",
+                "no_json",
+            );
+            assert_eq!(
+                page_bytes.get_sample_sum(),
+                responses
+                    .iter()
+                    .map(|response| response.encoded_len() as f64)
+                    .sum::<f64>()
+            );
+            let final_poll = list_histogram(
+                &families,
+                "kv_rpc_final_stream_poll_wait_ms",
+                "list_events",
+                "no_json",
+            );
+            assert_eq!(final_poll.get_sample_count(), responses.len() as u64);
+        } else {
+            let first = responses.try_next().await.unwrap().unwrap();
+            assert_eq!(first.event, Some(expected));
+            tokio::task::yield_now().await;
+            drop(responses);
+            let families = registry.gather();
+            for name in [
+                "kv_rpc_response_render_latency_ms",
+                "kv_rpc_response_page_bytes",
+                "kv_rpc_stream_first_item_latency_ms",
+            ] {
+                let histogram = list_histogram(&families, name, "list_events", "no_json");
+                assert_eq!(histogram.get_sample_count(), 1);
+            }
+            assert_list_histogram_absent(&families, "kv_rpc_stream_item_yield_wait_ms");
+            let final_poll = list_histogram(
+                &families,
+                "kv_rpc_final_stream_poll_wait_ms",
+                "list_events",
+                "no_json",
+            );
+            assert_eq!(final_poll.get_sample_count(), 1);
+        }
+        server.abort();
+    }
+
+    #[test]
+    fn resolution_uses_validated_read_mask_predicate() {
+        let mut request = ListEventsRequest::default();
+        for (path, expected) in [("event_type", "no_json"), ("json", "json")] {
+            assert_eq!(resolution(&mut request, path), expected);
+        }
+    }
+
+    #[test]
+    fn resolution_is_independent_of_filter_and_non_json_fields() {
+        let mut event_type_filter = proto::EventTypeFilter::default();
+        event_type_filter.event_type = Some("0x2::observability::ArbitraryEvent".to_owned());
+        let mut literal = proto::EventLiteral::default();
+        literal.predicate = Some(proto::event_literal::Predicate::EventType(
+            event_type_filter,
+        ));
+        let mut request = ListEventsRequest::default();
+        let filter = request.filter.insert(proto::EventFilter::default());
+        filter.terms.push(proto::EventTerm::default());
+        filter.terms[0].literals.push(literal);
+        for (path, expected) in [
+            ("event_type", "no_json"),
+            ("checkpoint", "no_json"),
+            ("transaction_digest", "no_json"),
+            ("json", "json"),
+        ] {
+            assert_eq!(resolution(&mut request, path), expected);
+        }
+    }
 
     #[tokio::test]
-    async fn empty_ledger_tip_emits_one_standalone_event_boundary() {
-        let (ctx, server) = query_context("test_list_events_natural_end", 0).await;
+    async fn list_events_metric_coverage_excludes_discarded_render_ahead_items() {
+        assert_event_metrics(1).await;
+        assert_event_metrics(2).await;
+    }
+
+    #[tokio::test]
+    async fn empty_ledger_metric_coverage_records_only_event_terminal_page_bytes() {
+        let (ctx, registry, server) = query_context_with_registry("list_events", 0).await;
         let mut request = ListEventsRequest::default();
         request.read_mask = Some(FieldMask::from_paths(["event_type"]));
         request.options = Some(ascending_options());
@@ -865,6 +1009,20 @@ mod tests {
         .encode();
         assert_eq!(watermark.cursor.as_ref(), Some(&expected_cursor));
         assert_eq!(watermark.checkpoint, None);
+        let families = registry.gather();
+        let page_bytes = list_histogram(
+            &families,
+            "kv_rpc_response_page_bytes",
+            "list_events",
+            "no_json",
+        );
+        assert_eq!(page_bytes.get_sample_count(), 1);
+        assert_eq!(page_bytes.get_sample_sum(), response.encoded_len() as f64);
+        for name in LIST_PIPELINE_METRICS {
+            if name != "kv_rpc_response_page_bytes" {
+                assert_list_histogram_absent(&families, name);
+            }
+        }
     }
     use std::ops::Bound;
     use sui_rpc_api::ledger_history::query_options::Ordering;

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -72,7 +72,7 @@ enum RenderedTransactionItem {
         tx_seq: u64,
         checkpoint: u64,
         tx_offset: u32,
-        executed: ExecutedTransaction,
+        executed: Box<ExecutedTransaction>,
         render_elapsed: Duration,
     },
 }
@@ -258,7 +258,7 @@ pub(crate) async fn list_transactions(
                             tx_seq,
                             checkpoint,
                             tx_offset,
-                            executed,
+                            executed: Box::new(executed),
                             render_elapsed: render_started.elapsed(),
                         }
                     }
@@ -329,7 +329,7 @@ pub(crate) async fn list_transactions(
                             ctx.observe_response_render(resolution, render_elapsed);
                             transaction_item_response(
                                 watermark,
-                                executed,
+                                *executed,
                                 tx_offset,
                                 &read_mask,
                             )

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
+use prost::Message;
 use sui_inverted_index::ScanDirection;
 use sui_inverted_index::ScanStop;
 use sui_kvstore::BitmapIndexSpec;
@@ -97,6 +98,9 @@ pub(crate) async fn list_transactions(
         checkpoint_hi_exclusive,
     )?;
     let read_mask = validate_read_mask(request.read_mask)?;
+    let needs_objects = needs_object_types(&read_mask);
+    let render_transaction_contents = should_render_transaction_contents(&read_mask);
+    let resolution = transaction_resolution(needs_objects, render_transaction_contents);
     let options = QueryOptions::transactions_from_proto(
         request.options.as_ref(),
         endpoint.default_limit_items,
@@ -125,7 +129,7 @@ pub(crate) async fn list_transactions(
         );
         // Empty resolved ranges still surface their terminal cursor, but claim
         // no checkpoint coverage.
-        return Ok(futures::stream::iter([Ok(range_end_response(
+        let response = range_end_response(
             &options,
             exhaustion,
             Position::Transactions {
@@ -135,7 +139,11 @@ pub(crate) async fn list_transactions(
             None,
             true,
         )
-        .0)])
+        .0;
+        return Ok(async_stream::try_stream! {
+            ctx.observe_response_page_bytes(resolution, response.encoded_len());
+            yield response;
+        }
         .boxed());
     }
 
@@ -178,11 +186,9 @@ pub(crate) async fn list_transactions(
             scan_tx_seq_digests(client.clone(), tx_range.clone(), limit_items, &options).await?
         };
 
-    let render_transaction_contents = should_render_transaction_contents(&read_mask);
     let transaction_stream: BoxStream<'static, Result<Watermarked<TransactionListItem>, ScanStop>> =
         if render_transaction_contents {
             let columns: Arc<[&'static str]> = transaction_columns(&read_mask).into();
-            let needs_objects = needs_object_types(&read_mask);
 
             // Stage 3: Watermarked<TxSeqDigestData> ->
             // Watermarked<(tx_seq, TransactionData)>.
@@ -233,7 +239,7 @@ pub(crate) async fn list_transactions(
         client.tx_wm_resolver(direction),
         std::convert::identity,
     );
-    let rendered_stream = render_ahead(transaction_stream, endpoint.render_ahead, {
+    let mut rendered_stream = render_ahead(transaction_stream, endpoint.render_ahead, {
         let read_mask = read_mask.clone();
         let resolver = resolver.clone();
         move |item| {
@@ -262,11 +268,13 @@ pub(crate) async fn list_transactions(
     });
 
     Ok(async_stream::try_stream! {
-        futures::pin_mut!(rendered_stream);
         let mut emitted = 0usize;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
-            let Some(item) = rendered_stream.next().await else {
+            let Some(item) = ctx
+                .next_response_item(resolution, &mut rendered_stream)
+                .await
+            else {
                 let (response, reason) = range_end_response(
                     &options,
                     exhaustion,
@@ -277,6 +285,7 @@ pub(crate) async fn list_transactions(
                     covered_checkpoint_bound,
                     false,
                 );
+                ctx.observe_response_page_bytes(resolution, response.encoded_len());
                 yield response;
                 break reason;
             };
@@ -305,7 +314,11 @@ pub(crate) async fn list_transactions(
                     );
                     let mut response = match item {
                         RenderedTransactionItem::Digest(row) => {
-                            transaction_response_from_tx_seq_digest(row, &read_mask, watermark)
+                            let render_started = Instant::now();
+                            let response =
+                                transaction_response_from_tx_seq_digest(row, &read_mask, watermark);
+                            ctx.observe_response_render(resolution, render_started.elapsed());
+                            response
                         }
                         RenderedTransactionItem::Full {
                             tx_offset,
@@ -313,7 +326,7 @@ pub(crate) async fn list_transactions(
                             render_elapsed,
                             ..
                         } => {
-                            ctx.observe_response_render(render_elapsed);
+                            ctx.observe_response_render(resolution, render_elapsed);
                             transaction_item_response(
                                 watermark,
                                 executed,
@@ -323,17 +336,22 @@ pub(crate) async fn list_transactions(
                         }
                     };
                     emitted += 1;
-                    let yield_started = Instant::now();
-                    if emitted == limit_items {
+                    let item_limit = emitted == limit_items;
+                    if item_limit {
                         let mut end = QueryEnd::default();
                         end.reason = Some(QueryEndReason::ItemLimit as i32);
                         response.end = Some(end);
-                        yield response;
-                        ctx.observe_stream_item_yield_wait(yield_started.elapsed());
+                    }
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    if emitted == 1 {
+                        ctx.observe_stream_first_item_latency(resolution, started.elapsed());
+                    }
+                    let yield_started = Instant::now();
+                    yield response;
+                    ctx.observe_stream_item_yield_wait(resolution, yield_started.elapsed());
+                    if item_limit {
                         break QueryEndReason::ItemLimit;
                     }
-                    yield response;
-                    ctx.observe_stream_item_yield_wait(yield_started.elapsed());
                 }
                 Ok(ResolvedWatermarked::Watermark {
                     position,
@@ -347,16 +365,20 @@ pub(crate) async fn list_transactions(
                         position,
                         Some(checkpoint_at_frontier),
                     )?;
-                    yield watermark_response(watermark);
+                    let response = watermark_response(watermark);
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    yield response;
                 }
                 Err(RenderAheadError::Upstream(stop)) => {
-                    yield terminal_response_from_scan_stop(
+                    let response = terminal_response_from_scan_stop(
                         stop,
                         &options,
                         direction,
                         entry_checkpoint,
                         &mut covered_checkpoint_bound,
                     )?;
+                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    yield response;
                     break QueryEndReason::ScanLimit;
                 }
                 Err(RenderAheadError::Render(error)) => Err(error)?,
@@ -530,6 +552,14 @@ async fn fetch_transactions(
     .boxed())
 }
 
+fn transaction_resolution(needs_objects: bool, render_transaction_contents: bool) -> &'static str {
+    match (needs_objects, render_transaction_contents) {
+        (true, _) => "full_objects",
+        (false, true) => "full",
+        (false, false) => "digest",
+    }
+}
+
 fn should_render_transaction_contents(read_mask: &FieldMaskTree) -> bool {
     // `digest`, `checkpoint`, and `transaction_index` are all available from the
     // tx_seq_digest index row, so a mask limited to them skips the full
@@ -664,6 +694,7 @@ fn range_end_response(
 
 #[cfg(test)]
 mod tests {
+    use sui_kvstore::testing::insert_checkpoint_rows;
     use sui_rpc::field::FieldMask;
     use sui_rpc::field::FieldMaskUtil;
     use sui_types::digests::TransactionDigest;
@@ -671,12 +702,88 @@ mod tests {
     use super::*;
     use sui_rpc_cursor::CursorToken;
 
-    use crate::v2::test_utils::ascending_options;
-    use crate::v2::test_utils::query_context;
+    use crate::v2::test_utils::{
+        LIST_PIPELINE_METRICS, ascending_options, assert_list_histogram_absent, list_histogram,
+        query_context_with_mock_and_registry, query_context_with_registry,
+    };
 
     #[tokio::test]
-    async fn empty_ledger_tip_emits_one_standalone_transaction_boundary() {
-        let (ctx, server) = query_context("test_list_transactions_natural_end", 0).await;
+    async fn digest_resolution_records_all_metrics_without_hydration() {
+        let outputs = [
+            ["digest"].as_slice(),
+            ["transaction"].as_slice(),
+            ["effects.changed_objects"].as_slice(),
+            ["transaction", "effects.changed_objects"].as_slice(),
+        ]
+        .map(|paths| {
+            let mask =
+                validate_read_mask(Some(FieldMask::from_paths(paths.iter().copied()))).unwrap();
+            transaction_resolution(
+                needs_object_types(&mask),
+                should_render_transaction_contents(&mask),
+            )
+        });
+        assert_eq!(outputs, ["digest", "full", "full_objects", "full_objects"]);
+        let method = "list_transactions";
+        let (ctx, registry, mock, server) = query_context_with_mock_and_registry(method, 1).await;
+        let mut builder = sui_types::test_checkpoint_data_builder::TestCheckpointBuilder::new(0);
+        builder = builder.start_transaction(1).finish_transaction();
+        builder = builder.start_transaction(2).finish_transaction();
+        let checkpoint = builder.build_checkpoint();
+        insert_checkpoint_rows(&mock, &checkpoint).await;
+        let mut request = ListTransactionsRequest::default();
+        request.start_checkpoint = Some(0);
+        request.end_checkpoint = Some(1);
+        request.read_mask = Some(FieldMask::from_paths(["digest"]));
+        validate_read_mask(request.read_mask.clone()).unwrap();
+        let stream = list_transactions(ctx, request).await.unwrap();
+        let responses: Vec<_> = stream.try_collect().await.unwrap();
+        let emitted_digests = responses
+            .iter()
+            .filter_map(|response| response.transaction.as_ref())
+            .map(|transaction| transaction.digest.clone().unwrap());
+        let expected_digests = checkpoint
+            .transactions
+            .iter()
+            .map(|transaction| transaction.transaction.digest().to_string());
+        assert!(emitted_digests.eq(expected_digests));
+        let families = registry.gather();
+        let data_items = checkpoint.transactions.len() as u64;
+        for (name, sample_count) in [
+            ("kv_rpc_response_render_latency_ms", data_items),
+            ("kv_rpc_response_page_bytes", responses.len() as u64),
+            ("kv_rpc_stream_first_item_latency_ms", 1),
+            ("kv_rpc_stream_item_yield_wait_ms", data_items),
+        ] {
+            let histogram = list_histogram(&families, name, method, "digest");
+            assert_eq!(histogram.get_sample_count(), sample_count);
+        }
+        let page_bytes = list_histogram(&families, "kv_rpc_response_page_bytes", method, "digest");
+        assert_eq!(
+            page_bytes.get_sample_sum(),
+            responses
+                .iter()
+                .map(|response| response.encoded_len() as f64)
+                .sum::<f64>()
+        );
+        let final_poll = list_histogram(
+            &families,
+            "kv_rpc_final_stream_poll_wait_ms",
+            method,
+            "digest",
+        );
+        assert_eq!(final_poll.get_sample_count(), responses.len() as u64);
+        let calls = mock.read_rows_calls().await;
+        assert!(calls.iter().all(|call| {
+            call.table != sui_kvstore::tables::transactions::NAME
+                && call.table != sui_kvstore::tables::objects::NAME
+        }));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn empty_ledger_metric_coverage_records_only_transaction_terminal_page_bytes() {
+        let (ctx, registry, server) = query_context_with_registry("list_transactions", 0).await;
         let mut request = ListTransactionsRequest::default();
         request.read_mask = Some(FieldMask::from_paths(["digest"]));
         request.options = Some(ascending_options());
@@ -710,6 +817,20 @@ mod tests {
         .encode();
         assert_eq!(watermark.cursor.as_ref(), Some(&expected_cursor));
         assert_eq!(watermark.checkpoint, None);
+        let families = registry.gather();
+        let page_bytes = list_histogram(
+            &families,
+            "kv_rpc_response_page_bytes",
+            "list_transactions",
+            "digest",
+        );
+        assert_eq!(page_bytes.get_sample_count(), 1);
+        assert_eq!(page_bytes.get_sample_sum(), response.encoded_len() as f64);
+        for name in LIST_PIPELINE_METRICS {
+            if name != "kv_rpc_response_page_bytes" {
+                assert_list_histogram_absent(&families, name);
+            }
+        }
     }
 
     #[test]

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use futures::StreamExt;
@@ -41,10 +42,12 @@ use crate::config::PipelineStage;
 use crate::object_cache::ObjectMap;
 use crate::operation::QueryContext;
 use crate::pipeline::InputOrderEmitter;
+use crate::pipeline::RenderAheadError;
 use crate::pipeline::ResolvedScanStop;
 use crate::pipeline::ResolvedWatermarked;
 use crate::pipeline::Watermarked;
 use crate::pipeline::pipelined_chunks;
+use crate::pipeline::render_ahead;
 use crate::pipeline::resolve_scan_watermarks;
 use crate::pipeline::take_items;
 use crate::render::transaction_to_response;
@@ -60,6 +63,17 @@ type TransactionWithObjectsStreamItem = (u64, u32, Box<TransactionData>, ObjectM
 enum TransactionListItem {
     Digest(TxSeqDigestData),
     Full(TransactionWithObjectsStreamItem),
+}
+
+enum RenderedTransactionItem {
+    Digest(TxSeqDigestData),
+    Full {
+        tx_seq: u64,
+        checkpoint: u64,
+        tx_offset: u32,
+        executed: ExecutedTransaction,
+        render_elapsed: Duration,
+    },
 }
 
 pub(crate) async fn list_transactions(
@@ -219,13 +233,40 @@ pub(crate) async fn list_transactions(
         client.tx_wm_resolver(direction),
         std::convert::identity,
     );
+    let rendered_stream = render_ahead(transaction_stream, endpoint.render_ahead, {
+        let read_mask = read_mask.clone();
+        let resolver = resolver.clone();
+        move |item| {
+            let read_mask = read_mask.clone();
+            let resolver = resolver.clone();
+            async move {
+                Ok::<_, RpcError>(match item {
+                    TransactionListItem::Digest(row) => RenderedTransactionItem::Digest(row),
+                    TransactionListItem::Full((tx_seq, tx_offset, tx_data, objects)) => {
+                        let checkpoint = tx_data.checkpoint_number;
+                        let render_started = Instant::now();
+                        let executed =
+                            transaction_to_response(*tx_data, &read_mask, &objects, &resolver)
+                                .await?;
+                        RenderedTransactionItem::Full {
+                            tx_seq,
+                            checkpoint,
+                            tx_offset,
+                            executed,
+                            render_elapsed: render_started.elapsed(),
+                        }
+                    }
+                })
+            }
+        }
+    });
 
     Ok(async_stream::try_stream! {
-        futures::pin_mut!(transaction_stream);
+        futures::pin_mut!(rendered_stream);
         let mut emitted = 0usize;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
-            let Some(item) = transaction_stream.next().await else {
+            let Some(item) = rendered_stream.next().await else {
                 let (response, reason) = range_end_response(
                     &options,
                     exhaustion,
@@ -242,12 +283,12 @@ pub(crate) async fn list_transactions(
             match item {
                 Ok(ResolvedWatermarked::Item(item)) => {
                     let (tx_seq, item_checkpoint) = match &item {
-                        TransactionListItem::Digest(row) => {
+                        RenderedTransactionItem::Digest(row) => {
                             (row.tx_sequence_number, row.checkpoint_number)
                         }
-                        TransactionListItem::Full((tx_seq, _, tx_data, _)) => {
-                            (*tx_seq, tx_data.checkpoint_number)
-                        }
+                        RenderedTransactionItem::Full {
+                            tx_seq, checkpoint, ..
+                        } => (*tx_seq, *checkpoint),
                     };
                     covered_checkpoint_bound = advance_covered_bound_before_checkpoint(
                         covered_checkpoint_bound,
@@ -263,15 +304,16 @@ pub(crate) async fn list_transactions(
                         covered_checkpoint_bound,
                     );
                     let mut response = match item {
-                        TransactionListItem::Digest(row) => {
+                        RenderedTransactionItem::Digest(row) => {
                             transaction_response_from_tx_seq_digest(row, &read_mask, watermark)
                         }
-                        TransactionListItem::Full((_, tx_offset, tx_data, objects)) => {
-                            let render_started = Instant::now();
-                            let executed =
-                                transaction_to_response(*tx_data, &read_mask, &objects, &resolver)
-                                    .await?;
-                            ctx.observe_response_render(render_started.elapsed());
+                        RenderedTransactionItem::Full {
+                            tx_offset,
+                            executed,
+                            render_elapsed,
+                            ..
+                        } => {
+                            ctx.observe_response_render(render_elapsed);
                             transaction_item_response(
                                 watermark,
                                 executed,
@@ -307,7 +349,7 @@ pub(crate) async fn list_transactions(
                     )?;
                     yield watermark_response(watermark);
                 }
-                Err(stop) => {
+                Err(RenderAheadError::Upstream(stop)) => {
                     yield terminal_response_from_scan_stop(
                         stop,
                         &options,
@@ -317,6 +359,7 @@ pub(crate) async fn list_transactions(
                     )?;
                     break QueryEndReason::ScanLimit;
                 }
+                Err(RenderAheadError::Render(error)) => Err(error)?,
             }
         };
 

--- a/crates/sui-kv-rpc/src/v2/list_transactions.rs
+++ b/crates/sui-kv-rpc/src/v2/list_transactions.rs
@@ -141,8 +141,11 @@ pub(crate) async fn list_transactions(
         )
         .0;
         return Ok(async_stream::try_stream! {
-            ctx.observe_response_page_bytes(resolution, response.encoded_len());
+            ctx.inc_stream_watermark_frames();
+            ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+            let yield_started = Instant::now();
             yield response;
+            ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
         }
         .boxed());
     }
@@ -269,6 +272,7 @@ pub(crate) async fn list_transactions(
 
     Ok(async_stream::try_stream! {
         let mut emitted = 0usize;
+        let mut first_frame_emitted = false;
         let mut covered_checkpoint_bound: Option<u64> = None;
         let terminal_reason = loop {
             let Some(item) = ctx
@@ -285,8 +289,13 @@ pub(crate) async fn list_transactions(
                     covered_checkpoint_bound,
                     false,
                 );
-                ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                ctx.inc_stream_watermark_frames();
+                if !first_frame_emitted {
+                    ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                }
+                let yield_started = Instant::now();
                 yield response;
+                ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                 break reason;
             };
             match item {
@@ -343,12 +352,13 @@ pub(crate) async fn list_transactions(
                         response.end = Some(end);
                     }
                     ctx.observe_response_page_bytes(resolution, response.encoded_len());
-                    if emitted == 1 {
-                        ctx.observe_stream_first_item_latency(resolution, started.elapsed());
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                        first_frame_emitted = true;
                     }
                     let yield_started = Instant::now();
                     yield response;
-                    ctx.observe_stream_item_yield_wait(resolution, yield_started.elapsed());
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                     if item_limit {
                         break QueryEndReason::ItemLimit;
                     }
@@ -366,8 +376,14 @@ pub(crate) async fn list_transactions(
                         Some(checkpoint_at_frontier),
                     )?;
                     let response = watermark_response(watermark);
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                        first_frame_emitted = true;
+                    }
+                    let yield_started = Instant::now();
                     yield response;
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                 }
                 Err(RenderAheadError::Upstream(stop)) => {
                     let response = terminal_response_from_scan_stop(
@@ -377,8 +393,13 @@ pub(crate) async fn list_transactions(
                         entry_checkpoint,
                         &mut covered_checkpoint_bound,
                     )?;
-                    ctx.observe_response_page_bytes(resolution, response.encoded_len());
+                    ctx.inc_stream_watermark_frames();
+                    if !first_frame_emitted {
+                        ctx.observe_stream_first_frame_latency(resolution, started.elapsed());
+                    }
+                    let yield_started = Instant::now();
                     yield response;
+                    ctx.observe_stream_frame_yield_wait(resolution, yield_started.elapsed());
                     break QueryEndReason::ScanLimit;
                 }
                 Err(RenderAheadError::Render(error)) => Err(error)?,
@@ -703,7 +724,7 @@ mod tests {
     use sui_rpc_cursor::CursorToken;
 
     use crate::v2::test_utils::{
-        LIST_PIPELINE_METRICS, ascending_options, assert_list_histogram_absent, list_histogram,
+        ascending_options, assert_list_metric_absent, list_counter, list_histogram,
         query_context_with_mock_and_registry, query_context_with_registry,
     };
 
@@ -749,11 +770,12 @@ mod tests {
         assert!(emitted_digests.eq(expected_digests));
         let families = registry.gather();
         let data_items = checkpoint.transactions.len() as u64;
+        let non_data_frames = responses.len() as u64 - data_items;
         for (name, sample_count) in [
             ("kv_rpc_response_render_latency_ms", data_items),
-            ("kv_rpc_response_page_bytes", responses.len() as u64),
-            ("kv_rpc_stream_first_item_latency_ms", 1),
-            ("kv_rpc_stream_item_yield_wait_ms", data_items),
+            ("kv_rpc_response_page_bytes", data_items),
+            ("kv_rpc_stream_first_frame_latency_ms", 1),
+            ("kv_rpc_stream_frame_yield_wait_ms", responses.len() as u64),
         ] {
             let histogram = list_histogram(&families, name, method, "digest");
             assert_eq!(histogram.get_sample_count(), sample_count);
@@ -763,9 +785,13 @@ mod tests {
             page_bytes.get_sample_sum(),
             responses
                 .iter()
+                .filter(|response| response.transaction.is_some())
                 .map(|response| response.encoded_len() as f64)
                 .sum::<f64>()
         );
+        let watermark_frames =
+            list_counter(&families, "kv_rpc_stream_watermark_frames_total", method);
+        assert_eq!(watermark_frames.value(), non_data_frames as f64);
         let final_poll = list_histogram(
             &families,
             "kv_rpc_final_stream_poll_wait_ms",
@@ -782,7 +808,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_ledger_metric_coverage_records_only_transaction_terminal_page_bytes() {
+    async fn empty_ledger_metric_coverage_records_transaction_terminal_frame_metrics() {
         let (ctx, registry, server) = query_context_with_registry("list_transactions", 0).await;
         let mut request = ListTransactionsRequest::default();
         request.read_mask = Some(FieldMask::from_paths(["digest"]));
@@ -818,19 +844,26 @@ mod tests {
         assert_eq!(watermark.cursor.as_ref(), Some(&expected_cursor));
         assert_eq!(watermark.checkpoint, None);
         let families = registry.gather();
-        let page_bytes = list_histogram(
-            &families,
+        for name in [
+            "kv_rpc_response_render_latency_ms",
             "kv_rpc_response_page_bytes",
-            "list_transactions",
-            "digest",
-        );
-        assert_eq!(page_bytes.get_sample_count(), 1);
-        assert_eq!(page_bytes.get_sample_sum(), response.encoded_len() as f64);
-        for name in LIST_PIPELINE_METRICS {
-            if name != "kv_rpc_response_page_bytes" {
-                assert_list_histogram_absent(&families, name);
-            }
+            "kv_rpc_final_stream_poll_wait_ms",
+        ] {
+            assert_list_metric_absent(&families, name);
         }
+        for name in [
+            "kv_rpc_stream_first_frame_latency_ms",
+            "kv_rpc_stream_frame_yield_wait_ms",
+        ] {
+            let histogram = list_histogram(&families, name, "list_transactions", "digest");
+            assert_eq!(histogram.get_sample_count(), 1);
+        }
+        let watermark_frames = list_counter(
+            &families,
+            "kv_rpc_stream_watermark_frames_total",
+            "list_transactions",
+        );
+        assert_eq!(watermark_frames.value(), 1.0);
     }
 
     #[test]

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -357,7 +357,6 @@ mod test_utils {
                 method,
                 checkpoint_hi_exclusive,
                 ledger_history,
-                2,
                 stages,
             ),
             registry,

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -248,13 +248,23 @@ mod test_utils {
         method: &'static str,
         checkpoint_hi_exclusive: u64,
     ) -> (QueryContext, tokio::task::JoinHandle<()>) {
+        let (ctx, _registry, server) =
+            query_context_with_registry(method, checkpoint_hi_exclusive).await;
+        (ctx, server)
+    }
+
+    pub(super) async fn query_context_with_registry(
+        method: &'static str,
+        checkpoint_hi_exclusive: u64,
+    ) -> (QueryContext, Registry, tokio::task::JoinHandle<()>) {
         let mock = MockBigtableServer::new();
         let (addr, server) = mock.start().await.expect("start mock BigTable");
         let inner = InnerBigTableClient::new_local(addr.to_string(), "test".to_string())
             .await
             .expect("connect to mock BigTable");
 
-        let metrics = KvRpcMetrics::new(&Registry::new());
+        let registry = Registry::new();
+        let metrics = KvRpcMetrics::new(&registry);
         let client =
             BigTableClient::new(inner.clone(), 2, metrics.bigtable_limiter.clone(), method);
         let package_store: Arc<dyn PackageStore> = Arc::new(BigTablePackageStore::new(inner));
@@ -264,6 +274,7 @@ mod test_utils {
             timeout_ms: Some(5_000),
             default_limit_items: Some(10),
             max_limit_items: Some(100),
+            render_ahead: Some(2),
         };
         let ledger_history = LedgerHistoryConfig {
             list_transactions: Some(method_config.clone()),
@@ -296,6 +307,7 @@ mod test_utils {
                 2,
                 stages,
             ),
+            registry,
             server,
         )
     }

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -221,6 +221,7 @@ mod test_utils {
     use std::sync::Arc;
 
     use prometheus::Registry;
+    use prometheus::proto::{Histogram, MetricFamily};
     use sui_kvstore::BigTableClient as InnerBigTableClient;
     use sui_kvstore::testing::MockBigtableServer;
     use sui_package_resolver::PackageStore;
@@ -236,6 +237,45 @@ mod test_utils {
     use crate::bigtable_client::BigTableClient;
     use crate::operation::QueryContext;
     use crate::package_store::BigTablePackageStore;
+
+    pub(super) const LIST_PIPELINE_METRICS: [&str; 5] = [
+        "kv_rpc_response_render_latency_ms",
+        "kv_rpc_response_page_bytes",
+        "kv_rpc_stream_first_item_latency_ms",
+        "kv_rpc_stream_item_yield_wait_ms",
+        "kv_rpc_final_stream_poll_wait_ms",
+    ];
+
+    pub(super) fn list_histogram<'a>(
+        families: &'a [MetricFamily],
+        name: &str,
+        method: &str,
+        resolution: &str,
+    ) -> &'a Histogram {
+        let family = families
+            .iter()
+            .find(|family| family.name() == name)
+            .unwrap_or_else(|| panic!("metric family {name} not registered"));
+        let [metric] = family.get_metric() else {
+            panic!("{name} has unexpected series");
+        };
+        assert!(
+            metric
+                .get_label()
+                .iter()
+                .map(|label| (label.name(), label.value()))
+                .eq([("method", method), ("resolution", resolution)]),
+            "{name} has unexpected labels"
+        );
+        metric.get_histogram()
+    }
+
+    pub(super) fn assert_list_histogram_absent(families: &[MetricFamily], name: &str) {
+        assert!(
+            families.iter().all(|family| family.name() != name),
+            "{name} unexpectedly registered"
+        );
+    }
 
     pub(super) fn ascending_options() -> QueryOptions {
         let mut options = QueryOptions::default();
@@ -257,6 +297,20 @@ mod test_utils {
         method: &'static str,
         checkpoint_hi_exclusive: u64,
     ) -> (QueryContext, Registry, tokio::task::JoinHandle<()>) {
+        let (ctx, registry, _mock, server) =
+            query_context_with_mock_and_registry(method, checkpoint_hi_exclusive).await;
+        (ctx, registry, server)
+    }
+
+    pub(super) async fn query_context_with_mock_and_registry(
+        method: &'static str,
+        checkpoint_hi_exclusive: u64,
+    ) -> (
+        QueryContext,
+        Registry,
+        MockBigtableServer,
+        tokio::task::JoinHandle<()>,
+    ) {
         let mock = MockBigtableServer::new();
         let (addr, server) = mock.start().await.expect("start mock BigTable");
         let inner = InnerBigTableClient::new_local(addr.to_string(), "test".to_string())
@@ -308,6 +362,7 @@ mod test_utils {
                 stages,
             ),
             registry,
+            mock,
             server,
         )
     }

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -220,7 +220,7 @@ mod test_utils {
     use std::sync::Arc;
 
     use prometheus::Registry;
-    use prometheus::proto::{Histogram, MetricFamily};
+    use prometheus::proto::{Counter, Histogram, MetricFamily};
     use sui_kvstore::BigTableClient as InnerBigTableClient;
     use sui_kvstore::testing::MockBigtableServer;
     use sui_package_resolver::PackageStore;
@@ -237,11 +237,12 @@ mod test_utils {
     use crate::operation::QueryContext;
     use crate::package_store::BigTablePackageStore;
 
-    pub(super) const LIST_PIPELINE_METRICS: [&str; 5] = [
+    pub(super) const LIST_PIPELINE_METRICS: [&str; 6] = [
         "kv_rpc_response_render_latency_ms",
         "kv_rpc_response_page_bytes",
-        "kv_rpc_stream_first_item_latency_ms",
-        "kv_rpc_stream_item_yield_wait_ms",
+        "kv_rpc_stream_first_frame_latency_ms",
+        "kv_rpc_stream_frame_yield_wait_ms",
+        "kv_rpc_stream_watermark_frames_total",
         "kv_rpc_final_stream_poll_wait_ms",
     ];
 
@@ -268,8 +269,30 @@ mod test_utils {
         );
         metric.get_histogram()
     }
+    pub(super) fn list_counter<'a>(
+        families: &'a [MetricFamily],
+        name: &str,
+        method: &str,
+    ) -> &'a Counter {
+        let family = families
+            .iter()
+            .find(|family| family.name() == name)
+            .unwrap_or_else(|| panic!("metric family {name} not registered"));
+        let [metric] = family.get_metric() else {
+            panic!("{name} has unexpected series");
+        };
+        assert!(
+            metric
+                .get_label()
+                .iter()
+                .map(|label| (label.name(), label.value()))
+                .eq([("method", method)]),
+            "{name} has unexpected labels"
+        );
+        metric.get_counter()
+    }
 
-    pub(super) fn assert_list_histogram_absent(families: &[MetricFamily], name: &str) {
+    pub(super) fn assert_list_metric_absent(families: &[MetricFamily], name: &str) {
         assert!(
             families.iter().all(|family| family.name() != name),
             "{name} unexpectedly registered"

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -138,11 +138,10 @@ impl LedgerService for KvRpcServer {
         .map_err(Into::into)
     }
 
-    // The list RPCs carry a per-RPC hard request timeout (from
-    // `LedgerHistoryConfig`). The outer `operation::with_deadline` wrapper
-    // drops the response stream with `DeadlineExceeded` when this fires;
-    // debounced intermediate `Watermark` frames let the client resume from
-    // wherever it got to.
+    // The list RPC hard timeout covers both computation and response delivery.
+    // Expiry drops the stream with `DeadlineExceeded` without emitting a
+    // terminal resume-cursor frame, so a client can resume only from the last
+    // `Watermark` it retained.
     async fn list_checkpoints(
         &self,
         request: tonic::Request<ListCheckpointsRequest>,

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -923,7 +923,114 @@ impl BigTableClient {
             filter: Some(Filter::ColumnQualifierRegexFilter(pattern.into())),
         }
     }
+}
 
+struct ActivePollWait {
+    accumulated_wait: Duration,
+    demand_started_at: Option<Instant>,
+}
+
+impl ActivePollWait {
+    fn new(open_wait: Duration) -> Self {
+        Self {
+            accumulated_wait: open_wait,
+            demand_started_at: None,
+        }
+    }
+
+    fn start(&mut self, now: Instant) {
+        self.demand_started_at.get_or_insert(now);
+    }
+
+    fn finish(&mut self, now: Instant) {
+        if let Some(started_at) = self.demand_started_at.take() {
+            self.accumulated_wait += now.duration_since(started_at);
+        }
+    }
+}
+
+type MultiGetRowStream = futures::stream::BoxStream<'static, Result<(Bytes, Vec<(Bytes, Bytes)>)>>;
+
+struct MultiGetStreamPollWait {
+    inner: MultiGetRowStream,
+    active_poll_wait: ActivePollWait,
+    metrics: Arc<KvMetrics>,
+    client_name: String,
+    table_name: String,
+    requested_key_count: usize,
+    failed: bool,
+    finished: bool,
+}
+
+impl MultiGetStreamPollWait {
+    fn new(
+        inner: MultiGetRowStream,
+        open_wait: Duration,
+        metrics: Arc<KvMetrics>,
+        client_name: String,
+        table_name: String,
+        requested_key_count: usize,
+    ) -> Self {
+        Self {
+            inner,
+            active_poll_wait: ActivePollWait::new(open_wait),
+            metrics,
+            client_name,
+            table_name,
+            requested_key_count,
+            failed: false,
+            finished: false,
+        }
+    }
+}
+
+impl futures::Stream for MultiGetStreamPollWait {
+    type Item = Result<(Bytes, Vec<(Bytes, Bytes)>)>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.finished {
+            return std::task::Poll::Ready(None);
+        }
+
+        this.active_poll_wait.start(Instant::now());
+        match this.inner.as_mut().poll_next(cx) {
+            std::task::Poll::Pending => std::task::Poll::Pending,
+            std::task::Poll::Ready(item) => {
+                this.active_poll_wait.finish(Instant::now());
+                match item {
+                    Some(Ok(row)) => std::task::Poll::Ready(Some(Ok(row))),
+                    Some(Err(error)) => {
+                        this.failed = true;
+                        std::task::Poll::Ready(Some(Err(error)))
+                    }
+                    None => {
+                        this.finished = true;
+                        if !this.failed {
+                            let elapsed_ms =
+                                this.active_poll_wait.accumulated_wait.as_secs_f64() * 1000.0;
+                            let labels = [this.client_name.as_str(), this.table_name.as_str()];
+                            this.metrics
+                                .kv_get_stream_poll_wait_ms
+                                .with_label_values(&labels)
+                                .observe(elapsed_ms);
+                            this.metrics
+                                .kv_get_stream_poll_wait_ms_per_key
+                                .with_label_values(&labels)
+                                .observe(elapsed_ms / this.requested_key_count as f64);
+                        }
+                        std::task::Poll::Ready(None)
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl BigTableClient {
     /// Streaming variant of `multi_get`. Rows arrive on the stream as soon as
     /// BigTable writes them on the wire, so downstream stages in a pipeline
     /// can start work before the full batch completes. Emits rows in arrival
@@ -941,7 +1048,23 @@ impl BigTableClient {
         if keys.is_empty() {
             return Ok(futures::stream::empty().boxed());
         }
+        let requested_key_count = keys.len();
         let request = self.build_multi_get_request(table_name, keys, filter);
+        if let Some(metrics) = self.metrics.clone() {
+            let open_started_at = Instant::now();
+            let stream = self.read_rows_stream(request, table_name).await?;
+            let open_wait = open_started_at.elapsed();
+            return Ok(MultiGetStreamPollWait::new(
+                stream.boxed(),
+                open_wait,
+                metrics,
+                self.client_name.clone(),
+                table_name.to_owned(),
+                requested_key_count,
+            )
+            .boxed());
+        }
+
         let stream = self.read_rows_stream(request, table_name).await?;
         Ok(stream.boxed())
     }
@@ -2040,8 +2163,8 @@ fn column_exists_filter(column: &str) -> RowFilter {
 
 #[cfg(test)]
 mod tests {
-    use futures::TryStreamExt;
-    use futures::stream;
+    use futures::{TryStreamExt, stream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
 
@@ -2053,6 +2176,118 @@ mod tests {
         let bytes: [u8; 8] = key.as_ref().try_into().context("invalid key")?;
         let sequence = u64::from_be_bytes(bytes);
         Ok((sequence, sequence))
+    }
+
+    const TOTAL: &str = "kv_get_stream_poll_wait_ms";
+    const PER_KEY: &str = "kv_get_stream_poll_wait_ms_per_key";
+    fn histogram(registry: &Registry, name: &str, labels: [&str; 2]) -> (u64, f64) {
+        let Some(family) = registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+        else {
+            return (0, 0.0);
+        };
+        let Some(metric) = family.get_metric().iter().find(|metric| {
+            metric
+                .get_label()
+                .iter()
+                .map(|label| (label.name(), label.value()))
+                .eq([("client", labels[0]), ("table", labels[1])])
+        }) else {
+            return (0, 0.0);
+        };
+        let histogram = metric.get_histogram();
+        (histogram.get_sample_count(), histogram.get_sample_sum())
+    }
+    fn counts(registry: &Registry, labels: [&str; 2]) -> [u64; 2] {
+        [TOTAL, PER_KEY].map(|name| histogram(registry, name, labels).0)
+    }
+    type Metrics = Arc<KvMetrics>;
+    fn wrap(metrics: &Metrics, table: &str, inner: MultiGetRowStream) -> MultiGetStreamPollWait {
+        let wait = Duration::from_millis(4);
+        let client = "poll-client";
+        MultiGetStreamPollWait::new(inner, wait, metrics.clone(), client.into(), table.into(), 2)
+    }
+    #[test]
+    fn active_poll_wait_excludes_idle_and_includes_pending() {
+        let first_poll = Instant::now();
+        let mut wait = ActivePollWait::new(Duration::from_millis(7));
+        wait.finish(first_poll);
+        assert_eq!(wait.accumulated_wait, Duration::from_millis(7));
+        wait.start(first_poll);
+        wait.start(first_poll + Duration::from_millis(3));
+        wait.finish(first_poll + Duration::from_millis(8));
+        assert_eq!(wait.accumulated_wait, Duration::from_millis(15));
+    }
+    #[tokio::test]
+    async fn multi_get_stream_poll_wait_observes_natural_drain_and_preserves_lazy_order() {
+        let registry = Registry::new();
+        let metrics = KvMetrics::new(&registry);
+        let polls = Arc::new(AtomicUsize::new(0));
+        let poll_count = polls.clone();
+        let mut rows = [row(7), row(3)].into_iter();
+        let inner = stream::poll_fn(move |_| {
+            poll_count.fetch_add(1, Ordering::SeqCst);
+            std::task::Poll::Ready(rows.next())
+        })
+        .boxed();
+        let labels = ["poll-client", "natural-drain"];
+        let mut drained = wrap(&metrics, labels[1], inner);
+        assert_eq!(polls.load(Ordering::SeqCst), 0);
+        for (sequence, expected_polls) in [(7, 1), (3, 2)] {
+            assert_eq!(
+                drained.next().await.unwrap().unwrap().0,
+                row(sequence).unwrap().0
+            );
+            assert_eq!(polls.load(Ordering::SeqCst), expected_polls);
+            assert_eq!(counts(&registry, labels), [0; 2]);
+        }
+        assert!(drained.next().await.is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 3);
+        let sums = [TOTAL, PER_KEY].map(|name| {
+            let (count, sum) = histogram(&registry, name, labels);
+            assert_eq!(count, 1);
+            sum
+        });
+        assert!(sums[0] >= 4.0);
+        assert_eq!(sums[1], sums[0] / 2.0);
+    }
+    #[tokio::test]
+    async fn multi_get_stream_poll_wait_ignores_drop_and_error() {
+        let registry = Registry::new();
+        let metrics = KvMetrics::new(&registry);
+        let mut dropped = wrap(&metrics, "dropped", stream::iter([row(1), row(2)]).boxed());
+        assert_eq!(dropped.next().await.unwrap().unwrap().0, row(1).unwrap().0);
+        drop(dropped);
+        let inner = stream::iter([row(3), Err(anyhow::anyhow!("injected stream error"))]).boxed();
+        let mut errored = wrap(&metrics, "errored", inner);
+        assert_eq!(errored.next().await.unwrap().unwrap().0, row(3).unwrap().0);
+        let error = errored.next().await.unwrap().unwrap_err();
+        assert_eq!(error.to_string(), "injected stream error");
+        assert!(errored.next().await.is_none());
+        for table in ["dropped", "errored"] {
+            assert_eq!(counts(&registry, ["poll-client", table]), [0; 2]);
+        }
+    }
+    #[tokio::test]
+    async fn multi_get_stream_empty_keys_issue_no_read_or_observation() {
+        let mock = crate::bigtable::mock_server::MockBigtableServer::new();
+        let (addr, _handle) = mock.start().await.unwrap();
+        let registry = Registry::new();
+        let host = addr.to_string();
+        let name = "empty-client";
+        let mut client = BigTableClient::new_for_host(host, "test".into(), name)
+            .await
+            .unwrap();
+        client.metrics = Some(KvMetrics::new(&registry));
+        let mut rows = client
+            .multi_get_stream("empty-table", Vec::new(), None)
+            .await
+            .unwrap();
+        assert!(rows.next().await.is_none());
+        assert!(mock.read_rows_calls().await.is_empty());
+        assert_eq!(counts(&registry, [name, "empty-table"]), [0; 2]);
     }
 
     #[tokio::test]

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -707,6 +707,13 @@ impl BigTableClient {
         if let Some(ref app_profile_id) = self.app_profile_id {
             request.app_profile_id = app_profile_id.clone();
         }
+        if let Some(metrics) = &self.metrics {
+            let labels = [self.client_name.as_str(), table_name];
+            metrics
+                .kv_bt_read_rows_started_total
+                .with_label_values(&labels)
+                .inc();
+        }
         let response = self.client.clone().read_rows(request).await?.into_inner();
         let metrics = self.metrics.clone();
         let client_name = self.client_name.clone();

--- a/crates/sui-kvstore/src/bigtable/metrics.rs
+++ b/crates/sui-kvstore/src/bigtable/metrics.rs
@@ -16,6 +16,8 @@ pub(crate) struct KvMetrics {
     pub kv_get_latency_ms: HistogramVec,
     pub kv_get_batch_size: HistogramVec,
     pub kv_get_latency_ms_per_key: HistogramVec,
+    pub kv_get_stream_poll_wait_ms: HistogramVec,
+    pub kv_get_stream_poll_wait_ms_per_key: HistogramVec,
     pub kv_scan_success: IntCounterVec,
     pub kv_scan_not_found: IntCounterVec,
     pub kv_scan_error: IntCounterVec,
@@ -73,6 +75,26 @@ impl KvMetrics {
             kv_get_latency_ms_per_key: register_histogram_vec_with_registry!(
                 "kv_get_latency_ms_per_key",
                 "Latency of fetches from kv store per key",
+                &["client", "table"],
+                prometheus::exponential_buckets(1.0, 1.6, 24)
+                    .unwrap()
+                    .to_vec(),
+                registry,
+            )
+            .unwrap(),
+            kv_get_stream_poll_wait_ms: register_histogram_vec_with_registry!(
+                "kv_get_stream_poll_wait_ms",
+                "Accumulated demand-visible supply wait for a successfully drained streamed BigTable multi-get: ReadRows RPC open time plus time from downstream polling for a row until that demand returns a row or natural EOF. Excludes idle time after delivering a row and before the next downstream poll. May include BigTable service time, network transit, gRPC decoding, and executor scheduling while demand is pending; pair with kv_bt_chunk_latency_ms for BigTable frontend latency. Observed only after natural successful EOF, so errors, early drops, cancellations, and item-limit truncation are absent and create survivorship bias.",
+                &["client", "table"],
+                prometheus::exponential_buckets(1.0, 1.6, 24)
+                    .unwrap()
+                    .to_vec(),
+                registry,
+            )
+            .unwrap(),
+            kv_get_stream_poll_wait_ms_per_key: register_histogram_vec_with_registry!(
+                "kv_get_stream_poll_wait_ms_per_key",
+                "Accumulated demand-visible supply wait per requested key for a successfully drained streamed BigTable multi-get: ReadRows RPC open time plus downstream-active row poll-to-ready time, divided by requested keys. Excludes idle time between delivered rows and later demand. May include BigTable service time, network transit, gRPC decoding, and executor scheduling; pair with kv_bt_chunk_latency_ms. Observed only after natural successful EOF, so errors, early drops, cancellations, and item-limit truncation are absent and create survivorship bias.",
                 &["client", "table"],
                 prometheus::exponential_buckets(1.0, 1.6, 24)
                     .unwrap()

--- a/crates/sui-kvstore/src/bigtable/metrics.rs
+++ b/crates/sui-kvstore/src/bigtable/metrics.rs
@@ -21,6 +21,7 @@ pub(crate) struct KvMetrics {
     pub kv_scan_error: IntCounterVec,
     pub kv_scan_latency_ms: HistogramVec,
     pub kv_bt_chunk_latency_ms: HistogramVec,
+    pub kv_bt_read_rows_started_total: IntCounterVec,
     pub kv_bt_chunk_rows_returned_count: IntCounterVec,
     pub kv_bt_chunk_rows_seen_count: IntCounterVec,
 }
@@ -117,6 +118,13 @@ impl KvMetrics {
                 prometheus::exponential_buckets(1.0, 1.6, 24)
                     .unwrap()
                     .to_vec(),
+                registry,
+            )
+            .unwrap(),
+            kv_bt_read_rows_started_total: register_int_counter_vec_with_registry!(
+                "kv_bt_read_rows_started_total",
+                "ReadRows RPCs initiated per table; incremented at RPC start, covering point multi-gets and range scans alike",
+                &["client", "table"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-kvstore/src/bigtable/mock_server.rs
+++ b/crates/sui-kvstore/src/bigtable/mock_server.rs
@@ -11,7 +11,8 @@
 //!   the column filters this crate builds (`None`, `CellsPerColumnLimitFilter(1)`,
 //!   `ColumnQualifierRegexFilter`, and `Chain`s of those plus an optional
 //!   `FamilyNameRegexFilter`), records each call for assertions, and can emit
-//!   rows in reverse request order. Row ranges and reverse scans are unsupported.
+//!   rows in reverse request order and ascending row-range scans.
+//!   Reverse scans are unsupported.
 //! - `CheckAndMutateRow`: `PassAllFilter(true)` and the CAS helper shape used
 //!   by this crate (`Chain` of family regex, column qualifier regex, optional
 //!   value range, and optional cells-per-column limit).
@@ -67,6 +68,7 @@ use crate::bigtable::proto::bigtable::v2::read_rows_response::cell_chunk::RowSta
 use crate::bigtable::proto::bigtable::v2::row_filter::Filter;
 use crate::bigtable::proto::bigtable::v2::value_range::EndValue;
 use crate::bigtable::proto::bigtable::v2::value_range::StartValue;
+use crate::bigtable::proto::bigtable::v2::{RowRange, row_range};
 use crate::bigtable::proto::rpc::Status as RpcStatus;
 
 /// Expected call: which row keys should arrive, and which entry indices should fail.
@@ -79,7 +81,7 @@ pub struct ExpectedCall {
 }
 
 /// A single recorded `ReadRows` call: the resolved table name (suffix after
-/// `/tables/`) and the explicit row keys requested, in request order.
+/// `/tables/`) and the row keys selected by the request.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReadRowsCall {
     pub table: String,
@@ -452,6 +454,18 @@ fn parse_read_filter(filter: Option<Filter>) -> Result<Option<HashSet<Vec<u8>>>,
     }
 }
 
+fn row_key_in_range(row_key: &Bytes, range: &RowRange) -> bool {
+    (match &range.start_key {
+        Some(row_range::StartKey::StartKeyClosed(start)) => row_key >= start,
+        Some(row_range::StartKey::StartKeyOpen(start)) => row_key > start,
+        None => true,
+    }) && match &range.end_key {
+        Some(row_range::EndKey::EndKeyClosed(end)) => row_key <= end,
+        Some(row_range::EndKey::EndKeyOpen(end)) => row_key < end,
+        None => true,
+    }
+}
+
 /// Evaluate a ValueRangeFilter against a raw cell value. Unbounded sides are treated
 /// as open-ended. Handles both closed and open range endpoints.
 fn value_in_range(value: &Bytes, vr: &crate::bigtable::proto::bigtable::v2::ValueRange) -> bool {
@@ -646,21 +660,31 @@ impl Bigtable for MockBigtableServer {
         };
         let Some(row_set) = req.rows else {
             return Err(Status::unimplemented(
-                "mock ReadRows requires explicit row_keys",
+                "mock ReadRows requires row_keys or row_ranges",
             ));
         };
-        if !row_set.row_ranges.is_empty() {
+        if !row_set.row_keys.is_empty() && !row_set.row_ranges.is_empty() {
             return Err(Status::unimplemented(
-                "mock ReadRows only supports explicit row_keys, not row_ranges",
+                "mock ReadRows does not support mixing row_keys and row_ranges",
             ));
         }
-        let limit = if req.rows_limit == 0 {
-            row_set.row_keys.len()
-        } else {
-            req.rows_limit as usize
-        };
 
-        let mut requested_keys: Vec<Bytes> = row_set.row_keys.into_iter().take(limit).collect();
+        let ranges = &row_set.row_ranges;
+        let mut requested_keys = row_set.row_keys;
+        if !ranges.is_empty() {
+            requested_keys = state
+                .rows
+                .keys()
+                .filter(|(t, key)| {
+                    t == &table && ranges.iter().any(|range| row_key_in_range(key, range))
+                })
+                .map(|(_, row_key)| row_key.clone())
+                .collect();
+            requested_keys.sort_unstable();
+        }
+        if req.rows_limit != 0 {
+            requested_keys.truncate(req.rows_limit as usize);
+        }
         state.read_rows_calls.push(ReadRowsCall {
             table: table.clone(),
             row_keys: requested_keys.clone(),

--- a/crates/sui-kvstore/src/testing.rs
+++ b/crates/sui-kvstore/src/testing.rs
@@ -19,6 +19,9 @@ use anyhow::bail;
 use futures::future::try_join_all;
 use tokio::process::Command as TokioCommand;
 
+#[cfg(any(test, feature = "testing"))]
+use sui_types::full_checkpoint_content::Checkpoint;
+
 pub const INSTANCE_ID: &str = "bigtable_test_instance";
 
 /// New tables must be added here when introduced. The indexer will fail to write to missing
@@ -163,3 +166,44 @@ pub async fn create_tables(host: &str, instance_id: &str) -> Result<()> {
 /// builds. See [`crate::bigtable::mock_server`].
 #[cfg(any(test, feature = "testing"))]
 pub use crate::bigtable::mock_server::{MockBigtableServer, ReadRowsCall, ReadRowsResponseOrder};
+
+/// Inserts checkpoint, transaction sequence, and transaction rows into mock BigTable.
+#[cfg(any(test, feature = "testing"))]
+pub async fn insert_checkpoint_rows(mock: &MockBigtableServer, checkpoint: &Checkpoint) {
+    use crate::tables::{checkpoints, transactions, tx_seq_digest};
+    use sui_types::balance_change::derive_balance_changes_2;
+    let summary = checkpoint.summary.data();
+    let checkpoint_number = summary.sequence_number;
+    let row = checkpoints::encode(summary, checkpoint.summary.auth_sig(), &checkpoint.contents)
+        .expect("encode checkpoint");
+    let key = checkpoints::encode_key(checkpoint_number);
+    mock.insert_row(checkpoints::NAME, key, row).await;
+    let first_transaction_sequence = summary
+        .network_total_transactions
+        .checked_sub(checkpoint.transactions.len() as u64)
+        .expect("checkpoint transaction range");
+    for (offset, transaction) in checkpoint.transactions.iter().enumerate() {
+        let transaction_sequence = first_transaction_sequence + offset as u64;
+        let digest = transaction.transaction.digest();
+        let events = transaction.events.as_ref();
+        let event_count = events.map_or(0, |events| events.data.len() as u32);
+        let row = tx_seq_digest::encode(&digest, event_count, offset as u32, checkpoint_number);
+        let key = tx_seq_digest::encode_key(transaction_sequence);
+        mock.insert_row(tx_seq_digest::NAME, key, row).await;
+        let balance_changes =
+            derive_balance_changes_2(&transaction.effects, &checkpoint.object_set);
+        let row = transactions::encode(
+            &transaction.transaction,
+            &transaction.signatures,
+            &transaction.effects,
+            &transaction.events,
+            checkpoint_number,
+            summary.timestamp_ms,
+            &balance_changes,
+            &transaction.unchanged_loaded_runtime_objects,
+        )
+        .expect("encode transaction");
+        mock.insert_row(transactions::NAME, transactions::encode_key(&digest), row)
+            .await;
+    }
+}


### PR DESCRIPTION
## Description

- Adding a bunch of metrics
- Fixing 2 bottlenecks
  - spawn tx_digest fetches in the background
  - render-ahead a small fixed number of payloads
- Adjust defaults based on empirical test results
- Enable zst support

## Test plan

Slowly increased load to ~90% CPU utilization, held it for 15 minutes, verified no errors observed by client.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
