### PR TITLE
[tracing] support per-instruction/event filtering

### DIFF
--- a/external-crates/move/crates/move-trace-format/src/format.rs
+++ b/external-crates/move/crates/move-trace-format/src/format.rs
@@ -3,7 +3,7 @@
 
 // IDEA: Post trace analysis -- report when values are dropped.
 
-use crate::interface::{Tracer, Writer};
+use crate::interface::{EventFilter, Tracer, Writer};
 use crate::tracers::nop::NopTracer;
 use crate::value::SerializableMoveValue;
 use move_binary_format::{
@@ -327,10 +327,14 @@ impl MoveTraceBuilder {
         }
     }
 
-    /// Whether the tracer wants effect events. If false, the VM tracer can skip the expensive
-    /// value conversion work needed to build effects.
-    pub fn wants_effects(&self) -> bool {
-        self.tracer.wants_effects()
+    /// Get the instruction filter for the given instruction and program counter. This is used to
+    /// determine whether the tracer wants to receive effect events for this instruction.
+    pub fn instruction_filter<I: Into<Opcodes>>(
+        &self,
+        instruction: I,
+        pc: u16,
+    ) -> Option<EventFilter> {
+        self.tracer.instruction_filter(&instruction.into(), pc)
     }
 
     /// Consume the `MoveTraceBuilder` and return the `MoveTrace` that has been built by it.

--- a/external-crates/move/crates/move-trace-format/src/interface.rs
+++ b/external-crates/move/crates/move-trace-format/src/interface.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::format::{MoveTrace, TraceEvent, TraceVersion};
+use move_binary_format::file_format_common::Opcodes;
 use serde::Serialize;
 
 /// This is meant to be an internal tracing interface for the VM, and should only be implemented
@@ -14,9 +15,10 @@ pub trait Tracer {
     /// and immediatlye _after_ the `event` has been added to the trace held inside of the `writer`.
     fn notify(&mut self, event: &TraceEvent, writer: Writer<'_>) -> bool;
 
-    /// Whether this tracer wants effect events (Push, Pop, Read, Write, DataLoad). If false, the
-    /// VM tracer can skip the expensive value conversion work needed to build effects.
-    fn wants_effects(&self) -> bool;
+    /// Whether this tracer wants effect events for an instruction (and possibly only a specific
+    /// subset of those events). If the events are not needed the VM tracer can skip the expensive
+    /// value conversion work needed to build effects.
+    fn instruction_filter(&self, instruction: &Opcodes, pc: u16) -> Option<EventFilter>;
 }
 
 impl<T: Tracer> Tracer for &mut T {
@@ -24,8 +26,8 @@ impl<T: Tracer> Tracer for &mut T {
         <T as Tracer>::notify(self, event, writer)
     }
 
-    fn wants_effects(&self) -> bool {
-        <T as Tracer>::wants_effects(self)
+    fn instruction_filter(&self, instruction: &Opcodes, pc: u16) -> Option<EventFilter> {
+        <T as Tracer>::instruction_filter(self, instruction, pc)
     }
 }
 
@@ -46,3 +48,25 @@ impl Writer<'_> {
         self.0.version
     }
 }
+
+// NB: event indices are 1-based so that there is a clear distinction betwen pre-instruction
+// events (negative indices) and post-instruction events (positive indices).
+// pre effects - negative indices
+// post effects - positive indices
+// e.g., For Add
+// -2     -1     1
+// Pop    Pop    Push
+// So if you were interested in the post effects of an `Add` instruction, you would want to filter
+// for event indices > 0. If you were interested in the pre effects of a `Sub` instruction, you would
+// want to filter for event indices < 0.
+// fn instruction_filter_example(instruction: &Opcodes, pc: u16) -> Option<EventFilter> {
+//     match instruction {
+//         // Only interested in the post effects of an `Add` instruction
+//         Opcodes::ADD => Some(|relative_event_index: i16| relative_event_index > 0),
+//         // Only interested in the pre effects of a `Sub` instruction
+//         Opcodes::SUB => Some(|relative_event_index: i16| relative_event_index < 0),
+//         // Otherwise, we don't care about the effects of this instruction
+//         _ => None,
+//     }
+// }
+pub type EventFilter = fn(event_index: i16) -> bool;

--- a/external-crates/move/crates/move-trace-format/src/tracers/function_only.rs
+++ b/external-crates/move/crates/move-trace-format/src/tracers/function_only.rs
@@ -1,8 +1,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::format::TraceEvent;
-use crate::interface::{Tracer, Writer};
+use crate::{
+    format::TraceEvent,
+    interface::{EventFilter, Tracer, Writer},
+};
+use move_binary_format::file_format_common::Opcodes;
 
 /// A tracer that only keeps `OpenFrame`, and `CloseFrame` events.
 pub struct FunctionOnlyTracer;
@@ -14,7 +17,7 @@ impl Tracer for FunctionOnlyTracer {
         )
     }
 
