### PR TITLE
Fix flaky test_auto_fork_recovery_transaction_fork by driving the missed transaction explicitly

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1745,36 +1745,41 @@ mod test {
 
         let target = test_cluster.swarm.validator_nodes().next().unwrap().name();
 
-        let mut load_config = SimulatedLoadConfig::default();
-        load_config.composite_weight = 0;
-
-        // Background load so certified checkpoints carrying user transactions accumulate while the
-        // target is down and during its catch-up.
-        let load_task = tokio::spawn({
-            let test_cluster = test_cluster.clone();
-            async move {
-                test_simulated_load_with_test_config(
-                    test_cluster,
-                    60,
-                    load_config,
-                    None,
-                    None,
-                    None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
-                    false,
-                )
-                .await;
-            }
-        });
-
-        // Let certified checkpoints accumulate, then stop the target so it falls behind the tip.
-        tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+        // Stop the target so it falls behind the tip.
         test_cluster
             .swarm
             .validator_nodes()
             .find(|validator| validator.name() == target)
             .unwrap()
             .stop();
-        tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+
+        // The fork injection skips system transactions, so the target's catch-up must
+        // re-execute a user transaction it has never executed. Land one to checkpoint
+        // finality: submitted after the stop, the target cannot have executed it. Retrying
+        // the same signed transaction on transient failures cannot equivocate the gas object.
+        let tx_data = test_cluster
+            .test_transaction_builder()
+            .await
+            .transfer_sui(Some(1), test_cluster.get_address_1())
+            .build();
+        let tx = test_cluster.sign_transaction(&tx_data).await;
+        while test_cluster
+            .wallet
+            .execute_transaction_may_fail(tx.clone())
+            .await
+            .is_err()
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+
+        // Wait for the epoch holding the transfer to close: a closed epoch can only be
+        // replayed through the checkpoint executor (peers tear down its consensus at
+        // reconfig), so the target's catch-up must re-execute the transfer there — and fork.
+        let finality_epoch = test_cluster
+            .fullnode_handle
+            .sui_node
+            .with(|node| node.state().epoch_store_for_testing().epoch());
+        test_cluster.wait_for_epoch(Some(finality_epoch + 1)).await;
 
         // Arm the injection and kill hooks BEFORE restarting the target: its catch-up
         // re-execution can complete inside start()'s internal awaits, so arming afterwards
@@ -1849,7 +1854,6 @@ mod test {
 
         // Corrected binary: stop injecting forks.
         clear_fail_point("simulate_fork_during_execution");
-        load_task.abort();
 
         // Confirm it was a transaction fork: checkpoint_overrides (set only by the checkpoint/split-
         // brain failpoints) is empty even though the target forked.


### PR DESCRIPTION
## Description

`test_auto_fork_recovery_transaction_fork` failed in the [2026-07-16 nightly](https://github.com/MystenLabs/sui/actions/runs/29535967381) on two seeds with `target should transaction-fork while catching up on the executor path`. This is a different failure mode from the arm-after-restart race fixed in #27322, and still reproduces on top of that fix (see test plan).

The fork injection skips system transactions, so the restarted target's catch-up must re-execute at least one user transaction to fork. The test relied on fixed sleeps to line the down-window up with background load traffic, but the load's setup phase can stall for many seconds (in the reproduced seed, a setup transaction was rejected at the epoch end and went into retry backoff, leaving all of epoch 1 with zero user transactions). When the down-window lands in that lull, the target re-executes only system transactions during catch-up, and once caught up it executes everything via the consensus path (no `expected_effects_digest`), so the fork window is closed forever.

The test never needed the load — its assertions only need one missed user transaction — so drop it and construct that transaction explicitly, making every precondition hold by construction rather than by timing:

- Stop the target, then land a transfer to checkpoint finality: submitted after the stop, the target cannot have executed it.
- Wait for the epoch holding the transfer to close before restarting: a closed epoch can only be replayed through the checkpoint executor (peers tear down its consensus at reconfig), so catch-up must re-execute the transfer with `expected_effects_digest` set — and fork.

Fork-recovery under concurrent load traffic remains covered by the sibling tests (`test_auto_fork_recovery_checkpoint_fork`, `test_split_brain_recovery_via_checkpoint_overrides`), which genuinely depend on the load. The test is also considerably faster (~25s vs ~70s) since it no longer waits out load setup and fixed sleeps.

## Test plan

Reproduced and validated with `scripts/simtest/seed-search.py` sweeps of this test:

- The failure mode: seed `1784310332005` fails on the pre-#27322 base and seed `1784310332059` fails on current `main` (which includes #27322), both with the same assertion. Traces show the injection armed in time but no user transaction in the catch-up window (epoch 1 `total_gas_reward=0`).
- With this change: 200/200 seeds pass over the same seed range, and the fork fires promptly on the executor path (`fork detected!` during certified-checkpoint re-execution) followed by the kill hook and auto-recovery.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