-    fn wants_effects(&self) -> bool {
-        false
+    fn instruction_filter(&self, _instruction: &Opcodes, _pc: u16) -> Option<EventFilter> {
+        None
     }
 }

--- a/external-crates/move/crates/move-trace-format/src/tracers/instruction_only.rs
+++ b/external-crates/move/crates/move-trace-format/src/tracers/instruction_only.rs
@@ -1,8 +1,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::format::TraceEvent;
-use crate::interface::{Tracer, Writer};
+use crate::{
+    format::TraceEvent,
+    interface::{EventFilter, Tracer, Writer},
+};
+use move_binary_format::file_format_common::Opcodes;
 
 /// A tracer that only keeps `Instruction`, `OpenFrame`, and `CloseFrame` events.
 pub struct InstructionOnlyTracer;
@@ -16,7 +19,7 @@ impl Tracer for InstructionOnlyTracer {
         )
     }
 
-    fn wants_effects(&self) -> bool {
-        false
+    fn instruction_filter(&self, _instruction: &Opcodes, _pc: u16) -> Option<EventFilter> {
+        None
     }
 }

--- a/external-crates/move/crates/move-trace-format/src/tracers/memory.rs
+++ b/external-crates/move/crates/move-trace-format/src/tracers/memory.rs
@@ -13,10 +13,11 @@
 
 use crate::{
     format::{DataLoad, Effect, Location, Read, TraceEvent, TraceIndex, TraceValue, Write},
-    interface::{Tracer, Writer},
+    interface::{EventFilter, Tracer, Writer},
     value::SerializableMoveValue,
 };
 use core::fmt;
+use move_binary_format::file_format_common::Opcodes;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
@@ -160,8 +161,8 @@ impl Tracer for TraceState {
         true
     }
 
-    fn wants_effects(&self) -> bool {
-        true
+    fn instruction_filter(&self, _instruction: &Opcodes, _pc: u16) -> Option<EventFilter> {
+        Some(|_event_index| true)
     }
 }
 

--- a/external-crates/move/crates/move-trace-format/src/tracers/nop.rs
+++ b/external-crates/move/crates/move-trace-format/src/tracers/nop.rs
@@ -1,8 +1,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::format::TraceEvent;
-use crate::interface::{Tracer, Writer};
+use crate::{
+    format::TraceEvent,
+    interface::{EventFilter, Tracer, Writer},
+};
+use move_binary_format::file_format_common::Opcodes;
 
 pub struct NopTracer;
 impl Tracer for NopTracer {
@@ -11,7 +14,7 @@ impl Tracer for NopTracer {
         true
     }
 
-    fn wants_effects(&self) -> bool {
-        true
+    fn instruction_filter(&self, _instruction: &Opcodes, _pc: u16) -> Option<EventFilter> {
+        Some(|_event_index| true)
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -48,7 +48,6 @@ pub(crate) struct VMTracer<'a> {
     type_stack: Vec<StackType>,
     loaded_data: BTreeMap<TraceIndex, GlobalValue>,
     effects: Vec<EF>,
-    wants_effects: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -256,14 +255,8 @@ impl VMTracer<'_> {
             .map(|(i, _)| i)
     }
 
-    /// Register the pre-effects for the instruction (i.e., reads, pops.)
-    fn register_pre_effects(&mut self, effects: Vec<EF>) {
-        assert!(self.effects.is_empty());
-        self.effects = effects;
-    }
-
-    /// Register a post-effect for the instruction (i.e., push, writ).
-    fn register_post_effect(&mut self, effect: EF) {
+    /// Register an effect for the instruction (i.e., pop, push, write).
+    fn register_effect(&mut self, effect: EF) {
         self.effects.push(effect);
     }
 
@@ -913,6 +906,7 @@ impl VMTracer<'_> {
         use crate::jit::execution::ast::Bytecode as B;
 
         let pc = machine.call_stack.current_frame.pc;
+        let instruction = &machine.call_stack.current_frame.function.to_ref().code()[pc as usize];
         self.pc = Some(pc);
 
         assert_eq!(
@@ -928,7 +922,9 @@ impl VMTracer<'_> {
             pc,
         );
 
-        if !self.wants_effects {
+        let instruction_filter = self.trace.instruction_filter(instruction, pc);
+
+        if instruction_filter.is_none() {
             match &machine.call_stack.current_frame.function.to_ref().code()[pc as usize] {
                 // StLoc: still need store_global and insert_local side effects.
                 B::StLoc(lidx) => {
@@ -945,27 +941,40 @@ impl VMTracer<'_> {
                 // end_instruction_no_effects_impl needs it for the type_stack Indexed location.
                 B::VecImmBorrow(_) | B::VecMutBorrow(_) => {
                     let v = self.resolve_stack_value(vtables, machine, 0)?;
-                    self.register_pre_effects(vec![EF::Pop(v)]);
+                    self.register_effect(EF::Pop(v));
                     return Some(());
                 }
                 // VecPushBack: no special handling needed. The reference location is available
                 // from the type_stack in end_instruction_no_effects_impl.
                 _ => {}
             }
-            self.register_pre_effects(vec![]);
+            self.effects.clear();
             return Some(());
         }
 
-        let popn = |n: usize| {
-            let mut effects = vec![];
+        assert!(self.effects.is_empty());
+
+        macro_rules! emit_pre_effect {
+            ($idx:expr => $($body:tt)*) => {{
+                if instruction_filter.is_some_and(|f| f(-i16::try_from($idx).unwrap() - 1)) {
+                    self.register_effect({ $($body)* });
+                }
+            }};
+            ($($body:tt)*) => {{
+                if instruction_filter.is_some_and(|f| f(-1)) {
+                    self.register_effect({ $($body)* });
+                }
+            }};
+        }
+
+        let mut popn = |n: usize| {
             for i in 0..n {
-                let v = self.resolve_stack_value(vtables, machine, i)?;
-                effects.push(EF::Pop(v));
+                emit_pre_effect!(i => EF::Pop(self.resolve_stack_value(vtables, machine, i)?));
             }
-            Some(effects)
+            Some(())
         };
 
-        match &machine.call_stack.current_frame.function.to_ref().code()[pc as usize] {
+        match instruction {
             B::Nop
             | B::Branch(_)
             | B::Ret
@@ -978,7 +987,7 @@ impl VMTracer<'_> {
             | B::LdFalse
             | B::LdTrue
             | B::LdConst(_) => {
-                self.register_pre_effects(vec![]);
+                self.effects.clear();
             }
             B::MutBorrowField(_)
             | B::ImmBorrowField(_)
@@ -1007,9 +1016,7 @@ impl VMTracer<'_> {
             | B::UnpackVariantGenericImmRef(_)
             | B::UnpackVariantGenericMutRef(_)
             | B::UnpackVariant(_)
-            | B::UnpackVariantGeneric(_) => {
-                self.register_pre_effects(popn(1)?);
-            }
+            | B::UnpackVariantGeneric(_) => popn(1)?,
             B::Add
             | B::Sub
             | B::Mul
@@ -1031,66 +1038,67 @@ impl VMTracer<'_> {
             | B::WriteRef
             | B::VecImmBorrow(_)
             | B::VecMutBorrow(_)
-            | B::VecPushBack(_) => self.register_pre_effects(popn(2)?),
-            B::VecSwap(_) => self.register_pre_effects(popn(3)?),
-            B::VecPack(_, n) => self.register_pre_effects(popn(*n as usize)?),
+            | B::VecPushBack(_) => popn(2)?,
+            B::VecSwap(_) => popn(3)?,
+            B::VecPack(_, n) => popn(*n as usize)?,
             i @ (B::MoveLoc(l) | B::CopyLoc(l)) => {
-                let v = self.resolve_local(vtables, machine, *l as usize)?;
-                let effects = vec![EF::Read(Read {
-                    location: Location::Local(self.current_frame_identifier()?, *l as usize),
-                    root_value_read: v.clone(),
-                    moved: matches!(i, B::MoveLoc(_)),
-                })];
-                self.register_pre_effects(effects);
+                emit_pre_effect! {
+                    let v = self.resolve_local(vtables, machine, *l as usize)?;
+                    EF::Read(Read {
+                        location: Location::Local(self.current_frame_identifier()?, *l as usize),
+                        root_value_read: v.clone(),
+                        moved: matches!(i, B::MoveLoc(_)),
+                    })
+                }
             }
             B::StLoc(lidx) => {
                 let ty = self.type_stack.last()?.clone();
-                let v = self.resolve_stack_value(vtables, machine, 0)?;
                 self.store_global(machine, self.current_frame_identifier()?, 0, *lidx as usize)?;
                 self.insert_local(*lidx as usize, ty)?;
-                let effects = vec![EF::Pop(v.clone())];
-                self.register_pre_effects(effects);
+                emit_pre_effect!(EF::Pop(self.resolve_stack_value(vtables, machine, 0)?));
             }
             B::ImmBorrowLoc(l_idx) | B::MutBorrowLoc(l_idx) => {
-                let val = self.resolve_local(vtables, machine, *l_idx as usize)?;
-                let location = Location::Local(self.current_frame_identifier()?, *l_idx as usize);
-                self.register_pre_effects(vec![EF::Read(Read {
-                    location,
-                    root_value_read: val,
-                    moved: false,
-                })]);
+                emit_pre_effect! {
+                    let val = self.resolve_local(vtables, machine, *l_idx as usize)?;
+                    let location = Location::Local(self.current_frame_identifier()?, *l_idx as usize);
+                    EF::Read(Read {
+                        location,
+                        root_value_read: val,
+                        moved: false,
+                    })
+                }
             }
             // Handled by open frame
             B::DirectCall(_) | B::VirtualCall(_) | B::CallGeneric(_) => {}
             B::Pack(struct_ptr) => {
                 let field_count = struct_ptr.field_count();
-                self.register_pre_effects(popn(field_count)?);
+                popn(field_count)?;
             }
             B::PackGeneric(struct_inst_ptr) => {
                 let field_count = struct_inst_ptr.field_count as usize;
-                self.register_pre_effects(popn(field_count)?);
+                popn(field_count)?;
             }
             B::PackVariant(variant_ptr) => {
                 let field_count = variant_ptr.field_count();
-                self.register_pre_effects(popn(field_count)?);
+                popn(field_count)?;
             }
             B::PackVariantGeneric(variant_inst_ptr) => {
                 let field_count = variant_inst_ptr.field_count();
-                self.register_pre_effects(popn(field_count)?);
+                popn(field_count)?;
             }
             B::ReadRef => {
                 let ref_value = self.resolve_stack_value(vtables, machine, 0)?;
                 let location = ref_value.location()?.clone();
-                let runtime_location = RuntimeLocation::as_runtime_location(location.clone());
-                let value = self.resolve_location(vtables, machine, &runtime_location)?;
-                self.register_pre_effects(vec![
-                    EF::Pop(ref_value),
+                emit_pre_effect!(EF::Pop(ref_value));
+                emit_pre_effect! {
+                    let runtime_location = RuntimeLocation::as_runtime_location(location.clone());
+                    let value = self.resolve_location(vtables, machine, &runtime_location)?;
                     EF::Read(Read {
                         location,
                         root_value_read: value.clone(),
                         moved: false,
-                    }),
-                ]);
+                    })
+                }
             }
         }
         Some(())
@@ -1117,19 +1125,30 @@ impl VMTracer<'_> {
         // instruction along with snapshoting the effects of the instruction's execution.
         let instruction = &machine.call_stack.current_frame.function.to_ref().code()[pc as usize];
 
+        // Get the instruction filter for this instruction. If it is None, then we don't need to
+        // emit any effects for this instruction. Otherwise we use this to determine the post
+        // effects that are emitted.
+        let instruction_filter = self.trace.instruction_filter(instruction, pc);
+
         macro_rules! emit_effect {
+            ($idx:expr => $($body:tt)*) => {{
+                if instruction_filter.is_some_and(|f| f(i16::try_from($idx).unwrap() + 1)) {
+                    self.register_effect({ $($body)* })
+                }
+            }};
             ($($body:tt)*) => {{
-                if self.wants_effects {
-                    self.register_post_effect({ $($body)* })
+                if instruction_filter.is_some_and(|f| f(1)) {
+                    self.register_effect({ $($body)* })
                 }
             }};
         }
 
         macro_rules! get_effects {
             () => {{
-                if self.wants_effects {
+                if instruction_filter.is_some() {
                     self.get_effects()
                 } else {
+                    self.effects.clear();
                     vec![]
                 }
             }};
@@ -1318,8 +1337,8 @@ impl VMTracer<'_> {
                         ref_type: None,
                     });
                 }
-                for i in (0..s.fields.len()).rev() {
-                    emit_effect!(EF::Push(self.resolve_stack_value(vtables, machine, i)?));
+                for (j, i) in (0..s.fields.len()).rev().enumerate() {
+                    emit_effect!(j => EF::Push(self.resolve_stack_value(vtables, machine, i)?));
                 }
                 let effects = get_effects!();
                 self.trace
@@ -1514,7 +1533,7 @@ impl VMTracer<'_> {
                     return None;
                 };
                 let i = *i;
-                if !self.wants_effects {
+                if instruction_filter.is_none() {
                     self.effects.remove(0);
                 }
                 let location =
@@ -1588,8 +1607,8 @@ impl VMTracer<'_> {
                         ref_type: None,
                     });
                 }
-                for i in (0..*n as usize).rev() {
-                    emit_effect!(EF::Push(self.resolve_stack_value(vtables, machine, i)?));
+                for (j, i) in (0..*n as usize).rev().enumerate() {
+                    emit_effect!(j => EF::Push(self.resolve_stack_value(vtables, machine, i)?));
                 }
                 let effects = get_effects!();
                 self.trace
@@ -1669,8 +1688,8 @@ impl VMTracer<'_> {
                         ref_type: None,
                     });
                 }
-                for i in (0..field_count).rev() {
-                    emit_effect!(EF::Push(self.resolve_stack_value(vtables, machine, i)?));
+                for (j, i) in (0..field_count).rev().enumerate() {
+                    emit_effect!(j => EF::Push(self.resolve_stack_value(vtables, machine, i)?));
                 }
                 let effects = get_effects!();
                 self.trace
@@ -1713,8 +1732,8 @@ impl VMTracer<'_> {
                         ref_type: Some((ref_type.clone(), location)),
                     });
                 }
-                for i in (0..field_count).rev() {
-                    emit_effect!(EF::Push(self.resolve_stack_value(vtables, machine, i)?));
+                for (j, i) in (0..field_count).rev().enumerate() {
+                    emit_effect!(j => EF::Push(self.resolve_stack_value(vtables, machine, i)?));
                 }
                 let effects = get_effects!();
                 self.trace
@@ -1735,7 +1754,6 @@ impl VMTracer<'_> {
 /// The (public crate) API for the VM tracer.
 impl<'a> VMTracer<'a> {
     pub(crate) fn new(trace: &'a mut MoveTraceBuilder, interner: Arc<IdentifierInterner>) -> Self {
-        let wants_effects = trace.wants_effects();
         Self {
             trace,
             interner,
@@ -1744,7 +1762,6 @@ impl<'a> VMTracer<'a> {
             type_stack: vec![],
             loaded_data: BTreeMap::new(),
             effects: vec![],
-            wants_effects,
         }
     }
 
@@ -1842,7 +1859,7 @@ impl<'a> VMTracer<'a> {
             };
             let instruction =
                 &machine.call_stack.current_frame.function.to_ref().code()[pc as usize];
-            self.register_post_effect(EF::ExecutionError(error_string));
+            self.register_effect(EF::ExecutionError(error_string));
             let effects = self.get_effects();
             // TODO(tracer): type params here?
             self.trace


### PR DESCRIPTION
## Description 

Replace `wants_effects` with a per-instruction `EventFilter` which can provide more precise upstream filtering/determination if an event should be created.

The `per_instruction_filter` is called for each instruction with the bytecode and current pc. It can then return:
- `None` -- Do not keep any of this instructions effects (instruction event will still be created though).
- Some(EventFilter)` -- Keep this instructions effects, based on the `EventFilter` function returned.

See the comments on the `EventFilter` type but the returned function is called with the relative index to the instruction where the instruction is at index 0 (so negative for pre-effects, and positive for post-effects).

E.g., if you wanted to only keep the result of `Add` instructions, and the arguments to the `Sub` instructions, and not keep any any others you could do so with something like the following:

```rust
fn instruction_filter_example(instruction: &Opcodes, _pc: u16) -> Option<EventFilter> {
     match instruction {
         // Only interested in the post effects of an `Add` instruction
         Opcodes::ADD => Some(|relative_event_index: i16| relative_event_index > 0),
         // Only interested in the pre effects of a `Sub` instruction
         Opcodes::SUB => Some(|relative_event_index: i16| relative_event_index < 0),
         // Otherwise, we don't care about the effects of this instruction
         _ => None,
     }
}
```

## Test plan 

CI/existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: